### PR TITLE
Update MicrosoftBuildTasksCoreVersionForMetrics to 17.11.48

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -108,7 +108,7 @@
     Analyzer, it needs to directly reference patched versions of some transitive dependencies.
   -->
   <PropertyGroup>
-    <MicrosoftBuildTasksCoreVersionForMetrics>17.10.48</MicrosoftBuildTasksCoreVersionForMetrics>
+    <MicrosoftBuildTasksCoreVersionForMetrics>17.11.48</MicrosoftBuildTasksCoreVersionForMetrics>
     <SystemTextJsonVersionForMetrics>8.0.5</SystemTextJsonVersionForMetrics>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
The current version is marked as vulnerable and flagged by CG

This should get backported into the corresponding .NET 10 GA branch.