### PR TITLE
Add order attribute to PeekableItemSourceProvider

### DIFF
--- a/src/EditorFeatures/Core/Peek/PeekableItemSourceProvider.cs
+++ b/src/EditorFeatures/Core/Peek/PeekableItemSourceProvider.cs
@@ -15,6 +15,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Peek;
 [Export(typeof(IPeekableItemSourceProvider))]
 [ContentType(ContentTypeNames.RoslynContentType)]
 [Name("Roslyn Peekable Item Provider")]
+[Order(Before = "LSPPeekableSourceProvider")]
 [SupportsStandaloneFiles(true)]
 [SupportsPeekRelationship("IsDefinedBy")]
 internal sealed class PeekableItemSourceProvider : IPeekableItemSourceProvider


### PR DESCRIPTION
#80951 slightly broke Peek Definition by making editor pick VS LSP client implementation of IPeekableSourceProvider instead of this one. Similarly to command handlers this provider also needs to be ordered before LSP's  one.