### PR TITLE
Install .NET 10 SDK in single machine windows CI

### DIFF
--- a/eng/pipelines/test-windows-job-single-machine.yml
+++ b/eng/pipelines/test-windows-job-single-machine.yml
@@ -28,13 +28,12 @@ jobs:
   steps:
     - checkout: none
 
-    # A .NET 10 runtime is needed since our unit tests target net10.0
+    # .NET 10 is needed since our unit tests target net10.0
     - task: UseDotNet@2
       displayName: 'Install .NET 10 Runtime'
       inputs:
-        packageType: runtime
-        version: '10.0.0'
-        includePreviewVersions: true
+        packageType: sdk
+        version: '10.0.x'
         installationPath: '$(Build.SourcesDirectory)/.dotnet'
 
     - task: DownloadPipelineArtifact@2


### PR DESCRIPTION
Seeing consistent [failures](https://dev.azure.com/dnceng-public/public/public%20Team/_build/results?buildId=1253801&view=logs&j=25b00362-06cc-5921-ad4b-34638988b7b4&t=da74a059-8acf-500b-6dc1-372111119b19&l=25) installing the .NET 10 runtime on its own, so switch to installing the SDK which includes the runtime.