### PR TITLE
Workaround up-to-date bug in generate-compiler-code.cs

### DIFF
--- a/eng/generate-compiler-code.cmd
+++ b/eng/generate-compiler-code.cmd
@@ -1,3 +1,2 @@
 @echo off
-call "%~dp0\common\dotnet.cmd" run --file "%~dp0\generate-compiler-code.cs" %* 
-
+call "%~dp0\common\dotnet.cmd" run --file "%~dp0\generate-compiler-code.cs" --no-cache %* 


### PR DESCRIPTION
Needed until we have SDK with the fix for https://github.com/dotnet/sdk/issues/52057.
Doesn't matter if we keep this anyway though, the fix in the SDK is basically doing the same thing.