### PR TITLE
Fix typos and improve clarity in documentation

### DIFF
--- a/docs/compilers/CSharp/Warnversion Warning Waves.md
+++ b/docs/compilers/CSharp/Warnversion Warning Waves.md
@@ -36,7 +36,7 @@ The compiler shipped with .NET 7 (the C# 11 compiler) contains the following war
 
 | Warning ID | Description |
 |------------|-------------|
-| CS8981 | [Type names only containing lower-cased ascii characters may become reserved for the language](https://github.com/dotnet/roslyn/issues/56653) |
+| CS8981 | [Type names only containing lowercase ASCII characters may become reserved for the language](https://github.com/dotnet/roslyn/issues/56653) |
 
 ## Warning level 6
 

--- a/docs/contributing/Developing a Language Feature.md
+++ b/docs/contributing/Developing a Language Feature.md
@@ -42,7 +42,7 @@ This page discusses the process by which language feature *implementations* are 
     left some language details unspecified, to be resolved based
     on implementation experience, or when experience with the prototype suggests that some language design
     decisions should be reconsidered. 
-    * **Closed**: The feature hit unforeseen design issues, implementation road blocks, etc. that caused it to be removed.
+    * **Closed**: The feature hit unforeseen design issues, implementation roadblocks, etc. that caused it to be removed.
 
 1. **Finishing**: Once a feature is integrated into the main tree, it's time to lock down and finish the implementation. This includes any remaining areas not completed in the prototype, and completing all of the corner cases and tests (lots and lots of tests!).  
 
@@ -52,7 +52,7 @@ This page discusses the process by which language feature *implementations* are 
 
 It's important to note there are **no guarantees** about a feature being a part of the language until it has reached the 'Acceptance' state **and** shipped in an official build. Features in any other state--no matter how complete--can be pulled at the last minute if the Language Team deems it's necessary to do so.  
 
-Pulling a feature after the prototype phase completes is not a decision the Langauge Team takes lightly; however, in the past, unforeseen circumstances have caused us to do so. The best example of this was the decision to pull parameterless struct constructors very late in the C# 6.0 timeframe.  
+Pulling a feature after the prototype phase completes is not a decision the Language Team takes lightly; however, in the past, unforeseen circumstances have caused us to do so. The best example of this was the decision to pull parameterless struct constructors very late in the C# 6.0 timeframe.  
 
 ## Community Contributions
 The intent of this document is to codify the process used by the Language Team to implement language features so that the community can contribute implementations. Community members can contribute to ongoing prototypes or in some cases be the primary driver of the prototype.  
@@ -66,7 +66,7 @@ Community members who wish to drive a particular feature can request so by comme
 
 - **Why are features disabled by default?**: Language features spend a considerable amount of time in the same branch as our shipping product which is often main.  The main branch of Roslyn is kept in a ship ready state at all times.  To facilitate this all features which haven't been fully accepted into the language must be disabled.
 
-- **What is the difference between the feature and main branches?**: The main branch represents code which will ship in updates to the current version of the compiler.  The feature branches represents each feature which are still in progress, therefore not merged yet.
+- **What is the difference between the feature and main branches?**: The main branch represents code which will ship in updates to the current version of the compiler. The feature branches represent features that are still in progress, therefore not merged yet.
 
 - **Why weren't speclets filed for early features?**: Features such as tuples and local functions were done before this process was fully developed.  Their speclets were considered internally and eventually became the `docs/feature/<feature name.md>` file.
 

--- a/docs/features/tuples.md
+++ b/docs/features/tuples.md
@@ -75,7 +75,7 @@ var t1 = new (int sum, int count) (0, 1);
 var t2 = new (int sum, int count) { sum = 0, count = 0 };
 var t3 = new (int, int) (0, 1);     // field names are optional    
 ```
-Note that specifying field names is optional, however when names are provided, all fields must be named. Duplicate names are disallowed.
+Note that specifying field names is optional; however, when names are provided, all fields must be named. Duplicate names are disallowed.
 
 Tuple literals
 --------------
@@ -99,7 +99,7 @@ Note that specifying field names is optional, however when names are provided, a
 
 
 ```C#
-var t1 = (sum: 0, 1);		// error! some fields are named some are not.
+var t1 = (sum: 0, 1);		// error! Some fields are named, some are not.
 var t2 = (sum: 0, sum: 1);	// error! duplicate names.
 ```
 

--- a/docs/wiki/Diagnosing-Project-System-Build-Errors.md
+++ b/docs/wiki/Diagnosing-Project-System-Build-Errors.md
@@ -58,7 +58,7 @@ you'll see a bunch of files that end in `.designtime.log`.
 
   `Project "c:\Projects\ConsoleApplication53\ConsoleApplication53\ConsoleApplication53.csproj" (Compile target(s)):`
 
-  This shows the full name of the project, along with the target (Compile) being ran. Once again, look for the "Compile"
+  This shows the full name of the project, along with the target (Compile) being run. Once again, look for the "Compile"
   target. There are files with other targets being invoked, you'll want to ignore those. You might want to consider
   using Visual Studio's "find in files" feature to find the right file.
 
@@ -67,15 +67,15 @@ see something like this:
 
     Build FAILED.
 
-    c:\ConsoleApplication53\ConsoleApplication53\ConsoleApplication53.csproj(17,5): error : An error occured!
+    c:\ConsoleApplication53\ConsoleApplication53\ConsoleApplication53.csproj(17,5): error : An error occurred!
         0 Warning(s)
         1 Error(s)
 
-Notably, you should see `Build FAILED` and then one or more errors. This is summary of the errors in the log, so if you
+Notably, you should see `Build FAILED` and then one or more errors. This is a summary of the errors in the log, so if you
 do see an error, you should now search this log file for that error and find out where it is. Hopefully, the error will
 give some sort of a hint; it's looking for some file or SDK that's not installed, or some permissions were denied, etc.
 In that case, you can follow up with the owner of that to figure out what went wrong.
 
 If it seems to be a problem with Visual Studio itself, you might want to file a bug on
-[the Roslyn GitHub project](https://github.com/dotnet/roslyn) have a Visual Studio engineer take a look. Make sure you
+[the Roslyn GitHub project](https://github.com/dotnet/roslyn) to have a Visual Studio engineer take a look. Make sure you
 provide the full log and if possible your project file, since we may need both to diagnose the problem.


### PR DESCRIPTION
This pull request makes minor documentation improvements across several files to correct spelling, grammar, and phrasing for clarity and consistency. No functional or structural changes are introduced.

Documentation corrections and clarifications:

* Fixed casing and phrasing in the description for warning `CS8981` in `Warnversion Warning Waves.md` to use "lowercase ASCII characters" instead of "lower-cased ascii characters".
* Improved grammar and clarity in sentences describing feature pull decisions and branch differences in `Developing a Language Feature.md`. [[1]](diffhunk://#diff-ffc243732958ef619a6431381f57856307b6929084ca76be83cba99daf07cb98L55-R55) [[2]](diffhunk://#diff-ffc243732958ef619a6431381f57856307b6929084ca76be83cba99daf07cb98L69-R69)
* Corrected punctuation and capitalization in tuple feature documentation, including examples and explanatory text in `tuples.md`. [[1]](diffhunk://#diff-1c644e66cb434163a9d5c8c18bdf8a7c8a2f3a96aedc7b98aed9ce28f2c95d60L78-R78) [[2]](diffhunk://#diff-1c644e66cb434163a9d5c8c18bdf8a7c8a2f3a96aedc7b98aed9ce28f2c95d60L102-R102)
* Fixed spelling and phrasing in build error diagnostic instructions, including correcting "being ran" to "being run" and "occured" to "occurred" in `Diagnosing-Project-System-Build-Errors.md`. [[1]](diffhunk://#diff-6f02e1bc2f1fe0892380fbf7db1deef01bf6d20b0b9248ad6b467d3e8d4cbad6L61-R61) [[2]](diffhunk://#diff-6f02e1bc2f1fe0892380fbf7db1deef01bf6d20b0b9248ad6b467d3e8d4cbad6L70-R80)