### PR TITLE
Add a couple of misc runtime async tests

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -10550,7 +10550,7 @@ static class Test1
                 """;
 
             var comp = CreateRuntimeAsyncCompilation(code);
-            var verifier = CompileAndVerify(comp);
+            var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify);
             verifier.VerifyDiagnostics();
 
             verifier.VerifyIL("<top-level-statements-entry-point>", """
@@ -10611,7 +10611,7 @@ static class Test1
                 """;
 
             var comp = CreateRuntimeAsyncCompilation(code);
-            var verifier = CompileAndVerify(comp);
+            var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify);
             verifier.VerifyDiagnostics();
 
             verifier.VerifyIL("<top-level-statements-entry-point>", """


### PR DESCRIPTION
A couple of conversations over the past week have turned up some interesting areas to test for runtime async, so I've added them to document current behavior. Sequence point testing will need further expansion, as we need to adjust where hidden sequence points are emitted, but this will do for the moment.

Relates to test plan https://github.com/dotnet/roslyn/issues/75960