### PR TITLE
SyntheticBoundNodeFactory: Remove ability to create arbitrary conversions 

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
@@ -90,6 +90,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         private void EmitConversion(BoundConversion conversion)
         {
+            AssertIsEmitConversionKind(conversion.ConversionKind);
+
             switch (conversion.ConversionKind)
             {
                 case ConversionKind.Identity:
@@ -176,6 +178,34 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 case ConversionKind.ExplicitNullable:
                 default:
                     throw ExceptionUtilities.UnexpectedValue(conversion.ConversionKind);
+            }
+        }
+
+        [Conditional("DEBUG")]
+        internal static void AssertIsEmitConversionKind(ConversionKind conversionKind)
+        {
+            switch (conversionKind)
+            {
+                case ConversionKind.Identity:
+                case ConversionKind.ImplicitNumeric:
+                case ConversionKind.ExplicitNumeric:
+                case ConversionKind.ImplicitReference:
+                case ConversionKind.Boxing:
+                case ConversionKind.ExplicitReference:
+                case ConversionKind.Unboxing:
+                case ConversionKind.ImplicitEnumeration:
+                case ConversionKind.ExplicitEnumeration:
+                case ConversionKind.ImplicitPointerToVoid:
+                case ConversionKind.ExplicitPointerToPointer:
+                case ConversionKind.ImplicitPointer:
+                case ConversionKind.ExplicitPointerToInteger:
+                case ConversionKind.ExplicitIntegerToPointer:
+                case ConversionKind.PinnedObjectToPointer:
+                case ConversionKind.ImplicitNullToPointer:
+                    break;
+                default:
+                    ExceptionUtilities.UnexpectedValue(conversionKind);
+                    break;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Compiler/AnonymousTypeMethodBodySynthesizer.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/AnonymousTypeMethodBodySynthesizer.cs
@@ -122,9 +122,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 //  Generate expression for return statement
                 //      retExpression <= 'local != null'
+                Conversion c = F.ClassifyEmitConversion(boundLocal, manager.System_Object);
+                Debug.Assert(c.IsImplicit);
+                Debug.Assert(c.IsReference);
+
                 BoundExpression retExpression = F.Binary(BinaryOperatorKind.ObjectNotEqual,
                                                          manager.System_Boolean,
-                                                         F.Convert(manager.System_Object, boundLocal),
+                                                         F.Convert(manager.System_Object, boundLocal, c),
                                                          F.Null(manager.System_Object));
 
                 // Compare fields

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncExceptionHandlerRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncExceptionHandlerRewriter.cs
@@ -613,11 +613,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var catchType = node.ExceptionTypeOpt ?? _F.SpecialType(SpecialType.System_Object);
             var catchTemp = _F.SynthesizedLocal(catchType);
+            BoundLocal carchTempRef = _F.Local(catchTemp);
+            TypeSymbol pendingCaughtExceptionType = currentAwaitCatchFrame.pendingCaughtException.Type;
+            Debug.Assert(pendingCaughtExceptionType.IsObjectType());
+            Conversion c = _F.ClassifyEmitConversion(carchTempRef, pendingCaughtExceptionType);
+            Debug.Assert(c.IsImplicit);
+            Debug.Assert(c.IsReference || c.IsIdentity);
 
             var storePending = _F.AssignmentExpression(
                         _F.Local(currentAwaitCatchFrame.pendingCaughtException),
-                        _F.Convert(currentAwaitCatchFrame.pendingCaughtException.Type,
-                            _F.Local(catchTemp)));
+                        _F.Convert(pendingCaughtExceptionType,
+                                   carchTempRef,
+                                   c));
 
             var setPendingCatchNum = _F.Assignment(
                             _F.Local(currentAwaitCatchFrame.pendingCatch),
@@ -728,11 +735,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (rewrittenSource != null)
             {
                 // exceptionSource = (exceptionSourceType)pendingCaughtException;
+                BoundLocal pendingExceptionRef = _F.Local(currentAwaitCatchFrame.pendingCaughtException);
+                TypeSymbol rewrittenSourceType = rewrittenSource.Type;
+                Debug.Assert(pendingExceptionRef.Type.IsObjectType());
+                Conversion c = _F.ClassifyEmitConversion(pendingExceptionRef, rewrittenSourceType);
+                Debug.Assert(c.IsReference || c.IsIdentity);
                 assignSource = _F.AssignmentExpression(
                                     rewrittenSource,
                                     _F.Convert(
-                                        rewrittenSource.Type,
-                                        _F.Local(currentAwaitCatchFrame.pendingCaughtException)));
+                                        rewrittenSourceType,
+                                        pendingExceptionRef,
+                                        c));
             }
 
             return assignSource;

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
@@ -485,13 +485,23 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // Emit await yield point to be injected into PDB
                     F.NoOp(NoOpStatementFlavor.AwaitYieldPoint));
 
+            // this.<>t__awaiter = $awaiterTemp
+
+            BoundExpression awaiterTempRef = F.Local(awaiterTemp);
+
+            if (!TypeSymbol.Equals(awaiterFieldType, awaiterTemp.Type, TypeCompareKind.ConsiderEverything2))
+            {
+                Debug.Assert(awaiterFieldType.IsObjectType());
+                Conversion c = F.ClassifyEmitConversion(awaiterTempRef, awaiterFieldType);
+                Debug.Assert(c.IsImplicit);
+                Debug.Assert(c.IsReference || c.IsIdentity);
+                awaiterTempRef = F.Convert(awaiterFieldType, awaiterTempRef, c);
+            }
+
             blockBuilder.Add(
-                    // this.<>t__awaiter = $awaiterTemp
                     F.Assignment(
                     F.Field(F.This(), awaiterField),
-                    (TypeSymbol.Equals(awaiterField.Type, awaiterTemp.Type, TypeCompareKind.ConsiderEverything2))
-                        ? F.Local(awaiterTemp)
-                        : F.Convert(awaiterFieldType, F.Local(awaiterTemp))));
+                    awaiterTempRef));
 
             blockBuilder.Add(awaiterTemp.Type.IsDynamic()
                 ? GenerateAwaitOnCompletedDynamic(awaiterTemp)
@@ -516,14 +526,23 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // Emit await resume point to be injected into PDB
                     F.NoOp(NoOpStatementFlavor.AwaitResumePoint));
 
+            // $awaiterTemp = this.<>t__awaiter   or   $awaiterTemp = (AwaiterType)this.<>t__awaiter
+            // $this.<>t__awaiter = null;
+
+            BoundExpression awaiterFieldRef = F.Field(F.This(), awaiterField);
+
+            if (!TypeSymbol.Equals(awaiterTemp.Type, awaiterField.Type, TypeCompareKind.ConsiderEverything2))
+            {
+                Debug.Assert(awaiterFieldRef.Type.IsObjectType());
+                Conversion c = F.ClassifyEmitConversion(awaiterFieldRef, awaiterTemp.Type);
+                Debug.Assert(c.IsReference || c.IsIdentity);
+                awaiterFieldRef = F.Convert(awaiterTemp.Type, awaiterFieldRef, c);
+            }
+
             blockBuilder.Add(
-                    // $awaiterTemp = this.<>t__awaiter   or   $awaiterTemp = (AwaiterType)this.<>t__awaiter
-                    // $this.<>t__awaiter = null;
                     F.Assignment(
                     F.Local(awaiterTemp),
-                    TypeSymbol.Equals(awaiterTemp.Type, awaiterField.Type, TypeCompareKind.ConsiderEverything2)
-                        ? F.Field(F.This(), awaiterField)
-                        : F.Convert(awaiterTemp.Type, F.Field(F.This(), awaiterField))));
+                    awaiterFieldRef));
 
             blockBuilder.Add(
                 F.Assignment(F.Field(F.This(), awaiterField), F.NullOrDefault(awaiterField.Type)));

--- a/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/ExpressionLambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/ExpressionLambdaRewriter.cs
@@ -19,6 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly SyntheticBoundNodeFactory _bound;
         private readonly TypeMap _typeMap;
         private readonly Dictionary<ParameterSymbol, BoundExpression> _parameterMap = new Dictionary<ParameterSymbol, BoundExpression>();
+        private Dictionary<BoundValuePlaceholder, BoundExpression> _placeholderReplacementMap;
         private int _recursionDepth;
 
         private NamedTypeSymbol _ExpressionType;
@@ -173,7 +174,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             _bound.Syntax = node.Syntax;
             var result = VisitInternal(node);
             _bound.Syntax = old;
-            return _bound.Convert(ExpressionType, result);
+            Conversion c = _bound.ClassifyEmitConversion(result, ExpressionType);
+            Debug.Assert(c.IsImplicit);
+            Debug.Assert(c.IsReference || c.IsIdentity);
+            return _bound.Convert(ExpressionType, result, c);
         }
 
         private BoundExpression VisitExpressionWithoutStackGuard(BoundExpression node)
@@ -246,6 +250,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.ThisReference:
                 case BoundKind.TypeOfOperator:
                     return Constant(node);
+                case BoundKind.ValuePlaceholder:
+                    return _placeholderReplacementMap[(BoundValuePlaceholder)node];
                 default:
                     throw ExceptionUtilities.UnexpectedValue(node.Kind);
             }
@@ -758,7 +764,17 @@ namespace Microsoft.CodeAnalysis.CSharp
         private BoundExpression DelegateCreation(BoundExpression receiver, MethodSymbol method, TypeSymbol delegateType, bool requiresInstanceReceiver)
         {
             var nullObject = _bound.Null(_objectType);
-            receiver = requiresInstanceReceiver ? nullObject : receiver.Type.IsReferenceType ? receiver : _bound.Convert(_objectType, receiver);
+            if (requiresInstanceReceiver)
+            {
+                receiver = nullObject;
+            }
+            else if (!receiver.Type.IsReferenceType)
+            {
+                Conversion c = _bound.ClassifyEmitConversion(receiver, _objectType);
+                Debug.Assert(c.IsImplicit);
+                Debug.Assert(c.IsBoxing);
+                receiver = _bound.Convert(_objectType, receiver, c);
+            }
 
             var createDelegate = _bound.WellKnownMethod(WellKnownMember.System_Reflection_MethodInfo__CreateDelegate, isOptional: true);
             BoundExpression unquoted;
@@ -875,36 +891,38 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var left = Visit(node.LeftOperand);
             var right = Visit(node.RightOperand);
-            if (BoundNode.GetConversion(node.LeftConversion, node.LeftPlaceholder) is { IsUserDefined: true } leftConversion)
+            if (BoundNode.GetConversion(node.LeftConversion, node.LeftPlaceholder) is { IsUserDefined: true })
             {
                 Debug.Assert(node.LeftPlaceholder is not null);
-                TypeSymbol lambdaParamType = node.LeftPlaceholder.Type;
-                return _bound.StaticCall(WellKnownMember.System_Linq_Expressions_Expression__Coalesce_Lambda, left, right, MakeConversionLambda(leftConversion, lambdaParamType, node.LeftConversion.Type));
+                return _bound.StaticCall(WellKnownMember.System_Linq_Expressions_Expression__Coalesce_Lambda, left, right, makeConversionLambda(node.LeftConversion, node.LeftPlaceholder));
             }
             else
             {
                 return _bound.StaticCall(WellKnownMember.System_Linq_Expressions_Expression__Coalesce, left, right);
             }
-        }
 
-        private BoundExpression MakeConversionLambda(Conversion conversion, TypeSymbol fromType, TypeSymbol toType)
-        {
-            string parameterName = "p";
-            ParameterSymbol lambdaParameter = _bound.SynthesizedParameter(fromType, parameterName);
-            var param = _bound.SynthesizedLocal(ParameterExpressionType);
-            var parameterReference = _bound.Local(param);
-            var parameter = _bound.StaticCall(WellKnownMember.System_Linq_Expressions_Expression__Parameter, _bound.Typeof(fromType, _bound.WellKnownType(WellKnownType.System_Type)), _bound.Literal(parameterName));
-            _parameterMap[lambdaParameter] = parameterReference;
-            var convertedValue = Visit(_bound.Convert(toType, _bound.Parameter(lambdaParameter), conversion));
-            _parameterMap.Remove(lambdaParameter);
-            var result = _bound.Sequence(
-                ImmutableArray.Create(param),
-                ImmutableArray.Create<BoundExpression>(_bound.AssignmentExpression(parameterReference, parameter)),
-                _bound.StaticCall(
-                    WellKnownMember.System_Linq_Expressions_Expression__Lambda,
-                    convertedValue,
-                    _bound.ArrayOrEmpty(ParameterExpressionType, ImmutableArray.Create<BoundExpression>(parameterReference))));
-            return result;
+            BoundExpression makeConversionLambda(BoundExpression leftConversion, BoundValuePlaceholder leftPlaceholder)
+            {
+                string parameterName = "p";
+                var fromType = leftPlaceholder.Type;
+                ParameterSymbol lambdaParameter = _bound.SynthesizedParameter(fromType, parameterName);
+                var param = _bound.SynthesizedLocal(ParameterExpressionType);
+                var parameterReference = _bound.Local(param);
+                var parameter = _bound.StaticCall(WellKnownMember.System_Linq_Expressions_Expression__Parameter, _bound.Typeof(fromType, _bound.WellKnownType(WellKnownType.System_Type)), _bound.Literal(parameterName));
+
+                _placeholderReplacementMap ??= new Dictionary<BoundValuePlaceholder, BoundExpression>();
+                _placeholderReplacementMap.Add(leftPlaceholder, parameterReference);
+                var convertedValue = Visit(leftConversion);
+                _placeholderReplacementMap.Remove(leftPlaceholder);
+                var result = _bound.Sequence(
+                    ImmutableArray.Create(param),
+                    ImmutableArray.Create<BoundExpression>(_bound.AssignmentExpression(parameterReference, parameter)),
+                    _bound.StaticCall(
+                        WellKnownMember.System_Linq_Expressions_Expression__Lambda,
+                        convertedValue,
+                        _bound.ArrayOrEmpty(ParameterExpressionType, ImmutableArray.Create<BoundExpression>(parameterReference))));
+                return result;
+            }
         }
 
         private BoundExpression InitializerMemberSetter(Symbol symbol)
@@ -912,11 +930,23 @@ namespace Microsoft.CodeAnalysis.CSharp
             switch (symbol.Kind)
             {
                 case SymbolKind.Field:
-                    return _bound.Convert(MemberInfoType, _bound.FieldInfo((FieldSymbol)symbol));
+                    {
+                        BoundExpression fieldInfo = _bound.FieldInfo((FieldSymbol)symbol);
+                        Conversion c = _bound.ClassifyEmitConversion(fieldInfo, MemberInfoType);
+                        Debug.Assert(c.IsImplicit);
+                        Debug.Assert(c.IsReference);
+                        return _bound.Convert(MemberInfoType, fieldInfo, c);
+                    }
                 case SymbolKind.Property:
                     return _bound.MethodInfo(((PropertySymbol)symbol).GetOwnOrInheritedSetMethod(), _bound.WellKnownType(WellKnownType.System_Reflection_MethodInfo));
                 case SymbolKind.Event:
-                    return _bound.Convert(MemberInfoType, _bound.FieldInfo(((EventSymbol)symbol).AssociatedField));
+                    {
+                        BoundExpression fieldInfo = _bound.FieldInfo(((EventSymbol)symbol).AssociatedField);
+                        Conversion c = _bound.ClassifyEmitConversion(fieldInfo, MemberInfoType);
+                        Debug.Assert(c.IsImplicit);
+                        Debug.Assert(c.IsReference);
+                        return _bound.Convert(MemberInfoType, fieldInfo, c);
+                    }
                 default:
                     throw ExceptionUtilities.UnexpectedValue(symbol.Kind);
             }
@@ -927,11 +957,23 @@ namespace Microsoft.CodeAnalysis.CSharp
             switch (symbol.Kind)
             {
                 case SymbolKind.Field:
-                    return _bound.Convert(MemberInfoType, _bound.FieldInfo((FieldSymbol)symbol));
+                    {
+                        BoundExpression fieldInfo = _bound.FieldInfo((FieldSymbol)symbol);
+                        Conversion c = _bound.ClassifyEmitConversion(fieldInfo, MemberInfoType);
+                        Debug.Assert(c.IsImplicit);
+                        Debug.Assert(c.IsReference);
+                        return _bound.Convert(MemberInfoType, fieldInfo, c);
+                    }
                 case SymbolKind.Property:
                     return _bound.MethodInfo(((PropertySymbol)symbol).GetOwnOrInheritedGetMethod(), _bound.WellKnownType(WellKnownType.System_Reflection_MethodInfo));
                 case SymbolKind.Event:
-                    return _bound.Convert(MemberInfoType, _bound.FieldInfo(((EventSymbol)symbol).AssociatedField));
+                    {
+                        BoundExpression fieldInfo = _bound.FieldInfo(((EventSymbol)symbol).AssociatedField);
+                        Conversion c = _bound.ClassifyEmitConversion(fieldInfo, MemberInfoType);
+                        Debug.Assert(c.IsImplicit);
+                        Debug.Assert(c.IsReference);
+                        return _bound.Convert(MemberInfoType, fieldInfo, c);
+                    }
                 default:
                     throw ExceptionUtilities.UnexpectedValue(symbol.Kind);
             }
@@ -1061,7 +1103,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var ctor = _bound.ConstructorInfo(node.Constructor);
-            var args = _bound.Convert(_IEnumerableType.Construct(ExpressionType), Expressions(node.Arguments));
+            NamedTypeSymbol iEnumerableType = _IEnumerableType.Construct(ExpressionType);
+            BoundExpression args = Expressions(node.Arguments);
+            Debug.Assert(args.Type.IsSZArray());
+            Conversion c = _bound.ClassifyEmitConversion(args, iEnumerableType);
+            Debug.Assert(c.IsImplicit);
+            Debug.Assert(c.IsReference);
+            args = _bound.Convert(iEnumerableType, args, c);
             if (node.Type.IsAnonymousType && node.Arguments.Length != 0)
             {
                 var anonType = (NamedTypeSymbol)node.Type;
@@ -1202,9 +1250,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundExpression Constant(BoundExpression node)
         {
+            Conversion c = _bound.ClassifyEmitConversion(node, _objectType);
+            Debug.Assert(c.IsImplicit);
+            Debug.Assert(c.IsBoxing || c.IsReference || c.IsIdentity);
             return _bound.StaticCall(
                 WellKnownMember.System_Linq_Expressions_Expression__Constant,
-                _bound.Convert(_objectType, node),
+                _bound.Convert(_objectType, node, c),
                 _bound.Typeof(node.Type, _bound.WellKnownType(WellKnownType.System_Type)));
         }
     }

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/LocalStateTracingInstrumenter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/LocalStateTracingInstrumenter.cs
@@ -484,7 +484,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return ImmutableArray.Create(toString, index);
             }
 
-            return ImmutableArray.Create(_factory.Convert(parameter.Type, value), index);
+            Conversion c = _factory.ClassifyEmitConversion(value, parameter.Type);
+            Debug.Assert(c.IsNumeric || c.IsReference || c.IsIdentity || c.IsPointer || c.IsBoxing || c.IsEnumeration);
+            return ImmutableArray.Create(_factory.Convert(parameter.Type, value, c), index);
         }
 
         private BoundExpression VariableRead(Symbol localOrParameterSymbol)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.DecisionDagRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.DecisionDagRewriter.cs
@@ -789,13 +789,21 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         case SpecialType.System_IntPtr:
                             {
-                                input = _factory.Convert(_factory.SpecialType(SpecialType.System_Int64), input);
+                                NamedTypeSymbol int64Type = _factory.SpecialType(SpecialType.System_Int64);
+                                Conversion c = _factory.ClassifyEmitConversion(input, int64Type);
+                                Debug.Assert(c.IsImplicit);
+                                Debug.Assert(c.IsNumeric);
+                                input = _factory.Convert(int64Type, input, c);
                                 cases = node.Cases.SelectAsArray(p => (ConstantValue.Create((long)p.value.Int32Value), p.label));
                                 break;
                             }
                         case SpecialType.System_UIntPtr:
                             {
-                                input = _factory.Convert(_factory.SpecialType(SpecialType.System_UInt64), input);
+                                NamedTypeSymbol uint64Type = _factory.SpecialType(SpecialType.System_UInt64);
+                                Conversion c = _factory.ClassifyEmitConversion(input, uint64Type);
+                                Debug.Assert(c.IsImplicit);
+                                Debug.Assert(c.IsNumeric);
+                                input = _factory.Convert(uint64Type, input, c);
                                 cases = node.Cases.SelectAsArray(p => (ConstantValue.Create((ulong)p.value.UInt32Value), p.label));
                                 break;
                             }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
@@ -510,7 +510,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 arrayOrList = CreateAndPopulateList(node, elementType, elements);
             }
 
-            return _factory.Convert(collectionType, arrayOrList);
+            Conversion c = _factory.ClassifyEmitConversion(arrayOrList, collectionType);
+            Debug.Assert(c.IsImplicit);
+            Debug.Assert(c.IsReference || c.IsIdentity);
+            return _factory.Convert(collectionType, arrayOrList, c);
 
             BoundExpression createArray(BoundCollectionExpression node, ArrayTypeSymbol arrayType)
             {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Event.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Event.cs
@@ -307,10 +307,22 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if ((object)addRemove != null)
                 {
+                    TypeSymbol parameters0Type = addRemove.Parameters[0].Type;
+                    Debug.Assert(parameters0Type.IsObjectType());
+                    Conversion c0 = _factory.ClassifyEmitConversion(rewrittenReceiver, parameters0Type);
+                    Debug.Assert(c0.IsImplicit);
+                    Debug.Assert(c0.IsReference);
+
+                    TypeSymbol parameters1Type = addRemove.Parameters[1].Type;
+                    Debug.Assert(parameters1Type.SpecialType == SpecialType.System_Delegate);
+                    Conversion c1 = _factory.ClassifyEmitConversion(rewrittenArgument, parameters1Type);
+                    Debug.Assert(c1.IsImplicit);
+                    Debug.Assert(c1.IsReference);
+
                     BoundExpression eventInfo = _factory.New(ctor, _factory.Typeof(node.Event.ContainingType, ctor.Parameters[0].Type), _factory.Literal(node.Event.MetadataName));
                     result = _factory.Call(eventInfo, addRemove,
-                                          _factory.Convert(addRemove.Parameters[0].Type, rewrittenReceiver),
-                                          _factory.Convert(addRemove.Parameters[1].Type, rewrittenArgument));
+                                          _factory.Convert(parameters0Type, rewrittenReceiver, c0),
+                                          _factory.Convert(parameters1Type, rewrittenArgument, c1));
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectCreationExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectCreationExpression.cs
@@ -183,11 +183,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(withExpr.CloneMethod is not null);
                 Debug.Assert(withExpr.CloneMethod.ParameterCount == 0);
 
+                BoundCall clone = _factory.Call(
+                        rewrittenReceiver,
+                        withExpr.CloneMethod);
+
+                Conversion c = _factory.ClassifyEmitConversion(clone, type);
+                Debug.Assert(c.IsReference || c.IsIdentity);
                 expression = _factory.Convert(
                     type,
-                    _factory.Call(
-                        rewrittenReceiver,
-                        withExpr.CloneMethod));
+                    clone,
+                    c);
             }
 
             return MakeExpressionWithInitializer(
@@ -412,7 +417,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if ((object)createInstance != null)
             {
-                rewrittenObjectCreation = _factory.Convert(node.Type, _factory.Call(null, createInstance, callGetTypeFromCLSID));
+                BoundCall instance = _factory.Call(null, createInstance, callGetTypeFromCLSID);
+                Debug.Assert(instance.Type.IsObjectType());
+                Conversion c = _factory.ClassifyEmitConversion(instance, node.Type);
+                Debug.Assert(c.IsReference);
+                rewrittenObjectCreation = _factory.Convert(node.Type, instance, c);
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/ReadOnlyListType/SynthesizedReadOnlyListEnumeratorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/ReadOnlyListType/SynthesizedReadOnlyListEnumeratorTypeSymbol.cs
@@ -55,8 +55,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         var containingType = (SynthesizedReadOnlyListEnumeratorTypeSymbol)method.ContainingType;
                         var itemField = containingType._itemField;
                         var itemFieldReference = f.Field(f.This(), itemField);
+
+                        Debug.Assert(method.ReturnType.IsObjectType());
+                        Debug.Assert(itemFieldReference.Type.IsTypeParameter());
+
+                        Conversion c = f.ClassifyEmitConversion(itemFieldReference, method.ReturnType);
+                        Debug.Assert(c.IsImplicit);
+                        Debug.Assert(c.IsBoxing);
+
                         // return (object)_item;
-                        return f.Return(f.Convert(method.ReturnType, itemFieldReference));
+                        return f.Return(f.Convert(method.ReturnType, itemFieldReference, c));
                     }));
             addProperty(membersBuilder,
                 new SynthesizedReadOnlyListProperty(

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/ReadOnlyListType/SynthesizedReadOnlyListTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/ReadOnlyListType/SynthesizedReadOnlyListTypeSymbol.cs
@@ -484,11 +484,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 else
                 {
                     // return _items.GetEnumerator();
+                    NamedTypeSymbol interfaceType = interfaceMethod.ContainingType;
+                    Debug.Assert(interfaceType.IsInterface);
+                    Conversion c = f.ClassifyEmitConversion(fieldReference, interfaceType);
+                    Debug.Assert(c.IsImplicit);
+                    Debug.Assert(c.IsReference);
+
                     return f.Return(
                         f.Call(
                             f.Convert(
-                                interfaceMethod.ContainingType,
-                                fieldReference),
+                                interfaceType,
+                                fieldReference,
+                                c),
                             interfaceMethod));
                 }
             }
@@ -532,10 +539,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             static BoundStatement generateSyncRoot(SyntheticBoundNodeFactory f, MethodSymbol method, MethodSymbol interfaceMethod)
             {
                 // return (object)this;
+                BoundThisReference thisRef = f.This();
+                TypeSymbol returnType = interfaceMethod.ReturnType;
+                Debug.Assert(returnType.IsObjectType());
+                Conversion c = f.ClassifyEmitConversion(thisRef, returnType);
+                Debug.Assert(c.IsImplicit);
+                Debug.Assert(c.IsReference);
+
                 return f.Return(
                     f.Convert(
-                        interfaceMethod.ReturnType,
-                        f.This()));
+                        returnType,
+                        thisRef,
+                        c));
             }
 
             // IList.IsFixedSize
@@ -568,11 +583,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 else if (containingType.IsArray || !interfaceMethod.ContainingType.IsGenericType)
                 {
                     // return ((ICollection<T>)_items).Contains(param0);
+                    NamedTypeSymbol interfaceType = interfaceMethod.ContainingType;
+                    Debug.Assert(interfaceType.IsInterface);
+                    Conversion c = f.ClassifyEmitConversion(fieldReference, interfaceType);
+                    Debug.Assert(c.IsImplicit);
+                    Debug.Assert(c.IsReference);
+
                     return f.Return(
                         f.Call(
                             f.Convert(
-                                interfaceMethod.ContainingType,
-                                fieldReference),
+                                interfaceType,
+                                fieldReference,
+                                c),
                             interfaceMethod,
                             parameterReference));
                 }
@@ -604,9 +626,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         var arraySetValueMethod = (MethodSymbol)method.DeclaringCompilation.GetSpecialTypeMember(SpecialMember.System_Array__SetValue)!;
 
                         // param0.SetValue((object)_item, param1)
+                        NamedTypeSymbol objectType = f.SpecialType(SpecialType.System_Object);
+                        Conversion c = f.ClassifyEmitConversion(fieldReference, objectType);
+                        Debug.Assert(c.IsImplicit);
+                        Debug.Assert(c.IsBoxing);
+
                         statement = f.ExpressionStatement(
                             f.Call(parameterReference0, arraySetValueMethod,
-                                f.Convert(f.SpecialType(SpecialType.System_Object), fieldReference),
+                                f.Convert(objectType, fieldReference, c),
                                 parameterReference1));
                     }
                     else
@@ -622,11 +649,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 else if (containingType.IsArray || !interfaceMethod.ContainingType.IsGenericType)
                 {
                     // ((ICollection<T>)_items).CopyTo(param0, param1);
+                    NamedTypeSymbol interfaceType = interfaceMethod.ContainingType;
+                    Debug.Assert(interfaceType.IsInterface);
+                    Conversion c = f.ClassifyEmitConversion(fieldReference, interfaceType);
+                    Debug.Assert(c.IsImplicit);
+                    Debug.Assert(c.IsReference);
+
                     statement = f.ExpressionStatement(
                         f.Call(
                             f.Convert(
-                                interfaceMethod.ContainingType,
-                                fieldReference),
+                                interfaceType,
+                                fieldReference,
+                                c),
                             interfaceMethod,
                             parameterReference0,
                             parameterReference1));
@@ -699,11 +733,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 else if (containingType.IsArray || !interfaceMethod.ContainingType.IsGenericType)
                 {
                     // return ((IList<T>)_items).IndexOf(param0);
+                    NamedTypeSymbol interfaceType = interfaceMethod.ContainingType;
+                    Debug.Assert(interfaceType.IsInterface);
+                    Conversion c = f.ClassifyEmitConversion(fieldReference, interfaceType);
+                    Debug.Assert(c.IsImplicit);
+                    Debug.Assert(c.IsReference);
+
                     return f.Return(
                         f.Call(
                             f.Convert(
-                                interfaceMethod.ContainingType,
-                                fieldReference),
+                                interfaceType,
+                                fieldReference,
+                                c),
                             interfaceMethod,
                             parameterReference));
                 }
@@ -748,6 +789,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var equalityComparerType = equalityComparer_Equals.ContainingType;
                 var constructedEqualityComparer = equalityComparerType.Construct(fieldType);
 
+                Conversion c = f.ClassifyEmitConversion(parameterReference, fieldType);
+                Debug.Assert(c.IsUnboxing || c.IsIdentity);
+
                 // If the parameter type is object:
                 //
                 //      EqualityComparer<T>.Default.Equals(_item, (T)param0)
@@ -762,7 +806,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         equalityComparer_get_Default.AsMember(constructedEqualityComparer)),
                     equalityComparer_Equals.AsMember(constructedEqualityComparer),
                     fieldReference,
-                    f.Convert(fieldType, parameterReference));
+                    f.Convert(fieldType, parameterReference, c));
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordBaseEquals.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordBaseEquals.cs
@@ -62,10 +62,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return;
                 }
 
+                BoundParameter parameterRef = F.Parameter(parameter);
+                NamedTypeSymbol objectType = F.SpecialType(SpecialType.System_Object);
+                Conversion c = F.ClassifyEmitConversion(parameterRef, objectType);
+                Debug.Assert(c.IsImplicit);
+                Debug.Assert(c.IsReference);
+
                 var retExpr = F.Call(
                     F.This(),
                     ContainingType.GetMembersUnordered().OfType<SynthesizedRecordObjEquals>().Single(),
-                    F.Convert(F.SpecialType(SpecialType.System_Object), F.Parameter(parameter)));
+                    F.Convert(objectType, parameterRef, c));
 
                 F.CloseMethod(F.Block(F.Return(retExpr)));
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordEquals.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordEquals.cs
@@ -120,10 +120,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     // virtual bool Equals(Derived other) =>
                     //     (object)other == this || (base.Equals((Base)other) &&
                     //     field1 == other.field1 && ... && fieldN == other.fieldN);
+                    TypeSymbol baseType = baseEquals.Parameters[0].Type;
+                    Conversion c = F.ClassifyEmitConversion(other, baseType);
+                    Debug.Assert(c.IsImplicit);
+                    Debug.Assert(c.IsReference);
                     retExpr = F.Call(
                         F.Base(baseEquals.ContainingType),
                         baseEquals,
-                        F.Convert(baseEquals.Parameters[0].Type, other));
+                        F.Convert(baseType, other, c));
                 }
 
                 // field1 == other.field1 && ... && fieldN == other.fieldN

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordObjEquals.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordObjEquals.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -58,9 +59,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     // For record structs:
                     //      return other is R && Equals((R)other)
+                    Debug.Assert(paramAccess.Type.IsObjectType());
+                    Conversion c = F.ClassifyEmitConversion(paramAccess, ContainingType);
+                    Debug.Assert(c.IsUnboxing);
                     expression = F.LogicalAnd(
                         F.Is(paramAccess, ContainingType),
-                        F.Call(F.This(), _typedRecordEquals, F.Convert(ContainingType, paramAccess)));
+                        F.Call(F.This(), _typedRecordEquals, F.Convert(ContainingType, paramAccess, c)));
                 }
                 else
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordPrintMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordPrintMembers.cs
@@ -216,10 +216,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     else if (!value.Type.IsRestrictedType())
                     {
                         // Otherwise, an error has been reported elsewhere (SourceMemberFieldSymbol.TypeChecks)
+                        var objectType = F.SpecialType(SpecialType.System_Object);
+                        Conversion c = F.ClassifyEmitConversion(value, objectType);
+                        Debug.Assert(c.IsImplicit);
+                        Debug.Assert(c.IsIdentity || c.IsReference || c.IsBoxing);
                         block.Add(F.ExpressionStatement(
                             F.Call(receiver: builder,
                                 F.WellKnownMethod(WellKnownMember.System_Text_StringBuilder__AppendObject),
-                                F.Convert(F.SpecialType(SpecialType.System_Object), value))));
+                                F.Convert(objectType, value, c))));
                     }
                 }
 


### PR DESCRIPTION
Language rules around conversions are getting more and more complex. At the same time Convert APIs in SyntheticBoundNodeFactory might confuse consumer into thinking that they are able to synthesize nodes for arbitrary conversions, which is not the case.

This change removes one API and adds an assert to remaining API to verify that only conversions that are natively supported by Emit layer are coming through.