### PR TITLE
Mark dependency on FBP source package as private

### DIFF
--- a/src/Features/CSharp/Portable/Microsoft.CodeAnalysis.CSharp.Features.csproj
+++ b/src/Features/CSharp/Portable/Microsoft.CodeAnalysis.CSharp.Features.csproj
@@ -67,7 +67,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Humanizer.Core" PrivateAssets="compile" />
-    <PackageReference Include="Microsoft.DotNet.FileBasedPrograms" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.DotNet.FileBasedPrograms" GeneratePathProperty="true" PrivateAssets="All" />
     <EmbeddedResource
       Include="$(PkgMicrosoft_DotNet_FileBasedPrograms)\contentFiles\cs\any\FileBasedProgramsResources.resx"
       GenerateSource="true"


### PR DESCRIPTION
Noticed when trying to consume the EA.OmniSharp.CSharp package. It was attempting to restore the "Microsoft.DotNet.FileBasedPrograms" source package.