### PR TITLE
Fix regex escape sequence typo in Simplified Chinese localization

### DIFF
--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -2409,7 +2409,7 @@ If ECMAScript-compliant behavior is specified, \s is equivalent to [ \f\n\r\t\v]
 
     \f	换页符 \u000C
     \n	换行符 \u000A
-    \rr	回车符 \u000D
+    \r	回车符 \u000D
     \t	制表符 \u0009
     \v	垂直制表符 \u000B
     \x85	省略号或下一行(NEL)字符(…) \u0085


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/81555
Fixes a typo in the Simplified Chinese translation for the `\s` regex tooltip.
The carriage return escape sequence was incorrectly shown as `\rr` instead of `\r`.

File: src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf