### PR TITLE
Enable GetTypeInfo for type of object creation syntax

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -2035,10 +2035,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var boundExpr = lowestBoundNode as BoundExpression;
             var highestBoundExpr = highestBoundNode as BoundExpression;
 
-            if (boundExpr != null &&
-                !(boundNodeForSyntacticParent != null &&
-                  boundNodeForSyntacticParent.Syntax.Kind() == SyntaxKind.ObjectCreationExpression &&
-                  ((ObjectCreationExpressionSyntax)boundNodeForSyntacticParent.Syntax).Type == boundExpr.Syntax)) // Do not return any type information for a ObjectCreationExpressionSyntax.Type node.
+            if (boundExpr != null)
             {
                 // TODO: Should parenthesized expression really not have symbols? At least for C#, I'm not sure that 
                 // is right. For example, C# allows the assignment statement:

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ObjectAndCollectionInitializerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ObjectAndCollectionInitializerTests.cs
@@ -4021,7 +4021,7 @@ class X
             {
                 Assert.Equal("List<string>", name.ToString());
                 Assert.Equal("System.Collections.Generic.List<System.String>", semanticModel.GetSymbolInfo(name).Symbol.ToTestDisplayString());
-                Assert.Null(semanticModel.GetTypeInfo(name).Type);
+                Assert.Equal("System.Collections.Generic.List<System.String>", semanticModel.GetTypeInfo(name).Type.ToTestDisplayString());
             }
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
@@ -1241,7 +1241,7 @@ class C
             var bindInfo = model.GetSemanticInfoSummary(exprSyntaxToBind);
 
             var systemActionType = GetSystemActionType(comp);
-            Assert.Null(bindInfo.Type);
+            Assert.Equal("System.Action", bindInfo.Type.ToTestDisplayString());
             Assert.Equal(systemActionType, bindInfo.Symbol);
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
@@ -400,8 +400,8 @@ namespace Test
 }";
             var semanticInfo = GetSemanticInfoForTest<NameSyntax>(sourceCode);
 
-            Assert.Null(semanticInfo.Type);
-            Assert.Null(semanticInfo.ConvertedType);
+            Assert.Equal("Test.Base", semanticInfo.Type.ToTestDisplayString());
+            Assert.Equal("Test.Base", semanticInfo.ConvertedType.ToTestDisplayString());
 
             Assert.Equal("Test.Base", semanticInfo.Symbol.ToTestDisplayString());
             Assert.Equal(CandidateReason.None, semanticInfo.CandidateReason);
@@ -2609,8 +2609,8 @@ class A
 ";
             var semanticInfo = GetSemanticInfoForTest(sourceCode);
 
-            Assert.Null(semanticInfo.Type);
-            Assert.Null(semanticInfo.ConvertedType);
+            Assert.Equal("A", semanticInfo.Type.ToTestDisplayString());
+            Assert.Equal("A", semanticInfo.ConvertedType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
             Assert.Equal("A", semanticInfo.Symbol.ToTestDisplayString());
@@ -4210,8 +4210,8 @@ class C<T1>
 ";
             var semanticInfo = GetSemanticInfoForTest<ExpressionSyntax>(sourceCode);
 
-            Assert.Null(semanticInfo.Type);
-            Assert.Null(semanticInfo.ConvertedType);
+            Assert.Equal("C<T1>", semanticInfo.Type.ToTestDisplayString());
+            Assert.Equal("C<T1>", semanticInfo.ConvertedType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
             Assert.Null(semanticInfo.Symbol);
@@ -5064,8 +5064,8 @@ class Class1
 ";
             var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode);
 
-            Assert.Null(semanticInfo.Type);
-            Assert.Null(semanticInfo.ConvertedType);
+            Assert.Equal("Class1", semanticInfo.Type.ToTestDisplayString());
+            Assert.Equal("Class1", semanticInfo.ConvertedType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
             Assert.Equal("Class1", semanticInfo.Symbol.ToTestDisplayString());
@@ -5236,8 +5236,8 @@ class Class1
 ";
             var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode);
 
-            Assert.Null(semanticInfo.Type);
-            Assert.Null(semanticInfo.ConvertedType);
+            Assert.Equal("Class1", semanticInfo.Type.ToTestDisplayString());
+            Assert.Equal("Class1", semanticInfo.ConvertedType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
             Assert.Equal("Class1", semanticInfo.Symbol.ToTestDisplayString());
@@ -6638,8 +6638,8 @@ class Program
 ";
             var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode);
 
-            Assert.Null(semanticInfo.Type);
-            Assert.Null(semanticInfo.ConvertedType);
+            Assert.Equal("C", semanticInfo.Type.ToTestDisplayString());
+            Assert.Equal("C", semanticInfo.ConvertedType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
             Assert.Equal("C", semanticInfo.Symbol.ToTestDisplayString());
@@ -7044,8 +7044,8 @@ struct Struct{
 ";
             var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode);
 
-            Assert.Null(semanticInfo.Type);
-            Assert.Null(semanticInfo.ConvertedType);
+            Assert.Equal("Struct", semanticInfo.Type.ToTestDisplayString());
+            Assert.Equal("Struct", semanticInfo.ConvertedType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
             Assert.Equal("Struct", semanticInfo.Symbol.ToTestDisplayString());
@@ -7259,8 +7259,8 @@ class Program
 ";
             var semanticInfo = GetSemanticInfoForTest<TypeSyntax>(sourceCode);
 
-            Assert.Null(semanticInfo.Type);
-            Assert.Null(semanticInfo.ConvertedType);
+            Assert.Equal("System.Func<System.Int32, System.Int32>", semanticInfo.Type.ToTestDisplayString());
+            Assert.Equal("System.Func<System.Int32, System.Int32>", semanticInfo.ConvertedType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
             Assert.Equal("System.Func<System.Int32, System.Int32>", semanticInfo.Symbol.ToTestDisplayString());
@@ -7815,8 +7815,8 @@ class C
 ";
             var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode);
 
-            Assert.Null(semanticInfo.Type);
-            Assert.Null(semanticInfo.ConvertedType);
+            Assert.Equal("C.MyDelegate", semanticInfo.Type.ToTestDisplayString());
+            Assert.Equal("C.MyDelegate", semanticInfo.ConvertedType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
             Assert.Equal("C.MyDelegate", semanticInfo.Symbol.ToTestDisplayString());
@@ -7880,8 +7880,8 @@ class C
 ";
             var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode);
 
-            Assert.Null(semanticInfo.Type);
-            Assert.Null(semanticInfo.ConvertedType);
+            Assert.Equal("C.MyDelegate", semanticInfo.Type.ToTestDisplayString());
+            Assert.Equal("C.MyDelegate", semanticInfo.ConvertedType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
             Assert.Equal("C.MyDelegate", semanticInfo.Symbol.ToTestDisplayString());
@@ -7946,8 +7946,8 @@ class Program
 ";
             var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode);
 
-            Assert.Null(semanticInfo.Type);
-            Assert.Null(semanticInfo.ConvertedType);
+            Assert.Equal("System.Action", semanticInfo.Type.ToTestDisplayString());
+            Assert.Equal("System.Action", semanticInfo.ConvertedType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
             Assert.Equal("System.Action", semanticInfo.Symbol.ToTestDisplayString());
@@ -11185,8 +11185,8 @@ class Goo
 ";
             var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode);
 
-            Assert.Null(semanticInfo.Type);
-            Assert.Null(semanticInfo.ConvertedType);
+            Assert.Equal("Goo", semanticInfo.Type.ToTestDisplayString());
+            Assert.Equal("Goo", semanticInfo.ConvertedType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
             Assert.Equal("Goo", semanticInfo.Symbol.ToTestDisplayString());
@@ -12149,8 +12149,8 @@ static class Stat { }
 ";
             var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode);
 
-            Assert.Null(semanticInfo.Type);
-            Assert.Null(semanticInfo.ConvertedType);
+            Assert.Equal("Stat", semanticInfo.Type.ToTestDisplayString());
+            Assert.Equal("Stat", semanticInfo.ConvertedType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
             Assert.Null(semanticInfo.Symbol);
@@ -12216,8 +12216,8 @@ interface X { }
 ";
             var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode);
 
-            Assert.Null(semanticInfo.Type);
-            Assert.Null(semanticInfo.ConvertedType);
+            Assert.Equal("X", semanticInfo.Type.ToTestDisplayString());
+            Assert.Equal("X", semanticInfo.ConvertedType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
             Assert.Null(semanticInfo.Symbol);
@@ -12284,8 +12284,8 @@ class Program<T>
 ";
             var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode);
 
-            Assert.Null(semanticInfo.Type);
-            Assert.Null(semanticInfo.ConvertedType);
+            Assert.Equal("T", semanticInfo.Type.ToTestDisplayString());
+            Assert.Equal("T", semanticInfo.ConvertedType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
             Assert.Null(semanticInfo.Symbol);
@@ -12352,8 +12352,8 @@ abstract class X { }
 ";
             var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode);
 
-            Assert.Null(semanticInfo.Type);
-            Assert.Null(semanticInfo.ConvertedType);
+            Assert.Equal("X", semanticInfo.Type.ToTestDisplayString());
+            Assert.Equal("X", semanticInfo.ConvertedType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
             Assert.Null(semanticInfo.Symbol);
@@ -12388,8 +12388,8 @@ abstract class X
 ";
             var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode);
 
-            Assert.Null(semanticInfo.Type);
-            Assert.Null(semanticInfo.ConvertedType);
+            Assert.Equal("X", semanticInfo.Type.ToTestDisplayString());
+            Assert.Equal("X", semanticInfo.ConvertedType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
             Assert.Null(semanticInfo.Symbol);
@@ -12450,8 +12450,8 @@ class Program
 ";
             var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode);
 
-            Assert.Null(semanticInfo.Type);
-            Assert.Null(semanticInfo.ConvertedType);
+            Assert.Equal("dynamic", semanticInfo.Type.ToTestDisplayString());
+            Assert.Equal("dynamic", semanticInfo.ConvertedType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
             Assert.Equal("dynamic", semanticInfo.Symbol.ToTestDisplayString());
@@ -14039,8 +14039,8 @@ public class Program
 ";
             var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode);
 
-            Assert.Null(semanticInfo.Type);
-            Assert.Null(semanticInfo.ConvertedType);
+            Assert.Equal("InterfaceType", semanticInfo.Type.ToTestDisplayString());
+            Assert.Equal("InterfaceType", semanticInfo.ConvertedType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
             Assert.Equal("InterfaceType", semanticInfo.Symbol.ToTestDisplayString());
@@ -14198,8 +14198,8 @@ public class MainClass
 ";
             var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode);
 
-            Assert.Null(semanticInfo.Type);
-            Assert.Null(semanticInfo.ConvertedType);
+            Assert.Equal("NonGenericInterfaceType", semanticInfo.Type.ToTestDisplayString());
+            Assert.Equal("NonGenericInterfaceType", semanticInfo.ConvertedType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
             Assert.Equal("NonGenericInterfaceType", semanticInfo.Symbol.ToTestDisplayString());
@@ -14288,8 +14288,8 @@ public class MainClass
 ";
             var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode);
 
-            Assert.Null(semanticInfo.Type);
-            Assert.Null(semanticInfo.ConvertedType);
+            Assert.Equal("Wrapper.InterfaceType", semanticInfo.Type.ToTestDisplayString());
+            Assert.Equal("Wrapper.InterfaceType", semanticInfo.ConvertedType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
             Assert.Equal("Wrapper.InterfaceType", semanticInfo.Symbol.ToTestDisplayString());
@@ -14415,8 +14415,8 @@ public class MainClass
 ";
             var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode);
 
-            Assert.Null(semanticInfo.Type);
-            Assert.Null(semanticInfo.ConvertedType);
+            Assert.Equal("InterfaceType", semanticInfo.Type.ToTestDisplayString());
+            Assert.Equal("InterfaceType", semanticInfo.ConvertedType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
             Assert.Null(semanticInfo.Symbol);
@@ -14504,8 +14504,8 @@ public class Program
 ";
             var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode);
 
-            Assert.Null(semanticInfo.Type);
-            Assert.Null(semanticInfo.ConvertedType);
+            Assert.Equal("System.IFormattable", semanticInfo.Type.ToTestDisplayString());
+            Assert.Equal("System.IFormattable", semanticInfo.ConvertedType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
             Assert.Null(semanticInfo.Symbol);
@@ -14802,8 +14802,8 @@ namespace Test
                 Assert.Equal(0, memberGroup.Length);
 
                 TypeInfo typeInfo = model.GetTypeInfo(creation.Type);
-                Assert.Null(typeInfo.Type);
-                Assert.Null(typeInfo.ConvertedType);
+                Assert.Equal("Test.C", typeInfo.Type.ToTestDisplayString());
+                Assert.Equal("Test.C", typeInfo.ConvertedType.ToTestDisplayString());
 
                 var conv = model.GetConversion(creation.Type);
                 Assert.True(conv.IsIdentity);
@@ -14898,8 +14898,8 @@ namespace Test
                 Assert.Equal(0, memberGroup.Length);
 
                 TypeInfo typeInfo = model.GetTypeInfo(creation.Type);
-                Assert.Null(typeInfo.Type);
-                Assert.Null(typeInfo.ConvertedType);
+                Assert.Equal("Test.I", typeInfo.Type.ToTestDisplayString());
+                Assert.Equal("Test.I", typeInfo.ConvertedType.ToTestDisplayString());
 
                 var conv = model.GetConversion(creation.Type);
                 Assert.True(conv.IsIdentity);
@@ -15009,8 +15009,8 @@ namespace Test
                 Assert.Equal(0, memberGroup.Length);
 
                 TypeInfo typeInfo = model.GetTypeInfo(creation.Type);
-                Assert.Null(typeInfo.Type);
-                Assert.Null(typeInfo.ConvertedType);
+                Assert.Equal("Test.I", typeInfo.Type.ToTestDisplayString());
+                Assert.Equal("Test.I", typeInfo.ConvertedType.ToTestDisplayString());
 
                 var conv = model.GetConversion(creation.Type);
                 Assert.True(conv.IsIdentity);
@@ -15302,7 +15302,7 @@ get
 ", parseOptions: TestOptions.Regular);
             var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(comp);
 
-            Assert.Null(semanticInfo.Type);
+            Assert.Equal("BaselineLog", semanticInfo.Type.ToTestDisplayString());
 
             Assert.Equal("BaselineLog", semanticInfo.Symbol.ToDisplayString());
             Assert.Equal(SymbolKind.NamedType, semanticInfo.Symbol.Kind);
@@ -15701,6 +15701,80 @@ class K
                 Assert.Equal("R..ctor(System.Int32 I)", candidate.ToTestDisplayString());
                 Assert.Equal(SymbolKind.Method, candidate.Kind);
             }
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/78783")]
+        public void GetTypeInfo_ObjectCreation_01()
+        {
+            var src = """
+var c = new C();
+class C { }
+""";
+            var comp = CreateCompilation(src);
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var objectCreation = GetSyntax<ObjectCreationExpressionSyntax>(tree, "new C()");
+            var typeInfo = model.GetTypeInfo(objectCreation.Type);
+            Assert.Equal("C", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal("C", typeInfo.ConvertedType.ToTestDisplayString());
+
+            Assert.Equal("C..ctor()", model.GetSymbolInfo(objectCreation).Symbol.ToTestDisplayString());
+            Assert.Equal("C", model.GetSymbolInfo(objectCreation.Type).Symbol.ToTestDisplayString());
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/78783")]
+        public void GetTypeInfo_ObjectCreation_02()
+        {
+            var src = """
+var c = new C<int>();
+class C<T> { }
+""";
+            var comp = CreateCompilation(src);
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var objectCreation = GetSyntax<ObjectCreationExpressionSyntax>(tree, "new C<int>()");
+            var typeInfo = model.GetTypeInfo(objectCreation.Type);
+            Assert.Equal("C<System.Int32>", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal("C<System.Int32>", typeInfo.ConvertedType.ToTestDisplayString());
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/78783")]
+        public void GetTypeInfo_ObjectCreation_03()
+        {
+            var src = """
+var c = new N.C();
+
+namespace N
+{
+    class C { }
+}
+""";
+            var comp = CreateCompilation(src);
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var objectCreation = GetSyntax<ObjectCreationExpressionSyntax>(tree, "new N.C()");
+            var typeInfo = model.GetTypeInfo(objectCreation.Type);
+            Assert.Equal("N.C", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal("N.C", typeInfo.ConvertedType.ToTestDisplayString());
+
+            var qualifiedName = GetSyntax<QualifiedNameSyntax>(tree, "N.C");
+            Assert.Equal("N.C", model.GetTypeInfo(qualifiedName.Right).Type.ToTestDisplayString());
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/78783")]
+        public void GetTypeInfo_ObjectCreation_04()
+        {
+            var src = """
+object c = new C();
+class C { }
+""";
+            var comp = CreateCompilation(src);
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var objectCreation = GetSyntax<ObjectCreationExpressionSyntax>(tree, "new C()");
+            var typeInfo = model.GetTypeInfo(objectCreation.Type);
+            Assert.Equal("C", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal("C", typeInfo.ConvertedType.ToTestDisplayString());
         }
     }
 }

--- a/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
@@ -927,13 +927,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return Nothing
             End If
 
-            ' Do not return any type information for a ObjectCreationExpressionSyntax.Type node.
-            If boundNodes.LowestBoundNodeOfSyntacticParent IsNot Nothing AndAlso
-               boundNodes.LowestBoundNodeOfSyntacticParent.Syntax.Kind = SyntaxKind.ObjectCreationExpression AndAlso
-               DirectCast(boundNodes.LowestBoundNodeOfSyntacticParent.Syntax, ObjectCreationExpressionSyntax).Type Is lowestExpr.Syntax Then
-                Return Nothing
-            End If
-
             Dim type As TypeSymbol
 
             ' Similar to a lambda expression, array literal doesn't have a type.

--- a/src/Compilers/VisualBasic/Test/Semantic/Binding/BindingCollectionInitializerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Binding/BindingCollectionInitializerTests.vb
@@ -2002,7 +2002,7 @@ End Class
             For Each name In nodes
                 Assert.Equal("List(Of String)", name.ToString())
                 Assert.Equal("System.Collections.Generic.List(Of System.String)", semanticModel.GetSymbolInfo(name).Symbol.ToTestDisplayString())
-                Assert.Null(semanticModel.GetTypeInfo(name).Type)
+                Assert.Equal("System.Collections.Generic.List(Of System.String)", semanticModel.GetTypeInfo(name).Type.ToTestDisplayString())
             Next
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetExtendedSemanticInfoTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetExtendedSemanticInfoTests.vb
@@ -740,8 +740,8 @@ End Class
 
             Dim semanticSummary = CompilationUtils.GetSemanticInfoSummary(Of IdentifierNameSyntax)(compilation, "a.vb")
 
-            Assert.Null(semanticSummary.Type)
-            Assert.Null(semanticSummary.ConvertedType)
+            Assert.Equal("Class1", semanticSummary.Type.ToTestDisplayString())
+            Assert.Equal("Class1", semanticSummary.ConvertedType.ToTestDisplayString())
             Assert.Equal(ConversionKind.Identity, semanticSummary.ImplicitConversion.Kind)
 
             Assert.Equal("Class1", semanticSummary.Symbol.ToTestDisplayString())
@@ -951,8 +951,8 @@ End Class
 
             Dim semanticSummary = CompilationUtils.GetSemanticInfoSummary(Of IdentifierNameSyntax)(compilation, "a.vb")
 
-            Assert.Null(semanticSummary.Type)
-            Assert.Null(semanticSummary.ConvertedType)
+            Assert.Equal("Class1", semanticSummary.Type.ToTestDisplayString())
+            Assert.Equal("Class1", semanticSummary.ConvertedType.ToTestDisplayString())
             Assert.Equal(ConversionKind.Identity, semanticSummary.ImplicitConversion.Kind)
 
             Assert.Equal("Class1", semanticSummary.Symbol.ToTestDisplayString())
@@ -2738,8 +2738,8 @@ End Class
 
             Dim semanticInfo = CompilationUtils.GetSemanticInfoSummary(Of IdentifierNameSyntax)(compilation, "a.vb")
 
-            Assert.Null(semanticInfo.Type)
-            Assert.Null(semanticInfo.ConvertedType)
+            Assert.Equal("C", semanticInfo.Type.ToTestDisplayString())
+            Assert.Equal("C", semanticInfo.ConvertedType.ToTestDisplayString())
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind)
 
             Assert.Equal("C", semanticInfo.Symbol.ToTestDisplayString())
@@ -6768,8 +6768,8 @@ End Module
 
             Dim semanticInfo = CompilationUtils.GetSemanticInfoSummary(Of IdentifierNameSyntax)(compilation, "a.vb")
 
-            Assert.Null(semanticInfo.Type)
-            Assert.Null(semanticInfo.ConvertedType)
+            Assert.Equal("Del", semanticInfo.Type.ToTestDisplayString())
+            Assert.Equal("Del", semanticInfo.ConvertedType.ToTestDisplayString())
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind)
 
             Assert.Equal("Del", semanticInfo.Symbol.ToTestDisplayString())
@@ -6843,8 +6843,8 @@ End Module
 
             Dim semanticInfo = CompilationUtils.GetSemanticInfoSummary(Of IdentifierNameSyntax)(compilation, "a.vb")
 
-            Assert.Null(semanticInfo.Type)
-            Assert.Null(semanticInfo.ConvertedType)
+            Assert.Equal("Del", semanticInfo.Type.ToTestDisplayString())
+            Assert.Equal("Del", semanticInfo.ConvertedType.ToTestDisplayString())
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind)
 
             Assert.Equal("Del", semanticInfo.Symbol.ToTestDisplayString())
@@ -6918,8 +6918,8 @@ End Module
 
             Dim semanticInfo = CompilationUtils.GetSemanticInfoSummary(Of IdentifierNameSyntax)(compilation, "a.vb")
 
-            Assert.Null(semanticInfo.Type)
-            Assert.Null(semanticInfo.ConvertedType)
+            Assert.Equal("Del", semanticInfo.Type.ToTestDisplayString())
+            Assert.Equal("Del", semanticInfo.ConvertedType.ToTestDisplayString())
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind)
 
             Assert.Equal("Del", semanticInfo.Symbol.ToTestDisplayString())
@@ -6993,8 +6993,8 @@ End Module
 
             Dim semanticInfo = CompilationUtils.GetSemanticInfoSummary(Of IdentifierNameSyntax)(compilation, "a.vb")
 
-            Assert.Null(semanticInfo.Type)
-            Assert.Null(semanticInfo.ConvertedType)
+            Assert.Equal("Del", semanticInfo.Type.ToTestDisplayString())
+            Assert.Equal("Del", semanticInfo.ConvertedType.ToTestDisplayString())
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind)
 
             Assert.Equal("Del", semanticInfo.Symbol.ToTestDisplayString())
@@ -7071,8 +7071,8 @@ End Module
 
             Dim semanticInfo = CompilationUtils.GetSemanticInfoSummary(Of QualifiedNameSyntax)(compilation, "a.vb")
 
-            Assert.Null(semanticInfo.Type)
-            Assert.Null(semanticInfo.ConvertedType)
+            Assert.Equal("X.Y", semanticInfo.Type.ToTestDisplayString())
+            Assert.Equal("X.Y", semanticInfo.ConvertedType.ToTestDisplayString())
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind)
 
             Assert.Null(semanticInfo.Symbol)
@@ -7155,8 +7155,8 @@ End Module
 
             Dim semanticInfo = CompilationUtils.GetSemanticInfoSummary(Of IdentifierNameSyntax)(compilation, "a.vb")
 
-            Assert.Null(semanticInfo.Type)
-            Assert.Null(semanticInfo.ConvertedType)
+            Assert.Equal("X", semanticInfo.Type.ToTestDisplayString())
+            Assert.Equal("X", semanticInfo.ConvertedType.ToTestDisplayString())
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind)
 
             Assert.Equal("X", semanticInfo.Symbol.ToTestDisplayString())
@@ -8575,8 +8575,8 @@ End Module
 
             Dim semanticSummary = CompilationUtils.GetSemanticInfoSummary(Of IdentifierNameSyntax)(compilation, "a.vb")
 
-            Assert.Null(semanticSummary.Type)
-            Assert.Null(semanticSummary.ConvertedType)
+            Assert.Equal("Program", semanticSummary.Type.ToTestDisplayString())
+            Assert.Equal("Program", semanticSummary.ConvertedType.ToTestDisplayString())
             Assert.Equal(ConversionKind.Identity, semanticSummary.ImplicitConversion.Kind)
 
             Assert.Null(semanticSummary.Symbol)
@@ -8657,8 +8657,8 @@ End Module
 
             Dim semanticSummary = CompilationUtils.GetSemanticInfoSummary(Of IdentifierNameSyntax)(compilation, "a.vb")
 
-            Assert.Null(semanticSummary.Type)
-            Assert.Null(semanticSummary.ConvertedType)
+            Assert.Equal("C1", semanticSummary.Type.ToTestDisplayString())
+            Assert.Equal("C1", semanticSummary.ConvertedType.ToTestDisplayString())
             Assert.Equal(ConversionKind.Identity, semanticSummary.ImplicitConversion.Kind)
 
             Assert.Equal("C1", semanticSummary.Symbol.ToTestDisplayString())
@@ -8806,8 +8806,8 @@ End Module
 
             Dim semanticSummary = CompilationUtils.GetSemanticInfoSummary(Of IdentifierNameSyntax)(compilation, "a.vb")
 
-            Assert.Null(semanticSummary.Type)
-            Assert.Null(semanticSummary.ConvertedType)
+            Assert.Equal("X", semanticSummary.Type.ToTestDisplayString())
+            Assert.Equal("X", semanticSummary.ConvertedType.ToTestDisplayString())
             Assert.Equal(ConversionKind.Identity, semanticSummary.ImplicitConversion.Kind)
 
             Assert.Null(semanticSummary.Symbol)
@@ -8879,8 +8879,8 @@ End Interface
 
             Dim semanticSummary = CompilationUtils.GetSemanticInfoSummary(Of IdentifierNameSyntax)(compilation, "a.vb")
 
-            Assert.Null(semanticSummary.Type)
-            Assert.Null(semanticSummary.ConvertedType)
+            Assert.Equal("X", semanticSummary.Type.ToTestDisplayString())
+            Assert.Equal("X", semanticSummary.ConvertedType.ToTestDisplayString())
             Assert.Equal(ConversionKind.Identity, semanticSummary.ImplicitConversion.Kind)
 
             Assert.Null(semanticSummary.Symbol)
@@ -8954,8 +8954,8 @@ End Class
 
             Dim semanticSummary = CompilationUtils.GetSemanticInfoSummary(Of IdentifierNameSyntax)(compilation, "a.vb")
 
-            Assert.Null(semanticSummary.Type)
-            Assert.Null(semanticSummary.ConvertedType)
+            Assert.Equal("X", semanticSummary.Type.ToTestDisplayString())
+            Assert.Equal("X", semanticSummary.ConvertedType.ToTestDisplayString())
             Assert.Equal(ConversionKind.Identity, semanticSummary.ImplicitConversion.Kind)
 
             Assert.Null(semanticSummary.Symbol)
@@ -9050,8 +9050,8 @@ End Class
             Assert.Equal(0, memberGroup.Count)
 
             Dim typeInfo As TypeInfo = model.GetTypeInfo(creation.Type)
-            Assert.Null(typeInfo.Type)
-            Assert.Null(typeInfo.ConvertedType)
+            Assert.Equal("X", typeInfo.Type.ToTestDisplayString())
+            Assert.Equal("X", typeInfo.ConvertedType.ToTestDisplayString())
             Dim conv = model.GetConversion(creation.Type)
             Assert.True(conv.IsIdentity)
 
@@ -9114,8 +9114,8 @@ End Class
             Assert.Equal(0, memberGroup.Count)
 
             Dim typeInfo As TypeInfo = model.GetTypeInfo(creation.Type)
-            Assert.Null(typeInfo.Type)
-            Assert.Null(typeInfo.ConvertedType)
+            Assert.Equal("X", typeInfo.Type.ToTestDisplayString())
+            Assert.Equal("X", typeInfo.ConvertedType.ToTestDisplayString())
             Dim conv = model.GetConversion(creation.Type)
             Assert.True(conv.IsIdentity)
 
@@ -9178,8 +9178,8 @@ End Class
             Assert.Equal(0, memberGroup.Count)
 
             Dim typeInfo As TypeInfo = model.GetTypeInfo(creation.Type)
-            Assert.Null(typeInfo.Type)
-            Assert.Null(typeInfo.ConvertedType)
+            Assert.Equal("X", typeInfo.Type.ToTestDisplayString())
+            Assert.Equal("X", typeInfo.ConvertedType.ToTestDisplayString())
             Dim conv = model.GetConversion(creation.Type)
             Assert.True(conv.IsIdentity)
 
@@ -9243,8 +9243,8 @@ End Class
             Assert.Equal(0, memberGroup.Count)
 
             Dim typeInfo As TypeInfo = model.GetTypeInfo(creation.Type)
-            Assert.Null(typeInfo.Type)
-            Assert.Null(typeInfo.ConvertedType)
+            Assert.Equal("X", typeInfo.Type.ToTestDisplayString())
+            Assert.Equal("X", typeInfo.ConvertedType.ToTestDisplayString())
             Dim conv = model.GetConversion(creation.Type)
             Assert.True(conv.IsIdentity)
 
@@ -9304,8 +9304,8 @@ End Class
             Assert.Equal(0, memberGroup.Count)
 
             Dim typeInfo As TypeInfo = model.GetTypeInfo(creation.Type)
-            Assert.Null(typeInfo.Type)
-            Assert.Null(typeInfo.ConvertedType)
+            Assert.Equal("X", typeInfo.Type.ToTestDisplayString())
+            Assert.Equal("X", typeInfo.ConvertedType.ToTestDisplayString())
             Dim conv = model.GetConversion(creation.Type)
             Assert.True(conv.IsIdentity)
 
@@ -9348,8 +9348,8 @@ End Class
 
             Dim semanticSummary = CompilationUtils.GetSemanticInfoSummary(Of IdentifierNameSyntax)(compilation, "a.vb")
 
-            Assert.Null(semanticSummary.Type)
-            Assert.Null(semanticSummary.ConvertedType)
+            Assert.Equal("T", semanticSummary.Type.ToTestDisplayString())
+            Assert.Equal("T", semanticSummary.ConvertedType.ToTestDisplayString())
             Assert.Equal(ConversionKind.Identity, semanticSummary.ImplicitConversion.Kind)
 
             Assert.Null(semanticSummary.Symbol)
@@ -9419,8 +9419,8 @@ End Class
 
             Dim semanticSummary = CompilationUtils.GetSemanticInfoSummary(Of IdentifierNameSyntax)(compilation, "a.vb")
 
-            Assert.Null(semanticSummary.Type)
-            Assert.Null(semanticSummary.ConvertedType)
+            Assert.Equal("I", semanticSummary.Type.ToTestDisplayString())
+            Assert.Equal("I", semanticSummary.ConvertedType.ToTestDisplayString())
             Assert.Equal(ConversionKind.Identity, semanticSummary.ImplicitConversion.Kind)
 
             Assert.Null(semanticSummary.Symbol)
@@ -10224,6 +10224,56 @@ BC30002: Type 'ShortName.Class1' is not defined.
             Assert.Null(symbolInfo.Symbol)
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length)
             Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason)
+        End Sub
+
+        <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75147")>
+        Public Sub GetTypeInfo_ObjectCreation_01()
+            Dim comp = CreateCompilation(
+<compilation>
+    <file name="a.vb">
+Class C
+End Class
+
+Module TestModule
+    Sub Main()
+        Dim obj = New C()
+    End Sub
+End Module
+    </file>
+</compilation>)
+
+            comp.VerifyDiagnostics()
+            Dim tree = comp.SyntaxTrees(0)
+            Dim model = comp.GetSemanticModel(tree)
+            Dim objectCreation = tree.GetRoot().DescendantNodes().OfType(Of ObjectCreationExpressionSyntax)().Single()
+            Dim typeInfo = model.GetTypeInfo(objectCreation.Type)
+            Assert.Equal("C", typeInfo.Type.ToTestDisplayString())
+            Assert.Equal("C", typeInfo.ConvertedType.ToTestDisplayString())
+        End Sub
+
+        <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75147")>
+        Public Sub GetTypeInfo_ObjectCreation_02()
+            Dim comp = CreateCompilation(
+<compilation>
+    <file name="a.vb">
+Class C(Of T)
+End Class
+
+Module TestModule
+    Sub Main()
+        Dim obj = New C(Of System.Int32)()
+    End Sub
+End Module
+    </file>
+</compilation>)
+
+            comp.VerifyDiagnostics()
+            Dim tree = comp.SyntaxTrees(0)
+            Dim model = comp.GetSemanticModel(tree)
+            Dim objectCreation = tree.GetRoot().DescendantNodes().OfType(Of ObjectCreationExpressionSyntax)().Single()
+            Dim typeInfo = model.GetTypeInfo(objectCreation.Type)
+            Assert.Equal("C(Of System.Int32)", typeInfo.Type.ToTestDisplayString())
+            Assert.Equal("C(Of System.Int32)", typeInfo.ConvertedType.ToTestDisplayString())
         End Sub
 
     End Class

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetSemanticInfoTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetSemanticInfoTests.vb
@@ -5350,8 +5350,8 @@ End Namespace
                 Assert.Equal(0, memberGroup.Length)
 
                 Dim typeInfo As TypeInfo = model.GetTypeInfo(creation.Type)
-                Assert.Null(typeInfo.Type)
-                Assert.Null(typeInfo.ConvertedType)
+                Assert.Equal("Test.C", typeInfo.Type.ToTestDisplayString())
+                Assert.Equal("Test.C", typeInfo.ConvertedType.ToTestDisplayString())
 
                 Dim conv = model.GetConversion(creation.Type)
                 Assert.True(conv.IsIdentity)
@@ -5439,8 +5439,8 @@ End Namespace
                 Assert.Equal(0, memberGroup.Length)
 
                 Dim typeInfo As TypeInfo = model.GetTypeInfo(creation.Type)
-                Assert.Null(typeInfo.Type)
-                Assert.Null(typeInfo.ConvertedType)
+                Assert.Equal("Test.I", typeInfo.Type.ToTestDisplayString())
+                Assert.Equal("Test.I", typeInfo.ConvertedType.ToTestDisplayString())
 
                 Dim conv = model.GetConversion(creation.Type)
                 Assert.True(conv.IsIdentity)
@@ -5544,8 +5544,8 @@ End Namespace
                 Assert.Equal(0, memberGroup.Length)
 
                 Dim typeInfo As TypeInfo = model.GetTypeInfo(creation.Type)
-                Assert.Null(typeInfo.Type)
-                Assert.Null(typeInfo.ConvertedType)
+                Assert.Equal("Test.I", typeInfo.Type.ToTestDisplayString())
+                Assert.Equal("Test.I", typeInfo.ConvertedType.ToTestDisplayString())
 
                 Dim conv = model.GetConversion(creation.Type)
                 Assert.True(conv.IsIdentity)

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/NewOnInterfaceTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/NewOnInterfaceTests.vb
@@ -1198,8 +1198,8 @@ End Module
             Assert.Equal(SymbolKind.NamedType, semanticInfo.Symbol.Kind)
             Assert.Equal("IInterface", semanticInfo.Symbol.ToDisplayString())
 
-            Assert.Null(semanticInfo.Type)
-            Assert.Null(semanticInfo.ConvertedType)
+            Assert.Equal("IInterface", semanticInfo.Type.ToDisplayString())
+            Assert.Equal("IInterface", semanticInfo.ConvertedType.ToDisplayString())
         End Sub
 
         <Fact()>


### PR DESCRIPTION
The scenario was blocked, but from discussion in the linked issues we can't think of a good reason for that. This PR just unblocks it.

Fixes https://github.com/dotnet/roslyn/issues/78783
Fixes https://github.com/dotnet/roslyn/issues/75147