### PR TITLE
Fix RoslynAssembliesPath when toolset package is used in fx builds

### DIFF
--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/AnyCpu/build/Microsoft.Net.Compilers.Toolset.props
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/AnyCpu/build/Microsoft.Net.Compilers.Toolset.props
@@ -26,7 +26,7 @@
 
     <!-- Framework/Core (depending on the host) compiler assemblies. -->
     <RoslynAssembliesPath Condition="'$(RoslynAssembliesPath)' == '' and '$(MSBuildRuntimeType)' == 'Core'">$(RoslynCoreAssembliesPath)</RoslynAssembliesPath>
-    <RoslynAssembliesPath Condition="'$(RoslynAssembliesPath)' == '' and '$(MSBuildRuntimeType)' != 'Core'">$(_RoslynTasksDirectory)</RoslynAssembliesPath>
+    <RoslynAssembliesPath Condition="'$(RoslynAssembliesPath)' == '' and '$(MSBuildRuntimeType)' != 'Core'">$(_RoslynTargetsDirectory)</RoslynAssembliesPath>
 
     <RoslynTasksAssembly Condition="'$(_UseRoslynBridgeTask)' != 'true'">$(_RoslynTasksDirectory)Microsoft.Build.Tasks.CodeAnalysis.dll</RoslynTasksAssembly>
     <RoslynTasksAssembly Condition="'$(_UseRoslynBridgeTask)' == 'true'">$(_RoslynTasksDirectory)Microsoft.Build.Tasks.CodeAnalysis.Sdk.dll</RoslynTasksAssembly>


### PR DESCRIPTION
Follow up on https://github.com/dotnet/roslyn/pull/80631.

Validation:
- Broken here: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/689538
- With this PR fixed here: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/689871