### PR TITLE
Fix signed build sign validation

### DIFF
--- a/global.json
+++ b/global.json
@@ -10,7 +10,7 @@
       "version": "17.14.0"
     },
     "vswhere": "3.1.7",
-    "xcopy-msbuild": "17.14.16"
+    "xcopy-msbuild": "18.0.0"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.25608.6",


### PR DESCRIPTION
failing due to .net10 in VS17.14 error. 