### PR TITLE
Another round of ComponentGovernance fixes for 17.12

### DIFF
--- a/eng/Directory.Packages.props
+++ b/eng/Directory.Packages.props
@@ -39,17 +39,17 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(TargetFramework)' != 'net472'">
-    <PackageVersion Include="Microsoft.Build" Version="17.8.29" />
-    <PackageVersion Include="Microsoft.Build.Framework" Version="17.8.29" />
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.8.29" />
-    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.8.29" />
+    <PackageVersion Include="Microsoft.Build" Version="17.8.43" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="17.8.43" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.8.43" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.8.43" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(TargetFramework)' == 'net472'">
-    <PackageVersion Include="Microsoft.Build" Version="17.10.29" />
-    <PackageVersion Include="Microsoft.Build.Framework" Version="17.10.29" />
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.10.29" />
-    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.10.29" />
+    <PackageVersion Include="Microsoft.Build" Version="17.10.46" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="17.10.46" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.10.46" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.10.46" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -35,7 +35,7 @@
     <SystemSecurityPermissionsVersion>8.0.0</SystemSecurityPermissionsVersion>
     <!-- Note: When updating SystemTextJsonVersion ensure that the version is no higher than what is used by MSBuild. -->
     <SystemTextEncodingsWebVersion>8.0.0</SystemTextEncodingsWebVersion>
-    <SystemTextJsonVersion>8.0.4</SystemTextJsonVersion>
+    <SystemTextJsonVersion>8.0.5</SystemTextJsonVersion>
     <SystemThreadingTasksDataflowVersion>8.0.0</SystemThreadingTasksDataflowVersion>
     <SystemWindowsExtensionsVersion>8.0.0</SystemWindowsExtensionsVersion>
     <MicrosoftBclAsyncInterfacesVersion>8.0.0</MicrosoftBclAsyncInterfacesVersion>


### PR DESCRIPTION
Not sure why the last round didn't have me update the MSBuild ones directly to these suggested versions. Maybe it's a new item, or maybe I just missed something.