### PR TITLE
Fix links to the standard

### DIFF
--- a/docs/compilers/CSharp/Deviations from Standard.md
+++ b/docs/compilers/CSharp/Deviations from Standard.md
@@ -6,9 +6,9 @@ This document lists inconsistencies between Roslyn and the C# standard where the
 
 ### Implicit enum conversions from zero
 
-From [§10.2.4](http://csharpstandard/standard/conversions.md#1024-implicit-enumeration-conversions):
+From [§10.2.4](https://github.com/dotnet/csharpstandard/blob/draft-v9/standard/conversions.md#1024-implicit-enumeration-conversions):
 
-> An implicit enumeration conversion permits a *constant_expression* ([§11.21](http://csharpstandard/standard/expressions.md#1121-constant-expressions)) with any integer type and the value zero to be converted to any *enum_type* and to any *nullable_value_type* whose underlying type is an *enum_type*.
+> An implicit enumeration conversion permits a *constant_expression* ([§12.25](https://github.com/dotnet/csharpstandard/blob/draft-v9/standard/expressions.md#1225-constant-expressions)) with any integer type and the value zero to be converted to any *enum_type* and to any *nullable_value_type* whose underlying type is an *enum_type*.
 
 Roslyn performs implicit enumeration conversions from constant expressions with types of `float`, `double` and `decimal` as well:
 
@@ -38,7 +38,7 @@ Conversions are (correctly) *not* permitted from constant expressions which have
 
 ## Member lookup
 
-From [§12.5.1](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#125-member-lookup):
+From [§12.5.1](https://github.com/dotnet/csharpstandard/blob/draft-v9/standard/expressions.md#125-member-lookup):
 
 > - Finally, having removed hidden members, the result of the lookup is determined:
 >   - If the set consists of a single member that is not a method, then this member is the result of the lookup.


### PR DESCRIPTION
A couple were missing part of the URL. In addition, draft-v9 will soon be the default branch, and a couple clauses moved.