### PR TITLE
Build our libraries against net10.0

### DIFF
--- a/eng/targets/TargetFrameworks.props
+++ b/eng/targets/TargetFrameworks.props
@@ -13,7 +13,7 @@
   -->
   <PropertyGroup>
     <NetRoslyn>net9.0</NetRoslyn>
-    <NetRoslynAll>net8.0;net9.0</NetRoslynAll>
+    <NetRoslynAll>net8.0;net9.0;net10.0</NetRoslynAll>
     <NetVS>net8.0</NetVS>
     <NetVSCode>net10.0</NetVSCode>
     <NetVSShared>net8.0</NetVSShared>

--- a/eng/test-rebuild.ps1
+++ b/eng/test-rebuild.ps1
@@ -60,6 +60,7 @@ try {
   " --exclude netstandard2.0\Microsoft.CodeAnalysis.Contracts.Package.dll" +
   " --exclude net8.0\Microsoft.CodeAnalysis.Contracts.Package.dll" +
   " --exclude net9.0\Microsoft.CodeAnalysis.Contracts.Package.dll" +
+  " --exclude net10.0\Microsoft.CodeAnalysis.Contracts.Package.dll" +
   " --exclude netcoreapp3.1\Microsoft.CodeAnalysis.Collections.Package.dll" +
   " --exclude netstandard2.0\Microsoft.CodeAnalysis.Collections.Package.dll" +
   " --exclude netstandard2.0\Microsoft.CodeAnalysis.Debugging.Package.dll" +


### PR DESCRIPTION
Missed as part of building the Roslyn LSP against net10.0 was also building our libraries against net10.0.