### PR TITLE
Add a shorter timeout for retrieving clipboard data

### DIFF
--- a/src/EditorFeatures/Core/StringCopyPaste/WpfStringCopyPasteService.cs
+++ b/src/EditorFeatures/Core/StringCopyPaste/WpfStringCopyPasteService.cs
@@ -12,7 +12,6 @@ using System.Threading;
 using System.Windows.Forms;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.VisualStudio;
 using IComDataObject = System.Runtime.InteropServices.ComTypes.IDataObject;
 
 namespace Microsoft.CodeAnalysis.Editor.StringCopyPaste;
@@ -84,7 +83,7 @@ internal sealed class WpfStringCopyPasteService() : IStringCopyPasteService
         do
         {
             hr = OleGetClipboard(ref dataObject);
-            if (!ErrorHandler.Succeeded(hr))
+            if (hr != 0)
             {
                 if (retry == 0)
                     return null;


### PR DESCRIPTION
Winforms exposes this (and we make use of it) already for setting clipboard data.  This just exposes the same for reading clipboard data.

Noticed in local development where cutting code could take up to 1 second due to other apps on my system locking the clipboard.