### PR TITLE
Extensions: Use deterministic order for MergedNamespaceSymbol.GetMembers and GetExtensionMembers

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/MergedNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MergedNamespaceSymbol.cs
@@ -178,7 +178,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             foreach (var ns in _namespacesToMerge)
             {
-                foreach (var child in ns.GetMembersUnordered())
+                foreach (var child in ns.GetMembers())
                 {
                     childNames.Add(child.Name.AsMemory());
                 }
@@ -303,12 +303,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // CreateRange and OfType Linq calls in MergedNamespaceSymbol.GetTypeMembersUnordered causes a full array allocation.
         internal sealed override void GetExtensionMembers(ArrayBuilder<Symbol> members, string? name, string? alternativeName, int arity, LookupOptions options, ConsList<FieldSymbol> fieldsBeingBound)
         {
-            foreach (var member in GetMembersUnordered())
+            foreach (var type in GetTypeMembers())
             {
-                if (member is NamedTypeSymbol type)
-                {
-                    type.GetExtensionMembers(members, name, alternativeName, arity, options, fieldsBeingBound);
-                }
+                type.GetExtensionMembers(members, name, alternativeName, arity, options, fieldsBeingBound);
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -360,7 +360,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal void DoGetExtensionMethods(ArrayBuilder<MethodSymbol> methods, string nameOpt, int arity, LookupOptions options)
         {
             var members = nameOpt == null
-                ? this.GetMembersUnordered()
+                ? this.GetMembers()
                 : this.GetSimpleNonTypeMembers(nameOpt);
 
             foreach (var member in members)
@@ -414,7 +414,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (!this.IsClassType() || !IsStatic || IsGenericType || !MightContainExtensionMethods) return;
 
-            foreach (NamedTypeSymbol nestedType in GetTypeMembersUnordered())
+            foreach (NamedTypeSymbol nestedType in GetTypeMembers())
             {
                 if (nestedType is not { IsExtension: true, ExtensionParameter: { } extensionParameter }
                     || !IsValidExtensionReceiverParameter(extensionParameter))
@@ -423,7 +423,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 var candidates = name is null || alternativeName is not null
-                    ? nestedType.GetMembersUnordered()
+                    ? nestedType.GetMembers()
                     : nestedType.GetMembers(name);
 
                 foreach (var candidate in candidates)

--- a/src/Compilers/CSharp/Portable/Symbols/NamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamespaceSymbol.cs
@@ -361,7 +361,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <remarks>Does not perform a full viability check</remarks>
         internal virtual void GetExtensionMembers(ArrayBuilder<Symbol> members, string? name, string? alternativeName, int arity, LookupOptions options, ConsList<FieldSymbol> fieldsBeingBound)
         {
-            foreach (var type in this.GetTypeMembersUnordered())
+            foreach (var type in this.GetTypeMembers())
             {
                 type.GetExtensionMembers(members, name, alternativeName, arity, options, fieldsBeingBound);
             }

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionOperatorsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionOperatorsTests.cs
@@ -4265,14 +4265,8 @@ class Program
 
             Assert.Null(symbolInfo.Symbol);
             Assert.Equal(CandidateReason.Ambiguous, symbolInfo.CandidateReason);
-
-#if DEBUG // Collection of extension blocks depends on GetTypeMembersUnordered for namespace, which conditionally de-orders types for DEBUG only.
-            AssertEx.Equal("Extensions2.extension(S2).operator -(S2)", symbolInfo.CandidateSymbols[0].ToDisplayString());
-            AssertEx.Equal("Extensions1.extension(S2).operator -(S2)", symbolInfo.CandidateSymbols[1].ToDisplayString());
-#else
             AssertEx.Equal("Extensions1.extension(S2).operator -(S2)", symbolInfo.CandidateSymbols[0].ToDisplayString());
             AssertEx.Equal("Extensions2.extension(S2).operator -(S2)", symbolInfo.CandidateSymbols[1].ToDisplayString());
-#endif
         }
 
         [Theory]
@@ -7707,18 +7701,9 @@ class Program
 """ + CompilerFeatureRequiredAttribute;
 
             var comp = CreateCompilation(src, options: TestOptions.DebugExe);
+            AssertEx.Equal(["Extensions1", "Extensions2", "C1", "Program"],
+                comp.GlobalNamespace.GetTypeMembers().Where(t => t.ContainingModule is SourceModuleSymbol).ToTestDisplayStrings());
 
-#if DEBUG // Collection of extension blocks depends on GetTypeMembersUnordered for namespace, which conditionally de-orders types for DEBUG only.
-            comp.VerifyEmitDiagnostics(
-                // (32,13): error CS0121: The call is ambiguous between the following methods or properties: 'Extensions2.extension(C1).operator --()' and 'Extensions1.extension(C1).operator --()'
-                //         _ = --c1;
-                Diagnostic(ErrorCode.ERR_AmbigCall, "--").WithArguments("Extensions2.extension(C1).operator --()", "Extensions1.extension(C1).operator --()").WithLocation(32, 13),
-                // (36,17): error CS0121: The call is ambiguous between the following methods or properties: 'Extensions1.extension(C1).operator checked --()' and 'Extensions2.extension(C1).operator --()'
-                //             _ = --c1;
-                Diagnostic(ErrorCode.ERR_AmbigCall, "--").WithArguments("Extensions1.extension(C1).operator checked --()", "Extensions2.extension(C1).operator --()").WithLocation(36, 17)
-                );
-#else
-            // https://github.com/dotnet/roslyn/issues/78968: Understand what is causing DEBUG/RELEASE behavior difference
             comp.VerifyEmitDiagnostics(
                 // (32,13): error CS0121: The call is ambiguous between the following methods or properties: 'Extensions1.extension(C1).operator --()' and 'Extensions2.extension(C1).operator --()'
                 //         _ = --c1;
@@ -7727,7 +7712,6 @@ class Program
                 //             _ = --c1;
                 Diagnostic(ErrorCode.ERR_AmbigCall, "--").WithArguments("Extensions1.extension(C1).operator checked --()", "Extensions2.extension(C1).operator --()").WithLocation(36, 17)
                 );
-#endif
 
             var tree = comp.SyntaxTrees.First();
             var model = comp.GetSemanticModel(tree);
@@ -7739,6 +7723,19 @@ class Program
             Assert.Equal(2, symbolInfo.CandidateSymbols.Length);
             AssertEx.Equal("Extensions1.extension(C1).operator checked --()", symbolInfo.CandidateSymbols[0].ToDisplayString());
             AssertEx.Equal("Extensions2.extension(C1).operator --()", symbolInfo.CandidateSymbols[1].ToDisplayString());
+        }
+
+        [Fact]
+        public void GetMembers_01()
+        {
+            var src = """
+public class A;
+public class B;
+""";
+
+            var comp = CreateCompilation(src);
+            AssertEx.Equal(["A", "B"],
+                comp.GlobalNamespace.GetMembers().Where(t => t is SourceNamedTypeSymbol).ToTestDisplayStrings());
         }
 
         [Fact]
@@ -10456,19 +10453,11 @@ class Program
 
             var comp = CreateCompilation(src, options: TestOptions.DebugExe);
 
-#if DEBUG // Collection of extension blocks depends on GetTypeMembersUnordered for namespace, which conditionally de-orders types for DEBUG only.
-            comp.VerifyDiagnostics(
-                // (26,9): error CS0121: The call is ambiguous between the following methods or properties: 'Extensions2.extension(ref S2).operator ++()' and 'Extensions1.extension(ref S2).operator ++()'
-                //         ++s2;
-                Diagnostic(ErrorCode.ERR_AmbigCall, "++").WithArguments("Extensions2.extension(ref S2).operator ++()", "Extensions1.extension(ref S2).operator ++()").WithLocation(26, 9)
-                );
-#else
             comp.VerifyDiagnostics(
                 // (26,9): error CS0121: The call is ambiguous between the following methods or properties: 'Extensions1.extension(ref S2).operator ++()' and 'Extensions2.extension(ref S2).operator ++()'
                 //         ++s2;
                 Diagnostic(ErrorCode.ERR_AmbigCall, "++").WithArguments("Extensions1.extension(ref S2).operator ++()", "Extensions2.extension(ref S2).operator ++()").WithLocation(26, 9)
                 );
-#endif
 
             var tree = comp.SyntaxTrees.First();
             var model = comp.GetSemanticModel(tree);
@@ -10478,13 +10467,8 @@ class Program
             Assert.Null(symbolInfo.Symbol);
             Assert.Equal(CandidateReason.OverloadResolutionFailure, symbolInfo.CandidateReason);
 
-#if DEBUG // Collection of extension blocks depends on GetTypeMembersUnordered for namespace, which conditionally de-orders types for DEBUG only.
-            AssertEx.Equal("Extensions2.extension(ref S2).operator ++()", symbolInfo.CandidateSymbols[0].ToDisplayString());
-            AssertEx.Equal("Extensions1.extension(ref S2).operator ++()", symbolInfo.CandidateSymbols[1].ToDisplayString());
-#else
             AssertEx.Equal("Extensions1.extension(ref S2).operator ++()", symbolInfo.CandidateSymbols[0].ToDisplayString());
             AssertEx.Equal("Extensions2.extension(ref S2).operator ++()", symbolInfo.CandidateSymbols[1].ToDisplayString());
-#endif
         }
 
         [Fact]
@@ -10536,14 +10520,8 @@ class Program
 
             Assert.Null(symbolInfo.Symbol);
             Assert.Equal(CandidateReason.Ambiguous, symbolInfo.CandidateReason);
-
-#if DEBUG // Collection of extension blocks depends on GetTypeMembersUnordered for namespace, which conditionally de-orders types for DEBUG only.
-            AssertEx.Equal("Extensions2.extension(S2).operator ++(S2)", symbolInfo.CandidateSymbols[0].ToDisplayString());
-            AssertEx.Equal("Extensions1.extension(S2).operator ++(S2)", symbolInfo.CandidateSymbols[1].ToDisplayString());
-#else
             AssertEx.Equal("Extensions1.extension(S2).operator ++(S2)", symbolInfo.CandidateSymbols[0].ToDisplayString());
             AssertEx.Equal("Extensions2.extension(S2).operator ++(S2)", symbolInfo.CandidateSymbols[1].ToDisplayString());
-#endif
         }
 
         [Theory]
@@ -23790,17 +23768,6 @@ class Program
 
             var comp = CreateCompilation([src, CompilerFeatureRequiredAttribute], options: TestOptions.DebugExe);
 
-#if DEBUG // Collection of extension blocks depends on GetTypeMembersUnordered for namespace, which conditionally de-orders types for DEBUG only.
-            comp.VerifyEmitDiagnostics(
-                // (35,16): error CS0121: The call is ambiguous between the following methods or properties: 'Extensions2.extension(C1).operator -=(C1)' and 'Extensions1.extension(C1).operator -=(C1)'
-                //         _ = c1 -= c1;
-                Diagnostic(ErrorCode.ERR_AmbigCall, "-=").WithArguments("Extensions2.extension(C1).operator -=(C1)", "Extensions1.extension(C1).operator -=(C1)").WithLocation(35, 16),
-                // (39,20): error CS0121: The call is ambiguous between the following methods or properties: 'Extensions1.extension(C1).operator checked -=(C1)' and 'Extensions2.extension(C1).operator -=(C1)'
-                //             _ = c1 -= c1;
-                Diagnostic(ErrorCode.ERR_AmbigCall, "-=").WithArguments("Extensions1.extension(C1).operator checked -=(C1)", "Extensions2.extension(C1).operator -=(C1)").WithLocation(39, 20)
-                );
-#else
-            // https://github.com/dotnet/roslyn/issues/78968: Understand what is causing DEBUG/RELEASE behavior difference
             comp.VerifyEmitDiagnostics(
                 // (35,16): error CS0121: The call is ambiguous between the following methods or properties: 'Extensions1.extension(C1).operator -=(C1)' and 'Extensions2.extension(C1).operator -=(C1)'
                 //         _ = c1 -= c1;
@@ -23809,7 +23776,6 @@ class Program
                 //             _ = c1 -= c1;
                 Diagnostic(ErrorCode.ERR_AmbigCall, "-=").WithArguments("Extensions1.extension(C1).operator checked -=(C1)", "Extensions2.extension(C1).operator -=(C1)").WithLocation(39, 20)
                 );
-#endif
 
             var tree = comp.SyntaxTrees.First();
             var model = comp.GetSemanticModel(tree);

--- a/src/Dependencies/Collections/Extensions/ImmutableArrayExtensions.cs
+++ b/src/Dependencies/Collections/Extensions/ImmutableArrayExtensions.cs
@@ -679,6 +679,7 @@ namespace Microsoft.CodeAnalysis
 
         // In DEBUG, swap the first and last elements of a read-only array, yielding a new read only array.
         // This helps to avoid depending on accidentally sorted arrays.
+        // Use more aggressive reordering with Array.Reverse(copy) for spot-checking
         internal static ImmutableArray<T> ConditionallyDeOrder<T>(this ImmutableArray<T> array)
         {
 #if DEBUG
@@ -689,7 +690,6 @@ namespace Microsoft.CodeAnalysis
                 var temp = copy[0];
                 copy[0] = copy[last];
                 copy[last] = temp;
-
                 return ImmutableCollectionsMarshal.AsImmutableArray(copy);
             }
 #endif


### PR DESCRIPTION
Addresses ordering issue tracked by https://github.com/dotnet/roslyn/issues/78968
Relates to test plan https://github.com/dotnet/roslyn/issues/76130