### PR TITLE
Remove VSIX publishing from bootstrap leg

### DIFF
--- a/eng/pipelines/build-bootstrap.yml
+++ b/eng/pipelines/build-bootstrap.yml
@@ -31,10 +31,3 @@ steps:
         PathtoPublish: '$(Build.SourcesDirectory)\artifacts\packages\Release\PreRelease'
         ArtifactName: 'Bootstrap Packages - ${{parameters.toolset}}'
         publishLocation: Container
-
-    - task: PublishBuildArtifacts@1
-      displayName: Publish VSIX Packages
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\VSSetup\Release\Installer'
-        ArtifactName: 'Bootstrap VSIX - ${{parameters.toolset}}'
-        publishLocation: Container


### PR DESCRIPTION
Follow up on https://github.com/dotnet/roslyn/pull/81038 to fix bootstrap leg in roslyn CI. cc @dibarbet