### PR TITLE
PEDeltaAssemblyBuilder: Don't freeze `_needsGeneratedAttributes` compilation state.

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
         private EmbeddableAttributes GetNeedsGeneratedAttributesInternal()
         {
-            return (EmbeddableAttributes)_needsGeneratedAttributes | Compilation.GetNeedsGeneratedAttributes();
+            return (EmbeddableAttributes)_needsGeneratedAttributes | Compilation.GetNeedsGeneratedAttributes(freezeState: this is not PEDeltaAssemblyBuilder);
         }
 
         private void SetNeedsGeneratedAttributes(EmbeddableAttributes attributes)

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -43,9 +43,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// The value is set during binding the symbols that need those attributes, and is frozen on first trial to get it.
         /// Freezing is needed to make sure that nothing tries to modify the value after the value is read.
         /// </summary>
-        internal EmbeddableAttributes GetNeedsGeneratedAttributes()
+        internal EmbeddableAttributes GetNeedsGeneratedAttributes(bool freezeState = true)
         {
-            _needsGeneratedAttributes_IsFrozen = true;
+            if (freezeState)
+            {
+                _needsGeneratedAttributes_IsFrozen = true;
+            }
+
             return (EmbeddableAttributes)_needsGeneratedAttributes;
         }
 


### PR DESCRIPTION
Related to #80405.