### PR TITLE
Handle potential null in extension lookup (#80621)

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Crefs.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Crefs.cs
@@ -341,6 +341,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         if (result.Kind == LookupResultKind.Viable)
                         {
+                            Debug.Assert(result.Symbol is not null);
                             sortedSymbolsBuilder ??= ArrayBuilder<Symbol>.GetInstance();
                             sortedSymbolsBuilder.Add(result.Symbol);
                         }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -10873,7 +10873,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     foreach (SingleLookupResult singleLookupResult in singleLookupResults)
                     {
-                        Symbol extensionMember = singleLookupResult.Symbol;
+                        var extensionMember = singleLookupResult.Symbol;
+                        Debug.Assert(extensionMember is not null);
                         if (IsStaticInstanceMismatchForUniqueSignatureFromMethodGroup(receiver, extensionMember))
                         {
                             // Remove static/instance mismatches
@@ -11086,7 +11087,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var methods = ArrayBuilder<MethodSymbol>.GetInstance(capacity: singleLookupResults.Count);
                     foreach (SingleLookupResult singleLookupResult in singleLookupResults)
                     {
-                        Symbol extensionMember = singleLookupResult.Symbol;
+                        var extensionMember = singleLookupResult.Symbol;
+                        Debug.Assert(extensionMember is not null);
                         if (IsStaticInstanceMismatchForUniqueSignatureFromMethodGroup(receiver, extensionMember))
                         {
                             // Remove static/instance mismatches

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -217,6 +217,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 foreach (var candidate in candidates)
                 {
                     SingleLookupResult resultOfThisMember = originalBinder.CheckViability(candidate, arity, options, null, diagnose: true, useSiteInfo: ref useSiteInfo);
+                    if (resultOfThisMember.Kind == LookupResultKind.Empty)
+                    {
+                        continue;
+                    }
+
+                    Debug.Assert(resultOfThisMember.Symbol is not null);
                     result.Add(resultOfThisMember);
 
                     if (candidate is MethodSymbol { IsStatic: false } shadows &&
@@ -240,7 +246,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (implementationsToShadow is null || !implementationsToShadow.Remove(method.OriginalDefinition))
                 {
                     SingleLookupResult resultOfThisMember = originalBinder.CheckViability(method, arity, options, null, diagnose: true, useSiteInfo: ref classicExtensionUseSiteInfo);
-                    result.Add(resultOfThisMember);
+                    if (resultOfThisMember.Kind != LookupResultKind.Empty)
+                    {
+                        result.Add(resultOfThisMember);
+                    }
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/SingleLookupResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SingleLookupResult.cs
@@ -2,11 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
+using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -22,13 +21,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal readonly LookupResultKind Kind;
 
         // the symbol or null.
-        internal readonly Symbol Symbol;
+        internal readonly Symbol? Symbol;
 
         // the error of the result, if it is NonViable or Inaccessible
-        internal readonly DiagnosticInfo Error;
+        internal readonly DiagnosticInfo? Error;
 
-        internal SingleLookupResult(LookupResultKind kind, Symbol symbol, DiagnosticInfo error)
+        internal SingleLookupResult(LookupResultKind kind, Symbol? symbol, DiagnosticInfo? error)
         {
+            Debug.Assert(symbol is not null || kind == LookupResultKind.Empty);
             this.Kind = kind;
             this.Symbol = symbol;
             this.Error = error;


### PR DESCRIPTION
There are specific scenarios where applicability will remove a symbol from lookup entirely; no error, just silent removal. This introduces a `null` that consumers were not expecting and caused an NRE. I've handled that NRE here and annotated the API. Fixes https://developercommunity.visualstudio.com/t/NRE-in-Roslyn-v500-225451107/10979295.

(cherry picked from commit 16883a538d09956096aef64c4e61ad764c1f4d96)
