### PR TITLE
Add xcopy-msbuild version to global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -9,7 +9,8 @@
     "vs": {
       "version": "17.14.0"
     },
-    "vswhere": "3.1.7"
+    "vswhere": "3.1.7",
+    "xcopy-msbuild": "17.14.16"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.25509.1",


### PR DESCRIPTION
Without specifying the xcopy-msbuild version explicitly it is inferred from the tools.vs.version. This does not work because there is not 17.14.0 package on the dotnet-eng feed. Setting this to explicitly be the 17.14.x version that is available from the feed.

Discovered while trying to reproduce #80644