### PR TITLE
Simplify condition with DeMorgan's Law

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2095,7 +2095,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 !IsInsideNameof)
                         {
                             // Give a better error for the simple case of using an extension parameter in a static member, while avoiding any of the other cases where it is always illegal
-                            if (this.ContainingMember().IsStatic && !InParameterDefaultValue && !InAttributeArgument && (object)this.ContainingMember().ContainingSymbol == parameter.ContainingSymbol)
+                            if (this.ContainingMember() is { IsStatic: true } && !InParameterDefaultValue && !InAttributeArgument && (object)this.ContainingMember().ContainingSymbol == parameter.ContainingSymbol)
                             {
                                 // Static members cannot access the value of extension parameter '{0}'.
                                 Error(diagnostics, ErrorCode.ERR_ExtensionParameterInStaticContext, node, parameter.Name);


### PR DESCRIPTION
The existing pattern is 3 `not`s and an (implicit) `and`. Can be much simpler as just an `or`. I found the existing condition highly complex to read.