### PR TITLE
Fix XAML peek in VS editor. XamlPeekableItemFactory needs to implement exported interface.

### DIFF
--- a/src/VisualStudio/Xaml/Impl/Features/Peek/IXamlPeekableItemFactory.cs
+++ b/src/VisualStudio/Xaml/Impl/Features/Peek/IXamlPeekableItemFactory.cs
@@ -30,4 +30,6 @@ internal interface IXamlPeekableItemFactory
 internal sealed class XamlPeekableItemFactory(
     IMetadataAsSourceFileService metadataAsSourceFileService,
     IGlobalOptionService globalOptions,
-    IThreadingContext threadingContext) : PeekableItemFactory(metadataAsSourceFileService, globalOptions, threadingContext);
+    IThreadingContext threadingContext)
+    : PeekableItemFactory(metadataAsSourceFileService, globalOptions, threadingContext)
+    , IXamlPeekableItemFactory;


### PR DESCRIPTION
`XamlPeekableItemFactory` was meant to implement `IXamlPeekableItemFactory` for the XAML editor to use, but that interface was missed. Adding it fixes the XAML peek feature.