### PR TITLE
Log a debug message for ContentModified exceptions.

### DIFF
--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework.UnitTests/Microsoft.CommonLanguageServerProtocol.Framework.UnitTests.csproj
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework.UnitTests/Microsoft.CommonLanguageServerProtocol.Framework.UnitTests.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <StartupObject />
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>$(NetRoslynAll);net472</TargetFrameworks>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.CommonLanguageServerProtocol.Framework.UnitTests</RootNamespace>
     <RoslynProjectType>UnitTest</RoslynProjectType>

--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework.UnitTests/Microsoft.CommonLanguageServerProtocol.Framework.UnitTests.csproj
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework.UnitTests/Microsoft.CommonLanguageServerProtocol.Framework.UnitTests.csproj
@@ -3,14 +3,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <StartupObject />
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.CommonLanguageServerProtocol.Framework.UnitTests</RootNamespace>
     <RoslynProjectType>UnitTest</RoslynProjectType>
   </PropertyGroup>
-  
+
   <ItemGroup Label="Project References">
-    <ProjectReference Include="..\..\EditorFeatures\TestUtilities\Microsoft.CodeAnalysis.EditorFeatures.Test.Utilities.csproj" />
+    <ProjectReference Include="..\..\Features\TestUtilities\Microsoft.CodeAnalysis.Features.Test.Utilities.csproj" />
     <ProjectReference Include="..\Microsoft.CommonLanguageServerProtocol.Framework.Example\Microsoft.CommonLanguageServerProtocol.Framework.Example.csproj" />
   </ItemGroup>
 </Project>

--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework.UnitTests/QueueItemTests.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework.UnitTests/QueueItemTests.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using StreamJsonRpc;
+using Xunit;
+
+namespace Microsoft.CommonLanguageServerProtocol.Framework.UnitTests;
+
+public sealed class QueueItemTests
+{
+    [Fact]
+    public async Task QueueItem_CancellationToken_Cancelled()
+    {
+        Mock<ILspLogger> mockLogger = new(MockBehavior.Strict);
+        mockLogger
+            .Setup(l => l.LogDebug("Starting request handler", Array.Empty<object>()))
+            .Verifiable();
+        mockLogger
+            .Setup(l => l.LogDebug(
+                It.Is<string>(message => message.Contains(ThrowLocalRpcExceptionMethodHandler.ErrorMessage)), Array.Empty<object>()))
+            .Verifiable();
+
+        var lspServices = TestLspServices.Create(
+            [(typeof(IMethodHandler), ThrowLocalRpcExceptionMethodHandler.Instance)],
+            supportsMethodHandlerProvider: false);
+        var queueItem = new QueueItem<int>(
+            ThrowLocalRpcExceptionMethodHandler.Name,
+            null,
+            lspServices,
+            mockLogger.Object,
+            CancellationToken.None);
+
+        var exception = await Assert.ThrowsAsync<LocalRpcException>(async () =>
+        {
+            await queueItem.StartRequestAsync<object?, object?>(
+                request: null,
+                context: 1,
+                ThrowLocalRpcExceptionMethodHandler.Instance,
+                string.Empty,
+                CancellationToken.None);
+        });
+        Assert.Equal(LspErrorCodes.ContentModified, exception.ErrorCode);
+
+        mockLogger.VerifyAll();
+    }
+
+    private sealed class ThrowLocalRpcExceptionMethodHandler : IRequestHandler<object?, object?, int>
+    {
+        public const string Name = "Test/Method";
+        public const string ErrorMessage = "Request resolve version does not match current version";
+
+        public static readonly ThrowLocalRpcExceptionMethodHandler Instance = new();
+
+        public bool MutatesSolutionState => false;
+
+        public Task<object?> HandleRequestAsync(object? request, int context, CancellationToken cancellationToken)
+        {
+            throw new LocalRpcException(ErrorMessage) { ErrorCode = LspErrorCodes.ContentModified };
+        }
+    }
+}

--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework.UnitTests/TestExampleLanguageServer.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework.UnitTests/TestExampleLanguageServer.cs
@@ -81,7 +81,7 @@ internal sealed class TestExampleLanguageServer : ExampleLanguageServer
         return base.ConstructLspServices();
     }
 
-    private void _clientRpc_Disconnected(object sender, JsonRpcDisconnectedEventArgs e)
+    private void _clientRpc_Disconnected(object? sender, JsonRpcDisconnectedEventArgs e)
     {
         throw new NotImplementedException();
     }

--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/LspErrorCodes.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/LspErrorCodes.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Microsoft.CodeAnalysis.LanguageServer.Handler;
+namespace Microsoft.CommonLanguageServerProtocol.Framework;
 
 /// <summary>
 /// See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#errorCodes

--- a/src/LanguageServer/Protocol/Handler/CodeLens/CodeLensResolveHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/CodeLens/CodeLensResolveHandler.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeLens;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CommonLanguageServerProtocol.Framework;
 using StreamJsonRpc;
 using LSP = Roslyn.LanguageServer.Protocol;
 

--- a/src/LanguageServer/Protocol/Handler/InlayHint/InlayHintResolveHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/InlayHint/InlayHintResolveHandler.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.InlineHints;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CommonLanguageServerProtocol.Framework;
 using Roslyn.LanguageServer.Protocol;
 using StreamJsonRpc;
 using LSP = Roslyn.LanguageServer.Protocol;


### PR DESCRIPTION
CodeLens and InlineHints are highly susceptible to throwing ContentModified exceptions. These are expected in the normal use of the LSP but showup in the logs as errors which can be confusing to users. Instead we will look for these exceptions and log them as debug messages.