### PR TITLE
Delete Solution.WithCachedSourceGeneratorState

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1697,17 +1697,6 @@ public partial class Solution
         => WithCompilationState(CompilationState.WithoutFrozenSourceGeneratedDocuments());
 
     /// <summary>
-    /// Returns a new Solution which represents the same state as before, but with the cached generator driver state from the given project updated to match.
-    /// </summary>
-    /// <remarks>
-    /// When generators are ran in a Solution snapshot, they may cache state to speed up future runs. For Razor, we only run their generator on forked
-    /// solutions that are thrown away; this API gives us a way to reuse that cached state in other forked solutions, since otherwise there's no way to reuse
-    /// the cached state.
-    /// </remarks>
-    internal Solution WithCachedSourceGeneratorState(ProjectId projectToUpdate, Project projectWithCachedGeneratorState)
-        => WithCompilationState(CompilationState.WithCachedSourceGeneratorState(projectToUpdate, projectWithCachedGeneratorState));
-
-    /// <summary>
     /// Gets an objects that lists the added, changed and removed projects between
     /// this solution and the specified solution.
     /// </summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
@@ -171,18 +171,7 @@ internal sealed partial class SolutionCompilationState
         if (stateChange.NewSolutionState == this.SolutionState)
             return this;
 
-        return ForceForkProject(stateChange, translate.Invoke(stateChange, arg), forkTracker);
-    }
-
-    /// <summary>
-    /// Same as <see cref="ForkProject{TArg}(StateChange, Func{StateChange, TArg, TranslationAction?}, bool, TArg)"/>
-    /// except that it will still fork even if newSolutionState is unchanged from <see cref="SolutionState"/>.
-    /// </summary>
-    private SolutionCompilationState ForceForkProject(
-        StateChange stateChange,
-        TranslationAction? translate,
-        bool forkTracker)
-    {
+        var translationAction = translate.Invoke(stateChange, arg);
         var newSolutionState = stateChange.NewSolutionState;
         var newProjectState = stateChange.NewProjectState;
         var projectId = newProjectState.Id;
@@ -200,10 +189,10 @@ internal sealed partial class SolutionCompilationState
                     if (!arg.forkTracker)
                         trackerMap.Remove(arg.projectId);
                     else
-                        trackerMap[arg.projectId] = tracker.Fork(arg.newProjectState, arg.translate);
+                        trackerMap[arg.projectId] = tracker.Fork(arg.newProjectState, arg.translationAction);
                 }
             },
-            (translate, forkTracker, projectId, newProjectState),
+            (translationAction, forkTracker, projectId, newProjectState),
             skipEmptyCallback: true);
 
         return this.Branch(
@@ -1854,35 +1843,6 @@ internal sealed partial class SolutionCompilationState
             ImmutableArray<AnalyzerConfigDocumentState> analyzerConfigDocumentStates => new TranslationAction.TouchAnalyzerConfigDocumentsAction(oldProject, oldProject.AddAnalyzerConfigDocuments(analyzerConfigDocumentStates)),
             _ => throw ExceptionUtilities.UnexpectedValue(states)
         };
-
-    /// <inheritdoc cref="Solution.WithCachedSourceGeneratorState(ProjectId, Project)"/>
-    public SolutionCompilationState WithCachedSourceGeneratorState(ProjectId projectToUpdate, Project projectWithCachedGeneratorState)
-    {
-        this.SolutionState.CheckContainsProject(projectToUpdate);
-
-        // First see if we have a generator driver that we can get from the other project.
-
-        if (!projectWithCachedGeneratorState.Solution.CompilationState.TryGetCompilationTracker(projectWithCachedGeneratorState.Id, out var tracker) ||
-            tracker.GeneratorDriver is null)
-        {
-            // We don't actually have any state at all, so no change.
-            return this;
-        }
-
-        var projectToUpdateState = this.SolutionState.GetRequiredProjectState(projectToUpdate);
-
-        // Note: we have to force this fork to happen as the actual solution-state object is not changing. We're just
-        // changing the tracker for a particular project.
-        var newCompilationState = this.ForceForkProject(
-            new(this.SolutionState, projectToUpdateState, projectToUpdateState),
-            translate: new TranslationAction.ReplaceGeneratorDriverAction(
-                oldProjectState: projectToUpdateState,
-                newProjectState: projectToUpdateState,
-                tracker.GeneratorDriver),
-            forkTracker: true);
-
-        return newCompilationState;
-    }
 
     /// <summary>
     /// Creates a new solution instance with all the documents specified updated to have the same specified text.


### PR DESCRIPTION
This was used to speed up Razor runs prior to cohosting, where we would be creating lots of forks of things. But now that
https://github.com/dotnet/roslyn/pull/81914 is merged, there is no calling code.