### PR TITLE
Remove outdated comment

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/ExplicitInterfaceHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ExplicitInterfaceHelpers.cs
@@ -315,9 +315,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (!foundMatchingMember)
             {
-                // CONSIDER: we may wish to suppress these errors in the event that another error
-                // has been reported about the signature.
-
                 if (foundMatchingMemberWithoutReturnTypeComparer)
                 {
                     var errorType = implementingMember.Kind is SymbolKind.Method


### PR DESCRIPTION
As discussed with @333fred and @RikkiGibson, it would be not worth the effort to implement and review this suggestion, the comment is obsolete and can be removed (to avoid any further confusion about whether it should be implemented or not as it happened here https://github.com/dotnet/roslyn/pull/80376#discussion_r2383257357)
(also see discussion on C# discord server, https://discord.com/channels/143867839282020352/598678594750775301/1422279577337860186)

Edit: Discussion was somewhat similar to
333fred:
> But I don't think that is worth any effort to suppress, either from you implementing something for us, or from us reviewing it and maintaining it
> Generally, if our view of the world is so messed up that you've managed to have an interface member that has a type that isn't even resolved, lots of things are going to go off the rails
> I'll also ping @rikki here as well to see if he agrees

RikkiGibson:
> my understanding was, the CONSIDER was to avoid reporting an error when the candidate implementation method has an error type, accessibility issues, etc in the signature.
> Removing the "return type mismatch" error, in the case that the return type already has errors, is consistent with the way we handle bad return differences in overrides, for example.
> However, I do think it's a small enough deal that if you prefer the contributor doesn't submit such a change, then, I think it would be fine to do nothing, or take a PR to delete the CONSIDER comment instead. Thanks