### PR TITLE
Ensure custom attributes bag of a parameter backing field is properly initialized during "completion" of a primary constructor.

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -3997,7 +3997,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeWithState convertCollection(BoundCollectionExpression node, TypeWithAnnotations targetCollectionType, ArrayBuilder<Func<TypeWithAnnotations, TypeSymbol, TypeWithState>> completions)
             {
                 var strippedTargetCollectionType = targetCollectionType.Type.StrippedType();
-                Debug.Assert(TypeSymbol.Equals(strippedTargetCollectionType, node.Type, TypeCompareKind.IgnoreNullableModifiersForReferenceTypes));
+                Debug.Assert(TypeSymbol.Equals(strippedTargetCollectionType, node.Type, TypeCompareKind.AllIgnoreOptions));
 
                 // https://github.com/dotnet/roslyn/issues/68786: Use inferInitialObjectState() to set the initial
                 // state of the instance: see the call to InheritNullableStateOfTrackableStruct() in particular.

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -901,15 +901,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     case CompletionPart.Attributes:
                         GetAttributes();
-
-                        if (this is SynthesizedPrimaryConstructor primaryConstructor)
-                        {
-                            // The constructor is responsible for completion of the backing fields
-                            foreach (var field in primaryConstructor.GetBackingFields())
-                            {
-                                field.GetAttributes();
-                            }
-                        }
                         break;
 
                     case CompletionPart.ReturnTypeAttributes:
@@ -925,6 +916,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         foreach (var parameter in this.Parameters)
                         {
                             parameter.ForceComplete(locationOpt, filter: null, cancellationToken);
+                        }
+
+                        if (this is SynthesizedPrimaryConstructor primaryConstructor)
+                        {
+                            // The constructor is responsible for completion of the backing fields
+                            foreach (var field in primaryConstructor.GetBackingFields())
+                            {
+                                field.GetAttributes();
+                            }
                         }
 
                         state.NotePartComplete(CompletionPart.Parameters);

--- a/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
@@ -3502,7 +3502,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     'From a type T? to a type S?
                     conv = ClassifyPredefinedConversion(srcUnderlying, dstUnderlying, useSiteInfo)
                     Debug.Assert((conv And ConversionKind.VarianceConversionAmbiguity) = 0)
-                    Debug.Assert((conv And ConversionKind.DelegateRelaxationLevelMask) = 0 OrElse (conv And ConversionKind.Tuple) <> 0)
+                    Debug.Assert(Not ConversionExists(conv) OrElse (conv And ConversionKind.DelegateRelaxationLevelMask) = 0 OrElse (conv And ConversionKind.Tuple) <> 0)
 
                     If IsWideningConversion(conv) Then
                         'From a type T? to a type S?, where there is a widening conversion from the type T to the type S.
@@ -3531,7 +3531,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return ConversionKind.NarrowingNullable
                 Else
                     conv = ClassifyPredefinedConversion(srcUnderlying, destination, useSiteInfo)
-                    Debug.Assert((conv And ConversionKind.DelegateRelaxationLevelMask) = 0 OrElse (conv And ConversionKind.Tuple) <> 0)
+                    Debug.Assert(Not ConversionExists(conv) OrElse (conv And ConversionKind.DelegateRelaxationLevelMask) = 0 OrElse (conv And ConversionKind.Tuple) <> 0)
 
                     If ConversionExists(conv) Then
                         'From a type S? to a type T, where there is a conversion from the type S to the type T.
@@ -3550,7 +3550,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 Dim conv = ClassifyPredefinedConversion(source, dstUnderlying, useSiteInfo)
                 Debug.Assert((conv And ConversionKind.VarianceConversionAmbiguity) = 0)
-                Debug.Assert((conv And ConversionKind.DelegateRelaxationLevelMask) = 0 OrElse (conv And ConversionKind.Tuple) <> 0)
+                Debug.Assert(Not ConversionExists(conv) OrElse (conv And ConversionKind.DelegateRelaxationLevelMask) = 0 OrElse (conv And ConversionKind.Tuple) <> 0)
 
                 If IsWideningConversion(conv) Then
                     'From a type T to a type S?, where there is a widening conversion from the type T to the type S.


### PR DESCRIPTION
Closes #78433
Closes #78188

Also relaxed some asserts that looked to "tight" and were blocking investigation.