### PR TITLE
Fix SG items appearing in navto

### DIFF
--- a/src/VisualStudio/Core/Def/NavigateTo/RoslynSearchItemsSourceProvider.cs
+++ b/src/VisualStudio/Core/Def/NavigateTo/RoslynSearchItemsSourceProvider.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.LanguageServices;
+using Microsoft.VisualStudio.LanguageServices.Implementation;
 using Microsoft.VisualStudio.Search.Data;
 using Microsoft.VisualStudio.Utilities;
 
@@ -35,6 +36,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo;
 internal sealed partial class RoslynSearchItemsSourceProvider : ISearchItemsSourceProvider
 {
     private readonly VisualStudioWorkspace _workspace;
+    private readonly SourceGeneratedFileManager _sourceGeneratedFileManager;
     private readonly IThreadingContext _threadingContext;
     private readonly IUIThreadOperationExecutor _threadOperationExecutor;
     private readonly IAsynchronousOperationListener _asyncListener;
@@ -44,11 +46,13 @@ internal sealed partial class RoslynSearchItemsSourceProvider : ISearchItemsSour
     [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
     public RoslynSearchItemsSourceProvider(
         VisualStudioWorkspace workspace,
+        SourceGeneratedFileManager sourceGeneratedFileManager,
         IThreadingContext threadingContext,
         IUIThreadOperationExecutor threadOperationExecutor,
         IAsynchronousOperationListenerProvider listenerProvider)
     {
         _workspace = workspace;
+        _sourceGeneratedFileManager = sourceGeneratedFileManager;
         _threadingContext = threadingContext;
         _threadOperationExecutor = threadOperationExecutor;
         _asyncListener = listenerProvider.GetListener(FeatureAttribute.NavigateTo);

--- a/src/VisualStudio/Core/Def/NavigateTo/RoslynSearchResultViewFactory.cs
+++ b/src/VisualStudio/Core/Def/NavigateTo/RoslynSearchResultViewFactory.cs
@@ -19,14 +19,9 @@ internal sealed partial class RoslynSearchItemsSourceProvider
     /// Implementation of the <see cref="ISearchResultViewFactory"/>.  Responsible for actually producing both the
     /// item presented in the search results list, and the async preview for that item.
     /// </summary>
-    private sealed class RoslynSearchResultViewFactory : ISearchResultViewFactory
+    private sealed class RoslynSearchResultViewFactory(RoslynSearchItemsSourceProvider provider) : ISearchResultViewFactory
     {
-        private readonly RoslynSearchItemsSourceProvider _provider;
-
-        public RoslynSearchResultViewFactory(RoslynSearchItemsSourceProvider provider)
-        {
-            _provider = provider;
-        }
+        private readonly RoslynSearchItemsSourceProvider _provider = provider;
 
         public SearchResultViewBase CreateSearchResultView(SearchResult result)
         {
@@ -59,43 +54,40 @@ internal sealed partial class RoslynSearchItemsSourceProvider
             // fail, don't show any preview for this item.
 
             var document = roslynResult.SearchResult.NavigableItem.Document;
-            var filePath = document.FilePath;
+
+            // RoslynNavigateToSearchCallback will have placed the file-path for this document in the .Location property
+            // of this search result.  This will either be the true location of a real file in the workspace.  Or a
+            // temporary dummy file placed on disk for source-generated documents.  This dummy file will have been made
+            // in coordination with the SourceGeneratedFileManager.  That way when the editor tries to open that file,
+            // SourceGeneratedFileManager will intercept, fetch the actual contents, and pressent those in the text
+            // buffer that the user sees.
+            var filePath = roslynResult.Location;
             if (filePath is null)
                 return null;
 
             Uri? absoluteUri;
-            if (document.SourceGeneratedDocumentIdentity is not null)
+            try
             {
-                absoluteUri = SourceGeneratedDocumentUri.Create(document.SourceGeneratedDocumentIdentity.Value).GetRequiredParsedUri();
+                absoluteUri = ProtocolConversions.CreateAbsoluteUri(filePath);
             }
-            else
+            catch (UriFormatException)
             {
-                try
-                {
-                    absoluteUri = ProtocolConversions.CreateAbsoluteUri(filePath);
-                }
-                catch (UriFormatException)
-                {
-                    // Unable to create an absolute URI for this path
-                    return null;
-                }
+                // Unable to create an absolute URI for this path
+                return null;
             }
 
             var projectGuid = _provider._workspace.GetProjectGuid(document.Project.Id);
             if (projectGuid == Guid.Empty)
                 return null;
 
-            return new SearchResultPreviewPanelBase[]
-            {
-                new RoslynSearchResultPreviewPanel(
-                    _provider,
-                    // Editor APIs require a parseable System.Uri instance
-                    absoluteUri,
-                    projectGuid,
-                    roslynResult.SearchResult.NavigableItem.SourceSpan.ToSpan(),
-                    searchResultView.Title.Text,
-                    searchResultView.PrimaryIcon)
-            };
+            return [new RoslynSearchResultPreviewPanel(
+                _provider,
+                // Editor APIs require a parseable System.Uri instance
+                absoluteUri,
+                projectGuid,
+                roslynResult.SearchResult.NavigableItem.SourceSpan.ToSpan(),
+                searchResultView.Title.Text,
+                searchResultView.PrimaryIcon)];
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/81631

Looks like:

<img width="2929" height="1533" alt="image" src="https://github.com/user-attachments/assets/53bdf488-dbf3-4fca-bc34-183fc30375e6" />

Navigation to these items works as expected, and opens the doc in the right SG mode:

<img width="2968" height="986" alt="image" src="https://github.com/user-attachments/assets/7cdc4ba4-eabd-453f-8c04-a9fbba825156" />
