### PR TITLE
Fix InvalidCastException in ConvertForToForEach with tuples

### DIFF
--- a/src/Features/CSharpTest/ConvertForToForEach/ConvertForToForEachTests.cs
+++ b/src/Features/CSharpTest/ConvertForToForEach/ConvertForToForEachTests.cs
@@ -1277,6 +1277,25 @@ public sealed class ConvertForToForEachTests : AbstractCSharpCodeActionTest_NoEd
             }
             """);
 
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/81530")]
+    public Task TestNotWithIterationVariableInTupleExpression()
+        => TestMissingInRegularAndScriptAsync(
+            """
+            using System;
+
+            class C
+            {
+                void Test(string[] array)
+                {
+                    [||]for (int i = 0; i < array.Length; i++)
+                    {
+                        var tuple = (array[i], i);
+                        Console.WriteLine(tuple);
+                    }
+                }
+            }
+            """);
+
     [Fact]
     public Task TestMultidimensionalArray1()
         => TestMissingInRegularAndScriptAsync(

--- a/src/Features/Core/Portable/ConvertForToForEach/AbstractConvertForToForEachCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertForToForEach/AbstractConvertForToForEachCodeRefactoringProvider.cs
@@ -162,11 +162,8 @@ internal abstract class AbstractConvertForToForEachCodeRefactoringProvider<
                     if (argumentList is null)
                         return true;
 
-                    var arguments = syntaxFacts.GetArgumentsOfArgumentList(argumentList);
-                    // was used in a multi-dimensional indexing, or multiple argument method call.  Can't convert this.
-                    if (arguments.Count != 1)
-                        return true;
-
+                    // Check if this is a valid element access or invocation BEFORE getting arguments
+                    // to avoid InvalidCastException when argumentList is something like TupleExpressionSyntax
                     if (!IsGoodElementAccessExpression(argumentList) &&
                         !IsGoodInvocationExpression(argumentList))
                     {
@@ -174,6 +171,11 @@ internal abstract class AbstractConvertForToForEachCodeRefactoringProvider<
                         // can't convert this for-loop.
                         return true;
                     }
+
+                    var arguments = syntaxFacts.GetArgumentsOfArgumentList(argumentList);
+                    // was used in a multi-dimensional indexing, or multiple argument method call.  Can't convert this.
+                    if (arguments.Count != 1)
+                        return true;
                 }
 
                 // this usage of the for-variable is fine.


### PR DESCRIPTION
Fixes [81530](https://github.com/dotnet/roslyn/issues/81530)

## Problem
VS crashes with `InvalidCastException` when "Convert to foreach" refactoring analyzes
a for loop where the iteration variable is used inside a tuple:

```csharp
for (int i = 0; i < array.Length; i++)
{
    var tuple = (array[i], i);  // crash here
}
```
### Cause
`TupleExpressionSyntax` contains `ArgumentSyntax` children but is NOT a `BaseArgumentListSyntax`
The code assumed argument's parent is always a valid argument list.

### Fix
Check if it's a valid element access or invocation BEFORE calling `GetArgumentsOfArgumentList`

### Testing
Added `TestNotWithIterationVariableInTupleExpression`
