### PR TITLE
Perf improvement for SourceText.ToString in net fx

### DIFF
--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -744,19 +744,21 @@ namespace Microsoft.CodeAnalysis.Text
                 }
             });
 #else
-            var builder = PooledStringBuilder.GetInstance();
-            builder.Builder.EnsureCapacity(length);
-
-            while (position < this.Length && length > 0)
+            unsafe
             {
-                int copyLength = Math.Min(tempBuffer.Length, length);
-                this.CopyTo(position, tempBuffer, 0, copyLength);
-                builder.Builder.Append(tempBuffer, 0, copyLength);
-                length -= copyLength;
-                position += copyLength;
+                result = new('\0', length);
+                fixed (char* pointer = result)
+                {
+                    while (position < this.Length && length > 0)
+                    {
+                        int copyLength = Math.Min(tempBuffer.Length, length);
+                        this.CopyTo(position, tempBuffer, 0, copyLength);
+                        tempBuffer.AsSpan(0, copyLength).CopyTo(new Span<char>(pointer + (position - span.Start), copyLength));
+                        length -= copyLength;
+                        position += copyLength;
+                    }
+                }
             }
-
-            result = builder.ToStringAndFree();
 #endif
 
             s_charArrayPool.Free(tempBuffer);

--- a/src/Tools/IdeCoreBenchmarks/IdeCoreBenchmarks.csproj
+++ b/src/Tools/IdeCoreBenchmarks/IdeCoreBenchmarks.csproj
@@ -7,7 +7,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(NetRoslyn);net472</TargetFrameworks>
     <IsShipping>false</IsShipping>
-    <LangVersion>11</LangVersion>
+    <LangVersion>12</LangVersion>
     <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
     <NoWarn>$(NoWarn);NETSDK1206</NoWarn>
     <!-- This project is not a test project in context of how this repo views test projects.

--- a/src/Tools/IdeCoreBenchmarks/SourceTextBenchmarks.cs
+++ b/src/Tools/IdeCoreBenchmarks/SourceTextBenchmarks.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using Microsoft.CodeAnalysis.Text;
+
+namespace IdeCoreBenchmarks
+{
+    [MemoryDiagnoser]
+    public class SourceTextBenchmarks
+    {
+        const int OperationsPerInvoke = 1000;
+
+        [Params(10, 100, 1_000, 10_000, 100_000, 1_000_000)]
+        public int Length { get; set; }
+
+        private SourceText? _sourceText;
+
+        [IterationSetup]
+        public void Setup()
+        {
+            var change = new TextChange(new TextSpan(0, 0), "a");
+            _sourceText = SourceText.From(new string('a', Length - 1)).WithChanges([change]);
+        }
+
+        [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+        public void SourceText_ToString()
+        {
+            var span = new TextSpan(1, Length - 2);
+            for (var i = 0; i < OperationsPerInvoke; i++)
+                _ = _sourceText!.ToString(span);
+        }
+    }
+}


### PR DESCRIPTION
1) Halves allocations when PooledStringBuilder exceeds pooling threshold size (1000 chars) 
2) Reduces number of times data is copied from 3 to 2

<img width="1375" height="403" alt="image" src="https://github.com/user-attachments/assets/dc5b854f-a98b-446f-855c-2cb8c81a6a74" />