### PR TITLE
Hot Reload: Temporarily disable project-level analysis

### DIFF
--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -29,6 +29,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue;
 
 internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContinueAnalyzer
 {
+    // TODO: https://github.com/dotnet/roslyn/issues/81728
+    // Temporarily disabled until https://devdiv.visualstudio.com/DevDiv/_queries/edit/1835505 is implemented.
+    // Only enabled in dotnet-watch and tests.
+    internal static bool EnableProjectLevelAnalysis = false;
+
     internal const int DefaultStatementPart = 0;
     private const string CreateNewOnMetadataUpdateAttributeName = "CreateNewOnMetadataUpdateAttribute";
     private const string RestartRequiredOnMetadataUpdateAttributeName = "RestartRequiredOnMetadataUpdateAttribute";
@@ -578,7 +583,7 @@ internal abstract partial class AbstractEditAndContinueAnalyzer : IEditAndContin
             // since the option changed would have different semantics than the parts that have changed.
             //
             // Skip further analysis of the document if we detect any such change (classified as rude edits) in parse options.
-            if (GetParseOptionsRudeEdits(oldTree.Options, newTree.Options).Any())
+            if (EnableProjectLevelAnalysis && GetParseOptionsRudeEdits(oldTree.Options, newTree.Options).Any())
             {
                 log.Write($"Parse options differ for '{filePath}'");
 

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -343,7 +343,7 @@ internal sealed class EditSession
             return false;
         }
 
-        if (HasProjectLevelDifferences(oldProject, newProject, differences) && differences == null)
+        if (AbstractEditAndContinueAnalyzer.EnableProjectLevelAnalysis && HasProjectLevelDifferences(oldProject, newProject, differences) && differences == null)
         {
             return true;
         }
@@ -1213,7 +1213,7 @@ internal sealed class EditSession
 
                     var projectSummary = GetProjectAnalysisSummary(changedDocumentAnalyses);
 
-                    if (HasProjectSettingsBlockingRudeEdits(oldProject, newProject, projectDiagnostics))
+                    if (AbstractEditAndContinueAnalyzer.EnableProjectLevelAnalysis && HasProjectSettingsBlockingRudeEdits(oldProject, newProject, projectDiagnostics))
                     {
                         // If the project settings have changed and the change is a rude edit,
                         // block applying the changes even if there no other changes to the project documents.

--- a/src/Features/ExternalAccess/HotReload/Api/HotReloadService.cs
+++ b/src/Features/ExternalAccess/HotReload/Api/HotReloadService.cs
@@ -138,6 +138,7 @@ internal sealed class HotReloadService(SolutionServices services, Func<ValueTask
     public HotReloadService(HostWorkspaceServices services, ImmutableArray<string> capabilities)
         : this(services.SolutionServices, () => ValueTask.FromResult(AddImplicitDotNetCapabilities(capabilities)))
     {
+        AbstractEditAndContinueAnalyzer.EnableProjectLevelAnalysis = true;
     }
 
     private DebuggingSessionId GetDebuggingSession()

--- a/src/Features/TestUtilities/EditAndContinue/EditAndContinueWorkspaceTestBase.cs
+++ b/src/Features/TestUtilities/EditAndContinue/EditAndContinueWorkspaceTestBase.cs
@@ -33,6 +33,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests;
 
 public abstract class EditAndContinueWorkspaceTestBase : TestBase, IDisposable
 {
+    static EditAndContinueWorkspaceTestBase()
+    {
+        // TODO: remove https://github.com/dotnet/roslyn/issues/81728
+        AbstractEditAndContinueAnalyzer.EnableProjectLevelAnalysis = true;
+    }
+
     private protected static readonly Guid s_solutionTelemetryId = Guid.Parse("00000000-AAAA-AAAA-AAAA-000000000000");
     private protected static readonly Guid s_defaultProjectTelemetryId = Guid.Parse("00000000-AAAA-AAAA-AAAA-111111111111");
     private protected static readonly Regex s_timePropertiesRegex = new("[|](EmitDifferenceMilliseconds|TotalAnalysisMilliseconds)=[0-9]+");


### PR DESCRIPTION
Disable project change detection and reporting project-level rude edits until https://devdiv.visualstudio.com/DevDiv/_queries/edit/1835505 is implemented.

When a solution is opened the following operations may take place:
 
1) Project is loaded, restored and DTB is kicked off. The Project System sends data to Roslyn to initialize Roslyn project from the results of DTB.
2) User hits F5/Ctrl+F5.
3) Debugger calls Roslyn to start Hot Reload session. Roslyn captures the current project state.
4) User hits "Apply Hot Reload" (either explicitly or implicitly through other debugger operations such as stepping).
5) Debugger tells Roslyn to apply changes. Roslyn compares the current project state with the state captured at (3).
 
Currently, (2) and (3) may occur before (1) is complete. Roslyn Hot Reload then concludes changes were made to the project and reports rude edits or tries to apply them. These changes are just artifacts of Roslyn's project representation being updated by the Project System, not real changes made by the user.

We need to block project launch until Roslyn projects are entirely initialized. 

Workaround for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2606868

