### PR TITLE
Update Roslyn LSP server to .net10

### DIFF
--- a/eng/targets/TargetFrameworks.props
+++ b/eng/targets/TargetFrameworks.props
@@ -15,7 +15,7 @@
     <NetRoslyn>net9.0</NetRoslyn>
     <NetRoslynAll>net8.0;net9.0</NetRoslynAll>
     <NetVS>net8.0</NetVS>
-    <NetVSCode>net9.0</NetVSCode>
+    <NetVSCode>net10.0</NetVSCode>
     <NetVSShared>net8.0</NetVSShared>
     <NetRoslynBuildHostNetCoreVersion>net8.0</NetRoslynBuildHostNetCoreVersion>
     <NetRoslynNext>net10.0</NetRoslynNext>


### PR DESCRIPTION
C# and C#DK are wanting to target .NET 10 as it is the new LTS release.