### PR TITLE
Main: Revert "Use immutable types in signature help (#80322)"

### DIFF
--- a/src/EditorFeatures/CSharpTest/SignatureHelp/AttributeSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/AttributeSignatureHelpProviderTests.cs
@@ -26,6 +26,11 @@ public sealed class AttributeSignatureHelpProviderTests : AbstractCSharpSignatur
     [Fact]
     public async Task TestInvocationWithoutParameters()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("SomethingAttribute()", string.Empty, null, currentParameterIndex: 0)
+        };
+
         await TestAsync("""
             class SomethingAttribute : System.Attribute
             {
@@ -35,13 +40,17 @@ public sealed class AttributeSignatureHelpProviderTests : AbstractCSharpSignatur
             class D
             {
             }
-            """,
-            [new("SomethingAttribute()", string.Empty, null, currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
     public async Task TestInvocationWithoutParametersMethodXmlComments()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("SomethingAttribute()", "Summary For Attribute", null, currentParameterIndex: 0)
+        };
+
         await TestAsync("""
             class SomethingAttribute : System.Attribute
             {
@@ -53,13 +62,18 @@ public sealed class AttributeSignatureHelpProviderTests : AbstractCSharpSignatur
             class D
             {
             }
-            """,
-            [new("SomethingAttribute()", "Summary For Attribute", null, currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/25830")]
     public async Task PickCorrectOverload_PickInt()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("SomethingAttribute(int i)", currentParameterIndex: 0, isSelected: true),
+            new("SomethingAttribute(string i)", currentParameterIndex: 0),
+        };
+
         await TestAsync("""
             class SomethingAttribute : System.Attribute
             {
@@ -69,14 +83,18 @@ public sealed class AttributeSignatureHelpProviderTests : AbstractCSharpSignatur
             }
             [[|Something(i: 1$$|])]
             class D { }
-            """, [
-                new("SomethingAttribute(int i)", currentParameterIndex: 0, isSelected: true),
-                new("SomethingAttribute(string i)", currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/25830")]
     public async Task PickCorrectOverload_PickString()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("SomethingAttribute(int i)", currentParameterIndex: 0),
+            new("SomethingAttribute(string i)", currentParameterIndex: 0, isSelected: true),
+        };
+
         await TestAsync("""
             class SomethingAttribute : System.Attribute
             {
@@ -86,14 +104,17 @@ public sealed class AttributeSignatureHelpProviderTests : AbstractCSharpSignatur
             }
             [[|Something(i: null$$|])]
             class D { }
-            """, [
-                new("SomethingAttribute(int i)", currentParameterIndex: 0),
-                new("SomethingAttribute(string i)", currentParameterIndex: 0, isSelected: true)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
     public async Task TestInvocationWithParametersOn1()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("SomethingAttribute(int someInteger, string someString)", string.Empty, string.Empty, currentParameterIndex: 0)
+        };
+
         await TestAsync("""
             class SomethingAttribute : System.Attribute
             {
@@ -104,13 +125,17 @@ public sealed class AttributeSignatureHelpProviderTests : AbstractCSharpSignatur
             class D
             {
             }
-            """,
-            [new("SomethingAttribute(int someInteger, string someString)", string.Empty, string.Empty, currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
     public async Task TestInvocationWithParametersXmlCommentsOn1()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("SomethingAttribute(int someInteger, string someString)", "Summary For Attribute", "Param someInteger", currentParameterIndex: 0)
+        };
+
         await TestAsync("""
             class SomethingAttribute : System.Attribute
             {
@@ -126,13 +151,17 @@ public sealed class AttributeSignatureHelpProviderTests : AbstractCSharpSignatur
             |]class D
             {
             }
-            """,
-            [new("SomethingAttribute(int someInteger, string someString)", "Summary For Attribute", "Param someInteger", currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
     public async Task TestInvocationWithParametersOn2()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("SomethingAttribute(int someInteger, string someString)", string.Empty, string.Empty, currentParameterIndex: 1)
+        };
+
         await TestAsync("""
             class SomethingAttribute : System.Attribute
             {
@@ -143,13 +172,17 @@ public sealed class AttributeSignatureHelpProviderTests : AbstractCSharpSignatur
             class D
             {
             }
-            """,
-            [new("SomethingAttribute(int someInteger, string someString)", string.Empty, string.Empty, currentParameterIndex: 1)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
     public async Task TestInvocationWithParametersXmlComentsOn2()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("SomethingAttribute(int someInteger, string someString)", "Summary For Attribute", "Param someString", currentParameterIndex: 1)
+        };
+
         await TestAsync("""
             class SomethingAttribute : System.Attribute
             {
@@ -165,13 +198,17 @@ public sealed class AttributeSignatureHelpProviderTests : AbstractCSharpSignatur
             |]class D
             {
             }
-            """,
-            [new("SomethingAttribute(int someInteger, string someString)", "Summary For Attribute", "Param someString", currentParameterIndex: 1)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
     public async Task TestInvocationWithClosingParen()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("SomethingAttribute()", string.Empty, null, currentParameterIndex: 0)
+        };
+
         await TestAsync("""
             class SomethingAttribute : System.Attribute
             { }
@@ -180,8 +217,7 @@ public sealed class AttributeSignatureHelpProviderTests : AbstractCSharpSignatur
             class D
             {
             }
-            """,
-            [new("SomethingAttribute()", string.Empty, null, currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
@@ -961,6 +997,7 @@ public sealed class AttributeSignatureHelpProviderTests : AbstractCSharpSignatur
     [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1081535")]
     public async Task TestInvocationWithBadParameterList()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>();
         await TestAsync("""
             class SomethingAttribute : System.Attribute
             {
@@ -970,6 +1007,6 @@ public sealed class AttributeSignatureHelpProviderTests : AbstractCSharpSignatur
             class D
             {
             }
-            """, []);
+            """, expectedOrderedItems);
     }
 }

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/ConstructorInitializerSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/ConstructorInitializerSignatureHelpProviderTests.cs
@@ -26,6 +26,11 @@ public sealed class ConstructorInitializerSignatureHelpProviderTests : AbstractC
     [Fact]
     public async Task TestInvocationWithoutParameters()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("BaseClass()", string.Empty, null, currentParameterIndex: 0)
+        };
+
         await TestAsync("""
             class BaseClass
             {
@@ -37,13 +42,17 @@ public sealed class ConstructorInitializerSignatureHelpProviderTests : AbstractC
                 public Derived() [|: base($$|])
                 { }
             }
-            """,
-            [new("BaseClass()", string.Empty, null, currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
     public async Task TestInvocationWithoutParametersMethodXmlComments()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("BaseClass()", "Summary for BaseClass", null, currentParameterIndex: 0)
+        };
+
         await TestAsync("""
             class BaseClass
             {
@@ -56,13 +65,17 @@ public sealed class ConstructorInitializerSignatureHelpProviderTests : AbstractC
                 public Derived() [|: base($$|])
                 { }
             }
-            """,
-            [new("BaseClass()", "Summary for BaseClass", null, currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
     public async Task TestInvocationWithParametersOn1()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("BaseClass(int a, int b)", string.Empty, string.Empty, currentParameterIndex: 0)
+        };
+
         await TestAsync("""
             class BaseClass
             {
@@ -74,13 +87,17 @@ public sealed class ConstructorInitializerSignatureHelpProviderTests : AbstractC
                 public Derived() [|: base($$2, 3|])
                 { }
             }
-            """,
-            [new("BaseClass(int a, int b)", string.Empty, string.Empty, currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
     public async Task TestInvocationWithParametersXmlCommentsOn1()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("BaseClass(int a, int b)", "Summary for BaseClass", "Param a", currentParameterIndex: 0)
+        };
+
         await TestAsync("""
             class BaseClass
             {
@@ -95,13 +112,17 @@ public sealed class ConstructorInitializerSignatureHelpProviderTests : AbstractC
                 public Derived() [|: base($$2, 3|])
                 { }
             }
-            """,
-            [new("BaseClass(int a, int b)", "Summary for BaseClass", "Param a", currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
     public async Task TestInvocationWithParametersOn2()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("BaseClass(int a, int b)", "Summary for BaseClass", "Param b", currentParameterIndex: 1)
+        };
+
         await TestAsync("""
             class BaseClass
             {
@@ -117,13 +138,17 @@ public sealed class ConstructorInitializerSignatureHelpProviderTests : AbstractC
                 public Derived() [|: base(2, $$3|])
                 { }
             }
-            """,
-            [new("BaseClass(int a, int b)", "Summary for BaseClass", "Param b", currentParameterIndex: 1)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
     public async Task TestInvocationWithParametersXmlComentsOn2()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("BaseClass(int a, int b)", "Summary for BaseClass", "Param b", currentParameterIndex: 1)
+        };
+
         await TestAsync("""
             class BaseClass
             {
@@ -138,65 +163,86 @@ public sealed class ConstructorInitializerSignatureHelpProviderTests : AbstractC
                 public Derived() [|: base(2, $$3|])
                 { }
             }
-            """,
-            [new("BaseClass(int a, int b)", "Summary for BaseClass", "Param b", currentParameterIndex: 1)]);
+            """, expectedOrderedItems);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/2579")]
     public async Task TestThisInvocation()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("Goo(int a, int b)", string.Empty, string.Empty, currentParameterIndex: 1)
+        };
+
         await TestAsync("""
             class Goo
             {
                 public Goo(int a, int b) { }
                 public Goo() [|: this(2, $$3|]) { }
             }
-            """,
-            [new("Goo(int a, int b)", string.Empty, string.Empty, currentParameterIndex: 1)]);
+            """, expectedOrderedItems);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/2579")]
     public async Task TestThisInvocationWithNonEmptyArgumentList()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("Foo()", string.Empty, null, currentParameterIndex: 0),
+        };
+
         await TestAsync("""
             class Foo
             {
                 public Foo(int a, int b) [|: this($$|]) { }
                 public Foo() { }
             }
-            """,
-            [new("Foo()", string.Empty, null, currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/2579")]
     public async Task TestInvocationWithoutClosingParen()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("Goo(int a, int b)", string.Empty, string.Empty, currentParameterIndex: 1)
+        };
+
         await TestAsync("""
             class Goo
             {
                 public Goo(int a, int b) { }
                 public Goo() [|: this(2, $$
             |]}
-            """,
-            [new("Goo(int a, int b)", string.Empty, string.Empty, currentParameterIndex: 1)]);
+            """, expectedOrderedItems);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/2579")]
     public async Task TestThisInvocationWithoutClosingParenWithNonEmptyArgumentList()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("Foo()", string.Empty, null, currentParameterIndex: 0),
+        };
+
         await TestAsync("""
             class Foo
             {
                 public Foo() { }
                 public Foo(int a, int b)  [|: this($$
             |]}
-            """,
-            [new("Foo()", string.Empty, null, currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/25830")]
     public async Task PickCorrectOverload_PickInt()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("D(int i)", currentParameterIndex: 0, isSelected: true),
+            new("D(string i)", currentParameterIndex: 0),
+        };
+
         await TestAsync("""
             class D
             {
@@ -206,14 +252,18 @@ public sealed class ConstructorInitializerSignatureHelpProviderTests : AbstractC
                 D(string i) => throw null;
                 D(int i) => throw null;
             }
-            """, [
-                new("D(int i)", currentParameterIndex: 0, isSelected: true),
-                new("D(string i)", currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/25830")]
     public async Task PickCorrectOverload_PickString()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("D(int i)", currentParameterIndex: 0),
+            new("D(string i)", currentParameterIndex: 0, isSelected: true),
+        };
+
         await TestAsync("""
             class D
             {
@@ -223,9 +273,7 @@ public sealed class ConstructorInitializerSignatureHelpProviderTests : AbstractC
                 D(string i) => throw null;
                 D(int i) => throw null;
             }
-            """, [
-                new("D(int i)", currentParameterIndex: 0),
-                new("D(string i)", currentParameterIndex: 0, isSelected: true)]);
+            """, expectedOrderedItems);
     }
 
     #endregion

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNameFullyWrittenSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNameFullyWrittenSignatureHelpProviderTests.cs
@@ -27,6 +27,11 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
     [Fact]
     public async Task NestedGenericTerminated()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("G<T>", string.Empty, string.Empty, currentParameterIndex: 0)
+        };
+
         await TestAsync("""
             class G<T> { };
 
@@ -37,13 +42,17 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
                     G<G<int>$$>
                 }
             }
-            """,
-            [new("G<T>", string.Empty, string.Empty, currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
     public async Task DeclaringGenericTypeWith1ParameterTerminated()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("G<T>", string.Empty, string.Empty, currentParameterIndex: 0)
+        };
+
         await TestAsync("""
             class G<T> { };
 
@@ -54,13 +63,17 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
                     [|G<$$|]>
                 }
             }
-            """,
-            [new("G<T>", string.Empty, string.Empty, currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
     public async Task DeclaringGenericTypeWith2ParametersOn1()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("G<S, T>", string.Empty, string.Empty, currentParameterIndex: 0)
+        };
+
         await TestAsync("""
             class G<S, T> { };
 
@@ -71,13 +84,17 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
                     [|G<$$|]>
                 }
             }
-            """,
-            [new("G<S, T>", string.Empty, string.Empty, currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
     public async Task DeclaringGenericTypeWith2ParametersOn2()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("G<S, T>", string.Empty, string.Empty, currentParameterIndex: 1)
+        };
+
         await TestAsync("""
             class G<S, T> { };
 
@@ -88,13 +105,20 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
                     [|G<int, $$|]>
                 }
             }
-            """,
-            [new("G<S, T>", string.Empty, string.Empty, currentParameterIndex: 1)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
     public async Task DeclaringGenericTypeWith2ParametersOn1XmlDoc()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("G<S, T>",
+                "Summary for G",
+                "TypeParamS. Also see T",
+                currentParameterIndex: 0)
+        };
+
         await TestAsync("""
             /// <summary>
             /// Summary for G
@@ -110,16 +134,17 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
                     [|G<$$|]>
                 }
             }
-            """,
-            [new("G<S, T>",
-                "Summary for G",
-                "TypeParamS. Also see T",
-                currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
     public async Task DeclaringGenericTypeWith2ParametersOn2XmlDoc()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("G<S, T>", "Summary for G", "TypeParamT. Also see S", currentParameterIndex: 1)
+        };
+
         await TestAsync("""
             /// <summary>
             /// Summary for G
@@ -135,8 +160,7 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
                     [|G<int, $$|]>
                 }
             }
-            """,
-            [new("G<S, T>", "Summary for G", "TypeParamT. Also see S", currentParameterIndex: 1)]);
+            """, expectedOrderedItems);
     }
 
     #endregion
@@ -146,6 +170,11 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
     [Fact]
     public async Task DeclaringGenericTypeWithConstraintsStruct()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("G<S> where S : struct", string.Empty, string.Empty, currentParameterIndex: 0)
+        };
+
         await TestAsync("""
             class G<S> where S : struct
             { };
@@ -157,13 +186,17 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
                     [|G<$$|]>
                 }
             }
-            """,
-            [new("G<S> where S : struct", string.Empty, string.Empty, currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
     public async Task DeclaringGenericTypeWithConstraintsClass()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("G<S> where S : class", string.Empty, string.Empty, currentParameterIndex: 0)
+        };
+
         await TestAsync("""
             class G<S> where S : class
             { };
@@ -175,13 +208,17 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
                     [|G<$$|]>
                 }
             }
-            """,
-            [new("G<S> where S : class", string.Empty, string.Empty, currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
     public async Task DeclaringGenericTypeWithConstraintsNew()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("G<S> where S : new()", string.Empty, string.Empty, currentParameterIndex: 0)
+        };
+
         await TestAsync("""
             class G<S> where S : new()
             { };
@@ -193,13 +230,17 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
                     [|G<$$|]>
                 }
             }
-            """,
-            [new("G<S> where S : new()", string.Empty, string.Empty, currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
     public async Task DeclaringGenericTypeWithConstraintsBase()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("G<S> where S : Base", string.Empty, string.Empty, currentParameterIndex: 0)
+        };
+
         await TestAsync("""
             class Base { }
 
@@ -213,13 +254,17 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
                     [|G<$$|]>
                 }
             }
-            """,
-            [new("G<S> where S : Base", string.Empty, string.Empty, currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
     public async Task DeclaringGenericTypeWithConstraintsBaseGenericWithGeneric()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("G<S> where S : Base<S>", string.Empty, string.Empty, currentParameterIndex: 0)
+        };
+
         await TestAsync("""
             class Base<T> { }
 
@@ -233,13 +278,17 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
                     [|G<$$|]>
                 }
             }
-            """,
-            [new("G<S> where S : Base<S>", string.Empty, string.Empty, currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
     public async Task DeclaringGenericTypeWithConstraintsBaseGenericWithNonGeneric()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("G<S> where S : Base<int>", string.Empty, string.Empty, currentParameterIndex: 0)
+        };
+
         await TestAsync("""
             class Base<T> { }
 
@@ -253,13 +302,17 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
                     [|G<$$|]>
                 }
             }
-            """,
-            [new("G<S> where S : Base<int>", string.Empty, string.Empty, currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
     public async Task DeclaringGenericTypeWithConstraintsBaseGenericNested()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("G<S> where S : Base<Base<int>>", string.Empty, string.Empty, currentParameterIndex: 0)
+        };
+
         await TestAsync("""
             class Base<T> { }
 
@@ -273,13 +326,17 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
                     [|G<$$|]>
                 }
             }
-            """,
-            [new("G<S> where S : Base<Base<int>>", string.Empty, string.Empty, currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
     public async Task DeclaringGenericTypeWithConstraintsDeriveFromAnotherGenericParameter()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("G<S, T> where S : T", string.Empty, string.Empty, currentParameterIndex: 0)
+        };
+
         await TestAsync("""
             class G<S, T> where S : T
             { };
@@ -291,13 +348,17 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
                     [|G<$$|]>
                 }
             }
-            """,
-            [new("G<S, T> where S : T", string.Empty, string.Empty, currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
     public async Task DeclaringGenericTypeWithConstraintsMixed1()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("G<S, T> where S : Base, new()", "Summary1", "SummaryS", currentParameterIndex: 0)
+        };
+
         await TestAsync("""
             /// <summary>
             /// Summary1
@@ -320,13 +381,17 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
                     [|G<$$|]>
                 }
             }
-            """,
-            [new("G<S, T> where S : Base, new()", "Summary1", "SummaryS", currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
     public async Task DeclaringGenericTypeWithConstraintsMixed2()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("G<S, T> where T : class, S, IGoo, new()", "Summary1", "SummaryT", currentParameterIndex: 1)
+        };
+
         await TestAsync("""
             /// <summary>
             /// Summary1
@@ -349,13 +414,17 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
                     [|G<bar, $$|]>
                 }
             }
-            """,
-            [new("G<S, T> where T : class, S, IGoo, new()", "Summary1", "SummaryT", currentParameterIndex: 1)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
     public async Task DeclaringGenericTypeWithConstraintsAllowRefStruct()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("G<S> where S : allows ref struct", string.Empty, string.Empty, currentParameterIndex: 0)
+        };
+
         await TestAsync("""
             class G<S> where S : allows ref struct
             { };
@@ -367,8 +436,7 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
                     [|G<$$|]>
                 }
             }
-            """,
-            [new("G<S> where S : allows ref struct", string.Empty, string.Empty, currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     #endregion
@@ -378,6 +446,11 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
     [Fact]
     public async Task InvokingGenericMethodWith1ParameterTerminated()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("void C.Goo<T>()", string.Empty, string.Empty, currentParameterIndex: 0)
+        };
+
         await TestAsync("""
             class C
             {
@@ -388,13 +461,18 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
                     [|Goo<$$|]>
                 }
             }
-            """,
-            [new("void C.Goo<T>()", string.Empty, string.Empty, currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544091")]
     public async Task InvokingGenericMethodWith2ParametersOn1()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("void C.Goo<S, T>(S s, T t)",
+                "Method summary", "type param S. see T", currentParameterIndex: 0)
+        };
+
         await TestAsync("""
             class C
             {
@@ -412,14 +490,17 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
                     [|Goo<$$|]>
                 }
             }
-            """,
-            [new("void C.Goo<S, T>(S s, T t)",
-                "Method summary", "type param S. see T", currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544091")]
     public async Task InvokingGenericMethodWith2ParametersOn2()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("void C.Goo<S, T>(S s, T t)", string.Empty, string.Empty, currentParameterIndex: 1)
+        };
+
         await TestAsync("""
             class C
             {
@@ -430,13 +511,17 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
                     [|Goo<int, $$|]>
                 }
             }
-            """,
-            [new("void C.Goo<S, T>(S s, T t)", string.Empty, string.Empty, currentParameterIndex: 1)]);
+            """, expectedOrderedItems);
     }
 
     [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544091")]
     public async Task InvokingGenericMethodWith2ParametersOn1XmlDoc()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("void C.Goo<S, T>(S s, T t)", "SummaryForGoo", "SummaryForS", currentParameterIndex: 0)
+        };
+
         await TestAsync("""
             class C
             {
@@ -452,13 +537,17 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
                     [|Goo<$$|]>
                 }
             }
-            """,
-            [new("void C.Goo<S, T>(S s, T t)", "SummaryForGoo", "SummaryForS", currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544091")]
     public async Task InvokingGenericMethodWith2ParametersOn2XmlDoc()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("void C.Goo<S, T>(S s, T t)", "SummaryForGoo", "SummaryForT", currentParameterIndex: 1)
+        };
+
         await TestAsync("""
             class C
             {
@@ -474,13 +563,17 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
                     [|Goo<int, $$|]>
                 }
             }
-            """,
-            [new("void C.Goo<S, T>(S s, T t)", "SummaryForGoo", "SummaryForT", currentParameterIndex: 1)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
     public async Task CallingGenericExtensionMethod()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new($"({CSharpFeaturesResources.extension}) void G.Goo<T>()", string.Empty, string.Empty, currentParameterIndex: 0)
+        };
+
         // TODO: Enable the script case when we have support for extension methods in scripts
         await TestAsync("""
             class G
@@ -499,9 +592,7 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
             {
                 public static void Goo<T>(this G g) { }
             }
-            """,
-            [new($"({CSharpFeaturesResources.extension}) void G.Goo<T>()", string.Empty, string.Empty, currentParameterIndex: 0)],
-            usePreviousCharAsTrigger: false, sourceCodeKind: SourceCodeKind.Regular);
+            """, expectedOrderedItems, usePreviousCharAsTrigger: false, sourceCodeKind: Microsoft.CodeAnalysis.SourceCodeKind.Regular);
     }
 
     #endregion
@@ -511,6 +602,11 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
     [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544091")]
     public async Task InvokingGenericMethodWithConstraintsMixed1()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("S C.Goo<S, T>(S s, T t) where S : Base, new()", "GooSummary", "ParamS", currentParameterIndex: 0)
+        };
+
         await TestAsync("""
             class Base { }
             interface IGoo { }
@@ -532,12 +628,17 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
                     [|Goo<$$|]>
                 }
             }
-            """, [new("S C.Goo<S, T>(S s, T t) where S : Base, new()", "GooSummary", "ParamS", currentParameterIndex: 0)]);
+            """, expectedOrderedItems);
     }
 
     [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544091")]
     public async Task InvokingGenericMethodWithConstraintsMixed2()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("S C.Goo<S, T>(S s, T t) where T : class, S, IGoo, new()", "GooSummary", "ParamT", currentParameterIndex: 1)
+        };
+
         await TestAsync("""
             class Base { }
             interface IGoo { }
@@ -559,7 +660,7 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
                     [|Goo<Base, $$|]>
                 }
             }
-            """, [new("S C.Goo<S, T>(S s, T t) where T : class, S, IGoo, new()", "GooSummary", "ParamT", currentParameterIndex: 1)]);
+            """, expectedOrderedItems);
     }
 
     [Fact]
@@ -581,7 +682,9 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
                 }
             }
             """,
-            [new SignatureHelpTestItem("void C.M<T>(T arg) where T : unmanaged", "summary headline", "T documentation", currentParameterIndex: 0)]);
+        [
+            new SignatureHelpTestItem("void C.M<T>(T arg) where T : unmanaged", "summary headline", "T documentation", currentParameterIndex: 0)
+        ]);
 
     #endregion
 
@@ -792,6 +895,7 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
     [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1083601")]
     public async Task DeclaringGenericTypeWithBadTypeArgumentList()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>();
         await TestAsync("""
             class G<T> { };
 
@@ -802,12 +906,28 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
                     G{$$>
                 }
             }
-            """, []);
+            """, expectedOrderedItems);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/50114")]
     public async Task DeclaringGenericTypeWithDocCommentList()
     {
+        var expectedOrderedItems = new List<SignatureHelpTestItem>
+        {
+            new("G<S, T>", """
+            List:
+
+            Item 1.
+            """,
+            classificationTypeNames: ImmutableArray.Create(
+                ClassificationTypeNames.Text,
+                ClassificationTypeNames.WhiteSpace,
+                ClassificationTypeNames.WhiteSpace,
+                ClassificationTypeNames.WhiteSpace,
+                ClassificationTypeNames.Text,
+                ClassificationTypeNames.WhiteSpace))
+        };
+
         await TestAsync("""
             /// <summary>
             /// List:
@@ -828,19 +948,7 @@ public sealed class GenericNameFullyWrittenSignatureHelpProviderTests : Abstract
                     [|G<int, $$|]>
                 }
             }
-            """,
-            [new("G<S, T>", """
-                List:
-
-                Item 1.
-                """,
-                classificationTypeNames: ImmutableArray.Create(
-                    ClassificationTypeNames.Text,
-                    ClassificationTypeNames.WhiteSpace,
-                    ClassificationTypeNames.WhiteSpace,
-                    ClassificationTypeNames.WhiteSpace,
-                    ClassificationTypeNames.Text,
-                    ClassificationTypeNames.WhiteSpace))]);
+            """, expectedOrderedItems);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/80233")]

--- a/src/EditorFeatures/Test2/IntelliSense/SignatureHelpControllerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/SignatureHelpControllerTests.vb
@@ -21,7 +21,6 @@ Imports Microsoft.VisualStudio.Text.Editor
 Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 Imports Microsoft.VisualStudio.Text.Projection
 Imports Moq
-Imports Roslyn.Utilities
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
@@ -152,7 +151,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
             If provider Is Nothing Then
                 items = If(items, CreateItems(1))
-                provider = New MockSignatureHelpProvider(items.ToImmutableArray())
+                provider = New MockSignatureHelpProvider(items)
             End If
 
             Dim presenter = New Mock(Of IIntelliSensePresenter(Of ISignatureHelpPresenterSession, ISignatureHelpSession))(MockBehavior.Strict) With {.DefaultValue = DefaultValue.Mock}
@@ -195,16 +194,16 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             Return controller
         End Function
 
-        Private Shared Function CreateItems(count As Integer) As ImmutableArray(Of SignatureHelpItem)
-            Return Enumerable.Range(0, count).SelectAsArray(Function(i) New SignatureHelpItem(isVariadic:=False, documentationFactory:=Nothing, prefixParts:=New List(Of TaggedText), separatorParts:={}, suffixParts:={}, parameters:={}, descriptionParts:={}))
+        Private Shared Function CreateItems(count As Integer) As IList(Of SignatureHelpItem)
+            Return Enumerable.Range(0, count).Select(Function(i) New SignatureHelpItem(isVariadic:=False, documentationFactory:=Nothing, prefixParts:=New List(Of TaggedText), separatorParts:={}, suffixParts:={}, parameters:={}, descriptionParts:={})).ToList()
         End Function
 
         Friend Class MockSignatureHelpProvider
             Implements ISignatureHelpProvider
 
-            Private ReadOnly _items As ImmutableArray(Of SignatureHelpItem)
+            Private ReadOnly _items As IList(Of SignatureHelpItem)
 
-            Public Sub New(items As ImmutableArray(Of SignatureHelpItem))
+            Public Sub New(items As IList(Of SignatureHelpItem))
                 Me._items = items
             End Sub
 
@@ -213,8 +212,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             Public Function GetItemsAsync(document As Document, position As Integer, triggerInfo As SignatureHelpTriggerInfo, options As MemberDisplayOptions, cancellationToken As CancellationToken) As Task(Of SignatureHelpItems) Implements ISignatureHelpProvider.GetItemsAsync
                 GetItemsCount += 1
                 Return Task.FromResult(If(_items.Any(),
-                    New SignatureHelpItems(_items, TextSpan.FromBounds(position, position), selectedItem:=0, semanticParameterIndex:=0, syntacticArgumentCount:=0, argumentName:=Nothing),
-                    Nothing))
+                                       New SignatureHelpItems(_items, TextSpan.FromBounds(position, position), selectedItem:=0, semanticParameterIndex:=0, syntacticArgumentCount:=0, argumentName:=Nothing),
+                                       Nothing))
             End Function
 
             Public ReadOnly Property TriggerCharacters As ImmutableArray(Of Char) Implements ISignatureHelpProvider.TriggerCharacters

--- a/src/EditorFeatures/TestUtilities/SignatureHelp/AbstractSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/SignatureHelp/AbstractSignatureHelpProviderTests.cs
@@ -181,7 +181,7 @@ public abstract class AbstractSignatureHelpProviderTests<TWorkspaceFixture> : Te
     private static void CompareAndAssertCollectionsAndCurrentParameter(
         IEnumerable<SignatureHelpTestItem> expectedTestItems, SignatureHelpItems actualSignatureHelpItems)
     {
-        Assert.True(expectedTestItems.Count() == actualSignatureHelpItems.Items.Length, $"Expected {expectedTestItems.Count()} items, but got {actualSignatureHelpItems.Items.Length}");
+        Assert.True(expectedTestItems.Count() == actualSignatureHelpItems.Items.Count, $"Expected {expectedTestItems.Count()} items, but got {actualSignatureHelpItems.Items.Count}");
 
         for (var i = 0; i < expectedTestItems.Count(); i++)
         {

--- a/src/Features/CSharp/Portable/ExternalAccess/Pythia/Api/PythiaSignatureHelpItemWrapper.cs
+++ b/src/Features/CSharp/Portable/ExternalAccess/Pythia/Api/PythiaSignatureHelpItemWrapper.cs
@@ -21,5 +21,5 @@ internal readonly struct PythiaSignatureHelpItemWrapper(SignatureHelpItem underl
         int position,
         SemanticModel semanticModel,
         IList<SymbolDisplayPart> descriptionParts)
-    => new(AbstractOrdinaryMethodSignatureHelpProvider.ConvertMethodGroupMethod(document, method, position, semanticModel, [.. descriptionParts]));
+    => new(AbstractOrdinaryMethodSignatureHelpProvider.ConvertMethodGroupMethod(document, method, position, semanticModel, descriptionParts));
 }

--- a/src/Features/CSharp/Portable/SignatureHelp/AbstractCSharpSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/AbstractCSharpSignatureHelpProvider.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.DocumentationComments;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.SignatureHelp;
@@ -34,13 +33,13 @@ internal abstract partial class AbstractCSharpSignatureHelpProvider : AbstractSi
     protected static SymbolDisplayPart NewLine()
         => new(SymbolDisplayPartKind.LineBreak, null, "\r\n");
 
-    private static readonly ImmutableArray<SymbolDisplayPart> _separatorParts =
+    private static readonly IList<SymbolDisplayPart> _separatorParts =
         [
             Punctuation(SyntaxKind.CommaToken),
             Space()
         ];
 
-    protected static ImmutableArray<SymbolDisplayPart> GetSeparatorParts() => _separatorParts;
+    protected static IList<SymbolDisplayPart> GetSeparatorParts() => _separatorParts;
 
     protected static SignatureHelpSymbolParameter Convert(
         IParameterSymbol parameter,

--- a/src/Features/CSharp/Portable/SignatureHelp/AbstractGenericNameSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/AbstractGenericNameSignatureHelpProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -13,7 +14,6 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.DocumentationComments;
 using Microsoft.CodeAnalysis.LanguageService;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.SignatureHelp;
 using Microsoft.CodeAnalysis.Text;
@@ -156,9 +156,9 @@ internal abstract partial class AbstractGenericNameSignatureHelpProvider : Abstr
             throw ExceptionUtilities.UnexpectedValue(symbol);
         }
 
-        ImmutableArray<SignatureHelpSymbolParameter> GetTypeArguments(IMethodSymbol method)
+        IList<SignatureHelpSymbolParameter> GetTypeArguments(IMethodSymbol method)
         {
-            using var _ = ArrayBuilder<SignatureHelpSymbolParameter>.GetInstance(out var result);
+            var result = new List<SignatureHelpSymbolParameter>();
 
             // Signature help for generic modern extensions must include the generic type *arguments* for the containing
             // extension as well.  These are fixed given the receiver, and need to be repeated in the method type argument
@@ -173,7 +173,7 @@ internal abstract partial class AbstractGenericNameSignatureHelpProvider : Abstr
 
             result.AddRange(method.TypeParameters.Select(p => Convert(p, semanticModel, position, documentationCommentFormattingService)));
 
-            return result.ToImmutableAndClear();
+            return result;
         }
     }
 
@@ -195,12 +195,12 @@ internal abstract partial class AbstractGenericNameSignatureHelpProvider : Abstr
             selectedDisplayParts: GetSelectedDisplayParts(parameter, semanticModel, position));
     }
 
-    private static ImmutableArray<SymbolDisplayPart> GetSelectedDisplayParts(
+    private static IList<SymbolDisplayPart> GetSelectedDisplayParts(
         ITypeParameterSymbol typeParam,
         SemanticModel semanticModel,
         int position)
     {
-        using var _ = ArrayBuilder<SymbolDisplayPart>.GetInstance(out var parts);
+        var parts = new List<SymbolDisplayPart>();
 
         if (TypeParameterHasConstraints(typeParam))
         {
@@ -276,7 +276,7 @@ internal abstract partial class AbstractGenericNameSignatureHelpProvider : Abstr
             }
         }
 
-        return parts.ToImmutableAndClear();
+        return parts;
     }
 
     private static bool TypeParameterHasConstraints(ITypeParameterSymbol typeParam)

--- a/src/Features/CSharp/Portable/SignatureHelp/AbstractGenericNameSignatureHelpProvider_Method.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/AbstractGenericNameSignatureHelpProvider_Method.cs
@@ -2,20 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
-using Microsoft.CodeAnalysis.PooledObjects;
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp;
 
 internal partial class AbstractGenericNameSignatureHelpProvider
 {
-    private static ImmutableArray<SymbolDisplayPart> GetPreambleParts(
+    private static IList<SymbolDisplayPart> GetPreambleParts(
         IMethodSymbol method,
         SemanticModel semanticModel,
         int position)
     {
-        using var _ = ArrayBuilder<SymbolDisplayPart>.GetInstance(out var result);
+        var result = new List<SymbolDisplayPart>();
 
         var awaitable = method.GetOriginalUnreducedDefinition().IsAwaitableNonDynamic(semanticModel, position);
         var extension = method.GetOriginalUnreducedDefinition().IsExtensionMethod();
@@ -56,7 +55,7 @@ internal partial class AbstractGenericNameSignatureHelpProvider
         result.Add(new SymbolDisplayPart(SymbolDisplayPartKind.MethodName, method, method.Name));
         result.Add(Punctuation(SyntaxKind.LessThanToken));
 
-        return result.ToImmutableAndClear();
+        return result;
     }
 
     private static ITypeSymbol? GetContainingType(IMethodSymbol method)
@@ -72,11 +71,13 @@ internal partial class AbstractGenericNameSignatureHelpProvider
         }
     }
 
-    private static ImmutableArray<SymbolDisplayPart> GetPostambleParts(IMethodSymbol method, SemanticModel semanticModel, int position)
+    private static IList<SymbolDisplayPart> GetPostambleParts(IMethodSymbol method, SemanticModel semanticModel, int position)
     {
-        using var _ = ArrayBuilder<SymbolDisplayPart>.GetInstance(out var result);
-        result.Add(Punctuation(SyntaxKind.GreaterThanToken));
-        result.Add(Punctuation(SyntaxKind.OpenParenToken));
+        var result = new List<SymbolDisplayPart>
+        {
+            Punctuation(SyntaxKind.GreaterThanToken),
+            Punctuation(SyntaxKind.OpenParenToken)
+        };
 
         var first = true;
         foreach (var parameter in method.Parameters)
@@ -92,6 +93,6 @@ internal partial class AbstractGenericNameSignatureHelpProvider
         }
 
         result.Add(Punctuation(SyntaxKind.CloseParenToken));
-        return result.ToImmutableAndClear();
+        return result;
     }
 }

--- a/src/Features/CSharp/Portable/SignatureHelp/AbstractGenericNameSignatureHelpProvider_NamedType.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/AbstractGenericNameSignatureHelpProvider_NamedType.cs
@@ -2,13 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
+using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp;
 
 internal partial class AbstractGenericNameSignatureHelpProvider
 {
-    private static ImmutableArray<SymbolDisplayPart> GetPreambleParts(
+    private static IList<SymbolDisplayPart> GetPreambleParts(
         INamedTypeSymbol namedType,
         SemanticModel semanticModel,
         int position)
@@ -16,6 +16,6 @@ internal partial class AbstractGenericNameSignatureHelpProvider
         return [.. namedType.ToMinimalDisplayParts(semanticModel, position, MinimallyQualifiedWithoutTypeParametersFormat), Punctuation(SyntaxKind.LessThanToken)];
     }
 
-    private static ImmutableArray<SymbolDisplayPart> GetPostambleParts()
+    private static IList<SymbolDisplayPart> GetPostambleParts()
         => [Punctuation(SyntaxKind.GreaterThanToken)];
 }

--- a/src/Features/CSharp/Portable/SignatureHelp/AbstractOrdinaryMethodSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/AbstractOrdinaryMethodSignatureHelpProvider.cs
@@ -2,11 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.DocumentationComments;
 using Microsoft.CodeAnalysis.LanguageService;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.SignatureHelp;
 
@@ -28,7 +27,7 @@ internal abstract class AbstractOrdinaryMethodSignatureHelpProvider : AbstractCS
         IMethodSymbol method,
         int position,
         SemanticModel semanticModel,
-        ImmutableArray<SymbolDisplayPart>? descriptionParts)
+        IList<SymbolDisplayPart>? descriptionParts)
     {
         var structuralTypeDisplayService = document.GetRequiredLanguageService<IStructuralTypeDisplayService>();
         var documentationCommentFormattingService = document.GetRequiredLanguageService<IDocumentationCommentFormattingService>();
@@ -45,12 +44,12 @@ internal abstract class AbstractOrdinaryMethodSignatureHelpProvider : AbstractCS
             descriptionParts: descriptionParts);
     }
 
-    private static ImmutableArray<SymbolDisplayPart> GetMethodGroupPreambleParts(
+    private static IList<SymbolDisplayPart> GetMethodGroupPreambleParts(
         IMethodSymbol method,
         SemanticModel semanticModel,
         int position)
     {
-        using var _ = ArrayBuilder<SymbolDisplayPart>.GetInstance(out var result);
+        var result = new List<SymbolDisplayPart>();
 
         var awaitable = method.GetOriginalUnreducedDefinition().IsAwaitableNonDynamic(semanticModel, position);
         var extension = method.GetOriginalUnreducedDefinition().IsExtensionMethod();
@@ -82,9 +81,9 @@ internal abstract class AbstractOrdinaryMethodSignatureHelpProvider : AbstractCS
         result.AddRange(method.ToMinimalDisplayParts(semanticModel, position, MinimallyQualifiedWithoutParametersFormat));
         result.Add(Punctuation(SyntaxKind.OpenParenToken));
 
-        return result.ToImmutableAndClear();
+        return result;
     }
 
-    private static ImmutableArray<SymbolDisplayPart> GetMethodGroupPostambleParts()
+    private static IList<SymbolDisplayPart> GetMethodGroupPostambleParts()
         => [Punctuation(SyntaxKind.CloseParenToken)];
 }

--- a/src/Features/CSharp/Portable/SignatureHelp/AttributeSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/AttributeSignatureHelpProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
@@ -15,7 +16,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.DocumentationComments;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageService;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.SignatureHelp;
 using Microsoft.CodeAnalysis.Text;
@@ -135,10 +135,10 @@ internal sealed partial class AttributeSignatureHelpProvider : AbstractCSharpSig
         var position = attribute.SpanStart;
         var namedParameters = constructor.ContainingType.GetAttributeNamedParameters(semanticModel.Compilation, within)
             .OrderBy(s => s.Name)
-            .ToImmutableArray();
+            .ToList();
 
         var isVariadic =
-            constructor.Parameters is [.., { IsParams: true }] && namedParameters.IsEmpty;
+            constructor.Parameters is [.., { IsParams: true }] && namedParameters.Count == 0;
 
         var item = CreateItem(
             constructor, semanticModel, position,
@@ -152,45 +152,51 @@ internal sealed partial class AttributeSignatureHelpProvider : AbstractCSharpSig
         return item;
     }
 
-    private static ImmutableArray<SignatureHelpSymbolParameter> GetParameters(
+    private static IList<SignatureHelpSymbolParameter> GetParameters(
         IMethodSymbol constructor,
         SemanticModel semanticModel,
         int position,
-        ImmutableArray<ISymbol> namedParameters,
+        IList<ISymbol> namedParameters,
         IDocumentationCommentFormattingService documentationCommentFormatter,
         CancellationToken cancellationToken)
     {
-        using var _ = ArrayBuilder<SignatureHelpSymbolParameter>.GetInstance(out var result);
+        var result = new List<SignatureHelpSymbolParameter>();
         foreach (var parameter in constructor.Parameters)
+        {
             result.Add(Convert(parameter, semanticModel, position, documentationCommentFormatter));
+        }
 
-        for (var i = 0; i < namedParameters.Length; i++)
+        for (var i = 0; i < namedParameters.Count; i++)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             var namedParameter = namedParameters[i];
 
-            var type = namedParameter is IFieldSymbol field ? field.Type : ((IPropertySymbol)namedParameter).Type;
+            var type = namedParameter is IFieldSymbol ? ((IFieldSymbol)namedParameter).Type : ((IPropertySymbol)namedParameter).Type;
+
+            var displayParts = new List<SymbolDisplayPart>
+            {
+                new(
+                namedParameter is IFieldSymbol ? SymbolDisplayPartKind.FieldName : SymbolDisplayPartKind.PropertyName,
+                namedParameter, namedParameter.Name.ToIdentifierToken().ToString()),
+                Space(),
+                Punctuation(SyntaxKind.EqualsToken),
+                Space()
+            };
+            displayParts.AddRange(type.ToMinimalDisplayParts(semanticModel, position));
+
             result.Add(new SignatureHelpSymbolParameter(
                 namedParameter.Name,
                 isOptional: true,
                 documentationFactory: namedParameter.GetDocumentationPartsFactory(semanticModel, position, documentationCommentFormatter),
-                displayParts:
-                [
-                    new(namedParameter is IFieldSymbol ? SymbolDisplayPartKind.FieldName : SymbolDisplayPartKind.PropertyName,
-                        namedParameter, namedParameter.Name.ToIdentifierToken().ToString()),
-                    Space(),
-                    Punctuation(SyntaxKind.EqualsToken),
-                    Space(),
-                    .. type.ToMinimalDisplayParts(semanticModel, position),
-                ],
+                displayParts: displayParts,
                 prefixDisplayParts: GetParameterPrefixDisplayParts(i)));
         }
 
-        return result.ToImmutableAndClear();
+        return result;
     }
 
-    private static ImmutableArray<SymbolDisplayPart>? GetParameterPrefixDisplayParts(int i)
+    private static List<SymbolDisplayPart>? GetParameterPrefixDisplayParts(int i)
     {
         if (i == 0)
         {
@@ -205,7 +211,7 @@ internal sealed partial class AttributeSignatureHelpProvider : AbstractCSharpSig
         return null;
     }
 
-    private static ImmutableArray<SymbolDisplayPart> GetPreambleParts(
+    private static IList<SymbolDisplayPart> GetPreambleParts(
         IMethodSymbol method,
         SemanticModel semanticModel,
         int position)
@@ -213,6 +219,6 @@ internal sealed partial class AttributeSignatureHelpProvider : AbstractCSharpSig
         return [.. method.ContainingType.ToMinimalDisplayParts(semanticModel, position), Punctuation(SyntaxKind.OpenParenToken)];
     }
 
-    private static ImmutableArray<SymbolDisplayPart> GetPostambleParts()
+    private static IList<SymbolDisplayPart> GetPostambleParts()
         => [Punctuation(SyntaxKind.CloseParenToken)];
 }

--- a/src/Features/CSharp/Portable/SignatureHelp/ConstructorInitializerSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/ConstructorInitializerSignatureHelpProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
@@ -147,7 +148,7 @@ internal sealed partial class ConstructorInitializerSignatureHelpProvider : Abst
         return item;
     }
 
-    private static ImmutableArray<SymbolDisplayPart> GetPreambleParts(
+    private static IList<SymbolDisplayPart> GetPreambleParts(
         IMethodSymbol method,
         SemanticModel semanticModel,
         int position)
@@ -155,6 +156,6 @@ internal sealed partial class ConstructorInitializerSignatureHelpProvider : Abst
         return [.. method.ContainingType.ToMinimalDisplayParts(semanticModel, position), Punctuation(SyntaxKind.OpenParenToken)];
     }
 
-    private static ImmutableArray<SymbolDisplayPart> GetPostambleParts()
+    private static IList<SymbolDisplayPart> GetPostambleParts()
         => [Punctuation(SyntaxKind.CloseParenToken)];
 }

--- a/src/Features/CSharp/Portable/SignatureHelp/ElementAccessExpressionSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/ElementAccessExpressionSignatureHelpProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
@@ -15,7 +16,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.DocumentationComments;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageService;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.SignatureHelp;
 using Microsoft.CodeAnalysis.Text;
@@ -234,12 +234,12 @@ internal sealed class ElementAccessExpressionSignatureHelpProvider : AbstractCSh
         return item;
     }
 
-    private static ImmutableArray<SymbolDisplayPart> GetPreambleParts(
+    private static IList<SymbolDisplayPart> GetPreambleParts(
         IPropertySymbol indexer,
         int position,
         SemanticModel semanticModel)
     {
-        using var _ = ArrayBuilder<SymbolDisplayPart>.GetInstance(out var result);
+        var result = new List<SymbolDisplayPart>();
 
         if (indexer.ReturnsByRef)
         {
@@ -266,10 +266,10 @@ internal sealed class ElementAccessExpressionSignatureHelpProvider : AbstractCSh
 
         result.Add(Punctuation(SyntaxKind.OpenBracketToken));
 
-        return result.ToImmutableAndClear();
+        return result;
     }
 
-    private static ImmutableArray<SymbolDisplayPart> GetPostambleParts()
+    private static IList<SymbolDisplayPart> GetPostambleParts()
         => [Punctuation(SyntaxKind.CloseBracketToken)];
 
     private static class CompleteElementAccessExpression

--- a/src/Features/CSharp/Portable/SignatureHelp/InvocationExpressionSignatureHelpProviderBase_DelegateAndFunctionPointerInvoke.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/InvocationExpressionSignatureHelpProviderBase_DelegateAndFunctionPointerInvoke.cs
@@ -2,13 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
+using System.Collections.Generic;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.DocumentationComments;
 using Microsoft.CodeAnalysis.LanguageService;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.SignatureHelp;
 
@@ -37,7 +36,7 @@ internal abstract partial class InvocationExpressionSignatureHelpProviderBase
         return invokeMethod;
     }
 
-    private static ImmutableArray<SignatureHelpItem> GetDelegateOrFunctionPointerInvokeItems(InvocationExpressionSyntax invocationExpression, IMethodSymbol invokeMethod, SemanticModel semanticModel, IStructuralTypeDisplayService structuralTypeDisplayService, IDocumentationCommentFormattingService documentationCommentFormattingService, out int? selectedItem, CancellationToken cancellationToken)
+    private static IList<SignatureHelpItem> GetDelegateOrFunctionPointerInvokeItems(InvocationExpressionSyntax invocationExpression, IMethodSymbol invokeMethod, SemanticModel semanticModel, IStructuralTypeDisplayService structuralTypeDisplayService, IDocumentationCommentFormattingService documentationCommentFormattingService, out int? selectedItem, CancellationToken cancellationToken)
     {
         var position = invocationExpression.SpanStart;
         var item = CreateItem(
@@ -56,9 +55,9 @@ internal abstract partial class InvocationExpressionSignatureHelpProviderBase
         return [item];
     }
 
-    private static ImmutableArray<SymbolDisplayPart> GetDelegateOrFunctionPointerInvokePreambleParts(IMethodSymbol invokeMethod, SemanticModel semanticModel, int position)
+    private static IList<SymbolDisplayPart> GetDelegateOrFunctionPointerInvokePreambleParts(IMethodSymbol invokeMethod, SemanticModel semanticModel, int position)
     {
-        using var _ = ArrayBuilder<SymbolDisplayPart>.GetInstance(out var displayParts);
+        var displayParts = new List<SymbolDisplayPart>();
         displayParts.AddRange(invokeMethod.ReturnType.ToMinimalDisplayParts(semanticModel, position));
         displayParts.Add(Space());
 
@@ -74,13 +73,13 @@ internal abstract partial class InvocationExpressionSignatureHelpProviderBase
 
         displayParts.Add(Punctuation(SyntaxKind.OpenParenToken));
 
-        return displayParts.ToImmutableAndClear();
+        return displayParts;
     }
 
-    private static ImmutableArray<SignatureHelpSymbolParameter> GetDelegateOrFunctionPointerInvokeParameters(
+    private static IList<SignatureHelpSymbolParameter> GetDelegateOrFunctionPointerInvokeParameters(
         IMethodSymbol invokeMethod, SemanticModel semanticModel, int position, IDocumentationCommentFormattingService formattingService, CancellationToken cancellationToken)
     {
-        using var _ = ArrayBuilder<SignatureHelpSymbolParameter>.GetInstance(out var result);
+        var result = new List<SignatureHelpSymbolParameter>();
 
         foreach (var parameter in invokeMethod.Parameters)
         {
@@ -92,9 +91,9 @@ internal abstract partial class InvocationExpressionSignatureHelpProviderBase
                 parameter.ToMinimalDisplayParts(semanticModel, position)));
         }
 
-        return result.ToImmutableAndClear();
+        return result;
     }
 
-    private static ImmutableArray<SymbolDisplayPart> GetDelegateOrFunctionPointerInvokePostambleParts()
+    private static IList<SymbolDisplayPart> GetDelegateOrFunctionPointerInvokePostambleParts()
         => [Punctuation(SyntaxKind.CloseParenToken)];
 }

--- a/src/Features/CSharp/Portable/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider_DelegateType.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider_DelegateType.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.LanguageService;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.SignatureHelp;
 
 namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp;
@@ -33,17 +33,21 @@ internal sealed partial class ObjectCreationExpressionSignatureHelpProvider
         return [item];
     }
 
-    private static ImmutableArray<SymbolDisplayPart> GetDelegateTypePreambleParts(IMethodSymbol invokeMethod, SemanticModel semanticModel, int position)
-        => [
-            .. invokeMethod.ContainingType.ToMinimalDisplayParts(semanticModel, position),
-            Punctuation(SyntaxKind.OpenParenToken),
-        ];
+    private static IList<SymbolDisplayPart> GetDelegateTypePreambleParts(IMethodSymbol invokeMethod, SemanticModel semanticModel, int position)
+    {
+        var result = new List<SymbolDisplayPart>();
 
-    private static ImmutableArray<SignatureHelpSymbolParameter> GetDelegateTypeParameters(IMethodSymbol invokeMethod, SemanticModel semanticModel, int position)
+        result.AddRange(invokeMethod.ContainingType.ToMinimalDisplayParts(semanticModel, position));
+        result.Add(Punctuation(SyntaxKind.OpenParenToken));
+
+        return result;
+    }
+
+    private static IList<SignatureHelpSymbolParameter> GetDelegateTypeParameters(IMethodSymbol invokeMethod, SemanticModel semanticModel, int position)
     {
         const string TargetName = "target";
 
-        using var _ = ArrayBuilder<SymbolDisplayPart>.GetInstance(out var parts);
+        var parts = new List<SymbolDisplayPart>();
         parts.AddRange(invokeMethod.ReturnType.ToMinimalDisplayParts(semanticModel, position));
         parts.Add(Space());
         parts.Add(Punctuation(SyntaxKind.OpenParenToken));
@@ -69,9 +73,9 @@ internal sealed partial class ObjectCreationExpressionSignatureHelpProvider
             TargetName,
             isOptional: false,
             documentationFactory: null,
-            displayParts: parts.ToImmutableAndClear())];
+            displayParts: parts)];
     }
 
-    private static ImmutableArray<SymbolDisplayPart> GetDelegateTypePostambleParts()
+    private static IList<SymbolDisplayPart> GetDelegateTypePostambleParts()
         => [Punctuation(SyntaxKind.CloseParenToken)];
 }

--- a/src/Features/CSharp/Portable/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider_NormalType.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider_NormalType.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -36,13 +36,19 @@ internal sealed partial class ObjectCreationExpressionSignatureHelpProvider
         return item;
     }
 
-    private static ImmutableArray<SymbolDisplayPart> GetNormalTypePreambleParts(
-        IMethodSymbol method, SemanticModel semanticModel, int position)
-        => [
-            .. method.ContainingType.ToMinimalDisplayParts(semanticModel, position),
-            Punctuation(SyntaxKind.OpenParenToken),
-        ];
+    private static IList<SymbolDisplayPart> GetNormalTypePreambleParts(
+        IMethodSymbol method,
+        SemanticModel semanticModel,
+        int position)
+    {
+        var result = new List<SymbolDisplayPart>();
 
-    private static ImmutableArray<SymbolDisplayPart> GetNormalTypePostambleParts()
+        result.AddRange(method.ContainingType.ToMinimalDisplayParts(semanticModel, position));
+        result.Add(Punctuation(SyntaxKind.OpenParenToken));
+
+        return result;
+    }
+
+    private static IList<SymbolDisplayPart> GetNormalTypePostambleParts()
         => [Punctuation(SyntaxKind.CloseParenToken)];
 }

--- a/src/Features/CSharp/Portable/SignatureHelp/PrimaryConstructorBaseTypeSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/PrimaryConstructorBaseTypeSignatureHelpProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
@@ -127,16 +128,26 @@ internal sealed partial class PrimaryConstructorBaseTypeSignatureHelpProvider : 
             structuralTypeDisplayService,
             constructor.IsParams(),
             constructor.GetDocumentationPartsFactory(semanticModel, position, documentationCommentFormattingService),
-            GetPreambleParts(),
+            GetPreambleParts(constructor, semanticModel, position),
             GetSeparatorParts(),
             GetPostambleParts(),
             [.. constructor.Parameters.Select(p => Convert(p, semanticModel, position, documentationCommentFormattingService))]);
         return item;
 
-        ImmutableArray<SymbolDisplayPart> GetPreambleParts()
-            => [.. constructor.ContainingType.ToMinimalDisplayParts(semanticModel, position), Punctuation(SyntaxKind.OpenParenToken)];
+        static IList<SymbolDisplayPart> GetPreambleParts(
+            IMethodSymbol method,
+            SemanticModel semanticModel,
+            int position)
+        {
+            var result = new List<SymbolDisplayPart>();
 
-        static ImmutableArray<SymbolDisplayPart> GetPostambleParts()
+            result.AddRange(method.ContainingType.ToMinimalDisplayParts(semanticModel, position));
+            result.Add(Punctuation(SyntaxKind.OpenParenToken));
+
+            return result;
+        }
+
+        static IList<SymbolDisplayPart> GetPostambleParts()
             => [Punctuation(SyntaxKind.CloseParenToken)];
     }
 }

--- a/src/Features/CSharp/Portable/SignatureHelp/TupleConstructionSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/TupleConstructionSignatureHelpProvider.cs
@@ -153,8 +153,9 @@ internal sealed class TupleConstructionSignatureHelpProvider : AbstractCSharpSig
         var suffixParts = SpecializedCollections.SingletonEnumerable(new SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, null, ")")).ToTaggedText();
         var separatorParts = GetSeparatorParts().ToTaggedText();
 
-        var items = tupleTypes.SelectAsArray(tupleType => Convert(
-            tupleType, prefixParts, suffixParts, separatorParts, semanticModel, position));
+        var items = tupleTypes.Select(tupleType => Convert(
+            tupleType, prefixParts, suffixParts, separatorParts, semanticModel, position))
+            .ToList();
 
         var state = GetCurrentArgumentState(root, position, syntaxFacts, targetExpression.FullSpan, cancellationToken);
         return CreateSignatureHelpItems(items, targetExpression.Span, state, selectedItemIndex: null, parameterIndexOverride: -1);
@@ -191,7 +192,7 @@ internal sealed class TupleConstructionSignatureHelpProvider : AbstractCSharpSig
                 typeParts.Add(new SymbolDisplayPart(SymbolDisplayPartKind.PropertyName, null, elementName));
             }
 
-            result.Add(new SignatureHelpParameter(name: string.Empty, isOptional: false, documentationFactory: null, displayParts: [.. typeParts]));
+            result.Add(new SignatureHelpParameter(name: string.Empty, isOptional: false, documentationFactory: null, displayParts: typeParts));
         }
 
         return result;

--- a/src/Features/Core/Portable/LanguageServices/AnonymousTypeDisplayService/AbstractStructuralTypeDisplayService.cs
+++ b/src/Features/Core/Portable/LanguageServices/AnonymousTypeDisplayService/AbstractStructuralTypeDisplayService.cs
@@ -66,12 +66,16 @@ internal abstract partial class AbstractStructuralTypeDisplayService : IStructur
         int position)
     {
         if (directStructuralTypeReferences.Length == 0)
-            return StructuralTypeDisplayInfo.Empty;
+        {
+            return new StructuralTypeDisplayInfo(
+                SpecializedCollections.EmptyDictionary<INamedTypeSymbol, string>(),
+                SpecializedCollections.EmptyList<SymbolDisplayPart>());
+        }
 
         var transitiveStructuralTypeReferences = GetTransitiveStructuralTypeReferences(directStructuralTypeReferences);
         transitiveStructuralTypeReferences = OrderStructuralTypes(transitiveStructuralTypeReferences, orderSymbol);
 
-        using var _ = ArrayBuilder<SymbolDisplayPart>.GetInstance(out var typeParts);
+        IList<SymbolDisplayPart> typeParts = [];
 
         if (transitiveStructuralTypeReferences.Length > 0)
         {
@@ -108,10 +112,10 @@ internal abstract partial class AbstractStructuralTypeDisplayService : IStructur
 
         // Finally, assign a name to all the anonymous types.
         var structuralTypeToName = GenerateStructuralTypeNames(transitiveStructuralTypeReferences);
-        var typePartsArray = StructuralTypeDisplayInfo.ReplaceStructuralTypes(
-            typeParts.ToImmutableAndClear(), structuralTypeToName, semanticModel, position);
+        typeParts = StructuralTypeDisplayInfo.ReplaceStructuralTypes(
+            typeParts, structuralTypeToName, semanticModel, position);
 
-        return new StructuralTypeDisplayInfo(structuralTypeToName, typePartsArray);
+        return new StructuralTypeDisplayInfo(structuralTypeToName, typeParts);
     }
 
     private static Dictionary<INamedTypeSymbol, string> GenerateStructuralTypeNames(

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AnonymousTypes.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AnonymousTypes.cs
@@ -33,7 +33,7 @@ internal abstract partial class AbstractSymbolDisplayService
             var info = LanguageServices.GetRequiredService<IStructuralTypeDisplayService>().GetTypeDisplayInfo(
                 firstSymbol, directStructuralTypes.ToImmutableArrayOrEmpty(), _semanticModel, _position);
 
-            if (info.TypesParts.Length > 0)
+            if (info.TypesParts.Count > 0)
                 AddToGroup(SymbolDescriptionGroups.StructuralTypes, info.TypesParts);
 
             foreach (var (group, parts) in _groupMap.ToArray())

--- a/src/Features/Core/Portable/SignatureHelp/AbstractSignatureHelpProvider.cs
+++ b/src/Features/Core/Portable/SignatureHelp/AbstractSignatureHelpProvider.cs
@@ -38,9 +38,9 @@ internal abstract partial class AbstractSignatureHelpProvider : ISignatureHelpPr
     protected abstract Task<SignatureHelpItems?> GetItemsWorkerAsync(Document document, int position, SignatureHelpTriggerInfo triggerInfo, MemberDisplayOptions options, CancellationToken cancellationToken);
 
     protected static SignatureHelpItems? CreateSignatureHelpItems(
-        ImmutableArray<SignatureHelpItem> items, TextSpan applicableSpan, SignatureHelpState? state, int? selectedItemIndex, int parameterIndexOverride)
+        IList<SignatureHelpItem> items, TextSpan applicableSpan, SignatureHelpState? state, int? selectedItemIndex, int parameterIndexOverride)
     {
-        if (items.IsDefaultOrEmpty || state == null)
+        if (items is null || items.Count == 0 || state == null)
             return null;
 
         if (selectedItemIndex < 0)
@@ -70,7 +70,7 @@ internal abstract partial class AbstractSignatureHelpProvider : ISignatureHelpPr
     }
 
     protected static SignatureHelpItems? CreateCollectionInitializerSignatureHelpItems(
-        ImmutableArray<SignatureHelpItem> items, TextSpan applicableSpan, SignatureHelpState? state)
+        IList<SignatureHelpItem> items, TextSpan applicableSpan, SignatureHelpState? state)
     {
         // We will have added all the accessible '.Add' methods that take at least one
         // arguments. However, in general the one-arg Add method is the least likely for the
@@ -94,15 +94,15 @@ internal abstract partial class AbstractSignatureHelpProvider : ISignatureHelpPr
             items, applicableSpan, state, items.IndexOf(i => i.Parameters.Length >= 2), parameterIndexOverride: -1);
     }
 
-    private static (ImmutableArray<SignatureHelpItem> items, int? selectedItem) Filter(ImmutableArray<SignatureHelpItem> items, ImmutableArray<string> parameterNames, int? selectedItem)
+    private static (IList<SignatureHelpItem> items, int? selectedItem) Filter(IList<SignatureHelpItem> items, ImmutableArray<string> parameterNames, int? selectedItem)
     {
         if (parameterNames.IsDefault)
-            return (items, selectedItem);
+            return (items.ToList(), selectedItem);
 
-        var filteredList = items.WhereAsArray(i => Include(i, parameterNames));
-        var isEmpty = filteredList.IsEmpty;
+        var filteredList = items.Where(i => Include(i, parameterNames)).ToList();
+        var isEmpty = filteredList.Count == 0;
         if (!selectedItem.HasValue || isEmpty)
-            return (isEmpty ? items : filteredList, selectedItem);
+            return (isEmpty ? [.. items] : filteredList, selectedItem);
 
         // adjust the selected item
         var selection = items[selectedItem.Value];
@@ -138,11 +138,11 @@ internal abstract partial class AbstractSignatureHelpProvider : ISignatureHelpPr
         IStructuralTypeDisplayService structuralTypeDisplayService,
         bool isVariadic,
         Func<CancellationToken, IEnumerable<TaggedText>> documentationFactory,
-        ImmutableArray<SymbolDisplayPart> prefixParts,
-        ImmutableArray<SymbolDisplayPart> separatorParts,
-        ImmutableArray<SymbolDisplayPart> suffixParts,
-        ImmutableArray<SignatureHelpSymbolParameter> parameters,
-        ImmutableArray<SymbolDisplayPart>? descriptionParts = null)
+        IList<SymbolDisplayPart> prefixParts,
+        IList<SymbolDisplayPart> separatorParts,
+        IList<SymbolDisplayPart> suffixParts,
+        IList<SignatureHelpSymbolParameter> parameters,
+        IList<SymbolDisplayPart>? descriptionParts = null)
     {
         return CreateItem(orderSymbol, semanticModel, position, structuralTypeDisplayService,
             isVariadic, documentationFactory, prefixParts, separatorParts, suffixParts, parameters, descriptionParts);
@@ -155,11 +155,11 @@ internal abstract partial class AbstractSignatureHelpProvider : ISignatureHelpPr
         IStructuralTypeDisplayService structuralTypeDisplayService,
         bool isVariadic,
         Func<CancellationToken, IEnumerable<TaggedText>>? documentationFactory,
-        ImmutableArray<SymbolDisplayPart> prefixParts,
-        ImmutableArray<SymbolDisplayPart> separatorParts,
-        ImmutableArray<SymbolDisplayPart> suffixParts,
-        ImmutableArray<SignatureHelpSymbolParameter> parameters,
-        ImmutableArray<SymbolDisplayPart>? descriptionParts = null)
+        IList<SymbolDisplayPart> prefixParts,
+        IList<SymbolDisplayPart> separatorParts,
+        IList<SymbolDisplayPart> suffixParts,
+        IList<SignatureHelpSymbolParameter> parameters,
+        IList<SymbolDisplayPart>? descriptionParts = null)
     {
         return CreateItemImpl(orderSymbol, semanticModel, position, structuralTypeDisplayService,
             isVariadic, documentationFactory, prefixParts, separatorParts, suffixParts, parameters, descriptionParts);
@@ -172,13 +172,15 @@ internal abstract partial class AbstractSignatureHelpProvider : ISignatureHelpPr
         IStructuralTypeDisplayService structuralTypeDisplayService,
         bool isVariadic,
         Func<CancellationToken, IEnumerable<TaggedText>>? documentationFactory,
-        ImmutableArray<SymbolDisplayPart> prefixParts,
-        ImmutableArray<SymbolDisplayPart> separatorParts,
-        ImmutableArray<SymbolDisplayPart> suffixParts,
-        ImmutableArray<SignatureHelpSymbolParameter> parameters,
-        ImmutableArray<SymbolDisplayPart>? descriptionParts)
+        IList<SymbolDisplayPart> prefixParts,
+        IList<SymbolDisplayPart> separatorParts,
+        IList<SymbolDisplayPart> suffixParts,
+        IList<SignatureHelpSymbolParameter> parameters,
+        IList<SymbolDisplayPart>? descriptionParts)
     {
-        descriptionParts ??= [];
+        descriptionParts = descriptionParts == null
+            ? SpecializedCollections.EmptyList<SymbolDisplayPart>()
+            : descriptionParts;
 
         var allParts = prefixParts.Concat(separatorParts)
                                   .Concat(suffixParts)
@@ -193,7 +195,7 @@ internal abstract partial class AbstractSignatureHelpProvider : ISignatureHelpPr
         var info = structuralTypeDisplayService.GetTypeDisplayInfo(
             orderSymbol, [.. structuralTypes], semanticModel, position);
 
-        if (info.TypesParts.Length > 0)
+        if (info.TypesParts.Count > 0)
         {
             var structuralTypeParts = new List<SymbolDisplayPart>
             {
@@ -258,7 +260,7 @@ internal abstract partial class AbstractSignatureHelpProvider : ISignatureHelpPr
         var semanticModel = await document.ReuseExistingSpeculativeModelAsync(position, cancellationToken).ConfigureAwait(false);
         var compilation = semanticModel.Compilation;
 
-        using var _1 = ArrayBuilder<SignatureHelpItem>.GetInstance(out var finalItems);
+        var finalItems = new List<SignatureHelpItem>();
         foreach (var item in itemsForCurrentDocument.Items)
         {
             if (item is not SymbolKeySignatureHelpItem symbolKeyItem ||
@@ -276,7 +278,7 @@ internal abstract partial class AbstractSignatureHelpProvider : ISignatureHelpPr
                 symbolKey = SymbolKey.Create(methodSymbol.OriginalDefinition, cancellationToken);
             }
 
-            using var _2 = ArrayBuilder<ProjectId>.GetInstance(out var invalidProjectsForCurrentSymbol);
+            using var _ = ArrayBuilder<ProjectId>.GetInstance(out var invalidProjectsForCurrentSymbol);
             foreach (var relatedDocument in relatedDocuments)
             {
                 // Try to resolve symbolKey in each related compilation,
@@ -293,7 +295,7 @@ internal abstract partial class AbstractSignatureHelpProvider : ISignatureHelpPr
         }
 
         return new SignatureHelpItems(
-            finalItems.ToImmutableAndClear(),
+            finalItems,
             itemsForCurrentDocument.ApplicableSpan,
             itemsForCurrentDocument.SemanticParameterIndex,
             itemsForCurrentDocument.SyntacticArgumentCount,

--- a/src/Features/VisualBasic/Portable/SignatureHelp/AbstractIntrinsicOperatorSignatureHelpProvider.vb
+++ b/src/Features/VisualBasic/Portable/SignatureHelp/AbstractIntrinsicOperatorSignatureHelpProvider.vb
@@ -5,7 +5,6 @@
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.LanguageService
-Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.SignatureHelp
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
@@ -38,7 +37,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
                 Return Nothing
             End If
 
-            Dim items = ArrayBuilder(Of SignatureHelpItem).GetInstance()
+            Dim items As New List(Of SignatureHelpItem)
 
             Dim semanticModel = Await document.ReuseExistingSpeculativeModelAsync(node, cancellationToken).ConfigureAwait(False)
             For Each documentation In Await GetIntrinsicOperatorDocumentationAsync(node, document, cancellationToken).ConfigureAwait(False)
@@ -50,12 +49,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
             Dim syntaxFacts = document.GetLanguageService(Of ISyntaxFactsService)
 
             Return CreateSignatureHelpItems(
-                items.ToImmutableAndFree(), textSpan,
+                items, textSpan,
                 GetCurrentArgumentState(root, position, syntaxFacts, textSpan, cancellationToken), selectedItemIndex:=Nothing, parameterIndexOverride:=-1)
         End Function
 
         Friend Shared Function GetSignatureHelpItemForIntrinsicOperator(document As Document, semanticModel As SemanticModel, position As Integer, documentation As AbstractIntrinsicOperatorDocumentation, cancellationToken As CancellationToken) As SignatureHelpItem
-            Dim parameters = ArrayBuilder(Of SignatureHelpSymbolParameter).GetInstance()
+            Dim parameters As New List(Of SignatureHelpSymbolParameter)
 
             For i = 0 To documentation.ParameterCount - 1
                 Dim capturedIndex = i
@@ -79,7 +78,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
                 prefixParts:=documentation.PrefixParts,
                 separatorParts:=GetSeparatorParts(),
                 suffixParts:=suffixParts,
-                parameters:=parameters.ToImmutableAndFree())
+                parameters:=parameters)
         End Function
 
         Protected Overridable Function GetCurrentArgumentStateWorker(node As SyntaxNode, position As Integer) As SignatureHelpState

--- a/src/Features/VisualBasic/Portable/SignatureHelp/AbstractOrdinaryMethodSignatureHelpProvider.vb
+++ b/src/Features/VisualBasic/Portable/SignatureHelp/AbstractOrdinaryMethodSignatureHelpProvider.vb
@@ -2,15 +2,13 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.DocumentationComments
 Imports Microsoft.CodeAnalysis.LanguageService
-Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.SignatureHelp
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
-    Friend MustInherit Class AbstractOrdinaryMethodSignatureHelpProvider
-        Inherits AbstractVisualBasicSignatureHelpProvider
+    friend MustInherit class AbstractOrdinaryMethodSignatureHelpProvider
+        inherits AbstractVisualBasicSignatureHelpProvider
 
         Protected Shared Function ConvertMemberGroupMember(document As Document,
                                                     member As ISymbol,
@@ -28,11 +26,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
                 GetMemberGroupPreambleParts(member, semanticModel, position),
                 GetSeparatorParts(),
                 GetMemberGroupPostambleParts(member, semanticModel, position),
-                member.GetParameters().SelectAsArray(Function(p) Convert(p, semanticModel, position, documentationCommentFormattingService)))
+                member.GetParameters().Select(Function(p) Convert(p, semanticModel, position, documentationCommentFormattingService)).ToList())
         End Function
 
-        Private Shared Function GetMemberGroupPreambleParts(symbol As ISymbol, semanticModel As SemanticModel, position As Integer) As ImmutableArray(Of SymbolDisplayPart)
-            Dim result = ArrayBuilder(Of SymbolDisplayPart).GetInstance()
+        Private Shared Function GetMemberGroupPreambleParts(symbol As ISymbol, semanticModel As SemanticModel, position As Integer) As IList(Of SymbolDisplayPart)
+            Dim result = New List(Of SymbolDisplayPart)()
 
             AddExtensionPreamble(symbol, result)
 
@@ -46,14 +44,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
 
             result.AddRange(symbol.ToMinimalDisplayParts(semanticModel, position, format))
             result.Add(Punctuation(SyntaxKind.OpenParenToken))
-            Return result.ToImmutableAndFree()
+            Return result
         End Function
 
-        Private Shared Function GetMemberGroupPostambleParts(
-                symbol As ISymbol,
-                semanticModel As SemanticModel,
-                position As Integer) As ImmutableArray(Of SymbolDisplayPart)
-            Dim parts = ArrayBuilder(Of SymbolDisplayPart).GetInstance()
+        Private Shared Function GetMemberGroupPostambleParts(symbol As ISymbol,
+                                                      semanticModel As SemanticModel,
+                                                      position As Integer) As IList(Of SymbolDisplayPart)
+            Dim parts = New List(Of SymbolDisplayPart)
             parts.Add(Punctuation(SyntaxKind.CloseParenToken))
 
             If TypeOf symbol Is IMethodSymbol Then
@@ -73,7 +70,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
                 parts.AddRange([property].Type.ToMinimalDisplayParts(semanticModel, position))
             End If
 
-            Return parts.ToImmutableAndFree()
+            Return parts
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/SignatureHelp/AbstractVisualBasicSignatureHelpProvider.vb
+++ b/src/Features/VisualBasic/Portable/SignatureHelp/AbstractVisualBasicSignatureHelpProvider.vb
@@ -2,9 +2,7 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.DocumentationComments
-Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.SignatureHelp
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
@@ -36,8 +34,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
             Return New SymbolDisplayPart(SymbolDisplayPartKind.Space, Nothing, vbCrLf)
         End Function
 
-        Protected Shared Function GetSeparatorParts() As ImmutableArray(Of SymbolDisplayPart)
-            Return ImmutableArray.Create(Punctuation(SyntaxKind.CommaToken), Space())
+        Protected Shared Function GetSeparatorParts() As IList(Of SymbolDisplayPart)
+            Return {Punctuation(SyntaxKind.CommaToken), Space()}
         End Function
 
         Protected Shared Function Convert(parameter As IParameterSymbol,
@@ -50,7 +48,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
                 parameter.ToMinimalDisplayParts(semanticModel, position))
         End Function
 
-        Protected Shared Sub AddExtensionPreamble(symbol As ISymbol, result As ArrayBuilder(Of SymbolDisplayPart))
+        Protected Shared Sub AddExtensionPreamble(symbol As ISymbol, result As IList(Of SymbolDisplayPart))
             If symbol.GetOriginalUnreducedDefinition().IsExtensionMethod() Then
                 result.Add(Punctuation(SyntaxKind.LessThanToken))
                 result.Add(Text(VBFeaturesResources.Extension))

--- a/src/Features/VisualBasic/Portable/SignatureHelp/CollectionInitializerSignatureHelpProvider.vb
+++ b/src/Features/VisualBasic/Portable/SignatureHelp/CollectionInitializerSignatureHelpProvider.vb
@@ -60,7 +60,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
 
             Dim semanticModel = Await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(False)
             Return CreateCollectionInitializerSignatureHelpItems(
-                addMethods.SelectAsArray(Function(s) ConvertMemberGroupMember(document, s, collectionInitializer.OpenBraceToken.SpanStart, semanticModel)),
+                addMethods.Select(Function(s) ConvertMemberGroupMember(document, s, collectionInitializer.OpenBraceToken.SpanStart, semanticModel)).ToList(),
                 textSpan, GetCurrentArgumentState(root, position, syntaxFacts, textSpan, cancellationToken))
         End Function
 

--- a/src/Features/VisualBasic/Portable/SignatureHelp/GenericNameSignatureHelpProvider.Method.vb
+++ b/src/Features/VisualBasic/Portable/SignatureHelp/GenericNameSignatureHelpProvider.Method.vb
@@ -2,13 +2,12 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Collections.Immutable
-Imports Microsoft.CodeAnalysis.PooledObjects
-
 Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
+
     Partial Friend Class GenericNameSignatureHelpProvider
-        Private Shared Function GetPreambleParts(method As IMethodSymbol, semanticModel As SemanticModel, position As Integer) As ImmutableArray(Of SymbolDisplayPart)
-            Dim result = ArrayBuilder(Of SymbolDisplayPart).GetInstance()
+
+        Private Shared Function GetPreambleParts(method As IMethodSymbol, semanticModel As SemanticModel, position As Integer) As IList(Of SymbolDisplayPart)
+            Dim result = New List(Of SymbolDisplayPart)()
 
             AddExtensionPreamble(method, result)
 
@@ -23,7 +22,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
             result.Add(Punctuation(SyntaxKind.OpenParenToken))
             result.Add(Keyword(SyntaxKind.OfKeyword))
             result.Add(Space())
-            Return result.ToImmutableAndFree()
+            Return result
         End Function
 
         Private Shared Function GetContainingType(method As IMethodSymbol) As ITypeSymbol
@@ -36,8 +35,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
             End If
         End Function
 
-        Private Shared Function GetPostambleParts(method As IMethodSymbol, semanticModel As SemanticModel, position As Integer) As ImmutableArray(Of SymbolDisplayPart)
-            Dim result = ArrayBuilder(Of SymbolDisplayPart).GetInstance()
+        Private Shared Function GetPostambleParts(method As IMethodSymbol, semanticModel As SemanticModel, position As Integer) As IList(Of SymbolDisplayPart)
+            Dim result = New List(Of SymbolDisplayPart)()
             result.Add(Punctuation(SyntaxKind.CloseParenToken))
             result.Add(Punctuation(SyntaxKind.OpenParenToken))
 
@@ -61,7 +60,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
                 result.AddRange(method.ReturnType.ToMinimalDisplayParts(semanticModel, position))
             End If
 
-            Return result.ToImmutableAndFree()
+            Return result
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/SignatureHelp/GenericNameSignatureHelpProvider.NamedType.vb
+++ b/src/Features/VisualBasic/Portable/SignatureHelp/GenericNameSignatureHelpProvider.NamedType.vb
@@ -2,15 +2,12 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Collections.Immutable
-Imports Microsoft.CodeAnalysis.PooledObjects
-
 Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
 
     Partial Friend Class GenericNameSignatureHelpProvider
 
-        Private Shared Function GetPreambleParts(namedType As INamedTypeSymbol, semanticModel As SemanticModel, position As Integer) As ImmutableArray(Of SymbolDisplayPart)
-            Dim result = ArrayBuilder(Of SymbolDisplayPart).GetInstance()
+        Private Shared Function GetPreambleParts(namedType As INamedTypeSymbol, semanticModel As SemanticModel, position As Integer) As IList(Of SymbolDisplayPart)
+            Dim result = New List(Of SymbolDisplayPart)()
             Dim format = New SymbolDisplayFormat(
                 memberOptions:=SymbolDisplayMemberOptions.IncludeContainingType,
                 miscellaneousOptions:=SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers Or SymbolDisplayMiscellaneousOptions.UseSpecialTypes)
@@ -18,11 +15,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
             result.Add(Punctuation(SyntaxKind.OpenParenToken))
             result.Add(Keyword(SyntaxKind.OfKeyword))
             result.Add(Space())
-            Return result.ToImmutableAndFree()
+            Return result
         End Function
 
-        Private Shared Function GetPostambleParts() As ImmutableArray(Of SymbolDisplayPart)
-            Return ImmutableArray.Create(Punctuation(SyntaxKind.CloseParenToken))
+        Private Shared Function GetPostambleParts() As IList(Of SymbolDisplayPart)
+            Return {Punctuation(SyntaxKind.CloseParenToken)}
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider.DelegateInvoke.vb
+++ b/src/Features/VisualBasic/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider.DelegateInvoke.vb
@@ -2,12 +2,10 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.DocumentationComments
 Imports Microsoft.CodeAnalysis.LanguageService
-Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.SignatureHelp
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -39,8 +37,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
             Return SpecializedCollections.SingletonEnumerable(item)
         End Function
 
-        Private Shared Function GetDelegateInvokePreambleParts(invokeMethod As IMethodSymbol, semanticModel As SemanticModel, position As Integer) As ImmutableArray(Of SymbolDisplayPart)
-            Dim displayParts = ArrayBuilder(Of SymbolDisplayPart).GetInstance()
+        Private Shared Function GetDelegateInvokePreambleParts(invokeMethod As IMethodSymbol, semanticModel As SemanticModel, position As Integer) As IList(Of SymbolDisplayPart)
+            Dim displayParts = New List(Of SymbolDisplayPart)()
 
             If invokeMethod.ContainingType.IsAnonymousType Then
                 displayParts.Add(New SymbolDisplayPart(SymbolDisplayPartKind.MethodName, invokeMethod, invokeMethod.Name))
@@ -49,11 +47,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
             End If
 
             displayParts.Add(Punctuation(SyntaxKind.OpenParenToken))
-            Return displayParts.ToImmutableAndFree()
+            Return displayParts
         End Function
 
-        Private Shared Function GetDelegateInvokeParameters(invokeMethod As IMethodSymbol, semanticModel As SemanticModel, position As Integer, documentationCommentFormattingService As IDocumentationCommentFormattingService, cancellationToken As CancellationToken) As ImmutableArray(Of SignatureHelpSymbolParameter)
-            Dim parameters = ArrayBuilder(Of SignatureHelpSymbolParameter).GetInstance()
+        Private Shared Function GetDelegateInvokeParameters(invokeMethod As IMethodSymbol, semanticModel As SemanticModel, position As Integer, documentationCommentFormattingService As IDocumentationCommentFormattingService, cancellationToken As CancellationToken) As IList(Of SignatureHelpSymbolParameter)
+            Dim parameters = New List(Of SignatureHelpSymbolParameter)
             For Each parameter In invokeMethod.Parameters
                 cancellationToken.ThrowIfCancellationRequested()
                 parameters.Add(New SignatureHelpSymbolParameter(
@@ -63,14 +61,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
                     displayParts:=parameter.ToMinimalDisplayParts(semanticModel, position)))
             Next
 
-            Return parameters.ToImmutableAndFree()
+            Return parameters
         End Function
 
-        Private Shared Function GetDelegateInvokePostambleParts(
-                invokeMethod As IMethodSymbol,
-                semanticModel As SemanticModel,
-                position As Integer) As ImmutableArray(Of SymbolDisplayPart)
-            Dim parts = ArrayBuilder(Of SymbolDisplayPart).GetInstance()
+        Private Shared Function GetDelegateInvokePostambleParts(invokeMethod As IMethodSymbol,
+                                                         semanticModel As SemanticModel,
+                                                         position As Integer) As IList(Of SymbolDisplayPart)
+            Dim parts = New List(Of SymbolDisplayPart)
 
             parts.Add(Punctuation(SyntaxKind.CloseParenToken))
 
@@ -81,7 +78,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
                 parts.AddRange(invokeMethod.ReturnType.ToMinimalDisplayParts(semanticModel, position))
             End If
 
-            Return parts.ToImmutableAndFree()
+            Return parts
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider.ElementAccess.vb
+++ b/src/Features/VisualBasic/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider.ElementAccess.vb
@@ -2,12 +2,10 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.DocumentationComments
 Imports Microsoft.CodeAnalysis.LanguageService
-Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.SignatureHelp
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -15,14 +13,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
 
     Partial Friend Class InvocationExpressionSignatureHelpProvider
 
-        Private Shared Function GetElementAccessItems(
-                leftExpression As ExpressionSyntax,
-                semanticModel As SemanticModel,
-                structuralTypeDisplayService As IStructuralTypeDisplayService,
-                documentationCommentFormattingService As IDocumentationCommentFormattingService,
-                within As ISymbol,
-                defaultProperties As ImmutableArray(Of IPropertySymbol),
-                cancellationToken As CancellationToken) As IEnumerable(Of SignatureHelpItem)
+        Private Shared Function GetElementAccessItems(leftExpression As ExpressionSyntax,
+                                               semanticModel As SemanticModel,
+                                               structuralTypeDisplayService As IStructuralTypeDisplayService,
+                                               documentationCommentFormattingService As IDocumentationCommentFormattingService,
+                                               within As ISymbol,
+                                               defaultProperties As IList(Of IPropertySymbol),
+                                               cancellationToken As CancellationToken) As IEnumerable(Of SignatureHelpItem)
             Dim throughType As ITypeSymbol = Nothing
             If leftExpression IsNot Nothing Then
                 throughType = semanticModel.GetTypeInfo(leftExpression, cancellationToken).Type
@@ -50,22 +47,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
                 GetIndexerPreambleParts(indexer, semanticModel, position),
                 GetSeparatorParts(),
                 GetIndexerPostambleParts(indexer, semanticModel, position),
-                indexer.Parameters.SelectAsArray(Function(p) Convert(p, semanticModel, position, documentationCommentFormattingService)))
+                indexer.Parameters.Select(Function(p) Convert(p, semanticModel, position, documentationCommentFormattingService)).ToList())
             Return item
         End Function
 
-        Private Shared Function GetIndexerPreambleParts(symbol As IPropertySymbol, semanticModel As SemanticModel, position As Integer) As ImmutableArray(Of SymbolDisplayPart)
-            Dim result = ArrayBuilder(Of SymbolDisplayPart).GetInstance()
+        Private Shared Function GetIndexerPreambleParts(symbol As IPropertySymbol, semanticModel As SemanticModel, position As Integer) As IList(Of SymbolDisplayPart)
+            Dim result = New List(Of SymbolDisplayPart)()
             result.AddRange(symbol.ContainingType.ToMinimalDisplayParts(semanticModel, position))
             result.Add(Punctuation(SyntaxKind.OpenParenToken))
-            Return result.ToImmutableAndFree()
+            Return result
         End Function
 
-        Private Shared Function GetIndexerPostambleParts(
-                symbol As IPropertySymbol,
-                semanticModel As SemanticModel,
-                position As Integer) As ImmutableArray(Of SymbolDisplayPart)
-            Dim parts = ArrayBuilder(Of SymbolDisplayPart).GetInstance()
+        Private Shared Function GetIndexerPostambleParts(symbol As IPropertySymbol,
+                                                  semanticModel As SemanticModel,
+                                                  position As Integer) As IList(Of SymbolDisplayPart)
+            Dim parts = New List(Of SymbolDisplayPart)
             parts.Add(Punctuation(SyntaxKind.CloseParenToken))
 
             Dim [property] = DirectCast(symbol, IPropertySymbol)
@@ -75,7 +71,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
             parts.Add(Space())
             parts.AddRange([property].Type.ToMinimalDisplayParts(semanticModel, position))
 
-            Return parts.ToImmutableAndFree()
+            Return parts
         End Function
+
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider.vb
+++ b/src/Features/VisualBasic/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider.vb
@@ -9,7 +9,6 @@ Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.DocumentationComments
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.LanguageService
-Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.SignatureHelp
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -102,18 +101,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
             Dim expressionType = If(typeInfo.Type, typeInfo.ConvertedType)
             Dim defaultProperties =
                 If(expressionType Is Nothing,
-                    ImmutableArray(Of IPropertySymbol).Empty,
-                    semanticModel.LookupSymbols(position, expressionType, includeReducedExtensionMethods:=True).
-                                  OfType(Of IPropertySymbol).
-                                  ToImmutableArrayOrEmpty().
-                                  WhereAsArray(Function(p) p.IsIndexer).
-                                  FilterToVisibleAndBrowsableSymbolsAndNotUnsafeSymbols(options.HideAdvancedMembers, semanticModel.Compilation).
-                                  Sort(semanticModel, invocationExpression.SpanStart))
+                   SpecializedCollections.EmptyList(Of IPropertySymbol),
+                   semanticModel.LookupSymbols(position, expressionType, includeReducedExtensionMethods:=True).
+                                 OfType(Of IPropertySymbol).
+                                 ToImmutableArrayOrEmpty().
+                                 WhereAsArray(Function(p) p.IsIndexer).
+                                 FilterToVisibleAndBrowsableSymbolsAndNotUnsafeSymbols(options.HideAdvancedMembers, semanticModel.Compilation).
+                                 Sort(semanticModel, invocationExpression.SpanStart))
 
             Dim structuralTypeDisplayService = document.GetLanguageService(Of IStructuralTypeDisplayService)()
             Dim documentationCommentFormattingService = document.GetLanguageService(Of IDocumentationCommentFormattingService)()
 
-            Dim items = ArrayBuilder(Of SignatureHelpItem).GetInstance()
+            Dim items = New List(Of SignatureHelpItem)
             Dim accessibleMembers = ImmutableArray(Of ISymbol).Empty
             If memberGroup.Length > 0 Then
                 accessibleMembers = GetAccessibleMembers(invocationExpression, semanticModel, within, memberGroup, cancellationToken)
@@ -133,7 +132,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
 
             Dim selectedItem = TryGetSelectedIndex(accessibleMembers, symbolInfo.Symbol)
             Return CreateSignatureHelpItems(
-                items.ToImmutableAndFree(), textSpan, GetCurrentArgumentState(root, position, syntaxFacts, textSpan, cancellationToken),
+                items, textSpan, GetCurrentArgumentState(root, position, syntaxFacts, textSpan, cancellationToken),
                 selectedItem, parameterIndexOverride:=-1)
         End Function
     End Class

--- a/src/Features/VisualBasic/Portable/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider.DelegateType.vb
+++ b/src/Features/VisualBasic/Portable/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider.DelegateType.vb
@@ -2,22 +2,21 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.DocumentationComments
 Imports Microsoft.CodeAnalysis.LanguageService
-Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.SignatureHelp
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
+
     Partial Friend Class ObjectCreationExpressionSignatureHelpProvider
-        Private Shared Function GetDelegateTypeConstructors(
-                objectCreationExpression As ObjectCreationExpressionSyntax,
-                semanticModel As SemanticModel,
-                structuralTypeDisplayService As IStructuralTypeDisplayService,
-                documentationCommentFormattingService As IDocumentationCommentFormattingService,
-                delegateType As INamedTypeSymbol) As (items As ImmutableArray(Of SignatureHelpItem), selectedItem As Integer?)
+
+        Private Shared Function GetDelegateTypeConstructors(objectCreationExpression As ObjectCreationExpressionSyntax,
+                                                     semanticModel As SemanticModel,
+                                                     structuralTypeDisplayService As IStructuralTypeDisplayService,
+                                                     documentationCommentFormattingService As IDocumentationCommentFormattingService,
+                                                     delegateType As INamedTypeSymbol) As (items As IList(Of SignatureHelpItem), selectedItem As Integer?)
             Dim invokeMethod = delegateType.DelegateInvokeMethod
             If invokeMethod Is Nothing Then
                 Return (Nothing, Nothing)
@@ -34,20 +33,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
                 suffixParts:=GetDelegateTypePostambleParts(),
                 parameters:=GetDelegateTypeParameters(invokeMethod, semanticModel, position))
 
-            Return (ImmutableArray.Create(item), 0)
+            Return (SpecializedCollections.SingletonList(item), 0)
         End Function
 
-        Private Shared Function GetDelegateTypePreambleParts(invokeMethod As IMethodSymbol, semanticModel As SemanticModel, position As Integer) As ImmutableArray(Of SymbolDisplayPart)
-            Dim result = ArrayBuilder(Of SymbolDisplayPart).GetInstance()
+        Private Shared Function GetDelegateTypePreambleParts(invokeMethod As IMethodSymbol, semanticModel As SemanticModel, position As Integer) As IList(Of SymbolDisplayPart)
+            Dim result = New List(Of SymbolDisplayPart)()
             result.AddRange(invokeMethod.ContainingType.ToMinimalDisplayParts(semanticModel, position))
             result.Add(Punctuation(SyntaxKind.OpenParenToken))
-            Return result.ToImmutableAndFree()
+            Return result
         End Function
 
-        Private Shared Function GetDelegateTypeParameters(invokeMethod As IMethodSymbol, semanticModel As SemanticModel, position As Integer) As ImmutableArray(Of SignatureHelpSymbolParameter)
+        Private Shared Function GetDelegateTypeParameters(invokeMethod As IMethodSymbol, semanticModel As SemanticModel, position As Integer) As IList(Of SignatureHelpSymbolParameter)
             Const TargetName As String = "target"
 
-            Dim parts = ArrayBuilder(Of SymbolDisplayPart).GetInstance()
+            Dim parts = New List(Of SymbolDisplayPart)()
 
             If invokeMethod.ReturnsVoid Then
                 parts.Add(Keyword(SyntaxKind.SubKeyword))
@@ -78,15 +77,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
                 parts.AddRange(invokeMethod.ReturnType.ToMinimalDisplayParts(semanticModel, position))
             End If
 
-            Return ImmutableArray.Create(New SignatureHelpSymbolParameter(
+            Return {New SignatureHelpSymbolParameter(
                 TargetName,
                 isOptional:=False,
                 documentationFactory:=Nothing,
-                displayParts:=parts.ToImmutableAndFree()))
+                displayParts:=parts)}
         End Function
 
-        Private Shared Function GetDelegateTypePostambleParts() As ImmutableArray(Of SymbolDisplayPart)
-            Return ImmutableArray.Create(Punctuation(SyntaxKind.CloseParenToken))
+        Private Shared Function GetDelegateTypePostambleParts() As IList(Of SymbolDisplayPart)
+            Return {Punctuation(SyntaxKind.CloseParenToken)}
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider.NormalType.vb
+++ b/src/Features/VisualBasic/Portable/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider.NormalType.vb
@@ -2,12 +2,10 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.DocumentationComments
 Imports Microsoft.CodeAnalysis.LanguageService
-Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.SignatureHelp
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -22,7 +20,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
             structuralTypeDisplayService As IStructuralTypeDisplayService,
             normalType As INamedTypeSymbol,
             within As ISymbol,
-            options As MemberDisplayOptions, cancellationToken As CancellationToken) As (items As ImmutableArray(Of SignatureHelpItem), selectedItem As Integer?)
+            options As MemberDisplayOptions, cancellationToken As CancellationToken) As (items As IList(Of SignatureHelpItem), selectedItem As Integer?)
 
             Dim accessibleConstructors = normalType.InstanceConstructors.
                                                     WhereAsArray(Function(c) c.IsAccessibleWithin(within)).
@@ -35,8 +33,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
 
             Dim documentationCommentFormattingService = document.GetLanguageService(Of IDocumentationCommentFormattingService)()
 
-            Dim items = accessibleConstructors.SelectAsArray(
-                Function(c) ConvertNormalTypeConstructor(c, objectCreationExpression, semanticModel, structuralTypeDisplayService, documentationCommentFormattingService))
+            Dim items = accessibleConstructors.Select(
+                Function(c) ConvertNormalTypeConstructor(c, objectCreationExpression, semanticModel, structuralTypeDisplayService, documentationCommentFormattingService)).ToList()
 
             Dim currentConstructor = semanticModel.GetSymbolInfo(objectCreationExpression, cancellationToken)
             Dim selectedItem = TryGetSelectedIndex(accessibleConstructors, currentConstructor.Symbol)
@@ -55,19 +53,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
                 constructor.GetDocumentationPartsFactory(semanticModel, position, documentationCommentFormattingService),
                 GetNormalTypePreambleParts(constructor, semanticModel, position), GetSeparatorParts(),
                 GetNormalTypePostambleParts(),
-                constructor.Parameters.SelectAsArray(Function(p) Convert(p, semanticModel, position, documentationCommentFormattingService)))
+                constructor.Parameters.Select(Function(p) Convert(p, semanticModel, position, documentationCommentFormattingService)).ToList())
             Return item
         End Function
 
-        Private Shared Function GetNormalTypePreambleParts(method As IMethodSymbol, semanticModel As SemanticModel, position As Integer) As ImmutableArray(Of SymbolDisplayPart)
-            Dim result = ArrayBuilder(Of SymbolDisplayPart).GetInstance()
+        Private Shared Function GetNormalTypePreambleParts(method As IMethodSymbol, semanticModel As SemanticModel, position As Integer) As IList(Of SymbolDisplayPart)
+            Dim result = New List(Of SymbolDisplayPart)()
             result.AddRange(method.ContainingType.ToMinimalDisplayParts(semanticModel, position))
             result.Add(Punctuation(SyntaxKind.OpenParenToken))
-            Return result.ToImmutableAndFree()
+            Return result
         End Function
 
-        Private Shared Function GetNormalTypePostambleParts() As ImmutableArray(Of SymbolDisplayPart)
-            Return ImmutableArray.Create(Punctuation(SyntaxKind.CloseParenToken))
+        Private Shared Function GetNormalTypePostambleParts() As IList(Of SymbolDisplayPart)
+            Return {Punctuation(SyntaxKind.CloseParenToken)}
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/SignatureHelp/RaiseEventStatementSignatureHelpProvider.vb
+++ b/src/Features/VisualBasic/Portable/SignatureHelp/RaiseEventStatementSignatureHelpProvider.vb
@@ -8,7 +8,6 @@ Imports System.Threading
 Imports Microsoft.CodeAnalysis.DocumentationComments
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.LanguageService
-Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.SignatureHelp
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -94,7 +93,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
             Dim syntaxFacts = document.GetLanguageService(Of ISyntaxFactsService)
 
             Return CreateSignatureHelpItems(
-                allowedEvents.SelectAsArray(Function(e) Convert(e, raiseEventStatement, semanticModel, structuralTypeDisplayService, documentationCommentFormattingService)),
+                allowedEvents.Select(Function(e) Convert(e, raiseEventStatement, semanticModel, structuralTypeDisplayService, documentationCommentFormattingService)).ToList(),
                 textSpan, GetCurrentArgumentState(root, position, syntaxFacts, textSpan, cancellationToken), selectedItemIndex:=Nothing, parameterIndexOverride:=-1)
         End Function
 
@@ -118,17 +117,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
                 GetPreambleParts(eventSymbol, semanticModel, position),
                 GetSeparatorParts(),
                 GetPostambleParts(),
-                type.DelegateInvokeMethod.GetParameters().SelectAsArray(Function(p) Convert(p, semanticModel, position, documentationCommentFormattingService)))
+                type.DelegateInvokeMethod.GetParameters().Select(Function(p) Convert(p, semanticModel, position, documentationCommentFormattingService)).ToList())
 
             Return item
         End Function
 
         Private Shared Function GetPreambleParts(
-                eventSymbol As IEventSymbol,
-                semanticModel As SemanticModel,
-                position As Integer) As ImmutableArray(Of SymbolDisplayPart)
+            eventSymbol As IEventSymbol,
+            semanticModel As SemanticModel,
+            position As Integer
+        ) As IList(Of SymbolDisplayPart)
 
-            Dim result = ArrayBuilder(Of SymbolDisplayPart).GetInstance()
+            Dim result = New List(Of SymbolDisplayPart)()
 
             result.AddRange(eventSymbol.ContainingType.ToMinimalDisplayParts(semanticModel, position))
             result.Add(Punctuation(SyntaxKind.DotToken))
@@ -140,11 +140,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
             result.AddRange(eventSymbol.ToMinimalDisplayParts(semanticModel, position, format))
             result.Add(Punctuation(SyntaxKind.OpenParenToken))
 
-            Return result.ToImmutableAndFree()
+            Return result
         End Function
 
-        Private Shared Function GetPostambleParts() As ImmutableArray(Of SymbolDisplayPart)
-            Return ImmutableArray.Create(Punctuation(SyntaxKind.CloseParenToken))
+        Private Shared Function GetPostambleParts() As IList(Of SymbolDisplayPart)
+            Return {Punctuation(SyntaxKind.CloseParenToken)}
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/SignatureHelp/SignatureHelpUtilities.vb
+++ b/src/Features/VisualBasic/Portable/SignatureHelp/SignatureHelpUtilities.vb
@@ -7,6 +7,7 @@ Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
+
     Friend Module SignatureHelpUtilities
         Private ReadOnly s_getArgumentListOpenToken As Func(Of ArgumentListSyntax, SyntaxToken) = Function(list) list.OpenParenToken
         Private ReadOnly s_getTypeArgumentListOpenToken As Func(Of TypeArgumentListSyntax, SyntaxToken) = Function(list) list.OpenParenToken

--- a/src/VisualStudio/ExternalAccess/FSharp/Internal/SignatureHelp/FSharpSignatureHelpProvider.cs
+++ b/src/VisualStudio/ExternalAccess/FSharp/Internal/SignatureHelp/FSharpSignatureHelpProvider.cs
@@ -5,12 +5,12 @@
 using System;
 using System.Collections.Immutable;
 using System.Composition;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ExternalAccess.FSharp.SignatureHelp;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.SignatureHelp;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.SignatureHelp;
 
@@ -61,23 +61,23 @@ internal class FSharpSignatureHelpProvider : ISignatureHelpProvider
         if (mappedSignatureHelpItems != null)
         {
             return new SignatureHelpItems(
-                mappedSignatureHelpItems.Items.SelectAsArray(x =>
+                mappedSignatureHelpItems.Items.Select(x =>
                     new SignatureHelpItem(
                         x.IsVariadic,
                         x.DocumentationFactory,
                         x.PrefixDisplayParts,
                         x.SeparatorDisplayParts,
                         x.SuffixDisplayParts,
-                        x.Parameters.SelectAsArray(y =>
+                        x.Parameters.Select(y =>
                             new SignatureHelpParameter(
                                 y.Name,
                                 y.IsOptional,
                                 y.DocumentationFactory,
-                                y.DisplayParts.ToImmutableArrayOrEmpty(),
-                                y.PrefixDisplayParts.ToImmutableArrayOrEmpty(),
-                                y.SuffixDisplayParts.ToImmutableArrayOrEmpty(),
-                                y.SelectedDisplayParts.ToImmutableArrayOrEmpty())),
-                        x.DescriptionParts)),
+                                y.DisplayParts,
+                                y.PrefixDisplayParts,
+                                y.SuffixDisplayParts,
+                                y.SelectedDisplayParts)).ToList(),
+                        x.DescriptionParts)).ToList(),
                 mappedSignatureHelpItems.ApplicableSpan,
                 mappedSignatureHelpItems.ArgumentIndex,
                 mappedSignatureHelpItems.ArgumentCount,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/SymbolDisplayPartExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/SymbolDisplayPartExtensions.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.Shared.Extensions;
 
@@ -16,7 +15,7 @@ internal static class SymbolDisplayPartExtensions
     public static void AddLineBreak(this IList<SymbolDisplayPart> parts, string text = "\r\n")
         => parts.Add(new SymbolDisplayPart(SymbolDisplayPartKind.LineBreak, null, text));
 
-    public static void AddMethodName(this ArrayBuilder<SymbolDisplayPart> parts, string text)
+    public static void AddMethodName(this IList<SymbolDisplayPart> parts, string text)
         => parts.Add(new SymbolDisplayPart(SymbolDisplayPartKind.MethodName, null, text));
 
     public static void AddPunctuation(this IList<SymbolDisplayPart> parts, string text)

--- a/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/AbstractIntrinsicOperatorDocumentation.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/AbstractIntrinsicOperatorDocumentation.vb
@@ -2,10 +2,8 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
@@ -21,20 +19,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
             End Get
         End Property
 
-        Public MustOverride ReadOnly Property PrefixParts As ImmutableArray(Of SymbolDisplayPart)
+        Public MustOverride ReadOnly Property PrefixParts As IList(Of SymbolDisplayPart)
         Public MustOverride Function GetParameterName(index As Integer) As String
         Public MustOverride Function GetParameterDocumentation(index As Integer) As String
 
-        Public Overridable Function GetParameterDisplayParts(index As Integer) As ImmutableArray(Of SymbolDisplayPart)
-            Return ImmutableArray.Create(New SymbolDisplayPart(SymbolDisplayPartKind.ParameterName, Nothing, GetParameterName(index)))
+        Public Overridable Function GetParameterDisplayParts(index As Integer) As IList(Of SymbolDisplayPart)
+            Return {New SymbolDisplayPart(SymbolDisplayPartKind.ParameterName, Nothing, GetParameterName(index))}
         End Function
 
         Public Overridable Function TryGetTypeNameParameter(syntaxNode As SyntaxNode, index As Integer) As TypeSyntax
             Return Nothing
         End Function
 
-        Public Overridable Function GetSuffix(semanticModel As SemanticModel, position As Integer, nodeToBind As SyntaxNode, cancellationToken As CancellationToken) As ImmutableArray(Of SymbolDisplayPart)
-            Dim suffixParts = ArrayBuilder(Of SymbolDisplayPart).GetInstance()
+        Public Overridable Function GetSuffix(semanticModel As SemanticModel, position As Integer, nodeToBind As SyntaxNode, cancellationToken As CancellationToken) As IList(Of SymbolDisplayPart)
+            Dim suffixParts As New List(Of SymbolDisplayPart)
 
             If IncludeAsType Then
                 suffixParts.Add(New SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, Nothing, ")"))
@@ -46,7 +44,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
                     Dim typeInfo = semanticModel.GetTypeInfo(nodeToBind, cancellationToken)
                     If typeInfo.Type IsNot Nothing Then
                         suffixParts.AddRange(typeInfo.Type.ToMinimalDisplayParts(semanticModel, position))
-                        Return suffixParts.ToImmutableAndFree()
+                        Return suffixParts
                     End If
                 End If
 
@@ -60,13 +58,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
                         suffixParts.Add(New SymbolDisplayPart(SymbolDisplayPartKind.Text, Nothing, ReturnTypeMetadataName))
                     End If
 
-                    Return suffixParts.ToImmutableAndFree()
+                    Return suffixParts
                 End If
 
                 suffixParts.Add(New SymbolDisplayPart(SymbolDisplayPartKind.Text, Nothing, VBWorkspaceResources.result))
             End If
 
-            Return suffixParts.ToImmutableAndFree()
+            Return suffixParts
         End Function
     End Class
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/AddHandlerStatementDocumentation.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/AddHandlerStatementDocumentation.vb
@@ -2,14 +2,15 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Collections.Immutable
-
 Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
     Friend NotInheritable Class AddHandlerStatementDocumentation
         Inherits AbstractAddRemoveHandlerStatementDocumentation
 
-        Public Overrides ReadOnly Property DocumentationText As String =
-            VBWorkspaceResources.Associates_an_event_with_an_event_handler_delegate_or_lambda_expression_at_run_time
+        Public Overrides ReadOnly Property DocumentationText As String
+            Get
+                Return VBWorkspaceResources.Associates_an_event_with_an_event_handler_delegate_or_lambda_expression_at_run_time
+            End Get
+        End Property
 
         Public Overrides Function GetParameterDocumentation(index As Integer) As String
             Select Case index
@@ -22,9 +23,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
             End Select
         End Function
 
-        Public Overrides ReadOnly Property PrefixParts As ImmutableArray(Of SymbolDisplayPart) = ImmutableArray.Create(
-            New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, "AddHandler"),
-            New SymbolDisplayPart(SymbolDisplayPartKind.Space, Nothing, " "))
+        Public Overrides ReadOnly Property PrefixParts As IList(Of SymbolDisplayPart)
+            Get
+                Return {New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, "AddHandler"),
+                        New SymbolDisplayPart(SymbolDisplayPartKind.Space, Nothing, " ")}
+            End Get
+        End Property
     End Class
 End Namespace
 

--- a/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/BinaryConditionalExpressionDocumentation.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/BinaryConditionalExpressionDocumentation.vb
@@ -2,14 +2,15 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Collections.Immutable
-
 Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
     Friend NotInheritable Class BinaryConditionalExpressionDocumentation
         Inherits AbstractIntrinsicOperatorDocumentation
 
-        Public Overrides ReadOnly Property DocumentationText As String =
-            VBWorkspaceResources.If_expression_evaluates_to_a_reference_or_Nullable_value_that_is_not_Nothing_the_function_returns_that_value_Otherwise_it_calculates_and_returns_expressionIfNothing
+        Public Overrides ReadOnly Property DocumentationText As String
+            Get
+                Return VBWorkspaceResources.If_expression_evaluates_to_a_reference_or_Nullable_value_that_is_not_Nothing_the_function_returns_that_value_Otherwise_it_calculates_and_returns_expressionIfNothing
+            End Get
+        End Property
 
         Public Overrides Function GetParameterDocumentation(index As Integer) As String
             Select Case index
@@ -33,12 +34,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
             End Select
         End Function
 
-        Public Overrides ReadOnly Property IncludeAsType As Boolean = True
+        Public Overrides ReadOnly Property IncludeAsType As Boolean
+            Get
+                Return True
+            End Get
+        End Property
 
-        Public Overrides ReadOnly Property ParameterCount As Integer = 2
+        Public Overrides ReadOnly Property ParameterCount As Integer
+            Get
+                Return 2
+            End Get
+        End Property
 
-        Public Overrides ReadOnly Property PrefixParts As ImmutableArray(Of SymbolDisplayPart) = ImmutableArray.Create(
-            New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, "If"),
-            New SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, Nothing, "("))
+        Public Overrides ReadOnly Property PrefixParts As IList(Of SymbolDisplayPart)
+            Get
+                Return {New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, "If"),
+                        New SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, Nothing, "(")}
+            End Get
+        End Property
     End Class
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/CTypeCastExpressionDocumentation.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/CTypeCastExpressionDocumentation.vb
@@ -2,17 +2,23 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Collections.Immutable
-
 Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
     Friend NotInheritable Class CTypeCastExpressionDocumentation
         Inherits AbstractCastExpressionDocumentation
 
-        Public Overrides ReadOnly Property DocumentationText As String =
-            VBWorkspaceResources.Returns_the_result_of_explicitly_converting_an_expression_to_a_specified_data_type
+        Public Overrides ReadOnly Property DocumentationText As String
+            Get
+                Return VBWorkspaceResources.Returns_the_result_of_explicitly_converting_an_expression_to_a_specified_data_type
+            End Get
+        End Property
 
-        Public Overrides ReadOnly Property PrefixParts As ImmutableArray(Of SymbolDisplayPart) = ImmutableArray.Create(
-            New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, "CType"),
-            New SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, Nothing, "("))
+        Public Overrides ReadOnly Property PrefixParts As IList(Of SymbolDisplayPart)
+            Get
+                Return {
+                    New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, "CType"),
+                    New SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, Nothing, "(")
+                }
+            End Get
+        End Property
     End Class
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/DirectCastExpressionDocumentation.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/DirectCastExpressionDocumentation.vb
@@ -2,17 +2,23 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Collections.Immutable
-
 Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
     Friend NotInheritable Class DirectCastExpressionDocumentation
         Inherits AbstractCastExpressionDocumentation
 
-        Public Overrides ReadOnly Property DocumentationText As String =
-            VBWorkspaceResources.Introduces_a_type_conversion_operation_similar_to_CType_The_difference_is_that_CType_succeeds_as_long_as_there_is_a_valid_conversion_whereas_DirectCast_requires_that_one_type_inherit_from_or_implement_the_other_type
+        Public Overrides ReadOnly Property DocumentationText As String
+            Get
+                Return VBWorkspaceResources.Introduces_a_type_conversion_operation_similar_to_CType_The_difference_is_that_CType_succeeds_as_long_as_there_is_a_valid_conversion_whereas_DirectCast_requires_that_one_type_inherit_from_or_implement_the_other_type
+            End Get
+        End Property
 
-        Public Overrides ReadOnly Property PrefixParts As ImmutableArray(Of SymbolDisplayPart) = ImmutableArray.Create(
-            New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, "DirectCast"),
-            New SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, Nothing, "("))
+        Public Overrides ReadOnly Property PrefixParts As IList(Of SymbolDisplayPart)
+            Get
+                Return {
+                    New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, "DirectCast"),
+                    New SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, Nothing, "(")
+                }
+            End Get
+        End Property
     End Class
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/GetTypeExpressionDocumentation.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/GetTypeExpressionDocumentation.vb
@@ -2,7 +2,6 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
@@ -27,16 +26,32 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
             End Select
         End Function
 
-        Public Overrides ReadOnly Property ParameterCount As Integer = 1
+        Public Overrides ReadOnly Property ParameterCount As Integer
+            Get
+                Return 1
+            End Get
+        End Property
 
-        Public Overrides ReadOnly Property DocumentationText As String =
-            VBWorkspaceResources.Returns_a_System_Type_object_for_the_specified_type_name
+        Public Overrides ReadOnly Property DocumentationText As String
+            Get
+                Return VBWorkspaceResources.Returns_a_System_Type_object_for_the_specified_type_name
+            End Get
+        End Property
 
-        Public Overrides ReadOnly Property PrefixParts As ImmutableArray(Of SymbolDisplayPart) = ImmutableArray.Create(
-            New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, "GetType"),
-            New SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, Nothing, "("))
+        Public Overrides ReadOnly Property PrefixParts As IList(Of SymbolDisplayPart)
+            Get
+                Return {
+                    New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, "GetType"),
+                    New SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, Nothing, "(")
+                }
+            End Get
+        End Property
 
-        Public Overrides ReadOnly Property IncludeAsType As Boolean = True
+        Public Overrides ReadOnly Property IncludeAsType As Boolean
+            Get
+                Return True
+            End Get
+        End Property
 
         Public Overrides Function TryGetTypeNameParameter(syntaxNode As SyntaxNode, index As Integer) As TypeSyntax
             Dim getTypeExpression = TryCast(syntaxNode, GetTypeExpressionSyntax)
@@ -48,6 +63,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
             End If
         End Function
 
-        Public Overrides ReadOnly Property ReturnTypeMetadataName As String = "System.Type"
+        Public Overrides ReadOnly Property ReturnTypeMetadataName As String
+            Get
+                Return "System.Type"
+            End Get
+        End Property
     End Class
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/GetXmlNamespaceExpressionDocumentation.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/GetXmlNamespaceExpressionDocumentation.vb
@@ -2,19 +2,18 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Collections.Immutable
-
 Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
     Friend NotInheritable Class GetXmlNamespaceExpressionDocumentation
         Inherits AbstractIntrinsicOperatorDocumentation
 
-        Public Overrides Function GetParameterDisplayParts(index As Integer) As ImmutableArray(Of SymbolDisplayPart)
+        Public Overrides Function GetParameterDisplayParts(index As Integer) As IList(Of SymbolDisplayPart)
             Select Case index
                 Case 0
-                    Return ImmutableArray.Create(
+                    Return {
                         New SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, Nothing, "["),
                         New SymbolDisplayPart(SymbolDisplayPartKind.ParameterName, Nothing, GetParameterName(index)),
-                        New SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, Nothing, "]"))
+                        New SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, Nothing, "]")
+                   }
                 Case Else
                     Throw New ArgumentException(NameOf(index))
             End Select
@@ -38,17 +37,37 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
             End Select
         End Function
 
-        Public Overrides ReadOnly Property ParameterCount As Integer = 1
+        Public Overrides ReadOnly Property ParameterCount As Integer
+            Get
+                Return 1
+            End Get
+        End Property
 
-        Public Overrides ReadOnly Property DocumentationText As String =
-            VBWorkspaceResources.Returns_the_System_Xml_Linq_XNamespace_object_corresponding_to_the_specified_XML_namespace_prefix
+        Public Overrides ReadOnly Property DocumentationText As String
+            Get
+                Return VBWorkspaceResources.Returns_the_System_Xml_Linq_XNamespace_object_corresponding_to_the_specified_XML_namespace_prefix
+            End Get
+        End Property
 
-        Public Overrides ReadOnly Property PrefixParts As ImmutableArray(Of SymbolDisplayPart) = ImmutableArray.Create(
-            New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, "GetXmlNamespace"),
-            New SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, Nothing, "("))
+        Public Overrides ReadOnly Property PrefixParts As IList(Of SymbolDisplayPart)
+            Get
+                Return {
+                    New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, "GetXmlNamespace"),
+                    New SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, Nothing, "(")
+                }
+            End Get
+        End Property
 
-        Public Overrides ReadOnly Property IncludeAsType As Boolean = True
+        Public Overrides ReadOnly Property IncludeAsType As Boolean
+            Get
+                Return True
+            End Get
+        End Property
 
-        Public Overrides ReadOnly Property ReturnTypeMetadataName As String = "System.Xml.Linq.XNamespace"
+        Public Overrides ReadOnly Property ReturnTypeMetadataName As String
+            Get
+                Return "System.Xml.Linq.XNamespace"
+            End Get
+        End Property
     End Class
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/MidAssignmentDocumentation.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/MidAssignmentDocumentation.vb
@@ -2,15 +2,17 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Collections.Immutable
 Imports System.Threading
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
     Friend NotInheritable Class MidAssignmentDocumentation
         Inherits AbstractIntrinsicOperatorDocumentation
 
-        Public Overrides ReadOnly Property DocumentationText As String =
-            VBWorkspaceResources.Replaces_a_specified_number_of_characters_in_a_String_variable_with_characters_from_another_string
+        Public Overrides ReadOnly Property DocumentationText As String
+            Get
+                Return VBWorkspaceResources.Replaces_a_specified_number_of_characters_in_a_String_variable_with_characters_from_another_string
+            End Get
+        End Property
 
         Public Overrides Function GetParameterDocumentation(index As Integer) As String
             Select Case index
@@ -38,29 +40,41 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
             End Select
         End Function
 
-        Public Overrides Function GetParameterDisplayParts(index As Integer) As ImmutableArray(Of SymbolDisplayPart)
+        Public Overrides Function GetParameterDisplayParts(index As Integer) As IList(Of SymbolDisplayPart)
             If index = 2 Then
-                Return ImmutableArray.Create(New SymbolDisplayPart(SymbolDisplayPartKind.ParameterName, Nothing, "[" + GetParameterName(2) + "]"))
+                Return {New SymbolDisplayPart(SymbolDisplayPartKind.ParameterName, Nothing, "[" + GetParameterName(2) + "]")}
             Else
                 Return MyBase.GetParameterDisplayParts(index)
             End If
         End Function
 
-        Public Overrides ReadOnly Property IncludeAsType As Boolean = False
+        Public Overrides ReadOnly Property IncludeAsType As Boolean
+            Get
+                Return False
+            End Get
+        End Property
 
-        Public Overrides ReadOnly Property ParameterCount As Integer = 3
+        Public Overrides ReadOnly Property ParameterCount As Integer
+            Get
+                Return 3
+            End Get
+        End Property
 
-        Public Overrides Function GetSuffix(semanticModel As SemanticModel, position As Integer, nodeToBind As SyntaxNode, cancellationToken As CancellationToken) As ImmutableArray(Of SymbolDisplayPart)
-            Return ImmutableArray.Create(
+        Public Overrides Function GetSuffix(semanticModel As SemanticModel, position As Integer, nodeToBind As SyntaxNode, cancellationToken As CancellationToken) As IList(Of SymbolDisplayPart)
+            Return {
                 New SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, Nothing, ")"),
                 New SymbolDisplayPart(SymbolDisplayPartKind.Space, Nothing, " "),
                 New SymbolDisplayPart(SymbolDisplayPartKind.Operator, Nothing, "="),
                 New SymbolDisplayPart(SymbolDisplayPartKind.Space, Nothing, " "),
-                New SymbolDisplayPart(SymbolDisplayPartKind.Text, Nothing, VBWorkspaceResources.stringExpression))
+                New SymbolDisplayPart(SymbolDisplayPartKind.Text, Nothing, VBWorkspaceResources.stringExpression)
+            }
         End Function
 
-        Public Overrides ReadOnly Property PrefixParts As ImmutableArray(Of SymbolDisplayPart) = ImmutableArray.Create(
-            New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, "Mid"),
-            New SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, Nothing, "("))
+        Public Overrides ReadOnly Property PrefixParts As IList(Of SymbolDisplayPart)
+            Get
+                Return {New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, "Mid"),
+                        New SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, Nothing, "(")}
+            End Get
+        End Property
     End Class
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/NameOfExpressionDocumentation.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/NameOfExpressionDocumentation.vb
@@ -2,22 +2,34 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Collections.Immutable
-
 Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
     Friend NotInheritable Class NameOfExpressionDocumentation
         Inherits AbstractIntrinsicOperatorDocumentation
 
-        Public Overrides ReadOnly Property DocumentationText As String =
-            VBWorkspaceResources.Produces_a_string_for_the_name_of_the_specified_type_or_member
+        Public Overrides ReadOnly Property DocumentationText As String
+            Get
+                Return VBWorkspaceResources.Produces_a_string_for_the_name_of_the_specified_type_or_member
+            End Get
+        End Property
 
-        Public Overrides ReadOnly Property IncludeAsType As Boolean = True
+        Public Overrides ReadOnly Property IncludeAsType As Boolean
+            Get
+                Return True
+            End Get
+        End Property
 
-        Public Overrides ReadOnly Property ParameterCount As Integer = 1
+        Public Overrides ReadOnly Property ParameterCount As Integer
+            Get
+                Return 1
+            End Get
+        End Property
 
-        Public Overrides ReadOnly Property PrefixParts As ImmutableArray(Of SymbolDisplayPart) = ImmutableArray.Create(
-            New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, "NameOf"),
-            New SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, Nothing, "("))
+        Public Overrides ReadOnly Property PrefixParts As IList(Of SymbolDisplayPart)
+            Get
+                Return {New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, "NameOf"),
+                        New SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, Nothing, "(")}
+            End Get
+        End Property
 
         Public Overrides Function GetParameterDocumentation(index As Integer) As String
             Select Case index
@@ -37,6 +49,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
             End Select
         End Function
 
-        Public Overrides ReadOnly Property ReturnTypeMetadataName As String = "System.String"
+        Public Overrides ReadOnly Property ReturnTypeMetadataName As String
+            Get
+                Return "System.String"
+            End Get
+        End Property
+
     End Class
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/PredefinedCastExpressionDocumentation.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/PredefinedCastExpressionDocumentation.vb
@@ -2,8 +2,6 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Collections.Immutable
-
 Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
     Friend NotInheritable Class PredefinedCastExpressionDocumentation
         Inherits AbstractIntrinsicOperatorDocumentation
@@ -40,15 +38,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
             End Select
         End Function
 
-        Public Overrides ReadOnly Property IncludeAsType As Boolean = True
-
-        Public Overrides ReadOnly Property ParameterCount As Integer = 1
-
-        Public Overrides ReadOnly Property PrefixParts As ImmutableArray(Of SymbolDisplayPart)
+        Public Overrides ReadOnly Property IncludeAsType As Boolean
             Get
-                Return ImmutableArray.Create(
-                    New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, _keywordText),
-                    New SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, Nothing, "("))
+                Return True
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property ParameterCount As Integer
+            Get
+                Return 1
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property PrefixParts As IList(Of SymbolDisplayPart)
+            Get
+                Return {New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, _keywordText),
+                        New SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, Nothing, "(")}
             End Get
         End Property
 

--- a/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/RemoveHandlerStatementDocumentation.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/RemoveHandlerStatementDocumentation.vb
@@ -2,14 +2,15 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Collections.Immutable
-
 Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
     Friend NotInheritable Class RemoveHandlerStatementDocumentation
         Inherits AbstractAddRemoveHandlerStatementDocumentation
 
-        Public Overrides ReadOnly Property DocumentationText As String =
-            VBWorkspaceResources.Removes_the_association_between_an_event_and_an_event_handler_or_delegate_at_run_time
+        Public Overrides ReadOnly Property DocumentationText As String
+            Get
+                Return VBWorkspaceResources.Removes_the_association_between_an_event_and_an_event_handler_or_delegate_at_run_time
+            End Get
+        End Property
 
         Public Overrides Function GetParameterDocumentation(index As Integer) As String
             Select Case index
@@ -22,8 +23,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
             End Select
         End Function
 
-        Public Overrides ReadOnly Property PrefixParts As ImmutableArray(Of SymbolDisplayPart) = ImmutableArray.Create(
-            New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, "RemoveHandler"),
-            New SymbolDisplayPart(SymbolDisplayPartKind.Space, Nothing, " "))
+        Public Overrides ReadOnly Property PrefixParts As IList(Of SymbolDisplayPart)
+            Get
+                Return {New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, "RemoveHandler"),
+                        New SymbolDisplayPart(SymbolDisplayPartKind.Space, Nothing, " ")}
+            End Get
+        End Property
     End Class
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/TernaryConditionalExpressionDocumentation.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/TernaryConditionalExpressionDocumentation.vb
@@ -2,25 +2,25 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Collections.Immutable
-
 Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
     Friend NotInheritable Class TernaryConditionalExpressionDocumentation
         Inherits AbstractIntrinsicOperatorDocumentation
 
-        Public Overrides ReadOnly Property DocumentationText As String =
-            VBWorkspaceResources.If_condition_returns_True_the_function_calculates_and_returns_expressionIfTrue_Otherwise_it_returns_expressionIfFalse
+        Public Overrides ReadOnly Property DocumentationText As String
+            Get
+                Return VBWorkspaceResources.If_condition_returns_True_the_function_calculates_and_returns_expressionIfTrue_Otherwise_it_returns_expressionIfFalse
+            End Get
+        End Property
 
-        Public Overrides Function GetParameterDisplayParts(index As Integer) As ImmutableArray(Of SymbolDisplayPart)
+        Public Overrides Function GetParameterDisplayParts(index As Integer) As IList(Of SymbolDisplayPart)
             If index = 0 Then
-                Return ImmutableArray.Create(
-                    New SymbolDisplayPart(SymbolDisplayPartKind.ParameterName, Nothing, GetParameterName(index)),
-                    New SymbolDisplayPart(SymbolDisplayPartKind.Space, Nothing, " "),
-                    New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, "As"),
-                    New SymbolDisplayPart(SymbolDisplayPartKind.Space, Nothing, " "),
-                    New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, "Boolean"))
+                Return {New SymbolDisplayPart(SymbolDisplayPartKind.ParameterName, Nothing, GetParameterName(index)),
+                        New SymbolDisplayPart(SymbolDisplayPartKind.Space, Nothing, " "),
+                        New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, "As"),
+                        New SymbolDisplayPart(SymbolDisplayPartKind.Space, Nothing, " "),
+                        New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, "Boolean")}
             Else
-                Return ImmutableArray.Create(New SymbolDisplayPart(SymbolDisplayPartKind.ParameterName, Nothing, GetParameterName(index)))
+                Return {New SymbolDisplayPart(SymbolDisplayPartKind.ParameterName, Nothing, GetParameterName(index))}
             End If
         End Function
 
@@ -50,12 +50,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
             End Select
         End Function
 
-        Public Overrides ReadOnly Property IncludeAsType As Boolean = True
+        Public Overrides ReadOnly Property IncludeAsType As Boolean
+            Get
+                Return True
+            End Get
+        End Property
 
-        Public Overrides ReadOnly Property ParameterCount As Integer = 3
+        Public Overrides ReadOnly Property ParameterCount As Integer
+            Get
+                Return 3
+            End Get
+        End Property
 
-        Public Overrides ReadOnly Property PrefixParts As ImmutableArray(Of SymbolDisplayPart) = ImmutableArray.Create(
-            New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, "If"),
-            New SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, Nothing, "("))
+        Public Overrides ReadOnly Property PrefixParts As IList(Of SymbolDisplayPart)
+            Get
+                Return {New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, "If"),
+                        New SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, Nothing, "(")}
+            End Get
+        End Property
     End Class
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/TryCastExpressionDocumentation.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/IntrinsicOperators/TryCastExpressionDocumentation.vb
@@ -2,17 +2,23 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Collections.Immutable
-
 Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities.IntrinsicOperators
     Friend NotInheritable Class TryCastExpressionDocumentation
         Inherits AbstractCastExpressionDocumentation
 
-        Public Overrides ReadOnly Property DocumentationText As String =
-            VBWorkspaceResources.Introduces_a_type_conversion_operation_that_does_not_throw_an_exception_If_an_attempted_conversion_fails_TryCast_returns_Nothing_which_your_program_can_test_for
+        Public Overrides ReadOnly Property DocumentationText As String
+            Get
+                Return VBWorkspaceResources.Introduces_a_type_conversion_operation_that_does_not_throw_an_exception_If_an_attempted_conversion_fails_TryCast_returns_Nothing_which_your_program_can_test_for
+            End Get
+        End Property
 
-        Public Overrides ReadOnly Property PrefixParts As ImmutableArray(Of SymbolDisplayPart) = ImmutableArray.Create(
-            New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, "TryCast"),
-            New SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, Nothing, "("))
+        Public Overrides ReadOnly Property PrefixParts As IList(Of SymbolDisplayPart)
+            Get
+                Return {
+                    New SymbolDisplayPart(SymbolDisplayPartKind.Keyword, Nothing, "TryCast"),
+                    New SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, Nothing, "(")
+                }
+            End Get
+        End Property
     End Class
 End Namespace


### PR DESCRIPTION
This reverts commit 1a8bea99de65e384e4d036da478da1613eba5c33.

TypeScript uses this API (unfortunately, not through EA).  So we can't take this yet.