### PR TITLE
Restore fully qualify for Razor

### DIFF
--- a/src/Features/Core/Portable/FullyQualify/AbstractFullyQualifyCodeFixProvider.cs
+++ b/src/Features/Core/Portable/FullyQualify/AbstractFullyQualifyCodeFixProvider.cs
@@ -25,8 +25,9 @@ internal abstract class AbstractFullyQualifyCodeFixProvider : CodeFixProvider
         var document = context.Document;
 
         // Don't bother executing this within a source-generated document.  Changing the code here isn't actually
-        // possible, and we don't need to make pointless calls to oop to compute things.
-        if (document.Id.IsSourceGenerated)
+        // possible, and we don't need to make pointless calls to oop to compute things. The exception is Razor
+        // which uses generated documents, but does its own mapping of changes back to the original source.
+        if (document.Id.IsSourceGenerated && !document.IsRazorSourceGeneratedDocument())
             return;
 
         var service = document.GetRequiredLanguageService<IFullyQualifyService>();


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/12315

https://github.com/dotnet/roslyn/pull/80649 disabled Fully Qualify for source generated documents because it was crashing for users. In actual fact the crash was already fixed in https://github.com/dotnet/roslyn/pull/77587:
https://github.com/dotnet/roslyn/blob/d2b50b654642d54afd1a0e3ab6218dcb5c4745a0/src/Workspaces/Remote/ServiceHub/Services/FullyQualify/RemoteFullyQualifyService.cs#L30-L31

It still probably makes sense to not run the code action on normal source generated documents. Razor documents are not normal.