### PR TITLE
Map edits in LSP rename, like in VS

### DIFF
--- a/src/LanguageServer/Protocol/Handler/Rename/RenameHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Rename/RenameHandler.cs
@@ -67,18 +67,8 @@ internal sealed class RenameHandler() : ILspServiceDocumentRequestHandler<LSP.Re
         // Linked files can correspond to multiple roslyn documents each with changes.  Merge the changes in the linked files so that all linked documents have the same text.
         // Then we can just take the text changes from the first document to avoid returning duplicate edits.
         renamedSolution = await renamedSolution.WithMergedLinkedFileChangesAsync(oldSolution, solutionChanges, cancellationToken: cancellationToken).ConfigureAwait(false);
-        solutionChanges = renamedSolution.GetChanges(oldSolution);
 
-        var changedDocuments = solutionChanges
-            .GetProjectChanges()
-            .SelectMany(p => p.GetChangedDocuments(onlyGetDocumentsWithTextChanges: true))
-            .GroupBy(docId => renamedSolution.GetRequiredDocument(docId).FilePath, StringComparer.OrdinalIgnoreCase).Select(group => group.First())
-            .Concat(solutionChanges.GetExplicitlyChangedSourceGeneratedDocuments());
-
-        var textDiffService = renamedSolution.Services.GetRequiredService<IDocumentTextDifferencingService>();
-
-        var documentEdits = await ProtocolConversions.ChangedDocumentsToTextDocumentEditsAsync(changedDocuments, renamedSolution, oldSolution,
-            textDiffService, cancellationToken).ConfigureAwait(false);
+        var documentEdits = await ProtocolConversions.ChangedDocumentsToTextDocumentEditsAsync(renamedSolution, oldSolution, cancellationToken).ConfigureAwait(false);
 
         return new WorkspaceEdit { DocumentChanges = documentEdits };
     }

--- a/src/Workspaces/CoreTestUtilities/Workspaces/TestWorkspace`1.cs
+++ b/src/Workspaces/CoreTestUtilities/Workspaces/TestWorkspace`1.cs
@@ -404,7 +404,7 @@ public abstract partial class TestWorkspace<TDocument, TProject, TSolution> : Wo
         var hostProject = this.GetTestProject(info.Id.ProjectId);
         Contract.ThrowIfNull(hostProject);
 
-        var hostDocument = CreateDocument(text.ToString(), info.Name, id: info.Id, exportProvider: ExportProvider);
+        var hostDocument = CreateDocument(text.ToString(), info.Name, id: info.Id, filePath: info.FilePath, folders: info.Folders, exportProvider: ExportProvider);
         hostProject.AddAdditionalDocument(hostDocument);
         this.OnAdditionalDocumentAdded(hostDocument.ToDocumentInfo());
     }


### PR DESCRIPTION
Not sure how I missed this, but in https://github.com/dotnet/roslyn/pull/79604 rename was changed to call a source generated document edit helper to allow Razor to map edits when rename originates from a C# document. This brings that to LSP too.

More extensive tests coming in a Razor-side PR for this too.