### PR TITLE
Allow semantic tokens in Razor to be better behaved

### DIFF
--- a/src/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensRefreshQueue.cs
+++ b/src/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensRefreshQueue.cs
@@ -28,6 +28,8 @@ internal sealed class SemanticTokensRefreshQueue : AbstractRefreshQueue
     /// </summary>
     private readonly Dictionary<ProjectId, Checksum> _projectIdToLastComputedChecksum = [];
 
+    public bool AllowRazorRefresh { get; set; }
+
     public SemanticTokensRefreshQueue(
         IAsynchronousOperationListenerProvider asynchronousOperationListenerProvider,
         LspWorkspaceRegistrationService lspWorkspaceRegistrationService,
@@ -79,7 +81,7 @@ internal sealed class SemanticTokensRefreshQueue : AbstractRefreshQueue
                 var document = e.NewSolution.GetRequiredAdditionalDocument(e.DocumentId);
 
                 // Changes to files with certain extensions (eg: razor) shouldn't trigger semantic a token refresh
-                if (DisallowsAdditionalDocumentChangedRefreshes(document.FilePath))
+                if (!AllowRazorRefresh && DisallowsAdditionalDocumentChangedRefreshes(document.FilePath))
                     return;
             }
             else if (e.Kind is WorkspaceChangeKind.DocumentReloaded)

--- a/src/Tools/ExternalAccess/Razor/Features/Cohost/Handlers/SemanticTokensRange.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/Cohost/Handlers/SemanticTokensRange.cs
@@ -13,25 +13,28 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost.Handlers
 {
     internal static class SemanticTokensRange
     {
+        public static void RegisterRefresh(RazorCohostRequestContext requestContext)
+        {
+            var refreshQueue = requestContext.GetRequiredService<SemanticTokensRefreshQueue>();
+            refreshQueue.AllowRazorRefresh = true;
+        }
+
+        public static Task TryEnqueueRefreshComputationAsync(RazorCohostRequestContext requestContext, Project project, CancellationToken cancellationToken)
+        {
+            var refreshQueue = requestContext.GetRequiredService<SemanticTokensRefreshQueue>();
+            return refreshQueue.TryEnqueueRefreshComputationAsync(project, cancellationToken);
+        }
+
         public static Task<int[]> GetSemanticTokensAsync(
             Document document,
             ImmutableArray<LinePositionSpan> spans,
             bool supportsVisualStudioExtensions,
             CancellationToken cancellationToken)
-        {
-            var tokens = SemanticTokensHelpers.HandleRequestHelperAsync(
+            => SemanticTokensHelpers.HandleRequestHelperAsync(
                 document,
                 spans,
                 supportsVisualStudioExtensions,
                 ClassificationOptions.Default,
                 cancellationToken);
-
-            // The above call to get semantic tokens may be inaccurate (because we use frozen partial semantics).  Kick
-            // off a request to ensure that the OOP side gets a fully up to compilation for this project.  Once it does
-            // we can optionally choose to notify our caller to do a refresh if we computed a compilation for a new
-            // solution snapshot.
-            // TODO: await semanticTokensRefreshQueue.TryEnqueueRefreshComputationAsync(project, cancellationToken).ConfigureAwait(false);
-            return tokens;
-        }
     }
 }


### PR DESCRIPTION
Part of https://github.com/dotnet/razor/issues/11848

This makes the Razor experience for semantic tokens the same as the C# experience for the most part.

Razor side: https://github.com/dotnet/razor/pull/12367