### PR TITLE
Fix check for extension params parameter in nullable analysis

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -8353,7 +8353,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var type = parameter.TypeWithAnnotations;
-            if (expanded && parameter.Ordinal == parametersOpt.Length - 1)
+            if (expanded && (object)parameter == parametersOpt[^1])
             {
                 if (!paramsIterationType.HasType)
                 {


### PR DESCRIPTION
Closes #80024

For a static extension call, the receiver type is included as an "argument" so that it can contribute to type (re)inference. The `parameters` used to analyze the call is adjusted accordingly to include the extension parameter. See [`getParameters()` helper on line 6752](https://github.com/dotnet/roslyn/blame/b4f64f4bbedbc6c4168cc1577aac507389d8b48b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs#L6752). I think a similar adjustment is also made in overload resolution and possibly elsewhere.

The `Ordinal`s of the parameter symbols are not adjusted based on this, so using them to decide if a parameter is the "last parameter in the list" is buggy. Instead, helper `Binder.GetCorrespondingParameter` already gave us the right symbol, so, we can just do a more direct check for whether the parameter we got, was the "last parameter in the list".

Relates to test plan https://github.com/dotnet/roslyn/issues/76130
