### PR TITLE
Stack Trace Explorer - Change color for text that is unlinked

### DIFF
--- a/src/VisualStudio/Core/Def/StackTraceExplorer/IgnoredFrameViewModel.cs
+++ b/src/VisualStudio/Core/Def/StackTraceExplorer/IgnoredFrameViewModel.cs
@@ -25,7 +25,7 @@ internal sealed class IgnoredFrameViewModel : FrameViewModel
 
     protected override IEnumerable<Inline> CreateInlines()
     {
-        var run = MakeClassifiedRun(ClassificationTypeNames.ExcludedCode, _frame.ToString());
+        var run = MakeClassifiedRun(ClassificationTypeNames.Comment, _frame.ToString());
         yield return run;
     }
 }


### PR DESCRIPTION
Changed from Excluded Code to Comment. Could also be Text, but that coincides with some of the text in the stack trace so it may look confusing.
<img width="1695" height="487" alt="image" src="https://github.com/user-attachments/assets/c058ff97-e621-4350-a568-1f0104573005" />
versus
<img width="1715" height="502" alt="image" src="https://github.com/user-attachments/assets/40f5c543-8502-4f66-a0b1-3e0c424fc557" />
