### PR TITLE
Eliminate closure allocation by referencing UriString property instead of captured uriString parameter

### DIFF
--- a/src/LanguageServer/Protocol/Protocol/DocumentUri.cs
+++ b/src/LanguageServer/Protocol/Protocol/DocumentUri.cs
@@ -27,7 +27,7 @@ internal sealed class DocumentUri : IEquatable<DocumentUri>
     public DocumentUri(string uriString)
     {
         UriString = uriString;
-        _parsedUriLazy = new(() => ParseUri(uriString));
+        _parsedUriLazy = new(() => ParseUri(UriString));
     }
 
     public DocumentUri(Uri parsedUri)


### PR DESCRIPTION
This pull request was generated by the VS Perf Rel AI Agent. Please review this AI-generated PR with extra care! For more information, visit our [wiki](https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/49206/PerfRel-Agent). Please share feedback with [TIP Insights](mailto:tipinsights@microsoft.com)

- Issue: The `DocumentUri(string uriString)` constructor allocates a closure/display class (`<>c__DisplayClass1_0`) on every invocation because the lambda `() => ParseUri(uriString)` captures the `uriString` parameter instead of using already-assigned instance property, causing unnecessary display class allocations.
**Evidence:**
1. Stack trace shows allocation type `TypeAllocated!<>c__DisplayClass1_0` (compiler-generated closure)
2. Source code at line 28 shows: `_parsedUriLazy = new(() => ParseUri(uriString));` which captures the `uriString` parameter
3. The `UriString` property is assigned before the `Lazy<>` creation, so we can use `this.UriString` instead to avoid parameter capture

```
TypeAllocated!<>c__DisplayClass1_0
clr.dll!JIT_New
microsoft.codeanalysis.languageserver.protocol.dll!Roslyn.LanguageServer.Protocol.DocumentUri..ctor
microsoft.codeanalysis.languageserver.protocol.dll!Roslyn.LanguageServer.Protocol.DocumentUriConverter.Read
system.text.json.dll!System.Text.Json.Serialization.JsonConverter`[System.__Canon].TryRead
```

- Issue type: AVOID creating lambdas that capture variables on hot path

- Proposed fix: Change the lambda in `DocumentUri(string uriString)` constructor to reference the instance property `UriString` instead of the captured parameter `uriString`. UriString is a get-only auto-property set in the constructor and never mutated afterward. So this is a minimal and safe fix that eliminates the display class allocation while maintaining identical behavior.

[Best practices wiki](https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/24181/Garbage-collection-(GC))
[See related failure in PRISM](https://vsprismdev.azurewebsites.net/failure/?eventType=allocation&failureType=dualdirection&failureHash=cca902e1-7504-71a5-29c0-ebc62a122c72)
[ADO work item](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2678180)
