### PR TITLE
Fix a few Replay issues

### DIFF
--- a/src/Tools/Replay/Replay.cs
+++ b/src/Tools/Replay/Replay.cs
@@ -146,11 +146,22 @@ static async Task<(TimeSpan BuildTime, TimeSpan TotalTime)> RunOneAsync(List<Com
     var stopwatch = new Stopwatch();
     stopwatch.Start();
     TimeSpan buildTime;
+
     try
     {
         await foreach (var buildData in BuildAllAsync(options, compilerCalls, compilerServerLogger, CancellationToken.None).ConfigureAwait(false))
         {
-            Console.WriteLine($"{buildData.CompilerCall.GetDiagnosticName()} ... {buildData.BuildResponse.Type}");
+            if (buildData.BuildResponse is not CompletedBuildResponse completedBuildResponse)
+            {
+                throw new Exception($"Error sending build request to server: {buildData.BuildResponse.Type}");
+            }
+
+            var succeeded = completedBuildResponse.ReturnCode == 0;
+            Console.WriteLine($"{buildData.CompilerCall.GetDiagnosticName()} ... {(succeeded ? "Succeeded" : "Failed")}");
+            if (!succeeded)
+            {
+                Console.WriteLine(completedBuildResponse.Output);
+            }
         }
 
         buildTime = stopwatch.Elapsed;
@@ -220,9 +231,12 @@ static async IAsyncEnumerable<BuildData> BuildAllAsync(
             name = $"{compilerCall.ProjectFileName}-{compilerCall.TargetFramework}-{compilerCall.Kind}";
         }
 
-        if (!outputSet.Add(name))
+        var rootName = name;
+        var count = 0;
+        while (!outputSet.Add(name))
         {
-            name = $"{name}-{outputSet.Count}";
+            name = $"{rootName}-{count}";
+            count++;
         }
 
         return name;


### PR DESCRIPTION
Fixed a few small issues

1. The tool wasn't properly detecting failed compilations just failed server communications. Changed it to be declarative when builds failed
2. Made clashing output names more regular. The number suffix per output name vs. the entire build