### PR TITLE
#81118: Fix dropdown in "Move static members" dialog

### DIFF
--- a/src/VisualStudio/Core/Def/MoveStaticMembers/MoveStaticMembersDialog.xaml
+++ b/src/VisualStudio/Core/Def/MoveStaticMembers/MoveStaticMembersDialog.xaml
@@ -63,7 +63,7 @@
                     </Style>
                 </ComboBox.ItemContainerStyle>
                 <ComboBox.ItemTemplate>
-                    <DataTemplate DataType="Microsoft.VisualStudio.LanguageServices.Implementation.MoveMembersToType.TypeNameItem">
+                    <DataTemplate DataType="movestaticmembers:TypeNameItem">
                         <Grid>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto"/>
@@ -73,18 +73,18 @@
                             </Grid.ColumnDefinitions>
                             <imaging:CrispImage
                                 Grid.Column="0"
-                                Visibility="{Binding IsFromHistory, Converter={StaticResource BooleanToVisibilityConverter}}" 
+                                Visibility="{Binding Path=IsFromHistory, Mode=OneTime, Converter={StaticResource BooleanToVisibilityConverter}}"
                                 Margin="0 0 5 0" 
                                 Moniker="{x:Static imagecatalog:KnownMonikers.History}" />
                             <TextBlock
                                 Grid.Column="3"
                                 HorizontalAlignment="Left"
                                 TextTrimming="CharacterEllipsis"
-                                Text="{Binding TypeName}"/>
+                                Text="{Binding Path=FullyQualifiedTypeName, Mode=OneTime}"/>
                             <TextBlock
                                 Grid.Column="4"
                                 HorizontalAlignment="Right"
-                                Text="{Binding DeclarationFile}"/>
+                                Text="{Binding Path=DeclarationFileName, Mode=OneTime}"/>
                         </Grid>
                     </DataTemplate>
                 </ComboBox.ItemTemplate>


### PR DESCRIPTION
Fixes #81118.

Apparently the dialog broke when the `TypeNameItem` type was moved to another namespace. This fixes that reference and fixes up some of the bindings that are used in the dialog (and also sets `Mode=OneTime` since the bound properties are readonly and so the model does not change while the dialog is open).

<img width="486" height="491" alt="grafik" src="https://github.com/user-attachments/assets/c7de8b8a-3a4b-43cf-aa27-93541f84e35f" />
