### PR TITLE
[release/dev18.0] Fix null reference crash in CheckUnderspecifiedGenericExtension for namespace-level extensions

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -532,7 +532,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(extensionMember.GetIsNewExtensionMember());
 
             NamedTypeSymbol extension = extensionMember.ContainingType;
-            if (extension.ExtensionParameter is not { } extensionParameter || extension.ContainingType.Arity != 0)
+            if (extension.ExtensionParameter is not { } extensionParameter || extension.ContainingType?.Arity != 0)
             {
                 // error cases, already reported elsewhere
                 return;

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
@@ -3303,6 +3303,22 @@ public static class E
     }
 
     [Fact]
+    public void ReceiverParameter_TypeParameter_TopLevelExtension()
+    {
+        var src = """
+extension<T>(int i)
+{
+    public int P => 0;
+}
+""";
+        var comp = CreateCompilation(src);
+        comp.VerifyEmitDiagnostics(
+            // (1,1): error CS9283: Extensions must be declared in a top-level, non-generic, static class
+            // extension<T>(int)
+            Diagnostic(ErrorCode.ERR_BadExtensionContainingType, "extension").WithLocation(1, 1));
+    }
+
+    [Fact]
     public void ReceiverParameter_TypeParameter_Missing_Local()
     {
         var src = """
@@ -4269,6 +4285,7 @@ public static class Extensions
         var type = tree.GetRoot().DescendantNodes().OfType<ExtensionBlockDeclarationSyntax>().Single();
         var symbol = model.GetDeclaredSymbol(type);
         AssertEx.Equal("?", symbol.ExtensionParameter.ToTestDisplayString());
+        Assert.True(symbol.ExtensionParameter.Type.IsErrorType());
     }
 
     [Fact]
@@ -50910,6 +50927,47 @@ public class D { }
     </members>
 </doc>
 """, GetDocumentationCommentText(comp));
+    }
+
+    [Fact]
+    public void XmlDoc_18()
+    {
+        // Extension without containing type
+        var src = """
+/// <summary>Summary for extension block</summary>
+extension<T>(T t)
+{
+}
+""";
+        var comp = CreateCompilation(src, parseOptions: TestOptions.RegularPreviewWithDocumentationComments, assemblyName: "Test");
+        comp.VerifyEmitDiagnostics(
+            // (2,1): error CS9283: Extensions must be declared in a top-level, non-generic, static class
+            // extension<T>(T t)
+            Diagnostic(ErrorCode.ERR_BadExtensionContainingType, "extension").WithLocation(2, 1));
+
+        var extension = comp.GlobalNamespace.GetTypeMember("");
+        AssertEx.Equal("T:<G>$8048A6C8BE30A622530249B904B537EB`1.<M>$D1693D81A12E8DED4ED68FE22D9E856F", extension.GetDocumentationCommentId());
+        AssertEx.Equal("""
+<member name="T:&lt;G&gt;$8048A6C8BE30A622530249B904B537EB`1.&lt;M&gt;$D1693D81A12E8DED4ED68FE22D9E856F">
+    <summary>Summary for extension block</summary>
+</member>
+
+""", extension.GetDocumentationCommentXml());
+
+        var expected = """
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>Test</name>
+    </assembly>
+    <members>
+        <member name="T:&lt;G&gt;$8048A6C8BE30A622530249B904B537EB`1.&lt;M&gt;$D1693D81A12E8DED4ED68FE22D9E856F">
+            <summary>Summary for extension block</summary>
+        </member>
+    </members>
+</doc>
+""";
+        AssertEx.Equal(expected, GetDocumentationCommentText(comp));
     }
 
     [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/80829

Cherry-picked from https://github.com/dotnet/roslyn/pull/80929 with test `ReduceExtensionMember_14` removed (the ~~`RemoveExtensionMember`~~ `ReduceExtensionMember` API didn't exist in `release/dev18.0`)