### PR TITLE
Don't capture method type parameters when extracting a local function

### DIFF
--- a/src/Features/CSharpTest/ExtractMethod/ExtractLocalFunctionTests.cs
+++ b/src/Features/CSharpTest/ExtractMethod/ExtractLocalFunctionTests.cs
@@ -5524,4 +5524,31 @@ class Program
                 }
             }
             """, new(TestOptions.Regular, index: CodeActionIndex));
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/81789")]
+    public Task TestGenericNotCarried()
+        => TestAsync("""
+            public class Class1
+            {
+                public static List<T> CreateList<T>()
+                    where T : class
+                {
+                    return [|new List<T>()|];
+                }
+            }
+            """, """
+            public class Class1
+            {
+                public static List<T> CreateList<T>()
+                    where T : class
+                {
+                    return {|Rename:NewMethod|}();
+
+                    static List<T> NewMethod()
+                    {
+                        return new List<T>();
+                    }
+                }
+            }
+            """, new(TestOptions.Regular, index: CodeActionIndex));
 }

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.Analyzer.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.Analyzer.cs
@@ -859,6 +859,10 @@ internal abstract partial class AbstractExtractMethodService<
 
             private ImmutableArray<ITypeParameterSymbol> GetMethodTypeParametersInDeclaration(ITypeSymbol returnType, SortedDictionary<int, ITypeParameterSymbol> sortedMap)
             {
+                // No need to pass generic type args to a local function.  They are already implicitly referenceable.
+                if (this.LocalFunction)
+                    return [];
+
                 // add return type to the map
                 AddTypeParametersToMap(TypeParameterCollector.Collect(returnType), sortedMap);
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/81789