### PR TITLE
Improve error recovery when object initializer uses ':' instead of '='

### DIFF
--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Internal.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Internal.Generated.cs
@@ -29041,7 +29041,8 @@ internal partial class ContextAwareSyntax
             case SyntaxKind.LessThanLessThanEqualsToken:
             case SyntaxKind.GreaterThanGreaterThanEqualsToken:
             case SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken:
-            case SyntaxKind.QuestionQuestionEqualsToken: break;
+            case SyntaxKind.QuestionQuestionEqualsToken:
+            case SyntaxKind.ColonToken: break;
             default: throw new ArgumentException(nameof(operatorToken));
         }
         if (right == null) throw new ArgumentNullException(nameof(right));
@@ -34408,7 +34409,8 @@ internal static partial class SyntaxFactory
             case SyntaxKind.LessThanLessThanEqualsToken:
             case SyntaxKind.GreaterThanGreaterThanEqualsToken:
             case SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken:
-            case SyntaxKind.QuestionQuestionEqualsToken: break;
+            case SyntaxKind.QuestionQuestionEqualsToken:
+            case SyntaxKind.ColonToken: break;
             default: throw new ArgumentException(nameof(operatorToken));
         }
         if (right == null) throw new ArgumentNullException(nameof(right));

--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Main.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Main.Generated.cs
@@ -2869,35 +2869,13 @@ public static partial class SyntaxFactory
             case SyntaxKind.LessThanLessThanEqualsToken:
             case SyntaxKind.GreaterThanGreaterThanEqualsToken:
             case SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken:
-            case SyntaxKind.QuestionQuestionEqualsToken: break;
+            case SyntaxKind.QuestionQuestionEqualsToken:
+            case SyntaxKind.ColonToken: break;
             default: throw new ArgumentException(nameof(operatorToken));
         }
         if (right == null) throw new ArgumentNullException(nameof(right));
         return (AssignmentExpressionSyntax)Syntax.InternalSyntax.SyntaxFactory.AssignmentExpression(kind, (Syntax.InternalSyntax.ExpressionSyntax)left.Green, (Syntax.InternalSyntax.SyntaxToken)operatorToken.Node!, (Syntax.InternalSyntax.ExpressionSyntax)right.Green).CreateRed();
     }
-
-    /// <summary>Creates a new AssignmentExpressionSyntax instance.</summary>
-    public static AssignmentExpressionSyntax AssignmentExpression(SyntaxKind kind, ExpressionSyntax left, ExpressionSyntax right)
-        => SyntaxFactory.AssignmentExpression(kind, left, SyntaxFactory.Token(GetAssignmentExpressionOperatorTokenKind(kind)), right);
-
-    private static SyntaxKind GetAssignmentExpressionOperatorTokenKind(SyntaxKind kind)
-        => kind switch
-        {
-            SyntaxKind.SimpleAssignmentExpression => SyntaxKind.EqualsToken,
-            SyntaxKind.AddAssignmentExpression => SyntaxKind.PlusEqualsToken,
-            SyntaxKind.SubtractAssignmentExpression => SyntaxKind.MinusEqualsToken,
-            SyntaxKind.MultiplyAssignmentExpression => SyntaxKind.AsteriskEqualsToken,
-            SyntaxKind.DivideAssignmentExpression => SyntaxKind.SlashEqualsToken,
-            SyntaxKind.ModuloAssignmentExpression => SyntaxKind.PercentEqualsToken,
-            SyntaxKind.AndAssignmentExpression => SyntaxKind.AmpersandEqualsToken,
-            SyntaxKind.ExclusiveOrAssignmentExpression => SyntaxKind.CaretEqualsToken,
-            SyntaxKind.OrAssignmentExpression => SyntaxKind.BarEqualsToken,
-            SyntaxKind.LeftShiftAssignmentExpression => SyntaxKind.LessThanLessThanEqualsToken,
-            SyntaxKind.RightShiftAssignmentExpression => SyntaxKind.GreaterThanGreaterThanEqualsToken,
-            SyntaxKind.UnsignedRightShiftAssignmentExpression => SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken,
-            SyntaxKind.CoalesceAssignmentExpression => SyntaxKind.QuestionQuestionEqualsToken,
-            _ => throw new ArgumentOutOfRangeException(),
-        };
 
     /// <summary>Creates a new ConditionalExpressionSyntax instance.</summary>
     public static ConditionalExpressionSyntax ConditionalExpression(ExpressionSyntax condition, SyntaxToken questionToken, ExpressionSyntax whenTrue, SyntaxToken colonToken, ExpressionSyntax whenFalse)

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -13001,7 +13001,7 @@ done:
 
         private bool IsNamedAssignment()
         {
-            return IsTrueIdentifier() && this.PeekToken(1).Kind == SyntaxKind.EqualsToken;
+            return IsTrueIdentifier() && this.PeekToken(1).Kind is SyntaxKind.EqualsToken or SyntaxKind.ColonToken;
         }
 
         private bool IsDictionaryInitializer()
@@ -13199,7 +13199,9 @@ done:
             return _syntaxFactory.AssignmentExpression(
                 SyntaxKind.SimpleAssignmentExpression,
                 this.ParseIdentifierName(),
-                this.EatToken(SyntaxKind.EqualsToken),
+                this.CurrentToken.Kind == SyntaxKind.ColonToken
+                    ? this.EatTokenWithPrejudice(SyntaxKind.EqualsToken)
+                    : this.EatToken(SyntaxKind.EqualsToken),
                 this.CurrentToken.Kind == SyntaxKind.OpenBraceToken
                     ? this.ParseObjectOrCollectionInitializer()
                     : this.ParsePossibleRefExpression());

--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -788,6 +788,7 @@
         <Kind Name="GreaterThanGreaterThanEqualsToken"/>
         <Kind Name="GreaterThanGreaterThanGreaterThanEqualsToken"/>
         <Kind Name="QuestionQuestionEqualsToken" />
+        <Kind Name="ColonToken" />
         <PropertyComment>
           <summary>SyntaxToken representing the operator of the assignment expression.</summary>
         </PropertyComment>

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingErrorRecoveryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingErrorRecoveryTests.cs
@@ -8763,5 +8763,28 @@ class c
             }
             EOF();
         }
+
+        [Fact]
+        public void ObjectInitializerWithColonInsteadOfEqualsSign()
+        {
+            var source = @"
+class Program
+{
+    public int X { get; set; }
+    static void Main()
+    {
+        var y = new Program { X: 42 };
+    }
+}
+";
+
+            var tree = SyntaxFactory.ParseSyntaxTree(source);
+            var toString = tree.GetRoot().ToFullString();
+            Assert.Equal(source, toString);
+            tree.GetDiagnostics().Verify(
+                // (7,32): error CS1003: Syntax error, '=' expected
+                //         var y = new Program { X: 42 };
+                Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("=").WithLocation(7, 32));
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/80537