### PR TITLE
Avoid broken NetCore1ESPool-Svc-Internal pool

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -116,7 +116,7 @@ extends:
       autoEnableRoslynWithNewRuleset: false
     sdl:
       sourceAnalysisPool:
-        name: NetCore1ESPool-Svc-Internal
+        name: NetCore1ESPool-Internal
         image: 1es-windows-2022
         os: windows
       sbom:
@@ -129,7 +129,7 @@ extends:
         enabled: true
         configFile: '$(Build.SourcesDirectory)/eng/TSAConfig.gdntsa'
     pool:
-      name: NetCore1ESPool-Svc-Internal
+      name: NetCore1ESPool-Internal
       image: windows.vs2022preview.scout.amd64
       os: windows
     customBuildTags:
@@ -368,7 +368,7 @@ extends:
           dependsOn:
           - OfficialBuild
           pool:
-            name: NetCore1ESPool-Svc-Internal
+            name: NetCore1ESPool-Internal
             demands: ImageOverride -equals windows.vs2022.amd64
 
       - ${{ if eq(variables.enableSourceIndex, 'true') }}:


### PR DESCRIPTION
Fixes (or works around?) broken official builds. Validation: https://dev.azure.com/dnceng/internal/_build/results?buildId=2831147&view=results