### PR TITLE
Update the condition used to include the CodeStyle .globalconfig

### DIFF
--- a/src/CodeStyle/Tools/Program.cs
+++ b/src/CodeStyle/Tools/Program.cs
@@ -210,6 +210,10 @@ public static class Program
                   <Target Name="AddGlobalAnalyzerConfigForPackage_MicrosoftCodeAnalysis{language}CodeStyle" BeforeTargets="GenerateMSBuildEditorConfigFileCore;CoreCompile" Condition="'$(SkipGlobalAnalyzerConfigForPackage)' != 'true'">
                     <!-- PropertyGroup to compute global analyzer config file to be used -->
                     <PropertyGroup>
+                      <_IncludeStyleConfiguration>false</_IncludeStyleConfiguration>
+                      <!-- Check whether 'Style' Level or Mode were configured separate from AnalysisLevel and AnalysisMode. -->
+                      <_IncludeStyleConfiguration Condition="'$(AnalysisLevelStyle)' != '' or '$(AnalysisModeStyle)' != ''>true</_IncludeStyleConfiguration>
+
                       <!-- Default 'AnalysisLevelStyle' to the core 'AnalysisLevel' -->
                       <AnalysisLevelStyle Condition="'$(AnalysisLevelStyle)' == ''">$(AnalysisLevel)</AnalysisLevelStyle>
 
@@ -241,6 +245,10 @@ public static class Program
                       <EffectiveAnalysisLevelStyle Condition="'$(EffectiveAnalysisLevelStyle)' == '' And
                                                           '$(AnalysisLevelStyle)' != ''">$(AnalysisLevelStyle)</EffectiveAnalysisLevelStyle>
 
+                      <!-- Check whether the analysis level is high enough that we should include the analyzer configuration.
+                           From .NET 11, the global config is systematically added if the file exists. Please check https://github.com/dotnet/roslyn/pull/71173 for more info. -->
+                      <_IncludeStyleConfiguration Condition="'$(EffectiveAnalysisLevelStyle)' != '' and $([MSBuild]::VersionGreaterThanOrEquals('$(EffectiveAnalysisLevelStyle)', '11.0'))">true<_IncludeStyleConfiguration>
+
                       <!-- Set the default analysis mode, if not set by the user -->
                       <_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>$(AnalysisModeStyle)</_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>
                       <_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle Condition="'$(_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle)' == ''">$(AnalysisLevelSuffixStyle)</_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>
@@ -255,9 +263,8 @@ public static class Program
                       <_GlobalAnalyzerConfigFile_MicrosoftCodeAnalysis{language}CodeStyle Condition="'$(_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle)' != ''">$(_GlobalAnalyzerConfigDir_MicrosoftCodeAnalysis{language}CodeStyle)\$(_GlobalAnalyzerConfigFileName_MicrosoftCodeAnalysis{language}CodeStyle)</_GlobalAnalyzerConfigFile_MicrosoftCodeAnalysis{language}CodeStyle>
                     </PropertyGroup>
 
-                    <!-- From .NET 11, the global config is systematically added if the file exists. Please check https://github.com/dotnet/roslyn/pull/71173 for more info. -->
-                    <ItemGroup Condition="Exists('$(_GlobalAnalyzerConfigFile_MicrosoftCodeAnalysis{language}CodeStyle)') and
-                                           ('$(AnalysisLevelStyle)' != '$(AnalysisLevel)' or '$(AnalysisModeStyle)' != '$(AnalysisMode)' or ('$(EffectiveAnalysisLevelStyle)' != '' and $([MSBuild]::VersionGreaterThanOrEquals('$(EffectiveAnalysisLevelStyle)', '11.0'))))">
+                    <!-- Add the analyzer configuration. -->
+                    <ItemGroup Condition="Exists('$(_GlobalAnalyzerConfigFile_MicrosoftCodeAnalysis{language}CodeStyle)') and '$(_IncludeStyleConfiguration)' == 'true')">
                       <EditorConfigFiles Include="$(_GlobalAnalyzerConfigFile_MicrosoftCodeAnalysis{language}CodeStyle)" />
                     </ItemGroup>
 

--- a/src/CodeStyle/Tools/Program.cs
+++ b/src/CodeStyle/Tools/Program.cs
@@ -212,7 +212,7 @@ public static class Program
                     <PropertyGroup>
                       <_IncludeStyleConfiguration>false</_IncludeStyleConfiguration>
                       <!-- Check whether 'Style' Level or Mode were configured separate from AnalysisLevel and AnalysisMode. -->
-                      <_IncludeStyleConfiguration Condition="'$(AnalysisLevelStyle)' != '' or '$(AnalysisModeStyle)' != ''>true</_IncludeStyleConfiguration>
+                      <_IncludeStyleConfiguration Condition="'$(AnalysisLevelStyle)' != '' Or '$(AnalysisModeStyle)' != ''">true</_IncludeStyleConfiguration>
 
                       <!-- Default 'AnalysisLevelStyle' to the core 'AnalysisLevel' -->
                       <AnalysisLevelStyle Condition="'$(AnalysisLevelStyle)' == ''">$(AnalysisLevel)</AnalysisLevelStyle>

--- a/src/CodeStyle/Tools/Program.cs
+++ b/src/CodeStyle/Tools/Program.cs
@@ -246,8 +246,8 @@ public static class Program
                                                           '$(AnalysisLevelStyle)' != ''">$(AnalysisLevelStyle)</EffectiveAnalysisLevelStyle>
 
                       <!-- Check whether the analysis level is high enough that we should include the analyzer configuration.
-                           From .NET 11, the global config is systematically added if the file exists. Please check https://github.com/dotnet/roslyn/pull/71173 for more info. -->
-                      <_IncludeStyleConfiguration Condition="'$(EffectiveAnalysisLevelStyle)' != '' and $([MSBuild]::VersionGreaterThanOrEquals('$(EffectiveAnalysisLevelStyle)', '11.0'))">true<_IncludeStyleConfiguration>
+                           From .NET 12, the global config is systematically added if the file exists. Please check https://github.com/dotnet/roslyn/pull/71173 for more info. -->
+                      <_IncludeStyleConfiguration Condition="'$(EffectiveAnalysisLevelStyle)' != '' and $([MSBuild]::VersionGreaterThanOrEquals('$(EffectiveAnalysisLevelStyle)', '12.0'))">true<_IncludeStyleConfiguration>
 
                       <!-- Set the default analysis mode, if not set by the user -->
                       <_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>$(AnalysisModeStyle)</_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>

--- a/src/CodeStyle/Tools/Program.cs
+++ b/src/CodeStyle/Tools/Program.cs
@@ -247,7 +247,7 @@ public static class Program
 
                       <!-- Check whether the analysis level is high enough that we should include the analyzer configuration.
                            From .NET 12, the global config is systematically added if the file exists. Please check https://github.com/dotnet/roslyn/pull/71173 for more info. -->
-                      <_IncludeStyleConfiguration Condition="'$(EffectiveAnalysisLevelStyle)' != '' and $([MSBuild]::VersionGreaterThanOrEquals('$(EffectiveAnalysisLevelStyle)', '12.0'))">true<_IncludeStyleConfiguration>
+                      <_IncludeStyleConfiguration Condition="'$(EffectiveAnalysisLevelStyle)' != '' and $([MSBuild]::VersionGreaterThanOrEquals('$(EffectiveAnalysisLevelStyle)', '12.0'))">true</_IncludeStyleConfiguration>
 
                       <!-- Set the default analysis mode, if not set by the user -->
                       <_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>$(AnalysisModeStyle)</_GlobalAnalyzerConfigAnalysisMode_MicrosoftCodeAnalysis{language}CodeStyle>

--- a/src/CodeStyle/Tools/Program.cs
+++ b/src/CodeStyle/Tools/Program.cs
@@ -264,7 +264,7 @@ public static class Program
                     </PropertyGroup>
 
                     <!-- Add the analyzer configuration. -->
-                    <ItemGroup Condition="Exists('$(_GlobalAnalyzerConfigFile_MicrosoftCodeAnalysis{language}CodeStyle)') and '$(_IncludeStyleConfiguration)' == 'true')">
+                    <ItemGroup Condition="Exists('$(_GlobalAnalyzerConfigFile_MicrosoftCodeAnalysis{language}CodeStyle)') and '$(_IncludeStyleConfiguration)' == 'true'">
                       <EditorConfigFiles Include="$(_GlobalAnalyzerConfigFile_MicrosoftCodeAnalysis{language}CodeStyle)" />
                     </ItemGroup>
 


### PR DESCRIPTION
The logic of the original check seems to be a bit confused. It seems reasonable to include the globalconfig if the build has specifically called for it by setting either AnalysisLevelStyle or AnalysisModeStyle prior to our target running. In addition we keep the AnalysisLevel gate that will automatically add the configuration when the level is high enough.