### PR TITLE
NormalizeWhitespace on nullable suppression

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -903,6 +903,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                 return true;
             }
 
+            if (token.Parent.Parent?.Kind() == SyntaxKind.SuppressNullableWarningExpression)
+            {
+                return false;
+            }
+
             if (IsKeyword(token.Kind()) && !token.IsKind(SyntaxKind.ExtensionKeyword))
             {
                 if (!next.IsKind(SyntaxKind.ColonToken) &&

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
@@ -6238,5 +6238,35 @@ static class E
 }
 """);
         }
+
+        [Fact]
+        public void TestNormalizeSuppression_01()
+        {
+            TestNormalizeDeclaration("""
+throw null!;
+""", """
+throw null!;
+""");
+        }
+
+        [Fact]
+        public void TestNormalizeSuppression_02()
+        {
+            TestNormalizeDeclaration("""
+throw x!;
+""", """
+throw x!;
+""");
+        }
+
+        [Fact]
+        public void TestNormalizeSuppression_03()
+        {
+            TestNormalizeDeclaration("""
+M()!;
+""", """
+M()!;
+""");
+        }
     }
 }


### PR DESCRIPTION
`NormalizeWhitespace` incorrectly introduced a space in `throw null!;` before the `!`. 
You can repro this on [.NET Lab](https://lab.razor.fyi/#45Lh4gooyk8vSszVSy4W4uPiKskoyi9XyCvNyVG09mIuKs1LYKxgBAA) where I observed this when adding the Formatting functionality.