### PR TITLE
Add accessibility check for pattern-based usage of extensions in foreach

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 11.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 11.md
@@ -154,3 +154,32 @@ void M()
 ```
 
 See also https://github.com/dotnet/roslyn/issues/80954.
+
+
+## Usage of extension `GetEnumerator` in `foreach` requires `public` accessibility
+
+***Introduced in Visual Studio 2026 version 18.3***
+
+The C# compiler previously allowed a pattern-based extension `GetEnumerator` to be used in `foreach`
+even when the extension method or extension block method was not `public`.
+
+```csharp
+public static class E
+{
+    public static void Main()
+    {
+        foreach (var i in new Enumerable()) { }
+    }
+
+    private static System.Collections.Generic.IEnumerator<int> GetEnumerator(this Enumerable e)
+    {
+        yield return 42;
+    }
+}
+
+public class Enumerable { }
+```
+
+This is now disallowed, in concordance with the specification:
+https://github.com/dotnet/csharplang/blob/main/proposals/csharp-9.0/extension-getenumerator.md
+

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -1337,6 +1337,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (viaExtensionMethod)
             {
                 getEnumeratorInfo = FindForEachPatternMethodViaExtension(syntax, collectionSyntax, collectionExpr, methodName, diagnostics);
+                if (getEnumeratorInfo?.Method.DeclaredAccessibility != Accessibility.Public)
+                {
+                    return false;
+                }
             }
             else
             {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
@@ -12906,36 +12906,11 @@ public static class Extensions
 {
     internal static C.Enumerator GetAsyncEnumerator(this C self) => new C.Enumerator();
 }";
-            var comp = CreateCompilationWithMscorlib46(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular9);
-            comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "123");
+            CreateCompilationWithMscorlib46(source, parseOptions: TestOptions.Regular9).VerifyEmitDiagnostics(
+                // (8,33): error CS8411: Asynchronous foreach statement cannot operate on variables of type 'C' because 'C' does not contain a suitable public instance or extension definition for 'GetAsyncEnumerator'
+                //         await foreach (var i in new C())
+                Diagnostic(ErrorCode.ERR_AwaitForEachMissingMember, "new C()").WithArguments("C", "GetAsyncEnumerator").WithLocation(8, 33));
 
-            var runtimeAsyncComp = CreateRuntimeAsyncCompilation(source, options: TestOptions.ReleaseExe);
-            var verifier = CompileAndVerify(runtimeAsyncComp, expectedOutput: RuntimeAsyncTestHelpers.ExpectedOutput("123"), verify: Verification.Fails with
-            {
-                ILVerifyMessage = """
-                    [Main]: Return value missing on the stack. { Offset = 0x25 }
-                    """
-            });
-            verifier.VerifyIL("C.Main()", """
-                {
-                  // Code size       38 (0x26)
-                  .maxstack  1
-                  .locals init (C.Enumerator V_0)
-                  IL_0000:  newobj     "C..ctor()"
-                  IL_0005:  call       "C.Enumerator Extensions.GetAsyncEnumerator(C)"
-                  IL_000a:  stloc.0
-                  IL_000b:  br.s       IL_0018
-                  IL_000d:  ldloc.0
-                  IL_000e:  callvirt   "int C.Enumerator.Current.get"
-                  IL_0013:  call       "void System.Console.Write(int)"
-                  IL_0018:  ldloc.0
-                  IL_0019:  callvirt   "System.Threading.Tasks.Task<bool> C.Enumerator.MoveNextAsync()"
-                  IL_001e:  call       "bool System.Runtime.CompilerServices.AsyncHelpers.Await<bool>(System.Threading.Tasks.Task<bool>)"
-                  IL_0023:  brtrue.s   IL_000d
-                  IL_0025:  ret
-                }
-                """);
         }
 
         [Fact]
@@ -14070,36 +14045,11 @@ public class C
         public Task<bool> MoveNextAsync() => Task.FromResult(Current++ != 3);
     }
 }";
-            var comp = CreateCompilationWithMscorlib46(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular9);
-            comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "123");
+            CreateCompilationWithMscorlib46(source, parseOptions: TestOptions.Regular9).VerifyEmitDiagnostics(
+                // (8,33): error CS8411: Asynchronous foreach statement cannot operate on variables of type 'C' because 'C' does not contain a suitable public instance or extension definition for 'GetAsyncEnumerator'
+                //         await foreach (var i in new C())
+                Diagnostic(ErrorCode.ERR_AwaitForEachMissingMember, "new C()").WithArguments("C", "GetAsyncEnumerator").WithLocation(8, 33));
 
-            var runtimeAsyncComp = CreateRuntimeAsyncCompilation(source, options: TestOptions.ReleaseExe);
-            var verifier = CompileAndVerify(runtimeAsyncComp, expectedOutput: RuntimeAsyncTestHelpers.ExpectedOutput("123"), verify: Verification.Fails with
-            {
-                ILVerifyMessage = """
-                    [Main]: Return value missing on the stack. { Offset = 0x25 }
-                    """
-            });
-            verifier.VerifyIL("Program.Main()", """
-                {
-                  // Code size       38 (0x26)
-                  .maxstack  1
-                  .locals init (C.Enumerator V_0)
-                  IL_0000:  newobj     "C..ctor()"
-                  IL_0005:  call       "C.Enumerator Program.GetAsyncEnumerator(C)"
-                  IL_000a:  stloc.0
-                  IL_000b:  br.s       IL_0018
-                  IL_000d:  ldloc.0
-                  IL_000e:  callvirt   "int C.Enumerator.Current.get"
-                  IL_0013:  call       "void System.Console.Write(int)"
-                  IL_0018:  ldloc.0
-                  IL_0019:  callvirt   "System.Threading.Tasks.Task<bool> C.Enumerator.MoveNextAsync()"
-                  IL_001e:  call       "bool System.Runtime.CompilerServices.AsyncHelpers.Await<bool>(System.Threading.Tasks.Task<bool>)"
-                  IL_0023:  brtrue.s   IL_000d
-                  IL_0025:  ret
-                }
-                """);
         }
 
         [Fact]
@@ -14132,36 +14082,11 @@ public class C
         public Task<bool> MoveNextAsync() => Task.FromResult(Current++ != 3);
     }
 }";
-            var comp = CreateCompilationWithMscorlib46(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular9);
-            comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "123");
+            CreateCompilationWithMscorlib46(source, parseOptions: TestOptions.Regular9).VerifyEmitDiagnostics(
+                // (10,37): error CS8411: Asynchronous foreach statement cannot operate on variables of type 'C' because 'C' does not contain a suitable public instance or extension definition for 'GetAsyncEnumerator'
+                //             await foreach (var i in new C())
+                Diagnostic(ErrorCode.ERR_AwaitForEachMissingMember, "new C()").WithArguments("C", "GetAsyncEnumerator").WithLocation(10, 37));
 
-            var runtimeAsyncComp = CreateRuntimeAsyncCompilation(source, options: TestOptions.ReleaseExe);
-            var verifier = CompileAndVerify(runtimeAsyncComp, expectedOutput: RuntimeAsyncTestHelpers.ExpectedOutput("123"), verify: Verification.Fails with
-            {
-                ILVerifyMessage = """
-                    [Main]: Return value missing on the stack. { Offset = 0x25 }
-                    """
-            });
-            verifier.VerifyIL("Program.Inner.Main()", """
-                {
-                  // Code size       38 (0x26)
-                  .maxstack  1
-                  .locals init (C.Enumerator V_0)
-                  IL_0000:  newobj     "C..ctor()"
-                  IL_0005:  call       "C.Enumerator Program.GetAsyncEnumerator(C)"
-                  IL_000a:  stloc.0
-                  IL_000b:  br.s       IL_0018
-                  IL_000d:  ldloc.0
-                  IL_000e:  callvirt   "int C.Enumerator.Current.get"
-                  IL_0013:  call       "void System.Console.Write(int)"
-                  IL_0018:  ldloc.0
-                  IL_0019:  callvirt   "System.Threading.Tasks.Task<bool> C.Enumerator.MoveNextAsync()"
-                  IL_001e:  call       "bool System.Runtime.CompilerServices.AsyncHelpers.Await<bool>(System.Threading.Tasks.Task<bool>)"
-                  IL_0023:  brtrue.s   IL_000d
-                  IL_0025:  ret
-                }
-                """);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenForEachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenForEachTests.cs
@@ -4463,7 +4463,10 @@ public static class Extensions
 {
     internal static C.Enumerator GetEnumerator(this C self) => new C.Enumerator();
 }";
-            CompileAndVerify(source, parseOptions: TestOptions.Regular9, expectedOutput: "123");
+            CreateCompilation(source, parseOptions: TestOptions.Regular9).VerifyEmitDiagnostics(
+                // (7,27): error CS1579: foreach statement cannot operate on variables of type 'C' because 'C' does not contain a public instance or extension definition for 'GetEnumerator'
+                //         foreach (var i in new C())
+                Diagnostic(ErrorCode.ERR_ForEachMissingMember, "new C()").WithArguments("C", "GetEnumerator").WithLocation(7, 27));
         }
 
         [Fact]
@@ -5214,7 +5217,10 @@ public class C
         public bool MoveNext() => Current++ != 3;
     }
 }";
-            CompileAndVerify(source, parseOptions: TestOptions.Regular9, expectedOutput: "123");
+            CreateCompilation(source, parseOptions: TestOptions.Regular9).VerifyEmitDiagnostics(
+                // (8,27): error CS1579: foreach statement cannot operate on variables of type 'C' because 'C' does not contain a public instance or extension definition for 'GetEnumerator'
+                //         foreach (var i in new C())
+                Diagnostic(ErrorCode.ERR_ForEachMissingMember, "new C()").WithArguments("C", "GetEnumerator").WithLocation(8, 27));
         }
 
         [Fact]
@@ -5247,7 +5253,10 @@ public class C
         public bool MoveNext() => Current++ != 3;
     }
 }";
-            CompileAndVerify(source, parseOptions: TestOptions.Regular9, expectedOutput: "123");
+            CreateCompilation(source, parseOptions: TestOptions.Regular9).VerifyEmitDiagnostics(
+                // (10,31): error CS1579: foreach statement cannot operate on variables of type 'C' because 'C' does not contain a public instance or extension definition for 'GetEnumerator'
+                //             foreach (var i in new C())
+                Diagnostic(ErrorCode.ERR_ForEachMissingMember, "new C()").WithArguments("C", "GetEnumerator").WithLocation(10, 31));
         }
 
         [Fact]


### PR DESCRIPTION
I noticed an irregularity: a private but accessible `GetEnumerator()` method is accepted, but a private but accessible `MoveNext()` is not.
This is expected according to the [spec for extension `GetEnumerator()`](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-9.0/extension-getenumerator.md)
