### PR TITLE
Fix the generator building twice

### DIFF
--- a/src/VisualStudio/IntegrationTest/Harness/XUnitIntegrationTests/Microsoft.VisualStudio.Extensibility.Testing.Xunit.IntegrationTests.csproj
+++ b/src/VisualStudio/IntegrationTest/Harness/XUnitIntegrationTests/Microsoft.VisualStudio.Extensibility.Testing.Xunit.IntegrationTests.csproj
@@ -26,7 +26,7 @@
     <ProjectReference Include="..\..\..\..\Compilers\Test\Core\Microsoft.CodeAnalysis.Test.Utilities.csproj" />
     <ProjectReference Include="..\..\TestSetup\Microsoft.VisualStudio.IntegrationTest.Setup.csproj" />
     <ProjectReference Include="..\XUnit\Microsoft.VisualStudio.Extensibility.Testing.Xunit.csproj" />
-    <ProjectReference Include="..\SourceGenerator\Microsoft.VisualStudio.Extensibility.Testing.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" SetTargetFramework="TargetFramework=netstandard2.0" SkipGetTargetFrameworkProperties="true" />
+    <ProjectReference Include="..\SourceGenerator\Microsoft.VisualStudio.Extensibility.Testing.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This explicit SetTargetFramework would have been necessary when IntegrationTests.csproj targeted a TFM which wouldn't support a netstandard2.0 reference. Since we're consuming this through a ProjectReference, MSBuild will try to validate that the consumed reference is compatible with our TFM, but by default won't realize that if we're actually outputting this as an Analyzer type it won't actually matter.

This is causing overbuilding though and since this project now targets only netstandard2.0 compatible TFMs, we can just drop this.

Fixes https://github.com/dotnet/dotnet/issues/4121