### PR TITLE
Let Razor fill in project information on diagnostics

### DIFF
--- a/src/Tools/ExternalAccess/Razor/Features/Cohost/Handlers/Diagnostics.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/Cohost/Handlers/Diagnostics.cs
@@ -16,6 +16,12 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost.Handlers;
 
 internal static class Diagnostics
 {
+    public static LSP.VSDiagnosticProjectInformation GetProjectInformation(Project project)
+    {
+        var service = project.Solution.Services.GetRequiredService<IDiagnosticProjectInformationService>();
+        return service.GetDiagnosticProjectInformation(project);
+    }
+
     public static async Task<ImmutableArray<LSP.Diagnostic>> GetDocumentDiagnosticsAsync(Document document, bool supportsVisualStudioExtensions, CancellationToken cancellationToken)
     {
         var solutionServices = document.Project.Solution.Services;


### PR DESCRIPTION
Part of https://github.com/dotnet/razor/issues/12628

Needed for the "Current Project" filter in the Error list to work