### PR TITLE
Make method non-generic

### DIFF
--- a/src/Features/Core/Portable/CodeFixes/Service/CodeFixService.cs
+++ b/src/Features/Core/Portable/CodeFixes/Service/CodeFixService.cs
@@ -280,19 +280,25 @@ internal sealed partial class CodeFixService : ICodeFixService
     }
 
     public async Task<CodeFixCollection?> GetDocumentFixAllForIdInSpanAsync(
-        TextDocument document, TextSpan range, string diagnosticId, DiagnosticSeverity minimumSeverity, CancellationToken cancellationToken)
+        Document document, TextSpan? textSpan, string diagnosticId, DiagnosticSeverity minimumSeverity, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
         using var _ = TelemetryLogging.LogBlockTimeAggregatedHistogram(FunctionId.CodeFix_Summary, $"{nameof(GetDocumentFixAllForIdInSpanAsync)}");
         ImmutableArray<DiagnosticData> diagnostics;
 
+        if (textSpan is null)
+        {
+            var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
+            textSpan = new TextSpan(0, text.Length);
+        }
+
         using (TelemetryLogging.LogBlockTimeAggregatedHistogram(
             FunctionId.CodeFix_Summary, $"{nameof(GetDocumentFixAllForIdInSpanAsync)}.{nameof(IDiagnosticAnalyzerService.GetDiagnosticsForSpanAsync)}"))
         {
             var service = document.Project.Solution.Services.GetRequiredService<IDiagnosticAnalyzerService>();
             diagnostics = await service.GetDiagnosticsForSpanAsync(
-                document, range, diagnosticId, priority: null,
+                document, textSpan, diagnosticId, priority: null,
                 DiagnosticKind.All, cancellationToken).ConfigureAwait(false);
 
             // NOTE(cyrusn): We do not include suppressed diagnostics here as they are effectively hidden from the
@@ -305,15 +311,13 @@ internal sealed partial class CodeFixService : ICodeFixService
         if (!diagnostics.Any())
             return null;
 
-        using var resultDisposer = ArrayBuilder<CodeFixCollection>.GetInstance(out var result);
         var spanToDiagnostics = new SortedDictionary<TextSpan, List<DiagnosticData>>
         {
-            { range, diagnostics.ToList() },
+            { textSpan.Value, diagnostics.ToList() },
         };
 
         await foreach (var collection in StreamFixesAsync(
-            document, spanToDiagnostics, fixAllForInSpan: true, priority: null,
-            cancellationToken).ConfigureAwait(false))
+            document, spanToDiagnostics, fixAllForInSpan: true, priority: null, cancellationToken).ConfigureAwait(false))
         {
             if (collection.FixAllState is not null && collection.SupportedScopes.Contains(FixAllScope.Document))
             {
@@ -328,6 +332,7 @@ internal sealed partial class CodeFixService : ICodeFixService
 
     public async Task<Document> ApplyCodeFixesForSpecificDiagnosticIdAsync(
         Document document,
+        TextSpan? textSpan,
         string diagnosticId,
         DiagnosticSeverity severity,
         IProgress<CodeAnalysisProgress> progressTracker,
@@ -335,15 +340,10 @@ internal sealed partial class CodeFixService : ICodeFixService
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
-        var textSpan = new TextSpan(0, text.Length);
-
         var fixCollection = await GetDocumentFixAllForIdInSpanAsync(
             document, textSpan, diagnosticId, severity, cancellationToken).ConfigureAwait(false);
         if (fixCollection == null)
-        {
             return document;
-        }
 
         var fixAllService = document.Project.Solution.Services.GetRequiredService<IFixAllGetFixesService>();
 

--- a/src/Features/Core/Portable/CodeFixes/Service/ICodeFixService.cs
+++ b/src/Features/Core/Portable/CodeFixes/Service/ICodeFixService.cs
@@ -23,8 +23,9 @@ internal interface ICodeFixService
     /// </summary>
     Task<CodeFixCollection?> GetMostSevereFixAsync(TextDocument document, TextSpan range, CodeActionRequestPriority? priority, CancellationToken cancellationToken);
 
-    Task<CodeFixCollection?> GetDocumentFixAllForIdInSpanAsync(TextDocument document, TextSpan textSpan, string diagnosticId, DiagnosticSeverity severity, CancellationToken cancellationToken);
-    Task<Document> ApplyCodeFixesForSpecificDiagnosticIdAsync(Document document, string diagnosticId, DiagnosticSeverity severity, IProgress<CodeAnalysisProgress> progressTracker, CancellationToken cancellationToken);
+    Task<CodeFixCollection?> GetDocumentFixAllForIdInSpanAsync(Document document, TextSpan? textSpan, string diagnosticId, DiagnosticSeverity severity, CancellationToken cancellationToken);
+    Task<Document> ApplyCodeFixesForSpecificDiagnosticIdAsync(Document document, TextSpan? textSpan, string diagnosticId, DiagnosticSeverity severity, IProgress<CodeAnalysisProgress> progressTracker, CancellationToken cancellationToken);
+
     CodeFixProvider? GetSuppressionFixer(string language, IEnumerable<string> diagnosticIds);
 }
 

--- a/src/LanguageServer/Protocol/Features/CodeCleanup/AbstractCodeCleanupService.cs
+++ b/src/LanguageServer/Protocol/Features/CodeCleanup/AbstractCodeCleanupService.cs
@@ -184,11 +184,8 @@ internal abstract class AbstractCodeCleanupService(ICodeFixService codeFixServic
     private async Task<Document> ApplyCodeFixesForSpecificDiagnosticIdAsync(
         Document document, string diagnosticId, DiagnosticSeverity minimumSeverity, IProgress<CodeAnalysisProgress> progressTracker, CancellationToken cancellationToken)
     {
-        var tree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-        var textSpan = new TextSpan(0, tree.Length);
-
         var fixCollection = await _codeFixService.GetDocumentFixAllForIdInSpanAsync(
-            document, textSpan, diagnosticId, minimumSeverity, cancellationToken).ConfigureAwait(false);
+            document, textSpan: null, diagnosticId, minimumSeverity, cancellationToken).ConfigureAwait(false);
         if (fixCollection == null)
         {
             return document;
@@ -243,7 +240,7 @@ internal abstract class AbstractCodeCleanupService(ICodeFixService codeFixServic
             progressTracker.Report(CodeAnalysisProgress.Description(string.Format(FeaturesResources.Fixing_0, title ?? diagnosticId)));
             // Apply codefixes for diagnostics with a severity of warning or higher
             var updatedDocument = await _codeFixService.ApplyCodeFixesForSpecificDiagnosticIdAsync(
-                document, diagnosticId, DiagnosticSeverity.Warning, progressTracker, cancellationToken).ConfigureAwait(false);
+                document, textSpan: null, diagnosticId, DiagnosticSeverity.Warning, progressTracker, cancellationToken).ConfigureAwait(false);
 
             // If changes were made to the solution snap shot outside the current document discard the changes.
             // The assumption here is that if we are applying a third party code fix to a document it only affects the document.


### PR DESCRIPTION
The generic aspect of this was never exercised (it was called by one client which always used the same type).