### PR TITLE
Run all CI legs on infra changes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -422,6 +422,7 @@ stages:
       jobName: Determine_Changes
       poolParameters: ${{ parameters.ubuntuPool }}
       paths:
+        # this subset includes infra changes (we want to run all legs when there are infra changes)
         - subset: compilers
           include:
           - src/Compilers/*
@@ -429,6 +430,13 @@ stages:
           - src/NuGet/Microsoft.Net.Compilers.Toolset/*
           - eng/*
           - src/Tools/Source/CompilerGeneratorTools/*
+          - '*.sln*'
+          - '*.yml'
+          - '*.props'
+          - '*.targets'
+          - '*.rsp'
+          - '*.*config'
+          - 'global.json'
 
   - job: Correctness_Build_Artifacts
     dependsOn: Determine_Changes


### PR DESCRIPTION
To avoid mistakes like https://github.com/dotnet/roslyn/pull/81048 in the future