### PR TITLE
Fix parameter syntax in pipeline definition

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -322,7 +322,7 @@ extends:
                        -officialSkipTests ${{ parameters.SkipTests }}
                        -officialSkipApplyOptimizationData ${{ parameters.SkipApplyOptimizationData }}
                        -officialSourceBranchName $(SourceBranchName)
-                       -officialIbcDrop $(IbcDrop)
+                       -officialIbcDrop ${{ parameters.IbcDrop }}
                        -officialVisualStudioDropAccessToken $(_DevDivDropAccessToken)
                        /p:RepositoryName=$(Build.Repository.Name)
                        /p:VisualStudioDropName=$(VisualStudio.DropName)


### PR DESCRIPTION
Not sure why it stopped working now all of a sudden but this should fix official builds.
Validation: https://dev.azure.com/dnceng/internal/_build/results?buildId=2840287&view=results