### PR TITLE
Extensions: RemovedUnusedMembers should analyze symbol usages within extension blocks too

### DIFF
--- a/src/Analyzers/CSharp/Tests/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
@@ -3640,7 +3640,7 @@ public sealed class RemoveUnusedMembersTests
                 {
                     extension(int i)
                     {
-                        private void [|M|]() { }
+                        private void {|IDE0051:M|}() { }
                     }
                 }
                 """,
@@ -3817,6 +3817,50 @@ public sealed class RemoveUnusedMembersTests
             LanguageVersion = LanguageVersion.CSharp14,
         }.RunAsync();
 
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/80645")]
+    public Task PrivateExtensionBlockMethod_11()
+        => new VerifyCS.Test
+        {
+            // method used as extension within extension block
+            TestCode = """
+                public static class C
+                {
+                    extension(int i)
+                    {
+                        public static void Test()
+                        {
+                            42.M();
+                        }
+
+                        private void M() { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp14,
+        }.RunAsync();
+
+    [Fact]
+    public Task PrivateExtensionBlockMethod_12()
+        => new VerifyCS.Test
+        {
+            // method used via disambiguation syntax within extension block
+            TestCode = """
+                public static class C
+                {
+                    extension(int i)
+                    {
+                        public static void Test()
+                        {
+                            C.M(42);
+                        }
+
+                        private void M() { }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp14,
+        }.RunAsync();
+
     [Fact]
     public Task PrivateExtensionBlockProperty_01()
         => new VerifyCS.Test
@@ -3849,7 +3893,7 @@ public sealed class RemoveUnusedMembersTests
                 {
                     extension(int i)
                     {
-                        private int [|Property|] => 0;
+                        private int {|IDE0051:Property|} => 0;
                     }
                 }
                 """,
@@ -3992,6 +4036,47 @@ public sealed class RemoveUnusedMembersTests
                     }
 
                     private static string M2() => null;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp14,
+        }.RunAsync();
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/81986")]
+    public Task PrivateMemberUsedFromExtensionBlock_01()
+        => new VerifyCS.Test
+        {
+            // private method used from extension block method
+            TestCode = """
+                public static class C
+                {
+                    private static void M() { }
+
+                    extension(int)
+                    {
+                        public static void M2()
+                        {
+                            M();
+                        }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp14,
+        }.RunAsync();
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/81986")]
+    public Task PrivateMemberUsedFromExtensionBlock_02()
+        => new VerifyCS.Test
+        {
+            // private field used from extension block property
+            TestCode = """
+                public static class C
+                {
+                    private static int _field;
+
+                    extension(int)
+                    {
+                        public static int Property { get => _field; set { _field = value; } }
+                    }
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp14,

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
@@ -286,11 +286,6 @@ internal abstract class AbstractRemoveUnusedMembersDiagnosticAnalyzer<
 
             bool ShouldAnalyze(SymbolStartAnalysisContext context, INamedTypeSymbol namedType)
             {
-                // Extension members are analyzed as part of the enclosing static class.
-                // When we enter the scope of the enclosing static class, we'll analyze extension members there.
-                if (namedType.IsExtension)
-                    return false;
-
                 // Check if we have at least one candidate symbol in analysis scope.
                 foreach (var member in GetMembersIncludingExtensionBlockMembers(namedType))
                 {
@@ -301,7 +296,7 @@ internal abstract class AbstractRemoveUnusedMembersDiagnosticAnalyzer<
                     }
                 }
 
-                // We have to analyze nested types if containing type contains a candidate field in analysis scope.
+                // We have to analyze nested types and extension blocks if containing type contains a candidate field in analysis scope.
                 if (namedType.ContainingType is { } containingType)
                     return ShouldAnalyze(context, containingType);
 
@@ -730,7 +725,6 @@ internal abstract class AbstractRemoveUnusedMembersDiagnosticAnalyzer<
         // We analyze extension block members as part of the enclosing static class.
         private static IEnumerable<ISymbol> GetMembersIncludingExtensionBlockMembers(INamedTypeSymbol namedType)
         {
-            Debug.Assert(!namedType.IsExtension);
             foreach (var member in namedType.GetMembers())
             {
                 if (member is INamedTypeSymbol { IsExtension: true } extensionBlock)


### PR DESCRIPTION
Follow-up on https://github.com/dotnet/roslyn/pull/81754
Fixes https://github.com/dotnet/roslyn/issues/81986