### PR TITLE
Send a key across identifying contents of the project context list

### DIFF
--- a/src/LanguageServer/Protocol/Handler/ProjectContext/GetTextDocumentWithContextHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/ProjectContext/GetTextDocumentWithContextHandler.cs
@@ -59,8 +59,8 @@ internal class GetTextDocumentWithContextHandler() : ILspServiceDocumentRequestH
         var openDocumentId = documentIds.First();
         var currentContextDocumentId = context.Workspace.GetDocumentIdInCurrentContext(openDocumentId);
 
-        // Create a key that uniquely identifies this set of contexts. We use this to track the user's preferred context
-        // on the client side.
+        // Create a key that uniquely identifies this set of contexts. The client side stores the preferred context
+        // against this key on the client side so we can restore the active context across different documents.
         var keyString = string.Join(";", contexts.Select(c => c.Label).OrderBy(l => l));
         var keyHash = XxHash128.Hash(Encoding.Unicode.GetBytes(keyString));
         var key = Convert.ToBase64String(keyHash);

--- a/src/LanguageServer/Protocol/Protocol/Extensions/VSProjectContextList.cs
+++ b/src/LanguageServer/Protocol/Protocol/Extensions/VSProjectContextList.cs
@@ -13,22 +13,20 @@ using System.Text.Json.Serialization;
 internal sealed class VSProjectContextList
 {
     /// <summary>
+    /// Gets or sets a unique key representing the group of project contexts the text document belongs to.
+    /// </summary>
+    [JsonPropertyName("_vs_key")]
+    public string Key { get; set; }
+
+    /// <summary>
     /// Gets or sets the document contexts associated with a text document.
     /// </summary>
     [JsonPropertyName("_vs_projectContexts")]
-    public VSProjectContext[] ProjectContexts
-    {
-        get;
-        set;
-    }
+    public VSProjectContext[] ProjectContexts { get; set; }
 
     /// <summary>
     /// Gets or sets the index of the default entry of the <see cref="VSProjectContext" /> array.
     /// </summary>
     [JsonPropertyName("_vs_defaultIndex")]
-    public int DefaultIndex
-    {
-        get;
-        set;
-    }
+    public int DefaultIndex { get; set; }
 }

--- a/src/LanguageServer/ProtocolUnitTests/ProjectContext/GetTextDocumentWithContextHandlerTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/ProjectContext/GetTextDocumentWithContextHandlerTests.cs
@@ -132,7 +132,7 @@ public sealed class GetTextDocumentWithContextHandlerTests : AbstractLanguageSer
 
         var results = await Task.WhenAll(project1.Documents.Select(document => RunGetProjectContext(testLspServer, document)));
 
-        var keys = results.Select(r => r.Key).ToArray();
+        var keys = results.Select(r => r?.Key).ToArray();
         Assert.DoesNotContain(null, keys);
         Assert.Single(keys.Distinct());
     }
@@ -163,14 +163,14 @@ public sealed class GetTextDocumentWithContextHandlerTests : AbstractLanguageSer
 
         var results = await Task.WhenAll(testLspServer.TestWorkspace.Projects.Select(project => RunGetProjectContext(testLspServer, project.Documents.First())));
 
-        var keys = results.Select(r => r.Key).ToArray();
+        var keys = results.Select(r => r?.Key).ToArray();
         Assert.DoesNotContain(null, keys);
         Assert.Distinct(keys);
     }
 
     internal static async Task<LSP.VSProjectContextList?> RunGetProjectContext(TestLspServer testLspServer, TestHostDocument document)
     {
-        var documentUri = ProtocolConversions.CreateAbsoluteDocumentUri(document.FilePath);
+        var documentUri = ProtocolConversions.CreateAbsoluteDocumentUri(document.FilePath!);
         return await testLspServer.ExecuteRequestAsync<LSP.VSGetProjectContextsParams, LSP.VSProjectContextList?>(LSP.VSMethods.GetProjectContextsName,
                         CreateGetProjectContextParams(documentUri), cancellationToken: CancellationToken.None);
     }

--- a/src/LanguageServer/ProtocolUnitTests/ProjectContext/GetTextDocumentWithContextHandlerTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/ProjectContext/GetTextDocumentWithContextHandlerTests.cs
@@ -5,6 +5,7 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.LanguageServer.Protocol;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -101,6 +102,77 @@ public sealed class GetTextDocumentWithContextHandlerTests : AbstractLanguageSer
             Assert.Equal(ProtocolConversions.ProjectIdToProjectContextId(project.Id), result!.ProjectContexts[result.DefaultIndex].Id);
             Assert.Equal(project.Name, result!.ProjectContexts[result.DefaultIndex].Label);
         }
+    }
+
+    [Theory, CombinatorialData]
+    public async Task ProjectContextListKeysShouldMatchForTheSameSetOfProjects(bool mutatingLspWorkspace)
+    {
+        var workspaceXml =
+            """
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" AssemblyName="CSProj1">
+                    <Document FilePath="C:\B.cs"></Document>
+                    <Document FilePath="C:\C.cs"></Document>
+                </Project>
+                <Project Language="C#" CommonReferences="true" AssemblyName="CSProj2">
+                    <Document IsLinkFile="true" LinkFilePath="C:\B.cs" LinkAssemblyName="CSProj1"></Document>
+                    <Document IsLinkFile="true" LinkFilePath="C:\C.cs" LinkAssemblyName="CSProj1"></Document>
+                </Project>
+            </Workspace>
+            """;
+
+        await using var testLspServer = await CreateXmlTestLspServerAsync(workspaceXml, mutatingLspWorkspace);
+
+        // Ensure all the documents are open
+        var project1 = testLspServer.TestWorkspace.Projects.First(p => p.Name == "CSProj1");
+        foreach (var document in project1.Documents)
+        {
+            await testLspServer.OpenDocumentInWorkspaceAsync(document.Id, openAllLinkedDocuments: true);
+        }
+
+        var results = await Task.WhenAll(project1.Documents.Select(document => RunGetProjectContext(testLspServer, document)));
+
+        var keys = results.Select(r => r.Key).ToArray();
+        Assert.DoesNotContain(null, keys);
+        Assert.Single(keys.Distinct());
+    }
+
+    [Theory, CombinatorialData]
+    public async Task ProjectContextListKeysShouldDifferForDifferentSetOfProjects(bool mutatingLspWorkspace)
+    {
+        var workspaceXml =
+            """
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" AssemblyName="CSProj1">
+                    <Document FilePath="C:\B.cs"></Document>
+                </Project>
+                <Project Language="C#" CommonReferences="true" AssemblyName="CSProj2">
+                    <Document FilePath="C:\C.cs"></Document>
+                </Project>
+            </Workspace>
+            """;
+
+        await using var testLspServer = await CreateXmlTestLspServerAsync(workspaceXml, mutatingLspWorkspace);
+
+        // Ensure all the documents are open
+        foreach (var project in testLspServer.TestWorkspace.Projects)
+        {
+            var document = project.Documents.First();
+            await testLspServer.OpenDocumentInWorkspaceAsync(document.Id, openAllLinkedDocuments: true);
+        }
+
+        var results = await Task.WhenAll(testLspServer.TestWorkspace.Projects.Select(project => RunGetProjectContext(testLspServer, project.Documents.First())));
+
+        var keys = results.Select(r => r.Key).ToArray();
+        Assert.DoesNotContain(null, keys);
+        Assert.Distinct(keys);
+    }
+
+    internal static async Task<LSP.VSProjectContextList?> RunGetProjectContext(TestLspServer testLspServer, TestHostDocument document)
+    {
+        var documentUri = ProtocolConversions.CreateAbsoluteDocumentUri(document.FilePath);
+        return await testLspServer.ExecuteRequestAsync<LSP.VSGetProjectContextsParams, LSP.VSProjectContextList?>(LSP.VSMethods.GetProjectContextsName,
+                        CreateGetProjectContextParams(documentUri), cancellationToken: CancellationToken.None);
     }
 
     internal static async Task<LSP.VSProjectContextList?> RunGetProjectContext(TestLspServer testLspServer, DocumentUri uri)

--- a/src/LanguageServer/ProtocolUnitTests/ProjectContext/GetTextDocumentWithContextHandlerTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/ProjectContext/GetTextDocumentWithContextHandlerTests.cs
@@ -133,7 +133,7 @@ public sealed class GetTextDocumentWithContextHandlerTests : AbstractLanguageSer
         var results = await Task.WhenAll(project1.Documents.Select(document => RunGetProjectContext(testLspServer, document)));
 
         var keys = results.Select(r => r?.Key).ToArray();
-        Assert.DoesNotContain(null, keys);
+        Assert.Equal(keys.Length, keys.OfType<string>().Count());
         Assert.Single(keys.Distinct());
     }
 
@@ -164,7 +164,7 @@ public sealed class GetTextDocumentWithContextHandlerTests : AbstractLanguageSer
         var results = await Task.WhenAll(testLspServer.TestWorkspace.Projects.Select(project => RunGetProjectContext(testLspServer, project.Documents.First())));
 
         var keys = results.Select(r => r?.Key).ToArray();
-        Assert.DoesNotContain(null, keys);
+        Assert.Equal(keys.Length, keys.OfType<string>().Count());
         Assert.Distinct(keys);
     }
 


### PR DESCRIPTION
This key uniquely identifies the projects the file is a part of. This can be used by the client to track which project is active for documents which share the same key.