### PR TITLE
Add back old DocumentSpan constructor

### DIFF
--- a/src/Features/Core/Portable/DocumentSpan.cs
+++ b/src/Features/Core/Portable/DocumentSpan.cs
@@ -13,7 +13,7 @@ internal readonly record struct DocumentSpan(
     Document Document, TextSpan SourceSpan, bool IsGeneratedCode)
 {
     public DocumentSpan(Document document, TextSpan sourceSpan)
-        : this(document, sourceSpan, false)
+        : this(document, sourceSpan, IsGeneratedCode: false)
     {
     }
 }


### PR DESCRIPTION
To fix ngen errors with Microsoft.CodeAnalysis.TypeScript.EditorFeatures.dll 

```
10/23/2025 12:11:39.887 [7296]: 4>    Compiling assembly C:\VisualStudio\Common7\IDE\CommonExtensions\Microsoft\TypeScript\Microsoft.CodeAnalysis.TypeScript.EditorFeatures.dll (CLR v4.0.30319) ...
10/23/2025 12:11:40.700 [7296]: 4>Warning: System.MissingMethodException: Method not found: 'Void Microsoft.CodeAnalysis.DocumentSpan..ctor(Microsoft.CodeAnalysis.Document, Microsoft.CodeAnalysis.Text.TextSpan)'. while resolving 0xa000bf1 - Microsoft.CodeAnalysis.DocumentSpan..ctor.
10/23/2025 12:11:40.734 [7296]: 3>    Compiling assembly C:\VisualStudio\Common7\IDE\CommonExtensions\Microsoft\TypeScript\Microsoft.VisualStudio.LanguageServices.TypeScript.dll (CLR v4.0.30319) ...
10/23/2025 12:11:41.617 [7296]: 4>Method not found: 'Void Microsoft.CodeAnalysis.DocumentSpan..ctor(Microsoft.CodeAnalysis.Document, Microsoft.CodeAnalysis.Text.TextSpan)'. while compiling method DefinitionItemReader.NewObject
```