### PR TITLE
Add test hook that suppresses runtime version check in MSBuildLocator

### DIFF
--- a/src/Workspaces/MSBuild/BuildHost/BuildHost.cs
+++ b/src/Workspaces/MSBuild/BuildHost/BuildHost.cs
@@ -49,7 +49,11 @@ internal sealed class BuildHost : IBuildHost
                 return true;
             }
 
-            var instance = FindMSBuild(projectOrSolutionFilePath, includeUnloadableInstances: false);
+            // When running in SDK test environment the runtime version might be lower than the SDK version.
+            // We need to force the load of "incompatible" version of the SDK in this case.
+            var includeUnloadableInstances = Environment.GetEnvironmentVariable("Microsoft_CodeAnalysis_BuildHost_SkipRuntimeVersionCheck") == "1";
+
+            var instance = FindMSBuild(projectOrSolutionFilePath, includeUnloadableInstances);
             if (instance is null)
             {
                 return false;


### PR DESCRIPTION
Allows us to run dotnet-watch tests in SDK repo during transition from version N to version N+1. During this time the version of the runtime may still be N while version of the SDK is on N+1. This currently results in failure to load MSBuild to the build host.