### PR TITLE
Fix output of 'use conditional expression' with tabs

### DIFF
--- a/src/Analyzers/CSharp/Tests/UseConditionalExpression/UseConditionalExpressionForReturnTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseConditionalExpression/UseConditionalExpressionForReturnTests.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.UseConditionalExpression;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
+using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -2292,4 +2293,84 @@ public sealed class UseConditionalExpressionForReturnTests(ITestOutputHelper log
                 public static implicit operator bool(C v) => true;
             }
             """);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/81115")]
+    public Task TestTabs_SpacesOption()
+    {
+        var input = """
+            using System;
+
+            class C
+            {
+            	int M()
+            	{
+            		[|if|] (!ThisMethodNameIsVeryLongForTestingWithManyWords(out var x))
+            		{
+            			throw new Exception($"This is a long exception message for repro");
+            		}
+
+            		return x;
+            	}
+
+            	bool ThisMethodNameIsVeryLongForTestingWithManyWords(out int x) { x = 0; return true; }
+            }
+            """;
+
+        Assert.True(input.Contains("\t"));
+        return TestInRegularAndScriptAsync(input, """
+            using System;
+            
+            class C
+            {
+            	int M()
+            	{
+                    return !ThisMethodNameIsVeryLongForTestingWithManyWords(out var x)
+                        ? throw new Exception($"This is a long exception message for repro")
+                        : x;
+                }
+
+                bool ThisMethodNameIsVeryLongForTestingWithManyWords(out int x) { x = 0; return true; }
+            }
+            """, new TestParameters(options: Option(FormattingOptions2.UseTabs, false)));
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/81115")]
+    public Task TestTabs_TabsOption()
+    {
+        var input = """
+            using System;
+
+            class C
+            {
+            	int M()
+            	{
+            		[|if|] (!ThisMethodNameIsVeryLongForTestingWithManyWords(out var x))
+            		{
+            			throw new Exception($"This is a long exception message for repro");
+            		}
+
+            		return x;
+            	}
+
+            	bool ThisMethodNameIsVeryLongForTestingWithManyWords(out int x) { x = 0; return true; }
+            }
+            """;
+
+        Assert.True(input.Contains("\t"));
+        return TestInRegularAndScriptAsync(input, """
+            using System;
+            
+            class C
+            {
+            	int M()
+            	{
+            		return !ThisMethodNameIsVeryLongForTestingWithManyWords(out var x)
+            			? throw new Exception($"This is a long exception message for repro")
+            			: x;
+            	}
+            
+            	bool ThisMethodNameIsVeryLongForTestingWithManyWords(out int x) { x = 0; return true; }
+            }
+            """, new TestParameters(options: Option(FormattingOptions2.UseTabs, true)));
+    }
 }

--- a/src/Analyzers/Core/CodeFixes/UseConditionalExpression/AbstractUseConditionalExpressionCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/UseConditionalExpression/AbstractUseConditionalExpressionCodeFixProvider.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -106,8 +108,8 @@ internal abstract class AbstractUseConditionalExpressionCodeFixProvider<
 
         var initialExpression = (TConditionalExpressionSyntax)generator.ConditionalExpression(
             condition.WithoutTrivia(),
-            trueExpression,
-            falseExpression);
+            WithoutLeadingWhiteSpaceOrEndOfLineTrivia(trueExpression),
+            WithoutLeadingWhiteSpaceOrEndOfLineTrivia(falseExpression));
         var (conditionalExpression, makeMultiLine) = UpdateConditionalExpression(ifOperation, initialExpression);
 
         conditionalExpression = conditionalExpression.WithAdditionalAnnotations(Simplifier.Annotation);
@@ -121,6 +123,14 @@ internal abstract class AbstractUseConditionalExpressionCodeFixProvider<
         }
 
         return MakeRef(generatorInternal, isRef, conditionalExpression);
+    }
+
+    private TExpressionSyntax WithoutLeadingWhiteSpaceOrEndOfLineTrivia(TExpressionSyntax expression)
+    {
+        var syntaxFacts = this.SyntaxFacts;
+        return expression.GetLeadingTrivia().All(syntaxFacts.IsWhitespaceOrEndOfLineTrivia)
+            ? expression.WithoutLeadingTrivia()
+            : expression;
     }
 
     protected virtual (TConditionalExpressionSyntax conditional, bool makeMultiLine) UpdateConditionalExpression(


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/81115