### PR TITLE
Allow Razor to respond to renames

### DIFF
--- a/src/Tools/ExternalAccess/Razor/EditorFeatures/IRazorRefactorNotifyService.cs
+++ b/src/Tools/ExternalAccess/Razor/EditorFeatures/IRazorRefactorNotifyService.cs
@@ -3,12 +3,16 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Editor;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Razor;
 
+/// <inheritdoc cref="IRefactorNotifyService" />
 internal interface IRazorRefactorNotifyService
 {
+    /// <inheritdoc cref="IRefactorNotifyService.TryOnBeforeGlobalSymbolRenamed" />
     bool TryOnBeforeGlobalSymbolRenamed(Workspace workspace, IEnumerable<DocumentId> changedDocumentIDs, ISymbol symbol, string newName, bool throwOnFailure);
 
+    /// <inheritdoc cref="IRefactorNotifyService.TryOnAfterGlobalSymbolRenamed" />
     bool TryOnAfterGlobalSymbolRenamed(Workspace workspace, IEnumerable<DocumentId> changedDocumentIDs, ISymbol symbol, string newName, bool throwOnFailure);
 }

--- a/src/Tools/ExternalAccess/Razor/EditorFeatures/RazorRefactorNotifyWrapper.cs
+++ b/src/Tools/ExternalAccess/Razor/EditorFeatures/RazorRefactorNotifyWrapper.cs
@@ -20,19 +20,13 @@ internal sealed class RazorRefactorNotifyWrapper(
 
     public bool TryOnAfterGlobalSymbolRenamed(Workspace workspace, IEnumerable<DocumentId> changedDocumentIDs, ISymbol symbol, string newName, bool throwOnFailure)
     {
-        // If we return false, we block the rename operation. We don't want to do that :)
-        if (_implementation is null)
-            return true;
-
-        return _implementation.TryOnAfterGlobalSymbolRenamed(workspace, changedDocumentIDs, symbol, newName, throwOnFailure);
+        // Return true if there is no implementation so rename isn't blocked
+        return _implementation?.TryOnAfterGlobalSymbolRenamed(workspace, changedDocumentIDs, symbol, newName, throwOnFailure) ?? true;
     }
 
     public bool TryOnBeforeGlobalSymbolRenamed(Workspace workspace, IEnumerable<DocumentId> changedDocumentIDs, ISymbol symbol, string newName, bool throwOnFailure)
     {
-        // If we return false, we block the rename operation. We don't want to do that :)
-        if (_implementation is null)
-            return true;
-
-        return _implementation.TryOnBeforeGlobalSymbolRenamed(workspace, changedDocumentIDs, symbol, newName, throwOnFailure);
+        // Return true if there is no implementation so rename isn't blocked
+        return _implementation?.TryOnBeforeGlobalSymbolRenamed(workspace, changedDocumentIDs, symbol, newName, throwOnFailure) ?? true;
     }
 }


### PR DESCRIPTION
Part of https://github.com/dotnet/razor/issues/8541

Needed so we can rename the .razor file when the user renames the component type name from a C# file.