### PR TITLE
Disable solutionless-load

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -37,7 +37,7 @@
     "dotnet.completion.showCompletionItemsFromUnimportedNamespaces": true,
     "dotnet.testWindow.disableAutoDiscovery": true,
     "dotnet.testWindow.disableBuildOnRefresh": true,
-	"dotnet.enableWorkspaceBasedDevelopment", false,
+	"dotnet.enableWorkspaceBasedDevelopment": false,
     "cSpell.words": [
         "darc",
         "Nerdbank",


### PR DESCRIPTION
This breaks test discovery and constantly pops errors about our test resource projects, which aren't part of any solution, as they're .NET Framework projects.
