### PR TITLE
Document Outline - Add selection indicator at left edge of items

### DIFF
--- a/src/VisualStudio/Core/Def/DocumentOutline/DocumentOutlineView.xaml
+++ b/src/VisualStudio/Core/Def/DocumentOutline/DocumentOutlineView.xaml
@@ -94,16 +94,34 @@
             <TreeView.Resources>
                 <HierarchicalDataTemplate DataType="{x:Type self:DocumentSymbolDataViewModel}">
                     <HierarchicalDataTemplate.ItemsSource>
-                        <MultiBinding Converter="{StaticResource ItemSorter}"> <!-- This binding ensures our TreeViewItems are sorted if the collection is changed OR the sort option is changed -->
+                        <MultiBinding Converter="{StaticResource ItemSorter}">
+                            <!-- This binding ensures our TreeViewItems are sorted if the collection is changed OR the sort option is changed -->
                             <Binding Path="Children" />
                             <Binding Path="DataContext.SortOption" RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=UserControl}" />
                         </MultiBinding>
                     </HierarchicalDataTemplate.ItemsSource>
-                    <StackPanel Orientation="Horizontal"
-                                VerticalAlignment="Center">
-                        <imaging:CrispImage Moniker="{Binding ImageMoniker}" Margin="0, 0, 5, 0" />
-                        <TextBlock Text="{Binding Data.Name}" />
-                    </StackPanel>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="3" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <Border x:Name="SelectionIndicator"
+                            Grid.Column="0"
+                            Background="{DynamicResource {x:Static vsui:EnvironmentColors.SnaplinesBrushKey}}"
+                            Visibility="Collapsed" />
+                        <StackPanel Grid.Column="1"
+                                Orientation="Horizontal"
+                                VerticalAlignment="Center"
+                                Margin="5, 0, 0, 0">
+                            <imaging:CrispImage Moniker="{Binding ImageMoniker}" Margin="0, 0, 5, 0" />
+                            <TextBlock Text="{Binding Data.Name}" />
+                        </StackPanel>
+                    </Grid>
+                    <HierarchicalDataTemplate.Triggers>
+                        <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                            <Setter TargetName="SelectionIndicator" Property="Visibility" Value="Visible" />
+                        </DataTrigger>
+                    </HierarchicalDataTemplate.Triggers>
                 </HierarchicalDataTemplate>
                 <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightBrushKey}"
                      Color="{StaticResource {x:Static vsshell:VsColors.ToolboxSelectedHeadingBeginKey}}" />
@@ -120,7 +138,7 @@
                     <Setter Property="AutomationProperties.Name" Value="{Binding Data.Name, Mode=OneWay}" />
                     <!-- See docs above for why we set `NotifyOnSourceUpdated=True, NotifyOnTargetUpdated=False` -->
                     <Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay, NotifyOnSourceUpdated=True, NotifyOnTargetUpdated=False}" />
-                    <Setter Property="Padding" Value="4, 0, 6, 1" />
+                    <Setter Property="Padding" Value="0, 0, 6, 1" />
                     <Setter Property="Margin" Value="0, 0, 0, 1" />
                 </Style>
             </TreeView.ItemContainerStyle>


### PR DESCRIPTION
Added to fix color contrast issues.

<img width="524" height="622" alt="image" src="https://github.com/user-attachments/assets/cd4e7757-6b49-4956-8d5a-6edc30c39691" />
