### PR TITLE
Revert "Remove the EnsureComponentModelAsync from the main thread queue"

### DIFF
--- a/src/VisualStudio/Core/Def/LanguageService/AbstractPackage.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractPackage.cs
@@ -52,14 +52,19 @@ internal abstract class AbstractPackage : AsyncPackage
 
     protected virtual void RegisterInitializeAsyncWork(PackageLoadTasks packageInitializationTasks)
     {
-        // We register this task so our ComponentModel property is available during other parts of package initialization and OnAfterPackageLoaded work. The
-        // expectation at this point is no work scheduled to the UI thread needs the ComponentModel, so we only schedule it for the background thread.
+        // This treatment of registering work on the bg/main threads is a bit unique as we want the component model initialized at the beginning
+        // of whichever context is invoked first. The current architecture doesn't execute any of the registered tasks concurrently,
+        // so that isn't a concern for calculating or setting _componentModel_doNotAccessDirectly multiple times.
         packageInitializationTasks.AddTask(isMainThreadTask: false, task: EnsureComponentModelAsync);
+        packageInitializationTasks.AddTask(isMainThreadTask: true, task: EnsureComponentModelAsync);
 
         async Task EnsureComponentModelAsync(PackageLoadTasks packageInitializationTasks, CancellationToken token)
         {
-            _componentModel_doNotAccessDirectly = (IComponentModel?)await GetServiceAsync(typeof(SComponentModel)).ConfigureAwait(false);
-            Assumes.Present(_componentModel_doNotAccessDirectly);
+            if (_componentModel_doNotAccessDirectly == null)
+            {
+                _componentModel_doNotAccessDirectly = (IComponentModel?)await GetServiceAsync(typeof(SComponentModel)).ConfigureAwait(false);
+                Assumes.Present(_componentModel_doNotAccessDirectly);
+            }
         }
     }
 


### PR DESCRIPTION
The component model is still being used by F# on the UI thread, so we need to keep this working for now.

This reverts commit 1b2c755c3625a72601fd2972767ae330f7addae5.