### PR TITLE
Fix detection of embedded c# code

### DIFF
--- a/src/Features/Core/Portable/EmbeddedLanguages/EmbeddedLanguageCommentDetector.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/EmbeddedLanguageCommentDetector.cs
@@ -25,7 +25,7 @@ internal readonly struct EmbeddedLanguageCommentDetector
     public EmbeddedLanguageCommentDetector(ImmutableArray<string> identifiers)
     {
         var namePortion = string.Join("|", identifiers.Select(n => $"({Regex.Escape(n)})"));
-        _regex = new Regex($@"^((//)|(')|(/\*))\s*lang(uage)?\s*=\s*(?<identifier>{namePortion})\b((\s*,\s*)(?<option>[a-zA-Z]+))*",
+        _regex = new Regex($@"^((//)|(')|(/\*))\s*lang(uage)?\s*=\s*(?<identifier>{namePortion})(?!\w)((\s*,\s*)(?<option>[a-z]+))*",
             RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase | RegexOptions.Compiled);
     }
 

--- a/src/Features/Test/EmbeddedLanguages/EmbeddedLanguageCommentDetectorTests.cs
+++ b/src/Features/Test/EmbeddedLanguages/EmbeddedLanguageCommentDetectorTests.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.EmbeddedLanguages;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests.EmbeddedLanguages;
+
+public sealed class EmbeddedLanguageCommentDetectorTests
+{
+    [Theory]
+    [InlineData("// lang=c#")]
+    [InlineData("// lang=C#")]
+    [InlineData("// Lang=c#")]
+    [InlineData("// Lang=C#")]
+    [InlineData("// lang=c#-test")]
+    [InlineData("// Lang=c#-test")]
+    [InlineData("// lang=C#-test")]
+    [InlineData("// Lang=C#-test")]
+    [InlineData("// Lang=C#-Test")]
+    [InlineData("//lang=c#")]
+    [InlineData("//lang=c#-test")]
+    [InlineData("//language=c#")]
+    [InlineData("//language=c#-test")]
+    [InlineData("// lang=c#.")]
+    [InlineData("// lang=c#-test.")]
+    public void TestCSharpDetection_Positive(string commentText)
+    {
+        var detector = new EmbeddedLanguageCommentDetector([LanguageNames.CSharp, PredefinedEmbeddedLanguageNames.CSharpTest]);
+        Assert.True(detector.TryMatch(commentText, out _, out _));
+        Assert.True(detector.TryMatch(commentText + " ", out _, out _));
+
+        Assert.True(detector.TryMatch(commentText + " This is C# code", out _, out _));
+    }
+
+    [Theory]
+    [InlineData("//c#")]
+    [InlineData("//lan=c#")]
+    [InlineData("//lang c#")]
+    [InlineData("// c#")]
+    [InlineData("// lan=c#")]
+    [InlineData("// lang c#")]
+    [InlineData("// lang=c")]
+    [InlineData("// lang=csharp")]
+    [InlineData("// lang=f#")]
+    [InlineData("// lang=#")]
+    [InlineData("// lang=.")]
+    public void TestCSharpDetection_Negative(string commentText)
+    {
+        var detector = new EmbeddedLanguageCommentDetector([LanguageNames.CSharp, PredefinedEmbeddedLanguageNames.CSharpTest]);
+        Assert.False(detector.TryMatch(commentText, out _, out _));
+    }
+}


### PR DESCRIPTION
`// lang=c#` wasn't working as the regex we had didn't like a `#` at the end. 

Looks like this:

<img width="1126" height="408" alt="image" src="https://github.com/user-attachments/assets/5d18b107-fbe7-45a1-8289-914dcdb70878" />
