### PR TITLE
Revert unintentionally commented code

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -9981,8 +9981,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool reportRemainingWarnings,
             Location diagnosticLocation)
         {
-            // Uncomment when https://github.com/dotnet/roslyn/issues/67153 is fixed
-            // Debug.Assert(!IsConditionalState);
+            Debug.Assert(!IsConditionalState);
             Debug.Assert(conversionOperand != null);
             Debug.Assert(targetTypeWithNullability.HasType);
             Debug.Assert(diagnosticLocation != null);


### PR DESCRIPTION
Closes https://github.com/dotnet/roslyn/issues/67153.

The assert was uncommented already in the original fix (https://github.com/dotnet/roslyn/pull/67157),
but then it got commented again via automatic code flow (https://github.com/dotnet/roslyn/pull/67507).