### PR TITLE
Pass the correct item ID when checking the type of an item

### DIFF
--- a/src/VisualStudio/Core/Impl/SolutionExplorer/SymbolTree/RootSymbolTreeItemSourceProvider.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/SymbolTree/RootSymbolTreeItemSourceProvider.cs
@@ -187,7 +187,7 @@ internal sealed partial class RootSymbolTreeItemSourceProvider : AttachedCollect
             return null;
 
         if (item.HierarchyIdentity.NestedHierarchy.GetGuidProperty(
-                item.HierarchyIdentity.ItemID,
+                item.HierarchyIdentity.NestedItemID,
                 (int)__VSHPROPID.VSHPROPID_TypeGuid,
                 out var guid) != VSConstants.S_OK)
         {


### PR DESCRIPTION
The HierarchyIdentity has both a regular hierarchy/item ID set and the nested set, and mixing them is bad.