### PR TITLE
Reduce allocations in SourceText.ToString

### DIFF
--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -737,7 +737,7 @@ namespace Microsoft.CodeAnalysis.Text
 
                 while (buffer.Length > 0)
                 {
-                    int copyLength = Math.Min(buffer.Length, length);
+                    int copyLength = Math.Min(tempBuffer.Length, length);
                     sourceText.CopyTo(position, tempBuffer, 0, copyLength);
                     tempBuffer.AsSpan(0, copyLength).CopyTo(buffer);
 


### PR DESCRIPTION
This method was using a PooledStringBuilder to do it's string buildup. When a PooledStringBuilder's underlying StringBuilder's length exceeeds 1024, it is no longer returned to the pool upon completion. SourceText.ToString results commonly exceeed 1024 characters. To better improve those cases, we can use string.Create directly to avoid the StringBuilder altogether.

This accounts for about 0.6% of all allocations in the RoslynCodeAnalysisService process in the razor CompletionInCohosting speedometer test.

<img width="1136" height="293" alt="image" src="https://github.com/user-attachments/assets/ef654c0e-bbc7-40a3-bde9-b75e64e70c04" />