### PR TITLE
Address Component Governance concerns around Microsoft.Build references

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -108,7 +108,7 @@
     Analyzer, it needs to directly reference patched versions of some transitive dependencies.
   -->
   <PropertyGroup>
-    <MicrosoftBuildTasksCoreVersionForMetrics>17.11.48</MicrosoftBuildTasksCoreVersionForMetrics>
+    <MicrosoftBuildVersionForMetrics>17.11.48</MicrosoftBuildVersionForMetrics>
     <SystemTextJsonVersionForMetrics>8.0.5</SystemTextJsonVersionForMetrics>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/RoslynAnalyzers/NuGet/Microsoft.CodeAnalysis.Metrics/Microsoft.CodeAnalysis.Metrics.Package.csproj
+++ b/src/RoslynAnalyzers/NuGet/Microsoft.CodeAnalysis.Metrics/Microsoft.CodeAnalysis.Metrics.Package.csproj
@@ -41,8 +41,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" VersionOverride="$(MicrosoftCodeAnalysisVersionForAnalyzers)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" VersionOverride="$(MicrosoftCodeAnalysisVersionForAnalyzers)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" VersionOverride="$(MicrosoftCodeAnalysisVersionForAnalyzers)" />
-    <PackageReference Include="Microsoft.Build" VersionOverride="$(MicrosoftBuildTasksCoreVersionForMetrics)" ExcludeAssets="Runtime" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" VersionOverride="$(MicrosoftBuildTasksCoreVersionForMetrics)" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.Build" VersionOverride="$(MicrosoftBuildVersionForMetrics)" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" VersionOverride="$(MicrosoftBuildVersionForMetrics)" ExcludeAssets="Runtime" />
     <PackageReference Include="System.Text.Json" VersionOverride="$(SystemTextJsonVersionForMetrics)" />
 
     <PackageReference Include="SQLitePCLRaw.bundle_green" VersionOverride="$(SQLitePCLRawVersion)" ExcludeAssets="All" />

--- a/src/RoslynAnalyzers/Tools/Metrics.Legacy/Metrics.Legacy.csproj
+++ b/src/RoslynAnalyzers/Tools/Metrics.Legacy/Metrics.Legacy.csproj
@@ -27,8 +27,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" VersionOverride="$(MicrosoftCodeAnalysisVersionForAnalyzers)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" VersionOverride="$(MicrosoftCodeAnalysisVersionForAnalyzers)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" VersionOverride="$(MicrosoftCodeAnalysisVersionForAnalyzers)" />
-    <PackageReference Include="Microsoft.Build" VersionOverride="$(MicrosoftBuildTasksCoreVersionForMetrics)" ExcludeAssets="Runtime" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" VersionOverride="$(MicrosoftBuildTasksCoreVersionForMetrics)" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.Build" VersionOverride="$(MicrosoftBuildVersionForMetrics)" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" VersionOverride="$(MicrosoftBuildVersionForMetrics)" ExcludeAssets="Runtime" />
     <PackageReference Include="System.Text.Json" VersionOverride="$(SystemTextJsonVersionForMetrics)" />
 
     <PackageReference Include="SQLitePCLRaw.bundle_green" VersionOverride="$(SQLitePCLRawVersion)" ExcludeAssets="All" />

--- a/src/RoslynAnalyzers/Tools/Metrics/Metrics.csproj
+++ b/src/RoslynAnalyzers/Tools/Metrics/Metrics.csproj
@@ -25,8 +25,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" VersionOverride="$(MicrosoftCodeAnalysisVersionForAnalyzers)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" VersionOverride="$(MicrosoftCodeAnalysisVersionForAnalyzers)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" VersionOverride="$(MicrosoftCodeAnalysisVersionForAnalyzers)" />
-    <PackageReference Include="Microsoft.Build" VersionOverride="$(MicrosoftBuildTasksCoreVersionForMetrics)" ExcludeAssets="Runtime" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" VersionOverride="$(MicrosoftBuildTasksCoreVersionForMetrics)" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.Build" VersionOverride="$(MicrosoftBuildVersionForMetrics)" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" VersionOverride="$(MicrosoftBuildVersionForMetrics)" ExcludeAssets="Runtime" />
     <PackageReference Include="System.Text.Json" VersionOverride="$(SystemTextJsonVersionForMetrics)" />
 
     <PackageReference Include="SQLitePCLRaw.bundle_green" VersionOverride="$(SQLitePCLRawVersion)" ExcludeAssets="All" />


### PR DESCRIPTION
Switched to explicitly specify package version, as the 4.12.0 version of Microsoft.CodeAnalysis.Workspaces.MSBuild references a flagged Microsoft.Build version