### PR TITLE
Fixes Stack Trace Explorer color contrast ratio

### DIFF
--- a/src/VisualStudio/Core/Def/StackTraceExplorer/StackTraceExplorer.xaml
+++ b/src/VisualStudio/Core/Def/StackTraceExplorer/StackTraceExplorer.xaml
@@ -15,7 +15,7 @@
     <UserControl.CommandBindings>
         <CommandBinding Command="{x:Static ApplicationCommands.Paste}" Executed="CommandBinding_Executed"/>
     </UserControl.CommandBindings>
-    <Grid>
+    <Grid Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}">
         <Grid.CommandBindings>
             <CommandBinding Command="{x:Static ApplicationCommands.Paste}" Executed="CommandBinding_Executed"/>
         </Grid.CommandBindings>


### PR DESCRIPTION
Before:
<img width="665" height="675" alt="image" src="https://github.com/user-attachments/assets/3fbaa807-8242-4c58-972f-506560c640a2" />

After:
<img width="666" height="671" alt="image" src="https://github.com/user-attachments/assets/ceb6f638-ab84-4956-a421-b0842481ed1a" />
