### PR TITLE
Update the diagnostics handler to work when partial results have been reported.

### DIFF
--- a/src/LanguageServer/Protocol/Handler/Diagnostics/Public/PublicDocumentPullDiagnosticsHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Diagnostics/Public/PublicDocumentPullDiagnosticsHandler.cs
@@ -63,12 +63,17 @@ internal sealed partial class PublicDocumentPullDiagnosticsHandler(
         var progressValues = progress.GetValues();
         if (progressValues != null && progressValues.Length > 0)
         {
-            if (progressValues.Single().TryGetFirst(out var value))
-            {
-                return value;
-            }
+            // The first report will always be the full report (either changed or unchanged).
+            var firstReport = progressValues[0];
 
-            return progressValues.Single().Second;
+            if (firstReport.TryGetFirst(out var changedReport))
+                return changedReport;
+
+            if (firstReport.TryGetSecond(out var unchangedReport))
+                return unchangedReport;
+
+            // It is unexpected to have the first report be a partial result.
+            throw ExceptionUtilities.UnexpectedValue(firstReport.Third);
         }
 
         return null;


### PR DESCRIPTION
A document diagnostic partial report is defined as having the first literal send = DocumentDiagnosticReport (aka changed / unchanged) followed by _n_ DocumentDiagnosticPartialResult literals ([see docs](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#documentDiagnosticParams)). We were calling `Single` which would fail for any request that had partial results following the initial full report.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2576168