### PR TITLE
Make constructor public

### DIFF
--- a/src/Tools/ExternalAccess/Razor/Features/RazorCSharpSyntaxFormattingOptions.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/RazorCSharpSyntaxFormattingOptions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Features
     {
         public static readonly RazorCSharpSyntaxFormattingOptions Default = new();
 
-        private RazorCSharpSyntaxFormattingOptions()
+        public RazorCSharpSyntaxFormattingOptions()
             : this(CSharpSyntaxFormattingOptions.Default)
         {
         }


### PR DESCRIPTION
I added extra logging to help us repro Razor formatting bugs, which included serializing C# options as they're a big cause of issues, and people can never be relied upon to accurately report what the closure of them is for a particular document.

Now I have received some logs, and I can't deserialize the options because there is no parameterless constructor 🤦‍♂️