### PR TITLE
When searching for the original file from a PDB, only allow absolute paths

### DIFF
--- a/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentLoaderService.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentLoaderService.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.MetadataAsSource;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.PdbSourceDocument;
 
@@ -167,7 +168,8 @@ internal sealed class PdbSourceDocumentLoaderService(
 
     private SourceFileInfo? TryGetOriginalFile(SourceDocument sourceDocument, Encoding encoding, TelemetryMessage telemetry)
     {
-        if (File.Exists(sourceDocument.FilePath))
+        // The path in the PDB could be a relative path; since we don't have any path to compute an absolute path from, just disregard those.
+        if (PathUtilities.IsAbsolute(sourceDocument.FilePath) && File.Exists(sourceDocument.FilePath))
         {
             var result = LoadSourceFile(sourceDocument.FilePath, sourceDocument, encoding, FeaturesResources.external, ignoreChecksum: false, fromRemoteLocation: false);
             if (result is not null)


### PR DESCRIPTION
Without this check, if the PDB in question used path map to create a relative path, it's possible for this check to pass and end up handing around relative paths to the rest of the system (and the VS Shell). This eventually causes other things to break that expect full paths.

Given a relative path would only work here by "luck" if the devenv current working directory happened to line up, it seems easiest just to assert it's an absolute path before going further.

Fixes https://github.com/dotnet/roslyn/issues/79014
Fixes https://developercommunity.visualstudio.com/t/When-external-C-code-file-opened-more-t/10802958 (or at least I think the case that appeared in the customer's private dump)