### PR TITLE
Improve diagnostic location for top-level-program with a reachable end

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/FlowAnalysisPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/FlowAnalysisPass.cs
@@ -100,7 +100,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // have already reported a non-void partial method error.
                 else if (method.Locations.Length == 1)
                 {
-                    diagnostics.Add(ErrorCode.ERR_ReturnExpected, method.GetFirstLocation(), method);
+                    var location = method is SynthesizedSimpleProgramEntryPointSymbol entryPoint
+                        ? entryPoint.ReturnTypeSyntax.GetLocation()
+                        : method.GetFirstLocation();
+                    diagnostics.Add(ErrorCode.ERR_ReturnExpected, location, method);
                 }
             }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TopLevelStatementsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TopLevelStatementsTests.cs
@@ -1571,7 +1571,7 @@ string e() => ""1"";
             Assert.Equal(CodeAnalysis.NullableFlowState.MaybeNull, model1.GetTypeInfo(reference).Nullability.FlowState);
         }
 
-        [Fact]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/80487")]
         public void FlowAnalysis_02()
         {
             var text = @"
@@ -1583,18 +1583,10 @@ if (args.Length == 0)
 }
 ";
 
-            var comp = CreateCompilation(text, options: TestOptions.DebugExe, parseOptions: DefaultParseOptions);
-            comp.VerifyDiagnostics(
+            CreateCompilation(text, options: TestOptions.DebugExe, parseOptions: DefaultParseOptions).VerifyDiagnostics(
                 // (2,1): error CS0161: '<top-level-statements-entry-point>': not all code paths return a value
                 // System.Console.WriteLine();
-                Diagnostic(ErrorCode.ERR_ReturnExpected, @"System.Console.WriteLine();
-
-if (args.Length == 0)
-{
-    return 10;
-}
-").WithArguments("<top-level-statements-entry-point>").WithLocation(2, 1)
-                );
+                Diagnostic(ErrorCode.ERR_ReturnExpected, "System.Console.WriteLine();").WithArguments("<top-level-statements-entry-point>").WithLocation(2, 1));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/80487