### PR TITLE
Clean up a Razor external access service

### DIFF
--- a/src/Tools/ExternalAccess/Razor/Features/Cohost/Handlers/SemanticTokensRange.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/Cohost/Handlers/SemanticTokensRange.cs
@@ -13,18 +13,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost.Handlers
 {
     internal static class SemanticTokensRange
     {
-        public static void RegisterRefresh(RazorCohostRequestContext requestContext)
-        {
-            var refreshQueue = requestContext.GetRequiredService<SemanticTokensRefreshQueue>();
-            refreshQueue.AllowRazorRefresh = true;
-        }
-
-        public static Task TryEnqueueRefreshComputationAsync(RazorCohostRequestContext requestContext, Project project, CancellationToken cancellationToken)
-        {
-            var refreshQueue = requestContext.GetRequiredService<SemanticTokensRefreshQueue>();
-            return refreshQueue.TryEnqueueRefreshComputationAsync(project, cancellationToken);
-        }
-
         public static Task<int[]> GetSemanticTokensAsync(
             Document document,
             ImmutableArray<LinePositionSpan> spans,

--- a/src/Tools/ExternalAccess/Razor/Features/Cohost/RazorSemanticTokensRefreshQueueWrapper.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/Cohost/RazorSemanticTokensRefreshQueueWrapper.cs
@@ -36,6 +36,7 @@ internal class RazorSemanticTokensRefreshQueueWrapperFactory() : ILspServiceFact
             // Initialize method in the queue itself is resilient to being called twice, so it doesn't actually do
             // any harm.
             semanticTokensRefreshQueue.Initialize(clientCapabilities);
+            semanticTokensRefreshQueue.AllowRazorRefresh = true;
         }
 
         public Task TryEnqueueRefreshComputationAsync(Project project, CancellationToken cancellationToken)


### PR DESCRIPTION
Noticed a bunch of double-dispose exceptions in some Razor integration test logs. We get the service from the DI container, so we shouldn't dispose it because the DI container will.