### PR TITLE
Simplify the virtual char api

### DIFF
--- a/src/EditorFeatures/CSharp/StringCopyPaste/StringCopyPasteData.cs
+++ b/src/EditorFeatures/CSharp/StringCopyPaste/StringCopyPasteData.cs
@@ -114,7 +114,7 @@ internal sealed class StringCopyPasteData(ImmutableArray<StringCopyPasteContent>
         var lastCharIndexInclusive = virtualChars.IndexOf(lastOverlappingChar.Value);
 
         // Grab that subsequence of characters and get the final interpreted string for it.
-        var subsequence = virtualChars.GetSubSequence(TextSpan.FromBounds(firstCharIndexInclusive, lastCharIndexInclusive + 1));
+        var subsequence = virtualChars.Slice(firstCharIndexInclusive..(lastCharIndexInclusive + 1));
         normalizedText = subsequence.CreateString();
         return true;
     }

--- a/src/EditorFeatures/Test/Utilities/StackFrameUtils.cs
+++ b/src/EditorFeatures/Test/Utilities/StackFrameUtils.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Text;
 using Microsoft.CodeAnalysis.EmbeddedLanguages.StackFrame;
+using Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars;
 using Roslyn.Test.Utilities;
 using Xunit;
 

--- a/src/Features/CSharp/Portable/ConvertBetweenRegularAndVerbatimString/AbstractConvertBetweenRegularAndVerbatimStringCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertBetweenRegularAndVerbatimString/AbstractConvertBetweenRegularAndVerbatimStringCodeRefactoringProvider.cs
@@ -108,10 +108,10 @@ internal abstract class AbstractConvertBetweenRegularAndVerbatimStringCodeRefact
             // just build the verbatim string by concatenating all the chars in the original
             // string.  The only exceptions are double-quotes which need to be doubled up in the
             // final string, and curlies which need to be doubled in interpolations.
-            ch.AppendTo(sb);
+            sb.Append(ch);
 
             if (ShouldDouble(ch, isInterpolation))
-                ch.AppendTo(sb);
+                sb.Append(ch);
         }
 
         static bool ShouldDouble(VirtualChar ch, bool isInterpolation)
@@ -144,11 +144,11 @@ internal abstract class AbstractConvertBetweenRegularAndVerbatimStringCodeRefact
             }
             else
             {
-                ch.AppendTo(sb);
+                sb.Append(ch);
 
                 // if it's an interpolation, we need to double-up open/close braces.
                 if (isInterpolation && IsOpenOrCloseBrace(ch))
-                    ch.AppendTo(sb);
+                    sb.Append(ch);
             }
         }
     }

--- a/src/Features/CSharp/Portable/ConvertToRawString/ConvertRegularStringToRawStringCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToRawString/ConvertRegularStringToRawStringCodeRefactoringProvider.cs
@@ -279,7 +279,7 @@ internal sealed partial class ConvertRegularStringToRawStringProvider
             else
             {
                 // Normal line.  Skip the common whitespace.
-                AddRange(result, line.Skip(commonWhitespacePrefix));
+                AddRange(result, line.Slice(commonWhitespacePrefix..));
             }
         }
 
@@ -325,7 +325,7 @@ internal sealed partial class ConvertRegularStringToRawStringProvider
         while (current < length && IsCSharpWhitespace(leadingWhitespace1[current]) && leadingWhitespace1[current].Value == leadingWhitespace2[current].Value)
             current++;
 
-        return leadingWhitespace1.GetSubSequence(TextSpan.FromBounds(0, current));
+        return leadingWhitespace1.Slice(0..current);
     }
 
     private static VirtualCharSequence GetLeadingWhitespace(VirtualCharSequence line)
@@ -334,7 +334,7 @@ internal sealed partial class ConvertRegularStringToRawStringProvider
         while (current < line.Length && IsCSharpWhitespace(line[current]))
             current++;
 
-        return line.GetSubSequence(TextSpan.FromBounds(0, current));
+        return line.Slice(0..current);
     }
 
     private static void BreakIntoLines(VirtualCharSequence characters, ArrayBuilder<VirtualCharSequence> lines)
@@ -356,7 +356,7 @@ internal sealed partial class ConvertRegularStringToRawStringProvider
         if (end != characters.Length)
             end += IsCarriageReturnNewLine(characters, end) ? 2 : 1;
 
-        var result = characters.GetSubSequence(TextSpan.FromBounds(index, end));
+        var result = characters.Slice(index..end);
         index = end;
         return result;
     }

--- a/src/Features/CSharp/Portable/ConvertToRawString/ConvertRegularStringToRawStringCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToRawString/ConvertRegularStringToRawStringCodeRefactoringProvider.cs
@@ -187,7 +187,7 @@ internal sealed partial class ConvertRegularStringToRawStringProvider
             builder.Append('"', quoteDelimiterCount);
 
             foreach (var ch in characters)
-                ch.AppendTo(builder);
+                builder.Append(ch);
 
             builder.Append('"', quoteDelimiterCount);
 
@@ -220,7 +220,7 @@ internal sealed partial class ConvertRegularStringToRawStringProvider
                 var ch = characters[i];
                 if (IsCSharpNewLine(ch))
                 {
-                    ch.AppendTo(builder);
+                    builder.Append(ch);
                     atStartOfLine = true;
                     continue;
                 }
@@ -231,7 +231,7 @@ internal sealed partial class ConvertRegularStringToRawStringProvider
                     atStartOfLine = false;
                 }
 
-                ch.AppendTo(builder);
+                builder.Append(ch);
             }
 
             builder.Append(formattingOptions.NewLine);

--- a/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/EmbeddedCompletionContext.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/EmbeddedCompletionContext.cs
@@ -62,9 +62,9 @@ internal sealed partial class DateAndTimeEmbeddedCompletionProvider
             foreach (var ch in virtualChars)
             {
                 if (ch.Span.End <= startPosition)
-                    ch.AppendTo(prefix);
+                    prefix.Append(ch);
                 else if (ch.Span.Start >= endPosition)
-                    ch.AppendTo(suffix);
+                    suffix.Append(ch);
             }
 
             return (prefix.ToString(), suffix.ToString());

--- a/src/Features/Core/Portable/EmbeddedLanguages/Json/JsonLexer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Json/JsonLexer.cs
@@ -34,7 +34,7 @@ internal struct JsonLexer
         => GetSubSequence(start, Position);
 
     public readonly VirtualCharSequence GetSubSequence(int start, int end)
-        => Text.GetSubSequence(TextSpan.FromBounds(start, end));
+        => Text.Slice(start..end);
 
     public JsonToken ScanNextToken()
     {
@@ -186,7 +186,7 @@ internal struct JsonLexer
 
     private (VirtualCharSequence, JsonKind, EmbeddedDiagnostic?) ScanSingleCharToken(JsonKind kind)
     {
-        var chars = this.Text.GetSubSequence(new TextSpan(Position, 1));
+        var chars = this.Text.Slice(Position..(Position + 1));
         Position++;
         return (chars, kind, null);
     }

--- a/src/Features/Core/Portable/EmbeddedLanguages/Json/JsonParser.JsonNetSyntaxChecks.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Json/JsonParser.JsonNetSyntaxChecks.cs
@@ -88,7 +88,7 @@ internal partial struct JsonParser
                 if (chars[1].Value is 'x' or 'X')
                 {
                     // Base 16.  Fortunately, we have helpers for this common case.
-                    if (!long.TryParse(chars.Skip("0x".Length).CreateString(), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out _))
+                    if (!long.TryParse(chars.Slice("0x".Length..).CreateString(), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out _))
                         return new EmbeddedDiagnostic(FeaturesResources.Invalid_number, GetSpan(chars));
                 }
                 else

--- a/src/Features/Core/Portable/EmbeddedLanguages/Json/JsonParser.StrictSyntaxChecker.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Json/JsonParser.StrictSyntaxChecker.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis.EmbeddedLanguages.Common;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars;
 
 namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.Json;
 

--- a/src/Features/Core/Portable/EmbeddedLanguages/Json/JsonParser.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Json/JsonParser.cs
@@ -394,12 +394,12 @@ internal partial struct JsonParser
     {
         minusToken = CreateToken(
             JsonKind.MinusToken, literalToken.LeadingTrivia,
-            literalToken.VirtualChars.GetSubSequence(new TextSpan(0, 1)),
+            literalToken.VirtualChars.Slice(0..1),
             []);
         newLiteralToken = CreateToken(
             literalToken.Kind,
             [],
-            literalToken.VirtualChars.GetSubSequence(TextSpan.FromBounds(1, literalToken.VirtualChars.Length)),
+            literalToken.VirtualChars.Slice(1..),
             literalToken.TrailingTrivia,
             literalToken.Diagnostics);
     }

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexLexer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexLexer.cs
@@ -50,7 +50,7 @@ internal struct RegexLexer
         => GetSubPattern(start, Position);
 
     public readonly VirtualCharSequence GetSubPattern(int start, int end)
-        => Text.GetSubSequence(TextSpan.FromBounds(start, end));
+        => Text.Slice(start..end);
 
     public RegexToken ScanNextToken(bool allowTrivia, RegexOptions options)
     {
@@ -63,7 +63,7 @@ internal struct RegexLexer
         var ch = this.CurrentChar;
         Position++;
 
-        return CreateToken(GetKind(ch), trivia, Text.GetSubSequence(new TextSpan(Position - 1, 1)));
+        return CreateToken(GetKind(ch), trivia, Text.Slice((Position - 1)..Position));
     }
 
     private static RegexKind GetKind(VirtualChar ch)

--- a/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameLexer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameLexer.cs
@@ -61,7 +61,7 @@ internal struct StackFrameLexer
         => GetSubSequence(start, Position);
 
     public readonly VirtualCharSequence GetSubSequence(int start, int end)
-        => Text.GetSubSequence(TextSpan.FromBounds(start, end));
+        => Text.Slice(start..end);
 
     public StackFrameTrivia? TryScanRemainingTrivia()
     {
@@ -126,7 +126,7 @@ internal struct StackFrameLexer
         }
 
         var ch = Text[Position];
-        return CreateToken(GetKind(ch), Text.GetSubSequence(new TextSpan(Position, 1)));
+        return CreateToken(GetKind(ch), Text.Slice(Position..(Position + 1)));
     }
 
     /// <summary>

--- a/src/Features/Core/Portable/StackTraceExplorer/ParsedStackFrame.cs
+++ b/src/Features/Core/Portable/StackTraceExplorer/ParsedStackFrame.cs
@@ -4,6 +4,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis.EmbeddedLanguages.StackFrame;
+using Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars;
 
 namespace Microsoft.CodeAnalysis.StackTraceExplorer;
 

--- a/src/Features/Core/Portable/StackTraceExplorer/StackTraceAnalyzer.cs
+++ b/src/Features/Core/Portable/StackTraceExplorer/StackTraceAnalyzer.cs
@@ -76,7 +76,7 @@ internal static class StackTraceAnalyzer
         {
             if (callstack[i] == '\n')
             {
-                yield return callstack.GetSubSequence(TextSpan.FromBounds(position, i));
+                yield return callstack.Slice(position..i);
 
                 // +1 to skip over the \n character
                 position = i + 1;
@@ -85,7 +85,7 @@ internal static class StackTraceAnalyzer
 
         if (position < callstack.Length)
         {
-            yield return callstack.GetSubSequence(TextSpan.FromBounds(position, callstack.Length));
+            yield return callstack.Slice(position..);
         }
     }
 
@@ -109,6 +109,6 @@ internal static class StackTraceAnalyzer
             end--;
         }
 
-        return virtualChars.GetSubSequence(TextSpan.FromBounds(start, end + 1));
+        return virtualChars.Slice(start..(end + 1));
     }
 }

--- a/src/Features/Core/Portable/StackTraceExplorer/VSDebugCallstackParser.cs
+++ b/src/Features/Core/Portable/StackTraceExplorer/VSDebugCallstackParser.cs
@@ -35,7 +35,7 @@ internal sealed class VSDebugCallstackParser : IStackFrameParser
             return false;
         }
 
-        var textToParse = line.GetSubSequence(TextSpan.FromBounds(startPoint, line.Length));
+        var textToParse = line.Slice(startPoint..);
         var tree = StackFrameParser.TryParse(textToParse);
 
         if (tree is null)

--- a/src/Features/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualCharSequence.cs
+++ b/src/Features/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualCharSequence.cs
@@ -31,13 +31,13 @@ internal readonly struct AspNetCoreVirtualCharSequence
     /// <inheritdoc cref="VirtualCharSequence.this"/>
     public AspNetCoreVirtualChar this[int index] => new(_virtualCharSequence[index]);
 
-    /// <inheritdoc cref="VirtualCharSequence.GetSubSequence"/>
-    public AspNetCoreVirtualCharSequence GetSubSequence(TextSpan span) => new(_virtualCharSequence.GetSubSequence(span));
+    /// <inheritdoc cref="VirtualCharSequence.Slice"/>
+    public AspNetCoreVirtualCharSequence GetSubSequence(TextSpan span) => new(_virtualCharSequence.Slice(span.Start..span.End));
 
     /// <inheritdoc cref="VirtualCharSequence.Find"/>
     public AspNetCoreVirtualChar? Find(int position) => (_virtualCharSequence.Find(position) is VirtualChar c) ? new(c) : null;
 
-    /// <inheritdoc cref="VirtualCharSequence.CreateString"/>
+    /// <inheritdoc cref="VirtualCharSequenceExtensions.CreateString"/>
     public string CreateString() => _virtualCharSequence.CreateString();
 
     /// <inheritdoc cref="VirtualCharSequence.FromBounds"/>
@@ -45,11 +45,11 @@ internal readonly struct AspNetCoreVirtualCharSequence
         AspNetCoreVirtualCharSequence chars1, AspNetCoreVirtualCharSequence chars2)
         => new(VirtualCharSequence.FromBounds(chars1._virtualCharSequence, chars2._virtualCharSequence));
 
-    /// <inheritdoc cref="VirtualCharSequence.IndexOf"/>
+    /// <inheritdoc cref="VirtualCharSequenceExtensions.IndexOf"/>
     public int IndexOf(AspNetCoreVirtualChar @char)
         => _virtualCharSequence.IndexOf(@char.VirtualChar);
 
-    /// <inheritdoc cref="VirtualCharSequence.Contains"/>
+    /// <inheritdoc cref="VirtualCharSequenceExtensions.Contains"/>
     public bool Contains(AspNetCoreVirtualChar @char)
         => _virtualCharSequence.Contains(@char.VirtualChar);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/EmbeddedLanguages/VirtualChars/CSharpVirtualCharService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/EmbeddedLanguages/VirtualChars/CSharpVirtualCharService.cs
@@ -249,7 +249,7 @@ internal class CSharpVirtualCharService : AbstractVirtualCharService
         if (!ContainsEscape(tokenText.AsSpan(startIndexInclusive, endIndexExclusive - startIndexInclusive), escapeBraces))
         {
             var sequence = VirtualCharGreenSequence.Create(tokenText);
-            return sequence.GetSubSequence(TextSpan.FromBounds(startIndexInclusive, endIndexExclusive));
+            return sequence.Slice(startIndexInclusive..endIndexExclusive);
         }
         else
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/AbstractVirtualCharService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/AbstractVirtualCharService.cs
@@ -219,7 +219,7 @@ internal abstract partial class AbstractVirtualCharService : IVirtualCharService
         if (textLength == result.Count)
         {
             var sequence = VirtualCharGreenSequence.Create(tokenText);
-            return sequence.GetSubSequence(TextSpan.FromBounds(startIndexInclusive, endIndexExclusive));
+            return sequence.Slice(startIndexInclusive..endIndexExclusive);
         }
 
         return VirtualCharGreenSequence.Create(result.ToImmutable());

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/VirtualChar.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/VirtualChar.cs
@@ -95,16 +95,9 @@ internal readonly record struct VirtualChar
 
     public TextSpan Span => new(TokenStart + Green.Offset, Green.Width);
 
-    #region string operations
-
     /// <inheritdoc/>
     public override string ToString()
         => Value.ToString();
-
-    public void AppendTo(StringBuilder builder)
-        => builder.Append(Value);
-
-    #endregion
 
     #region equality
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/VirtualCharGreenSequence.Chunks.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/VirtualCharGreenSequence.Chunks.cs
@@ -80,7 +80,7 @@ internal readonly partial struct VirtualCharGreenSequence
     /// <param name="data">
     /// The underlying string that we're returning virtual chars from.  Note: this will commonly include things like
     /// quote characters.  Clients who do not want that should then ask for an appropriate <see
-    /// cref="VirtualCharSequence.GetSubSequence"/> back that does not include those characters.
+    /// cref="VirtualCharSequence.Slice"/> back that does not include those characters.
     /// </param>
     private sealed class StringChunk(string data) : Chunk
     {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/VirtualCharSequence.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/VirtualCharSequence.cs
@@ -180,35 +180,6 @@ internal readonly struct VirtualCharSequence
     public VirtualChar? Find(int position)
         => _sequence.Find(_tokenStart, position);
 
-    public bool Contains(VirtualChar @char)
-        => IndexOf(@char) >= 0;
-
-    public int IndexOf(VirtualChar @char)
-    {
-        var index = 0;
-        foreach (var ch in this)
-        {
-            if (ch == @char)
-                return index;
-
-            index++;
-        }
-
-        return -1;
-    }
-
-    /// <summary>
-    /// Create a <see cref="string"/> from the <see cref="VirtualCharSequence"/>.
-    /// </summary>
-    public string CreateString()
-    {
-        using var _ = PooledStringBuilder.GetInstance(out var builder);
-        foreach (var ch in this)
-            builder.Append(ch);
-
-        return builder.ToString();
-    }
-
     /// <inheritdoc cref="VirtualCharGreenSequence.IsDefault"/>
     public bool IsDefault => _sequence.IsDefault;
 
@@ -228,68 +199,6 @@ internal readonly struct VirtualCharSequence
 
     public Enumerator GetEnumerator()
         => new(this);
-
-    public VirtualChar First() => this[0];
-    public VirtualChar Last() => this[^1];
-
-    public VirtualChar? FirstOrNull(Func<VirtualChar, bool> predicate)
-    {
-        foreach (var ch in this)
-        {
-            if (predicate(ch))
-                return ch;
-        }
-
-        return null;
-    }
-
-    public VirtualChar? LastOrNull(Func<VirtualChar, bool> predicate)
-    {
-        for (var i = this.Length - 1; i >= 0; i--)
-        {
-            var ch = this[i];
-            if (predicate(ch))
-                return ch;
-        }
-
-        return null;
-    }
-
-    public bool Any(Func<VirtualChar, bool> predicate)
-    {
-        foreach (var ch in this)
-        {
-            if (predicate(ch))
-                return true;
-        }
-
-        return false;
-    }
-
-    public bool All(Func<VirtualChar, bool> predicate)
-    {
-        foreach (var ch in this)
-        {
-            if (!predicate(ch))
-                return false;
-        }
-
-        return true;
-    }
-
-    public VirtualCharSequence SkipWhile(Func<VirtualChar, bool> predicate)
-    {
-        var start = 0;
-        foreach (var ch in this)
-        {
-            if (!predicate(ch))
-                break;
-
-            start++;
-        }
-
-        return this.GetSubSequence(TextSpan.FromBounds(start, this.Length));
-    }
 
     [Conditional("DEBUG")]
     public void AssertAdjacentTo(VirtualCharSequence virtualChars)
@@ -322,5 +231,99 @@ internal readonly struct VirtualCharSequence
 
         readonly object? IEnumerator.Current => this.Current;
         public readonly void Dispose() { }
+    }
+}
+
+internal static class VirtualCharSequenceExtensions
+{
+    public static bool Contains(this VirtualCharSequence sequence, VirtualChar @char)
+        => sequence.IndexOf(@char) >= 0;
+
+    public static int IndexOf(this VirtualCharSequence sequence, VirtualChar @char)
+    {
+        var index = 0;
+        foreach (var ch in sequence)
+        {
+            if (ch == @char)
+                return index;
+
+            index++;
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Create a <see cref="string"/> from the <see cref="VirtualCharSequence"/>.
+    /// </summary>
+    public static string CreateString(this VirtualCharSequence sequence)
+    {
+        using var _ = PooledStringBuilder.GetInstance(out var builder);
+        foreach (var ch in sequence)
+            builder.Append(ch);
+
+        return builder.ToString();
+    }
+
+    public static VirtualChar First(this VirtualCharSequence sequence) => sequence[0];
+    public static VirtualChar Last(this VirtualCharSequence sequence) => sequence[^1];
+
+    public static VirtualChar? FirstOrNull(this VirtualCharSequence sequence, Func<VirtualChar, bool> predicate)
+    {
+        foreach (var ch in sequence)
+        {
+            if (predicate(ch))
+                return ch;
+        }
+
+        return null;
+    }
+
+    public static VirtualChar? LastOrNull(this VirtualCharSequence sequence, Func<VirtualChar, bool> predicate)
+    {
+        for (var i = sequence.Length - 1; i >= 0; i--)
+        {
+            var ch = sequence[i];
+            if (predicate(ch))
+                return ch;
+        }
+
+        return null;
+    }
+
+    public static bool Any(this VirtualCharSequence sequence, Func<VirtualChar, bool> predicate)
+    {
+        foreach (var ch in sequence)
+        {
+            if (predicate(ch))
+                return true;
+        }
+
+        return false;
+    }
+
+    public static bool All(this VirtualCharSequence sequence, Func<VirtualChar, bool> predicate)
+    {
+        foreach (var ch in sequence)
+        {
+            if (!predicate(ch))
+                return false;
+        }
+
+        return true;
+    }
+
+    public static VirtualCharSequence SkipWhile(this VirtualCharSequence sequence, Func<VirtualChar, bool> predicate)
+    {
+        var start = 0;
+        foreach (var ch in sequence)
+        {
+            if (!predicate(ch))
+                break;
+
+            start++;
+        }
+
+        return sequence.GetSubSequence(TextSpan.FromBounds(start, sequence.Length));
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/VirtualCharSequence.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/VirtualCharSequence.cs
@@ -204,7 +204,7 @@ internal readonly struct VirtualCharSequence
     {
         using var _ = PooledStringBuilder.GetInstance(out var builder);
         foreach (var ch in this)
-            ch.AppendTo(builder);
+            builder.Append(ch);
 
         return builder.ToString();
     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/VirtualCharSequence.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/VirtualCharSequence.cs
@@ -86,8 +86,15 @@ internal partial struct VirtualCharGreenSequence
     /// <summary>
     /// Retreives a sub-sequence from this <see cref="VirtualCharSequence"/>.
     /// </summary>
-    public VirtualCharGreenSequence GetSubSequence(TextSpan span)
-       => new(_leafCharacters, new TextSpan(_span.Start + span.Start, span.Length));
+    public VirtualCharGreenSequence Slice(Range range)
+    {
+        var start = range.Start.IsFromEnd ? this.Length - range.Start.Value : range.Start.Value;
+        var end = range.End.IsFromEnd ? this.Length - range.End.Value : range.End.Value;
+
+        var finalLength = end - start;
+
+        return new(_leafCharacters, new TextSpan(_span.Start + start, finalLength));
+    }
 
     /// <summary>
     /// Finds the virtual char in this sequence that contains the position.  Will return null if this position is not
@@ -95,9 +102,6 @@ internal partial struct VirtualCharGreenSequence
     /// </summary>
     public VirtualChar? Find(int tokenStart, int position)
         => _leafCharacters?.Find(tokenStart, position);
-
-    public VirtualCharGreenSequence Skip(int count)
-        => this.GetSubSequence(TextSpan.FromBounds(count, this.Length));
 
     [Conditional("DEBUG")]
     public void AssertAdjacentTo(VirtualCharGreenSequence virtualChars)
@@ -189,13 +193,9 @@ internal readonly struct VirtualCharSequence
     /// <inheritdoc cref="VirtualCharGreenSequence.IsDefaultOrEmpty"/>
     public bool IsDefaultOrEmpty => _sequence.IsDefaultOrEmpty;
 
-    /// <inheritdoc cref="VirtualCharGreenSequence.GetSubSequence"/>
-    public VirtualCharSequence GetSubSequence(TextSpan span)
-       => new(_tokenStart, _sequence.GetSubSequence(span));
-
-    /// <inheritdoc cref="VirtualCharGreenSequence.Skip"/>
-    public VirtualCharSequence Skip(int count)
-        => new(_tokenStart, _sequence.Skip(count));
+    /// <inheritdoc cref="VirtualCharGreenSequence.Slice"/>
+    public VirtualCharSequence Slice(Range range)
+       => new(_tokenStart, _sequence.Slice(range));
 
     public Enumerator GetEnumerator()
         => new(this);
@@ -324,6 +324,6 @@ internal static class VirtualCharSequenceExtensions
             start++;
         }
 
-        return sequence.GetSubSequence(TextSpan.FromBounds(start, sequence.Length));
+        return sequence.Slice(start..);
     }
 }


### PR DESCRIPTION
1. Remove anything non-critical and move to extension methods if possible.
2. Use more idiomatic C# lang patterns (slices/ranges for example).