### PR TITLE
Add support for `with(...)` elements in collection expressions.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -1161,14 +1161,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return true;
                 }
 
-                // For params, we want to see, up front, if this type is suitable as a params collection. To do that, we
-                // explicitly go look to see if there is a suitable constructor that we can find that takes no arguments
-                // (not exactly the same the same as a no-params constructor).  If not, there is no collection conversion
-                // and params is not allowed.
+                // From the specification: https://github.com/dotnet/csharplang/blob/main/proposals/collection-expression-arguments.md#conversions
                 //
-                // For collection expressions, except in the case where it has a with() element.  In that case, it's ok
-                // to not have a no-arg constructor.  It just needs *some* constructor that would be accessible to the
-                // caller.  They can then potentially instantiate the type through one of those constructors.
+                // A struct or class type that implements System.Collections.IEnumerable where:
+                //
+                // a. the collection expression has no `with_element` and the type has an applicable constructor
+                //    that can be invoked with no arguments, accessible at the location of the collection expression.or
+                // b. the collection expression has a `with_element` and the type has at least one constructor
+                //    accessible at the location of the collection expression.
+
+                // This is the 'b' case above. 
                 if (hasWithElement)
                 {
                     var useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
@@ -1189,6 +1191,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // don't have the no-arg one, and should report the below message saying there is a problem.
                 }
 
+                // This is the 'a' case, and the error recovery path for the 'b' case as well.
                 var analyzedArguments = AnalyzedArguments.GetInstance();
                 var binder = new ParamsCollectionTypeInProgressBinder(namedType, this);
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -928,7 +928,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             else
             {
                 // PROTOTYPE: Add support for interfaces and Create methods.  Keep diagnostic for arrays/spans.
-                if (node.WithElement != null && collectionTypeKind)
+                if (node.WithElement != null)
                 {
                     diagnostics.Add(
                         ErrorCode.ERR_CollectionArgumentsNotSupportedForType,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -1106,23 +1106,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var binder = new ParamsCollectionTypeInProgressBinder(namedType, this, constructor);
                 collectionCreation = binder.BindClassCreationExpression(syntax, namedType.Name, syntax, namedType, analyzedArguments, diagnostics);
-
-                // PROTOTYPE: If this failed to bind a suitable constructor, and the user had no with() element and
-                // there was no constructor that could be called with no args, report a special diagnostic that a 
-                // 'with()' element is required here.
+                collectionCreation.WasCompilerGenerated = true;
             }
             else if (targetType is TypeParameterSymbol typeParameter)
             {
                 collectionCreation = BindTypeParameterCreationExpression(syntax, typeParameter, analyzedArguments, initializerOpt: null, typeSyntax: syntax, wasTargetTyped: true, diagnostics);
+                collectionCreation.WasCompilerGenerated = true;
             }
             else
             {
                 throw ExceptionUtilities.UnexpectedValue(targetType);
             }
-
             analyzedArguments.Free();
-
-            collectionCreation.WasCompilerGenerated = true;
             return collectionCreation;
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -928,7 +928,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             else
             {
                 // PROTOTYPE: Add support for interfaces and Create methods.  Keep diagnostic for arrays/spans.
-                if (node.WithElement != null)
+                if (node.WithElement != null && collectionTypeKind)
                 {
                     diagnostics.Add(
                         ErrorCode.ERR_CollectionArgumentsNotSupportedForType,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -5388,7 +5388,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (withElementSyntax == syntax.Elements.First())
                 {
                     // Got a with-element, and it was in the right place.  Pass it along directly in
-                    // unconverted-collection-expression so that we can construct the collectin properly.
+                    // unconverted-collection-expression so that we can construct the collection properly.
                     withElement = new BoundUnconvertedWithElement(
                         withElementSyntax,
                         analyzedArguments.Arguments.ToImmutable(),

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -12,7 +12,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Xml.Linq;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -5380,6 +5380,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var arg = arguments[i];
                     if (arg.Type is { TypeKind: TypeKind.Dynamic })
                     {
+                        // Collection arguments cannot be dynamic
                         diagnostics.Add(ErrorCode.ERR_CollectionArgumentsDynamicBinding, arg.Syntax);
                         arguments[i] = new BoundBadExpression(
                             arg.Syntax, LookupResultKind.Empty, symbols: [], childBoundNodes: [arg], type: @this.Compilation.GetSpecialType(SpecialType.System_Object));

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -5404,9 +5404,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     diagnostics.Add(ErrorCode.ERR_CollectionArgumentsMustBeFirst, withElementSyntax.WithKeyword);
 
                     withElement = null;
-                    badExpression = MakeBadExpressionForObjectCreation(
-                        withElementSyntax, this.Compilation.GetSpecialType(SpecialType.System_Object),
-                        analyzedArguments, initializerOpt: null, typeSyntax: null, diagnostics);
+                    badExpression = BadExpression(withElementSyntax, BuildArgumentsForErrorRecovery(analyzedArguments));
                 }
 
                 analyzedArguments.Free();

--- a/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
@@ -1081,6 +1081,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        public override BoundNode? VisitCollectionExpression(BoundCollectionExpression node)
+        {
+            Visit(node.CollectionCreation);
+            VisitList(node.Elements);
+            return null;
+        }
+
         public override BoundNode? VisitImplicitIndexerAccess(BoundImplicitIndexerAccess node)
         {
             // Verify we're only skipping placeholders for int values, where the escape scope is always CallingMethod.

--- a/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
@@ -1084,6 +1084,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitCollectionExpression(BoundCollectionExpression node)
         {
             Visit(node.CollectionCreation);
+            // PROTOTYPE: There seem to be no tests affected by this line.  See if we can produce something
+            // affected by this.
             VisitList(node.Elements);
             return null;
         }

--- a/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
@@ -1081,15 +1081,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        public override BoundNode? VisitCollectionExpression(BoundCollectionExpression node)
-        {
-            Visit(node.CollectionCreation);
-            // PROTOTYPE: There seem to be no tests affected by this line.  See if we can produce something
-            // affected by this.
-            VisitList(node.Elements);
-            return null;
-        }
-
         public override BoundNode? VisitImplicitIndexerAccess(BoundImplicitIndexerAccess node)
         {
             // Verify we're only skipping placeholders for int values, where the escape scope is always CallingMethod.

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/CollectionExpressionTypeKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/CollectionExpressionTypeKind.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ImplementsIEnumerable,
 
         /// <summary>
-        /// One of the well-known interfaces that can be implemented by an array:
+        /// One of the well-known interfaces known to be implemented by any array:
         /// <list type="bullet">
         /// <item><see cref="IReadOnlyCollection{T}"/></item>
         /// <item><see cref="IReadOnlyList{T}"/></item>

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/CollectionExpressionTypeKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/CollectionExpressionTypeKind.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+
 namespace Microsoft.CodeAnalysis.CSharp
 {
     internal enum CollectionExpressionTypeKind
@@ -12,6 +14,16 @@ namespace Microsoft.CodeAnalysis.CSharp
         ReadOnlySpan,
         CollectionBuilder,
         ImplementsIEnumerable,
+
+        /// <summary>
+        /// One of the well-known interfaces that can be implemented by an array:
+        /// <list type="bullet">
+        /// <item><see cref="IReadOnlyCollection{T}"/></item>
+        /// <item><see cref="IReadOnlyList{T}"/></item>
+        /// <item><see cref="ICollection{T}"/></item>
+        /// <item><see cref="IList{T}"/></item>
+        /// </list>
+        /// </summary>
         ArrayInterface,
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
@@ -216,8 +216,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 builder.Add(elementConversion);
             }
 
-            return Conversion.CreateCollectionExpressionConversion(
-                collectionTypeKind, elementType, constructor, isExpanded, builder.ToImmutableAndFree());
+            return Conversion.CreateCollectionExpressionConversion(collectionTypeKind, elementType, constructor, isExpanded, builder.ToImmutableAndFree());
 
             Conversion convertElement(BoundNode element, TypeSymbol elementType, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
             {

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1955,7 +1955,7 @@
     <!-- An expression placeholder value representing the initialized collection. -->
     <Field Name="Placeholder" Type="BoundObjectOrCollectionValuePlaceholder?" Null="allow" SkipInVisitor="true"/>
     <!-- Call to instantiate a collection with a constructor. -->
-    <Field Name="CollectionCreation" Type="BoundExpression?" Null="allow" SkipInVisitor="true"/>
+    <Field Name="CollectionCreation" Type="BoundExpression?" Null="allow" />
     <!-- Construct method for collection types with [CollectionBuilder]. -->
     <Field Name="CollectionBuilderMethod" Type="MethodSymbol?" Null="allow"/>
     <!-- Placeholder for collection builder method invocation. -->

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1952,7 +1952,7 @@
     <Field Name="CollectionTypeKind" Type="CollectionExpressionTypeKind"/>
     <!-- An expression placeholder value representing the initialized collection. -->
     <Field Name="Placeholder" Type="BoundObjectOrCollectionValuePlaceholder?" Null="allow" SkipInVisitor="true"/>
-    <!-- Constructor call to create the empty collection type. -->
+    <!-- Call to instantiate a collection with a constructor. -->
     <Field Name="CollectionCreation" Type="BoundExpression?" Null="allow" SkipInVisitor="true"/>
     <!-- Construct method for collection types with [CollectionBuilder]. -->
     <Field Name="CollectionBuilderMethod" Type="MethodSymbol?" Null="allow"/>

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1935,7 +1935,9 @@
     <!-- Type is not significant for this node type; always null -->
     <Field Name="Type" Type="TypeSymbol?" Override="true" Null="always"/>
     
-    <!-- With-arguments support for collection expression with(...) syntax -->
+    <!-- With-arguments support for collection expression with(...) syntax.
+         PROTOTYPE: Keep these stored separately like this, or place in the
+         BoundCollectionExpressionBase.Elements collection? -->
     <Field Name="WithElement" Type="BoundUnconvertedWithElement?" Null="allow"/>
   </Node>
 

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -8206,12 +8206,12 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>collection expression arguments</value>
   </data>
   <data name="ERR_CollectionArgumentsMustBeFirst" xml:space="preserve">
-    <value>Collection argument element must be the first element.</value>
+    <value>Collection argument element must be the first element</value>
   </data>
   <data name="ERR_CollectionArgumentsNotSupportedForType" xml:space="preserve">
-    <value>Collection arguments are not supported for type '{0}'.</value>
+    <value>Collection arguments are not supported for type '{0}'</value>
   </data>
   <data name="ERR_CollectionArgumentsDynamicBinding" xml:space="preserve">
-    <value>Collection arguments cannot be dynamic; compile-time binding is required.</value>
+    <value>Collection arguments cannot be dynamic</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -8206,12 +8206,12 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>collection expression arguments</value>
   </data>
   <data name="ERR_CollectionArgumentsMustBeFirst" xml:space="preserve">
-    <value>Collection argument element must be the first element</value>
+    <value>'with(...)' element must be the first element</value>
   </data>
   <data name="ERR_CollectionArgumentsNotSupportedForType" xml:space="preserve">
-    <value>Collection arguments are not supported for type '{0}'</value>
+    <value>'with(...)' elements are not supported for type '{0}'</value>
   </data>
   <data name="ERR_CollectionArgumentsDynamicBinding" xml:space="preserve">
-    <value>Collection arguments cannot be dynamic</value>
+    <value>'with(...)' element arguments cannot be dynamic</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -8211,4 +8211,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_CollectionArgumentsNotSupportedForType" xml:space="preserve">
     <value>Collection arguments are not supported for type '{0}'.</value>
   </data>
+  <data name="ERR_CollectionArgumentsDynamicBinding" xml:space="preserve">
+    <value>Collection arguments cannot be dynamic; compile-time binding is required.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2430,9 +2430,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_ExplicitInterfaceMemberTypeMismatch = 9333,
         ERR_ExplicitInterfaceMemberReturnTypeMismatch = 9334,
 
-        ERR_CollectionArgumentsMustBeFirst = 9335,
-        ERR_CollectionArgumentsNotSupportedForType = 9336,
-        ERR_CollectionArgumentsDynamicBinding = 9337,
+        // PROTOTYPE: Renumber accordingly.
+        ERR_CollectionArgumentsMustBeFirst = 9400,
+        ERR_CollectionArgumentsNotSupportedForType = 9401,
+        ERR_CollectionArgumentsDynamicBinding = 9402,
 
         // Note: you will need to do the following after adding errors:
         //  1) Update ErrorFacts.IsBuildOnlyDiagnostic (src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs)

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2432,6 +2432,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         ERR_CollectionArgumentsMustBeFirst = 9335,
         ERR_CollectionArgumentsNotSupportedForType = 9336,
+        ERR_CollectionArgumentsDynamicBinding = 9337,
 
         // Note: you will need to do the following after adding errors:
         //  1) Update ErrorFacts.IsBuildOnlyDiagnostic (src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs)

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -2540,6 +2540,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 or ErrorCode.ERR_ExplicitInterfaceMemberReturnTypeMismatch
                 or ErrorCode.ERR_CollectionArgumentsMustBeFirst
                 or ErrorCode.ERR_CollectionArgumentsNotSupportedForType
+                or ErrorCode.ERR_CollectionArgumentsDynamicBinding
                     => false,
             };
 #pragma warning restore CS8524 // The switch expression does not handle some values of its input type (it is not exhaustive) involving an unnamed enum value.

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -2074,9 +2074,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitCollectionExpression(BoundCollectionExpression node)
         {
-            if (node.HasWithElement)
-                this.Visit(node.CollectionCreation);
-
+            Visit(node.CollectionCreation);
             VisitCollectionExpression(node.Elements);
             return null;
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -3869,6 +3869,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             // When the target-typing conversion is processed, the completion continuation will be given a target-type and
             // we'll be able to process the element conversions and compute the final visit result.
 
+            // PROTOTYPE: Visit node.CollectionCreation as well?
+
             var (collectionKind, targetElementType) = getCollectionDetails(node, node.Type);
 
             var resultBuilder = ArrayBuilder<VisitResult>.GetInstance(node.Elements.Length);

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -10580,6 +10580,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitCollectionExpression(BoundCollectionExpression node)
         {
+            this.Visit(node.CollectionCreation);
             this.VisitList(node.Elements);
             return null;
         }
@@ -11991,7 +11992,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             MethodSymbol? collectionBuilderMethod = this.VisitMethodSymbol(node.CollectionBuilderMethod);
             BoundObjectOrCollectionValuePlaceholder? placeholder = node.Placeholder;
-            BoundExpression? collectionCreation = node.CollectionCreation;
+            BoundExpression? collectionCreation = (BoundExpression?)this.Visit(node.CollectionCreation);
             BoundValuePlaceholder? collectionBuilderInvocationPlaceholder = node.CollectionBuilderInvocationPlaceholder;
             BoundExpression? collectionBuilderInvocationConversion = node.CollectionBuilderInvocationConversion;
             BoundUnconvertedCollectionExpression unconvertedCollectionExpression = node.UnconvertedCollectionExpression;
@@ -14274,7 +14275,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             MethodSymbol? collectionBuilderMethod = GetUpdatedSymbol(node, node.CollectionBuilderMethod);
             BoundObjectOrCollectionValuePlaceholder? placeholder = node.Placeholder;
-            BoundExpression? collectionCreation = node.CollectionCreation;
+            BoundExpression? collectionCreation = (BoundExpression?)this.Visit(node.CollectionCreation);
             BoundValuePlaceholder? collectionBuilderInvocationPlaceholder = node.CollectionBuilderInvocationPlaceholder;
             BoundExpression? collectionBuilderInvocationConversion = node.CollectionBuilderInvocationConversion;
             BoundUnconvertedCollectionExpression unconvertedCollectionExpression = node.UnconvertedCollectionExpression;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
@@ -11,8 +11,6 @@ using Microsoft.CodeAnalysis.CSharp.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
-using static Microsoft.CodeAnalysis.CSharp.NullableWalker;
-using static Microsoft.CodeAnalysis.CSharp.SyntaxTokenParser;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
@@ -11,6 +11,8 @@ using Microsoft.CodeAnalysis.CSharp.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
+using static Microsoft.CodeAnalysis.CSharp.NullableWalker;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxTokenParser;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -44,6 +46,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case CollectionExpressionTypeKind.ImplementsIEnumerable:
                         // Don't optimize if the node has an explicit `with(...)` in it.  The code is being explicit
                         // about which constructor to use and we should respect that.
+                        //
+                        // Note this falls out from the original collection expression specification which says:
+                        //
+                        // Known length translation:
+                        //
+                        //      Having a known length allows for efficient construction of a result with the potential
+                        //      for no copying of data and no unnecessary slack space in a result.
+                        //
+                        //      For a known length literal [e1, ..s1, etc] ...
+                        //
+                        // So once we have a `with(...)` element we no longer match the pattern for a known length literal.
                         if (!node.HasWithElement &&
                             ConversionsBase.IsSpanOrListType(_compilation, node.Type, WellKnownType.System_Collections_Generic_List_T, out var listElementType))
                         {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
@@ -55,6 +55,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         //      For a known length literal [e1, ..s1, etc] ...
                         //
                         // So once we have a `with(...)` element we no longer match the pattern for a known length literal.
+                        //
+                        // PROTOTYPE: Revisit this.  We should not let construction be changed.  But we could still
+                        // have optimizations like calling .AddRange(spreadedElement) for `[.. spreadedElement]`.
+                        // Ensure that we're not giving that up.
                         if (!node.HasWithElement &&
                             ConversionsBase.IsSpanOrListType(_compilation, node.Type, WellKnownType.System_Collections_Generic_List_T, out var listElementType))
                         {

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -493,18 +493,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
-        <source>Collection arguments cannot be dynamic</source>
-        <target state="new">Collection arguments cannot be dynamic</target>
+        <source>'with(...)' element arguments cannot be dynamic</source>
+        <target state="new">'with(...)' element arguments cannot be dynamic</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
-        <source>Collection argument element must be the first element</source>
-        <target state="new">Collection argument element must be the first element</target>
+        <source>'with(...)' element must be the first element</source>
+        <target state="new">'with(...)' element must be the first element</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
-        <source>Collection arguments are not supported for type '{0}'</source>
-        <target state="new">Collection arguments are not supported for type '{0}'</target>
+        <source>'with(...)' elements are not supported for type '{0}'</source>
+        <target state="new">'with(...)' elements are not supported for type '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -492,6 +492,11 @@
         <target state="translated">{0} neimplementuje člen rozhraní {1}. {2} nemůže implementovat {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
+        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
+        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
         <source>Collection argument element must be the first element.</source>
         <target state="new">Collection argument element must be the first element.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -493,18 +493,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
-        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
-        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <source>Collection arguments cannot be dynamic</source>
+        <target state="new">Collection arguments cannot be dynamic</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
-        <source>Collection argument element must be the first element.</source>
-        <target state="new">Collection argument element must be the first element.</target>
+        <source>Collection argument element must be the first element</source>
+        <target state="new">Collection argument element must be the first element</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
-        <source>Collection arguments are not supported for type '{0}'.</source>
-        <target state="new">Collection arguments are not supported for type '{0}'.</target>
+        <source>Collection arguments are not supported for type '{0}'</source>
+        <target state="new">Collection arguments are not supported for type '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -493,18 +493,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
-        <source>Collection arguments cannot be dynamic</source>
-        <target state="new">Collection arguments cannot be dynamic</target>
+        <source>'with(...)' element arguments cannot be dynamic</source>
+        <target state="new">'with(...)' element arguments cannot be dynamic</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
-        <source>Collection argument element must be the first element</source>
-        <target state="new">Collection argument element must be the first element</target>
+        <source>'with(...)' element must be the first element</source>
+        <target state="new">'with(...)' element must be the first element</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
-        <source>Collection arguments are not supported for type '{0}'</source>
-        <target state="new">Collection arguments are not supported for type '{0}'</target>
+        <source>'with(...)' elements are not supported for type '{0}'</source>
+        <target state="new">'with(...)' elements are not supported for type '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -492,6 +492,11 @@
         <target state="translated">Der Schnittstellenmember "{1}" wird von "{0}" nicht implementiert. "{1}" kann von "{2}" nicht implementiert werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
+        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
+        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
         <source>Collection argument element must be the first element.</source>
         <target state="new">Collection argument element must be the first element.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -493,18 +493,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
-        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
-        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <source>Collection arguments cannot be dynamic</source>
+        <target state="new">Collection arguments cannot be dynamic</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
-        <source>Collection argument element must be the first element.</source>
-        <target state="new">Collection argument element must be the first element.</target>
+        <source>Collection argument element must be the first element</source>
+        <target state="new">Collection argument element must be the first element</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
-        <source>Collection arguments are not supported for type '{0}'.</source>
-        <target state="new">Collection arguments are not supported for type '{0}'.</target>
+        <source>Collection arguments are not supported for type '{0}'</source>
+        <target state="new">Collection arguments are not supported for type '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -493,18 +493,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
-        <source>Collection arguments cannot be dynamic</source>
-        <target state="new">Collection arguments cannot be dynamic</target>
+        <source>'with(...)' element arguments cannot be dynamic</source>
+        <target state="new">'with(...)' element arguments cannot be dynamic</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
-        <source>Collection argument element must be the first element</source>
-        <target state="new">Collection argument element must be the first element</target>
+        <source>'with(...)' element must be the first element</source>
+        <target state="new">'with(...)' element must be the first element</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
-        <source>Collection arguments are not supported for type '{0}'</source>
-        <target state="new">Collection arguments are not supported for type '{0}'</target>
+        <source>'with(...)' elements are not supported for type '{0}'</source>
+        <target state="new">'with(...)' elements are not supported for type '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -492,6 +492,11 @@
         <target state="translated">"{0}" no implementa el miembro de interfaz "{1}". "{2}" no puede implementar "{1}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
+        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
+        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
         <source>Collection argument element must be the first element.</source>
         <target state="new">Collection argument element must be the first element.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -493,18 +493,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
-        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
-        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <source>Collection arguments cannot be dynamic</source>
+        <target state="new">Collection arguments cannot be dynamic</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
-        <source>Collection argument element must be the first element.</source>
-        <target state="new">Collection argument element must be the first element.</target>
+        <source>Collection argument element must be the first element</source>
+        <target state="new">Collection argument element must be the first element</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
-        <source>Collection arguments are not supported for type '{0}'.</source>
-        <target state="new">Collection arguments are not supported for type '{0}'.</target>
+        <source>Collection arguments are not supported for type '{0}'</source>
+        <target state="new">Collection arguments are not supported for type '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -492,6 +492,11 @@
         <target state="translated">'{0}' n'implémente pas le membre d'interface '{1}'. '{2}' ne peut pas implémenter '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
+        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
+        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
         <source>Collection argument element must be the first element.</source>
         <target state="new">Collection argument element must be the first element.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -493,18 +493,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
-        <source>Collection arguments cannot be dynamic</source>
-        <target state="new">Collection arguments cannot be dynamic</target>
+        <source>'with(...)' element arguments cannot be dynamic</source>
+        <target state="new">'with(...)' element arguments cannot be dynamic</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
-        <source>Collection argument element must be the first element</source>
-        <target state="new">Collection argument element must be the first element</target>
+        <source>'with(...)' element must be the first element</source>
+        <target state="new">'with(...)' element must be the first element</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
-        <source>Collection arguments are not supported for type '{0}'</source>
-        <target state="new">Collection arguments are not supported for type '{0}'</target>
+        <source>'with(...)' elements are not supported for type '{0}'</source>
+        <target state="new">'with(...)' elements are not supported for type '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -493,18 +493,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
-        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
-        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <source>Collection arguments cannot be dynamic</source>
+        <target state="new">Collection arguments cannot be dynamic</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
-        <source>Collection argument element must be the first element.</source>
-        <target state="new">Collection argument element must be the first element.</target>
+        <source>Collection argument element must be the first element</source>
+        <target state="new">Collection argument element must be the first element</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
-        <source>Collection arguments are not supported for type '{0}'.</source>
-        <target state="new">Collection arguments are not supported for type '{0}'.</target>
+        <source>Collection arguments are not supported for type '{0}'</source>
+        <target state="new">Collection arguments are not supported for type '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -493,18 +493,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
-        <source>Collection arguments cannot be dynamic</source>
-        <target state="new">Collection arguments cannot be dynamic</target>
+        <source>'with(...)' element arguments cannot be dynamic</source>
+        <target state="new">'with(...)' element arguments cannot be dynamic</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
-        <source>Collection argument element must be the first element</source>
-        <target state="new">Collection argument element must be the first element</target>
+        <source>'with(...)' element must be the first element</source>
+        <target state="new">'with(...)' element must be the first element</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
-        <source>Collection arguments are not supported for type '{0}'</source>
-        <target state="new">Collection arguments are not supported for type '{0}'</target>
+        <source>'with(...)' elements are not supported for type '{0}'</source>
+        <target state="new">'with(...)' elements are not supported for type '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -493,18 +493,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
-        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
-        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <source>Collection arguments cannot be dynamic</source>
+        <target state="new">Collection arguments cannot be dynamic</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
-        <source>Collection argument element must be the first element.</source>
-        <target state="new">Collection argument element must be the first element.</target>
+        <source>Collection argument element must be the first element</source>
+        <target state="new">Collection argument element must be the first element</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
-        <source>Collection arguments are not supported for type '{0}'.</source>
-        <target state="new">Collection arguments are not supported for type '{0}'.</target>
+        <source>Collection arguments are not supported for type '{0}'</source>
+        <target state="new">Collection arguments are not supported for type '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -492,6 +492,11 @@
         <target state="translated">'{0}' non implementa il membro di interfaccia '{1}'. '{2}' non può implementare '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
+        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
+        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
         <source>Collection argument element must be the first element.</source>
         <target state="new">Collection argument element must be the first element.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -492,6 +492,11 @@
         <target state="translated">'{0}' は、インターフェイス メンバー '{1}' を実装していません。'{2}' は '{1}' を実装できません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
+        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
+        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
         <source>Collection argument element must be the first element.</source>
         <target state="new">Collection argument element must be the first element.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -493,18 +493,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
-        <source>Collection arguments cannot be dynamic</source>
-        <target state="new">Collection arguments cannot be dynamic</target>
+        <source>'with(...)' element arguments cannot be dynamic</source>
+        <target state="new">'with(...)' element arguments cannot be dynamic</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
-        <source>Collection argument element must be the first element</source>
-        <target state="new">Collection argument element must be the first element</target>
+        <source>'with(...)' element must be the first element</source>
+        <target state="new">'with(...)' element must be the first element</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
-        <source>Collection arguments are not supported for type '{0}'</source>
-        <target state="new">Collection arguments are not supported for type '{0}'</target>
+        <source>'with(...)' elements are not supported for type '{0}'</source>
+        <target state="new">'with(...)' elements are not supported for type '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -493,18 +493,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
-        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
-        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <source>Collection arguments cannot be dynamic</source>
+        <target state="new">Collection arguments cannot be dynamic</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
-        <source>Collection argument element must be the first element.</source>
-        <target state="new">Collection argument element must be the first element.</target>
+        <source>Collection argument element must be the first element</source>
+        <target state="new">Collection argument element must be the first element</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
-        <source>Collection arguments are not supported for type '{0}'.</source>
-        <target state="new">Collection arguments are not supported for type '{0}'.</target>
+        <source>Collection arguments are not supported for type '{0}'</source>
+        <target state="new">Collection arguments are not supported for type '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -493,18 +493,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
-        <source>Collection arguments cannot be dynamic</source>
-        <target state="new">Collection arguments cannot be dynamic</target>
+        <source>'with(...)' element arguments cannot be dynamic</source>
+        <target state="new">'with(...)' element arguments cannot be dynamic</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
-        <source>Collection argument element must be the first element</source>
-        <target state="new">Collection argument element must be the first element</target>
+        <source>'with(...)' element must be the first element</source>
+        <target state="new">'with(...)' element must be the first element</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
-        <source>Collection arguments are not supported for type '{0}'</source>
-        <target state="new">Collection arguments are not supported for type '{0}'</target>
+        <source>'with(...)' elements are not supported for type '{0}'</source>
+        <target state="new">'with(...)' elements are not supported for type '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -493,18 +493,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
-        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
-        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <source>Collection arguments cannot be dynamic</source>
+        <target state="new">Collection arguments cannot be dynamic</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
-        <source>Collection argument element must be the first element.</source>
-        <target state="new">Collection argument element must be the first element.</target>
+        <source>Collection argument element must be the first element</source>
+        <target state="new">Collection argument element must be the first element</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
-        <source>Collection arguments are not supported for type '{0}'.</source>
-        <target state="new">Collection arguments are not supported for type '{0}'.</target>
+        <source>Collection arguments are not supported for type '{0}'</source>
+        <target state="new">Collection arguments are not supported for type '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -492,6 +492,11 @@
         <target state="translated">'{0}'은(는) 인터페이스 멤버 '{1}'을(를) 구현하지 않습니다. '{2}'은(는) '{1}'을(를) 구현할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
+        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
+        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
         <source>Collection argument element must be the first element.</source>
         <target state="new">Collection argument element must be the first element.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -493,18 +493,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
-        <source>Collection arguments cannot be dynamic</source>
-        <target state="new">Collection arguments cannot be dynamic</target>
+        <source>'with(...)' element arguments cannot be dynamic</source>
+        <target state="new">'with(...)' element arguments cannot be dynamic</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
-        <source>Collection argument element must be the first element</source>
-        <target state="new">Collection argument element must be the first element</target>
+        <source>'with(...)' element must be the first element</source>
+        <target state="new">'with(...)' element must be the first element</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
-        <source>Collection arguments are not supported for type '{0}'</source>
-        <target state="new">Collection arguments are not supported for type '{0}'</target>
+        <source>'with(...)' elements are not supported for type '{0}'</source>
+        <target state="new">'with(...)' elements are not supported for type '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -493,18 +493,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
-        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
-        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <source>Collection arguments cannot be dynamic</source>
+        <target state="new">Collection arguments cannot be dynamic</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
-        <source>Collection argument element must be the first element.</source>
-        <target state="new">Collection argument element must be the first element.</target>
+        <source>Collection argument element must be the first element</source>
+        <target state="new">Collection argument element must be the first element</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
-        <source>Collection arguments are not supported for type '{0}'.</source>
-        <target state="new">Collection arguments are not supported for type '{0}'.</target>
+        <source>Collection arguments are not supported for type '{0}'</source>
+        <target state="new">Collection arguments are not supported for type '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -492,6 +492,11 @@
         <target state="translated">Element „{0}” nie implementuje składowej interfejsu „{1}”. Element „{2}” nie może implementować elementu „{1}”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
+        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
+        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
         <source>Collection argument element must be the first element.</source>
         <target state="new">Collection argument element must be the first element.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -493,18 +493,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
-        <source>Collection arguments cannot be dynamic</source>
-        <target state="new">Collection arguments cannot be dynamic</target>
+        <source>'with(...)' element arguments cannot be dynamic</source>
+        <target state="new">'with(...)' element arguments cannot be dynamic</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
-        <source>Collection argument element must be the first element</source>
-        <target state="new">Collection argument element must be the first element</target>
+        <source>'with(...)' element must be the first element</source>
+        <target state="new">'with(...)' element must be the first element</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
-        <source>Collection arguments are not supported for type '{0}'</source>
-        <target state="new">Collection arguments are not supported for type '{0}'</target>
+        <source>'with(...)' elements are not supported for type '{0}'</source>
+        <target state="new">'with(...)' elements are not supported for type '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -493,18 +493,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
-        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
-        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <source>Collection arguments cannot be dynamic</source>
+        <target state="new">Collection arguments cannot be dynamic</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
-        <source>Collection argument element must be the first element.</source>
-        <target state="new">Collection argument element must be the first element.</target>
+        <source>Collection argument element must be the first element</source>
+        <target state="new">Collection argument element must be the first element</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
-        <source>Collection arguments are not supported for type '{0}'.</source>
-        <target state="new">Collection arguments are not supported for type '{0}'.</target>
+        <source>Collection arguments are not supported for type '{0}'</source>
+        <target state="new">Collection arguments are not supported for type '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -492,6 +492,11 @@
         <target state="translated">'{0}' não implementa o membro de interface '{1}'. '{2}' não pode implementar '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
+        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
+        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
         <source>Collection argument element must be the first element.</source>
         <target state="new">Collection argument element must be the first element.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -493,18 +493,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
-        <source>Collection arguments cannot be dynamic</source>
-        <target state="new">Collection arguments cannot be dynamic</target>
+        <source>'with(...)' element arguments cannot be dynamic</source>
+        <target state="new">'with(...)' element arguments cannot be dynamic</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
-        <source>Collection argument element must be the first element</source>
-        <target state="new">Collection argument element must be the first element</target>
+        <source>'with(...)' element must be the first element</source>
+        <target state="new">'with(...)' element must be the first element</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
-        <source>Collection arguments are not supported for type '{0}'</source>
-        <target state="new">Collection arguments are not supported for type '{0}'</target>
+        <source>'with(...)' elements are not supported for type '{0}'</source>
+        <target state="new">'with(...)' elements are not supported for type '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -492,6 +492,11 @@
         <target state="translated">"{0}" не реализует элемент интерфейса "{1}". "{2}" не может реализовывать "{1}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
+        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
+        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
         <source>Collection argument element must be the first element.</source>
         <target state="new">Collection argument element must be the first element.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -493,18 +493,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
-        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
-        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <source>Collection arguments cannot be dynamic</source>
+        <target state="new">Collection arguments cannot be dynamic</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
-        <source>Collection argument element must be the first element.</source>
-        <target state="new">Collection argument element must be the first element.</target>
+        <source>Collection argument element must be the first element</source>
+        <target state="new">Collection argument element must be the first element</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
-        <source>Collection arguments are not supported for type '{0}'.</source>
-        <target state="new">Collection arguments are not supported for type '{0}'.</target>
+        <source>Collection arguments are not supported for type '{0}'</source>
+        <target state="new">Collection arguments are not supported for type '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -493,18 +493,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
-        <source>Collection arguments cannot be dynamic</source>
-        <target state="new">Collection arguments cannot be dynamic</target>
+        <source>'with(...)' element arguments cannot be dynamic</source>
+        <target state="new">'with(...)' element arguments cannot be dynamic</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
-        <source>Collection argument element must be the first element</source>
-        <target state="new">Collection argument element must be the first element</target>
+        <source>'with(...)' element must be the first element</source>
+        <target state="new">'with(...)' element must be the first element</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
-        <source>Collection arguments are not supported for type '{0}'</source>
-        <target state="new">Collection arguments are not supported for type '{0}'</target>
+        <source>'with(...)' elements are not supported for type '{0}'</source>
+        <target state="new">'with(...)' elements are not supported for type '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -493,18 +493,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
-        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
-        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <source>Collection arguments cannot be dynamic</source>
+        <target state="new">Collection arguments cannot be dynamic</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
-        <source>Collection argument element must be the first element.</source>
-        <target state="new">Collection argument element must be the first element.</target>
+        <source>Collection argument element must be the first element</source>
+        <target state="new">Collection argument element must be the first element</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
-        <source>Collection arguments are not supported for type '{0}'.</source>
-        <target state="new">Collection arguments are not supported for type '{0}'.</target>
+        <source>Collection arguments are not supported for type '{0}'</source>
+        <target state="new">Collection arguments are not supported for type '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -492,6 +492,11 @@
         <target state="translated">'{0}, '{1}' arabirim üyesini uygulamıyor. '{2}', '{1}' üyesini uygulayamaz.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
+        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
+        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
         <source>Collection argument element must be the first element.</source>
         <target state="new">Collection argument element must be the first element.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -493,18 +493,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
-        <source>Collection arguments cannot be dynamic</source>
-        <target state="new">Collection arguments cannot be dynamic</target>
+        <source>'with(...)' element arguments cannot be dynamic</source>
+        <target state="new">'with(...)' element arguments cannot be dynamic</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
-        <source>Collection argument element must be the first element</source>
-        <target state="new">Collection argument element must be the first element</target>
+        <source>'with(...)' element must be the first element</source>
+        <target state="new">'with(...)' element must be the first element</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
-        <source>Collection arguments are not supported for type '{0}'</source>
-        <target state="new">Collection arguments are not supported for type '{0}'</target>
+        <source>'with(...)' elements are not supported for type '{0}'</source>
+        <target state="new">'with(...)' elements are not supported for type '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -492,6 +492,11 @@
         <target state="translated">“{0}”不实现接口成员“{1}”。“{2}”无法实现“{1}”。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
+        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
+        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
         <source>Collection argument element must be the first element.</source>
         <target state="new">Collection argument element must be the first element.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -493,18 +493,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
-        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
-        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <source>Collection arguments cannot be dynamic</source>
+        <target state="new">Collection arguments cannot be dynamic</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
-        <source>Collection argument element must be the first element.</source>
-        <target state="new">Collection argument element must be the first element.</target>
+        <source>Collection argument element must be the first element</source>
+        <target state="new">Collection argument element must be the first element</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
-        <source>Collection arguments are not supported for type '{0}'.</source>
-        <target state="new">Collection arguments are not supported for type '{0}'.</target>
+        <source>Collection arguments are not supported for type '{0}'</source>
+        <target state="new">Collection arguments are not supported for type '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -493,18 +493,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
-        <source>Collection arguments cannot be dynamic</source>
-        <target state="new">Collection arguments cannot be dynamic</target>
+        <source>'with(...)' element arguments cannot be dynamic</source>
+        <target state="new">'with(...)' element arguments cannot be dynamic</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
-        <source>Collection argument element must be the first element</source>
-        <target state="new">Collection argument element must be the first element</target>
+        <source>'with(...)' element must be the first element</source>
+        <target state="new">'with(...)' element must be the first element</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
-        <source>Collection arguments are not supported for type '{0}'</source>
-        <target state="new">Collection arguments are not supported for type '{0}'</target>
+        <source>'with(...)' elements are not supported for type '{0}'</source>
+        <target state="new">'with(...)' elements are not supported for type '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -492,6 +492,11 @@
         <target state="translated">'{0}' 未實作介面成員 '{1}'。'{2}' 無法實作 '{1}'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
+        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
+        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
         <source>Collection argument element must be the first element.</source>
         <target state="new">Collection argument element must be the first element.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -493,18 +493,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsDynamicBinding">
-        <source>Collection arguments cannot be dynamic; compile-time binding is required.</source>
-        <target state="new">Collection arguments cannot be dynamic; compile-time binding is required.</target>
+        <source>Collection arguments cannot be dynamic</source>
+        <target state="new">Collection arguments cannot be dynamic</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsMustBeFirst">
-        <source>Collection argument element must be the first element.</source>
-        <target state="new">Collection argument element must be the first element.</target>
+        <source>Collection argument element must be the first element</source>
+        <target state="new">Collection argument element must be the first element</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionArgumentsNotSupportedForType">
-        <source>Collection arguments are not supported for type '{0}'.</source>
-        <target state="new">Collection arguments are not supported for type '{0}'.</target>
+        <source>Collection arguments are not supported for type '{0}'</source>
+        <target state="new">Collection arguments are not supported for type '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CollectionBuilderAttributeInvalidMethodName">

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
@@ -17,7 +17,6 @@ using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
-using Roslyn.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
@@ -12,7 +12,6 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.CSharp.UnitTests;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Test.Utilities;

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.CSharp.UnitTests;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Test.Utilities;

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_ArraysAndSpans.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_ArraysAndSpans.cs
@@ -594,9 +594,9 @@ public sealed class CollectionExpressionTests_WithElement_ArraysAndSpans : CShar
             """;
 
         CreateCompilation(source).VerifyDiagnostics(
-            // (6,24): error CS9336: Collection arguments are not supported for type 'int[]'.
+            // (6,29): error CS9337: Collection arguments cannot be dynamic
             //         int[] array = [with(d), 1, 2, 3];
-            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("int[]").WithLocation(6, 24));
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, "d").WithLocation(6, 29));
     }
 
     [Fact]
@@ -616,10 +616,10 @@ public sealed class CollectionExpressionTests_WithElement_ArraysAndSpans : CShar
             """;
 
         CreateCompilation(source, targetFramework: TargetFramework.Net80).VerifyDiagnostics(
-            // (8,27): error CS9336: Collection arguments are not supported for type 'Span<int>'.
+            // (8,42): error CS9337: Collection arguments cannot be dynamic
             //         Span<int> span = [with(capacity: d), 1, 2, 3];
-            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("System.Span<int>").WithLocation(8, 27));
-    }
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, "d").WithLocation(8, 42));
+}
 
     [Fact]
     public void WithElement_Array_ImplicitlyTyped()

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_ArraysAndSpans.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_ArraysAndSpans.cs
@@ -542,7 +542,7 @@ public sealed class CollectionExpressionTests_WithElement_ArraysAndSpans : CShar
             Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("System.Span<int>").WithLocation(8, 27));
     }
 
-    [Fact]
+    [Fact(Skip = "https://github.com/dotnet/roslyn/issues/80518")]
     public void WithElement_ReadOnlySpan_WithOutVar()
     {
         var source = """

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_ArraysAndSpans.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_ArraysAndSpans.cs
@@ -619,7 +619,7 @@ public sealed class CollectionExpressionTests_WithElement_ArraysAndSpans : CShar
             // (8,42): error CS9337: Collection arguments cannot be dynamic
             //         Span<int> span = [with(capacity: d), 1, 2, 3];
             Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, "d").WithLocation(8, 42));
-}
+    }
 
     [Fact]
     public void WithElement_Array_ImplicitlyTyped()

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
@@ -497,7 +497,7 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
         CompileAndVerify(source, expectedOutput: IncludeExpectedOutput("42"));
     }
 
-    [Fact]
+    [Fact(Skip = "https://github.com/dotnet/roslyn/issues/80518")]
     public void WithElement_OutParameters()
     {
         var source = """
@@ -525,7 +525,7 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
         CompileAndVerify(source, expectedOutput: IncludeExpectedOutput("2,42"));
     }
 
-    [Fact]
+    [Fact(Skip = "https://github.com/dotnet/roslyn/issues/80518")]
     public void WithElement_OutVar_UsedInLaterElements()
     {
         var source = """
@@ -553,7 +553,7 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
         CompileAndVerify(source, expectedOutput: IncludeExpectedOutput("100,200,300"));
     }
 
-    [Fact]
+    [Fact(Skip = "https://github.com/dotnet/roslyn/issues/80518")]
     public void WithElement_MultipleOutParameters()
     {
         var source = """

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
@@ -715,10 +715,10 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
             }
             """;
 
-        CompileAndVerify(
-            source,
-            references: [CSharpRef],
-            expectedOutput: IncludeExpectedOutput("42"));
+        CreateCompilation(source, references: [CSharpRef]).VerifyDiagnostics(
+            // (19,34): error CS9337: Collection arguments cannot be dynamic
+            //         MyList<int> list = [with(d), 1];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, "d").WithLocation(19, 34));
     }
 
     [Fact]
@@ -742,7 +742,10 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
             }
             """;
 
-        CreateCompilation(source).VerifyDiagnostics();
+        CreateCompilation(source).VerifyDiagnostics(
+            // (13,41): error CS9337: Collection arguments cannot be dynamic
+            //         MyList<int> list = [with(value: d)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, "d").WithLocation(13, 41));
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
@@ -219,7 +219,7 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
     #region Argument Count Tests
 
     [Fact]
-    public void WithElement_TooManyArguments()
+    public void WithElement_NonExistentNamedParameter()
     {
         var source = """
             using System.Collections.Generic;

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
@@ -346,7 +346,34 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
             }
             """;
 
-        CompileAndVerify(source, expectedOutput: IncludeExpectedOutput("GetSecond called. GetFirst called. 10,20"));
+        CompileAndVerify(source, expectedOutput: IncludeExpectedOutput("GetSecond called. GetFirst called. 10,20"))
+            .VerifyIL("C.Main", """
+            {
+              // Code size       63 (0x3f)
+              .maxstack  3
+              .locals init (MyList<int> V_0, //list
+                            int V_1)
+              IL_0000:  call       "int C.GetSecond()"
+              IL_0005:  stloc.1
+              IL_0006:  call       "int C.GetFirst()"
+              IL_000b:  ldloc.1
+              IL_000c:  newobj     "MyList<int>..ctor(int, int)"
+              IL_0011:  dup
+              IL_0012:  ldc.i4.1
+              IL_0013:  callvirt   "void System.Collections.Generic.List<int>.Add(int)"
+              IL_0018:  stloc.0
+              IL_0019:  ldstr      "{0},{1}"
+              IL_001e:  ldloc.0
+              IL_001f:  callvirt   "int MyList<int>.Value1.get"
+              IL_0024:  box        "int"
+              IL_0029:  ldloc.0
+              IL_002a:  callvirt   "int MyList<int>.Value2.get"
+              IL_002f:  box        "int"
+              IL_0034:  call       "string string.Format(string, object, object)"
+              IL_0039:  call       "void System.Console.WriteLine(string)"
+              IL_003e:  ret
+            }
+            """);
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
@@ -1055,12 +1055,13 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
     public void WithElement_OverloadResolution_Ambiguous()
     {
         var source = """
+            using System;
             using System.Collections.Generic;
             
             class MyList<T> : List<T>
             {
-                public MyList(int value) : base() { }
-                public MyList(long value) : base() { }
+                public MyList(int value) => Console.WriteLine("int chosen");
+                public MyList(long value) => Console.WriteLine("long chosen");
             }
             
             class C
@@ -1073,7 +1074,7 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
             }
             """;
 
-        CreateCompilation(source).VerifyDiagnostics();
+        CompileAndVerify(source, expectedOutput: IncludeExpectedOutput("int chosen"));
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
@@ -1012,7 +1012,7 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
             """);
     }
 
-    [Fact]
+    [ConditionalFact(typeof(DesktopOnly), Reason = ConditionalSkipReason.RestrictedTypesNeedDesktop)]
     public void WithElement_ArgList_Empty()
     {
         var source = """

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
@@ -1018,7 +1018,7 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
             {
                 internal MyList(int capacity) : base(capacity) 
                 {
-                    Console.WriteLine("Internal constructor");
+                    Console.Write("Internal constructor ");
                 }
             }
             
@@ -1032,7 +1032,7 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
             }
             """;
 
-        CompileAndVerify(source, expectedOutput: IncludeExpectedOutput("Internal constructor\r\n10 1"));
+        CompileAndVerify(source, expectedOutput: IncludeExpectedOutput("Internal constructor 10 1"));
     }
 
     #endregion

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -542,13 +543,16 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
         var source = $$"""
             using System;
             using System.Collections.Generic;
+            using System.Runtime.CompilerServices;
             
             class MyList<T> : List<T>
             {
                 public int Value { get; }
                 public MyList(in int value) : base() 
                 { 
+                    Console.Write(value + " ");
                     Value = value;
+                    Unsafe.AsRef(value) = 10;
                 }
             }
             
@@ -558,12 +562,12 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
                 {
                     int x = 42;
                     MyList<int> list = [with({{modifier}}x), 1];
-                    Console.WriteLine(list.Value);
+                    Console.WriteLine(x);
                 }
             }
             """;
 
-        CompileAndVerify(source, expectedOutput: IncludeExpectedOutput("42"));
+        CompileAndVerify(source, targetFramework: TargetFramework.Net90, expectedOutput: IncludeExpectedOutput("42 10"));
     }
 
     [Fact(Skip = "https://github.com/dotnet/roslyn/issues/80518")]

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
@@ -1066,7 +1067,7 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
             
             class C
             {
-                void M()
+                static void Main()
                 {
                     short s = 10;
                     MyList<int> list = [with(s)];
@@ -1645,6 +1646,36 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
                 {
                     MyList<int> list = [with(() => 42), 1];
                     Console.WriteLine(list.ValueFunc());
+                }
+            }
+            """;
+
+        CompileAndVerify(source, expectedOutput: IncludeExpectedOutput("42"));
+    }
+
+    [Fact]
+    public void WithElement_WithLambda_ToDelegate()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            
+            class MyList<T> : List<T>
+            {
+                public Delegate ValueFunc { get; }
+                
+                public MyList(Delegate func) : base()
+                {
+                    ValueFunc = func;
+                }
+            }
+            
+            class C
+            {
+                static void Main()
+                {
+                    MyList<int> list = [with(() => 42), 1];
+                    Console.WriteLine(list.DynamicInvoke());
                 }
             }
             """;

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
@@ -556,7 +556,7 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
             """);
     }
 
-    [ConditionalTheory(typeof(CoreClrOnly))]
+    [Theory]
     [InlineData("in ")]
     [InlineData("")]
     public void WithElement_InParameters(string modifier)
@@ -588,7 +588,8 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
             }
             """;
 
-        CompileAndVerify(source, targetFramework: TargetFramework.Net90, expectedOutput: IncludeExpectedOutput("42 10"));
+        CompileAndVerify(source, targetFramework: TargetFramework.Net90,
+            expectedOutput: ExecutionConditionUtil.IsCoreClr ? IncludeExpectedOutput("42 10") : null, verify: Verification.FailsPEVerify);
     }
 
     [Fact(Skip = "https://github.com/dotnet/roslyn/issues/80518")]

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
@@ -1349,6 +1349,38 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
             Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "int").WithArguments("MyList<T>", "T", "int").WithLocation(12, 16));
     }
 
+    [Fact]
+    public void WithElement_TypeConstraints2()
+    {
+        var source = """
+            using System.Collections.Generic;
+            
+            class MyList<T, TConstructorElementType> : List<T> where T : class
+            {
+                public MyList(TConstructorElementType item) : base() { }
+            }
+            
+            class C
+            {
+                void M()
+                {
+                    MyList<string, bool> list = [with(true)];
+                }
+            }
+            """;
+
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size        8 (0x8)
+              .maxstack  1
+              IL_0000:  ldc.i4.1
+              IL_0001:  newobj     "MyList<string, bool>..ctor(bool)"
+              IL_0006:  pop
+              IL_0007:  ret
+            }
+            """);
+    }
+
     #endregion
 
     #region Null and Default Tests

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
@@ -480,6 +480,32 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
         CreateCompilation(source).VerifyDiagnostics();
     }
 
+    [Fact]
+    public void WithElement_NamedArgumentInWrongPosition()
+    {
+        var source = """
+            using System.Collections.Generic;
+            
+            class MyList<T> : List<T>
+            {
+                public MyList(int first, int second) : base() { }
+            }
+            
+            class C
+            {
+                void M()
+                {
+                    MyList<int> list = [with(second: 20, 10)];
+                }
+            }
+            """;
+
+        CreateCompilation(source).VerifyDiagnostics(
+            // (12,34): error CS8323: Named argument 'second' is used out-of-position but is followed by an unnamed argument
+            //         MyList<int> list = [with(second: 20, 10)];
+            Diagnostic(ErrorCode.ERR_BadNonTrailingNamedArgument, "second").WithArguments("second").WithLocation(12, 34));
+    }
+
     #endregion
 
     #region Ref/In/Out Parameter Tests

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
@@ -1938,5 +1938,29 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
             Diagnostic(ErrorCode.ERR_CantConvAnonMethReturns, "i").WithArguments("lambda expression").WithLocation(15, 25));
     }
 
+    [Fact]
+    public void WithElement_Ambiguous_WithOverloads()
+    {
+        var source = $$"""
+            using System.Collections.Generic;
+            
+            class C
+            {
+                void M(List<int> list) { }
+                void M(HashSet<int> set) { }
+
+                void G()
+                {
+                    M([with(capacity: 10)]);
+                }
+            }
+            """;
+
+        CreateCompilation(source).VerifyDiagnostics(
+            // (10,9): error CS0121: The call is ambiguous between the following methods or properties: 'C.M(List<int>)' and 'C.M(HashSet<int>)'
+            //         M([with(capacity: 10)]);
+            Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("C.M(System.Collections.Generic.List<int>)", "C.M(System.Collections.Generic.HashSet<int>)").WithLocation(10, 9));
+    }
+
     #endregion
 }

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
@@ -960,7 +960,7 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
 
     #region ArgList Tests
 
-    [ConditionalFact(typeof(WindowsOnly))]
+    [Fact]
     public void WithElement_ArgList()
     {
         var source = """
@@ -983,7 +983,7 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
         CreateCompilation(source).VerifyDiagnostics();
     }
 
-    [ConditionalFact(typeof(WindowsOnly))]
+    [Fact]
     public void WithElement_ArgList_Empty()
     {
         var source = """
@@ -994,7 +994,7 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
             {
                 public MyList(__arglist) : base() 
                 {
-                    Console.WriteLine("ArgList constructor called");
+                    Console.Write ("ArgList constructor called ");
                 }
             }
             
@@ -1008,7 +1008,7 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
             }
             """;
 
-        CompileAndVerify(source, expectedOutput: IncludeExpectedOutput("ArgList constructor called\r\n1"));
+        CompileAndVerify(source, expectedOutput: IncludeExpectedOutput("ArgList constructor called 1"));
     }
 
     #endregion

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
@@ -326,15 +326,27 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
             
             class C
             {
+                static int GetSecond()
+                {
+                    Console.Write("GetSecond called. ");
+                    return 20;
+                }
+            
+                static int GetFirst()
+                {
+                    Console.Write("GetFirst called. ");
+                    return 10;
+                }
+
                 static void Main()
                 {
-                    MyList<int> list = [with(second: 20, first: 10), 1];
+                    MyList<int> list = [with(second: GetSecond(), first: GetFirst()), 1];
                     Console.WriteLine($"{list.Value1},{list.Value2}");
                 }
             }
             """;
 
-        CompileAndVerify(source, expectedOutput: IncludeExpectedOutput("10,20"));
+        CompileAndVerify(source, expectedOutput: IncludeExpectedOutput("GetSecond called. GetFirst called. 10,20"));
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
@@ -774,7 +775,7 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
 
     #region ArgList Tests
 
-    [Fact]
+    [ConditionalFact(typeof(WindowsOnly))]
     public void WithElement_ArgList()
     {
         var source = """
@@ -797,7 +798,7 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
         CreateCompilation(source).VerifyDiagnostics();
     }
 
-    [Fact]
+    [ConditionalFact(typeof(WindowsOnly))]
     public void WithElement_ArgList_Empty()
     {
         var source = """

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
@@ -962,7 +962,7 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
 
     #region ArgList Tests
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = ConditionalSkipReason.RestrictedTypesNeedDesktop)]
+    [Fact]
     public void WithElement_ArgList()
     {
         var source = """
@@ -999,7 +999,9 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
             }
             """;
 
-        CompileAndVerify(source, targetFramework: TargetFramework.NetFramework, expectedOutput: IncludeExpectedOutput("10 test "), verify: Verification.FailsILVerify).VerifyIL("C.Main", """
+        CompileAndVerify(source, targetFramework: TargetFramework.NetFramework,
+            expectedOutput: ExecutionConditionUtil.IsWindows ? IncludeExpectedOutput("10 test ") : null,
+            verify: Verification.FailsILVerify).VerifyIL("C.Main", """
             {
               // Code size       14 (0xe)
               .maxstack  2
@@ -1012,7 +1014,7 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
             """);
     }
 
-    [ConditionalFact(typeof(DesktopOnly), Reason = ConditionalSkipReason.RestrictedTypesNeedDesktop)]
+    [Fact]
     public void WithElement_ArgList_Empty()
     {
         var source = """
@@ -1037,7 +1039,8 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
             }
             """;
 
-        CompileAndVerify(source, expectedOutput: IncludeExpectedOutput("ArgList constructor called 1"));
+        CompileAndVerify(source,
+            expectedOutput: ExecutionConditionUtil.IsWindows ? IncludeExpectedOutput("ArgList constructor called 1") : null);
     }
 
     #endregion

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
@@ -1385,10 +1385,12 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
 
     #region Null and Default Tests
 
-    [Fact]
-    public void WithElement_NullArguments()
+    [Theory]
+    [InlineData("null")]
+    [InlineData("(string)null")]
+    public void WithElement_NullArguments(string argument)
     {
-        var source = """
+        var source = $$"""
             using System;
             using System.Collections.Generic;
             
@@ -1406,7 +1408,7 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
             {
                 static void Main()
                 {
-                    MyList<int> list = [with((string)null), 1];
+                    MyList<int> list = [with({{argument}}), 1];
                     Console.WriteLine(list.Value);
                 }
             }
@@ -1415,10 +1417,12 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
         CompileAndVerify(source, expectedOutput: IncludeExpectedOutput("null"));
     }
 
-    [Fact]
-    public void WithElement_DefaultArguments()
+    [Theory]
+    [InlineData("default(int)")]
+    [InlineData("default")]
+    public void WithElement_DefaultArguments(string argument)
     {
-        var source = """
+        var source = $$"""
             using System;
             using System.Collections.Generic;
             
@@ -1436,7 +1440,7 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
             {
                 static void Main()
                 {
-                    MyList<int> list = [with(default(int)), 1];
+                    MyList<int> list = [with({{argument}}), 1];
                     Console.WriteLine(list.Value);
                 }
             }

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
@@ -534,10 +534,12 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
         CreateCompilation(source).VerifyDiagnostics();
     }
 
-    [Fact]
-    public void WithElement_InParameters()
+    [Theory]
+    [InlineData("in ")]
+    [InlineData("")]
+    public void WithElement_InParameters(string modifier)
     {
-        var source = """
+        var source = $$"""
             using System;
             using System.Collections.Generic;
             
@@ -555,7 +557,7 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
                 static void Main()
                 {
                     int x = 42;
-                    MyList<int> list = [with(in x), 1];
+                    MyList<int> list = [with({{modifier}}x), 1];
                     Console.WriteLine(list.Value);
                 }
             }

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Constructor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -292,12 +293,12 @@ public sealed class CollectionExpressionTests_WithElement_Constructors : CSharpT
                     MyList<int> list3 = [with(name: "custom"), 3];
                     MyList<int> list4 = [with(capacity: 20, name: "both"), 4];
                     
-                    Console.WriteLine($"{list1.Name},{list2.Name},{list3.Name},{list4.Name}");
+                    Console.WriteLine($"{list1.Name}-{list1.Capacity},{list2.Name}-{list2.Capacity},{list3.Name}-{list3.Capacity},{list4.Name}-{list4.Capacity}");
                 }
             }
             """;
 
-        CompileAndVerify(source, expectedOutput: IncludeExpectedOutput("default,default,custom,both"));
+        CompileAndVerify(source, expectedOutput: IncludeExpectedOutput("default-4,default-10,custom-4,both-20"));
     }
 
     #endregion

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Extra.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Extra.cs
@@ -1,0 +1,5828 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// #DEFINE ARRAY_INTERFACES
+// #DEFINE CREATE_METHODS
+// #DEFINE DICTIONARY_EXPRESSIONS
+
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+using static Microsoft.CodeAnalysis.Test.Utilities.CompilationVerifier;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+public sealed class CollectionExpressionTests_WithElement_Extra : CSharpTestBase
+{
+    private static string? IncludeExpectedOutput(string expectedOutput) => ExecutionConditionUtil.IsMonoOrCoreClr ? expectedOutput : null;
+
+    private const string s_collectionExtensions = CollectionExpressionTests.s_collectionExtensions;
+
+    public static readonly TheoryData<LanguageVersion> LanguageVersions = new([LanguageVersion.CSharp14, LanguageVersion.Preview, LanguageVersionFacts.CSharpNext]);
+
+    [Theory]
+    [MemberData(nameof(LanguageVersions))]
+    public void LanguageVersion_01(LanguageVersion languageVersion)
+    {
+        string source = """
+                int[] a = [with()];
+                """;
+        var comp = CreateCompilation(source, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+        if (languageVersion == LanguageVersion.CSharp14)
+        {
+            comp.VerifyEmitDiagnostics(
+                // (1,12): error CS0103: The name 'with' does not exist in the current context
+                // int[] a = [with()];
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "with").WithArguments("with").WithLocation(1, 12));
+        }
+        else
+        {
+            comp.VerifyEmitDiagnostics(
+                // (1,12): error CS9336: Collection arguments are not supported for type 'int[]'.
+                // int[] a = [with()];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("int[]").WithLocation(1, 12));
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(LanguageVersions))]
+    public void LanguageVersion_02(LanguageVersion languageVersion)
+    {
+        string source = """
+                using System.Collections.Generic;
+                List<int> l = [1, with(), 3, with(capacity: 4)];
+                """;
+        var comp = CreateCompilation(source, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+        if (languageVersion == LanguageVersion.CSharp14)
+        {
+            comp.VerifyEmitDiagnostics(
+                // (2,19): error CS0103: The name 'with' does not exist in the current context
+                // List<int> l = [1, with(), 3, with(capacity: 4)];
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "with").WithArguments("with").WithLocation(2, 19),
+                // (2,30): error CS0103: The name 'with' does not exist in the current context
+                // List<int> l = [1, with(), 3, with(capacity: 4)];
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "with").WithArguments("with").WithLocation(2, 30));
+        }
+        else
+        {
+            comp.VerifyEmitDiagnostics(
+                // (2,19): error CS9501: Collection argument element must be the first element.
+                // List<int> l = [1, with(), 3, with(capacity: 4)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(2, 19),
+                // (2,30): error CS9501: Collection argument element must be the first element.
+                // List<int> l = [1, with(), 3, with(capacity: 4)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(2, 30));
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(LanguageVersions))]
+    public void LanguageVersion_03(LanguageVersion languageVersion)
+    {
+        string source = """
+                using System.Collections.Generic;
+                List<int> l = [with(x: 1), with(y: 2)];
+                """;
+        var comp = CreateCompilation(source, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+        if (languageVersion == LanguageVersion.CSharp14)
+        {
+            comp.VerifyEmitDiagnostics(
+                // (2,16): error CS0103: The name 'with' does not exist in the current context
+                // List<int> l = [with(x: 1), with(y: 2)];
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "with").WithArguments("with").WithLocation(2, 16),
+                // (2,28): error CS0103: The name 'with' does not exist in the current context
+                // List<int> l = [with(x: 1), with(y: 2)];
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "with").WithArguments("with").WithLocation(2, 28));
+        }
+        else
+        {
+            comp.VerifyEmitDiagnostics(
+                // (2,21): error CS1739: The best overload for 'List' does not have a parameter named 'x'
+                // List<int> l = [with(x: 1), with(y: 2)];
+                Diagnostic(ErrorCode.ERR_BadNamedArgument, "x").WithArguments("List", "x").WithLocation(2, 21),
+                // (2,28): error CS9335: Collection argument element must be the first element.
+                // List<int> l = [with(x: 1), with(y: 2)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(2, 28));
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(LanguageVersions))]
+    public void LanguageVersion_04(LanguageVersion languageVersion)
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                struct MyCollection<T> : IEnumerable<T>
+                {
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => default;
+                    IEnumerator IEnumerable.GetEnumerator() => default;
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T arg = default) => default;
+                }
+                """;
+        string sourceB = """
+                MyCollection<int> c = [
+                    with(),
+                    with(arg: 0),
+                    with(unknown: 1)];
+                """;
+        var comp = CreateCompilation(
+            [sourceA, sourceB],
+            parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+            targetFramework: TargetFramework.Net80);
+        if (languageVersion == LanguageVersion.CSharp14)
+        {
+            comp.VerifyEmitDiagnostics(
+                // (2,5): error CS0103: The name 'with' does not exist in the current context
+                //     with(),
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "with").WithArguments("with").WithLocation(2, 5),
+                // (3,5): error CS0103: The name 'with' does not exist in the current context
+                //     with(arg: 0),
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "with").WithArguments("with").WithLocation(3, 5),
+                // (4,5): error CS0103: The name 'with' does not exist in the current context
+                //     with(unknown: 1)];
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "with").WithArguments("with").WithLocation(4, 5));
+        }
+        else
+        {
+            comp.VerifyEmitDiagnostics(
+                // (1,23): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                // MyCollection<int> c = [
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, @"[
+    with(),
+    with(arg: 0),
+    with(unknown: 1)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(1, 23),
+                // (3,5): error CS9501: Collection argument element must be the first element.
+                //     with(arg: 0),
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(3, 5),
+                // (4,5): error CS9501: Collection argument element must be the first element.
+                //     with(unknown: 1)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(4, 5));
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(LanguageVersions))]
+    public void LanguageVersion_05(LanguageVersion languageVersion)
+    {
+        string source = """
+                using System.Collections.Generic;
+                List<string> list;
+                list = [with(capacity: 1), "one"];
+                list.Report();
+                list = [@with(capacity: 2), "two"];
+                list.Report();
+                string with(int capacity) => $"with({capacity})";
+                """;
+        var verifier = CompileAndVerify([source, s_collectionExtensions],
+            parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+            expectedOutput: (languageVersion == LanguageVersion.CSharp14 ? "[with(1), one], [with(2), two], " : "[one], [with(2), two], "));
+        verifier.VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void EmptyArguments_Array1()
+    {
+        string source = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        NoArgs<int>().Report();
+                    }
+                    static T[] NoArgs<T>() => [];
+                }
+                """;
+        var verifier = CompileAndVerify(
+            [source, s_collectionExtensions],
+            expectedOutput: "[], ");
+        verifier.VerifyDiagnostics();
+        string expectedIL = """
+                {
+                  // Code size        6 (0x6)
+                  .maxstack  1
+                  IL_0000:  call       "T[] System.Array.Empty<T>()"
+                  IL_0005:  ret
+                }
+                """;
+        verifier.VerifyIL("Program.NoArgs<T>", expectedIL);
+    }
+
+    [Fact]
+    public void EmptyArguments_Array2()
+    {
+        string source = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        EmptyArgs<int>().Report();
+                    }
+                    static T[] EmptyArgs<T>() => [with()];
+                }
+                """;
+        var verifier = CreateCompilation(
+            [source, s_collectionExtensions]);
+        verifier.VerifyDiagnostics(
+            // (7,35): error CS9336: Collection arguments are not supported for type 'T[]'.
+            //     static T[] EmptyArgs<T>() => [with()];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("T[]").WithLocation(7, 35));
+    }
+
+    [Fact]
+    public void Arguments_Array()
+    {
+        string source = """
+                class Program
+                {
+                    static void F<T>(T t)
+                    {
+                        T[] a;
+                        a = [with(default), t];
+                        a = [t, with(default)];
+                    }
+                }
+                """;
+        var comp = CreateCompilation(source);
+        comp.VerifyEmitDiagnostics(
+            // (6,14): error CS9336: Collection arguments are not supported for type 'T[]'.
+            //         a = [with(default), t];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("T[]").WithLocation(6, 14),
+            // (7,17): error CS9335: Collection argument element must be the first element.
+            //         a = [t, with(default)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(7, 17));
+
+        // Collection arguments do not affect convertibility.
+        var tree = comp.SyntaxTrees[0];
+        var model = comp.GetSemanticModel(tree);
+        var collections = tree.GetRoot().DescendantNodes().OfType<CollectionExpressionSyntax>().ToArray();
+        Assert.Equal(2, collections.Length);
+        VerifyTypes(model, collections[0], expectedType: null, expectedConvertedType: "T[]", ConversionKind.CollectionExpression);
+        VerifyTypes(model, collections[1], expectedType: null, expectedConvertedType: "T[]", ConversionKind.CollectionExpression);
+    }
+
+    private static void VerifyTypes(SemanticModel model, ExpressionSyntax expr, string? expectedType, string expectedConvertedType, ConversionKind expectedConversionKind)
+    {
+        var typeInfo = model.GetTypeInfo(expr);
+        var conversion = model.GetConversion(expr);
+        Assert.Equal(expectedType, typeInfo.Type?.ToTestDisplayString());
+        Assert.Equal(expectedConvertedType, typeInfo.ConvertedType?.ToTestDisplayString());
+        Assert.Equal(expectedConversionKind, conversion.Kind);
+    }
+
+    [Theory]
+    [InlineData("ReadOnlySpan")]
+    [InlineData("Span")]
+    public void EmptyArguments_Span(string spanType)
+    {
+        string source = $$"""
+                using System;
+                class Program
+                {
+                    static void Main()
+                    {
+                        NoArgs<int>().Report();
+                        EmptyArgs<int>().Report();
+                    }
+                    static T[] NoArgs<T>()
+                    {
+                        {{spanType}}<T> x = [];
+                        return x.ToArray();
+                    }
+                    static T[] EmptyArgs<T>()
+                    {
+                        {{spanType}}<T> x = [with()];
+                        return x.ToArray();
+                    }
+                }
+                """;
+        var verifier = CreateCompilation(
+            [source, s_collectionExtensions],
+            targetFramework: TargetFramework.Net80);
+        verifier.VerifyDiagnostics(
+            // (16,30): error CS9336: Collection arguments are not supported for type 'ReadOnlySpan<T>'.
+            //         ReadOnlySpan<T> x = [with()];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments($"System.{spanType}<T>"));
+    }
+
+    [Theory]
+    [InlineData("ReadOnlySpan")]
+    [InlineData("Span")]
+    public void Arguments_Span(string spanType)
+    {
+        string source = $$"""
+                using System;
+                class Program
+                {
+                    static void F<T>(T t)
+                    {
+                        {{spanType}}<T> x =
+                            [with(default), t];
+                        {{spanType}}<T> y =
+                            [t, with(default)];
+                    }
+                }
+                """;
+        var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (7,14): error CS9336: Collection arguments are not supported for type 'Span<T>'.
+            //             [with(default), t];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments($"System.{spanType}<T>").WithLocation(7, 14),
+            // (9,17): error CS9335: Collection argument element must be the first element.
+            //             [t, with(default)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(9, 17));
+    }
+
+    [Fact]
+    public void EmptyArguments_List_01()
+    {
+        string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        NoArgs<int>().Report();
+                        EmptyArgs<int>().Report();
+                    }
+                    static List<T> NoArgs<T>() => [];
+                    static List<T> EmptyArgs<T>() => [with()];
+                }
+                """;
+        var verifier = CompileAndVerify(
+            [source, s_collectionExtensions],
+            targetFramework: TargetFramework.Net80,
+            verify: Verification.Skipped,
+            expectedOutput: IncludeExpectedOutput("[], [], "));
+        verifier.VerifyDiagnostics();
+        string expectedIL = """
+                {
+                  // Code size        6 (0x6)
+                  .maxstack  1
+                  IL_0000:  newobj     "System.Collections.Generic.List<T>..ctor()"
+                  IL_0005:  ret
+                }
+                """;
+        verifier.VerifyIL("Program.NoArgs<T>", expectedIL);
+        verifier.VerifyIL("Program.EmptyArgs<T>", expectedIL);
+    }
+
+    [Fact]
+    public void EmptyArguments_List_02()
+    {
+        string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        NoArgs<int>(1, 2).Report();
+                        EmptyArgs<int>(3, 4).Report();
+                    }
+                    static List<T> NoArgs<T>(T x, T y) => [x, y];
+                    static List<T> EmptyArgs<T>(T x, T y) => [with(), x, y];
+                }
+                """;
+        var verifier = CompileAndVerify(
+            [source, s_collectionExtensions],
+            targetFramework: TargetFramework.Net80,
+            verify: Verification.Skipped,
+            expectedOutput: IncludeExpectedOutput("[1, 2], [3, 4], "));
+        verifier.VerifyDiagnostics();
+        verifier.VerifyIL("Program.NoArgs<T>", """
+            {
+                // Code size       57 (0x39)
+                .maxstack  3
+                .locals init (int V_0,
+                            System.Span<T> V_1,
+                            int V_2)
+                IL_0000:  ldc.i4.2
+                IL_0001:  stloc.0
+                IL_0002:  ldloc.0
+                IL_0003:  newobj     "System.Collections.Generic.List<T>..ctor(int)"
+                IL_0008:  dup
+                IL_0009:  ldloc.0
+                IL_000a:  call       "void System.Runtime.InteropServices.CollectionsMarshal.SetCount<T>(System.Collections.Generic.List<T>, int)"
+                IL_000f:  dup
+                IL_0010:  call       "System.Span<T> System.Runtime.InteropServices.CollectionsMarshal.AsSpan<T>(System.Collections.Generic.List<T>)"
+                IL_0015:  stloc.1
+                IL_0016:  ldc.i4.0
+                IL_0017:  stloc.2
+                IL_0018:  ldloca.s   V_1
+                IL_001a:  ldloc.2
+                IL_001b:  call       "ref T System.Span<T>.this[int].get"
+                IL_0020:  ldarg.0
+                IL_0021:  stobj      "T"
+                IL_0026:  ldloc.2
+                IL_0027:  ldc.i4.1
+                IL_0028:  add
+                IL_0029:  stloc.2
+                IL_002a:  ldloca.s   V_1
+                IL_002c:  ldloc.2
+                IL_002d:  call       "ref T System.Span<T>.this[int].get"
+                IL_0032:  ldarg.1
+                IL_0033:  stobj      "T"
+                IL_0038:  ret
+            }
+            """);
+        verifier.VerifyIL("Program.EmptyArgs<T>", """
+            {
+              // Code size       20 (0x14)
+              .maxstack  3
+              IL_0000:  newobj     "System.Collections.Generic.List<T>..ctor()"
+              IL_0005:  dup
+              IL_0006:  ldarg.0
+              IL_0007:  callvirt   "void System.Collections.Generic.List<T>.Add(T)"
+              IL_000c:  dup
+              IL_000d:  ldarg.1
+              IL_000e:  callvirt   "void System.Collections.Generic.List<T>.Add(T)"
+              IL_0013:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void Arguments_List()
+    {
+        string source = """
+                using System;
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var l = F(1);
+                        l.Report();
+                        Console.WriteLine(l.Capacity);
+                    }
+                    static List<T> F<T>(T t) => [with(capacity: 2), t];
+                }
+                """;
+        var verifier = CompileAndVerify(
+            [source, s_collectionExtensions],
+            expectedOutput: "[1], 2");
+        verifier.VerifyDiagnostics();
+        verifier.VerifyIL("Program.F<T>(T)", """
+                {
+                  // Code size       14 (0xe)
+                  .maxstack  3
+                  IL_0000:  ldc.i4.2
+                  IL_0001:  newobj     "System.Collections.Generic.List<T>..ctor(int)"
+                  IL_0006:  dup
+                  IL_0007:  ldarg.0
+                  IL_0008:  callvirt   "void System.Collections.Generic.List<T>.Add(T)"
+                  IL_000d:  ret
+                }
+                """);
+    }
+
+#if ARRAY_INTERFACES
+    [Theory]
+    [CombinatorialData]
+    public void List_KnownLength_ICollection(
+        [CombinatorialValues("", "with(), ", "with(3), ")] string argsPrefix)
+    {
+        string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Create(1, 2, 3).Report();
+                    }
+                    static ICollection<T> Create<T>(params T[] items)
+                    {
+                        return [{{argsPrefix}} ..items];
+                    }
+                }
+                """;
+        var verifier = CompileAndVerify(
+            [source, s_collectionExtensions],
+            targetFramework: TargetFramework.Net80,
+            verify: Verification.Skipped,
+            expectedOutput: IncludeExpectedOutput("[1, 2, 3], "));
+        verifier.VerifyDiagnostics();
+        string expectedIL;
+        switch (argsPrefix)
+        {
+            case "with(3), ":
+                expectedIL = """
+                        {
+                          // Code size       14 (0xe)
+                          .maxstack  3
+                          IL_0000:  ldc.i4.3
+                          IL_0001:  newobj     "System.Collections.Generic.List<T>..ctor(int)"
+                          IL_0006:  dup
+                          IL_0007:  ldarg.0
+                          IL_0008:  callvirt   "void System.Collections.Generic.List<T>.AddRange(System.Collections.Generic.IEnumerable<T>)"
+                          IL_000d:  ret
+                        }
+                        """;
+                break;
+            default:
+                expectedIL = """
+                        {
+                          // Code size       69 (0x45)
+                          .maxstack  5
+                          .locals init (T[] V_0,
+                                        int V_1,
+                                        System.Span<T> V_2,
+                                        int V_3,
+                                        System.ReadOnlySpan<T> V_4)
+                          IL_0000:  ldarg.0
+                          IL_0001:  stloc.0
+                          IL_0002:  ldloc.0
+                          IL_0003:  ldlen
+                          IL_0004:  conv.i4
+                          IL_0005:  stloc.1
+                          IL_0006:  ldloc.1
+                          IL_0007:  newobj     "System.Collections.Generic.List<T>..ctor(int)"
+                          IL_000c:  dup
+                          IL_000d:  ldloc.1
+                          IL_000e:  call       "void System.Runtime.InteropServices.CollectionsMarshal.SetCount<T>(System.Collections.Generic.List<T>, int)"
+                          IL_0013:  dup
+                          IL_0014:  call       "System.Span<T> System.Runtime.InteropServices.CollectionsMarshal.AsSpan<T>(System.Collections.Generic.List<T>)"
+                          IL_0019:  stloc.2
+                          IL_001a:  ldc.i4.0
+                          IL_001b:  stloc.3
+                          IL_001c:  ldloca.s   V_4
+                          IL_001e:  ldloc.0
+                          IL_001f:  call       "System.ReadOnlySpan<T>..ctor(T[])"
+                          IL_0024:  ldloca.s   V_4
+                          IL_0026:  ldloca.s   V_2
+                          IL_0028:  ldloc.3
+                          IL_0029:  ldloca.s   V_4
+                          IL_002b:  call       "int System.ReadOnlySpan<T>.Length.get"
+                          IL_0030:  call       "System.Span<T> System.Span<T>.Slice(int, int)"
+                          IL_0035:  call       "void System.ReadOnlySpan<T>.CopyTo(System.Span<T>)"
+                          IL_003a:  ldloc.3
+                          IL_003b:  ldloca.s   V_4
+                          IL_003d:  call       "int System.ReadOnlySpan<T>.Length.get"
+                          IL_0042:  add
+                          IL_0043:  stloc.3
+                          IL_0044:  ret
+                        }
+                        """;
+                break;
+        }
+        verifier.VerifyIL("Program.Create<T>", expectedIL);
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void InterfaceTarget_GenericMethod(
+        [CombinatorialValues("IDictionary", "IReadOnlyDictionary")] string typeName)
+    {
+        string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static {{typeName}}<K, V> Create<K, V>(IEqualityComparer<K> e)
+                    {
+                        return [with(e)];
+                    }
+                    static void Main()
+                    {
+                        Create<int, string>(null).Report();
+                    }
+                }
+                """;
+        var verifier = CompileAndVerify(
+            [source, s_collectionExtensions],
+            expectedOutput: "[], ");
+        verifier.VerifyDiagnostics();
+        verifier.VerifyIL("Program.Create<K, V>",
+            typeName == "IDictionary" ?
+            """
+                {
+                    // Code size        7 (0x7)
+                    .maxstack  1
+                    IL_0000:  ldarg.0
+                    IL_0001:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor(System.Collections.Generic.IEqualityComparer<K>)"
+                    IL_0006:  ret
+                }
+                """ :
+            """
+                {
+                    // Code size       12 (0xc)
+                    .maxstack  1
+                    IL_0000:  ldarg.0
+                    IL_0001:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor(System.Collections.Generic.IEqualityComparer<K>)"
+                    IL_0006:  newobj     "System.Collections.ObjectModel.ReadOnlyDictionary<K, V>..ctor(System.Collections.Generic.IDictionary<K, V>)"
+                    IL_000b:  ret
+                }
+                """);
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void InterfaceTarget_FieldInitializer(
+        [CombinatorialValues("IDictionary", "IReadOnlyDictionary")] string typeName)
+    {
+        string source = $$"""
+                using System.Collections.Generic;
+                class C<K, V>
+                {
+                    public {{typeName}}<K, V> F =
+                        [with(GetComparer())];
+                    static IEqualityComparer<K> GetComparer() => null;
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        var c = new C<int, string>();
+                        c.F.Report();
+                    }
+                }
+                """;
+        var verifier = CompileAndVerify(
+            [source, s_collectionExtensions],
+            expectedOutput: "[], ");
+        verifier.VerifyDiagnostics();
+        verifier.VerifyIL("C<K, V>..ctor",
+            typeName == "IDictionary" ?
+            """
+                {
+                  // Code size       23 (0x17)
+                  .maxstack  2
+                  IL_0000:  ldarg.0
+                  IL_0001:  call       "System.Collections.Generic.IEqualityComparer<K> C<K, V>.GetComparer()"
+                  IL_0006:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor(System.Collections.Generic.IEqualityComparer<K>)"
+                  IL_000b:  stfld      "System.Collections.Generic.IDictionary<K, V> C<K, V>.F"
+                  IL_0010:  ldarg.0
+                  IL_0011:  call       "object..ctor()"
+                  IL_0016:  ret
+                }
+                """ :
+            """
+                {
+                  // Code size       28 (0x1c)
+                  .maxstack  2
+                  IL_0000:  ldarg.0
+                  IL_0001:  call       "System.Collections.Generic.IEqualityComparer<K> C<K, V>.GetComparer()"
+                  IL_0006:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor(System.Collections.Generic.IEqualityComparer<K>)"
+                  IL_000b:  newobj     "System.Collections.ObjectModel.ReadOnlyDictionary<K, V>..ctor(System.Collections.Generic.IDictionary<K, V>)"
+                  IL_0010:  stfld      "System.Collections.Generic.IReadOnlyDictionary<K, V> C<K, V>.F"
+                  IL_0015:  ldarg.0
+                  IL_0016:  call       "object..ctor()"
+                  IL_001b:  ret
+                }
+                """);
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void InterfaceTarget_Nullability(
+        [CombinatorialValues("IDictionary", "IReadOnlyDictionary")] string typeName)
+    {
+        string source = $$"""
+#nullable enable
+                using System.Collections.Generic;
+                class Program
+                {
+                    static {{typeName}}<K, V> Create1<K, V>(bool b, IEqualityComparer<K>? c1)
+                    {
+                        if (b) return new Dictionary<K, V>(c1);
+                        return [with(c1)];
+                    }
+                    static {{typeName}}<K, V> Create2<K, V>(bool b, IEqualityComparer<K?> c2) where K : class
+                    {
+                        if (b) return new Dictionary<K, V>(c2);
+                        return [with(c2)];
+                    }
+                    static {{typeName}}<K?, V> Create3<K, V>(bool b, IEqualityComparer<K> c3) where K : class
+                    {
+                        if (b) return new Dictionary<K?, V>(c3);
+                        return [with(c3)];
+                    }
+                }
+                """;
+        var comp = CreateCompilation(source);
+        // PROTOTYPE: Handle collection arguments in flow analysis: report CS8620 for 'with(c3)'.
+        comp.VerifyEmitDiagnostics(
+            // (17,45): warning CS8620: Argument of type 'IEqualityComparer<K>' cannot be used for parameter 'comparer' of type 'IEqualityComparer<K?>' in 'Dictionary<K?, V>.Dictionary(IEqualityComparer<K?> comparer)' due to differences in the nullability of reference types.
+            //         if (b) return new Dictionary<K?, V>(c3);
+            Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "c3").WithArguments("System.Collections.Generic.IEqualityComparer<K>", "System.Collections.Generic.IEqualityComparer<K?>", "comparer", "Dictionary<K?, V>.Dictionary(IEqualityComparer<K?> comparer)").WithLocation(17, 45));
+    }
+
+    [Fact]
+    public void InterfaceTarget_ReorderedArguments()
+    {
+        string source = """
+                using System;
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Create<int, string>(EqualityComparer<int>.Default, 2, new(1, "one")).Report();
+                    }
+                    static IDictionary<K, V> Create<K, V>(IEqualityComparer<K> e, int c, KeyValuePair<K, V> x)
+                    {
+                        return [with(comparer: Identity(e), capacity: Identity(c)), Identity(x)];
+                    }
+                    static T Identity<T>(T value)
+                    {
+                        Console.WriteLine(value);
+                        return value;
+                    }
+                }
+                """;
+        var verifier = CompileAndVerify(
+            [source, s_collectionExtensions],
+                expectedOutput: """
+                        System.Collections.Generic.GenericEqualityComparer`1[System.Int32]
+                        2
+                        [1, one]
+                        [[1, one]],
+                        """);
+        verifier.VerifyDiagnostics();
+        verifier.VerifyIL("Program.Create<K, V>", """
+                {
+                  // Code size       47 (0x2f)
+                  .maxstack  4
+                  .locals init (System.Collections.Generic.KeyValuePair<K, V> V_0,
+                                System.Collections.Generic.IEqualityComparer<K> V_1)
+                  IL_0000:  ldarg.0
+                  IL_0001:  call       "System.Collections.Generic.IEqualityComparer<K> Program.Identity<System.Collections.Generic.IEqualityComparer<K>>(System.Collections.Generic.IEqualityComparer<K>)"
+                  IL_0006:  stloc.1
+                  IL_0007:  ldarg.1
+                  IL_0008:  call       "int Program.Identity<int>(int)"
+                  IL_000d:  ldloc.1
+                  IL_000e:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor(int, System.Collections.Generic.IEqualityComparer<K>)"
+                  IL_0013:  ldarg.2
+                  IL_0014:  call       "System.Collections.Generic.KeyValuePair<K, V> Program.Identity<System.Collections.Generic.KeyValuePair<K, V>>(System.Collections.Generic.KeyValuePair<K, V>)"
+                  IL_0019:  stloc.0
+                  IL_001a:  dup
+                  IL_001b:  ldloca.s   V_0
+                  IL_001d:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                  IL_0022:  ldloca.s   V_0
+                  IL_0024:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                  IL_0029:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                  IL_002e:  ret
+                }
+                """);
+    }
+
+    [Fact]
+    public void InterfaceTarget_Dynamic()
+    {
+        string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        CreateReadOnlyDictionary(null, 1, "one");
+                        CreateDictionary(2, null, 2, "two");
+                    }
+                    static IReadOnlyDictionary<K, V> CreateReadOnlyDictionary<K, V>(dynamic d, K k, V v)
+                    {
+                        return [with(d), k:v];
+                    }
+                    static IDictionary<K, V> CreateDictionary<K, V>(dynamic x, dynamic y, K k, V v)
+                    {
+                        return [with(x, y), k:v];
+                    }
+                }
+                """;
+        var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (11,22): error CS9503: Collection arguments cannot be dynamic; compile-time binding is required.
+            //         return [with(d), k:v];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, "d").WithLocation(11, 22),
+            // (15,22): error CS9503: Collection arguments cannot be dynamic; compile-time binding is required.
+            //         return [with(x, y), k:v];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, "x").WithLocation(15, 22),
+            // (15,25): error CS9503: Collection arguments cannot be dynamic; compile-time binding is required.
+            //         return [with(x, y), k:v];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, "y").WithLocation(15, 25));
+    }
+
+    /// <summary>
+    /// Implementation of List(int) uses a name other than capacity.
+    /// </summary>
+    [Fact]
+    public void InterfaceTarget_ImplementationParameterName()
+    {
+        string sourceA = """
+                namespace System
+                {
+                    public class Object { }
+                    public abstract class ValueType { }
+                    public class String { }
+                    public class Type { }
+                    public struct Void { }
+                    public struct Boolean { }
+                    public struct Int32 { }
+                    public class Array { }
+                    public interface IDisposable
+                    {
+                        void Dispose();
+                    }
+                }
+                namespace System.Collections
+                {
+                    public interface IEnumerator
+                    {
+                        bool MoveNext();
+                        object Current { get; }
+                    }
+                    public interface IEnumerable
+                    {
+                        IEnumerator GetEnumerator();
+                    }
+                }
+                namespace System.Collections.Generic
+                {
+                    public interface IEnumerator<T> : IEnumerator
+                    {
+                        new T Current { get; }
+                    }
+                    public interface IEnumerable<T> : IEnumerable
+                    {
+                        new IEnumerator<T> GetEnumerator();
+                    }
+                    public interface ICollection<T> : IEnumerable<T>
+                    {
+                    }
+                    public class List<T> : ICollection<T>
+                    {
+                        public List() { }
+                        public List(int __c) { }
+                        public void Add(T t) { }
+                        public T[] ToArray() => null;
+                        IEnumerator<T> IEnumerable<T>.GetEnumerator() => null;
+                        IEnumerator IEnumerable.GetEnumerator() => null;
+                    }
+                }
+                """;
+        string sourceB = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Create(1, 2);
+                    }
+                    static ICollection<T> Create<T>(T x, T y)
+                    {
+                        return [with(capacity: 3), x, y];
+                    }
+                }
+                """;
+        var comp = CreateEmptyCompilation(
+            [sourceA, sourceB],
+            parseOptions: TestOptions.RegularPreview.WithNoRefSafetyRulesAttribute(),
+            options: TestOptions.ReleaseExe);
+        var verifier = CompileAndVerify(
+            comp,
+            emitOptions: Microsoft.CodeAnalysis.Emit.EmitOptions.Default.WithRuntimeMetadataVersion("4.0.0.0"),
+            verify: Verification.Skipped);
+        verifier.VerifyDiagnostics();
+        verifier.VerifyIL("Program.Create<T>", """
+                {
+                  // Code size       21 (0x15)
+                  .maxstack  3
+                  IL_0000:  ldc.i4.3
+                  IL_0001:  newobj     "System.Collections.Generic.List<T>..ctor(int)"
+                  IL_0006:  dup
+                  IL_0007:  ldarg.0
+                  IL_0008:  callvirt   "void System.Collections.Generic.List<T>.Add(T)"
+                  IL_000d:  dup
+                  IL_000e:  ldarg.1
+                  IL_000f:  callvirt   "void System.Collections.Generic.List<T>.Add(T)"
+                  IL_0014:  ret
+                }
+                """);
+    }
+
+    [Theory]
+    [InlineData("IEnumerable")]
+    [InlineData("IReadOnlyCollection")]
+    [InlineData("IReadOnlyList")]
+    [InlineData("ICollection")]
+    [InlineData("IList")]
+    public void EmptyArguments_ArrayInterface(string interfaceType)
+    {
+        string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        NoArgs<int>().Report();
+                        EmptyArgs<int>().Report();
+                    }
+                    static {{interfaceType}}<T> NoArgs<T>() => [];
+                    static {{interfaceType}}<T> EmptyArgs<T>() => [with()];
+                }
+                """;
+        var verifier = CompileAndVerify(
+            [source, s_collectionExtensions],
+            verify: Verification.Skipped,
+            expectedOutput: IncludeExpectedOutput("[], [], "));
+        verifier.VerifyDiagnostics();
+        string expectedIL;
+        if (interfaceType is "IEnumerable" or "IReadOnlyCollection" or "IReadOnlyList")
+        {
+            expectedIL = """
+                    {
+                      // Code size        6 (0x6)
+                      .maxstack  1
+                      IL_0000:  call       "T[] System.Array.Empty<T>()"
+                      IL_0005:  ret
+                    }
+                    """;
+        }
+        else
+        {
+            expectedIL = """
+                    {
+                      // Code size        6 (0x6)
+                      .maxstack  1
+                      IL_0000:  newobj     "System.Collections.Generic.List<T>..ctor()"
+                      IL_0005:  ret
+                    }
+                    """;
+        }
+        verifier.VerifyIL("Program.NoArgs<T>", expectedIL);
+        verifier.VerifyIL("Program.EmptyArgs<T>", expectedIL);
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void InterfaceTarget_ArrayInterfaces(
+        [CombinatorialValues("IEnumerable", "IReadOnlyCollection", "IReadOnlyList", "ICollection", "IList")] string typeName)
+    {
+        bool isMutable = typeName is "ICollection" or "IList";
+        string sourceA = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Create(1, 2, 3).Report();
+                    }
+                    static {{typeName}}<T> Create<T>(T x, T y, T z)
+                    {
+                        return [with(), x, y, z];
+                    }
+                }
+                """;
+        var comp = CreateCompilation(
+            [sourceA, s_collectionExtensions],
+            options: TestOptions.ReleaseExe);
+        var verifier = CompileAndVerify(
+            comp,
+            expectedOutput: "[1, 2, 3], ");
+        verifier.VerifyDiagnostics();
+        verifier.VerifyIL("Program.Create<T>", isMutable ?
+            """
+                {
+                  // Code size       28 (0x1c)
+                  .maxstack  3
+                  IL_0000:  ldc.i4.3
+                  IL_0001:  newobj     "System.Collections.Generic.List<T>..ctor(int)"
+                  IL_0006:  dup
+                  IL_0007:  ldarg.0
+                  IL_0008:  callvirt   "void System.Collections.Generic.List<T>.Add(T)"
+                  IL_000d:  dup
+                  IL_000e:  ldarg.1
+                  IL_000f:  callvirt   "void System.Collections.Generic.List<T>.Add(T)"
+                  IL_0014:  dup
+                  IL_0015:  ldarg.2
+                  IL_0016:  callvirt   "void System.Collections.Generic.List<T>.Add(T)"
+                  IL_001b:  ret
+                }
+                """ :
+            """
+                {
+                  // Code size       36 (0x24)
+                  .maxstack  4
+                  IL_0000:  ldc.i4.3
+                  IL_0001:  newarr     "T"
+                  IL_0006:  dup
+                  IL_0007:  ldc.i4.0
+                  IL_0008:  ldarg.0
+                  IL_0009:  stelem     "T"
+                  IL_000e:  dup
+                  IL_000f:  ldc.i4.1
+                  IL_0010:  ldarg.1
+                  IL_0011:  stelem     "T"
+                  IL_0016:  dup
+                  IL_0017:  ldc.i4.2
+                  IL_0018:  ldarg.2
+                  IL_0019:  stelem     "T"
+                  IL_001e:  newobj     "<>z__ReadOnlyArray<T>..ctor(T[])"
+                  IL_0023:  ret
+                }
+                """);
+
+        string sourceB = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Create1(2, 1, 2, 3).Report();
+                        Create2(2, 4, 5, 6).Report();
+                    }
+                    static {{typeName}}<T> Create1<T>(int c, T x, T y, T z)
+                    {
+                        return [with(c), x, y, z];
+                    }
+                    static {{typeName}}<T> Create2<T>(int c, T x, T y, T z)
+                    {
+                        return [with(capacity: c), x, y, z];
+                    }
+                }
+                """;
+        comp = CreateCompilation(
+            [sourceB, s_collectionExtensions],
+            options: TestOptions.ReleaseExe);
+        if (isMutable)
+        {
+            verifier = CompileAndVerify(
+                comp,
+                expectedOutput: "[1, 2, 3], [4, 5, 6], ");
+            verifier.VerifyDiagnostics();
+            string expectedIL = """
+                    {
+                      // Code size       28 (0x1c)
+                      .maxstack  3
+                      IL_0000:  ldarg.0
+                      IL_0001:  newobj     "System.Collections.Generic.List<T>..ctor(int)"
+                      IL_0006:  dup
+                      IL_0007:  ldarg.1
+                      IL_0008:  callvirt   "void System.Collections.Generic.List<T>.Add(T)"
+                      IL_000d:  dup
+                      IL_000e:  ldarg.2
+                      IL_000f:  callvirt   "void System.Collections.Generic.List<T>.Add(T)"
+                      IL_0014:  dup
+                      IL_0015:  ldarg.3
+                      IL_0016:  callvirt   "void System.Collections.Generic.List<T>.Add(T)"
+                      IL_001b:  ret
+                    }
+                    """;
+            verifier.VerifyIL("Program.Create1<T>", expectedIL);
+            verifier.VerifyIL("Program.Create2<T>", expectedIL);
+        }
+        else
+        {
+            comp.VerifyEmitDiagnostics(
+                // (11,16): error CS1501: No overload for method '<signature>' takes 1 arguments
+                //         return [with(c), x, y, z];
+                Diagnostic(ErrorCode.ERR_BadArgCount, "[with(c), x, y, z]").WithArguments("<signature>", "1").WithLocation(11, 16),
+                // (15,22): error CS1739: The best overload for '<signature>' does not have a parameter named 'capacity'
+                //         return [with(capacity: c), x, y, z];
+                Diagnostic(ErrorCode.ERR_BadNamedArgument, "capacity").WithArguments("<signature>", "capacity").WithLocation(15, 22));
+        }
+
+        string sourceC = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static {{typeName}}<T> Create1<T>(IEnumerable<T> c, T x, T y, T z)
+                    {
+                        return [with(c), x, y, z];
+                    }
+                    static {{typeName}}<T> Create2<T>(IEnumerable<T> c, T x, T y, T z)
+                    {
+                        return [with(collection: c), x, y, z];
+                    }
+                }
+                """;
+        comp = CreateCompilation(sourceC);
+        if (isMutable)
+        {
+            comp.VerifyEmitDiagnostics(
+                // (6,22): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.IEnumerable<T>' to 'int'
+                //         return [with(c), x, y, z];
+                Diagnostic(ErrorCode.ERR_BadArgType, "c").WithArguments("1", "System.Collections.Generic.IEnumerable<T>", "int").WithLocation(6, 22),
+                // (10,22): error CS1739: The best overload for '<signature>' does not have a parameter named 'collection'
+                //         return [with(collection: c), x, y, z];
+                Diagnostic(ErrorCode.ERR_BadNamedArgument, "collection").WithArguments("<signature>", "collection").WithLocation(10, 22));
+        }
+        else
+        {
+            comp.VerifyEmitDiagnostics(
+                // (6,16): error CS1501: No overload for method '<signature>' takes 1 arguments
+                //         return [with(c), x, y, z];
+                Diagnostic(ErrorCode.ERR_BadArgCount, "[with(c), x, y, z]").WithArguments("<signature>", "1").WithLocation(6, 16),
+                // (10,22): error CS1739: The best overload for '<signature>' does not have a parameter named 'collection'
+                //         return [with(collection: c), x, y, z];
+                Diagnostic(ErrorCode.ERR_BadNamedArgument, "collection").WithArguments("<signature>", "collection").WithLocation(10, 22));
+        }
+    }
+
+
+    [Theory]
+    [CombinatorialData]
+    public void CollectionArguments_CapacityAndComparer_01(
+        [CombinatorialValues(
+                "T[]",
+                "System.ReadOnlySpan<T>",
+                "System.Span<T>",
+                "System.Collections.Generic.IEnumerable<T>",
+                "System.Collections.Generic.IReadOnlyCollection<T>",
+                "System.Collections.Generic.IReadOnlyList<T>",
+                "System.Collections.Generic.ICollection<T>",
+                "System.Collections.Generic.IList<T>")]
+            string typeName)
+    {
+        string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Create<T>(int capacity, IEqualityComparer<T> comparer)
+                    {
+                        {{typeName}} c;
+                        c = [];
+                        c = [with()];
+                        c = [with(default)];
+                        c = [with(capacity)];
+                        c = [with(comparer)];
+                        c = [with(capacity, comparer)];
+                    }
+                }
+                """;
+        var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+        switch (typeName)
+        {
+            case "T[]":
+            case "System.ReadOnlySpan<T>":
+            case "System.Span<T>":
+                comp.VerifyEmitDiagnostics(
+                    // (9,14): error CS9502: Collection arguments are not supported for type 'T[]'.
+                    //         c = [with(default)];
+                    Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments(typeName).WithLocation(9, 14),
+                    // (10,14): error CS9502: Collection arguments are not supported for type 'T[]'.
+                    //         c = [with(capacity)];
+                    Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments(typeName).WithLocation(10, 14),
+                    // (11,14): error CS9502: Collection arguments are not supported for type 'T[]'.
+                    //         c = [with(comparer)];
+                    Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments(typeName).WithLocation(11, 14),
+                    // (12,14): error CS9502: Collection arguments are not supported for type 'T[]'.
+                    //         c = [with(capacity, comparer)];
+                    Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments(typeName).WithLocation(12, 14));
+                break;
+            case "System.Collections.Generic.IEnumerable<T>":
+            case "System.Collections.Generic.IReadOnlyCollection<T>":
+            case "System.Collections.Generic.IReadOnlyList<T>":
+                comp.VerifyEmitDiagnostics(
+                    // (9,13): error CS1501: No overload for method '<signature>' takes 1 arguments
+                    //         c = [with(default)];
+                    Diagnostic(ErrorCode.ERR_BadArgCount, "[with(default)]").WithArguments("<signature>", "1").WithLocation(9, 13),
+                    // (10,13): error CS1501: No overload for method '<signature>' takes 1 arguments
+                    //         c = [with(capacity)];
+                    Diagnostic(ErrorCode.ERR_BadArgCount, "[with(capacity)]").WithArguments("<signature>", "1").WithLocation(10, 13),
+                    // (11,13): error CS1501: No overload for method '<signature>' takes 1 arguments
+                    //         c = [with(comparer)];
+                    Diagnostic(ErrorCode.ERR_BadArgCount, "[with(comparer)]").WithArguments("<signature>", "1").WithLocation(11, 13),
+                    // (12,13): error CS1501: No overload for method '<signature>' takes 2 arguments
+                    //         c = [with(capacity, comparer)];
+                    Diagnostic(ErrorCode.ERR_BadArgCount, "[with(capacity, comparer)]").WithArguments("<signature>", "2").WithLocation(12, 13));
+                break;
+            case "System.Collections.Generic.ICollection<T>":
+            case "System.Collections.Generic.IList<T>":
+                comp.VerifyEmitDiagnostics(
+                    // (11,19): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.IEqualityComparer<T>' to 'int'
+                    //         c = [with(comparer)];
+                    Diagnostic(ErrorCode.ERR_BadArgType, "comparer").WithArguments("1", "System.Collections.Generic.IEqualityComparer<T>", "int").WithLocation(11, 19),
+                    // (12,13): error CS1501: No overload for method '<signature>' takes 2 arguments
+                    //         c = [with(capacity, comparer)];
+                    Diagnostic(ErrorCode.ERR_BadArgCount, "[with(capacity, comparer)]").WithArguments("<signature>", "2").WithLocation(12, 13));
+                break;
+            default:
+                throw ExceptionUtilities.UnexpectedValue(typeName);
+        }
+    }
+
+    [Theory]
+    [InlineData("IEnumerable")]
+    [InlineData("IReadOnlyCollection")]
+    [InlineData("IReadOnlyList")]
+    [InlineData("ICollection")]
+    [InlineData("IList")]
+    public void Arguments_ArrayInterface(string interfaceType)
+    {
+        string source = $$"""
+            using System.Collections.Generic;
+            class Program
+            {
+                static void F<T>(T t)
+                {
+                    {{interfaceType}}<T> i;
+                    i = [with(default), t];
+                    i = [t, with(default)];
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        if (interfaceType is "ICollection" or "IList")
+        {
+            comp.VerifyEmitDiagnostics(
+                // (8,17): error CS9501: Collection argument element must be the first element.
+                //         i = [t, with(default)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(8, 17));
+        }
+        else
+        {
+            comp.VerifyEmitDiagnostics(
+                // (7,13): error CS1501: No overload for method '<signature>' takes 1 arguments
+                //         i = [with(default), t];
+                Diagnostic(ErrorCode.ERR_BadArgCount, "[with(default), t]").WithArguments("<signature>", "1").WithLocation(7, 13),
+                // (8,13): error CS1501: No overload for method '<signature>' takes 1 arguments
+                //         i = [t, with(default)];
+                Diagnostic(ErrorCode.ERR_BadArgCount, "[t, with(default)]").WithArguments("<signature>", "1").WithLocation(8, 13),
+                // (8,17): error CS9501: Collection argument element must be the first element.
+                //         i = [t, with(default)];
+                Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(8, 17));
+        }
+
+        // Collection arguments do not affect convertibility.
+        var tree = comp.SyntaxTrees[0];
+        var model = comp.GetSemanticModel(tree);
+        var collections = tree.GetRoot().DescendantNodes().OfType<CollectionExpressionSyntax>().ToArray();
+        Assert.Equal(2, collections.Length);
+        VerifyTypes(model, collections[0], expectedType: null, expectedConvertedType: $"System.Collections.Generic.{interfaceType}<T>", ConversionKind.CollectionExpression);
+        VerifyTypes(model, collections[1], expectedType: null, expectedConvertedType: $"System.Collections.Generic.{interfaceType}<T>", ConversionKind.CollectionExpression);
+    }
+#endif
+
+    [Fact]
+    public void CollectionInitializer_MultipleConstructors()
+    {
+        string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    public readonly T Arg;
+                    public MyCollection() { }
+                    public MyCollection(T arg) { Arg = arg; }
+                    public void Add(T t) { }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => throw null;
+                    IEnumerator IEnumerable.GetEnumerator() => throw null;
+                }
+                """;
+        string sourceB = """
+                using System;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Console.WriteLine((EmptyArgs<int>().Arg, NonEmptyArgs(2).Arg));
+                    }
+                    static MyCollection<T> EmptyArgs<T>() => [with()];
+                    static MyCollection<T> NonEmptyArgs<T>(T t) => [with(t)];
+                }
+                """;
+        var verifier = CompileAndVerify(
+            [sourceA, sourceB],
+            expectedOutput: "(0, 2)");
+        verifier.VerifyDiagnostics();
+        verifier.VerifyIL("Program.EmptyArgs<T>()", """
+                {
+                  // Code size        6 (0x6)
+                  .maxstack  1
+                  IL_0000:  newobj     "MyCollection<T>..ctor()"
+                  IL_0005:  ret
+                }
+                """);
+        verifier.VerifyIL("Program.NonEmptyArgs<T>(T)", """
+                {
+                  // Code size        7 (0x7)
+                  .maxstack  1
+                  IL_0000:  ldarg.0
+                  IL_0001:  newobj     "MyCollection<T>..ctor(T)"
+                  IL_0006:  ret
+                }
+                """);
+    }
+
+    [Fact]
+    public void CollectionInitializer_NoParameterlessConstructor()
+    {
+        string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    public readonly T Arg;
+                    public MyCollection(T arg) { Arg = arg; }
+                    public void Add(T t) { }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                }
+                class Program
+                {
+                    static MyCollection<T> EmptyArgs<T>() => [with()];
+                    static MyCollection<T> NonEmptyArgs<T>(T t) => [with(t)];
+                }
+                """;
+        var comp = CreateCompilation(source);
+        comp.VerifyEmitDiagnostics(
+            // (13,46): error CS9214: Collection expression type must have an applicable constructor that can be called with no arguments.
+            //     static MyCollection<T> EmptyArgs<T>() => [with()];
+            Diagnostic(ErrorCode.ERR_CollectionExpressionMissingConstructor, "[with()]").WithLocation(13, 46));
+    }
+
+    [Fact]
+    public void CollectionInitializer_OptionalParameter()
+    {
+        string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    public readonly T Arg;
+                    public MyCollection(T arg = default) { Arg = arg; }
+                    public void Add(T t) { }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => throw null;
+                    IEnumerator IEnumerable.GetEnumerator() => throw null;
+                }
+                """;
+        string sourceB = """
+                using System;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Console.WriteLine((EmptyArgs<int>().Arg, NonEmptyArgs(2).Arg));
+                    }
+                    static MyCollection<T> EmptyArgs<T>() => [with()];
+                    static MyCollection<T> NonEmptyArgs<T>(T t) => [with(t)];
+                }
+                """;
+        var verifier = CompileAndVerify(
+            [sourceA, sourceB],
+            expectedOutput: "(0, 2)");
+        verifier.VerifyDiagnostics();
+        verifier.VerifyIL("Program.EmptyArgs<T>()", """
+                {
+                  // Code size       15 (0xf)
+                  .maxstack  1
+                  .locals init (T V_0)
+                  IL_0000:  ldloca.s   V_0
+                  IL_0002:  initobj    "T"
+                  IL_0008:  ldloc.0
+                  IL_0009:  newobj     "MyCollection<T>..ctor(T)"
+                  IL_000e:  ret
+                }
+                """);
+        verifier.VerifyIL("Program.NonEmptyArgs<T>(T)", """
+                {
+                  // Code size        7 (0x7)
+                  .maxstack  1
+                  IL_0000:  ldarg.0
+                  IL_0001:  newobj     "MyCollection<T>..ctor(T)"
+                  IL_0006:  ret
+                }
+                """);
+    }
+
+    [Fact]
+    public void CollectionInitializer_ParamsParameter()
+    {
+        string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    public readonly T[] Args;
+                    public MyCollection(params T[] args) { Args = args; }
+                    public void Add(T t) { }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => throw null;
+                    IEnumerator IEnumerable.GetEnumerator() => throw null;
+                }
+                """;
+        string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        EmptyArgs<int>().Args.Report();
+                        OneArg(1).Args.Report();
+                        TwoArgs(2, 3).Args.Report();
+                        MultipleArgs([4, 5]).Args.Report();
+                    }
+                    static MyCollection<T> EmptyArgs<T>() => [with()];
+                    static MyCollection<T> OneArg<T>(T t) => [with(t)];
+                    static MyCollection<T> TwoArgs<T>(T x, T y) => [with(x, y)];
+                    static MyCollection<T> MultipleArgs<T>(T[] args) => [with(args)];
+                }
+                """;
+        var verifier = CompileAndVerify(
+            [sourceA, sourceB, s_collectionExtensions],
+            expectedOutput: "[], [1], [2, 3], [4, 5], ");
+        verifier.VerifyDiagnostics();
+        verifier.VerifyIL("Program.EmptyArgs<T>()", """
+                {
+                  // Code size       11 (0xb)
+                  .maxstack  1
+                  IL_0000:  call       "T[] System.Array.Empty<T>()"
+                  IL_0005:  newobj     "MyCollection<T>..ctor(params T[])"
+                  IL_000a:  ret
+                }
+                """);
+        verifier.VerifyIL("Program.OneArg<T>(T)", """
+                {
+                  // Code size       20 (0x14)
+                  .maxstack  4
+                  IL_0000:  ldc.i4.1
+                  IL_0001:  newarr     "T"
+                  IL_0006:  dup
+                  IL_0007:  ldc.i4.0
+                  IL_0008:  ldarg.0
+                  IL_0009:  stelem     "T"
+                  IL_000e:  newobj     "MyCollection<T>..ctor(params T[])"
+                  IL_0013:  ret
+                }
+                """);
+        verifier.VerifyIL("Program.TwoArgs<T>(T, T)", """
+                {
+                  // Code size       28 (0x1c)
+                  .maxstack  4
+                  IL_0000:  ldc.i4.2
+                  IL_0001:  newarr     "T"
+                  IL_0006:  dup
+                  IL_0007:  ldc.i4.0
+                  IL_0008:  ldarg.0
+                  IL_0009:  stelem     "T"
+                  IL_000e:  dup
+                  IL_000f:  ldc.i4.1
+                  IL_0010:  ldarg.1
+                  IL_0011:  stelem     "T"
+                  IL_0016:  newobj     "MyCollection<T>..ctor(params T[])"
+                  IL_001b:  ret
+                }
+                """);
+        verifier.VerifyIL("Program.MultipleArgs<T>(T[])", """
+                {
+                  // Code size        7 (0x7)
+                  .maxstack  1
+                  IL_0000:  ldarg.0
+                  IL_0001:  newobj     "MyCollection<T>..ctor(params T[])"
+                  IL_0006:  ret
+                }
+                """);
+    }
+
+    [Fact]
+    public void CollectionInitializer_ObsoleteConstructor_01()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    public MyCollection() { }
+                    [Obsolete]
+                    public MyCollection(T arg) { }
+                    public void Add(T t) { }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => throw null;
+                    IEnumerator IEnumerable.GetEnumerator() => throw null;
+                }
+                """;
+        string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<int> c;
+                        c = [with()];
+                        c = [with(default)];
+                    }
+                    static void F<T>(params MyCollection<T> c) { }
+                }
+                """;
+        var comp = CreateCompilation([sourceA, sourceB]);
+        comp.VerifyEmitDiagnostics(
+            // (7,13): warning CS0612: 'MyCollection<int>.MyCollection(int)' is obsolete
+            //         c = [with(default)];
+            Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "[with(default)]").WithArguments("MyCollection<int>.MyCollection(int)").WithLocation(7, 13));
+    }
+
+    [Fact]
+    public void CollectionInitializer_ObsoleteConstructor_02()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    [Obsolete]
+                    public MyCollection(T arg = default) { }
+                    public void Add(T t) { }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => throw null;
+                    IEnumerator IEnumerable.GetEnumerator() => throw null;
+                }
+                """;
+        string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<int> c;
+                        c = [with()];
+                        c = [with(default)];
+                    }
+                    static void F<T>(params MyCollection<T> c) { }
+                }
+                """;
+        var comp = CreateCompilation([sourceA, sourceB]);
+        comp.VerifyEmitDiagnostics(
+            // (6,13): warning CS0612: 'MyCollection<int>.MyCollection(int)' is obsolete
+            //         c = [with()];
+            Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "[with()]").WithArguments("MyCollection<int>.MyCollection(int)").WithLocation(6, 13),
+            // (7,13): warning CS0612: 'MyCollection<int>.MyCollection(int)' is obsolete
+            //         c = [with(default)];
+            Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "[with(default)]").WithArguments("MyCollection<int>.MyCollection(int)").WithLocation(7, 13),
+            // (9,22): warning CS0612: 'MyCollection<T>.MyCollection(T)' is obsolete
+            //     static void F<T>(params MyCollection<T> c) { }
+            Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "params MyCollection<T> c").WithArguments("MyCollection<T>.MyCollection(T)").WithLocation(9, 22));
+    }
+
+#if CREATE_METHODS
+    [Fact]
+    public void TypeInference_CollectionBuilder()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _items;
+                    public MyCollection(T[] args, ReadOnlySpan<T> items)
+                    {
+                        _items = new();
+                        _items.AddRange(items.ToArray());
+                        _items.AddRange(args);
+                    }
+                    public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, params T[] args) => new(args, items);
+                }
+                """;
+        string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        Identity([with()]);
+                        Identity([with(default, 2), default]);
+                        Identity([with(default), default, 3]);
+                    }
+                    static MyCollection<T> Identity<T>(MyCollection<T> c) => c;
+                }
+                """;
+        var comp = CreateCompilation(
+            [sourceA, sourceB],
+            targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (5,9): error CS0411: The type arguments for method 'Program.Identity<T>(MyCollection<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+            //         Identity([with()]);
+            Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Identity").WithArguments("Program.Identity<T>(MyCollection<T>)").WithLocation(5, 9),
+            // (6,9): error CS0411: The type arguments for method 'Program.Identity<T>(MyCollection<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+            //         Identity([with(default, 2), default]);
+            Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Identity").WithArguments("Program.Identity<T>(MyCollection<T>)").WithLocation(6, 9),
+            // (7,18): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         Identity([with(default), default, 3]);
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(default), default, 3]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(7, 18),
+            // (7,24): error CS8716: There is no target type for the default literal.
+            //         Identity([with(default), default, 3]);
+            Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(7, 24),
+            // (7,34): error CS8716: There is no target type for the default literal.
+            //         Identity([with(default), default, 3]);
+            Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(7, 34));
+    }
+
+    [Fact]
+    public void CollectionBuilder_MultipleBuilderMethods()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    public readonly T Arg;
+                    private readonly List<T> _items;
+                    public MyCollection(T arg, ReadOnlySpan<T> items) { Arg = arg; _items = new(items.ToArray()); }
+                    public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) => new(default, items);
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T arg) => new(arg, items);
+                }
+                """;
+        string sourceB = """
+                using System;
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<int> c;
+                        c = EmptyArgs(1);
+                        Console.Write("{0}, ", c.Arg);
+                        c.Report();
+                        c = NonEmptyArgs<int>(2);
+                        Console.Write("{0}, ", c.Arg);
+                        c.Report();
+                    }
+                    static MyCollection<T> EmptyArgs<T>(T t) => [with(), t];
+                    static MyCollection<T> NonEmptyArgs<T>(T t) => [with(t), t];
+                }
+                """;
+        var comp = CreateCompilation(
+            [sourceA, sourceB, s_collectionExtensions],
+            targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (15,53): error CS9502: Collection arguments are not supported for type 'MyCollection<T>'.
+            //     static MyCollection<T> NonEmptyArgs<T>(T t) => [with(t), t];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<T>").WithLocation(15, 53));
+    }
+
+    [Fact]
+    public void CollectionBuilder_NoParameterlessBuilderMethod()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T arg) => default;
+                }
+                """;
+        string sourceB = """
+                using System;
+                class Program
+                {
+                    static MyCollection<T> EmptyArgs<T>() => [with()];
+                    static MyCollection<T> NonEmptyArgs<T>(T t) => [with(t)];
+                    static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
+                }
+                """;
+        var comp = CreateCompilation([sourceA, sourceB], targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (4,46): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //     static MyCollection<T> EmptyArgs<T>() => [with()];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with()]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(4, 46),
+            // (5,52): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //     static MyCollection<T> NonEmptyArgs<T>(T t) => [with(t)];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(t)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(5, 52),
+            // (6,38): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //     static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "params MyCollection<T> c").WithArguments("Create", "T", "MyCollection<T>").WithLocation(6, 38));
+    }
+
+    [Fact]
+    public void CollectionBuilder_OptionalParameter()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    public readonly T Arg;
+                    public MyCollection(T arg, ReadOnlySpan<T> items) { Arg = arg; }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T arg = default) => new(arg, items);
+                }
+                """;
+        string sourceB = """
+                using System;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Console.WriteLine(EmptyArgs<int>().Arg);
+                        Console.WriteLine(NonEmptyArgs(2).Arg);
+                        Console.WriteLine(Params(3, 4).Arg);
+                    }
+                    static MyCollection<T> EmptyArgs<T>() => [with()];
+                    static MyCollection<T> NonEmptyArgs<T>(T t) => [with(t)];
+                    static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
+                }
+                """;
+        var comp = CreateCompilation(
+            [sourceA, sourceB],
+            targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (8,27): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         Console.WriteLine(Params(3, 4).Arg);
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "Params(3, 4)").WithArguments("Create", "T", "MyCollection<T>").WithLocation(8, 27),
+            // (10,46): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //     static MyCollection<T> EmptyArgs<T>() => [with()];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with()]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(10, 46),
+            // (11,52): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //     static MyCollection<T> NonEmptyArgs<T>(T t) => [with(t)];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(t)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(11, 52),
+            // (12,38): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //     static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "params MyCollection<T> c").WithArguments("Create", "T", "MyCollection<T>").WithLocation(12, 38));
+    }
+
+    [Fact]
+    public void CollectionBuilder_ParamsParameter()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    public readonly T[] Args;
+                    public MyCollection(ReadOnlySpan<T> items, T[] args) { Args = args; }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, params T[] args) => new(items, args);
+                }
+                """;
+        string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        EmptyArgs<int>().Args.Report();
+                        OneArg(1).Args.Report();
+                        TwoArgs(2, 3).Args.Report();
+                        MultipleArgs([4, 5]).Args.Report();
+                        Params(6).Args.Report();
+                    }
+                    static MyCollection<T> EmptyArgs<T>() => [with()];
+                    static MyCollection<T> OneArg<T>(T t) => [with(t)];
+                    static MyCollection<T> TwoArgs<T>(T x, T y) => [with(x, y)];
+                    static MyCollection<T> MultipleArgs<T>(T[] args) => [with(args)];
+                    static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
+                }
+                """;
+        var comp = CreateCompilation(
+            [sourceA, sourceB, s_collectionExtensions],
+            targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (9,9): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         Params(6).Args.Report();
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "Params(6)").WithArguments("Create", "T", "MyCollection<T>").WithLocation(9, 9),
+            // (11,46): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //     static MyCollection<T> EmptyArgs<T>() => [with()];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with()]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(11, 46),
+            // (12,46): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //     static MyCollection<T> OneArg<T>(T t) => [with(t)];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(t)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(12, 46),
+            // (13,52): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //     static MyCollection<T> TwoArgs<T>(T x, T y) => [with(x, y)];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(x, y)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(13, 52),
+            // (14,57): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //     static MyCollection<T> MultipleArgs<T>(T[] args) => [with(args)];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(args)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(14, 57),
+            // (15,38): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //     static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "params MyCollection<T> c").WithArguments("Create", "T", "MyCollection<T>").WithLocation(15, 38));
+    }
+
+    [Fact]
+    public void CollectionBuilder_ImplicitParameter_Optional()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                struct MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    internal MyCollection(ReadOnlySpan<T> items) { _list = new(items.ToArray()); }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items = default) => new(items);
+                }
+                """;
+
+        string sourceB1 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<int> c;
+                        c = [];
+                        c.Report();
+                        c = [1, 2, 3];
+                        c.Report();
+                        c = [with(), 4];
+                        c.Report();
+                        F(5, 6);
+                    }
+                    static void F<T>(params MyCollection<T> c)
+                    {
+                        c.Report();
+                    }
+                }
+                """;
+        var verifier = CompileAndVerify(
+            [sourceA, sourceB1, s_collectionExtensions],
+            targetFramework: TargetFramework.Net80,
+            verify: Verification.Skipped,
+            expectedOutput: IncludeExpectedOutput("[], [1, 2, 3], [4], [5, 6], "));
+        verifier.VerifyDiagnostics();
+
+        string sourceB2 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<int> c;
+                        c = [with(1)];
+                        c = [with(2), 3];
+                    }
+                }
+                """;
+        var comp = CreateCompilation([sourceA, sourceB2], targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (6,14): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            //         c = [with(1)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(6, 14),
+            // (7,14): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            //         c = [with(2), 3];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(7, 14));
+    }
+
+    [Fact]
+    public void CollectionBuilder_ImplicitParameter_Params_01()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                struct MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    internal MyCollection(ReadOnlySpan<T> items) { _list = new(items.ToArray()); }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(params ReadOnlySpan<T> items) => new(items);
+                }
+                """;
+
+        string sourceB1 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<int> c;
+                        c = [];
+                        c.Report();
+                        c = [1, 2, 3];
+                        c.Report();
+                        c = [with(), 4];
+                        c.Report();
+                        F(5, 6);
+                    }
+                    static void F<T>(params MyCollection<T> c)
+                    {
+                        c.Report();
+                    }
+                }
+                """;
+        var verifier = CompileAndVerify(
+            [sourceA, sourceB1, s_collectionExtensions],
+            targetFramework: TargetFramework.Net80,
+            verify: Verification.Skipped,
+            expectedOutput: IncludeExpectedOutput("[], [1, 2, 3], [4], [5, 6], "));
+        verifier.VerifyDiagnostics();
+
+        string sourceB2 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<int> c;
+                        c = [with(1)];
+                        c = [with(2), 3];
+                    }
+                }
+                """;
+        var comp = CreateCompilation([sourceA, sourceB2], targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (6,14): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            //         c = [with(1)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(6, 14),
+            // (7,14): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            //         c = [with(2), 3];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(7, 14));
+    }
+
+    [Fact]
+    public void CollectionBuilder_ImplicitParameter_Params_02()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                struct MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    internal MyCollection(ReadOnlySpan<T> items) { _list = new(items.ToArray()); }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(params ReadOnlySpan<T> items) => new(items);
+                }
+                """;
+        string sourceB = """
+                using System;
+                class MyItem
+                {
+                    public static implicit operator MyItem(ReadOnlySpan<MyItem> items) => new();
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyItem x = new();
+                        MyItem y = new();
+                        MyCollection<MyItem> c;
+                        c = [];
+                        c = [x, y];
+                        c = [with(x)];
+                        c = [with(x), y];
+                        c = [with(), x, y];
+                    }
+                }
+                """;
+        var comp = CreateCompilation([sourceA, sourceB], targetFramework: TargetFramework.Net80);
+        // https://github.com/dotnet/roslyn/issues/77866: [with(x)] and [with(x), y] should
+        // result in errors since x should not be included in the params argument. Should
+        // be fixed when the last parameter of the builder method is the items parameter.
+        comp.VerifyEmitDiagnostics(
+            // (15,14): error CS9502: Collection arguments are not supported for type 'MyCollection<MyItem>'.
+            //         c = [with(x)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<MyItem>").WithLocation(15, 14),
+            // (16,14): error CS9502: Collection arguments are not supported for type 'MyCollection<MyItem>'.
+            //         c = [with(x), y];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<MyItem>").WithLocation(16, 14));
+    }
+
+    // C#7.3 feature ImprovedOverloadCandidates drops candidates with constraint violations
+    // (see OverloadResolution.RemoveConstraintViolations()) which allows constructing
+    // MyCollection<T> and MyCollection<U> with different factory methods.
+    [Fact]
+    public void CollectionBuilder_MultipleBuilderMethods_GenericConstraints_ClassAndStruct()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _items;
+                    public MyCollection(ReadOnlySpan<T> items)
+                    {
+                        _items = new(items.ToArray());
+                    }
+                    public MyCollection(T arg, ReadOnlySpan<T> items)
+                    {
+                        _items = new();
+                        _items.Add(arg);
+                        _items.AddRange(items.ToArray());
+                    }
+                    public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) where T : class => new(items);
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T arg = default) where T : struct => new(arg, items);
+                }
+                """;
+
+        string sourceB1 = """
+                class Program
+                {
+                    static MyCollection<T> NoConstraints<T>(T x, T y) => [x, y];
+                }
+                """;
+        var comp = CreateCompilation([sourceA, sourceB1], targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (3,58): error CS0452: The type 'T' must be a reference type in order to use it as parameter 'T' in the generic type or method 'MyBuilder.Create<T>(ReadOnlySpan<T>)'
+            //     static MyCollection<T> NoConstraints<T>(T x, T y) => [x, y];
+            Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "[x, y]").WithArguments("MyBuilder.Create<T>(System.ReadOnlySpan<T>)", "T", "T").WithLocation(3, 58));
+
+        string sourceB2 = """
+                class Program
+                {
+                    static MyCollection<T> NoConstraints<T>(T x, T y) => NoConstraintsParams(x, y);
+                    static MyCollection<T> NoConstraintsParams<T>(params MyCollection<T> c) => c;
+                }
+                """;
+        comp = CreateCompilation([sourceA, sourceB2], targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (3,58): error CS0452: The type 'T' must be a reference type in order to use it as parameter 'T' in the generic type or method 'MyBuilder.Create<T>(ReadOnlySpan<T>)'
+            //     static MyCollection<T> NoConstraints<T>(T x, T y) => NoConstraintsParams(x, y);
+            Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "NoConstraintsParams(x, y)").WithArguments("MyBuilder.Create<T>(System.ReadOnlySpan<T>)", "T", "T").WithLocation(3, 58));
+
+        string sourceB3 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        StructConstraint(3, 4).Report();
+                        ClassConstraint((object)5, 6).Report();
+                    }
+                    static MyCollection<T> StructConstraint<T>(T x, T y) where T : struct => [x, y];
+                    static MyCollection<T> ClassConstraint<T>(T x, T y) where T : class => [x, y];
+                }
+                """;
+        comp = CreateCompilation(
+            [sourceA, sourceB3, s_collectionExtensions],
+            targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (8,78): error CS0452: The type 'T' must be a reference type in order to use it as parameter 'T' in the generic type or method 'MyBuilder.Create<T>(ReadOnlySpan<T>)'
+            //     static MyCollection<T> StructConstraint<T>(T x, T y) where T : struct => [x, y];
+            Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "[x, y]").WithArguments("MyBuilder.Create<T>(System.ReadOnlySpan<T>)", "T", "T").WithLocation(8, 78));
+
+        string sourceB4 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        StructConstraint(3, 4).Report();
+                        ClassConstraint((object)5, 6).Report();
+                    }
+                    static MyCollection<T> StructConstraint<T>(T x, T y) where T : struct => StructConstraintParams(x, y);
+                    static MyCollection<T> ClassConstraint<T>(T x, T y) where T : class => ClassConstraintParams(x, y);
+                    static MyCollection<T> StructConstraintParams<T>(params MyCollection<T> c) where T : struct => c;
+                    static MyCollection<T> ClassConstraintParams<T>(params MyCollection<T> c) where T : class => c;
+                }
+                """;
+        comp = CreateCompilation(
+            [sourceA, sourceB4, s_collectionExtensions],
+            targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (8,78): error CS0452: The type 'T' must be a reference type in order to use it as parameter 'T' in the generic type or method 'MyBuilder.Create<T>(ReadOnlySpan<T>)'
+            //     static MyCollection<T> StructConstraint<T>(T x, T y) where T : struct => StructConstraintParams(x, y);
+            Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "StructConstraintParams(x, y)").WithArguments("MyBuilder.Create<T>(System.ReadOnlySpan<T>)", "T", "T").WithLocation(8, 78));
+    }
+
+    [Fact]
+    public void CollectionBuilder_MultipleBuilderMethods_GenericConstraints_NoneAndClass()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _items;
+                    public MyCollection(ReadOnlySpan<T> items)
+                    {
+                        _items = new(items.ToArray());
+                    }
+                    public MyCollection(T arg, ReadOnlySpan<T> items)
+                    {
+                        _items = new();
+                        _items.Add(arg);
+                        _items.AddRange(items.ToArray());
+                    }
+                    public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) => new(items);
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T arg = default) where T : class => new(arg, items);
+                }
+                """;
+
+        string sourceB1 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        NoConstraints(1, 2).Report();
+                        StructConstraint(3, 4).Report();
+                        ClassConstraint((object)5, 6).Report();
+                    }
+                    static MyCollection<T> NoConstraints<T>(T x, T y) => [x, y];
+                    static MyCollection<T> StructConstraint<T>(T x, T y) where T : struct => [x, y];
+                    static MyCollection<T> ClassConstraint<T>(T x, T y) where T : class => [x, y];
+                }
+                """;
+        var verifier = CompileAndVerify(
+            [sourceA, sourceB1, s_collectionExtensions],
+            targetFramework: TargetFramework.Net80,
+            verify: Verification.Skipped,
+            expectedOutput: IncludeExpectedOutput("[1, 2], [3, 4], [5, 6], "));
+        verifier.VerifyDiagnostics();
+        string expectedIL = """
+                {
+                  // Code size       50 (0x32)
+                  .maxstack  2
+                  .locals init (<>y__InlineArray2<T> V_0)
+                  IL_0000:  ldloca.s   V_0
+                  IL_0002:  initobj    "<>y__InlineArray2<T>"
+                  IL_0008:  ldloca.s   V_0
+                  IL_000a:  ldc.i4.0
+                  IL_000b:  call       "ref T <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray2<T>, T>(ref <>y__InlineArray2<T>, int)"
+                  IL_0010:  ldarg.0
+                  IL_0011:  stobj      "T"
+                  IL_0016:  ldloca.s   V_0
+                  IL_0018:  ldc.i4.1
+                  IL_0019:  call       "ref T <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray2<T>, T>(ref <>y__InlineArray2<T>, int)"
+                  IL_001e:  ldarg.1
+                  IL_001f:  stobj      "T"
+                  IL_0024:  ldloca.s   V_0
+                  IL_0026:  ldc.i4.2
+                  IL_0027:  call       "System.ReadOnlySpan<T> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray2<T>, T>(in <>y__InlineArray2<T>, int)"
+                  IL_002c:  call       "MyCollection<T> MyBuilder.Create<T>(System.ReadOnlySpan<T>)"
+                  IL_0031:  ret
+                }
+                """;
+        verifier.VerifyIL("Program.NoConstraints<T>", expectedIL);
+        verifier.VerifyIL("Program.StructConstraint<T>", expectedIL);
+        verifier.VerifyIL("Program.ClassConstraint<T>", expectedIL);
+
+        string sourceB2 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        NoConstraints(1, 2).Report();
+                        StructConstraint(3, 4).Report();
+                        ClassConstraint((object)5, 6).Report();
+                    }
+                    static MyCollection<T> NoConstraints<T>(T x, T y) => NoConstraintsParams(x, y);
+                    static MyCollection<T> StructConstraint<T>(T x, T y) where T : struct => StructConstraintParams(x, y);
+                    static MyCollection<T> ClassConstraint<T>(T x, T y) where T : class => ClassConstraintParams(x, y);
+                    static MyCollection<T> NoConstraintsParams<T>(params MyCollection<T> c) => c;
+                    static MyCollection<T> StructConstraintParams<T>(params MyCollection<T> c) where T : struct => c;
+                    static MyCollection<T> ClassConstraintParams<T>(params MyCollection<T> c) where T : class => c;
+                }
+                """;
+        verifier = CompileAndVerify(
+            [sourceA, sourceB2, s_collectionExtensions],
+            targetFramework: TargetFramework.Net80,
+            verify: Verification.Skipped,
+            expectedOutput: IncludeExpectedOutput("[1, 2], [3, 4], [5, 6], "));
+        verifier.VerifyDiagnostics();
+        expectedIL = """
+                {
+                  // Code size       55 (0x37)
+                  .maxstack  2
+                  .locals init (<>y__InlineArray2<T> V_0)
+                  IL_0000:  ldloca.s   V_0
+                  IL_0002:  initobj    "<>y__InlineArray2<T>"
+                  IL_0008:  ldloca.s   V_0
+                  IL_000a:  ldc.i4.0
+                  IL_000b:  call       "ref T <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray2<T>, T>(ref <>y__InlineArray2<T>, int)"
+                  IL_0010:  ldarg.0
+                  IL_0011:  stobj      "T"
+                  IL_0016:  ldloca.s   V_0
+                  IL_0018:  ldc.i4.1
+                  IL_0019:  call       "ref T <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray2<T>, T>(ref <>y__InlineArray2<T>, int)"
+                  IL_001e:  ldarg.1
+                  IL_001f:  stobj      "T"
+                  IL_0024:  ldloca.s   V_0
+                  IL_0026:  ldc.i4.2
+                  IL_0027:  call       "System.ReadOnlySpan<T> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray2<T>, T>(in <>y__InlineArray2<T>, int)"
+                  IL_002c:  call       "MyCollection<T> MyBuilder.Create<T>(System.ReadOnlySpan<T>)"
+                  IL_0031:  call       "MyCollection<T> Program.NoConstraintsParams<T>(params MyCollection<T>)"
+                  IL_0036:  ret
+                }
+                """;
+        verifier.VerifyIL("Program.NoConstraints<T>", expectedIL);
+        verifier.VerifyIL("Program.StructConstraint<T>", expectedIL.Replace("NoConstraintsParams", "StructConstraintParams"));
+        verifier.VerifyIL("Program.ClassConstraint<T>", expectedIL.Replace("NoConstraintsParams", "ClassConstraintParams"));
+    }
+
+    [Fact]
+    public void CollectionBuilder_MultipleBuilderMethods_GenericConstraints_StructAndNone()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _items;
+                    public MyCollection(ReadOnlySpan<T> items)
+                    {
+                        _items = new(items.ToArray());
+                    }
+                    public MyCollection(T arg, ReadOnlySpan<T> items)
+                    {
+                        _items = new();
+                        _items.Add(arg);
+                        _items.AddRange(items.ToArray());
+                    }
+                    public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) where T : struct => new(items);
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T arg = default) => new(arg, items);
+                }
+                """;
+
+        string sourceB1 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        NoConstraints(1, 2).Report();
+                        StructConstraint(3, 4).Report();
+                        ClassConstraint((object)5, 6).Report();
+                    }
+                    static MyCollection<T> NoConstraints<T>(T x, T y) => [x, y];
+                    static MyCollection<T> StructConstraint<T>(T x, T y) where T : struct => [x, y];
+                    static MyCollection<T> ClassConstraint<T>(T x, T y) where T : class => [x, y];
+                }
+                """;
+        var comp = CreateCompilation(
+            [sourceA, sourceB1, s_collectionExtensions],
+            targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (9,58): error CS0453: The type 'T' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'MyBuilder.Create<T>(ReadOnlySpan<T>)'
+            //     static MyCollection<T> NoConstraints<T>(T x, T y) => [x, y];
+            Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "[x, y]").WithArguments("MyBuilder.Create<T>(System.ReadOnlySpan<T>)", "T", "T").WithLocation(9, 58),
+            // (11,76): error CS0453: The type 'T' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'MyBuilder.Create<T>(ReadOnlySpan<T>)'
+            //     static MyCollection<T> ClassConstraint<T>(T x, T y) where T : class => [x, y];
+            Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "[x, y]").WithArguments("MyBuilder.Create<T>(System.ReadOnlySpan<T>)", "T", "T").WithLocation(11, 76));
+
+        string sourceB2 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        NoConstraints(1, 2).Report();
+                        StructConstraint(3, 4).Report();
+                        ClassConstraint((object)5, 6).Report();
+                    }
+                    static MyCollection<T> NoConstraints<T>(T x, T y) => NoConstraintsParams(x, y);
+                    static MyCollection<T> StructConstraint<T>(T x, T y) where T : struct => StructConstraintParams(x, y);
+                    static MyCollection<T> ClassConstraint<T>(T x, T y) where T : class => ClassConstraintParams(x, y);
+                    static MyCollection<T> NoConstraintsParams<T>(params MyCollection<T> c) => c;
+                    static MyCollection<T> StructConstraintParams<T>(params MyCollection<T> c) where T : struct => c;
+                    static MyCollection<T> ClassConstraintParams<T>(params MyCollection<T> c) where T : class => c;
+                }
+                """;
+        comp = CreateCompilation(
+            [sourceA, sourceB2, s_collectionExtensions],
+            targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (9,58): error CS0453: The type 'T' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'MyBuilder.Create<T>(ReadOnlySpan<T>)'
+            //     static MyCollection<T> NoConstraints<T>(T x, T y) => NoConstraintsParams(x, y);
+            Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "NoConstraintsParams(x, y)").WithArguments("MyBuilder.Create<T>(System.ReadOnlySpan<T>)", "T", "T").WithLocation(9, 58),
+            // (11,76): error CS0453: The type 'T' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'MyBuilder.Create<T>(ReadOnlySpan<T>)'
+            //     static MyCollection<T> ClassConstraint<T>(T x, T y) where T : class => ClassConstraintParams(x, y);
+            Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "ClassConstraintParams(x, y)").WithArguments("MyBuilder.Create<T>(System.ReadOnlySpan<T>)", "T", "T").WithLocation(11, 76));
+    }
+
+    [Fact]
+    public void CollectionBuilder_NamedParameter()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                struct MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    internal MyCollection(ReadOnlySpan<T> items, T x, T y)
+                    {
+                        _list = new();
+                        _list.Add(x);
+                        _list.Add(y);
+                        _list.AddRange(items.ToArray());
+                    }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) => default;
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T x = default, T y = default) => new(items, x, y);
+                }
+                """;
+        string sourceB = """
+                MyCollection<int> c;
+                c = [with(x: 1), 2, 3];
+                c.Report();
+                c = [with(y: 4), 5];
+                c.Report();
+                c = [with(y: 6, x: 7), 8];
+                c.Report();
+                """;
+        var comp = CreateCompilation(
+            [sourceA, sourceB, s_collectionExtensions],
+            targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (2,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(x: 1), 2, 3];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(2, 6),
+            // (4,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(y: 4), 5];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(4, 6),
+            // (6,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(y: 6, x: 7), 8];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(6, 6));
+    }
+
+    [Fact]
+    public void CollectionBuilder_RefParameter()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                struct MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    internal MyCollection(ReadOnlySpan<T> items, T arg) { _list = new(items.ToArray()); _list.Add(arg); }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) => throw null;
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, ref T x) => new(items, x);
+                }
+                """;
+
+        string sourceB1 = """
+#pragma warning disable 219 // variable assigned but never used
+                MyCollection<int> c;
+                int x = 1;
+                ref int r = ref x;
+                c = [with(ref x)];
+                c.Report();
+                x = 2;
+                c = [with(ref r)];
+                c.Report();
+                """;
+        var comp = CreateCompilation(
+            [sourceA, sourceB1, s_collectionExtensions],
+            targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (5,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(ref x)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(5, 6),
+            // (8,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(ref r)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(8, 6));
+
+        string sourceB2 = """
+#pragma warning disable 219 // variable assigned but never used
+                MyCollection<int> c;
+                int x = 1;
+                ref readonly int ro = ref x;
+                c = [with(0)];
+                c = [with(x)];
+                c = [with(in x)];
+                c = [with(ref ro)];
+                c = [with(out x)];
+                """;
+        comp = CreateCompilation([sourceA, sourceB2], targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (5,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(0)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(5, 6),
+            // (6,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(x)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(6, 6),
+            // (7,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(in x)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(7, 6),
+            // (8,15): error CS1510: A ref or out value must be an assignable variable
+            // c = [with(ref ro)];
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "ro").WithLocation(8, 15),
+            // (9,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(out x)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(9, 6));
+    }
+
+    [Fact]
+    public void CollectionBuilder_RefReadonlyParameter()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                struct MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    internal MyCollection(ReadOnlySpan<T> items, T arg) { _list = new(items.ToArray()); _list.Add(arg); }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) => throw null;
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, ref readonly T x) => new(items, x);
+                }
+                """;
+
+        string sourceB1 = """
+#pragma warning disable 219 // variable assigned but never used
+                MyCollection<int> c;
+                int x = 1;
+                ref int r = ref x;
+                ref readonly int ro = ref x;
+                c = [with(0)];
+                c.Report();
+                c = [with(x)];
+                c.Report();
+                x = 2;
+                c = [with(ref x)];
+                c.Report();
+                x = 3;
+                c = [with(ref r)];
+                c.Report();
+                x = 4;
+                c = [with(in ro)];
+                c.Report();
+                """;
+        var comp = CreateCompilation(
+            [sourceA, sourceB1, s_collectionExtensions],
+            targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (6,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(0)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(6, 6),
+            // (8,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(x)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(8, 6),
+            // (11,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(ref x)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(11, 6),
+            // (14,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(ref r)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(14, 6),
+            // (17,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(in ro)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(17, 6));
+
+        string sourceB2 = """
+#pragma warning disable 219 // variable assigned but never used
+                MyCollection<int> c;
+                int x = 1;
+                ref readonly int ro = ref x;
+                c = [with(in x)];
+                c = [with(ref ro)];
+                c = [with(out x)];
+                """;
+        comp = CreateCompilation([sourceA, sourceB2], targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (5,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(in x)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(5, 6),
+            // (6,15): error CS1510: A ref or out value must be an assignable variable
+            // c = [with(ref ro)];
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "ro").WithLocation(6, 15),
+            // (7,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(out x)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(7, 6));
+    }
+
+    [Fact]
+    public void CollectionBuilder_InParameter()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                struct MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    internal MyCollection(ReadOnlySpan<T> items, T arg) { _list = new(items.ToArray()); _list.Add(arg); }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) => throw null;
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, in T x) => new(items, x);
+                }
+                """;
+
+        string sourceB1 = """
+#pragma warning disable 219 // variable assigned but never used
+                MyCollection<int> c;
+                int x = 1;
+                ref int r = ref x;
+                ref readonly int ro = ref x;
+                c = [with(0)];
+                c.Report();
+                c = [with(x)];
+                c.Report();
+                x = 2;
+                c = [with(ref x)];
+                c.Report();
+                x = 3;
+                c = [with(in x)];
+                c.Report();
+                x = 4;
+                c = [with(in r)];
+                c.Report();
+                x = 5;
+                c = [with(in ro)];
+                c.Report();
+                """;
+        var comp = CreateCompilation([sourceA, sourceB1, s_collectionExtensions], targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (6,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(0)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(6, 6),
+            // (8,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(x)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(8, 6),
+            // (11,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(ref x)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(11, 6),
+            // (14,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(in x)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(14, 6),
+            // (17,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(in r)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(17, 6),
+            // (20,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(in ro)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(20, 6));
+
+        string sourceB2 = """
+#pragma warning disable 219 // variable assigned but never used
+                MyCollection<int> c;
+                int x = 1;
+                ref readonly int ro = ref x;
+                c = [with(ref ro)];
+                """;
+        comp = CreateCompilation([sourceA, sourceB2], targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (5,15): error CS1510: A ref or out value must be an assignable variable
+            // c = [with(ref ro)];
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "ro").WithLocation(5, 15));
+    }
+
+    [Fact]
+    public void CollectionBuilder_OutParameter()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                struct MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    internal MyCollection(ReadOnlySpan<T> items, T arg) { _list = new(items.ToArray()); _list.Add(arg); }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) => throw null;
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, out T x) { x = default; return new(items, x); }
+                }
+                """;
+
+        string sourceB1 = """
+#pragma warning disable 219 // variable assigned but never used
+                MyCollection<int> c;
+                int x = 1;
+                ref int r = ref x;
+                c = [with(out x)];
+                c.Report();
+                x = 2;
+                c = [with(out r), 3];
+                c.Report();
+                """;
+        var comp = CreateCompilation(
+            [sourceA, sourceB1, s_collectionExtensions],
+            targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (5,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(out x)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(5, 6),
+            // (8,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(out r), 3];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(8, 6));
+
+        string sourceB2 = """
+#pragma warning disable 219 // variable assigned but never used
+                MyCollection<int> c;
+                int x = 1;
+                c = [with(1)];
+                c = [with(x)];
+                c = [with(ref x)];
+                c = [with(in x)];
+                """;
+        comp = CreateCompilation([sourceA, sourceB2], targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (4,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(1)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(4, 6),
+            // (5,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(x)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(5, 6),
+            // (6,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(ref x)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(6, 6),
+            // (7,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(in x)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(7, 6));
+    }
+
+    [Fact]
+    public void CollectionBuilder_RefParameter_Overloads()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                struct MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    internal MyCollection(ReadOnlySpan<T> items, T x, T y)
+                    {
+                        _list = new();
+                        _list.Add(x);
+                        _list.Add(y);
+                        _list.AddRange(items.ToArray());
+                    }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) => default;
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, in T x) => new(items, x, default);
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T x, ref T y) => new(items, x, y);
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, out T x, T y) { x = default; return new(items, x, y); }
+                }
+                """;
+        string sourceB = """
+#pragma warning disable 219 // variable assigned but never used
+                MyCollection<int> c;
+                int x = 1;
+                int y = 2;
+                c = [with(in x)];
+                c.Report();
+                c = [with(1), 3];
+                c.Report();
+                c = [with(x, ref y)];
+                c.Report();
+                c = [with(out x, y), 3];
+                c.Report();
+                """;
+        var comp = CreateCompilation(
+            [sourceA, sourceB, s_collectionExtensions],
+            targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (5,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(in x)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(5, 6),
+            // (7,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(1), 3];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(7, 6),
+            // (9,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(x, ref y)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(9, 6),
+            // (11,6): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            // c = [with(out x, y), 3];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(11, 6));
+    }
+
+    [Fact]
+    public void CollectionBuilder_ReferenceImplicitParameter()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                struct MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    internal MyCollection(ReadOnlySpan<T> items, T arg) { _list = new(items.ToArray()); _list.Add(arg); }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T arg = default) => new(items, arg);
+                }
+                """;
+        string sourceB = """
+                MyCollection<int> c;
+                c = [with(items: default)];
+                c = [with(items: default, 1)];
+                c = [with(items: default, arg: 2)];
+                c = [with(3, items: default)];
+                c = [with(arg: 4, items: default)];
+                c = [with(default, 5)];
+                c = [with(default, arg: 6)];
+                """;
+        var comp = CreateCompilation([sourceA, sourceB], targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (2,5): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            // c = [with(items: default)];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(items: default)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(2, 5),
+            // (2,18): error CS8716: There is no target type for the default literal.
+            // c = [with(items: default)];
+            Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(2, 18),
+            // (3,5): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            // c = [with(items: default, 1)];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(items: default, 1)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(3, 5),
+            // (3,18): error CS8716: There is no target type for the default literal.
+            // c = [with(items: default, 1)];
+            Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(3, 18),
+            // (4,5): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            // c = [with(items: default, arg: 2)];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(items: default, arg: 2)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(4, 5),
+            // (4,18): error CS8716: There is no target type for the default literal.
+            // c = [with(items: default, arg: 2)];
+            Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(4, 18),
+            // (5,5): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            // c = [with(3, items: default)];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(3, items: default)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(5, 5),
+            // (5,21): error CS8716: There is no target type for the default literal.
+            // c = [with(3, items: default)];
+            Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(5, 21),
+            // (6,5): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            // c = [with(arg: 4, items: default)];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(arg: 4, items: default)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(6, 5),
+            // (6,26): error CS8716: There is no target type for the default literal.
+            // c = [with(arg: 4, items: default)];
+            Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(6, 26),
+            // (7,5): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            // c = [with(default, 5)];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(default, 5)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(7, 5),
+            // (7,11): error CS8716: There is no target type for the default literal.
+            // c = [with(default, 5)];
+            Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(7, 11),
+            // (8,5): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            // c = [with(default, arg: 6)];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(default, arg: 6)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(8, 5),
+            // (8,11): error CS8716: There is no target type for the default literal.
+            // c = [with(default, arg: 6)];
+            Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(8, 11));
+    }
+
+    [Fact]
+    public void CollectionBuilder_ReadOnlySpanConstraint()
+    {
+        string sourceA = """
+                namespace System
+                {
+                    public ref struct ReadOnlySpan<T>
+                        where T : struct
+                    {
+                    }
+                }
+                """;
+        string sourceB = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) => default;
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, int arg) where T : struct => default;
+                }
+                """;
+        string sourceC = """
+                class Program
+                {
+                    static MyCollection<T> NoArgs<T>() => [];
+                    static MyCollection<T> EmptyArgs<T>() => [with()];
+                    static MyCollection<T> WithArg<T>(int arg) => [with(arg)];
+                    static MyCollection<T> Params<T>(params MyCollection<T> c) => c;
+                }
+                """;
+        var comp = CreateCompilation([sourceA, sourceB, sourceC, CollectionBuilderAttributeDefinition]);
+        comp.VerifyEmitDiagnostics(
+            // (3,43): error CS0453: The type 'T' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'ReadOnlySpan<T>'
+            //     static MyCollection<T> NoArgs<T>() => [];
+            Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "[]").WithArguments("System.ReadOnlySpan<T>", "T", "T").WithLocation(3, 43),
+            // (4,46): error CS0453: The type 'T' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'ReadOnlySpan<T>'
+            //     static MyCollection<T> EmptyArgs<T>() => [with()];
+            Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "[with()]").WithArguments("System.ReadOnlySpan<T>", "T", "T").WithLocation(4, 46),
+            // (5,51): error CS0453: The type 'T' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'ReadOnlySpan<T>'
+            //     static MyCollection<T> WithArg<T>(int arg) => [with(arg)];
+            Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "[with(arg)]").WithArguments("System.ReadOnlySpan<T>", "T", "T").WithLocation(5, 51),
+            // (5,52): error CS9502: Collection arguments are not supported for type 'MyCollection<T>'.
+            //     static MyCollection<T> WithArg<T>(int arg) => [with(arg)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<T>").WithLocation(5, 52),
+            // (13,61): error CS0453: The type 'T' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'ReadOnlySpan<T>'
+            //     public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) => default;
+            Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "items").WithArguments("System.ReadOnlySpan<T>", "T", "T").WithLocation(13, 61));
+    }
+
+    [Fact]
+    public void CollectionBuilder_SpreadElement_BoxingConversion()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyCollectionBuilder), nameof(MyCollectionBuilder.Create))]
+                interface IMyCollection<T> : IEnumerable<T>
+                {
+                }
+                class MyCollectionBuilder
+                {
+                    public struct MyCollection<T> : IMyCollection<T>
+                    {
+                        private readonly List<T> _list;
+                        public MyCollection(ReadOnlySpan<T> items, T arg)
+                        {
+                            _list = new(items.ToArray());
+                            _list.Add(arg);
+                        }
+                        public IEnumerator<T> GetEnumerator() => _list.GetEnumerator();
+                        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    }
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) => throw null;
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T arg) => new(items, arg);
+                }
+                """;
+        string sourceB = """
+#nullable enable
+                using System;
+                class Program
+                {
+                    static void Main()
+                    {
+                        IMyCollection<string?> x = F<string>([], default!);
+                        x.Report();
+                        IMyCollection<int> y = F<int>([1, 2], 3);
+                        y.Report();
+                    }
+                    static IMyCollection<T?> F<T>(ReadOnlySpan<T> items, T arg) => [with(arg), ..items];
+                }
+                """;
+        var comp = CreateCompilation(
+            [sourceA, sourceB, s_collectionExtensions],
+            targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (12,69): error CS9502: Collection arguments are not supported for type 'IMyCollection<T?>'.
+            //     static IMyCollection<T?> F<T>(ReadOnlySpan<T> items, T arg) => [with(arg), ..items];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("IMyCollection<T?>").WithLocation(12, 69));
+    }
+
+    [Fact]
+    public void CollectionBuilder_UseSiteError_Method()
+    {
+        // [CollectionBuilder(typeof(MyCollectionBuilder), "Create")]
+        // public sealed class MyCollection<T>
+        // {
+        //     public IEnumerator<T> GetEnumerator() { }
+        // }
+        // public static class MyCollectionBuilder
+        // {
+        //     [CompilerFeatureRequired("MyFeature")]
+        //     public static MyCollection<T> MyCollectionBuilder.Create<T>(ReadOnlySpan<T>, object arg = null) { }
+        // }
+        string sourceA = """
+                .assembly extern System.Runtime { .ver 8:0:0:0 .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A) }
+                .class public sealed MyCollection`1<T>
+                {
+                  .custom instance void [System.Runtime]System.Runtime.CompilerServices.CollectionBuilderAttribute::.ctor(class [System.Runtime]System.Type, string) = { type(MyCollectionBuilder) string('Create') }
+                  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed { ret }
+                  .method public instance class [System.Runtime]System.Collections.Generic.IEnumerator`1<!T> GetEnumerator() { ldnull ret }
+                }
+                .class public abstract sealed MyCollectionBuilder
+                {
+                  .method public static class MyCollection`1<!!T> Create<T>(valuetype [System.Runtime]System.ReadOnlySpan`1<!!T> items, [opt] object arg)
+                  {
+                    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute::.ctor(string) = { string('MyFeature') }
+                    .param [2] = nullref
+                    ldnull ret
+                  }
+                }
+                """;
+        var refA = CompileIL(sourceA);
+
+        string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<int> c;
+                        c = [];
+                        c = [with()];
+                        c = [with(default)];
+                        c = F(1, 2);
+                    }
+                    static MyCollection<T> F<T>(params MyCollection<T> c) => c;
+                }
+                """;
+        var comp = CreateCompilation(sourceB, references: new[] { refA }, targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (6,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         c = [];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(6, 13),
+            // (7,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         c = [with()];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with()]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(7, 13),
+            // (8,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         c = [with(default)];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(default)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(8, 13),
+            // (8,19): error CS8716: There is no target type for the default literal.
+            //         c = [with(default)];
+            Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(8, 19),
+            // (9,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         c = F(1, 2);
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "F(1, 2)").WithArguments("Create", "T", "MyCollection<T>").WithLocation(9, 13),
+            // (11,33): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //     static MyCollection<T> F<T>(params MyCollection<T> c) => c;
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "params MyCollection<T> c").WithArguments("Create", "T", "MyCollection<T>").WithLocation(11, 33));
+    }
+
+    [Fact]
+    public void CollectionBuilder_ObsoleteBuilderMethod_01()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => default;
+                    IEnumerator IEnumerable.GetEnumerator() => default;
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) => default;
+                    [Obsolete]
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T arg) => default;
+                }
+                """;
+        string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<int> c;
+                        c = [];
+                        c = [with()];
+                        c = [with(default)];
+                        c = F(1, 2);
+                    }
+                    static MyCollection<T> F<T>(params MyCollection<T> c) => c;
+                }
+                """;
+        var comp = CreateCompilation([sourceA, sourceB], targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (8,14): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            //         c = [with(default)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(8, 14));
+    }
+
+    [Fact]
+    public void CollectionBuilder_ObsoleteBuilderMethod_02()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => default;
+                    IEnumerator IEnumerable.GetEnumerator() => default;
+                }
+                class MyBuilder
+                {
+                    [Obsolete]
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T arg = default) => default;
+                }
+                """;
+        string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<int> c;
+                        c = [];
+                        c = [with()];
+                        c = [with(default)];
+                        c = F(1, 2);
+                    }
+                    static MyCollection<T> F<T>(params MyCollection<T> c) => c;
+                }
+                """;
+        var comp = CreateCompilation([sourceA, sourceB], targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (6,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         c = [];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(6, 13),
+            // (7,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         c = [with()];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with()]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(7, 13),
+            // (8,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         c = [with(default)];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(default)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(8, 13),
+            // (8,19): error CS8716: There is no target type for the default literal.
+            //         c = [with(default)];
+            Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(8, 19),
+            // (9,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         c = F(1, 2);
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "F(1, 2)").WithArguments("Create", "T", "MyCollection<T>").WithLocation(9, 13),
+            // (11,33): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //     static MyCollection<T> F<T>(params MyCollection<T> c) => c;
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "params MyCollection<T> c").WithArguments("Create", "T", "MyCollection<T>").WithLocation(11, 33));
+    }
+
+    [Fact]
+    public void CollectionBuilder_UnmanagedCallersOnly()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                using System.Runtime.InteropServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection : IEnumerable<int>
+                {
+                    IEnumerator<int> IEnumerable<int>.GetEnumerator() => default;
+                    IEnumerator IEnumerable.GetEnumerator() => default;
+                }
+                class MyBuilder
+                {
+                    [UnmanagedCallersOnly]
+                    public static MyCollection Create(ReadOnlySpan<int> items, params object[] args) => default;
+                }
+                """;
+        string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection c;
+                        c = [];
+                        c = [with()];
+                        c = [with(0)];
+                        c = F(1, 2);
+                    }
+                    static MyCollection F(params MyCollection c) => c;
+                }
+                """;
+        var comp = CreateCompilation([sourceA, sourceB], targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (6,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<int>' and return type 'MyCollection'.
+            //         c = [];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[]").WithArguments("Create", "int", "MyCollection").WithLocation(6, 13),
+            // (7,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<int>' and return type 'MyCollection'.
+            //         c = [with()];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with()]").WithArguments("Create", "int", "MyCollection").WithLocation(7, 13),
+            // (8,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<int>' and return type 'MyCollection'.
+            //         c = [with(0)];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(0)]").WithArguments("Create", "int", "MyCollection").WithLocation(8, 13),
+            // (9,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<int>' and return type 'MyCollection'.
+            //         c = F(1, 2);
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "F(1, 2)").WithArguments("Create", "int", "MyCollection").WithLocation(9, 13),
+            // (11,27): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<int>' and return type 'MyCollection'.
+            //     static MyCollection F(params MyCollection c) => c;
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "params MyCollection c").WithArguments("Create", "int", "MyCollection").WithLocation(11, 27),
+            // (15,19): error CS8894: Cannot use 'MyCollection' as a return type on a method attributed with 'UnmanagedCallersOnly'.
+            //     public static MyCollection Create(ReadOnlySpan<int> items, params object[] args) => default;
+            Diagnostic(ErrorCode.ERR_CannotUseManagedTypeInUnmanagedCallersOnly, "MyCollection").WithArguments("MyCollection", "return").WithLocation(15, 19),
+            // (15,39): error CS8894: Cannot use 'ReadOnlySpan<int>' as a parameter type on a method attributed with 'UnmanagedCallersOnly'.
+            //     public static MyCollection Create(ReadOnlySpan<int> items, params object[] args) => default;
+            Diagnostic(ErrorCode.ERR_CannotUseManagedTypeInUnmanagedCallersOnly, "ReadOnlySpan<int> items").WithArguments("System.ReadOnlySpan<int>", "parameter").WithLocation(15, 39),
+            // (15,64): error CS8894: Cannot use 'object[]' as a parameter type on a method attributed with 'UnmanagedCallersOnly'.
+            //     public static MyCollection Create(ReadOnlySpan<int> items, params object[] args) => default;
+            Diagnostic(ErrorCode.ERR_CannotUseManagedTypeInUnmanagedCallersOnly, "params object[] args").WithArguments("object[]", "parameter").WithLocation(15, 64));
+    }
+
+    [Fact]
+    public void CollectionBuilder_GenericConstraints_01()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _items;
+                    public MyCollection(T arg, ReadOnlySpan<T> items)
+                    {
+                        _items = new();
+                        _items.Add(arg);
+                        _items.AddRange(items.ToArray());
+                    }
+                    public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) => new(default, items);
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T arg) where T : struct => new(arg, items);
+                }
+                """;
+
+        string sourceB1 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<object> x;
+                        x = [with(), 1];
+                        x.Report();
+                        MyCollection<int> y;
+                        y = [with(2), 3];
+                        y.Report();
+                        x = F((object)1);
+                        x.Report();
+                        y = F(3);
+                        y.Report();
+                    }
+                    static MyCollection<T> F<T>(params MyCollection<T> c) => c;
+                }
+                """;
+        var comp = CreateCompilation(
+            [sourceA, sourceB1, s_collectionExtensions],
+            targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (9,14): error CS9502: Collection arguments are not supported for type 'MyCollection<int>'.
+            //         y = [with(2), 3];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<int>").WithLocation(9, 14));
+
+        string sourceB2 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<object> x;
+                        x = [with(default)];
+                        x = [with(2), 3];
+                    }
+                }
+                """;
+        comp = CreateCompilation(
+            [sourceA, sourceB2],
+            targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (6,14): error CS9502: Collection arguments are not supported for type 'MyCollection<object>'.
+            //         x = [with(default)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<object>").WithLocation(6, 14),
+            // (7,14): error CS9502: Collection arguments are not supported for type 'MyCollection<object>'.
+            //         x = [with(2), 3];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsNotSupportedForType, "with").WithArguments("MyCollection<object>").WithLocation(7, 14));
+    }
+
+    [Fact]
+    public void CollectionBuilder_GenericConstraints_02()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _items;
+                    public MyCollection(T arg, ReadOnlySpan<T> items)
+                    {
+                        _items = new();
+                        _items.Add(arg);
+                        _items.AddRange(items.ToArray());
+                    }
+                    public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, T arg = default) where T : struct => new(arg, items);
+                }
+                """;
+
+        string sourceB1 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<int> c;
+                        c = [];
+                        c.Report();
+                        c = [with(), 1];
+                        c.Report();
+                        c = [with(2)];
+                        c.Report();
+                        F<int>();
+                        F(3);
+                        F(4, 5);
+                    }
+                    static void F<T>(params MyCollection<T> c) where T : struct
+                    {
+                        c.Report();
+                    }
+                }
+                """;
+        var comp = CreateCompilation(
+            [sourceA, sourceB1, s_collectionExtensions],
+            targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (6,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         c = [];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(6, 13),
+            // (8,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         c = [with(), 1];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(), 1]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(8, 13),
+            // (10,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         c = [with(2)];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(2)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(10, 13),
+            // (12,9): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         F<int>();
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "F<int>()").WithArguments("Create", "T", "MyCollection<T>").WithLocation(12, 9),
+            // (13,9): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         F(3);
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "F(3)").WithArguments("Create", "T", "MyCollection<T>").WithLocation(13, 9),
+            // (14,9): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         F(4, 5);
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "F(4, 5)").WithArguments("Create", "T", "MyCollection<T>").WithLocation(14, 9),
+            // (16,22): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //     static void F<T>(params MyCollection<T> c) where T : struct
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "params MyCollection<T> c").WithArguments("Create", "T", "MyCollection<T>").WithLocation(16, 22));
+
+        string sourceB2 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<object> c;
+                        c = [];
+                        c = [with(), 1];
+                        c = [with(2)];
+                        F<object>();
+                        F((object)3);
+                    }
+                    static void F<T>(params MyCollection<T> c)
+                    {
+                    }
+                }
+                """;
+        comp = CreateCompilation(
+            [sourceA, sourceB2],
+            targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (6,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         c = [];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(6, 13),
+            // (7,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         c = [with(), 1];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(), 1]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(7, 13),
+            // (8,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         c = [with(2)];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(2)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(8, 13),
+            // (9,9): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         F<object>();
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "F<object>()").WithArguments("Create", "T", "MyCollection<T>").WithLocation(9, 9),
+            // (10,9): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         F((object)3);
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "F((object)3)").WithArguments("Create", "T", "MyCollection<T>").WithLocation(10, 9),
+            // (12,22): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //     static void F<T>(params MyCollection<T> c)
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "params MyCollection<T> c").WithArguments("Create", "T", "MyCollection<T>").WithLocation(12, 22));
+    }
+
+    [Fact]
+    public void CollectionBuilder_GenericConstraints_03()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _items;
+                    public MyCollection(T[] args, ReadOnlySpan<T> items)
+                    {
+                        _items = new();
+                        _items.AddRange(args);
+                        _items.AddRange(items.ToArray());
+                    }
+                    public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, params T[] args) where T : struct => new(args, items);
+                }
+                """;
+
+        string sourceB1 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<int> c;
+                        c = [];
+                        c.Report();
+                        c = [with(), 1];
+                        c.Report();
+                        c = [with(2, 3)];
+                        c.Report();
+                        F<int>();
+                        F(4, 5);
+                    }
+                    static void F<T>(params MyCollection<T> c) where T : struct
+                    {
+                        c.Report();
+                    }
+                }
+                """;
+        var comp = CreateCompilation(
+            [sourceA, sourceB1, s_collectionExtensions],
+            targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (6,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         c = [];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(6, 13),
+            // (8,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         c = [with(), 1];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(), 1]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(8, 13),
+            // (10,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         c = [with(2, 3)];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(2, 3)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(10, 13),
+            // (12,9): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         F<int>();
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "F<int>()").WithArguments("Create", "T", "MyCollection<T>").WithLocation(12, 9),
+            // (13,9): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         F(4, 5);
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "F(4, 5)").WithArguments("Create", "T", "MyCollection<T>").WithLocation(13, 9),
+            // (15,22): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //     static void F<T>(params MyCollection<T> c) where T : struct
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "params MyCollection<T> c").WithArguments("Create", "T", "MyCollection<T>").WithLocation(15, 22));
+
+        string sourceB2 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<object> c;
+                        c = [];
+                        c = [with(), 1];
+                        c = [with(2, 3)];
+                        F<object>();
+                        F((object)4, 5);
+                    }
+                    static void F<T>(params MyCollection<T> c)
+                    {
+                    }
+                }
+                """;
+        comp = CreateCompilation(
+            [sourceA, sourceB2],
+            targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (6,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         c = [];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(6, 13),
+            // (7,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         c = [with(), 1];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(), 1]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(7, 13),
+            // (8,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         c = [with(2, 3)];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(2, 3)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(8, 13),
+            // (9,9): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         F<object>();
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "F<object>()").WithArguments("Create", "T", "MyCollection<T>").WithLocation(9, 9),
+            // (10,9): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         F((object)4, 5);
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "F((object)4, 5)").WithArguments("Create", "T", "MyCollection<T>").WithLocation(10, 9),
+            // (12,22): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //     static void F<T>(params MyCollection<T> c)
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "params MyCollection<T> c").WithArguments("Create", "T", "MyCollection<T>").WithLocation(12, 22));
+    }
+
+#endif
+
+    [Fact]
+    public void List_NoElements()
+    {
+        string source = """
+                using System;
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Report(ListNoArguments<int>());
+                        Report(ListEmptyArguments<int>());
+                        Report(ListWithCapacity<int>(16));
+                    }
+                    static void Report<T>(List<T> list)
+                    {
+                        Console.WriteLine("Count:{0}, Capacity:{1}", list.Count, list.Capacity);
+                    }
+                    static List<T> ListNoArguments<T>() => [];
+                    static List<T> ListEmptyArguments<T>() => [with()];
+                    static List<T> ListWithCapacity<T>(int capacity) => [with(capacity: capacity)];
+                }
+                """;
+        var verifier = CompileAndVerify(
+            source,
+            expectedOutput: """
+                    Count:0, Capacity:0
+                    Count:0, Capacity:0
+                    Count:0, Capacity:16
+                    """);
+        verifier.VerifyDiagnostics();
+        string expectedILNoArguments = """
+                {
+                  // Code size        6 (0x6)
+                  .maxstack  1
+                  IL_0000:  newobj     "System.Collections.Generic.List<T>..ctor()"
+                  IL_0005:  ret
+                }
+                """;
+        verifier.VerifyIL("Program.ListNoArguments<T>", expectedILNoArguments);
+        verifier.VerifyIL("Program.ListEmptyArguments<T>", expectedILNoArguments);
+        verifier.VerifyIL("Program.ListWithCapacity<T>", """
+                {
+                  // Code size        7 (0x7)
+                  .maxstack  1
+                  IL_0000:  ldarg.0
+                  IL_0001:  newobj     "System.Collections.Generic.List<T>..ctor(int)"
+                  IL_0006:  ret
+                }
+                """);
+    }
+
+    [Fact]
+    public void List_SingleSpread()
+    {
+        string source = """
+                using System;
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Report(ListNoArguments([1, 2]));
+                        Report(ListEmptyArguments([3, 4]));
+                        Report(ListWithCapacity([5, 6], 16));
+                    }
+                    static void Report<T>(List<T> list)
+                    {
+                        list.Report();
+                        Console.WriteLine("Capacity:{0}", list.Capacity);
+                    }
+                    static List<T> ListNoArguments<T>(IEnumerable<T> e) => [..e];
+                    static List<T> ListEmptyArguments<T>(IEnumerable<T> e) => [with(), ..e];
+                    static List<T> ListWithCapacity<T>(IEnumerable<T> e, int capacity) => [with(capacity: capacity), ..e];
+                }
+                """;
+        var verifier = CompileAndVerify(
+            [source, s_collectionExtensions],
+            expectedOutput: """
+                    [1, 2], Capacity:2
+                    [3, 4], Capacity:4
+                    [5, 6], Capacity:16
+                    """);
+        verifier.VerifyDiagnostics();
+        string expectedILNoArguments = """
+                {
+                  // Code size        7 (0x7)
+                  .maxstack  1
+                  IL_0000:  ldarg.0
+                  IL_0001:  call       "System.Collections.Generic.List<T> System.Linq.Enumerable.ToList<T>(System.Collections.Generic.IEnumerable<T>)"
+                  IL_0006:  ret
+                }
+                """;
+        verifier.VerifyIL("Program.ListNoArguments<T>", expectedILNoArguments);
+        verifier.VerifyIL("Program.ListEmptyArguments<T>", """
+            {
+              // Code size       51 (0x33)
+              .maxstack  2
+              .locals init (System.Collections.Generic.List<T> V_0,
+                            System.Collections.Generic.IEnumerator<T> V_1,
+                            T V_2)
+              IL_0000:  newobj     "System.Collections.Generic.List<T>..ctor()"
+              IL_0005:  stloc.0
+              IL_0006:  ldarg.0
+              IL_0007:  callvirt   "System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator()"
+              IL_000c:  stloc.1
+              .try
+              {
+                IL_000d:  br.s       IL_001d
+                IL_000f:  ldloc.1
+                IL_0010:  callvirt   "T System.Collections.Generic.IEnumerator<T>.Current.get"
+                IL_0015:  stloc.2
+                IL_0016:  ldloc.0
+                IL_0017:  ldloc.2
+                IL_0018:  callvirt   "void System.Collections.Generic.List<T>.Add(T)"
+                IL_001d:  ldloc.1
+                IL_001e:  callvirt   "bool System.Collections.IEnumerator.MoveNext()"
+                IL_0023:  brtrue.s   IL_000f
+                IL_0025:  leave.s    IL_0031
+              }
+              finally
+              {
+                IL_0027:  ldloc.1
+                IL_0028:  brfalse.s  IL_0030
+                IL_002a:  ldloc.1
+                IL_002b:  callvirt   "void System.IDisposable.Dispose()"
+                IL_0030:  endfinally
+              }
+              IL_0031:  ldloc.0
+              IL_0032:  ret
+            }
+            """);
+        verifier.VerifyIL("Program.ListWithCapacity<T>", """
+                {
+                  // Code size       52 (0x34)
+                  .maxstack  2
+                  .locals init (System.Collections.Generic.List<T> V_0,
+                                System.Collections.Generic.IEnumerator<T> V_1,
+                                T V_2)
+                  IL_0000:  ldarg.1
+                  IL_0001:  newobj     "System.Collections.Generic.List<T>..ctor(int)"
+                  IL_0006:  stloc.0
+                  IL_0007:  ldarg.0
+                  IL_0008:  callvirt   "System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator()"
+                  IL_000d:  stloc.1
+                  .try
+                  {
+                    IL_000e:  br.s       IL_001e
+                    IL_0010:  ldloc.1
+                    IL_0011:  callvirt   "T System.Collections.Generic.IEnumerator<T>.Current.get"
+                    IL_0016:  stloc.2
+                    IL_0017:  ldloc.0
+                    IL_0018:  ldloc.2
+                    IL_0019:  callvirt   "void System.Collections.Generic.List<T>.Add(T)"
+                    IL_001e:  ldloc.1
+                    IL_001f:  callvirt   "bool System.Collections.IEnumerator.MoveNext()"
+                    IL_0024:  brtrue.s   IL_0010
+                    IL_0026:  leave.s    IL_0032
+                  }
+                  finally
+                  {
+                    IL_0028:  ldloc.1
+                    IL_0029:  brfalse.s  IL_0031
+                    IL_002b:  ldloc.1
+                    IL_002c:  callvirt   "void System.IDisposable.Dispose()"
+                    IL_0031:  endfinally
+                  }
+                  IL_0032:  ldloc.0
+                  IL_0033:  ret
+                }
+                """);
+    }
+
+    [Fact]
+    public void CollectionBuilder_SingleSpread()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _items;
+                    public MyCollection(T[] args, ReadOnlySpan<T> items)
+                    {
+                        _items = new();
+                        _items.AddRange(items.ToArray());
+                        _items.AddRange(args);
+                    }
+                    public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, params T[] args) => new(args, items);
+                }
+                """;
+        string sourceB = """
+                using System;
+                class Program
+                {
+                    static void Main()
+                    {
+                        NoArguments([1, 2]).Report();
+                        EmptyArguments([3, 4]).Report();
+                        WithArguments([5, 6], 7).Report();
+                    }
+                    static MyCollection<T> NoArguments<T>(ReadOnlySpan<T> s) => [..s];
+                    static MyCollection<T> EmptyArguments<T>(ReadOnlySpan<T> s) => [with(), ..s];
+                    static MyCollection<T> WithArguments<T>(ReadOnlySpan<T> s, params T[] args) => [with(args), ..s];
+                }
+                """;
+        var comp = CreateCompilation(
+            [sourceA, sourceB, s_collectionExtensions],
+            targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (10,65): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //     static MyCollection<T> NoArguments<T>(ReadOnlySpan<T> s) => [..s];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[..s]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(10, 65),
+            // (11,68): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //     static MyCollection<T> EmptyArguments<T>(ReadOnlySpan<T> s) => [with(), ..s];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(), ..s]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(11, 68),
+            // (12,84): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //     static MyCollection<T> WithArguments<T>(ReadOnlySpan<T> s, params T[] args) => [with(args), ..s];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(args), ..s]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(12, 84));
+    }
+
+    [Fact]
+    public void ImmutableArray_NoElements()
+    {
+        string sourceA = """
+                #pragma warning disable 436 // type conflicts with imported type
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                namespace System.Collections.Immutable
+                {
+                    [CollectionBuilder(typeof(MyBuilder), "Create")]
+                    public struct ImmutableArray<T> : IEnumerable<T>
+                    {
+                        public static readonly ImmutableArray<T> Empty = new(default, new T[0]);
+                        private readonly List<T> _items;
+                        internal ImmutableArray(ReadOnlySpan<T> items, T[] args)
+                        {
+                            _items = new();
+                            _items.AddRange(items.ToArray());
+                            _items.AddRange(args);
+                        }
+                        public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+                        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    }
+                    public static class MyBuilder
+                    {
+                        public static ImmutableArray<T> Create<T>(ReadOnlySpan<T> items, params T[] args) => new(items, args);
+                    }
+                }
+                """;
+        string sourceB = """
+                #pragma warning disable 436 // type conflicts with imported type
+                using System.Collections.Immutable;
+                class Program
+                {
+                    static void Main()
+                    {
+                        ImmutableArrayNoArguments<int>().Report();
+                        ImmutableArrayEmptyArguments<int>().Report();
+                        ImmutableArrayWithArguments(5, 6).Report();
+                    }
+                    static ImmutableArray<T> ImmutableArrayNoArguments<T>() => [];
+                    static ImmutableArray<T> ImmutableArrayEmptyArguments<T>() => [with()];
+                    static ImmutableArray<T> ImmutableArrayWithArguments<T>(params T[] args) => [with(args)];
+                }
+                """;
+        var comp = CreateCompilation(
+            [sourceA, sourceB, s_collectionExtensions],
+            targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (11,64): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'ImmutableArray<T>'.
+            //     static ImmutableArray<T> ImmutableArrayNoArguments<T>() => [];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[]").WithArguments("Create", "T", "System.Collections.Immutable.ImmutableArray<T>").WithLocation(11, 64),
+            // (12,67): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'ImmutableArray<T>'.
+            //     static ImmutableArray<T> ImmutableArrayEmptyArguments<T>() => [with()];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with()]").WithArguments("Create", "T", "System.Collections.Immutable.ImmutableArray<T>").WithLocation(12, 67),
+            // (13,81): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'ImmutableArray<T>'.
+            //     static ImmutableArray<T> ImmutableArrayWithArguments<T>(params T[] args) => [with(args)];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(args)]").WithArguments("Create", "T", "System.Collections.Immutable.ImmutableArray<T>").WithLocation(13, 81));
+    }
+
+    [Fact]
+    public void ImmutableArray_SingleSpread()
+    {
+        string sourceA = """
+                #pragma warning disable 436 // type conflicts with imported type
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                namespace System.Collections.Immutable
+                {
+                    [CollectionBuilder(typeof(MyBuilder), "Create")]
+                    public struct ImmutableArray<T> : IEnumerable<T>
+                    {
+                        private readonly List<T> _items;
+                        internal ImmutableArray(ReadOnlySpan<T> items, T[] args)
+                        {
+                            _items = new();
+                            _items.AddRange(items.ToArray());
+                            _items.AddRange(args);
+                        }
+                        public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+                        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    }
+                    public static class MyBuilder
+                    {
+                        public static ImmutableArray<T> Create<T>(ReadOnlySpan<T> items, params T[] args) => new(items, args);
+                    }
+                }
+                """;
+        string sourceB = """
+                #pragma warning disable 436 // type conflicts with imported type
+                using System;
+                using System.Collections.Immutable;
+                class Program
+                {
+                    static void Main()
+                    {
+                        ImmutableArrayNoArguments([1, 2]).Report();
+                        ImmutableArrayEmptyArguments([3, 4]).Report();
+                        ImmutableArrayWithArguments([5, 6], 7).Report();
+                    }
+                    static ImmutableArray<T> ImmutableArrayNoArguments<T>(ReadOnlySpan<T> s) => [..s];
+                    static ImmutableArray<T> ImmutableArrayEmptyArguments<T>(ReadOnlySpan<T> s) => [with(), ..s];
+                    static ImmutableArray<T> ImmutableArrayWithArguments<T>(ReadOnlySpan<T> s, params T[] args) => [with(args), ..s];
+                }
+                """;
+        var comp = CreateCompilation(
+            [sourceA, sourceB, s_collectionExtensions],
+            targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (12,81): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'ImmutableArray<T>'.
+            //     static ImmutableArray<T> ImmutableArrayNoArguments<T>(ReadOnlySpan<T> s) => [..s];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[..s]").WithArguments("Create", "T", "System.Collections.Immutable.ImmutableArray<T>").WithLocation(12, 81),
+            // (13,84): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'ImmutableArray<T>'.
+            //     static ImmutableArray<T> ImmutableArrayEmptyArguments<T>(ReadOnlySpan<T> s) => [with(), ..s];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(), ..s]").WithArguments("Create", "T", "System.Collections.Immutable.ImmutableArray<T>").WithLocation(13, 84),
+            // (14,100): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'ImmutableArray<T>'.
+            //     static ImmutableArray<T> ImmutableArrayWithArguments<T>(ReadOnlySpan<T> s, params T[] args) => [with(args), ..s];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(args), ..s]").WithArguments("Create", "T", "System.Collections.Immutable.ImmutableArray<T>").WithLocation(14, 100));
+    }
+
+    [Theory(Skip = "PROTOTYPE: Ref safety")]
+    [CombinatorialData]
+    public void RefSafety_ConstructorArguments(bool scopedInParameter, bool scopedOutArgument)
+    {
+        string sourceA = $$"""
+                using System.Collections;
+                using System.Collections.Generic;
+                ref struct R<T>
+                {
+                    public R(ref T t) { }
+                }
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    public MyCollection() { }
+                    public MyCollection({{(scopedInParameter ? "scoped" : "")}} R<T> a, out R<T> b) { b = default; }
+                    public void Add(T t) { }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                }
+                """;
+        string sourceB = $$"""
+                class Program
+                {
+                    static void F<T>(T x, T y)
+                    {
+                        MyCollection<T> c;
+                        T t = default;
+                        R<T> a = new(ref t);
+                        {{(scopedOutArgument ? "scoped" : "")}} R<T> b;
+                        c = new(a, out b);
+                        c = [with(a, out b), x, y];
+                    }
+                }
+                """;
+        var comp = CreateCompilation([sourceA, sourceB]);
+        if (scopedInParameter || scopedOutArgument)
+        {
+            comp.VerifyEmitDiagnostics();
+        }
+        else
+        {
+            comp.VerifyEmitDiagnostics(
+                // (9,13): error CS8350: This combination of arguments to 'MyCollection<T>.MyCollection(R<T>, out R<T>)' is disallowed because it may expose variables referenced by parameter 'a' outside of their declaration scope
+                //         c = new(a, out b);
+                Diagnostic(ErrorCode.ERR_CallArgMixing, "new(a, out b)").WithArguments("MyCollection<T>.MyCollection(R<T>, out R<T>)", "a").WithLocation(9, 13),
+                // (9,17): error CS8352: Cannot use variable 'a' in this context because it may expose referenced variables outside of their declaration scope
+                //         c = new(a, out b);
+                Diagnostic(ErrorCode.ERR_EscapeVariable, "a").WithArguments("a").WithLocation(9, 17),
+                // (10,13): error CS8350: This combination of arguments to 'MyCollection<T>.MyCollection(R<T>, out R<T>)' is disallowed because it may expose variables referenced by parameter 'a' outside of their declaration scope
+                //         c = [with(a, out b), x, y];
+                Diagnostic(ErrorCode.ERR_CallArgMixing, "[with(a, out b), x, y]").WithArguments("MyCollection<T>.MyCollection(R<T>, out R<T>)", "a").WithLocation(10, 13),
+                // (10,19): error CS8352: Cannot use variable 'a' in this context because it may expose referenced variables outside of their declaration scope
+                //         c = [with(a, out b), x, y];
+                Diagnostic(ErrorCode.ERR_EscapeVariable, "a").WithArguments("a").WithLocation(10, 19));
+        }
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void RefSafety_CollectionBuilderArguments(bool scopedInParameter, bool scopedOutArgument)
+    {
+        string sourceA = $$"""
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>({{(scopedInParameter ? "scoped" : "")}} ReadOnlySpan<T> items, out ReadOnlySpan<T> other)
+                    {
+                        other = default;
+                        return default;
+                    }
+                }
+                """;
+        string sourceB = $$"""
+                using System;
+                class Program
+                {
+                    static void F<T>(T x, T y)
+                    {
+                        MyCollection<T> c;
+                        {{(scopedOutArgument ? "scoped" : "")}} ReadOnlySpan<T> s;
+                        c = MyBuilder.Create([x, y], out s);
+                        c = [with(out s), x, y];
+                    }
+                }
+                """;
+        var comp = CreateCompilation([sourceA, sourceB], targetFramework: TargetFramework.Net80);
+        if (scopedInParameter || scopedOutArgument)
+        {
+            comp.VerifyEmitDiagnostics(
+                // (9,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         c = [with(out s), x, y];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(out s), x, y]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(9, 13));
+        }
+        else
+        {
+            comp.VerifyEmitDiagnostics(
+                // (8,13): error CS8350: This combination of arguments to 'MyBuilder.Create<T>(ReadOnlySpan<T>, out ReadOnlySpan<T>)' is disallowed because it may expose variables referenced by parameter 'items' outside of their declaration scope
+                //         c = MyBuilder.Create([x, y], out s);
+                Diagnostic(ErrorCode.ERR_CallArgMixing, "MyBuilder.Create([x, y], out s)").WithArguments("MyBuilder.Create<T>(System.ReadOnlySpan<T>, out System.ReadOnlySpan<T>)", "items").WithLocation(8, 13),
+                // (8,30): error CS9203: A collection expression of type 'ReadOnlySpan<T>' cannot be used in this context because it may be exposed outside of the current scope.
+                //         c = MyBuilder.Create([x, y], out s);
+                Diagnostic(ErrorCode.ERR_CollectionExpressionEscape, "[x, y]").WithArguments("System.ReadOnlySpan<T>").WithLocation(8, 30),
+                // (9,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+                //         c = [with(out s), x, y];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(out s), x, y]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(9, 13));
+        }
+    }
+
+    [Fact]
+    public void Empty_TypeParameter()
+    {
+        string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                interface IAdd<T> : IEnumerable<T>
+                {
+                    void Add(T t);
+                }
+                struct MyCollection<T> : IAdd<T>
+                {
+                    private List<T> _list;
+                    void IAdd<T>.Add(T t) { GetList().Add(t); }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetList().GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetList().GetEnumerator();
+                    private List<T> GetList() => _list ??= new();
+                }
+                """;
+
+        string sourceB1 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        NoArgs<int, MyCollection<int>>().Report();
+                        EmptyArgs<int, MyCollection<int>>().Report();
+                    }
+                    static U NoArgs<T, U>()
+                        where U : IAdd<T>, new()
+                    {
+                        return [];
+                    }
+                    static U EmptyArgs<T, U>()
+                        where U : IAdd<T>, new()
+                    {
+                        return [with()];
+                    }
+                }
+                """;
+        var verifier = CompileAndVerify(
+            [sourceA, sourceB1, s_collectionExtensions],
+            verify: Verification.Skipped,
+            expectedOutput: IncludeExpectedOutput("[], [], "));
+        verifier.VerifyDiagnostics();
+        string expectedIL = """
+                {
+                  // Code size        6 (0x6)
+                  .maxstack  1
+                  IL_0000:  call       "U System.Activator.CreateInstance<U>()"
+                  IL_0005:  ret
+                }
+                """;
+        verifier.VerifyIL("Program.NoArgs<T, U>", expectedIL);
+        verifier.VerifyIL("Program.EmptyArgs<T, U>", expectedIL);
+
+        string sourceB2 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        NoArgs<int, MyCollection<int>>().Report();
+                        EmptyArgs<int, MyCollection<int>>().Report();
+                    }
+                    static U NoArgs<T, U>()
+                        where U : struct, IAdd<T>
+                    {
+                        return [];
+                    }
+                    static U EmptyArgs<T, U>()
+                        where U : struct, IAdd<T>
+                    {
+                        return [with()];
+                    }
+                }
+                """;
+        verifier = CompileAndVerify(
+            [sourceA, sourceB2, s_collectionExtensions],
+            verify: Verification.Skipped,
+            expectedOutput: IncludeExpectedOutput("[], [], "));
+        verifier.VerifyDiagnostics();
+        expectedIL = """
+                {
+                  // Code size        6 (0x6)
+                  .maxstack  1
+                  IL_0000:  call       "U System.Activator.CreateInstance<U>()"
+                  IL_0005:  ret
+                }
+                """;
+        verifier.VerifyIL("Program.NoArgs<T, U>", expectedIL);
+        verifier.VerifyIL("Program.EmptyArgs<T, U>", expectedIL);
+    }
+
+    [Fact]
+    public void Arguments_TypeParameter()
+    {
+        string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                interface IAdd<T> : IEnumerable<T>
+                {
+                    void Add(T t);
+                }
+                """;
+        string sourceB = """
+                class Program
+                {
+                    static void NonEmptyArgsNew<T, U>(T t)
+                        where U : IAdd<T>, new()
+                    {
+                        U x;
+                        x = [with(t), t];
+                        x = [t, with(t)];
+                    }
+                    static void NonEmptyArgsStruct<T, U>(T t)
+                        where U : struct, IAdd<T>
+                    {
+                        U y;
+                        y = [with(t), t];
+                        y = [t, with(t)];
+                    }
+                }
+                """;
+        var comp = CreateCompilation([sourceA, sourceB]);
+        comp.VerifyEmitDiagnostics(
+            // (7,13): error CS0417: 'U': cannot provide arguments when creating an instance of a variable type
+            //         x = [with(t), t];
+            Diagnostic(ErrorCode.ERR_NewTyvarWithArgs, "[with(t), t]").WithArguments("U").WithLocation(7, 13),
+            // (8,17): error CS9335: Collection argument element must be the first element.
+            //         x = [t, with(t)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(8, 17),
+            // (14,13): error CS0417: 'U': cannot provide arguments when creating an instance of a variable type
+            //         y = [with(t), t];
+            Diagnostic(ErrorCode.ERR_NewTyvarWithArgs, "[with(t), t]").WithArguments("U").WithLocation(14, 13),
+            // (15,17): error CS9335: Collection argument element must be the first element.
+            //         y = [t, with(t)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(15, 17));
+    }
+
+    [Fact]
+    public void UnrecognizedType()
+    {
+        string source = """
+                class Program
+                {
+                    static A EmptyArgs() => [with()];
+                    static B NonEmptyArgs() => [with(default)];
+                }
+                """;
+        var comp = CreateCompilation(source);
+        comp.VerifyEmitDiagnostics(
+            // (3,12): error CS0246: The type or namespace name 'A' could not be found (are you missing a using directive or an assembly reference?)
+            //     static A EmptyArgs() => [with()];
+            Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "A").WithArguments("A").WithLocation(3, 12),
+            // (4,12): error CS0246: The type or namespace name 'B' could not be found (are you missing a using directive or an assembly reference?)
+            //     static B NonEmptyArgs() => [with(default)];
+            Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "B").WithArguments("B").WithLocation(4, 12));
+    }
+
+    [Fact]
+    public void EvaluationOrder_CollectionInitializer()
+    {
+        string sourceA = """
+                using System;
+                class A
+                {
+                    private int _i;
+                    private A(int i) { _i = i; }
+                    public static implicit operator A(int i)
+                    {
+                        Console.WriteLine("{0} -> A", i);
+                        return new(i);
+                    }
+                    public override string ToString() => _i.ToString();
+                }
+                """;
+        string sourceB = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    public MyCollection(A x = null, A y = null) { Console.WriteLine("MyCollection({0}, {1})", x, y); }
+                    public void Add(T t) { Console.WriteLine("Add({0})", t); }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => throw null;
+                    IEnumerator IEnumerable.GetEnumerator() => throw null;
+                }
+                """;
+        string sourceC = """
+                using System;
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<A> c;
+                        c = [with(y: Identity(1), x: Identity(2)), Identity(3), Identity(4)];
+                    }
+                    static T Identity<T>(T value)
+                    {
+                        Console.WriteLine(value);
+                        return value;
+                    }
+                }
+                """;
+        var verifier = CompileAndVerify(
+            [sourceA, sourceB, sourceC],
+            expectedOutput: """
+                    1
+                    1 -> A
+                    2
+                    2 -> A
+                    MyCollection(2, 1)
+                    3
+                    3 -> A
+                    Add(3)
+                    4
+                    4 -> A
+                    Add(4)
+                    """);
+        verifier.VerifyDiagnostics();
+        verifier.VerifyIL("Program.Main()", """
+                {
+                  // Code size       65 (0x41)
+                  .maxstack  3
+                  .locals init (A V_0)
+                  IL_0000:  ldc.i4.1
+                  IL_0001:  call       "int Program.Identity<int>(int)"
+                  IL_0006:  call       "A A.op_Implicit(int)"
+                  IL_000b:  stloc.0
+                  IL_000c:  ldc.i4.2
+                  IL_000d:  call       "int Program.Identity<int>(int)"
+                  IL_0012:  call       "A A.op_Implicit(int)"
+                  IL_0017:  ldloc.0
+                  IL_0018:  newobj     "MyCollection<A>..ctor(A, A)"
+                  IL_001d:  dup
+                  IL_001e:  ldc.i4.3
+                  IL_001f:  call       "int Program.Identity<int>(int)"
+                  IL_0024:  call       "A A.op_Implicit(int)"
+                  IL_0029:  callvirt   "void MyCollection<A>.Add(A)"
+                  IL_002e:  dup
+                  IL_002f:  ldc.i4.4
+                  IL_0030:  call       "int Program.Identity<int>(int)"
+                  IL_0035:  call       "A A.op_Implicit(int)"
+                  IL_003a:  callvirt   "void MyCollection<A>.Add(A)"
+                  IL_003f:  pop
+                  IL_0040:  ret
+                }
+                """);
+    }
+
+    [Fact]
+    public void EvaluationOrder_CollectionBuilder()
+    {
+        string sourceA = """
+                using System;
+                class A
+                {
+                    private int _i;
+                    private A(int i) { _i = i; }
+                    public static implicit operator A(int i)
+                    {
+                        Console.WriteLine("{0} -> A", i);
+                        return new(i);
+                    }
+                    public override string ToString() => _i.ToString();
+                }
+                """;
+        string sourceB = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    public MyCollection(ReadOnlySpan<T> items, A x, A y) { Console.WriteLine("MyCollection({0}, {1})", x, y); }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => throw null;
+                    IEnumerator IEnumerable.GetEnumerator() => throw null;
+                }
+                class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items, A x = null, A y = null) => new(items, x, y);
+                }
+                """;
+        string sourceC = """
+                using System;
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<A> c;
+                        c = [with(y: Identity(1), x: Identity(2)), Identity(3), Identity(4)];
+                    }
+                    static T Identity<T>(T value)
+                    {
+                        Console.WriteLine(value);
+                        return value;
+                    }
+                }
+                """;
+        // https://github.com/dotnet/roslyn/issues/77866: 1, ..., 2, ..., should be evaluated before 3, ..., 4, ... .
+        // Should be fixed when the last parameter of the builder method is the items parameter.
+        var comp = CreateCompilation(
+            [sourceA, sourceB, sourceC],
+            targetFramework: TargetFramework.Net80);
+        comp.VerifyEmitDiagnostics(
+            // (7,13): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
+            //         c = [with(y: Identity(1), x: Identity(2)), Identity(3), Identity(4)];
+            Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(y: Identity(1), x: Identity(2)), Identity(3), Identity(4)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(7, 13));
+    }
+
+    [Fact]
+    public void Arglist()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection : IEnumerable
+                {
+                    public readonly List<int> Args;
+                    public MyCollection() { Args = new(); }
+                    public MyCollection(__arglist) { Args = GetArgs(0, new ArgIterator(__arglist)); }
+                    public MyCollection(int x, __arglist) { Args = GetArgs(x, new ArgIterator(__arglist)); }
+                    private static List<int> GetArgs(int x, ArgIterator iterator)
+                    {
+                        var args = new List<int>();
+                        args.Add(x);
+                        while (iterator.GetRemainingCount() > 0)
+                            args.Add(__refvalue(iterator.GetNextArg(), int));
+                        return args;
+                    }
+                    public void Add(object o) { }
+                    IEnumerator IEnumerable.GetEnumerator() => throw null;
+                }
+                """;
+        string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        F1().Args.Report();
+                        F2().Args.Report();
+                        F3(1, 2).Args.Report();
+                        F4(3, 4).Args.Report();
+                    }
+                    static MyCollection F1() => [with()];
+                    static MyCollection F2() => [with(__arglist())];
+                    static MyCollection F3(int x, int y) => [with(__arglist(x, y))];
+                    static MyCollection F4(int x, int y) => [with(x, __arglist(y))];
+                }
+                """;
+        var verifier = CompileAndVerify(
+            [sourceA, sourceB, s_collectionExtensions],
+            targetFramework: TargetFramework.NetFramework,
+            verify: Verification.FailsILVerify,
+            expectedOutput: ExecutionConditionUtil.IsMonoOrCoreClr ? null : "[], [0], [0, 1, 2], [3, 4], ");
+        verifier.VerifyDiagnostics();
+        verifier.VerifyIL("Program.F1", """
+                {
+                  // Code size        6 (0x6)
+                  .maxstack  1
+                  IL_0000:  newobj     "MyCollection..ctor()"
+                  IL_0005:  ret
+                }
+                """);
+        verifier.VerifyIL("Program.F2", """
+                {
+                  // Code size        6 (0x6)
+                  .maxstack  1
+                  IL_0000:  newobj     "MyCollection..ctor(__arglist)"
+                  IL_0005:  ret
+                }
+                """);
+        verifier.VerifyIL("Program.F3", """
+                {
+                  // Code size        8 (0x8)
+                  .maxstack  2
+                  IL_0000:  ldarg.0
+                  IL_0001:  ldarg.1
+                  IL_0002:  newobj     "MyCollection..ctor(__arglist) with __arglist( int, int)"
+                  IL_0007:  ret
+                }
+                """);
+        verifier.VerifyIL("Program.F4", """
+                {
+                  // Code size        8 (0x8)
+                  .maxstack  2
+                  IL_0000:  ldarg.0
+                  IL_0001:  ldarg.1
+                  IL_0002:  newobj     "MyCollection..ctor(int, __arglist) with __arglist( int)"
+                  IL_0007:  ret
+                }
+                """);
+    }
+
+    [Fact]
+    public void Arglist_NoParameterlessConstructor()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                class MyCollection : IEnumerable
+                {
+                    public MyCollection(__arglist) { }
+                    public void Add(object o) { }
+                    IEnumerator IEnumerable.GetEnumerator() => throw null;
+                }
+                """;
+        string sourceB = """
+                using System;
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection c;
+                        c = [];
+                        c = [with()];
+                        c = [with(__arglist())];
+                        c = [with(__arglist(0))];
+                    }
+                }
+                """;
+        var comp = CreateCompilation([sourceA, sourceB]);
+        comp.VerifyEmitDiagnostics(
+            // (7,13): error CS9214: Collection expression type must have an applicable constructor that can be called with no arguments.
+            //         c = [];
+            Diagnostic(ErrorCode.ERR_CollectionExpressionMissingConstructor, "[]").WithLocation(7, 13),
+            // (8,13): error CS9214: Collection expression type must have an applicable constructor that can be called with no arguments.
+            //         c = [with()];
+            Diagnostic(ErrorCode.ERR_CollectionExpressionMissingConstructor, "[with()]").WithLocation(8, 13));
+    }
+
+    [Fact]
+    public void DynamicArguments_01()
+    {
+        string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        List<object> l;
+                        l = [with(), (dynamic)2];
+                        l = [with(capacity: 1)];
+                        l = [with(capacity: (dynamic)1)];
+                    }
+                }
+                """;
+        var comp = CreateCompilation(source);
+        comp.VerifyEmitDiagnostics(
+            // (9,29): error CS9503: Collection arguments cannot be dynamic; compile-time binding is required.
+            //         l = [with(capacity: (dynamic)1)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, "(dynamic)1").WithLocation(9, 29));
+    }
+
+    [Fact]
+    public void DynamicArguments_02()
+    {
+        string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    public MyCollection(object x = null, object y = null) { }
+                    public void Add(T t) { }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => throw null;
+                    IEnumerator IEnumerable.GetEnumerator() => throw null;
+                }
+                """;
+        string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<int> c;
+                        c = [with(), (dynamic)3];
+                        c = [with(1)];
+                        c = [with(y: "2")];
+                        c = [with(1, "2"), (dynamic)3];
+                        c = [with((dynamic)1)];
+                        c = [with(y: (dynamic)"2")];
+                        c = [3, with(1, (dynamic)"2")];
+                        c = [with((dynamic)1, (dynamic)"2"), 3];
+                        c = [with(x => { })];
+                    }
+                }
+                """;
+        var comp = CreateCompilation([sourceA, sourceB]);
+        comp.VerifyEmitDiagnostics(
+            // (10,19): error CS9503: Collection arguments cannot be dynamic; compile-time binding is required.
+            //         c = [with((dynamic)1)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, "(dynamic)1").WithLocation(10, 19),
+            // (11,22): error CS9503: Collection arguments cannot be dynamic; compile-time binding is required.
+            //         c = [with(y: (dynamic)"2")];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, @"(dynamic)""2""").WithLocation(11, 22),
+            // (12,17): error CS9501: Collection argument element must be the first element.
+            //         c = [3, with(1, (dynamic)"2")];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(12, 17),
+            // (12,25): error CS9503: Collection arguments cannot be dynamic; compile-time binding is required.
+            //         c = [3, with(1, (dynamic)"2")];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, @"(dynamic)""2""").WithLocation(12, 25),
+            // (13,19): error CS9503: Collection arguments cannot be dynamic; compile-time binding is required.
+            //         c = [with((dynamic)1, (dynamic)"2"), 3];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, "(dynamic)1").WithLocation(13, 19),
+            // (13,31): error CS9503: Collection arguments cannot be dynamic; compile-time binding is required.
+            //         c = [with((dynamic)1, (dynamic)"2"), 3];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, @"(dynamic)""2""").WithLocation(13, 31),
+            // (14,21): error CS8917: The delegate type could not be inferred.
+            //         c = [with(x => { })];
+            Diagnostic(ErrorCode.ERR_CannotInferDelegateType, "=>").WithLocation(14, 21));
+    }
+
+    [Theory]
+    [InlineData("ref")]
+    [InlineData("in ")]
+    [InlineData("out")]
+    public void DynamicArguments_03(string refKind)
+    {
+        string source = $$"""
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    public MyCollection() { }
+                    public MyCollection({{refKind}} object obj) { throw null; }
+                    public void Add(T t) { }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => throw null;
+                    IEnumerator IEnumerable.GetEnumerator() => throw null;
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        object o = null;
+                        dynamic d = o;
+                        MyCollection<object> c;
+                        c = [with({{refKind}} o)];
+                        c = [with({{refKind}} d)];
+                    }
+                }
+                """;
+        var comp = CreateCompilation(source);
+        comp.VerifyEmitDiagnostics(
+            // (19,23): error CS9503: Collection arguments cannot be dynamic; compile-time binding is required.
+            //         c = [with(in  d)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, "d").WithLocation(19, 23));
+    }
+
+    [Fact]
+    public void DynamicArguments_04()
+    {
+        string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection : IEnumerable
+                {
+                    public MyCollection(dynamic d = null) { }
+                    public void Add(object o) { }
+                    IEnumerator IEnumerable.GetEnumerator() => throw null;
+                }
+                """;
+        string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        object o = null;
+                        dynamic d = o;
+                        MyCollection c;
+                        c = [with()];
+                        c = [with(null)];
+                        c = [with(default)];
+                        c = [with(0)];
+                        c = [with((dynamic)null)];
+                        c = [with((dynamic)0)];
+                        c = [with(o)];
+                        c = [with(d)];
+                    }
+                }
+                """;
+        var comp = CreateCompilation([sourceA, sourceB]);
+        comp.VerifyEmitDiagnostics(
+            // (12,19): error CS9503: Collection arguments cannot be dynamic; compile-time binding is required.
+            //         c = [with((dynamic)null)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, "(dynamic)null").WithLocation(12, 19),
+            // (13,19): error CS9503: Collection arguments cannot be dynamic; compile-time binding is required.
+            //         c = [with((dynamic)0)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, "(dynamic)0").WithLocation(13, 19),
+            // (15,19): error CS9503: Collection arguments cannot be dynamic; compile-time binding is required.
+            //         c = [with(d)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, "d").WithLocation(15, 19));
+    }
+
+    [Fact]
+    public void DynamicArguments_05()
+    {
+        string source = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        A a;
+                        a = [with(null), (dynamic)null];
+                        a = [with((dynamic)null), null];
+                    }
+                }
+                """;
+        var comp = CreateCompilation(source);
+        comp.VerifyEmitDiagnostics(
+            // (5,9): error CS0246: The type or namespace name 'A' could not be found (are you missing a using directive or an assembly reference?)
+            //         A a;
+            Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "A").WithArguments("A").WithLocation(5, 9),
+            // (7,19): error CS9503: Collection arguments cannot be dynamic; compile-time binding is required.
+            //         a = [with((dynamic)null), null];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsDynamicBinding, "(dynamic)null").WithLocation(7, 19));
+    }
+
+    [Fact]
+    public void TypeInference_List()
+    {
+        string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Identity([with()]);
+                        Identity([with(capacity: 1), default]);
+                        Identity([with(capacity: 1), 3]);
+                        Identity([with(collection: [default, 2]), default]);
+                        Identity([with(collection: [default]), default, 3]);
+                    }
+                    static List<T> Identity<T>(List<T> c) => c;
+                }
+                """;
+        var comp = CreateCompilation(source);
+        comp.VerifyEmitDiagnostics(
+            // (6,9): error CS0411: The type arguments for method 'Program.Identity<T>(List<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+            //         Identity([with()]);
+            Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Identity").WithArguments("Program.Identity<T>(System.Collections.Generic.List<T>)").WithLocation(6, 9),
+            // (7,9): error CS0411: The type arguments for method 'Program.Identity<T>(List<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+            //         Identity([with(capacity: 1), default]);
+            Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Identity").WithArguments("Program.Identity<T>(System.Collections.Generic.List<T>)").WithLocation(7, 9),
+            // (9,9): error CS0411: The type arguments for method 'Program.Identity<T>(List<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+            //         Identity([with(collection: [default, 2]), default]);
+            Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Identity").WithArguments("Program.Identity<T>(System.Collections.Generic.List<T>)").WithLocation(9, 9));
+    }
+
+    [Fact]
+    public void TypeInference_CollectionInitializer()
+    {
+        string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _items;
+                    public MyCollection(params T[] args) { _items = new(args); }
+                    public void Add(T t) { _items.Add(t); }
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _items.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator();
+                }
+                """;
+        string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        Identity([with()]);
+                        Identity([with(default, 2), default]);
+                        Identity([with(default), default, 3]);
+                    }
+                    static MyCollection<T> Identity<T>(MyCollection<T> c) => c;
+                }
+                """;
+        var comp = CreateCompilation([sourceA, sourceB]);
+        comp.VerifyEmitDiagnostics(
+            // (5,9): error CS0411: The type arguments for method 'Program.Identity<T>(MyCollection<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+            //         Identity([with()]);
+            Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Identity").WithArguments("Program.Identity<T>(MyCollection<T>)").WithLocation(5, 9),
+            // (6,9): error CS0411: The type arguments for method 'Program.Identity<T>(MyCollection<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+            //         Identity([with(default, 2), default]);
+            Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Identity").WithArguments("Program.Identity<T>(MyCollection<T>)").WithLocation(6, 9));
+    }
+
+    // PROTOTYPE: Semantic model for collection creation: what method is returned if any?
+
+#if DICTIONARY_EXPRESSIONS
+    [Theory]
+    [CombinatorialData]
+    public void InterfaceTarget_DictionaryInterfaces(
+        [CombinatorialValues("IDictionary", "IReadOnlyDictionary")] string typeName)
+    {
+        string sourceA = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Create<int, string>(1, "one", new(2, "two")).Report();
+                    }
+                    static {{typeName}}<K, V> Create<K, V>(K k, V v, KeyValuePair<K, V> x)
+                    {
+                        return [with(), k:v, x];
+                    }
+                }
+                """;
+        var comp = CreateCompilation(
+            [sourceA, s_collectionExtensions],
+            options: TestOptions.ReleaseExe);
+        var verifier = CompileAndVerify(
+            comp,
+            expectedOutput: "[[1, one], [2, two]], ");
+        verifier.VerifyDiagnostics();
+        verifier.VerifyIL("Program.Create<K, V>", (typeName is "IDictionary") ?
+            """
+                {
+                  // Code size       36 (0x24)
+                  .maxstack  4
+                  .locals init (System.Collections.Generic.KeyValuePair<K, V> V_0)
+                  IL_0000:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor()"
+                  IL_0005:  dup
+                  IL_0006:  ldarg.0
+                  IL_0007:  ldarg.1
+                  IL_0008:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                  IL_000d:  ldarg.2
+                  IL_000e:  stloc.0
+                  IL_000f:  dup
+                  IL_0010:  ldloca.s   V_0
+                  IL_0012:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                  IL_0017:  ldloca.s   V_0
+                  IL_0019:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                  IL_001e:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                  IL_0023:  ret
+                }
+                """ :
+            """
+                {
+                  // Code size       41 (0x29)
+                  .maxstack  4
+                  .locals init (System.Collections.Generic.KeyValuePair<K, V> V_0)
+                  IL_0000:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor()"
+                  IL_0005:  dup
+                  IL_0006:  ldarg.0
+                  IL_0007:  ldarg.1
+                  IL_0008:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                  IL_000d:  ldarg.2
+                  IL_000e:  stloc.0
+                  IL_000f:  dup
+                  IL_0010:  ldloca.s   V_0
+                  IL_0012:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                  IL_0017:  ldloca.s   V_0
+                  IL_0019:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                  IL_001e:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                  IL_0023:  newobj     "System.Collections.ObjectModel.ReadOnlyDictionary<K, V>..ctor(System.Collections.Generic.IDictionary<K, V>)"
+                  IL_0028:  ret
+                }
+                """);
+
+        string sourceB = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Create1<int, string>(3, 1, "one", new(2, "two")).Report();
+                        Create2<int, string>(1, 3, "three", new(4, "four")).Report();
+                    }
+                    static {{typeName}}<K, V> Create1<K, V>(int c, K k, V v, KeyValuePair<K, V> x)
+                    {
+                        return [with(c), k:v, x];
+                    }
+                    static {{typeName}}<K, V> Create2<K, V>(int c, K k, V v, KeyValuePair<K, V> x)
+                    {
+                        return [with(capacity: c), k:v, x];
+                    }
+                }
+                """;
+        comp = CreateCompilation(
+            [sourceB, s_collectionExtensions],
+            options: TestOptions.ReleaseExe);
+        string expectedIL;
+        if (typeName is "IDictionary")
+        {
+            verifier = CompileAndVerify(
+                comp,
+                expectedOutput: "[[1, one], [2, two]], [[3, three], [4, four]], ");
+            verifier.VerifyDiagnostics();
+            expectedIL = """
+                    {
+                      // Code size       37 (0x25)
+                      .maxstack  4
+                      .locals init (System.Collections.Generic.KeyValuePair<K, V> V_0)
+                      IL_0000:  ldarg.0
+                      IL_0001:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor(int)"
+                      IL_0006:  dup
+                      IL_0007:  ldarg.1
+                      IL_0008:  ldarg.2
+                      IL_0009:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                      IL_000e:  ldarg.3
+                      IL_000f:  stloc.0
+                      IL_0010:  dup
+                      IL_0011:  ldloca.s   V_0
+                      IL_0013:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                      IL_0018:  ldloca.s   V_0
+                      IL_001a:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                      IL_001f:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                      IL_0024:  ret
+                    }
+                    """;
+            verifier.VerifyIL("Program.Create1<K, V>", expectedIL);
+            verifier.VerifyIL("Program.Create2<K, V>", expectedIL);
+        }
+        else
+        {
+            comp.VerifyEmitDiagnostics(
+                // (11,22): error CS1503: Argument 1: cannot convert from 'int' to 'System.Collections.Generic.IEqualityComparer<K>?'
+                //         return [with(c), k:v, x];
+                Diagnostic(ErrorCode.ERR_BadArgType, "c").WithArguments("1", "int", "System.Collections.Generic.IEqualityComparer<K>?").WithLocation(11, 22),
+                // (15,22): error CS1739: The best overload for '<signature>' does not have a parameter named 'capacity'
+                //         return [with(capacity: c), k:v, x];
+                Diagnostic(ErrorCode.ERR_BadNamedArgument, "capacity").WithArguments("<signature>", "capacity").WithLocation(15, 22));
+        }
+
+        string sourceC = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Create1<int, string>(null, 1, "one", new(2, "two")).Report();
+                        Create2<int, string>(null, 3, "three", new(4, "four")).Report();
+                    }
+                    static {{typeName}}<K, V> Create1<K, V>(IEqualityComparer<K> e, K k, V v, KeyValuePair<K, V> x)
+                    {
+                        return [with(e), k:v, x];
+                    }
+                    static {{typeName}}<K, V> Create2<K, V>(IEqualityComparer<K> e, K k, V v, KeyValuePair<K, V> x)
+                    {
+                        return [with(comparer: e), k:v, x];
+                    }
+                }
+                """;
+        comp = CreateCompilation(
+            [sourceC, s_collectionExtensions],
+            options: TestOptions.ReleaseExe);
+        verifier = CompileAndVerify(
+            comp,
+            expectedOutput: "[[1, one], [2, two]], [[3, three], [4, four]], ");
+        verifier.VerifyDiagnostics();
+        expectedIL = (typeName is "IDictionary") ?
+            """
+                {
+                  // Code size       37 (0x25)
+                  .maxstack  4
+                  .locals init (System.Collections.Generic.KeyValuePair<K, V> V_0)
+                  IL_0000:  ldarg.0
+                  IL_0001:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor(System.Collections.Generic.IEqualityComparer<K>)"
+                  IL_0006:  dup
+                  IL_0007:  ldarg.1
+                  IL_0008:  ldarg.2
+                  IL_0009:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                  IL_000e:  ldarg.3
+                  IL_000f:  stloc.0
+                  IL_0010:  dup
+                  IL_0011:  ldloca.s   V_0
+                  IL_0013:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                  IL_0018:  ldloca.s   V_0
+                  IL_001a:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                  IL_001f:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                  IL_0024:  ret
+                }
+                """ :
+            """
+                {
+                  // Code size       42 (0x2a)
+                  .maxstack  4
+                  .locals init (System.Collections.Generic.KeyValuePair<K, V> V_0)
+                  IL_0000:  ldarg.0
+                  IL_0001:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor(System.Collections.Generic.IEqualityComparer<K>)"
+                  IL_0006:  dup
+                  IL_0007:  ldarg.1
+                  IL_0008:  ldarg.2
+                  IL_0009:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                  IL_000e:  ldarg.3
+                  IL_000f:  stloc.0
+                  IL_0010:  dup
+                  IL_0011:  ldloca.s   V_0
+                  IL_0013:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                  IL_0018:  ldloca.s   V_0
+                  IL_001a:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                  IL_001f:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                  IL_0024:  newobj     "System.Collections.ObjectModel.ReadOnlyDictionary<K, V>..ctor(System.Collections.Generic.IDictionary<K, V>)"
+                  IL_0029:  ret
+                }
+                """;
+        verifier.VerifyIL("Program.Create1<K, V>", expectedIL);
+        verifier.VerifyIL("Program.Create2<K, V>", expectedIL);
+
+        string sourceD = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Create1<int, string>(null, 3, 1, "one", new(2, "two")).Report();
+                        Create2<int, string>(null, 1, 3, "three", new(4, "four")).Report();
+                    }
+                    static {{typeName}}<K, V> Create1<K, V>(IEqualityComparer<K> e, int c, K k, V v, KeyValuePair<K, V> x)
+                    {
+                        return [with(c, e), k:v, x];
+                    }
+                    static {{typeName}}<K, V> Create2<K, V>(IEqualityComparer<K> e, int c, K k, V v, KeyValuePair<K, V> x)
+                    {
+                        return [with(capacity: c, comparer: e), k:v, x];
+                    }
+                }
+                """;
+        comp = CreateCompilation(
+            [sourceD, s_collectionExtensions],
+            options: TestOptions.ReleaseExe);
+        if (typeName is "IDictionary")
+        {
+            verifier = CompileAndVerify(
+                comp,
+                expectedOutput: "[[1, one], [2, two]], [[3, three], [4, four]], ");
+            verifier.VerifyDiagnostics();
+            expectedIL = """
+                    {
+                      // Code size       39 (0x27)
+                      .maxstack  4
+                      .locals init (System.Collections.Generic.KeyValuePair<K, V> V_0)
+                      IL_0000:  ldarg.1
+                      IL_0001:  ldarg.0
+                      IL_0002:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor(int, System.Collections.Generic.IEqualityComparer<K>)"
+                      IL_0007:  dup
+                      IL_0008:  ldarg.2
+                      IL_0009:  ldarg.3
+                      IL_000a:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                      IL_000f:  ldarg.s    V_4
+                      IL_0011:  stloc.0
+                      IL_0012:  dup
+                      IL_0013:  ldloca.s   V_0
+                      IL_0015:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                      IL_001a:  ldloca.s   V_0
+                      IL_001c:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                      IL_0021:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                      IL_0026:  ret
+                    }
+                    """;
+            verifier.VerifyIL("Program.Create1<K, V>", expectedIL);
+            verifier.VerifyIL("Program.Create2<K, V>", expectedIL);
+        }
+        else
+        {
+            comp.VerifyEmitDiagnostics(
+                // (11,16): error CS1501: No overload for method '<signature>' takes 2 arguments
+                //         return [with(c, e), k:v, x];
+                Diagnostic(ErrorCode.ERR_BadArgCount, "[with(c, e), k:v, x]").WithArguments("<signature>", "2").WithLocation(11, 16),
+                // (15,22): error CS1739: The best overload for '<signature>' does not have a parameter named 'capacity'
+                //         return [with(capacity: c, comparer: e), k:v, x];
+                Diagnostic(ErrorCode.ERR_BadNamedArgument, "capacity").WithArguments("<signature>", "capacity").WithLocation(15, 22));
+        }
+
+        string sourceE = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static {{typeName}}<K, V> Create1<K, V>(IEnumerable<KeyValuePair<K, V>> c, K k, V v)
+                    {
+                        return [with(c), k:v];
+                    }
+                    static {{typeName}}<K, V> Create2<K, V>(IEnumerable<KeyValuePair<K, V>> c, K k, V v)
+                    {
+                        return [with(collection: c), k:v];
+                    }
+                }
+                """;
+        comp = CreateCompilation(sourceE);
+        comp.VerifyEmitDiagnostics(
+            // (6,22): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>' to 'System.Collections.Generic.IEqualityComparer<K>?'
+            //         return [with(c), k:v];
+            Diagnostic(ErrorCode.ERR_BadArgType, "c").WithArguments("1", "System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>", "System.Collections.Generic.IEqualityComparer<K>?").WithLocation(6, 22),
+            // (10,22): error CS1739: The best overload for '<signature>' does not have a parameter named 'collection'
+            //         return [with(collection: c), k:v];
+            Diagnostic(ErrorCode.ERR_BadNamedArgument, "collection").WithArguments("<signature>", "collection").WithLocation(10, 22));
+    }
+
+
+    [Theory]
+    [CombinatorialData]
+    public void CollectionArguments_CapacityAndComparer_02(
+        [CombinatorialValues(
+                "System.Collections.Generic.IReadOnlyDictionary<K, V>",
+                "System.Collections.Generic.IDictionary<K, V>")]
+            string typeName)
+    {
+        string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Create<K, V>(int capacity, IEqualityComparer<K> comparer)
+                    {
+                        {{typeName}} c;
+                        c = [];
+                        c = [with()];
+                        c = [with(default)];
+                        c = [with(capacity)];
+                        c = [with(comparer)];
+                        c = [with(capacity, comparer)];
+                    }
+                }
+                """;
+        var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+        switch (typeName)
+        {
+            case "System.Collections.Generic.IReadOnlyDictionary<K, V>":
+                comp.VerifyEmitDiagnostics(
+                    // (10,19): error CS1503: Argument 1: cannot convert from 'int' to 'System.Collections.Generic.IEqualityComparer<K>?'
+                    //         c = [with(capacity)];
+                    Diagnostic(ErrorCode.ERR_BadArgType, "capacity").WithArguments("1", "int", "System.Collections.Generic.IEqualityComparer<K>?").WithLocation(10, 19),
+                    // (12,13): error CS1501: No overload for method '<signature>' takes 2 arguments
+                    //         c = [with(capacity, comparer)];
+                    Diagnostic(ErrorCode.ERR_BadArgCount, "[with(capacity, comparer)]").WithArguments("<signature>", "2").WithLocation(12, 13));
+                break;
+            case "System.Collections.Generic.IDictionary<K, V>":
+                comp.VerifyEmitDiagnostics(
+                    // (9,13): error CS0121: The call is ambiguous between the following methods or properties: 'Program.<signature>(IEqualityComparer<K>?)' and 'Program.<signature>(int)'
+                    //         c = [with(default)];
+                    Diagnostic(ErrorCode.ERR_AmbigCall, "[with(default)]").WithArguments("Program.<signature>(System.Collections.Generic.IEqualityComparer<K>?)", "Program.<signature>(int)").WithLocation(9, 13));
+                break;
+            default:
+                throw ExceptionUtilities.UnexpectedValue(typeName);
+        }
+    }
+
+    [Theory]
+    [InlineData("IDictionary")]
+    [InlineData("IReadOnlyDictionary")]
+    public void EmptyArguments_DictionaryInterface(string interfaceType)
+    {
+        string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        NoArgs<string, int>().Report();
+                        EmptyArgs<string, int>().Report();
+                    }
+                    static {{interfaceType}}<K, V> NoArgs<K, V>() => [];
+                    static {{interfaceType}}<K, V> EmptyArgs<K, V>() => [with()];
+                }
+                """;
+        var verifier = CompileAndVerify(
+            [source, s_collectionExtensions],
+            verify: Verification.Skipped,
+            expectedOutput: IncludeExpectedOutput("[], [], "));
+        verifier.VerifyDiagnostics();
+        string expectedIL = (interfaceType == "IReadOnlyDictionary") ?
+            """
+                {
+                  // Code size       11 (0xb)
+                  .maxstack  1
+                  IL_0000:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor()"
+                  IL_0005:  newobj     "System.Collections.ObjectModel.ReadOnlyDictionary<K, V>..ctor(System.Collections.Generic.IDictionary<K, V>)"
+                  IL_000a:  ret
+                }
+                """ :
+            """
+                {
+                  // Code size        6 (0x6)
+                  .maxstack  1
+                  IL_0000:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor()"
+                  IL_0005:  ret
+                }
+                """;
+        verifier.VerifyIL("Program.NoArgs<K, V>", expectedIL);
+        verifier.VerifyIL("Program.EmptyArgs<K, V>", expectedIL);
+    }
+
+    [Theory]
+    [InlineData("IDictionary")]
+    [InlineData("IReadOnlyDictionary")]
+    public void Arguments_DictionaryInterface(string interfaceType)
+    {
+        string sourceA = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Pair(null, 1, "one").Report();
+                    }
+                    static {{interfaceType}}<K, V> Pair<K, V>(IEqualityComparer<K> c, K k, V v)
+                    {
+                        return [with(c), k:v];
+                    }
+                }
+                """;
+        var comp = CreateCompilation([sourceA, s_collectionExtensions], options: TestOptions.ReleaseExe);
+        comp.VerifyDiagnostics();
+        var verifier = CompileAndVerify(
+            comp,
+            verify: Verification.Skipped,
+            expectedOutput: IncludeExpectedOutput("[[1, one]], "));
+        verifier.VerifyIL("Program.Pair<K, V>", (interfaceType == "IReadOnlyDictionary") ?
+            """
+                {
+                  // Code size       20 (0x14)
+                  .maxstack  4
+                  IL_0000:  ldarg.0
+                  IL_0001:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor(System.Collections.Generic.IEqualityComparer<K>)"
+                  IL_0006:  dup
+                  IL_0007:  ldarg.1
+                  IL_0008:  ldarg.2
+                  IL_0009:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                  IL_000e:  newobj     "System.Collections.ObjectModel.ReadOnlyDictionary<K, V>..ctor(System.Collections.Generic.IDictionary<K, V>)"
+                  IL_0013:  ret
+                }
+                """ :
+            """
+                {
+                  // Code size       15 (0xf)
+                  .maxstack  4
+                  IL_0000:  ldarg.0
+                  IL_0001:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor(System.Collections.Generic.IEqualityComparer<K>)"
+                  IL_0006:  dup
+                  IL_0007:  ldarg.1
+                  IL_0008:  ldarg.2
+                  IL_0009:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                  IL_000e:  ret
+                }
+                """);
+
+        string sourceB = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Expression(null, new KeyValuePair<int, string>(2, "two")).Report();
+                    }
+                    static {{interfaceType}}<K, V> Expression<K, V>(IEqualityComparer<K> c, KeyValuePair<K, V> e)
+                    {
+                        return [with(1, c), e];
+                    }
+                }
+                """;
+        comp = CreateCompilation([sourceB, s_collectionExtensions], options: TestOptions.ReleaseExe);
+        if (interfaceType == "IReadOnlyDictionary")
+        {
+            comp.VerifyDiagnostics(
+                // (10,16): error CS1501: No overload for method '<signature>' takes 2 arguments
+                //         return [with(1, c), e];
+                Diagnostic(ErrorCode.ERR_BadArgCount, "[with(1, c), e]").WithArguments("<signature>", "2").WithLocation(10, 16));
+        }
+        else
+        {
+            comp.VerifyDiagnostics();
+            verifier = CompileAndVerify(
+                comp,
+                verify: Verification.Skipped,
+                expectedOutput: IncludeExpectedOutput("[[2, two]], "));
+            verifier.VerifyIL("Program.Expression<K, V>", """
+                {
+                  // Code size       30 (0x1e)
+                  .maxstack  4
+                  .locals init (System.Collections.Generic.KeyValuePair<K, V> V_0)
+                  IL_0000:  ldc.i4.1
+                  IL_0001:  ldarg.0
+                  IL_0002:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor(int, System.Collections.Generic.IEqualityComparer<K>)"
+                  IL_0007:  ldarg.1
+                  IL_0008:  stloc.0
+                  IL_0009:  dup
+                  IL_000a:  ldloca.s   V_0
+                  IL_000c:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                  IL_0011:  ldloca.s   V_0
+                  IL_0013:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                  IL_0018:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                  IL_001d:  ret
+                }
+                """);
+        }
+
+        string sourceC = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static {{interfaceType}}<K, V> Pair<K, V>(IEqualityComparer<K> c, K k, V v)
+                    {
+                        return [k:v, with(c)];
+                    }
+                }
+                """;
+        comp = CreateCompilation(sourceC);
+        comp.VerifyEmitDiagnostics(
+            // (6,22): error CS9501: Collection argument element must be the first element.
+            //         return [k:v, with(1)];
+            Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(6, 22));
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void InterfaceTarget_MissingMember_01(
+        [CombinatorialValues(
+                "IEnumerable",
+                "IReadOnlyCollection",
+                "IReadOnlyList",
+                "ICollection",
+                "IList")]
+            string typeName,
+        [CombinatorialValues(
+                0,
+                WellKnownMember.System_Collections_Generic_List_T__ctor,
+                WellKnownMember.System_Collections_Generic_List_T__ctorInt32,
+                WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor,
+                WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_IEqualityComparer_K,
+                WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_Int32,
+                WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_Int32_IEqualityComparer_K)]
+            int missingMember)
+    {
+        string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Create(int i)
+                    {
+                        {{typeName}}<int> c;
+                        c = [];
+                        c = [with()];
+                        c = [with(i)];
+                    }
+                }
+                """;
+        var comp = CreateCompilation(source);
+        comp.MakeMemberMissing((WellKnownMember)missingMember);
+        if (typeName is "ICollection" or "IList")
+        {
+            switch ((WellKnownMember)missingMember)
+            {
+                case WellKnownMember.System_Collections_Generic_List_T__ctor:
+                    comp.VerifyEmitDiagnostics(
+                        // (7,13): error CS0656: Missing compiler required member 'System.Collections.Generic.List`1..ctor'
+                        //         c = [];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.List`1", ".ctor").WithLocation(7, 13),
+                        // (7,13): error CS7036: There is no argument given that corresponds to the required parameter 'capacity' of 'Program.<signature>(int)'
+                        //         c = [];
+                        Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "[]").WithArguments("capacity", "Program.<signature>(int)").WithLocation(7, 13),
+                        // (8,13): error CS0656: Missing compiler required member 'System.Collections.Generic.List`1..ctor'
+                        //         c = [with()];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with()]").WithArguments("System.Collections.Generic.List`1", ".ctor").WithLocation(8, 13),
+                        // (8,13): error CS7036: There is no argument given that corresponds to the required parameter 'capacity' of 'Program.<signature>(int)'
+                        //         c = [with()];
+                        Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "[with()]").WithArguments("capacity", "Program.<signature>(int)").WithLocation(8, 13),
+                        // (9,13): error CS0656: Missing compiler required member 'System.Collections.Generic.List`1..ctor'
+                        //         c = [with(i)];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i)]").WithArguments("System.Collections.Generic.List`1", ".ctor").WithLocation(9, 13));
+                    break;
+                case WellKnownMember.System_Collections_Generic_List_T__ctorInt32:
+                    comp.VerifyEmitDiagnostics(
+                        // (7,13): error CS0656: Missing compiler required member 'System.Collections.Generic.List`1..ctor'
+                        //         c = [];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.List`1", ".ctor").WithLocation(7, 13),
+                        // (8,13): error CS0656: Missing compiler required member 'System.Collections.Generic.List`1..ctor'
+                        //         c = [with()];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with()]").WithArguments("System.Collections.Generic.List`1", ".ctor").WithLocation(8, 13),
+                        // (9,13): error CS0656: Missing compiler required member 'System.Collections.Generic.List`1..ctor'
+                        //         c = [with(i)];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i)]").WithArguments("System.Collections.Generic.List`1", ".ctor").WithLocation(9, 13),
+                        // (9,13): error CS1501: No overload for method '<signature>' takes 1 arguments
+                        //         c = [with(i)];
+                        Diagnostic(ErrorCode.ERR_BadArgCount, "[with(i)]").WithArguments("<signature>", "1").WithLocation(9, 13));
+                    break;
+                default:
+                    comp.VerifyEmitDiagnostics();
+                    break;
+            }
+        }
+        else
+        {
+            switch ((WellKnownMember)missingMember)
+            {
+                case WellKnownMember.System_Collections_Generic_List_T__ctor:
+                    comp.VerifyEmitDiagnostics(
+                        // (7,13): error CS0656: Missing compiler required member 'System.Collections.Generic.List`1..ctor'
+                        //         c = [];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.List`1", ".ctor").WithLocation(7, 13),
+                        // (8,13): error CS0656: Missing compiler required member 'System.Collections.Generic.List`1..ctor'
+                        //         c = [with()];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with()]").WithArguments("System.Collections.Generic.List`1", ".ctor").WithLocation(8, 13),
+                        // (9,13): error CS0656: Missing compiler required member 'System.Collections.Generic.List`1..ctor'
+                        //         c = [with(i)];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i)]").WithArguments("System.Collections.Generic.List`1", ".ctor").WithLocation(9, 13));
+                    break;
+                default:
+                    comp.VerifyEmitDiagnostics(
+                        // (9,13): error CS1501: No overload for method '<signature>' takes 1 arguments
+                        //         c = [with(i)];
+                        Diagnostic(ErrorCode.ERR_BadArgCount, "[with(i)]").WithArguments("<signature>", "1").WithLocation(9, 13));
+                    break;
+            }
+        }
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void InterfaceTarget_MissingMember_02(
+        [CombinatorialValues(
+                "IDictionary",
+                "IReadOnlyDictionary")]
+            string typeName,
+        [CombinatorialValues(
+                0,
+                WellKnownMember.System_Collections_Generic_List_T__ctor,
+                WellKnownMember.System_Collections_Generic_List_T__ctorInt32,
+                WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor,
+                WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_IEqualityComparer_K,
+                WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_Int32,
+                WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_Int32_IEqualityComparer_K)]
+            int missingMember)
+    {
+        string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Create(int i, IEqualityComparer<int> e)
+                    {
+                        {{typeName}}<int, string> c;
+                        c = [];
+                        c = [with()];
+                        c = [with(i)];
+                        c = [with(e)];
+                        c = [with(i, e)];
+                    }
+                }
+                """;
+        var comp = CreateCompilation(source);
+        comp.MakeMemberMissing((WellKnownMember)missingMember);
+        if (typeName is "IDictionary")
+        {
+            switch ((WellKnownMember)missingMember)
+            {
+                case WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor:
+                    comp.VerifyEmitDiagnostics(
+                        // (7,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(7, 13),
+                        // (7,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(7, 13),
+                        // (7,13): error CS1501: No overload for method '<signature>' takes 0 arguments
+                        //         c = [];
+                        Diagnostic(ErrorCode.ERR_BadArgCount, "[]").WithArguments("<signature>", "0").WithLocation(7, 13),
+                        // (8,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with()];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with()]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(8, 13),
+                        // (8,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with()];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with()]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(8, 13),
+                        // (8,13): error CS1501: No overload for method '<signature>' takes 0 arguments
+                        //         c = [with()];
+                        Diagnostic(ErrorCode.ERR_BadArgCount, "[with()]").WithArguments("<signature>", "0").WithLocation(8, 13),
+                        // (9,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with(i)];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(9, 13),
+                        // (9,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with(i)];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(9, 13),
+                        // (10,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with(e)];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(e)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(10, 13),
+                        // (10,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with(e)];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(e)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(10, 13),
+                        // (11,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with(i, e)];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i, e)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(11, 13),
+                        // (11,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with(i, e)];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i, e)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(11, 13));
+                    break;
+                case WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_IEqualityComparer_K:
+                    comp.VerifyEmitDiagnostics(
+                        // (7,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(7, 13),
+                        // (8,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with()];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with()]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(8, 13),
+                        // (9,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with(i)];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(9, 13),
+                        // (10,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with(e)];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(e)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(10, 13),
+                        // (10,19): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.IEqualityComparer<int>' to 'int'
+                        //         c = [with(e)];
+                        Diagnostic(ErrorCode.ERR_BadArgType, "e").WithArguments("1", "System.Collections.Generic.IEqualityComparer<int>", "int").WithLocation(10, 19),
+                        // (11,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with(i, e)];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i, e)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(11, 13));
+                    break;
+                case WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_Int32:
+                    comp.VerifyEmitDiagnostics(
+                        // (7,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(7, 13),
+                        // (8,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with()];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with()]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(8, 13),
+                        // (9,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with(i)];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(9, 13),
+                        // (9,19): error CS1503: Argument 1: cannot convert from 'int' to 'System.Collections.Generic.IEqualityComparer<int>?'
+                        //         c = [with(i)];
+                        Diagnostic(ErrorCode.ERR_BadArgType, "i").WithArguments("1", "int", "System.Collections.Generic.IEqualityComparer<int>?").WithLocation(9, 19),
+                        // (10,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with(e)];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(e)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(10, 13),
+                        // (11,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with(i, e)];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i, e)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(11, 13));
+                    break;
+                case WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_Int32_IEqualityComparer_K:
+                    comp.VerifyEmitDiagnostics(
+                        // (7,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(7, 13),
+                        // (8,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with()];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with()]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(8, 13),
+                        // (9,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with(i)];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(9, 13),
+                        // (10,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with(e)];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(e)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(10, 13),
+                        // (11,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with(i, e)];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i, e)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(11, 13),
+                        // (11,13): error CS1501: No overload for method '<signature>' takes 2 arguments
+                        //         c = [with(i, e)];
+                        Diagnostic(ErrorCode.ERR_BadArgCount, "[with(i, e)]").WithArguments("<signature>", "2").WithLocation(11, 13));
+                    break;
+                default:
+                    comp.VerifyEmitDiagnostics();
+                    break;
+            }
+        }
+        else
+        {
+            switch ((WellKnownMember)missingMember)
+            {
+                case WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor:
+                    comp.VerifyEmitDiagnostics(
+                        // (7,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(7, 13),
+                        // (7,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(7, 13),
+                        // (7,13): error CS7036: There is no argument given that corresponds to the required parameter 'comparer' of 'Program.<signature>(IEqualityComparer<int>?)'
+                        //         c = [];
+                        Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "[]").WithArguments("comparer", "Program.<signature>(System.Collections.Generic.IEqualityComparer<int>?)").WithLocation(7, 13),
+                        // (8,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with()];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with()]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(8, 13),
+                        // (8,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with()];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with()]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(8, 13),
+                        // (8,13): error CS7036: There is no argument given that corresponds to the required parameter 'comparer' of 'Program.<signature>(IEqualityComparer<int>?)'
+                        //         c = [with()];
+                        Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "[with()]").WithArguments("comparer", "Program.<signature>(System.Collections.Generic.IEqualityComparer<int>?)").WithLocation(8, 13),
+                        // (9,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with(i)];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(9, 13),
+                        // (9,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with(i)];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(9, 13),
+                        // (9,19): error CS1503: Argument 1: cannot convert from 'int' to 'System.Collections.Generic.IEqualityComparer<int>?'
+                        //         c = [with(i)];
+                        Diagnostic(ErrorCode.ERR_BadArgType, "i").WithArguments("1", "int", "System.Collections.Generic.IEqualityComparer<int>?").WithLocation(9, 19),
+                        // (10,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with(e)];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(e)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(10, 13),
+                        // (10,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with(e)];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(e)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(10, 13),
+                        // (11,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with(i, e)];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i, e)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(11, 13),
+                        // (11,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with(i, e)];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i, e)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(11, 13),
+                        // (11,13): error CS1501: No overload for method '<signature>' takes 2 arguments
+                        //         c = [with(i, e)];
+                        Diagnostic(ErrorCode.ERR_BadArgCount, "[with(i, e)]").WithArguments("<signature>", "2").WithLocation(11, 13));
+                    break;
+                case WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_IEqualityComparer_K:
+                    comp.VerifyEmitDiagnostics(
+                        // (7,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(7, 13),
+                        // (8,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with()];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with()]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(8, 13),
+                        // (9,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with(i)];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(9, 13),
+                        // (9,13): error CS1501: No overload for method '<signature>' takes 1 arguments
+                        //         c = [with(i)];
+                        Diagnostic(ErrorCode.ERR_BadArgCount, "[with(i)]").WithArguments("<signature>", "1").WithLocation(9, 13),
+                        // (10,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with(e)];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(e)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(10, 13),
+                        // (10,13): error CS1501: No overload for method '<signature>' takes 1 arguments
+                        //         c = [with(e)];
+                        Diagnostic(ErrorCode.ERR_BadArgCount, "[with(e)]").WithArguments("<signature>", "1").WithLocation(10, 13),
+                        // (11,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        //         c = [with(i, e)];
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i, e)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(11, 13),
+                        // (11,13): error CS1501: No overload for method '<signature>' takes 2 arguments
+                        //         c = [with(i, e)];
+                        Diagnostic(ErrorCode.ERR_BadArgCount, "[with(i, e)]").WithArguments("<signature>", "2").WithLocation(11, 13));
+                    break;
+                default:
+                    comp.VerifyEmitDiagnostics(
+                        // (9,19): error CS1503: Argument 1: cannot convert from 'int' to 'System.Collections.Generic.IEqualityComparer<int>?'
+                        //         c = [with(i)];
+                        Diagnostic(ErrorCode.ERR_BadArgType, "i").WithArguments("1", "int", "System.Collections.Generic.IEqualityComparer<int>?").WithLocation(9, 19),
+                        // (11,13): error CS1501: No overload for method '<signature>' takes 2 arguments
+                        //         c = [with(i, e)];
+                        Diagnostic(ErrorCode.ERR_BadArgCount, "[with(i, e)]").WithArguments("<signature>", "2").WithLocation(11, 13));
+                    break;
+            }
+        }
+    }
+#endif
+
+    [Theory]
+    [CombinatorialData]
+    public void List_KnownLength_List(
+        [CombinatorialValues("", "with(), ", "with(3), ")] string argsPrefix)
+    {
+        string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Create(1, 2, 3).Report();
+                    }
+                    static List<T> Create<T>(params T[] items)
+                    {
+                        return [{{argsPrefix}} ..items];
+                    }
+                }
+                """;
+        var verifier = CompileAndVerify(
+            [source, s_collectionExtensions],
+            targetFramework: TargetFramework.Net80,
+            verify: Verification.Skipped,
+            expectedOutput: IncludeExpectedOutput("[1, 2, 3], "));
+        verifier.VerifyDiagnostics();
+        string expectedIL;
+        switch (argsPrefix)
+        {
+            case "with(), ":
+                expectedIL = """
+                    {
+                      // Code size       39 (0x27)
+                      .maxstack  2
+                      .locals init (System.Collections.Generic.List<T> V_0,
+                                    T[] V_1,
+                                    int V_2,
+                                    T V_3)
+                      IL_0000:  newobj     "System.Collections.Generic.List<T>..ctor()"
+                      IL_0005:  stloc.0
+                      IL_0006:  ldarg.0
+                      IL_0007:  stloc.1
+                      IL_0008:  ldc.i4.0
+                      IL_0009:  stloc.2
+                      IL_000a:  br.s       IL_001f
+                      IL_000c:  ldloc.1
+                      IL_000d:  ldloc.2
+                      IL_000e:  ldelem     "T"
+                      IL_0013:  stloc.3
+                      IL_0014:  ldloc.0
+                      IL_0015:  ldloc.3
+                      IL_0016:  callvirt   "void System.Collections.Generic.List<T>.Add(T)"
+                      IL_001b:  ldloc.2
+                      IL_001c:  ldc.i4.1
+                      IL_001d:  add
+                      IL_001e:  stloc.2
+                      IL_001f:  ldloc.2
+                      IL_0020:  ldloc.1
+                      IL_0021:  ldlen
+                      IL_0022:  conv.i4
+                      IL_0023:  blt.s      IL_000c
+                      IL_0025:  ldloc.0
+                      IL_0026:  ret
+                    }
+                    """;
+                break;
+            case "with(3), ":
+                expectedIL = """
+                        {
+                          // Code size       40 (0x28)
+                          .maxstack  2
+                          .locals init (System.Collections.Generic.List<T> V_0,
+                                        T[] V_1,
+                                        int V_2,
+                                        T V_3)
+                          IL_0000:  ldc.i4.3
+                          IL_0001:  newobj     "System.Collections.Generic.List<T>..ctor(int)"
+                          IL_0006:  stloc.0
+                          IL_0007:  ldarg.0
+                          IL_0008:  stloc.1
+                          IL_0009:  ldc.i4.0
+                          IL_000a:  stloc.2
+                          IL_000b:  br.s       IL_0020
+                          IL_000d:  ldloc.1
+                          IL_000e:  ldloc.2
+                          IL_000f:  ldelem     "T"
+                          IL_0014:  stloc.3
+                          IL_0015:  ldloc.0
+                          IL_0016:  ldloc.3
+                          IL_0017:  callvirt   "void System.Collections.Generic.List<T>.Add(T)"
+                          IL_001c:  ldloc.2
+                          IL_001d:  ldc.i4.1
+                          IL_001e:  add
+                          IL_001f:  stloc.2
+                          IL_0020:  ldloc.2
+                          IL_0021:  ldloc.1
+                          IL_0022:  ldlen
+                          IL_0023:  conv.i4
+                          IL_0024:  blt.s      IL_000d
+                          IL_0026:  ldloc.0
+                          IL_0027:  ret
+                        }
+                        """;
+                break;
+            default:
+                expectedIL = """
+                        {
+                          // Code size        7 (0x7)
+                          .maxstack  1
+                          IL_0000:  ldarg.0
+                          IL_0001:  call       "System.Collections.Generic.List<T> System.Linq.Enumerable.ToList<T>(System.Collections.Generic.IEnumerable<T>)"
+                          IL_0006:  ret
+                        }
+                        """;
+                break;
+        }
+        verifier.VerifyIL("Program.Create<T>", expectedIL);
+    }
+
+    [Fact]
+    public void DefiniteAssignment_01()
+    {
+        string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static HashSet<T> Create<T>()
+                    {
+                        IEqualityComparer<T> e = null;
+                        return [with(e)];
+                    }
+                }
+                """;
+        var comp = CreateCompilation(source);
+        comp.VerifyEmitDiagnostics();
+    }
+
+    [Fact]
+    public void DefiniteAssignment_02()
+    {
+        string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static IEqualityComparer<T> Create<T>()
+                    {
+                        IEqualityComparer<T> e;
+                        HashSet<T> s = [with(e = null)];
+                        return e;
+                    }
+                }
+                """;
+        var comp = CreateCompilation(source);
+        comp.VerifyEmitDiagnostics();
+    }
+
+    [Fact]
+    public void NullableAnalysis_01()
+    {
+        string source = """
+                #nullable enable
+                using System.Collections.Generic;
+                class Program
+                {
+                    static IEqualityComparer<T> Create<T>()
+                    {
+                        IEqualityComparer<T>? e = null;
+                        HashSet<T> s = [with(e = Create<T>())];
+                        return e;
+                    }
+                }
+                """;
+        var comp = CreateCompilation(source);
+        // PROTOTYPE: Handle collection arguments in flow analysis.
+        comp.VerifyEmitDiagnostics(
+            // (9,16): warning CS8603: Possible null reference return.
+            //         return e;
+            Diagnostic(ErrorCode.WRN_NullReferenceReturn, "e").WithLocation(9, 16));
+    }
+
+    [Fact]
+    public void ParamsCycle_ParamsConstructorOnly()
+    {
+        string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                    public MyCollection(params MyCollection<T> other) { _list = new(other); }
+                    public void Add(T t) { _list.Add(t); }
+                }
+                """;
+        string sourceB = """
+                MyCollection<int> c;
+                c = [];
+                c = [with()];
+                c = [with(null)];
+                c = [with(1)];
+                """;
+        var comp = CreateCompilation([sourceA, sourceB]);
+        comp.VerifyEmitDiagnostics(
+            // (2,5): error CS9223: Creation of params collection 'MyCollection<int>' results in an infinite chain of invocation of constructor 'MyCollection<T>.MyCollection(params MyCollection<T>)'.
+            // c = [];
+            Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "[]").WithArguments("MyCollection<int>", "MyCollection<T>.MyCollection(params MyCollection<T>)").WithLocation(2, 5),
+            // (3,5): error CS9223: Creation of params collection 'MyCollection<int>' results in an infinite chain of invocation of constructor 'MyCollection<T>.MyCollection(params MyCollection<T>)'.
+            // c = [with()];
+            Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "[with()]").WithArguments("MyCollection<int>", "MyCollection<T>.MyCollection(params MyCollection<T>)").WithLocation(3, 5),
+            // (5,5): error CS9223: Creation of params collection 'MyCollection<int>' results in an infinite chain of invocation of constructor 'MyCollection<T>.MyCollection(params MyCollection<T>)'.
+            // c = [with(1)];
+            Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "[with(1)]").WithArguments("MyCollection<int>", "MyCollection<T>.MyCollection(params MyCollection<T>)").WithLocation(5, 5));
+    }
+
+    [Fact]
+    public void ParamsCycle_MultipleConstructors()
+    {
+        string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                    public MyCollection() { _list = new(); }
+                    public MyCollection(params MyCollection<T> other) { _list = new(other); }
+                    public void Add(T t) { _list.Add(t); }
+                }
+                """;
+        string sourceB = """
+                MyCollection<int> c;
+                c = [];
+                c = [with()];
+                c = [with(null)];
+                c = [with(1)];
+                """;
+        var comp = CreateCompilation([sourceA, sourceB]);
+        comp.VerifyEmitDiagnostics(
+            // (5,5): error CS9223: Creation of params collection 'MyCollection<int>' results in an infinite chain of invocation of constructor 'MyCollection<T>.MyCollection()'.
+            // c = [with(1)];
+            Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "[with(1)]").WithArguments("MyCollection<int>", "MyCollection<T>.MyCollection()").WithLocation(5, 5));
+    }
+
+    [Fact]
+    public void ParamsCycle_PrivateParameterlessConstructor()
+    {
+        string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                    private MyCollection() { }
+                    public MyCollection(params MyCollection<T> other) { _list = new(other); }
+                    public void Add(T t) { _list.Add(t); }
+                }
+                """;
+        string sourceB = """
+                MyCollection<int> c;
+                c = [];
+                c = [with()];
+                c = [with(null)];
+                c = [with(1)];
+                """;
+        var comp = CreateCompilation([sourceA, sourceB]);
+        comp.VerifyEmitDiagnostics(
+            // (2,5): error CS9223: Creation of params collection 'MyCollection<int>' results in an infinite chain of invocation of constructor 'MyCollection<T>.MyCollection(params MyCollection<T>)'.
+            // c = [];
+            Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "[]").WithArguments("MyCollection<int>", "MyCollection<T>.MyCollection(params MyCollection<T>)").WithLocation(2, 5),
+            // (3,5): error CS9223: Creation of params collection 'MyCollection<int>' results in an infinite chain of invocation of constructor 'MyCollection<T>.MyCollection(params MyCollection<T>)'.
+            // c = [with()];
+            Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "[with()]").WithArguments("MyCollection<int>", "MyCollection<T>.MyCollection(params MyCollection<T>)").WithLocation(3, 5),
+            // (5,5): error CS9223: Creation of params collection 'MyCollection<int>' results in an infinite chain of invocation of constructor 'MyCollection<T>.MyCollection(params MyCollection<T>)'.
+            // c = [with(1)];
+            Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "[with(1)]").WithArguments("MyCollection<int>", "MyCollection<T>.MyCollection(params MyCollection<T>)").WithLocation(5, 5),
+            // (9,25): error CS9224: Method 'MyCollection<T>.MyCollection()' cannot be less visible than the member with params collection 'MyCollection<T>.MyCollection(params MyCollection<T>)'.
+            //     public MyCollection(params MyCollection<T> other) { _list = new(other); }
+            Diagnostic(ErrorCode.ERR_ParamsMemberCannotBeLessVisibleThanDeclaringMember, "params MyCollection<T> other").WithArguments("MyCollection<T>.MyCollection()", "MyCollection<T>.MyCollection(params MyCollection<T>)").WithLocation(9, 25));
+    }
+
+    [Fact]
+    public void ParamsCycle_NoParameterlessConstructor()
+    {
+        string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _list;
+                    IEnumerator<T> IEnumerable<T>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                    public MyCollection(T x, params MyCollection<T> y)
+                    {
+                        _list = new();
+                        _list.Add(x);
+                        _list.AddRange(y);
+                    }
+                    public void Add(T t) { _list.Add(t); }
+                }
+                """;
+        string sourceB = """
+                MyCollection<int> c;
+                c = [];
+                c = [with()];
+                c = [with(1)];
+                """;
+        var comp = CreateCompilation([sourceA, sourceB]);
+        comp.VerifyEmitDiagnostics(
+            // (2,5): error CS9214: Collection expression type must have an applicable constructor that can be called with no arguments.
+            // c = [];
+            Diagnostic(ErrorCode.ERR_CollectionExpressionMissingConstructor, "[]").WithLocation(2, 5),
+            // (3,5): error CS9214: Collection expression type must have an applicable constructor that can be called with no arguments.
+            // c = [with()];
+            Diagnostic(ErrorCode.ERR_CollectionExpressionMissingConstructor, "[with()]").WithLocation(3, 5),
+            // (4,5): error CS9223: Creation of params collection 'MyCollection<int>' results in an infinite chain of invocation of constructor 'MyCollection<T>.MyCollection(T, params MyCollection<T>)'.
+            // c = [with(1)];
+            Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "[with(1)]").WithArguments("MyCollection<int>", "MyCollection<T>.MyCollection(T, params MyCollection<T>)").WithLocation(4, 5),
+            // (8,30): error CS9228: Non-array params collection type must have an applicable constructor that can be called with no arguments.
+            //     public MyCollection(T x, params MyCollection<T> y)
+            Diagnostic(ErrorCode.ERR_ParamsCollectionMissingConstructor, "params MyCollection<T> y").WithLocation(8, 30));
+    }
+}

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Extra.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Extra.cs
@@ -101,9 +101,6 @@ public sealed class CollectionExpressionTests_WithElement_Extra : CSharpTestBase
         else
         {
             comp.VerifyEmitDiagnostics(
-                // (2,21): error CS1739: The best overload for 'List' does not have a parameter named 'x'
-                // List<int> l = [with(x: 1), with(y: 2)];
-                Diagnostic(ErrorCode.ERR_BadNamedArgument, "x").WithArguments("List", "x").WithLocation(2, 21),
                 // (2,28): error CS9335: Collection argument element must be the first element.
                 // List<int> l = [with(x: 1), with(y: 2)];
                 Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(2, 28));
@@ -156,12 +153,6 @@ public sealed class CollectionExpressionTests_WithElement_Extra : CSharpTestBase
         else
         {
             comp.VerifyEmitDiagnostics(
-                // (1,23): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<T>' and return type 'MyCollection<T>'.
-                // MyCollection<int> c = [
-                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, @"[
-    with(),
-    with(arg: 0),
-    with(unknown: 1)]").WithArguments("Create", "T", "MyCollection<T>").WithLocation(1, 23),
                 // (3,5): error CS9501: Collection argument element must be the first element.
                 //     with(arg: 0),
                 Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeFirst, "with").WithLocation(3, 5),
@@ -268,7 +259,7 @@ public sealed class CollectionExpressionTests_WithElement_Extra : CSharpTestBase
         var collections = tree.GetRoot().DescendantNodes().OfType<CollectionExpressionSyntax>().ToArray();
         Assert.Equal(2, collections.Length);
         VerifyTypes(model, collections[0], expectedType: null, expectedConvertedType: "T[]", ConversionKind.CollectionExpression);
-        VerifyTypes(model, collections[1], expectedType: null, expectedConvertedType: "T[]", ConversionKind.CollectionExpression);
+        VerifyTypes(model, collections[1], expectedType: null, expectedConvertedType: "T[]", ConversionKind.NoConversion);
     }
 
     private static void VerifyTypes(SemanticModel model, ExpressionSyntax expr, string? expectedType, string expectedConvertedType, ConversionKind expectedConversionKind)

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Extra.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Extra.cs
@@ -3842,8 +3842,7 @@ public sealed class CollectionExpressionTests_WithElement_Extra : CSharpTestBase
             Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[with(args), ..s]").WithArguments("Create", "T", "System.Collections.Immutable.ImmutableArray<T>").WithLocation(14, 100));
     }
 
-    [Theory(Skip = "PROTOTYPE: Ref safety")]
-    [CombinatorialData]
+    [Theory, CombinatorialData]
     public void RefSafety_ConstructorArguments(bool scopedInParameter, bool scopedOutArgument)
     {
         string sourceA = $$"""

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/WithElementParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/WithElementParsingTests.cs
@@ -1080,80 +1080,34 @@ public sealed class WithElementParsingTests(ITestOutputHelper output) : ParsingT
             // [a:b, with()]
             Diagnostic(ErrorCode.ERR_SyntaxError, "b").WithArguments(",").WithLocation(1, 4));
 
-        if (languageVersion == LanguageVersion.CSharp14)
+        N(SyntaxKind.CollectionExpression);
         {
-            N(SyntaxKind.CollectionExpression);
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.ExpressionElement);
             {
-                N(SyntaxKind.OpenBracketToken);
-                N(SyntaxKind.ExpressionElement);
+                N(SyntaxKind.IdentifierName);
                 {
-                    N(SyntaxKind.IdentifierName);
-                    {
-                        N(SyntaxKind.IdentifierToken, "a");
-                    }
+                    N(SyntaxKind.IdentifierToken, "a");
                 }
-                M(SyntaxKind.CommaToken);
-                N(SyntaxKind.ExpressionElement);
-                {
-                    N(SyntaxKind.IdentifierName);
-                    {
-                        N(SyntaxKind.IdentifierToken, "b");
-                    }
-                }
-                N(SyntaxKind.CommaToken);
-                N(SyntaxKind.ExpressionElement);
-                {
-                    N(SyntaxKind.InvocationExpression);
-                    {
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken, "with");
-                        }
-                        N(SyntaxKind.ArgumentList);
-                        {
-                            N(SyntaxKind.OpenParenToken);
-                            N(SyntaxKind.CloseParenToken);
-                        }
-                    }
-                }
-                N(SyntaxKind.CloseBracketToken);
             }
-            EOF();
-        }
-        else
-        {
-            N(SyntaxKind.CollectionExpression);
+            M(SyntaxKind.CommaToken);
+            N(SyntaxKind.ExpressionElement);
             {
-                N(SyntaxKind.OpenBracketToken);
-                N(SyntaxKind.ExpressionElement);
+                N(SyntaxKind.IdentifierName);
                 {
-                    N(SyntaxKind.IdentifierName);
-                    {
-                        N(SyntaxKind.IdentifierToken, "a");
-                    }
+                    N(SyntaxKind.IdentifierToken, "b");
                 }
-                M(SyntaxKind.CommaToken);
-                N(SyntaxKind.ExpressionElement);
-                {
-                    N(SyntaxKind.IdentifierName);
-                    {
-                        N(SyntaxKind.IdentifierToken, "b");
-                    }
-                }
-                N(SyntaxKind.CommaToken);
-                N(SyntaxKind.WithElement);
-                {
-                    N(SyntaxKind.WithKeyword);
-                    N(SyntaxKind.ArgumentList);
-                    {
-                        N(SyntaxKind.OpenParenToken);
-                        N(SyntaxKind.CloseParenToken);
-                    }
-                }
-                N(SyntaxKind.CloseBracketToken);
             }
-            EOF();
+            N(SyntaxKind.CommaToken);
+            CollectionArgumentsOrInvocation(languageVersion);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.CloseBracketToken);
         }
+        EOF();
     }
 
     [Theory, MemberData(nameof(CollectionArgumentsLanguageVersions))]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/WithElementParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/WithElementParsingTests.cs
@@ -569,6 +569,176 @@ public sealed class WithElementParsingTests(ITestOutputHelper output) : ParsingT
     }
 
     [Theory, MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement19(LanguageVersion languageVersion)
+    {
+        UsingExpression("[a.with()]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.ExpressionElement);
+            {
+                N(SyntaxKind.InvocationExpression);
+                {
+                    N(SyntaxKind.SimpleMemberAccessExpression);
+                    {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "a");
+                        }
+                        N(SyntaxKind.DotToken);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "with");
+                        }
+                    }
+                    N(SyntaxKind.ArgumentList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory, MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement20(LanguageVersion languageVersion)
+    {
+        UsingExpression("[(with)()]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion),
+            // (1,9): error CS1525: Invalid expression term ')'
+            // [(with)()]
+            Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(1, 9));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.ExpressionElement);
+            {
+                N(SyntaxKind.CastExpression);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "with");
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                    N(SyntaxKind.ParenthesizedExpression);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        M(SyntaxKind.IdentifierName);
+                        {
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory, MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement21(LanguageVersion languageVersion)
+    {
+        UsingExpression("[(with)(with)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.ExpressionElement);
+            {
+                N(SyntaxKind.CastExpression);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "with");
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                    N(SyntaxKind.ParenthesizedExpression);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "with");
+                        }
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory, MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement22(LanguageVersion languageVersion)
+    {
+        UsingExpression("[(with)]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.ExpressionElement);
+            {
+                N(SyntaxKind.ParenthesizedExpression);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "with");
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory, MemberData(nameof(CollectionArgumentsLanguageVersions))]
+    public void NotWithElement23(LanguageVersion languageVersion)
+    {
+        UsingExpression("[(with())]",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.CollectionExpression);
+        {
+            N(SyntaxKind.OpenBracketToken);
+            N(SyntaxKind.ExpressionElement);
+            {
+                N(SyntaxKind.ParenthesizedExpression);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.InvocationExpression);
+                    {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "with");
+                        }
+                        N(SyntaxKind.ArgumentList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+            }
+            N(SyntaxKind.CloseBracketToken);
+        }
+        EOF();
+    }
+
+    [Theory, MemberData(nameof(CollectionArgumentsLanguageVersions))]
     public void WithElement1(LanguageVersion languageVersion)
     {
         UsingExpression("[with(]",

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/WithElementParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/WithElementParsingTests.cs
@@ -28,8 +28,6 @@ public sealed class WithElementParsingTests(ITestOutputHelper output) : ParsingT
         }
     }
 
-<<<<<<< HEAD
-=======
     [Fact]
     public void TestSyntaxFacts()
     {
@@ -39,7 +37,6 @@ public sealed class WithElementParsingTests(ITestOutputHelper output) : ParsingT
         Assert.Equal("with", SyntaxFacts.GetText(SyntaxKind.WithKeyword));
     }
 
->>>>>>> upstream/features/collection-expression-arguments
     [Theory, MemberData(nameof(CollectionArgumentsLanguageVersions))]
     public void NotWithElement1(LanguageVersion languageVersion)
     {
@@ -581,7 +578,6 @@ public sealed class WithElementParsingTests(ITestOutputHelper output) : ParsingT
     }
 
     [Theory, MemberData(nameof(CollectionArgumentsLanguageVersions))]
-<<<<<<< HEAD
     public void NotWithElement19(LanguageVersion languageVersion)
     {
         UsingExpression("[a.with()]",
@@ -752,8 +748,6 @@ public sealed class WithElementParsingTests(ITestOutputHelper output) : ParsingT
     }
 
     [Theory, MemberData(nameof(CollectionArgumentsLanguageVersions))]
-=======
->>>>>>> upstream/features/collection-expression-arguments
     public void WithElement1(LanguageVersion languageVersion)
     {
         UsingExpression("[with(]",
@@ -1095,7 +1089,6 @@ public sealed class WithElementParsingTests(ITestOutputHelper output) : ParsingT
             // [a:b, with()]
             Diagnostic(ErrorCode.ERR_SyntaxError, "b").WithArguments(",").WithLocation(1, 4));
 
-<<<<<<< HEAD
         N(SyntaxKind.CollectionExpression);
         {
             N(SyntaxKind.OpenBracketToken);
@@ -1124,82 +1117,6 @@ public sealed class WithElementParsingTests(ITestOutputHelper output) : ParsingT
             N(SyntaxKind.CloseBracketToken);
         }
         EOF();
-=======
-        if (languageVersion == LanguageVersion.CSharp14)
-        {
-            N(SyntaxKind.CollectionExpression);
-            {
-                N(SyntaxKind.OpenBracketToken);
-                N(SyntaxKind.ExpressionElement);
-                {
-                    N(SyntaxKind.IdentifierName);
-                    {
-                        N(SyntaxKind.IdentifierToken, "a");
-                    }
-                }
-                M(SyntaxKind.CommaToken);
-                N(SyntaxKind.ExpressionElement);
-                {
-                    N(SyntaxKind.IdentifierName);
-                    {
-                        N(SyntaxKind.IdentifierToken, "b");
-                    }
-                }
-                N(SyntaxKind.CommaToken);
-                N(SyntaxKind.ExpressionElement);
-                {
-                    N(SyntaxKind.InvocationExpression);
-                    {
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken, "with");
-                        }
-                        N(SyntaxKind.ArgumentList);
-                        {
-                            N(SyntaxKind.OpenParenToken);
-                            N(SyntaxKind.CloseParenToken);
-                        }
-                    }
-                }
-                N(SyntaxKind.CloseBracketToken);
-            }
-            EOF();
-        }
-        else
-        {
-            N(SyntaxKind.CollectionExpression);
-            {
-                N(SyntaxKind.OpenBracketToken);
-                N(SyntaxKind.ExpressionElement);
-                {
-                    N(SyntaxKind.IdentifierName);
-                    {
-                        N(SyntaxKind.IdentifierToken, "a");
-                    }
-                }
-                M(SyntaxKind.CommaToken);
-                N(SyntaxKind.ExpressionElement);
-                {
-                    N(SyntaxKind.IdentifierName);
-                    {
-                        N(SyntaxKind.IdentifierToken, "b");
-                    }
-                }
-                N(SyntaxKind.CommaToken);
-                N(SyntaxKind.WithElement);
-                {
-                    N(SyntaxKind.WithKeyword);
-                    N(SyntaxKind.ArgumentList);
-                    {
-                        N(SyntaxKind.OpenParenToken);
-                        N(SyntaxKind.CloseParenToken);
-                    }
-                }
-                N(SyntaxKind.CloseBracketToken);
-            }
-            EOF();
-        }
->>>>>>> upstream/features/collection-expression-arguments
     }
 
     [Theory, MemberData(nameof(CollectionArgumentsLanguageVersions))]

--- a/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
@@ -50,6 +50,7 @@ public sealed class DiagnosticAnalyzerDriverTests
             SyntaxKind.CollectionExpression,
             SyntaxKind.ExpressionElement,
             SyntaxKind.SpreadElement,
+            SyntaxKind.WithElement,
         };
 
         var analyzer = new CSharpTrackingDiagnosticAnalyzer();


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/80545
This is only for collections creatable with 'new', as well as the right errors for arrays/spans.   Interfaces/`Create` collections will also error, but that will change in followup PRs.