### PR TITLE
Remove an explicit package version that was only present in the release/dev18.0 branch

### DIFF
--- a/src/Workspaces/MSBuild/Core/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj
+++ b/src/Workspaces/MSBuild/Core/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj
@@ -33,13 +33,6 @@
       we are running against.
     -->
     <PackageReference Include="System.Text.Json" Condition="'$(TargetFramework)' == 'net472'" />
-
-    <!--
-      We use the MSBuild Framework dependency to allow MSBuild ILoggers to be passed when loading projects
-      and solutions. We do not need to be on the latest and instead want to reference an older version that
-      is already available on nuget.org.
-    -->
-    <PackageReference Update="Microsoft.Build.Framework" VersionOverride="17.15.0-preview-25277-114" Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(TargetFramework)' == 'net472'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
It looks like this was added directly to the 18.0 branch during the last package push, and I don't think it should be necessary since MSBuild published their 18.0.2 packages to NuGet.