### PR TITLE
Extensions: AssociatedExtensionImplementation on constructed symbols

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/PublicModel/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PublicModel/MethodSymbol.cs
@@ -349,15 +349,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
                     return null;
                 }
 
-                if (_underlying.IsDefinition)
+                var enclosing = _underlying.ContainingType.ContainingType;
+                var implementation = implDefinition.AsMember(enclosing);
+                if (implementation.Arity != 0)
                 {
-                    return implDefinition.GetPublicSymbol();
+                    var typeArguments = ArrayBuilder<TypeWithAnnotations>.GetInstance(implementation.Arity);
+                    typeArguments.AddRange(_underlying.ContainingType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics);
+                    typeArguments.AddRange(_underlying.TypeArgumentsWithAnnotations);
+                    implementation = implementation.Construct(typeArguments.ToImmutableAndFree());
                 }
 
-                var typeArguments = ArrayBuilder<TypeWithAnnotations>.GetInstance(implDefinition.Arity);
-                typeArguments.AddRange(_underlying.ContainingType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics);
-                typeArguments.AddRange(_underlying.TypeArgumentsWithAnnotations);
-                return implDefinition.Construct(typeArguments.ToImmutableAndFree()).GetPublicSymbol();
+                return implementation.GetPublicSymbol();
             }
         }
 #nullable disable

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
@@ -3867,6 +3867,9 @@ int.M();
             // (1,5): error CS0570: 'E.extension(int).M<T>()' is not supported by the language
             // int.M();
             Diagnostic(ErrorCode.ERR_BindToBogus, "M").WithArguments("E.extension(int).M<T>()").WithLocation(1, 5));
+
+        var method = comp.GlobalNamespace.GetTypeMember("E").GetTypeMembers().Single().GetMember<MethodSymbol>("M").GetPublicSymbol();
+        Assert.Null(method.AssociatedExtensionImplementation);
     }
 
     [Fact]
@@ -32540,8 +32543,7 @@ public static class E
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "42.M");
         var method = (IMethodSymbol)model.GetSymbolInfo(memberAccess).Symbol;
-        // Tracked by https://github.com/dotnet/roslyn/issues/78957 : public API, add support for constructed symbols
-        Assert.Null(method.AssociatedExtensionImplementation);
+        AssertEx.Equal("void E.M<System.Int32>(this System.Int32 t)", method.AssociatedExtensionImplementation.ToTestDisplayString());
         Assert.Equal("void E.M<T>(this T t)", method.OriginalDefinition.AssociatedExtensionImplementation.ToTestDisplayString());
     }
 
@@ -32645,6 +32647,87 @@ public class E
         var comp = CreateCompilationWithIL("", ilSrc);
         var method = comp.GlobalNamespace.GetTypeMember("E").GetTypeMembers().Single().GetMember<MethodSymbol>("M").GetPublicSymbol();
         Assert.Null(method.AssociatedExtensionImplementation);
+    }
+
+    [Fact]
+    public void AssociatedExtensionImplementation_06()
+    {
+        // not a definition, generic extension and method
+        var src = """
+42.M(43L, "");
+
+public static class E
+{
+    extension<T>(T t)
+    {
+        public void M<U, V>(U u, V v) { }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "42.M");
+        var method = (IMethodSymbol)model.GetSymbolInfo(memberAccess).Symbol;
+        AssertEx.Equal("void E.M<System.Int32, System.Int64, System.String>(this System.Int32 t, System.Int64 u, System.String v)",
+            method.AssociatedExtensionImplementation.ToTestDisplayString());
+    }
+
+    [Fact]
+    public void AssociatedExtensionImplementation_07()
+    {
+        // not a definition, generic extension and method, constructed with type parameters
+        var src = """
+public static class E
+{
+    extension<T>(T t)
+    {
+        public void M<U, V>(U u, V v)
+        {
+            t.M(u, v);
+        }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "t.M");
+        var method = (IMethodSymbol)model.GetSymbolInfo(memberAccess).Symbol;
+        var associated = method.AssociatedExtensionImplementation;
+        AssertEx.Equal("void E.M<T, U, V>(this T t, U u, V v)", associated.ToTestDisplayString());
+        Assert.True(associated.IsDefinition);
+    }
+
+    [Fact]
+    public void AssociatedExtensionImplementation_08()
+    {
+        // not a definition, generic extension and method, partially constructed with type parameters
+        var src = """
+public static class E
+{
+    extension<T>(T t)
+    {
+        public void M<U, V>(U u, V v)
+        {
+            t.M(42L, "");
+        }
+    }
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics();
+
+        var tree = comp.SyntaxTrees.First();
+        var model = comp.GetSemanticModel(tree);
+        var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "t.M");
+        var method = (IMethodSymbol)model.GetSymbolInfo(memberAccess).Symbol;
+        AssertEx.Equal("void E.M<T, System.Int64, System.String>(this T t, System.Int64 u, System.String v)",
+            method.AssociatedExtensionImplementation.ToTestDisplayString());
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/78606")]

--- a/src/Compilers/Core/Portable/Symbols/IMethodSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IMethodSymbol.cs
@@ -305,7 +305,6 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         bool IsIterator { get; }
 
-        // Tracked by https://github.com/dotnet/roslyn/issues/78957 : public API, add support for constructed symbols
         /// <summary>
         /// For a method/accessor/operator in an extension block, returns the corresponding implementation method if one exists.
         /// Returns null otherwise.

--- a/src/Compilers/Core/Portable/Symbols/IMethodSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IMethodSymbol.cs
@@ -320,7 +320,10 @@ namespace Microsoft.CodeAnalysis
         /// }
         /// </code>
         /// When given the method symbol for <c>E.extension(int i).M()</c>,
-        /// it will return the corresponding static implementation method <c>E.M(this int i)</c>.
+        /// it returns the corresponding static implementation method <c>E.M(this int i)</c>.
+        ///
+        /// When given a generic extension member definition, it returns an implementation method constructed
+        /// with the extension member's type parameters.
         /// </summary>
         IMethodSymbol? AssociatedExtensionImplementation { get; }
     }

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -832,7 +832,7 @@ public abstract class SyntaxGenerator : ILanguageService
                     {
                         if (extensionMember is IMethodSymbol { OriginalDefinition.AssociatedExtensionImplementation: { } toShadow })
                         {
-                            implementationsToHide.Add(toShadow);
+                            implementationsToHide.Add(toShadow.OriginalDefinition);
                         }
                     }
                 }

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -830,7 +830,7 @@ public abstract class SyntaxGenerator : ILanguageService
                 {
                     foreach (var extensionMember in nested.GetMembers())
                     {
-                        if (extensionMember is IMethodSymbol { OriginalDefinition.AssociatedExtensionImplementation: { } toShadow })
+                        if (extensionMember is IMethodSymbol { AssociatedExtensionImplementation: { } toShadow })
                         {
                             implementationsToHide.Add(toShadow.OriginalDefinition);
                         }


### PR DESCRIPTION
Addresses part of https://github.com/dotnet/roslyn/issues/78957 ("AssociatedExtensionImplementation should work on constructed symbols (currently only definitions)")
Closes https://github.com/dotnet/roslyn/issues/80167
Relates to test plan https://github.com/dotnet/roslyn/issues/76130