### PR TITLE
Remove unneeded MEF component

### DIFF
--- a/src/VisualStudio/Setup/source.extension.vsixmanifest
+++ b/src/VisualStudio/Setup/source.extension.vsixmanifest
@@ -69,7 +69,6 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.VisualStudio.LanguageServices.LiveShare.dll" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.VisualStudio.LanguageServices.ExternalAccess.Copilot.dll" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.CodeAnalysis.LanguageServer.Protocol.dll" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.CommonLanguageServerProtocol.Framework.dll" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.VisualStudio.Copilot.Roslyn.SemanticSearch.dll" />
   </Assets>
   <Prerequisites>


### PR DESCRIPTION
This component is registered as a MEF component yet contains no parts nor is needed for any MEF components.

From MEF log:
```
---------- Unused assemblies ----------
 - C:\VisualStudio\Common7\IDE\CommonExtensions\Microsoft\VBCSharp\LanguageServices\Microsoft.CommonLanguageServerProtocol.Framework.dll
 - C:\VisualStudio\Common7\IDE\Extensions\julayeqk.r5q\Packaging.TAfGT.dll
 - C:\VisualStudio\Common7\IDE\Extensions\Microsoft\Maui\Maui.VisualStudio\Xamarin.VisualStudio.dll
```