### PR TITLE
Do not run the 'fully qualify' fixer on sourcce-generated docs

### DIFF
--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionTest.cs
@@ -35,7 +35,7 @@ public abstract partial class AbstractCodeActionTest : AbstractCodeActionOrUserD
     {
         parameters ??= TestParameters.Default;
 
-        GetDocumentAndSelectSpanOrAnnotatedSpan(workspace, out var document, out var span, out var annotation);
+        var (document, span, annotation) = await GetDocumentAndSelectSpanOrAnnotatedSpan(workspace);
 
         var refactoring = await GetCodeRefactoringAsync(workspace, parameters);
         var actions = refactoring == null
@@ -90,7 +90,7 @@ public abstract partial class AbstractCodeActionTest : AbstractCodeActionOrUserD
     internal override async Task<CodeRefactoring> GetCodeRefactoringAsync(
         EditorTestWorkspace workspace, TestParameters parameters)
     {
-        GetDocumentAndSelectSpanOrAnnotatedSpan(workspace, out var document, out var span, out _);
+        var (document, span, _) = await GetDocumentAndSelectSpanOrAnnotatedSpan(workspace);
         return await GetCodeRefactoringAsync(document, span, workspace, parameters).ConfigureAwait(false);
     }
 

--- a/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
@@ -154,7 +154,7 @@ public abstract partial class AbstractDiagnosticProviderBasedUserDiagnosticTest(
         var (analyzer, fixer) = GetOrCreateDiagnosticProviderAndFixer(workspace, parameters);
         AddAnalyzerToWorkspace(workspace, analyzer);
 
-        GetDocumentAndSelectSpanOrAnnotatedSpan(workspace, out var document, out var span, out var annotation);
+        var (document, span, annotation) = await GetDocumentAndSelectSpanOrAnnotatedSpan(workspace);
 
         var testDriver = new TestDiagnosticAnalyzerDriver(workspace);
         var filterSpan = parameters.includeDiagnosticsOutsideSelection ? (TextSpan?)null : span;

--- a/src/Features/CSharpTest/FullyQualify/FullyQualifyTests.cs
+++ b/src/Features/CSharpTest/FullyQualify/FullyQualifyTests.cs
@@ -1747,4 +1747,31 @@ class C
                 class Something { }
             }
             """, new TestParameters(testHost: testHost));
+
+    [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/79462")]
+    public Task TestWithinSourceGeneratedFile(TestHost testHost)
+        => TestMissingAsync("""
+            <Workspace>
+                <Project Language="C#" AssemblyName="Console" CommonReferences="true">
+            <DocumentFromSourceGenerator>
+            using Goo;
+
+            Something a;
+            [|PInvoke|].GetMessage();
+
+            namespace Goo
+            {
+                class Something { }
+            }</DocumentFromSourceGenerator>
+            <DocumentFromSourceGenerator>
+            namespace Win32
+            {
+                public class PInvoke
+                {
+                }
+            }
+            </DocumentFromSourceGenerator>
+                </Project>
+            </Workspace>
+            """, new TestParameters(testHost: testHost));
 }

--- a/src/Features/Core/Portable/FullyQualify/AbstractFullyQualifyCodeFixProvider.cs
+++ b/src/Features/Core/Portable/FullyQualify/AbstractFullyQualifyCodeFixProvider.cs
@@ -21,7 +21,13 @@ internal abstract class AbstractFullyQualifyCodeFixProvider : CodeFixProvider
     public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
         var cancellationToken = context.CancellationToken;
+
         var document = context.Document;
+
+        // Don't bother executing this within a source-generated document.  Changing the code here isn't actually
+        // possible, and we don't need to make pointless calls to oop to compute things.
+        if (document.Id.IsSourceGenerated)
+            return;
 
         var service = document.GetRequiredLanguageService<IFullyQualifyService>();
         var optFixData = await service.GetFixDataAsync(document, context.Span, cancellationToken).ConfigureAwait(false);

--- a/src/Features/DiagnosticsTestUtilities/CodeActionsLegacy/AbstractCodeActionTest_NoEditor.cs
+++ b/src/Features/DiagnosticsTestUtilities/CodeActionsLegacy/AbstractCodeActionTest_NoEditor.cs
@@ -48,7 +48,7 @@ public abstract partial class AbstractCodeActionTest_NoEditor<
     {
         parameters ??= TestParameters.Default;
 
-        GetDocumentAndSelectSpanOrAnnotatedSpan(workspace, out var document, out var span, out var annotation);
+        var (document, span, annotation) = await GetDocumentAndSelectSpanOrAnnotatedSpan(workspace);
 
         var refactoring = await GetCodeRefactoringAsync(workspace, parameters);
         var actions = refactoring == null
@@ -103,7 +103,7 @@ public abstract partial class AbstractCodeActionTest_NoEditor<
     internal override async Task<CodeRefactoring> GetCodeRefactoringAsync(
         TTestWorkspace workspace, TestParameters parameters)
     {
-        GetDocumentAndSelectSpanOrAnnotatedSpan(workspace, out var document, out var span, out _);
+        var (document, span, _) = await GetDocumentAndSelectSpanOrAnnotatedSpan(workspace);
         return await GetCodeRefactoringAsync(document, span, workspace, parameters).ConfigureAwait(false);
     }
 

--- a/src/Features/DiagnosticsTestUtilities/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest_NoEditor.cs
+++ b/src/Features/DiagnosticsTestUtilities/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest_NoEditor.cs
@@ -166,7 +166,7 @@ public abstract partial class AbstractDiagnosticProviderBasedUserDiagnosticTest_
         var (analyzer, fixer) = GetOrCreateDiagnosticProviderAndFixer(workspace, parameters);
         AddAnalyzerToWorkspace(workspace, analyzer);
 
-        GetDocumentAndSelectSpanOrAnnotatedSpan(workspace, out var document, out var span, out var annotation);
+        var (document, span, annotation) = await GetDocumentAndSelectSpanOrAnnotatedSpan(workspace);
 
         var testDriver = new TestDiagnosticAnalyzerDriver(workspace);
         var filterSpan = parameters.includeDiagnosticsOutsideSelection ? (TextSpan?)null : span;

--- a/src/Features/DiagnosticsTestUtilities/Diagnostics/AbstractSuppressionDiagnosticTest_NoEditor.cs
+++ b/src/Features/DiagnosticsTestUtilities/Diagnostics/AbstractSuppressionDiagnosticTest_NoEditor.cs
@@ -81,7 +81,7 @@ public abstract class AbstractSuppressionDiagnosticTest_NoEditor(ITestOutputHelp
         var (analyzer, fixer) = CreateDiagnosticProviderAndFixer(workspace);
         AddAnalyzerToWorkspace(workspace, analyzer);
 
-        GetDocumentAndSelectSpanOrAnnotatedSpan(workspace, out var document, out var span, out var annotation);
+        var (document, span, annotation) = await GetDocumentAndSelectSpanOrAnnotatedSpan(workspace);
 
         var testDriver = new TestDiagnosticAnalyzerDriver(workspace, includeSuppressedDiagnostics: IncludeSuppressedDiagnostics);
         var diagnostics = (await testDriver.GetAllDiagnosticsAsync(document, span))

--- a/src/Features/DiagnosticsTestUtilities/Diagnostics/AbstractUnncessarySuppressionDiagnosticTest.cs
+++ b/src/Features/DiagnosticsTestUtilities/Diagnostics/AbstractUnncessarySuppressionDiagnosticTest.cs
@@ -48,7 +48,7 @@ public abstract class AbstractUnnecessarySuppressionDiagnosticTest(ITestOutputHe
     {
         AddAnalyzersToWorkspace(workspace);
 
-        GetDocumentAndSelectSpanOrAnnotatedSpan(workspace, out var document, out var span, out var annotation);
+        var (document, span, annotation) = await GetDocumentAndSelectSpanOrAnnotatedSpan(workspace);
 
         // Include suppressed diagnostics as they are needed by unnecessary suppressions analyzer.
         var testDriver = new TestDiagnosticAnalyzerDriver(workspace, includeSuppressedDiagnostics: true);


### PR DESCRIPTION
Fixes a crash reported by a customer on discord: https://discord.com/channels/143867839282020352/598678594750775301/1426300473933299794

Fixes https://github.com/dotnet/roslyn/issues/80099