### PR TITLE
Include Roslyn.Diagnostics.Analyzers in source build

### DIFF
--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -151,9 +151,11 @@
   <!--
     Analyzers
   -->
+  <ItemGroup>
+    <PackageReference Include="Roslyn.Diagnostics.Analyzers" PrivateAssets="all" />
+  </ItemGroup>
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" PrivateAssets="all" />
-    <PackageReference Include="Roslyn.Diagnostics.Analyzers" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/81805.
You can see there are no more warnings in the source build leg of this PR's CI build.