### PR TITLE
Reorder CI steps

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -491,16 +491,16 @@ stages:
           custom: 'run'
           arguments: '--file $(Build.SourcesDirectory)/eng/generate-compiler-code.cs -- -test -configuration Release'
 
-      - powershell: eng/validate-code-formatting.ps1 -ci -rootDirectory $(Build.SourcesDirectory)\src -includeDirectories Compilers\CSharp\Portable\Generated\, Compilers\VisualBasic\Portable\Generated\, ExpressionEvaluator\VisualBasic\Source\ResultProvider\Generated\ 
-        displayName: Validate Generated Syntax Files
-        condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['compilerChange'], 'true'))
-
       - task: DotNetCoreCLI@2
         displayName: Verify Synchronized Sources
         inputs:
           command: 'custom'
           custom: 'run'
           arguments: '--file $(Build.SourcesDirectory)/eng/ensure-sources-synced.cs'
+
+      - powershell: eng/validate-code-formatting.ps1 -ci -rootDirectory $(Build.SourcesDirectory)\src -includeDirectories Compilers\CSharp\Portable\Generated\, Compilers\VisualBasic\Portable\Generated\, ExpressionEvaluator\VisualBasic\Source\ResultProvider\Generated\ 
+        displayName: Validate Generated Syntax Files
+        condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['compilerChange'], 'true'))
 
       - template: eng/pipelines/publish-logs.yml
         parameters:


### PR DESCRIPTION
`eng/validate-code-formatting.ps1 -ci` kills build processes, so it's nice to have it run before `publish-logs.yml` which uploads compiler server logs which fails if they are used by a leftover running compiler server process.