### PR TITLE
Extract unbound arguments into their own holder.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -742,7 +742,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             SyntaxNode syntax, BoundUnconvertedObjectCreationExpression node, Conversion conversion, bool isCast, TypeSymbol destination,
             ConversionGroup? conversionGroupOpt, bool wasCompilerGenerated, BindingDiagnosticBag diagnostics)
         {
-            var arguments = AnalyzedArguments.GetInstance(node.Arguments, node.ArgumentRefKindsOpt, node.ArgumentNamesOpt);
+            var arguments = AnalyzedArguments.GetInstance(node.Arguments.Expressions, node.Arguments.RefKindsOpt, node.Arguments.NamesOpt);
             BoundExpression expr = bindObjectCreationExpression(node.Syntax, node.InitializerOpt, node.Binder, destination.StrippedType(), arguments, diagnostics);
             arguments.Free();
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -742,7 +742,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             SyntaxNode syntax, BoundUnconvertedObjectCreationExpression node, Conversion conversion, bool isCast, TypeSymbol destination,
             ConversionGroup? conversionGroupOpt, bool wasCompilerGenerated, BindingDiagnosticBag diagnostics)
         {
-            var arguments = AnalyzedArguments.GetInstance(node.Arguments.Expressions, node.Arguments.RefKindsOpt, node.Arguments.NamesOpt);
+            var arguments = AnalyzedArguments.GetInstance(node.Arguments);
             BoundExpression expr = bindObjectCreationExpression(node.Syntax, node.InitializerOpt, node.Binder, destination.StrippedType(), arguments, diagnostics);
             arguments.Free();
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -5182,9 +5182,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BindArgumentsAndNames(node.ArgumentList, diagnostics, arguments, allowArglist: true);
             var result = new BoundUnconvertedObjectCreationExpression(
                 node,
-                arguments.Arguments.ToImmutable(),
-                arguments.Names.ToImmutableOrNull(),
-                arguments.RefKinds.ToImmutableOrNull(),
+                arguments.ToBoundUnconvertedArguments(),
                 node.Initializer,
                 binder: this);
             arguments.Free();
@@ -5590,7 +5588,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal BoundExpression BindObjectCreationForErrorRecovery(BoundUnconvertedObjectCreationExpression node, BindingDiagnosticBag diagnostics)
         {
-            var arguments = AnalyzedArguments.GetInstance(node.Arguments, node.ArgumentRefKindsOpt, node.ArgumentNamesOpt);
+            var arguments = AnalyzedArguments.GetInstance(node.Arguments.Expressions, node.Arguments.RefKindsOpt, node.Arguments.NamesOpt);
             var result = MakeBadExpressionForObjectCreation(node.Syntax, CreateErrorType(), arguments, node.InitializerOpt, typeSyntax: node.Syntax, diagnostics);
             arguments.Free();
             return result;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -5588,7 +5588,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal BoundExpression BindObjectCreationForErrorRecovery(BoundUnconvertedObjectCreationExpression node, BindingDiagnosticBag diagnostics)
         {
-            var arguments = AnalyzedArguments.GetInstance(node.Arguments.Expressions, node.Arguments.RefKindsOpt, node.Arguments.NamesOpt);
+            var arguments = AnalyzedArguments.GetInstance(node.Arguments);
             var result = MakeBadExpressionForObjectCreation(node.Syntax, CreateErrorType(), arguments, node.InitializerOpt, typeSyntax: node.Syntax, diagnostics);
             arguments.Free();
             return result;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/AnalyzedArguments.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/AnalyzedArguments.cs
@@ -126,6 +126,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        public BoundUnconvertedArguments ToBoundUnconvertedArguments()
+            => new BoundUnconvertedArguments(
+                expressions: this.Arguments.ToImmutable(),
+                namesOpt: this.Names.ToImmutableOrNull(),
+                refKindsOpt: this.RefKinds.ToImmutableOrNull());
+
         #region "Poolable"
 
         public static AnalyzedArguments GetInstance()

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/AnalyzedArguments.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/AnalyzedArguments.cs
@@ -150,21 +150,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             return instance;
         }
 
-        public static AnalyzedArguments GetInstance(
-            ImmutableArray<BoundExpression> arguments,
-            ImmutableArray<RefKind> argumentRefKindsOpt,
-            ImmutableArray<(string, Location)?> argumentNamesOpt)
+        public static AnalyzedArguments GetInstance(BoundUnconvertedArguments original)
         {
             var instance = GetInstance();
-            instance.Arguments.AddRange(arguments);
-            if (!argumentRefKindsOpt.IsDefault)
+
+            instance.Arguments.AddRange(original.Expressions);
+            if (!original.RefKindsOpt.IsDefault)
             {
-                instance.RefKinds.AddRange(argumentRefKindsOpt);
+                instance.RefKinds.AddRange(original.RefKindsOpt);
             }
 
-            if (!argumentNamesOpt.IsDefault)
+            if (!original.NamesOpt.IsDefault)
             {
-                instance.Names.AddRange(argumentNamesOpt);
+                instance.Names.AddRange(original.NamesOpt);
             }
 
             return instance;

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -30,8 +30,8 @@
   <ValueType Name="LookupResultKind"/>
   <ValueType Name="NoOpStatementFlavor"/>
   <ValueType Name="RefKind"/>
-  <ValueType Name="BoundUnconvertedArguments"/>
   <ValueType Name="BoundTypeOrValueData"/>
+  <ValueType Name="BoundUnconvertedArguments"/>
   <ValueType Name="BoundLocalDeclarationKind"/>
   <ValueType Name="NullableAnnotation"/>
   <ValueType Name="ErrorCode"/>

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1888,9 +1888,7 @@
   <Node Name="BoundUnconvertedObjectCreationExpression" Base="BoundExpression">
     <!-- Type is not significant for this node type; always null -->
     <Field Name="Type" Type="TypeSymbol?" Override="true" Null="always"/>
-    <Field Name="Arguments" Type="ImmutableArray&lt;BoundExpression&gt;"/>
-    <Field Name="ArgumentNamesOpt" Type="ImmutableArray&lt;(string Name, Location Location)?&gt;" Null="allow"/>
-    <Field Name="ArgumentRefKindsOpt" Type="ImmutableArray&lt;RefKind&gt;" Null="allow"/>
+    <Field Name="Arguments" Type="BoundUnconvertedArguments"/>
     <Field Name="InitializerOpt" Type="InitializerExpressionSyntax?" Null="allow"/>
     <Field Name="Binder" Type="Binder" Null="disallow"/>
   </Node>

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -30,6 +30,7 @@
   <ValueType Name="LookupResultKind"/>
   <ValueType Name="NoOpStatementFlavor"/>
   <ValueType Name="RefKind"/>
+  <ValueType Name="BoundUnconvertedArguments"/>
   <ValueType Name="BoundTypeOrValueData"/>
   <ValueType Name="BoundLocalDeclarationKind"/>
   <ValueType Name="NullableAnnotation"/>

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundUnconvertedArguments.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundUnconvertedArguments.cs
@@ -12,14 +12,14 @@ namespace Microsoft.CodeAnalysis.CSharp;
 /// constructed can be found, which determines which actual constructors to bind the arguments against.
 /// </summary>
 internal readonly struct BoundUnconvertedArguments(
-    ImmutableArray<BoundExpression> arguments,
+    ImmutableArray<BoundExpression> expressions,
     ImmutableArray<(string Name, Location Location)?> argumentNamesOpt,
     ImmutableArray<RefKind> argumentRefKindsOpt)
 {
     /// <summary>
     /// The expressions as they exist in the source, left to right.
     /// </summary>
-    public readonly ImmutableArray<BoundExpression> Arguments = arguments;
+    public readonly ImmutableArray<BoundExpression> Expressions = expressions;
 
     /// <summary>
     /// Optional names provided with the arguments, or <see langword="default"/> if no names were provided.

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundUnconvertedArguments.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundUnconvertedArguments.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.CSharp;
+
+/// <summary>
+/// Represents the arguments passed to an implicit object creation expression <c>new(...)</c>.  These arguments are
+/// initially analyzed in the binder, but not fully bound until the conversion pass when the final type being
+/// constructed can be found, which determines which actual constructors to bind the arguments against.
+/// </summary>
+internal readonly struct BoundUnconvertedArguments(
+    ImmutableArray<BoundExpression> arguments,
+    ImmutableArray<(string Name, Location Location)?> argumentNamesOpt,
+    ImmutableArray<RefKind> argumentRefKindsOpt)
+{
+    /// <summary>
+    /// The expressions as they exist in the source, left to right.
+    /// </summary>
+    public readonly ImmutableArray<BoundExpression> Arguments = arguments;
+
+    /// <summary>
+    /// Optional names provided with the arguments, or <see langword="default"/> if no names were provided.
+    /// </summary>
+    public readonly ImmutableArray<(string Name, Location Location)?> ArgumentNamesOpt = argumentNamesOpt;
+
+    /// <summary>
+    /// Optional ref-kinds provided with the arguments, or <see langword="default"/> if no ref-kinds were provided.
+    /// </summary>
+    public readonly ImmutableArray<RefKind> ArgumentRefKindsOpt = argumentRefKindsOpt;
+}

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundUnconvertedArguments.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundUnconvertedArguments.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp;
 
@@ -13,8 +14,8 @@ namespace Microsoft.CodeAnalysis.CSharp;
 /// </summary>
 internal readonly struct BoundUnconvertedArguments(
     ImmutableArray<BoundExpression> expressions,
-    ImmutableArray<(string Name, Location Location)?> argumentNamesOpt,
-    ImmutableArray<RefKind> argumentRefKindsOpt)
+    ImmutableArray<(string Name, Location Location)?> namesOpt,
+    ImmutableArray<RefKind> refKindsOpt)
 {
     /// <summary>
     /// The expressions as they exist in the source, left to right.
@@ -24,10 +25,24 @@ internal readonly struct BoundUnconvertedArguments(
     /// <summary>
     /// Optional names provided with the arguments, or <see langword="default"/> if no names were provided.
     /// </summary>
-    public readonly ImmutableArray<(string Name, Location Location)?> ArgumentNamesOpt = argumentNamesOpt;
+    public readonly ImmutableArray<(string Name, Location Location)?> NamesOpt = namesOpt;
 
     /// <summary>
     /// Optional ref-kinds provided with the arguments, or <see langword="default"/> if no ref-kinds were provided.
     /// </summary>
-    public readonly ImmutableArray<RefKind> ArgumentRefKindsOpt = argumentRefKindsOpt;
+    public readonly ImmutableArray<RefKind> RefKindsOpt = refKindsOpt;
+
+    public static bool operator ==(in BoundUnconvertedArguments left, in BoundUnconvertedArguments right)
+        => left.Expressions == right.Expressions &&
+           left.NamesOpt == right.NamesOpt &&
+           left.RefKindsOpt == right.RefKindsOpt;
+
+    public static bool operator !=(in BoundUnconvertedArguments left, in BoundUnconvertedArguments right)
+        => !(left == right);
+
+    public override bool Equals(object? obj)
+        => obj is BoundUnconvertedArguments other && this == other;
+
+    public override int GetHashCode()
+        => Hash.Combine(this.Expressions.GetHashCode(), Hash.Combine(this.NamesOpt.GetHashCode(), this.RefKindsOpt.GetHashCode()));
 }

--- a/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
@@ -189,7 +189,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                var arguments = this.Arguments;
+                var arguments = this.Arguments.Expressions;
                 if (arguments.Length == 0)
                 {
                     return "new()";

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -6287,7 +6287,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             : base(BoundKind.UnconvertedObjectCreationExpression, syntax, null, hasErrors)
         {
 
-            RoslynDebug.Assert(arguments is object, "Field 'arguments' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
             RoslynDebug.Assert(binder is object, "Field 'binder' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
 
             this.Arguments = arguments;
@@ -6299,7 +6298,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             : base(BoundKind.UnconvertedObjectCreationExpression, syntax, null)
         {
 
-            RoslynDebug.Assert(arguments is object, "Field 'arguments' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
             RoslynDebug.Assert(binder is object, "Field 'binder' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
 
             this.Arguments = arguments;


### PR DESCRIPTION
This is the construct we create when binding `new(...)`.  As part of `with(...)` binding we will need the same data.  Instead of repeating the same pattern of declaring 3 separate values and then having to flow them all, and then reconstruct them.  This just encapsulates that simply into one type that both `new(...)` and `with(...)` will be able to use. 