### PR TITLE
Add telemetry indicating when file-based programs are used

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/FileBasedProgramsProjectSystem.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/FileBasedProgramsProjectSystem.cs
@@ -25,7 +25,6 @@ internal sealed class FileBasedProgramsProjectSystem : LanguageServerProjectLoad
     private readonly ILspServices _lspServices;
     private readonly ILogger<FileBasedProgramsProjectSystem> _logger;
     private readonly VirtualProjectXmlProvider _projectXmlProvider;
-    private readonly LanguageServerWorkspaceFactory _workspaceFactory;
 
     public FileBasedProgramsProjectSystem(
         ILspServices lspServices,
@@ -39,8 +38,7 @@ internal sealed class FileBasedProgramsProjectSystem : LanguageServerProjectLoad
         ServerConfigurationFactory serverConfigurationFactory,
         IBinLogPathProvider binLogPathProvider)
             : base(
-                workspaceFactory.TargetFrameworkManager,
-                workspaceFactory.ProjectSystemHostInfo,
+                workspaceFactory,
                 fileChangeWatcher,
                 globalOptionService,
                 loggerFactory,
@@ -52,7 +50,6 @@ internal sealed class FileBasedProgramsProjectSystem : LanguageServerProjectLoad
         _lspServices = lspServices;
         _logger = loggerFactory.CreateLogger<FileBasedProgramsProjectSystem>();
         _projectXmlProvider = projectXmlProvider;
-        _workspaceFactory = workspaceFactory;
     }
 
     private string GetDocumentFilePath(DocumentUri uri) => uri.ParsedUri is { } parsedUri ? ProtocolConversions.GetDocumentFilePathFromUri(parsedUri) : uri.UriString;
@@ -142,14 +139,17 @@ internal sealed class FileBasedProgramsProjectSystem : LanguageServerProjectLoad
         var buildHost = await buildHostProcessManager.GetBuildHostAsync(buildHostKind, virtualProjectPath, dotnetPath: null, cancellationToken);
         var loadedFile = await buildHost.LoadProjectAsync(virtualProjectPath, virtualProjectContent, languageName: LanguageNames.CSharp, cancellationToken);
 
-        return new RemoteProjectLoadResult(
-            loadedFile,
+        return new RemoteProjectLoadResult
+        {
+            ProjectFile = loadedFile,
             // If it's a proper file based program, we'll put it in the main host workspace factory since we want cross-project references to work.
             // Otherwise, we'll keep it in miscellaneous files.
-            ProjectFactory: isFileBasedProgram ? _workspaceFactory.HostProjectFactory : _workspaceFactory.MiscellaneousFilesWorkspaceProjectFactory,
-            IsMiscellaneousFile: !isFileBasedProgram,
-            Preferred: buildHostKind,
-            Actual: buildHostKind);
+            ProjectFactory = isFileBasedProgram ? _workspaceFactory.HostProjectFactory : _workspaceFactory.MiscellaneousFilesWorkspaceProjectFactory,
+            IsFileBasedProgram = isFileBasedProgram,
+            IsMiscellaneousFile = !isFileBasedProgram,
+            PreferredBuildHostKind = buildHostKind,
+            ActualBuildHostKind = buildHostKind,
+        };
     }
 
     protected override async ValueTask OnProjectUnloadedAsync(string projectFilePath)

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
@@ -29,8 +29,7 @@ internal abstract class LanguageServerProjectLoader
 {
     private readonly AsyncBatchingWorkQueue<ProjectToLoad> _projectsToReload;
 
-    private readonly ProjectTargetFrameworkManager _targetFrameworkManager;
-    private readonly ProjectSystemHostInfo _projectSystemHostInfo;
+    protected readonly LanguageServerWorkspaceFactory _workspaceFactory;
     private readonly IFileChangeWatcher _fileChangeWatcher;
     protected readonly IGlobalOptionService GlobalOptionService;
     protected readonly ILoggerFactory LoggerFactory;
@@ -86,8 +85,7 @@ internal abstract class LanguageServerProjectLoader
     }
 
     protected LanguageServerProjectLoader(
-        ProjectTargetFrameworkManager targetFrameworkManager,
-        ProjectSystemHostInfo projectSystemHostInfo,
+        LanguageServerWorkspaceFactory workspaceFactory,
         IFileChangeWatcher fileChangeWatcher,
         IGlobalOptionService globalOptionService,
         ILoggerFactory loggerFactory,
@@ -96,8 +94,7 @@ internal abstract class LanguageServerProjectLoader
         ServerConfigurationFactory serverConfigurationFactory,
         IBinLogPathProvider binLogPathProvider)
     {
-        _targetFrameworkManager = targetFrameworkManager;
-        _projectSystemHostInfo = projectSystemHostInfo;
+        _workspaceFactory = workspaceFactory;
         _fileChangeWatcher = fileChangeWatcher;
         GlobalOptionService = globalOptionService;
         LoggerFactory = loggerFactory;
@@ -193,7 +190,15 @@ internal abstract class LanguageServerProjectLoader
         }
     }
 
-    protected sealed record RemoteProjectLoadResult(RemoteProjectFile ProjectFile, ProjectSystemProjectFactory ProjectFactory, bool IsMiscellaneousFile, BuildHostProcessKind Preferred, BuildHostProcessKind Actual);
+    internal sealed record RemoteProjectLoadResult
+    {
+        public required RemoteProjectFile ProjectFile { get; init; }
+        public required ProjectSystemProjectFactory ProjectFactory { get; init; }
+        public required bool IsFileBasedProgram { get; init; }
+        public required bool IsMiscellaneousFile { get; init; }
+        public required BuildHostProcessKind PreferredBuildHostKind { get; init; }
+        public required BuildHostProcessKind ActualBuildHostKind { get; init; }
+    }
 
     /// <summary>Loads a project in the MSBuild host.</summary>
     /// <remarks>Caller needs to catch exceptions to avoid bringing down the project loader queue.</remarks>
@@ -236,8 +241,11 @@ internal abstract class LanguageServerProjectLoader
                 return false;
             }
 
-            (RemoteProjectFile remoteProjectFile, ProjectSystemProjectFactory projectFactory, bool isMiscellaneousFile, BuildHostProcessKind preferredBuildHostKind, BuildHostProcessKind actualBuildHostKind) = remoteProjectLoadResult;
-            if (preferredBuildHostKind != actualBuildHostKind)
+            var remoteProjectFile = remoteProjectLoadResult.ProjectFile;
+            var projectFactory = remoteProjectLoadResult.ProjectFactory;
+            var isMiscellaneousFile = remoteProjectLoadResult.IsMiscellaneousFile;
+            var preferredBuildHostKind = remoteProjectLoadResult.PreferredBuildHostKind;
+            if (preferredBuildHostKind != remoteProjectLoadResult.ActualBuildHostKind)
                 preferredBuildHostKindThatWeDidNotGet = preferredBuildHostKind;
 
             var diagnosticLogItems = await remoteProjectFile.GetDiagnosticLogItemsAsync(cancellationToken);
@@ -276,11 +284,19 @@ internal abstract class LanguageServerProjectLoader
                     var (target, targetAlreadyExists) = await GetOrCreateProjectTargetAsync(previousProjectTargets, projectFactory, loadedProjectInfo);
                     newProjectTargetsBuilder.Add(target);
 
-                    var (targetTelemetryInfo, targetNeedsRestore) = await target.UpdateWithNewProjectInfoAsync(loadedProjectInfo, isMiscellaneousFile, _logger);
+                    var (outputKind, metadataReferences, targetNeedsRestore) = await target.UpdateWithNewProjectInfoAsync(loadedProjectInfo, isMiscellaneousFile, _logger);
                     needsRestore |= targetNeedsRestore;
                     if (!targetAlreadyExists)
                     {
-                        telemetryInfos[loadedProjectInfo] = targetTelemetryInfo with { IsSdkStyle = preferredBuildHostKind == BuildHostProcessKind.NetCore };
+                        telemetryInfos[loadedProjectInfo] = new ProjectLoadTelemetryReporter.TelemetryInfo
+                        {
+                            OutputKind = outputKind,
+                            MetadataReferences = metadataReferences,
+                            IsSdkStyle = preferredBuildHostKind == BuildHostProcessKind.NetCore,
+                            HasSolutionFile = _workspaceFactory.HostProjectFactory.SolutionPath is not null,
+                            IsMiscellaneousFile = isMiscellaneousFile,
+                            IsFileBasedProgram = remoteProjectLoadResult.IsFileBasedProgram,
+                        };
                     }
                 }
 
@@ -359,9 +375,9 @@ internal abstract class LanguageServerProjectLoader
                 projectSystemName,
                 loadedProjectInfo.Language,
                 projectCreationInfo,
-                _projectSystemHostInfo);
+                _workspaceFactory.ProjectSystemHostInfo);
 
-            var loadedProject = new LoadedProject(projectSystemProject, projectFactory, _fileChangeWatcher, _targetFrameworkManager);
+            var loadedProject = new LoadedProject(projectSystemProject, projectFactory, _fileChangeWatcher, _workspaceFactory.TargetFrameworkManager);
             loadedProject.NeedsReload += (_, _) =>
                 _projectsToReload.AddWork(projectToLoad with { ReportTelemetry = false });
             return (loadedProject, alreadyExists: false);

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
@@ -37,8 +37,7 @@ internal sealed class LanguageServerProjectSystem : LanguageServerProjectLoader
         ServerConfigurationFactory serverConfigurationFactory,
         IBinLogPathProvider binLogPathProvider)
             : base(
-                workspaceFactory.TargetFrameworkManager,
-                workspaceFactory.ProjectSystemHostInfo,
+                workspaceFactory,
                 fileChangeWatcher,
                 globalOptionService,
                 loggerFactory,
@@ -90,7 +89,15 @@ internal sealed class LanguageServerProjectSystem : LanguageServerProjectLoader
         var (buildHost, actualBuildHostKind) = await buildHostProcessManager.GetBuildHostWithFallbackAsync(preferredBuildHostKind, projectPath, cancellationToken);
 
         var loadedFile = await buildHost.LoadProjectFileAsync(projectPath, languageName, cancellationToken);
-        return new RemoteProjectLoadResult(loadedFile, _hostProjectFactory, IsMiscellaneousFile: false, preferredBuildHostKind, actualBuildHostKind);
+        return new RemoteProjectLoadResult
+        {
+            ProjectFile = loadedFile,
+            ProjectFactory = _hostProjectFactory,
+            IsFileBasedProgram = false,
+            IsMiscellaneousFile = false,
+            PreferredBuildHostKind = preferredBuildHostKind,
+            ActualBuildHostKind = actualBuildHostKind
+        };
     }
 
     protected override ValueTask OnProjectUnloadedAsync(string projectFilePath)

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
@@ -137,7 +137,7 @@ internal sealed class LoadedProject : IDisposable
         _projectSystemProject.RemoveFromWorkspace();
     }
 
-    public async ValueTask<(ProjectLoadTelemetryReporter.TelemetryInfo, bool NeedsRestore)> UpdateWithNewProjectInfoAsync(ProjectFileInfo newProjectInfo, bool isMiscellaneousFile, ILogger logger)
+    public async ValueTask<(OutputKind OutputKind, ImmutableArray<CommandLineReference> MetadataReferences, bool NeedsRestore)> UpdateWithNewProjectInfoAsync(ProjectFileInfo newProjectInfo, bool isMiscellaneousFile, ILogger logger)
     {
         if (_mostRecentFileInfo != null)
         {
@@ -262,9 +262,7 @@ internal sealed class LoadedProject : IDisposable
         _mostRecentFileInfo = newProjectInfo;
 
         Contract.ThrowIfNull(_projectSystemProject.CompilationOptions, "Compilation options cannot be null for C#/VB project");
-        var outputKind = _projectSystemProject.CompilationOptions.OutputKind;
-        var telemetryInfo = new ProjectLoadTelemetryReporter.TelemetryInfo { OutputKind = outputKind, MetadataReferences = metadataReferences };
-        return (telemetryInfo, needsRestore);
+        return (_projectSystemProject.CompilationOptions.OutputKind, metadataReferences, needsRestore);
 
         // logMessage must have 4 placeholders: project name, number of items, added items count, and removed items count.
         void UpdateProjectSystemProjectCollection<T>(IEnumerable<T> loadedCollection, IEnumerable<T>? oldLoadedCollection, IEqualityComparer<T> comparer, Action<T> addItem, Action<T> removeItem, string logMessage)

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectTelemetry/ProjectLoadTelemetryEvent.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectTelemetry/ProjectLoadTelemetryEvent.cs
@@ -22,6 +22,9 @@ internal sealed record ProjectLoadTelemetryEvent(
     [property: JsonPropertyName("References")] IEnumerable<string> References,
     [property: JsonPropertyName("FileExtensions")] IEnumerable<string> FileExtensions,
     [property: JsonPropertyName("FileCounts")] IEnumerable<int> FileCounts,
-    [property: JsonPropertyName("SdkStyleProject")] bool SdkStyleProject)
+    [property: JsonPropertyName("SdkStyleProject")] bool SdkStyleProject,
+    [property: JsonPropertyName("HasSolutionFile")] bool HasSolutionFile,
+    [property: JsonPropertyName("IsFileBasedProgram")] bool IsFileBasedProgram,
+    [property: JsonPropertyName("IsMiscellaneousFile")] bool IsMiscellaneousFile)
 {
 }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectTelemetry/ProjectLoadTelemetryReporter.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectTelemetry/ProjectLoadTelemetryReporter.cs
@@ -26,6 +26,9 @@ internal sealed class ProjectLoadTelemetryReporter(ILoggerFactory loggerFactory,
         public ImmutableArray<CommandLineReference> MetadataReferences { get; init; }
         public OutputKind OutputKind { get; init; }
         public bool IsSdkStyle { get; init; }
+        public bool HasSolutionFile { get; init; }
+        public bool IsFileBasedProgram { get; init; }
+        public bool IsMiscellaneousFile { get; init; }
     }
 
     /// <summary>
@@ -77,7 +80,10 @@ internal sealed class ProjectLoadTelemetryReporter(ILoggerFactory loggerFactory,
                 References: hashedReferences,
                 FileExtensions: fileCounts.Keys,
                 FileCounts: fileCounts.Values,
-                SdkStyleProject: isSdkStyleProject);
+                SdkStyleProject: isSdkStyleProject,
+                HasSolutionFile: telemetryInfo.HasSolutionFile,
+                IsFileBasedProgram: telemetryInfo.IsFileBasedProgram,
+                IsMiscellaneousFile: telemetryInfo.IsMiscellaneousFile);
 
             await ReportEventAsync(projectEvent, cancellationToken);
         }


### PR DESCRIPTION
Closes dotnet/vscode-csharp#8586

@dibarbet @jasonmalinowski could you please take a look?

One bit of info that I didn't include, was: "did project initialization complete or not". I don't think that was one of the bits @DamianEdwards was asking for. It was more something I was interested in knowing, though not essential. I just didn't see an obvious way of obtaining that info during the design-time build.

I did verify that expected bits of info are present when debugging when C#+CDK are in use.
I wasn't sure if changes on CDK side are needed, in order to get a full picture of the case that file-based programs are *not* being used. I also wasn't sure if consumption side changes to `ProjectLoadTelemetryEvent` are needed, to ensure the telemetry actually makes it to the destination.