### PR TITLE
Fix source generator nuget package being locked by build when used as a project reference

### DIFF
--- a/src/VisualStudio/IntegrationTest/Harness/SourceGenerator/Microsoft.VisualStudio.Extensibility.Testing.SourceGenerator.csproj
+++ b/src/VisualStudio/IntegrationTest/Harness/SourceGenerator/Microsoft.VisualStudio.Extensibility.Testing.SourceGenerator.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <DevelopmentDependency>true</DevelopmentDependency>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSymbols>false</IncludeSymbols>


### PR DESCRIPTION
resolves https://github.com/dotnet/roslyn/issues/81883

the project was being packed twice, both by the regular pack, and also by another project referencing it as a project reference (due to the pack on build)