### PR TITLE
Add '-test' to the prerelease label for test signed builds

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,6 +10,7 @@
     <MinorVersion>3</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <PreReleaseVersionLabel>2</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel Condition="'$(DotNetSignType)' == 'test'">$(PreReleaseVersionLabel)-test</PreReleaseVersionLabel>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <!--
       By default the assembly version in official builds is "$(MajorVersion).$(MinorVersion).0.0".


### PR DESCRIPTION
To further distinguish packages from test signed builds from real signed builds.