### PR TITLE
Use `SignatureTypeEncoder.TypedReference()`

### DIFF
--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -3836,9 +3836,7 @@ namespace Microsoft.Cci
             {
                 if (module.IsPlatformType(typeReference, PlatformType.SystemTypedReference))
                 {
-                    // We should use `SignatureTypeEncoder.TypedReference()` once such a method is available
-                    // Tracked by https://github.com/dotnet/runtime/issues/80812
-                    encoder.Builder.WriteByte((byte)SignatureTypeCode.TypedReference);
+                    encoder.TypedReference();
                     return;
                 }
 


### PR DESCRIPTION
Follow-up on https://github.com/dotnet/roslyn/pull/66328 now that the [API](https://github.com/dotnet/runtime/issues/80812) was added
