### PR TITLE
Prototype: sharing transient inline arrays

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -2285,6 +2285,19 @@
     <Field Name="GetItemOrSliceHelper" Type="WellKnownMember"/>
   </Node>
 
+  <!--
+  Represents a transient span backed by an inline array. Local rewriting emits this node to defer
+  materialization of the inline array until the inline array sharing optimization pass. The node
+  captures the elements that should populate the inline array along with metadata required for
+  lifetime analysis.
+  -->
+  <Node Name="BoundTransientSpanFromInlineArray" Base="BoundExpression" DoesNotSurvive="Spilling">
+    <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow" />
+    <Field Name="Elements" Type="ImmutableArray&lt;BoundExpression&gt;" Null="disallow" />
+    <Field Name="ElementType" Type="TypeSymbol" Null="disallow" />
+    <Field Name="IsReadOnly" Type="bool" />
+  </Node>
+
   <Node Name="BoundDynamicIndexerAccess" Base="BoundExpression">
     <!-- Non-null type is required for this node kind -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -217,6 +217,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         IndexerAccess,
         ImplicitIndexerAccess,
         InlineArrayAccess,
+        TransientSpanFromInlineArray,
         DynamicIndexerAccess,
         Lambda,
         UnboundLambda,
@@ -7574,6 +7575,41 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
+    internal sealed partial class BoundTransientSpanFromInlineArray : BoundExpression
+    {
+        public BoundTransientSpanFromInlineArray(SyntaxNode syntax, ImmutableArray<BoundExpression> elements, TypeSymbol elementType, bool isReadOnly, TypeSymbol type, bool hasErrors = false)
+            : base(BoundKind.TransientSpanFromInlineArray, syntax, type, hasErrors || elements.HasErrors())
+        {
+
+            RoslynDebug.Assert(!elements.IsDefault, "Field 'elements' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            RoslynDebug.Assert(elementType is object, "Field 'elementType' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
+            RoslynDebug.Assert(type is object, "Field 'type' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
+
+            this.Elements = elements;
+            this.ElementType = elementType;
+            this.IsReadOnly = isReadOnly;
+        }
+
+        public new TypeSymbol Type => base.Type!;
+        public ImmutableArray<BoundExpression> Elements { get; }
+        public TypeSymbol ElementType { get; }
+        public bool IsReadOnly { get; }
+
+        [DebuggerStepThrough]
+        public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitTransientSpanFromInlineArray(this);
+
+        public BoundTransientSpanFromInlineArray Update(ImmutableArray<BoundExpression> elements, TypeSymbol elementType, bool isReadOnly, TypeSymbol type)
+        {
+            if (elements != this.Elements || !TypeSymbol.Equals(elementType, this.ElementType, TypeCompareKind.ConsiderEverything) || isReadOnly != this.IsReadOnly || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
+            {
+                var result = new BoundTransientSpanFromInlineArray(this.Syntax, elements, elementType, isReadOnly, type, this.HasErrors);
+                result.CopyAttributes(this);
+                return result;
+            }
+            return this;
+        }
+    }
+
     internal sealed partial class BoundDynamicIndexerAccess : BoundExpression
     {
         public BoundDynamicIndexerAccess(SyntaxNode syntax, BoundExpression receiver, ImmutableArray<BoundExpression> arguments, ImmutableArray<string?> argumentNamesOpt, ImmutableArray<RefKind> argumentRefKindsOpt, ImmutableArray<PropertySymbol> applicableIndexers, TypeSymbol type, bool hasErrors = false)
@@ -9290,6 +9326,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return VisitImplicitIndexerAccess((BoundImplicitIndexerAccess)node, arg);
                 case BoundKind.InlineArrayAccess:
                     return VisitInlineArrayAccess((BoundInlineArrayAccess)node, arg);
+                case BoundKind.TransientSpanFromInlineArray:
+                    return VisitTransientSpanFromInlineArray((BoundTransientSpanFromInlineArray)node, arg);
                 case BoundKind.DynamicIndexerAccess:
                     return VisitDynamicIndexerAccess((BoundDynamicIndexerAccess)node, arg);
                 case BoundKind.Lambda:
@@ -9565,6 +9603,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public virtual R VisitIndexerAccess(BoundIndexerAccess node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitImplicitIndexerAccess(BoundImplicitIndexerAccess node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitInlineArrayAccess(BoundInlineArrayAccess node, A arg) => this.DefaultVisit(node, arg);
+        public virtual R VisitTransientSpanFromInlineArray(BoundTransientSpanFromInlineArray node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitDynamicIndexerAccess(BoundDynamicIndexerAccess node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitLambda(BoundLambda node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitUnboundLambda(UnboundLambda node, A arg) => this.DefaultVisit(node, arg);
@@ -9801,6 +9840,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public virtual BoundNode? VisitIndexerAccess(BoundIndexerAccess node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitImplicitIndexerAccess(BoundImplicitIndexerAccess node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitInlineArrayAccess(BoundInlineArrayAccess node) => this.DefaultVisit(node);
+        public virtual BoundNode? VisitTransientSpanFromInlineArray(BoundTransientSpanFromInlineArray node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitDynamicIndexerAccess(BoundDynamicIndexerAccess node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitLambda(BoundLambda node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitUnboundLambda(UnboundLambda node) => this.DefaultVisit(node);
@@ -10692,6 +10732,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             this.Visit(node.Expression);
             this.Visit(node.Argument);
+            return null;
+        }
+        public override BoundNode? VisitTransientSpanFromInlineArray(BoundTransientSpanFromInlineArray node)
+        {
+            this.VisitList(node.Elements);
             return null;
         }
         public override BoundNode? VisitDynamicIndexerAccess(BoundDynamicIndexerAccess node)
@@ -12172,6 +12217,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression argument = (BoundExpression)this.Visit(node.Argument);
             TypeSymbol? type = this.VisitType(node.Type);
             return node.Update(expression, argument, node.IsValue, node.GetItemOrSliceHelper, type);
+        }
+        public override BoundNode? VisitTransientSpanFromInlineArray(BoundTransientSpanFromInlineArray node)
+        {
+            ImmutableArray<BoundExpression> elements = this.VisitList(node.Elements);
+            TypeSymbol? elementType = this.VisitType(node.ElementType);
+            TypeSymbol? type = this.VisitType(node.Type);
+            return node.Update(elements, elementType, node.IsReadOnly, type);
         }
         public override BoundNode? VisitDynamicIndexerAccess(BoundDynamicIndexerAccess node)
         {
@@ -14727,6 +14779,24 @@ namespace Microsoft.CodeAnalysis.CSharp
             return updatedNode;
         }
 
+        public override BoundNode? VisitTransientSpanFromInlineArray(BoundTransientSpanFromInlineArray node)
+        {
+            TypeSymbol elementType = GetUpdatedSymbol(node, node.ElementType);
+            ImmutableArray<BoundExpression> elements = this.VisitList(node.Elements);
+            BoundTransientSpanFromInlineArray updatedNode;
+
+            if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol? Type) infoAndType))
+            {
+                updatedNode = node.Update(elements, elementType, node.IsReadOnly, infoAndType.Type!);
+                updatedNode.TopLevelNullability = infoAndType.Info;
+            }
+            else
+            {
+                updatedNode = node.Update(elements, elementType, node.IsReadOnly, node.Type);
+            }
+            return updatedNode;
+        }
+
         public override BoundNode? VisitDynamicIndexerAccess(BoundDynamicIndexerAccess node)
         {
             ImmutableArray<PropertySymbol> applicableIndexers = GetUpdatedArray(node, node.ApplicableIndexers);
@@ -16986,6 +17056,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             new TreeDumperNode("hasErrors", node.HasErrors, null)
         }
         );
+        public override TreeDumperNode VisitTransientSpanFromInlineArray(BoundTransientSpanFromInlineArray node, object? arg) => new TreeDumperNode("transientSpanFromInlineArray", null, new TreeDumperNode[]
+        {
+            new TreeDumperNode("elements", null, from x in node.Elements select Visit(x, null)),
+            new TreeDumperNode("elementType", node.ElementType, null),
+            new TreeDumperNode("isReadOnly", node.IsReadOnly, null),
+            new TreeDumperNode("type", node.Type, null),
+            new TreeDumperNode("isSuppressed", node.IsSuppressed, null),
+            new TreeDumperNode("hasErrors", node.HasErrors, null)
+        }
+        );
         public override TreeDumperNode VisitDynamicIndexerAccess(BoundDynamicIndexerAccess node, object? arg) => new TreeDumperNode("dynamicIndexerAccess", null, new TreeDumperNode[]
         {
             new TreeDumperNode("receiver", null, new TreeDumperNode[] { Visit(node.Receiver, null) }),
@@ -17357,6 +17437,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 BoundKind.UnconvertedObjectCreationExpression => PipelinePhase.InitialBinding,
                 BoundKind.UnconvertedCollectionExpression => PipelinePhase.InitialBinding,
                 BoundKind.TupleLiteral => PipelinePhase.InitialBinding,
+                BoundKind.TransientSpanFromInlineArray => PipelinePhase.Spilling,
                 BoundKind.TypeOrInstanceInitializers => PipelinePhase.LocalRewriting,
                 BoundKind.UnconvertedInterpolatedString => PipelinePhase.InitialBinding,
                 BoundKind.InterpolatedStringHandlerPlaceholder => PipelinePhase.LocalRewriting,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             throw ExceptionUtilities.Unreachable();
         }
 
-        private BoundExpression RewriteCollectionExpressionConversion(Conversion conversion, BoundCollectionExpression node)
+        private BoundExpression RewriteCollectionExpressionConversion(Conversion conversion, BoundCollectionExpression node, ParameterSymbol? passedAsParameter)
         {
             Debug.Assert(conversion.Kind == ConversionKind.CollectionExpression);
             Debug.Assert(!_inExpressionLambda);
@@ -58,12 +58,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case CollectionExpressionTypeKind.Span:
                     case CollectionExpressionTypeKind.ReadOnlySpan:
                         Debug.Assert(elementType is { });
-                        return VisitArrayOrSpanCollectionExpression(node, node.Type);
+                        return VisitArrayOrSpanCollectionExpression(node, node.Type, passedAsParameter);
                     case CollectionExpressionTypeKind.CollectionBuilder:
                         // A few special cases when a collection type is an ImmutableArray<T>
                         if ((object)node.Type.OriginalDefinition == _compilation.GetWellKnownType(WellKnownType.System_Collections_Immutable_ImmutableArray_T))
                         {
-                            return VisitArrayOrSpanCollectionExpression(node, node.Type);
+                            return VisitArrayOrSpanCollectionExpression(node, node.Type, passedAsParameter);
                         }
 
                         return VisitCollectionBuilderCollectionExpression(node);
@@ -222,7 +222,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Note that Span/ROS/ImmutableArray cases, may or may not involve us actually creating an array.
         /// Depending on the collection elements, available APIs, or other context, we may use some other strategy.
         /// </summary>
-        private BoundExpression VisitArrayOrSpanCollectionExpression(BoundCollectionExpression node, TypeSymbol collectionType)
+        private BoundExpression VisitArrayOrSpanCollectionExpression(BoundCollectionExpression node, TypeSymbol collectionType, ParameterSymbol? passedAsParameter)
         {
             Debug.Assert(!_inExpressionLambda);
             Debug.Assert(_additionalLocals is { });
@@ -317,11 +317,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                     _additionalLocals is { })
                 {
                     Debug.Assert(!IsAllocatingRefStructCollectionExpression(node, isReadOnlySpan ? CollectionExpressionTypeKind.ReadOnlySpan : CollectionExpressionTypeKind.Span, elementType.Type, _compilation));
-                    return CreateAndPopulateSpanFromInlineArray(
+
+                    return CreateTransientArrayOrCreateAndPopulateSpanFromInlineArray(
                         node.Syntax,
                         elementType,
-                        elements,
-                        asReadOnlySpan: isReadOnlySpan);
+                        elements.SelectAsArray(static (element, @this) => @this.VisitExpression((BoundExpression)element), this),
+                        asReadOnlySpan: isReadOnlySpan,
+                        passedAsParameter);
                 }
 
                 return null;
@@ -550,7 +552,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // we can directly use `anotherReadOnlySpan` as collection builder argument and skip the copying assignment.
             BoundExpression span = CanOptimizeSingleSpreadAsCollectionBuilderArgument(node, out var spreadExpression)
                 ? VisitExpression(spreadExpression)
-                : VisitArrayOrSpanCollectionExpression(node, spanType);
+                : VisitArrayOrSpanCollectionExpression(node, spanType, passedAsParameter: null);
 
             var invocation = new BoundCall(
                 node.Syntax,
@@ -599,51 +601,78 @@ namespace Microsoft.CodeAnalysis.CSharp
                 compilation.Assembly.RuntimeSupportsInlineArrayTypes;
         }
 
-        private BoundExpression CreateAndPopulateSpanFromInlineArray(
+        private BoundExpression CreateTransientArrayOrCreateAndPopulateSpanFromInlineArray(
             SyntaxNode syntax,
             TypeWithAnnotations elementType,
-            ImmutableArray<BoundNode> elements,
-            bool asReadOnlySpan)
+            ImmutableArray<BoundExpression> elements,
+            bool asReadOnlySpan,
+            ParameterSymbol? passedAsParameter)
         {
             Debug.Assert(elements.Length > 0);
-            Debug.Assert(elements.All(e => e is BoundExpression));
-            Debug.Assert(_factory.ModuleBuilderOpt is { });
-            Debug.Assert(_diagnostics.DiagnosticBag is { });
-            Debug.Assert(_compilation.Assembly.RuntimeSupportsInlineArrayTypes);
+
+            // If the span is being passed to a scoped parameter, we can share inline array temps across invocations, we
+            // know that the inline array won't escape the current call. This will be done by a pass after local rewriting,
+            // as the array sizes won't be known until all of local rewriting is done.
+            if (passedAsParameter is { EffectiveScope: ScopedKind.ScopedValue, RefKind: RefKind.None })
+            {
+                _transientInlineArrayAllocator.AllocateInlineArray(elementType.Type, elements.Length, isReadOnly: asReadOnlySpan);
+                _allocatedTransientInlineArrays ??= ArrayBuilder<(TypeSymbol type, int length)>.GetInstance();
+                _allocatedTransientInlineArrays.Add((elementType.Type, elements.Length));
+
+                var spanType = _factory.WellKnownType(asReadOnlySpan ? WellKnownType.System_ReadOnlySpan_T : WellKnownType.System_Span_T).Construct([elementType]);
+
+                return new BoundTransientSpanFromInlineArray(syntax, elements, elementType.Type, asReadOnlySpan, spanType);
+            }
+
             Debug.Assert(_additionalLocals is { });
+            return CreateCreateAndPopulateSpanFromInlineArray(syntax, elementType, elements, asReadOnlySpan, _factory, _compilation, _additionalLocals, _diagnostics);
+        }
+
+        internal static BoundExpression CreateCreateAndPopulateSpanFromInlineArray(
+            SyntaxNode syntax,
+            TypeWithAnnotations elementType,
+            ImmutableArray<BoundExpression> elements,
+            bool asReadOnlySpan,
+            SyntheticBoundNodeFactory factory,
+            CSharpCompilation compilation,
+            ArrayBuilder<LocalSymbol> additionalLocals,
+            BindingDiagnosticBag diagnostics)
+        {
+            Debug.Assert(factory.ModuleBuilderOpt is { });
+            Debug.Assert(diagnostics.DiagnosticBag is { });
+            Debug.Assert(compilation.Assembly.RuntimeSupportsInlineArrayTypes);
 
             int arrayLength = elements.Length;
             if (arrayLength == 1
-                && _factory.WellKnownMember(asReadOnlySpan
+                && factory.WellKnownMember(asReadOnlySpan
                     ? WellKnownMember.System_ReadOnlySpan_T__ctor_ref_readonly_T
                     : WellKnownMember.System_Span_T__ctor_ref_T, isOptional: true) is MethodSymbol spanRefConstructor)
             {
                 // Special case: no need to create an InlineArray1 type. Just use a temp of the element type.
-                var spanType = _factory
+                var spanType = factory
                     .WellKnownType(asReadOnlySpan ? WellKnownType.System_ReadOnlySpan_T : WellKnownType.System_Span_T)
                     .Construct([elementType]);
                 var constructor = spanRefConstructor.AsMember(spanType);
-                var element = VisitExpression((BoundExpression)elements[0]);
-                var temp = _factory.StoreToTemp(element, out var assignment);
-                _additionalLocals.Add(temp.LocalSymbol);
-                var call = _factory.New(constructor, arguments: [temp], argumentRefKinds: [asReadOnlySpan ? RefKindExtensions.StrictIn : RefKind.Ref]);
-                return _factory.Sequence([assignment], call);
+                var temp = factory.StoreToTemp(elements[0], out var assignment);
+                additionalLocals.Add(temp.LocalSymbol);
+                var call = factory.New(constructor, arguments: [temp], argumentRefKinds: [asReadOnlySpan ? RefKindExtensions.StrictIn : RefKind.Ref]);
+                return factory.Sequence([assignment], call);
             }
 
-            var inlineArrayType = _factory.ModuleBuilderOpt.EnsureInlineArrayTypeExists(syntax, _factory, arrayLength, _diagnostics).Construct(ImmutableArray.Create(elementType));
+            var inlineArrayType = factory.ModuleBuilderOpt.EnsureInlineArrayTypeExists(syntax, factory, arrayLength, diagnostics).Construct(ImmutableArray.Create(elementType));
             Debug.Assert(inlineArrayType.HasInlineArrayAttribute(out int inlineArrayLength) && inlineArrayLength == arrayLength);
 
-            var intType = _factory.SpecialType(SpecialType.System_Int32);
-            MethodSymbol elementRef = _factory.ModuleBuilderOpt.EnsureInlineArrayElementRefExists(syntax, intType, _diagnostics.DiagnosticBag).
+            var intType = factory.SpecialType(SpecialType.System_Int32);
+            MethodSymbol elementRef = factory.ModuleBuilderOpt.EnsureInlineArrayElementRefExists(syntax, intType, diagnostics.DiagnosticBag).
                 Construct(ImmutableArray.Create(TypeWithAnnotations.Create(inlineArrayType), elementType));
 
             // Create an inline array and assign to a local.
             // var tmp = new <>y__InlineArrayN<ElementType>();
             BoundAssignmentOperator assignmentToTemp;
-            BoundLocal inlineArrayLocal = _factory.StoreToTemp(new BoundDefaultExpression(syntax, inlineArrayType), out assignmentToTemp);
+            BoundLocal inlineArrayLocal = factory.StoreToTemp(new BoundDefaultExpression(syntax, inlineArrayType), out assignmentToTemp);
             var sideEffects = ArrayBuilder<BoundExpression>.GetInstance();
             sideEffects.Add(assignmentToTemp);
-            _additionalLocals.Add(inlineArrayLocal.LocalSymbol);
+            additionalLocals.Add(inlineArrayLocal.LocalSymbol);
 
             // Populate the inline array.
             // InlineArrayElementRef<<>y__InlineArrayN<ElementType>, ElementType>(ref tmp, 0) = element0;
@@ -651,9 +680,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             // ...
             for (int i = 0; i < arrayLength; i++)
             {
-                var element = VisitExpression((BoundExpression)elements[i]);
-                var call = _factory.Call(null, elementRef, inlineArrayLocal, _factory.Literal(i), useStrictArgumentRefKinds: true);
-                var assignment = new BoundAssignmentOperator(syntax, call, element, type: call.Type) { WasCompilerGenerated = true };
+                var call = factory.Call(null, elementRef, inlineArrayLocal, factory.Literal(i), useStrictArgumentRefKinds: true);
+                var assignment = new BoundAssignmentOperator(syntax, call, elements[i], type: call.Type) { WasCompilerGenerated = true };
                 sideEffects.Add(assignment);
             }
 
@@ -662,14 +690,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             // or
             // ... InlineArrayAsSpan<<>y__InlineArrayN<ElementType>, ElementType>(ref tmp, N)
             MethodSymbol inlineArrayAsSpan = asReadOnlySpan ?
-                _factory.ModuleBuilderOpt.EnsureInlineArrayAsReadOnlySpanExists(syntax, _factory.WellKnownType(WellKnownType.System_ReadOnlySpan_T), intType, _diagnostics.DiagnosticBag) :
-                _factory.ModuleBuilderOpt.EnsureInlineArrayAsSpanExists(syntax, _factory.WellKnownType(WellKnownType.System_Span_T), intType, _diagnostics.DiagnosticBag);
+                factory.ModuleBuilderOpt.EnsureInlineArrayAsReadOnlySpanExists(syntax, factory.WellKnownType(WellKnownType.System_ReadOnlySpan_T), intType, diagnostics.DiagnosticBag) :
+                factory.ModuleBuilderOpt.EnsureInlineArrayAsSpanExists(syntax, factory.WellKnownType(WellKnownType.System_Span_T), intType, diagnostics.DiagnosticBag);
             inlineArrayAsSpan = inlineArrayAsSpan.Construct(ImmutableArray.Create(TypeWithAnnotations.Create(inlineArrayType), elementType));
-            var span = _factory.Call(
+            var span = factory.Call(
                 receiver: null,
                 inlineArrayAsSpan,
                 inlineArrayLocal,
-                _factory.Literal(arrayLength),
+                factory.Literal(arrayLength),
                 useStrictArgumentRefKinds: true);
 
             Debug.Assert(span.Type is { });

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/TransientInlineArrayAllocator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/TransientInlineArrayAllocator.cs
@@ -1,0 +1,99 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp;
+
+internal sealed class TransientInlineArrayAllocator
+{
+    private static readonly ObjectPool<Dictionary<TypeSymbol, int>> s_currentlyAllocatedSpacePool =
+        new ObjectPool<Dictionary<TypeSymbol, int>>(() => new Dictionary<TypeSymbol, int>(comparer: Symbols.SymbolEqualityComparer.IgnoringTupleNamesAndNullability), 10);
+
+    private static readonly ObjectPool<Dictionary<TypeSymbol, TransientInlineArrayInfo>> s_allocatedSpacePool =
+        new ObjectPool<Dictionary<TypeSymbol, TransientInlineArrayInfo>>(() => new Dictionary<TypeSymbol, TransientInlineArrayInfo>(comparer: Symbols.SymbolEqualityComparer.IgnoringTupleNamesAndNullability), 10);
+
+    private readonly Dictionary<TypeSymbol, int> _currentlyAllocatedSpace;
+    private readonly Dictionary<TypeSymbol, TransientInlineArrayInfo> _allocatedSpace;
+    public TransientInlineArrayAllocator()
+    {
+        _currentlyAllocatedSpace = s_currentlyAllocatedSpacePool.Allocate();
+        _allocatedSpace = s_allocatedSpacePool.Allocate();
+    }
+
+    public void AllocateInlineArray(TypeSymbol elementType, int length, bool isReadOnly)
+    {
+        if (_allocatedSpace.TryGetValue(elementType, out var allocatedSpace))
+        {
+            Debug.Assert(_currentlyAllocatedSpace.ContainsKey(elementType));
+            var currentSpace = _currentlyAllocatedSpace[elementType];
+            currentSpace += length;
+            _allocatedSpace[elementType] = allocatedSpace.AddUse(currentSpace, isReadOnly);
+            _currentlyAllocatedSpace[elementType] = currentSpace;
+        }
+        else
+        {
+            Debug.Assert(!_currentlyAllocatedSpace.ContainsKey(elementType));
+            _allocatedSpace[elementType] = new TransientInlineArrayInfo(elementType, length, numUses: 1, isReadOnly);
+            _currentlyAllocatedSpace[elementType] = length;
+        }
+    }
+
+    public void ReturnInlineArray(TypeSymbol elementType, int length)
+    {
+        Debug.Assert(_currentlyAllocatedSpace.ContainsKey(elementType));
+        var currentSpace = _currentlyAllocatedSpace[elementType];
+        currentSpace -= length;
+        Debug.Assert(currentSpace >= 0);
+        _currentlyAllocatedSpace[elementType] = currentSpace;
+    }
+
+    public ImmutableArray<TransientInlineArrayInfo> ToAllocatedArraysAndFree()
+    {
+        Debug.Assert(_currentlyAllocatedSpace.All(kv => kv.Value == 0), "All allocated space should have been returned.");
+        _currentlyAllocatedSpace.Clear();
+        s_currentlyAllocatedSpacePool.Free(_currentlyAllocatedSpace);
+        var result = _allocatedSpace.SelectAsArray(kv =>
+        {
+            Debug.Assert(kv.Key.Equals(kv.Value.ElementType, TypeCompareKind.IgnoreTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes));
+            return kv.Value;
+        });
+        _allocatedSpace.Clear();
+        s_allocatedSpacePool.Free(_allocatedSpace);
+        return result;
+    }
+}
+
+internal readonly struct TransientInlineArrayInfo(TypeSymbol elementType, int maxSpace, int numUses, bool needsReadOnly, bool needsMutable = false)
+{
+    public readonly TypeSymbol ElementType = elementType;
+    public readonly int MaxSpace = maxSpace;
+    public readonly int NumUses = numUses;
+    public readonly bool NeedsReadOnly = needsReadOnly;
+    public readonly bool NeedsMutable = needsMutable;
+
+    public TransientInlineArrayInfo(TypeSymbol elementType, int maxSpace, int numUses, bool isReadOnly)
+        : this(elementType, maxSpace, numUses, needsReadOnly: isReadOnly, needsMutable: !isReadOnly)
+    {
+    }
+
+    public TransientInlineArrayInfo AddUse(int currentlyUsedSpace, bool isReadOnly)
+    {
+        var needsReadonly = NeedsReadOnly || isReadOnly;
+        var needsMutable = NeedsMutable || !isReadOnly;
+        return new TransientInlineArrayInfo(
+            ElementType,
+            Math.Max(MaxSpace, currentlyUsedSpace),
+            NumUses + 1,
+            needsReadonly,
+            needsMutable);
+    }
+}

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/TransientInlineArrayRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/TransientInlineArrayRewriter.cs
@@ -1,0 +1,439 @@
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp;
+
+internal sealed class TransientInlineArrayRewriter : BoundTreeRewriterWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
+{
+    private static readonly ObjectPool<Dictionary<TypeSymbol, AllocatedArrayInfo>> s_allocatedLocalsPool =
+        new ObjectPool<Dictionary<TypeSymbol, AllocatedArrayInfo>>(() => new Dictionary<TypeSymbol, AllocatedArrayInfo>(comparer: Symbols.SymbolEqualityComparer.IgnoringTupleNamesAndNullability), 10);
+
+    private readonly Dictionary<TypeSymbol, AllocatedArrayInfo> _allocatedArrayLocals;
+    private readonly SyntheticBoundNodeFactory _factory;
+    private readonly BindingDiagnosticBag _diagnostics;
+    private CachedWellKnownInfo _cachedWellKnownInfo;
+
+    private TransientInlineArrayRewriter(Dictionary<TypeSymbol, AllocatedArrayInfo> allocatedArrayLocals, SyntheticBoundNodeFactory factory, BindingDiagnosticBag diagnostics, CachedWellKnownInfo cachedWellKnownInfo)
+    {
+        _allocatedArrayLocals = allocatedArrayLocals;
+        _factory = factory;
+        _diagnostics = diagnostics;
+        _cachedWellKnownInfo = cachedWellKnownInfo;
+    }
+
+    public static BoundStatement Rewrite(BoundStatement node, ImmutableArray<TransientInlineArrayInfo> allocatedArrays, SyntheticBoundNodeFactory factory, BindingDiagnosticBag diagnostics)
+    {
+        Debug.Assert(!allocatedArrays.IsDefault);
+        Debug.Assert(diagnostics.DiagnosticBag is not null);
+        if (allocatedArrays is [])
+        {
+            return node;
+        }
+
+        var cachedWellKnownInfo = new CachedWellKnownInfo(factory, diagnostics.DiagnosticBag);
+        var allocatedArrayLocals = AllocateArrays(allocatedArrays, node.Syntax, factory, ref cachedWellKnownInfo, diagnostics);
+        var rewriter = new TransientInlineArrayRewriter(allocatedArrayLocals, factory, diagnostics, cachedWellKnownInfo);
+        var result = (BoundStatement)rewriter.Visit(node);
+
+        if (allocatedArrayLocals.Count > 0)
+        {
+            result = factory.Block(
+                locals: allocatedArrayLocals.SelectAsArray(kvp => kvp.Value.Local),
+                statements: result);
+        }
+
+        allocatedArrayLocals.Clear();
+        s_allocatedLocalsPool.Free(allocatedArrayLocals);
+        return result;
+    }
+
+    private static Dictionary<TypeSymbol, AllocatedArrayInfo> AllocateArrays(ImmutableArray<TransientInlineArrayInfo> allocatedArrays, SyntaxNode syntax, SyntheticBoundNodeFactory factory, ref CachedWellKnownInfo cachedWellKnownInfo, BindingDiagnosticBag diagnostics)
+    {
+        Debug.Assert(factory.ModuleBuilderOpt is not null);
+        var allocatedArrayLocals = s_allocatedLocalsPool.Allocate();
+#if DEBUG
+        var actualCount = allocatedArrays.Select(a => a.ElementType).Distinct(Symbols.SymbolEqualityComparer.IgnoringTupleNamesAndNullability).Count();
+        Debug.Assert(actualCount == allocatedArrays.Length);
+#endif
+        foreach (var arrayInfo in allocatedArrays)
+        {
+            Debug.Assert(arrayInfo.NumUses > 0);
+            Debug.Assert(arrayInfo.MaxSpace > 0);
+            if (arrayInfo.NumUses == 1)
+            {
+                // If the array is only used once, then we don't need a shared value. The rewrite will create the local
+                // in place at the call site.
+                continue;
+            }
+
+            if (tryUseSingleElement(arrayInfo, ref cachedWellKnownInfo, out var singleLocal))
+            {
+                allocatedArrayLocals.Add(arrayInfo.ElementType, new AllocatedArrayInfo(singleLocal, isArray: false, currentStart: 0, length: 1));
+            }
+            else
+            {
+                // Otherwise, we need to allocate an array.
+                var inlineArrayType = factory.ModuleBuilderOpt.EnsureInlineArrayTypeExists(syntax, factory, arrayInfo.MaxSpace, diagnostics).Construct(ImmutableArray.Create(arrayInfo.ElementType));
+
+                var arrayLocal = factory.SynthesizedLocal(
+                    inlineArrayType,
+                    kind: SynthesizedLocalKind.SharedInlineArraySpace,
+                    syntax: syntax);
+                allocatedArrayLocals.Add(arrayInfo.ElementType, new AllocatedArrayInfo(arrayLocal, isArray: true, currentStart: 0, length: arrayInfo.MaxSpace));
+            }
+        }
+
+        return allocatedArrayLocals;
+
+        bool tryUseSingleElement(TransientInlineArrayInfo arrayInfo, ref CachedWellKnownInfo cachedWellKnownInfo, [NotNullWhen(true)] out LocalSymbol? singleLocal)
+        {
+            singleLocal = null;
+
+            // If the array only needs a single element, we can potentially just use a single element, assuming the right
+            // span/readonlyspan constructor is available.
+            if (arrayInfo.MaxSpace != 1)
+            {
+                return false;
+            }
+
+            if (arrayInfo.NeedsReadOnly && cachedWellKnownInfo.ReadOnlySpanRefConstructor is null
+                || arrayInfo.NeedsMutable && cachedWellKnownInfo.SpanRefConstructor is null)
+            {
+                return false;
+            }
+
+            singleLocal = factory.SynthesizedLocal(
+                arrayInfo.ElementType,
+                kind: SynthesizedLocalKind.SharedInlineArraySpace,
+                syntax: syntax);
+            return true;
+        }
+    }
+
+    public override BoundNode? VisitCall(BoundCall node)
+    {
+        if (!node.Arguments.Any(a => a is BoundTransientSpanFromInlineArray))
+        {
+            return base.VisitCall(node);
+        }
+
+        var rewrittenReceiver = (BoundExpression?)Visit(node.ReceiverOpt);
+        var rewrittenArguments = ArrayBuilder<BoundExpression>.GetInstance(node.Arguments.Length);
+        var allocatedSpace = ArrayBuilder<(TypeSymbol elementType, int length)>.GetInstance();
+        ArrayBuilder<LocalSymbol>? temps = null;
+        ArrayBuilder<BoundExpression>? clears = null;
+        foreach (var argument in node.Arguments)
+        {
+            if (argument is not BoundTransientSpanFromInlineArray transientSpan)
+            {
+                rewrittenArguments.Add((BoundExpression)Visit(argument));
+                continue;
+            }
+
+            var rewrittenElements = transientSpan.Elements.SelectAsArray(e => (BoundExpression)Visit(e));
+
+            if (!_allocatedArrayLocals.TryGetValue(transientSpan.ElementType, out var allocatedInfo))
+            {
+                // The array was only used once, so we can create a local for it here.
+                temps ??= ArrayBuilder<LocalSymbol>.GetInstance();
+                rewrittenArguments.Add(LocalRewriter.CreateCreateAndPopulateSpanFromInlineArray(
+                    transientSpan.Syntax,
+                    TypeWithAnnotations.Create(transientSpan.ElementType),
+                    transientSpan.Elements,
+                    transientSpan.IsReadOnly,
+                    _factory,
+                    _factory.Compilation,
+                    temps,
+                    _diagnostics));
+            }
+            else
+            {
+                Debug.Assert(allocatedInfo.CurrentStart + transientSpan.Elements.Length <= allocatedInfo.Length, $"{allocatedInfo.CurrentStart} + {transientSpan.Elements.Length} <= {allocatedInfo.Length}");
+                var start = allocatedInfo.CurrentStart;
+                allocatedInfo.CurrentStart += transientSpan.Elements.Length;
+                var needsClear = transientSpan.ElementType.IsManagedTypeNoUseSiteDiagnostics;
+                allocatedSpace.Add((transientSpan.ElementType, transientSpan.Elements.Length));
+
+                // If this is a single element local, create a span from the local
+                if (!allocatedInfo.IsArray)
+                {
+                    // globalTemp = <element expression>;
+                    // new Span<T>(ref globalTemp);
+                    Debug.Assert(allocatedInfo.Length == 1);
+                    Debug.Assert(rewrittenElements.Length == 1);
+                    var local = _factory.Local(allocatedInfo.Local);
+                    var constructor = transientSpan.IsReadOnly ? _cachedWellKnownInfo.ReadOnlySpanRefConstructor : _cachedWellKnownInfo.SpanRefConstructor;
+                    Debug.Assert(constructor is not null);
+                    constructor = constructor.AsMember(constructor.ContainingType.Construct(transientSpan.ElementType));
+                    rewrittenArguments.Add(
+                        _factory.Sequence(
+                            sideEffects: [_factory.AssignmentExpression(local, rewrittenElements[0])],
+                            result: _factory.New(
+                                constructor,
+                                arguments: [local],
+                                argumentRefKinds: [transientSpan.IsReadOnly ? RefKindExtensions.StrictIn : RefKind.Ref])));
+                    if (needsClear)
+                    {
+                        // We want to clear the local after the call to make sure that no references are held longer than necessary.
+                        clears ??= ArrayBuilder<BoundExpression>.GetInstance();
+                        clears.Add(_factory.AssignmentExpression(local, _factory.Default(local.Type)));
+                    }
+
+                    continue;
+                }
+
+                // Otherwise, we need to populate the shared inline array and take a span over the correct portion.
+                Debug.Assert(allocatedInfo.Local.Type.HasInlineArrayAttribute(out _));
+                var inlineArrayLocal = _factory.Local(allocatedInfo.Local);
+                var elementRef = _cachedWellKnownInfo.InlineArrayElementRef.Construct(allocatedInfo.Local.Type, transientSpan.ElementType);
+                var sideEffects = ArrayBuilder<BoundExpression>.GetInstance();
+
+                // Populate the inline array.
+                // InlineArrayElementRef<<>y__InlineArrayN<ElementType>, ElementType>(ref tmp, start + 0) = element0;
+                // InlineArrayElementRef<<>y__InlineArrayN<ElementType>, ElementType>(ref tmp, start + 1) = element1;
+                // ...
+                for (int i = 0; i < rewrittenElements.Length; i++)
+                {
+                    var element = rewrittenElements[i];
+                    var call = _factory.Call(null, elementRef, inlineArrayLocal, _factory.Literal(start + i), useStrictArgumentRefKinds: true);
+                    var assignment = _factory.AssignmentExpression(call, element);
+                    sideEffects.Add(assignment);
+                }
+
+                // Get a span to the inline array.
+                // ... InlineArrayAsReadOnlySpan<<>y__InlineArrayN<ElementType>, ElementType>(in tmp, N)
+                // or
+                // ... InlineArrayAsSpan<<>y__InlineArrayN<ElementType>, ElementType>(ref tmp, N)
+                MethodSymbol inlineArrayAsSpan = transientSpan.IsReadOnly ?
+                    _cachedWellKnownInfo.InlineArrayAsReadOnlySpan :
+                    _cachedWellKnownInfo.InlineArrayAsSpan;
+                inlineArrayAsSpan = inlineArrayAsSpan.Construct(inlineArrayLocal.Type, transientSpan.ElementType);
+                var span = _factory.Call(
+                    receiver: null,
+                    inlineArrayAsSpan,
+                    inlineArrayLocal,
+                    _factory.Literal(allocatedInfo.Length),
+                    useStrictArgumentRefKinds: true);
+
+                // If necessary, slice the array to the correct length.
+                if (start != 0 || rewrittenElements.Length != allocatedInfo.Length)
+                {
+                    sideEffects.Add(span);
+                    // ... .Slice(start, actualLength)
+                    var sliceMethod = transientSpan.IsReadOnly ?
+                        _cachedWellKnownInfo.ReadOnlySpanTSliceMethod :
+                        _cachedWellKnownInfo.SpanTSliceMethod;
+                    sliceMethod = sliceMethod.AsMember(sliceMethod.ContainingType.Construct(transientSpan.ElementType));
+                    span = _factory.Call(
+                        receiver: span,
+                        sliceMethod,
+                        _factory.Literal(start),
+                        _factory.Literal(rewrittenElements.Length));
+                }
+
+                rewrittenArguments.Add(
+                    _factory.Sequence(
+                        locals: [],
+                        sideEffects: sideEffects.ToImmutableAndFree(),
+                        result: span));
+
+                if (needsClear)
+                {
+                    clears ??= ArrayBuilder<BoundExpression>.GetInstance();
+                    for (int i = 0; i < rewrittenElements.Length; i++)
+                    {
+                        var call = _factory.Call(null, elementRef, inlineArrayLocal, _factory.Literal(start + i), useStrictArgumentRefKinds: true);
+                        clears.Add(_factory.AssignmentExpression(call, _factory.Default(call.Type)));
+                    }
+                }
+            }
+        }
+
+        var rewrittenCall = node.Update(
+            receiverOpt: rewrittenReceiver,
+            initialBindingReceiverIsSubjectToCloning: node.InitialBindingReceiverIsSubjectToCloning,
+            method: node.Method,
+            arguments: rewrittenArguments.ToImmutableAndFree(),
+            argumentNamesOpt: node.ArgumentNamesOpt,
+            argumentRefKindsOpt: node.ArgumentRefKindsOpt,
+            node.IsDelegateCall,
+            expanded: node.Expanded,
+            invokedAsExtensionMethod: node.InvokedAsExtensionMethod,
+            argsToParamsOpt: node.ArgsToParamsOpt,
+            node.DefaultArguments,
+            resultKind: node.ResultKind,
+            type: node.Type);
+
+        foreach (var (elementType, length) in allocatedSpace)
+        {
+            // Return the allocated space.
+            Debug.Assert(_allocatedArrayLocals.ContainsKey(elementType));
+            var allocatedInfo = _allocatedArrayLocals[elementType];
+            allocatedInfo.CurrentStart -= length;
+            Debug.Assert(allocatedInfo.CurrentStart >= 0);
+        }
+        allocatedSpace.Free();
+
+        if (clears is null && temps is null)
+        {
+            return rewrittenCall;
+        }
+
+        if (clears is null)
+        {
+            Debug.Assert(temps is not null);
+            // We don't need to clear anything, just wrap with a sequence for the temps.
+            return _factory.Sequence(
+                locals: temps.ToImmutableAndFree(),
+                sideEffects: [],
+                result: rewrittenCall);
+        }
+
+        temps ??= ArrayBuilder<LocalSymbol>.GetInstance();
+        // We need to clear some values after the call.
+        // PROTOTYPE: Handle unused result, void-returning rewrittenCall, etc.
+        var resultTemp = _factory.StoreToTemp(rewrittenCall, out var resultStore);
+        temps.Add(resultTemp.LocalSymbol);
+        clears.Insert(0, resultStore);
+
+        return _factory.Sequence(
+            locals: temps.ToImmutableAndFree(),
+            sideEffects: clears.ToImmutableAndFree(),
+            result: resultTemp);
+    }
+
+    public override BoundNode? VisitTransientSpanFromInlineArray(BoundTransientSpanFromInlineArray node)
+    {
+        // Should be handled during visiting method arguments
+        throw ExceptionUtilities.Unreachable();
+    }
+
+    private class AllocatedArrayInfo(LocalSymbol local, bool isArray, int currentStart, int length)
+    {
+        public readonly LocalSymbol Local = local;
+        public readonly bool IsArray = isArray;
+        public int CurrentStart = currentStart;
+        public readonly int Length = length;
+    }
+
+    private struct CachedWellKnownInfo(SyntheticBoundNodeFactory factory, DiagnosticBag diagnostics)
+    {
+        private readonly SyntheticBoundNodeFactory _factory = factory;
+        private readonly DiagnosticBag _diagnostics = diagnostics;
+
+        private bool? _hasSingleElementReadonlySpanCtor;
+        public MethodSymbol? ReadOnlySpanRefConstructor
+        {
+            get
+            {
+                CheckMemberAndInitializeField(ref _hasSingleElementReadonlySpanCtor, WellKnownMember.System_ReadOnlySpan_T__ctor_ref_readonly_T, ref field);
+                return field;
+            }
+        }
+
+        private bool? _hasSingleElementSpanCtor;
+        public MethodSymbol? SpanRefConstructor
+        {
+            get
+            {
+                CheckMemberAndInitializeField(ref _hasSingleElementSpanCtor, WellKnownMember.System_Span_T__ctor_ref_T, ref field);
+                return field;
+            }
+        }
+
+        private readonly void CheckMemberAndInitializeField(ref bool? hasMember, WellKnownMember member, ref MethodSymbol? field)
+        {
+            if (hasMember is null)
+            {
+                if (_factory.WellKnownMember(member) is MethodSymbol ctor)
+                {
+                    hasMember = true;
+                    field = ctor;
+                }
+                else
+                {
+                    hasMember = false;
+                }
+            }
+        }
+
+        public MethodSymbol InlineArrayElementRef
+        {
+            get
+            {
+                Debug.Assert(_factory.ModuleBuilderOpt is not null);
+                field ??=
+                    _factory.ModuleBuilderOpt.EnsureInlineArrayElementRefExists(
+                        _factory.Syntax,
+                        Int32Type,
+                        _diagnostics);
+                return field;
+            }
+        }
+
+        public MethodSymbol InlineArrayAsReadOnlySpan
+        {
+            get
+            {
+                Debug.Assert(_factory.ModuleBuilderOpt is not null);
+                field ??=
+                    _factory.ModuleBuilderOpt.EnsureInlineArrayAsReadOnlySpanExists(
+                        _factory.Syntax,
+                        ReadOnlySpanTType,
+                        Int32Type,
+                        _diagnostics);
+                return field;
+            }
+        }
+
+        public MethodSymbol InlineArrayAsSpan
+        {
+            get
+            {
+                Debug.Assert(_factory.ModuleBuilderOpt is not null);
+                field ??=
+                    _factory.ModuleBuilderOpt.EnsureInlineArrayAsSpanExists(
+                        _factory.Syntax,
+                        SpanTType,
+                        Int32Type,
+                        _diagnostics);
+                return field;
+            }
+        }
+
+        public MethodSymbol ReadOnlySpanTSliceMethod
+        {
+            get
+            {
+                // PROTOTYPE: Handle nulls?
+                field ??= (MethodSymbol)_factory.Compilation.GetWellKnownTypeMember(WellKnownMember.System_ReadOnlySpan_T__Slice_Int_Int)!;
+                return field;
+            }
+        }
+
+        public MethodSymbol SpanTSliceMethod
+        {
+            get
+            {
+                // PROTOTYPE: Handle nulls?
+                field ??= (MethodSymbol)_factory.Compilation.GetWellKnownTypeMember(WellKnownMember.System_Span_T__Slice_Int_Int)!;
+                return field;
+            }
+        }
+
+        public NamedTypeSymbol ReadOnlySpanTType => field ??= _factory.WellKnownType(WellKnownType.System_ReadOnlySpan_T);
+        public NamedTypeSymbol SpanTType => field ??= _factory.WellKnownType(WellKnownType.System_Span_T);
+        public NamedTypeSymbol Int32Type => field ??= _factory.Compilation.GetSpecialType(SpecialType.System_Int32);
+    }
+}

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
@@ -25284,11 +25284,9 @@ partial class Program
                 expectedOutput: IncludeExpectedOutput("[2], [3], [4], "));
             verifier.VerifyIL("Program.Main", """
                 {
-                  // Code size       61 (0x3d)
+                  // Code size       67 (0x43)
                   .maxstack  1
-                  .locals init (object V_0,
-                                object V_1,
-                                object V_2)
+                  .locals init (object V_0)
                   IL_0000:  ldc.i4.2
                   IL_0001:  box        "int"
                   IL_0006:  stloc.0
@@ -25296,21 +25294,27 @@ partial class Program
                   IL_0009:  newobj     "System.Span<object>..ctor(ref object)"
                   IL_000e:  call       "R Program.ReturnsRefStruct<object>(scoped System.Span<object>)"
                   IL_0013:  pop
-                  IL_0014:  ldc.i4.3
-                  IL_0015:  box        "int"
-                  IL_001a:  stloc.1
-                  IL_001b:  ldloca.s   V_1
-                  IL_001d:  newobj     "System.Span<object>..ctor(ref object)"
-                  IL_0022:  call       "ref int Program.ReturnsRef<object>(scoped System.Span<object>)"
-                  IL_0027:  pop
-                  IL_0028:  ldc.i4.4
-                  IL_0029:  box        "int"
-                  IL_002e:  stloc.2
-                  IL_002f:  ldloca.s   V_2
-                  IL_0031:  newobj     "System.Span<object>..ctor(ref object)"
-                  IL_0036:  call       "ref readonly int Program.ReturnsRefReadOnly<object>(scoped System.Span<object>)"
-                  IL_003b:  pop
-                  IL_003c:  ret
+                  IL_0014:  ldnull
+                  IL_0015:  stloc.0
+                  IL_0016:  ldc.i4.3
+                  IL_0017:  box        "int"
+                  IL_001c:  stloc.0
+                  IL_001d:  ldloca.s   V_0
+                  IL_001f:  newobj     "System.Span<object>..ctor(ref object)"
+                  IL_0024:  call       "ref int Program.ReturnsRef<object>(scoped System.Span<object>)"
+                  IL_0029:  pop
+                  IL_002a:  ldnull
+                  IL_002b:  stloc.0
+                  IL_002c:  ldc.i4.4
+                  IL_002d:  box        "int"
+                  IL_0032:  stloc.0
+                  IL_0033:  ldloca.s   V_0
+                  IL_0035:  newobj     "System.Span<object>..ctor(ref object)"
+                  IL_003a:  call       "ref readonly int Program.ReturnsRefReadOnly<object>(scoped System.Span<object>)"
+                  IL_003f:  pop
+                  IL_0040:  ldnull
+                  IL_0041:  stloc.0
+                  IL_0042:  ret
                 }
                 """);
         }

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ParamsCollectionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ParamsCollectionTests.cs
@@ -383,16 +383,15 @@ class Test : System.Attribute
                 {
                   // Code size       29 (0x1d)
                   .maxstack  1
-                  .locals init (int V_0,
-                                int V_1)
+                  .locals init (int V_0)
                   IL_0000:  ldc.i4.1
                   IL_0001:  stloc.0
                   IL_0002:  ldloca.s   V_0
                   IL_0004:  newobj     "System.Span<int>..ctor(ref int)"
                   IL_0009:  call       "void Program.M(params System.Span<int>)"
                   IL_000e:  ldc.i4.2
-                  IL_000f:  stloc.1
-                  IL_0010:  ldloca.s   V_1
+                  IL_000f:  stloc.0
+                  IL_0010:  ldloca.s   V_0
                   IL_0012:  newobj     "System.Span<int>..ctor(ref int)"
                   IL_0017:  call       "void Program.M(params System.Span<int>)"
                   IL_001c:  ret

--- a/src/Compilers/Core/Portable/SynthesizedLocalKind.cs
+++ b/src/Compilers/Core/Portable/SynthesizedLocalKind.cs
@@ -220,6 +220,13 @@ namespace Microsoft.CodeAnalysis
         LocalStoreTracker = 36,
 
         /// <summary>
+        /// Variable that represents shared inline array space for transient inline arrays, see Microsoft.CodeAnalysis.CSharp.TransientInlineArrayAllocator
+        /// and Microsoft.CodeAnalysis.CSharp.TransientInlineArrayRewriter. These can either be an InlineArray type, or a single local in the event that
+        /// only one element is needed.
+        /// </summary>
+        SharedInlineArraySpace = 37,
+
+        /// <summary>
         /// All values have to be less than or equal to <see cref="MaxValidValueForLocalVariableSerializedToDebugInformation"/> 
         /// (<see cref="EditAndContinueMethodDebugInformation"/>)
         /// </summary>


### PR DESCRIPTION
Based on some comments on https://github.com/dotnet/roslyn/pull/81788, I wanted to see what an implementation of sharing inline arrays across different calls might look like. This is very much still a prototype, and needs plenty of cleaning up (and extensive testing), but the concept is good enough to be reviewed, I think.

The general strategy is that, for by-value and scoped `Span/ReadOnlySpan` parameters that are directly passed a collection expression (either explicitly as a collection expression or implicitly as a params parameter), we know the precise lifetime that span needs to remain valid: from the start of the argument position in code until the end of the method call. We can record this information during local rewriting to know, for every type, what the maximum stack space needed at any given time is (including what might be needed for multiple nested calls with the same element type occurring at the same time). We then substitute in a "replace me with a real inline array ref" node. We can then pre-allocate an inline array of that max size, and slice off bits for each call as necessary, replacing the placeholders with real slicing in a new pass I've called the `TransientInlineArrayRewriter`. Since these arrays might be used later in the method, we do have to clear the arrays after use if the element type could be a reference type so the GC can reclaim their values.

As I mentioned, this is not yet ready for an in-depth code review. PROTOTYPE comments still exist, and there are several bugs failing tests that I haven't really looked into yet. But the general concept is ready for comment before I go further.
