### PR TITLE
Add SDK analyzer assembly redirector

### DIFF
--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/SdkAnalyzerAssemblyRedirectorTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/SdkAnalyzerAssemblyRedirectorTests.cs
@@ -86,6 +86,8 @@ public sealed class SdkAnalyzerAssemblyRedirectorTests : TestBase
 
     [Theory]
     [InlineData("8.0.100", "9.0.0-preview.7.24406.2")]
+    [InlineData("8.0.1", "8.01.1")]
+    [InlineData("8.01.1", "8.0.1")]
     [InlineData("9.1.100", "9.0.0-preview.7.24406.2")]
     [InlineData("9.1.0-preview.5.24306.11", "9.0.0-preview.7.24406.2")]
     [InlineData("9.0.100", "9.1.100")]

--- a/src/VisualStudio/Core/Def/ProjectSystem/SdkAnalyzerAssemblyRedirector.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/SdkAnalyzerAssemblyRedirector.cs
@@ -186,7 +186,7 @@ internal class SdkAnalyzerAssemblyRedirectorCore : IAnalyzerAssemblyRedirector
                 return false;
             }
 
-            return 0 == string.Compare(version1, 0, version2, 0, secondDotIndex, StringComparison.OrdinalIgnoreCase);
+            return 0 == string.Compare(version1, 0, version2, 0, secondDotIndex + 1, StringComparison.OrdinalIgnoreCase);
         }
     }
 


### PR DESCRIPTION
Moved here from the SDK per David Kean's request (to avoid another assembly load). Originally lived here:

- https://github.com/dotnet/sdk/blob/23be5664570f78e471a312692d962288831b7f29/src/Microsoft.Net.Sdk.AnalyzerRedirecting/SdkAnalyzerAssemblyRedirector.cs
- https://github.com/dotnet/sdk/blob/23be5664570f78e471a312692d962288831b7f29/test/Microsoft.Net.Sdk.AnalyzerRedirecting.Tests/SdkAnalyzerAssemblyRedirectorTests.cs

Validation: ~https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/684831~ ~https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/696938~
https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/699576