### PR TITLE
Fix issue when caching CompilationWithAnalyzers against ProjectState instead of a project

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/Service/ChecksumAndAnalyzersEqualityComparer.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/ChecksumAndAnalyzersEqualityComparer.cs
@@ -10,26 +10,23 @@ namespace Microsoft.CodeAnalysis.Diagnostics;
 
 internal sealed partial class DiagnosticAnalyzerService
 {
-    private sealed class ChecksumAndAnalyzersEqualityComparer
-        : IEqualityComparer<(Checksum checksum, ImmutableArray<DiagnosticAnalyzer> analyzers)>
+    private sealed class AnalyzersEqualityComparer
+        : IEqualityComparer<ImmutableArray<DiagnosticAnalyzer>>
     {
-        public static readonly ChecksumAndAnalyzersEqualityComparer Instance = new();
+        public static readonly AnalyzersEqualityComparer Instance = new();
 
-        public bool Equals((Checksum checksum, ImmutableArray<DiagnosticAnalyzer> analyzers) x, (Checksum checksum, ImmutableArray<DiagnosticAnalyzer> analyzers) y)
+        public bool Equals(ImmutableArray<DiagnosticAnalyzer> x, ImmutableArray<DiagnosticAnalyzer> y)
         {
-            if (x.checksum != y.checksum)
-                return false;
-
             // Fast path for when the analyzers are the same reference.
-            return x.analyzers == y.analyzers || x.analyzers.SetEquals(y.analyzers);
+            return x == y || x.SetEquals(y);
         }
 
-        public int GetHashCode((Checksum checksum, ImmutableArray<DiagnosticAnalyzer> analyzers) obj)
+        public int GetHashCode(ImmutableArray<DiagnosticAnalyzer> obj)
         {
-            var hashCode = obj.checksum.GetHashCode();
+            var hashCode = 0;
 
             // Use addition so that we're resilient to any order for the analyzers.
-            foreach (var analyzer in obj.analyzers)
+            foreach (var analyzer in obj)
                 hashCode += analyzer.GetHashCode();
 
             return hashCode;

--- a/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService_CompilationWithAnalyzersPair.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService_CompilationWithAnalyzersPair.cs
@@ -17,9 +17,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics;
 internal sealed partial class DiagnosticAnalyzerService
 {
     /// <summary>
-    /// Cached data from a <see cref="ProjectState"/> to the <see cref="CompilationWithAnalyzers"/>s
-    /// we've created for it.  Note: the CompilationWithAnalyzersPair instance is dependent on the set of <see
-    /// cref="DiagnosticAnalyzer"/>s passed along with the project.
+    /// Cached data from a <see cref="Project"/> to the <see cref="CompilationWithAnalyzers"/>s we've created for it.
+    /// Note: the CompilationWithAnalyzersPair instance is dependent on the set of <see cref="DiagnosticAnalyzer"/>s
+    /// passed along with the project.  It is important to be associated with the project as the <see
+    /// cref="CompilationWithAnalyzers"/> will use the <see cref="Compilation"/> it produces, and must see
+    /// agree on that for correctness.
     /// <para/>
     /// The value of the table is a SmallDictionary that maps from the 
     /// <see cref="Project"/> checksum the set of <see cref="DiagnosticAnalyzer"/>s being requested.

--- a/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService_CompilationWithAnalyzersPair.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService_CompilationWithAnalyzersPair.cs
@@ -20,8 +20,9 @@ internal sealed partial class DiagnosticAnalyzerService
     /// Cached data from a <see cref="Project"/> to the <see cref="CompilationWithAnalyzers"/>s we've created for it.
     /// Note: the CompilationWithAnalyzersPair instance is dependent on the set of <see cref="DiagnosticAnalyzer"/>s
     /// passed along with the project.  It is important to be associated with the project as the <see
-    /// cref="CompilationWithAnalyzers"/> will use the <see cref="Compilation"/> it produces, and must see
-    /// agree on that for correctness.
+    /// cref="CompilationWithAnalyzers"/> will use the <see cref="Compilation"/> it produces, and must see agree on that
+    /// for correctness.  By sharing the same compilations, we ensure also that all syntax trees in that shared
+    /// compilation are consistent with the trees retrieved from this project's documents.
     /// <para/>
     /// The value of the table is a SmallDictionary that maps from the 
     /// <see cref="Project"/> checksum the set of <see cref="DiagnosticAnalyzer"/>s being requested.


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2576607

Pipeline: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=12443017&view=results
Build: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/672951