### PR TITLE
Disallow simplifying `if` operator in case of `return` when `true`/`false` operators are used

### DIFF
--- a/src/Analyzers/CSharp/Tests/UseConditionalExpression/UseConditionalExpressionForAssignmentTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseConditionalExpression/UseConditionalExpressionForAssignmentTests.cs
@@ -2366,4 +2366,70 @@ public sealed partial class UseConditionalExpressionForAssignmentTests
             }
             """,
             languageVersion: LanguageVersion.CSharp14);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/80640")]
+    public Task TestWhenBooleanOperatorsAreUsed()
+        => TestInRegularAndScriptAsync("""
+            class C
+            {
+                void M(int i)
+                {
+                    [|if|] (this)
+                    {
+                        i = 1;
+                    }
+                    else
+                    {
+                        i = 0;
+                    }
+                }
+
+                public static bool operator true(C v) => true;
+
+                public static bool operator false(C v) => false;
+            }
+            """, """
+            class C
+            {
+                void M(int i)
+                {
+                    i = this ? 1 : 0;
+                }
+
+                public static bool operator true(C v) => true;
+
+                public static bool operator false(C v) => false;
+            }
+            """);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/80640")]
+    public Task TestWithImplicitBoolConversion()
+        => TestInRegularAndScriptAsync("""
+            class C
+            {
+                void M(int i)
+                {
+                    [|if|] (this)
+                    {
+                        i = 1;
+                    }
+                    else
+                    {
+                        i = 0;
+                    }
+                }
+
+                public static implicit operator bool(C v) => true;
+            }
+            """, """
+            class C
+            {
+                void M(int i)
+                {
+                    i = this ? 1 : 0;
+                }
+
+                public static implicit operator bool(C v) => true;
+            }
+            """);
 }

--- a/src/Analyzers/CSharp/Tests/UseConditionalExpression/UseConditionalExpressionForReturnTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseConditionalExpression/UseConditionalExpressionForReturnTests.cs
@@ -2238,4 +2238,58 @@ public sealed class UseConditionalExpressionForReturnTests(ITestOutputHelper log
                 }
             }
             """);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/80640")]
+    public Task TestMissingWhenBoolOperatorsAreUsed()
+        => TestMissingAsync("""
+            class C
+            {
+                bool M()
+                {
+                    [||]if (this)
+                    {
+                        return true;
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+
+                public static bool operator true(C v) => true;
+
+                public static bool operator false(C v) => false;
+            }
+            """);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/80640")]
+    public Task TestWithImplicitBoolConversion()
+        => TestInRegularAndScriptAsync("""
+            class C
+            {
+                bool M()
+                {
+                    [|if|] (this)
+                    {
+                        return true;
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+
+                public static implicit operator bool(C v) => true;
+            }
+            """, """
+            class C
+            {
+                bool M()
+                {
+                    return this;
+                }
+
+                public static implicit operator bool(C v) => true;
+            }
+            """);
 }

--- a/src/Analyzers/Core/Analyzers/UseConditionalExpression/ForReturn/UseConditionalExpressionForReturnHelpers.cs
+++ b/src/Analyzers/Core/Analyzers/UseConditionalExpression/ForReturn/UseConditionalExpressionForReturnHelpers.cs
@@ -46,6 +46,12 @@ internal static class UseConditionalExpressionForReturnHelpers
         //
         // note: either (but not both) of these statements can be throw-statements.
 
+        // If true/false operators are used simplifying expression will cause a compiler error
+        if (ifOperation.Condition is IUnaryOperation { OperatorKind: UnaryOperatorKind.True or UnaryOperatorKind.False })
+        {
+            return false;
+        }
+
         if (falseStatement == null)
         {
             if (ifOperation.Parent is not IBlockOperation parentBlock)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/80640