### PR TITLE
[release/dev18.0] Fix comparer in StringTokenMap

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Emit/StringTokenMapTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Emit/StringTokenMapTests.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis.CodeGen;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests.Emit;
+
+public sealed class StringTokenMapTests
+{
+    [Fact, WorkItem("https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2641964")]
+    public void UniqueStrings()
+    {
+        var map = new StringTokenMap(initialHeapSize: 0);
+        var a1 = new string('a', 5);
+        var a2 = new string('a', 5);
+        Assert.Equal(a1, a2);
+        Assert.NotSame(a1, a2);
+        Assert.True(map.TryGetOrAddToken(a1, out var token1));
+        Assert.True(map.TryGetOrAddToken(a2, out var token2));
+        var b = "b";
+        Assert.True(map.TryGetOrAddToken(b, out var token3));
+        Assert.True(map.TryGetOrAddToken(b, out var token4));
+        Assert.Equal((0u, 0u, 1u, 1u), (token1, token2, token3, token4));
+        Assert.Equal(["aaaaa", "b"], map.CopyValues());
+        Assert.Equal("aaaaa", map.GetValue(0));
+        Assert.Equal("b", map.GetValue(1));
+        Assert.Throws<IndexOutOfRangeException>(() => map.GetValue(2));
+    }
+}

--- a/src/Compilers/Core/Portable/CodeGen/StringTokenMap.cs
+++ b/src/Compilers/Core/Portable/CodeGen/StringTokenMap.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CodeGen;
 /// </summary>
 internal sealed class StringTokenMap(int initialHeapSize)
 {
-    private readonly ConcurrentDictionary<string, uint> _valueToToken = new ConcurrentDictionary<string, uint>(ReferenceEqualityComparer.Instance);
+    private readonly ConcurrentDictionary<string, uint> _valueToToken = new ConcurrentDictionary<string, uint>(StringComparer.Ordinal);
     private readonly ArrayBuilder<string> _uniqueValues = [];
     private int _heapSize = initialHeapSize;
 


### PR DESCRIPTION
Backport of https://github.com/dotnet/roslyn/pull/81341.

QB workitem: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2643422

### Customer Impact

Customers are unable to build large projects which contain many string literals because the limit is being computed incorrectly. The [vsfeedback ticket](https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2641964) has collected 4 votes in 1 day.

### Regression

- [x] Yes - from https://github.com/dotnet/roslyn/pull/78033; worked in VS 2022, broken in VS 2026
- [ ] No

### Testing

Verified manually on user's repro. Also added a unit test.

### Risk

Low. Simple change.