### PR TITLE
Support inserting initializers with smart break line for target-typed `new()`

### DIFF
--- a/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler.cs
@@ -318,7 +318,7 @@ internal sealed partial class AutomaticLineEnderCommandHandler(
                     or BaseMethodDeclarationSyntax
                     or LocalFunctionStatementSyntax
                     or AccessorDeclarationSyntax
-                    or ObjectCreationExpressionSyntax
+                    or BaseObjectCreationExpressionSyntax
                     or WhileStatementSyntax
                     or CommonForEachStatementSyntax
                     or ForStatementSyntax
@@ -412,7 +412,7 @@ internal sealed partial class AutomaticLineEnderCommandHandler(
         // 1. Add an initializer to it.
         // 2. make sure it has '()' after the type, and if its next token is a missing semicolon, add that semicolon. e.g
         // var c = new Obje$$ct() => var c = new Object();
-        if (selectedNode is ObjectCreationExpressionSyntax objectCreationExpressionNode)
+        if (selectedNode is BaseObjectCreationExpressionSyntax objectCreationExpressionNode)
         {
             var (newNode, oldNode) = ModifyObjectCreationExpressionNode(objectCreationExpressionNode, addOrRemoveInitializer: true, formattingOptions);
             var newRoot = ReplaceNodeAndFormat(

--- a/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler_Helpers.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler_Helpers.cs
@@ -474,7 +474,7 @@ internal sealed partial class AutomaticLineEnderCommandHandler
             BaseTypeDeclarationSyntax baseTypeDeclarationNode => ShouldAddBraceForBaseTypeDeclaration(baseTypeDeclarationNode, caretPosition),
             BaseMethodDeclarationSyntax baseMethodDeclarationNode => ShouldAddBraceForBaseMethodDeclaration(baseMethodDeclarationNode, caretPosition),
             LocalFunctionStatementSyntax localFunctionStatementNode => ShouldAddBraceForLocalFunctionStatement(localFunctionStatementNode, caretPosition),
-            ObjectCreationExpressionSyntax objectCreationExpressionNode => ShouldAddBraceForObjectCreationExpression(objectCreationExpressionNode),
+            BaseObjectCreationExpressionSyntax baseObjectCreationExpressionNode => ShouldAddBraceForBaseObjectCreationExpression(baseObjectCreationExpressionNode),
             BaseFieldDeclarationSyntax baseFieldDeclarationNode => ShouldAddBraceForBaseFieldDeclaration(baseFieldDeclarationNode),
             AccessorDeclarationSyntax accessorDeclarationNode => ShouldAddBraceForAccessorDeclaration(accessorDeclarationNode),
             IndexerDeclarationSyntax indexerDeclarationNode => ShouldAddBraceForIndexerDeclaration(indexerDeclarationNode, caretPosition),
@@ -536,10 +536,10 @@ internal sealed partial class AutomaticLineEnderCommandHandler
            && !WithinMethodBody(localFunctionStatementNode, caretPosition);
 
     /// <summary>
-    /// Add brace for ObjectCreationExpression if it doesn't have initializer
+    /// Add brace for BaseObjectCreationExpression if it doesn't have initializer
     /// </summary>
-    private static bool ShouldAddBraceForObjectCreationExpression(ObjectCreationExpressionSyntax objectCreationExpressionNode)
-        => objectCreationExpressionNode.Initializer == null;
+    private static bool ShouldAddBraceForBaseObjectCreationExpression(BaseObjectCreationExpressionSyntax baseObjectCreationExpressionNode)
+        => baseObjectCreationExpressionNode.Initializer is null;
 
     /// <summary>
     /// Add braces for field and event field if they only have one variable, semicolon is missing and don't have readonly keyword
@@ -783,7 +783,7 @@ internal sealed partial class AutomaticLineEnderCommandHandler
     private static bool ShouldRemoveBraces(SyntaxNode node, int caretPosition)
         => node switch
         {
-            BaseObjectCreationExpressionSyntax baseObjectCreationExpressionNode => ShouldRemoveBraceForObjectCreationExpression(baseObjectCreationExpressionNode),
+            BaseObjectCreationExpressionSyntax baseObjectCreationExpressionNode => ShouldRemoveBraceForBaseObjectCreationExpression(baseObjectCreationExpressionNode),
             AccessorDeclarationSyntax accessorDeclarationNode => ShouldRemoveBraceForAccessorDeclaration(accessorDeclarationNode, caretPosition),
             PropertyDeclarationSyntax propertyDeclarationNode => ShouldRemoveBraceForPropertyDeclaration(propertyDeclarationNode, caretPosition),
             EventDeclarationSyntax eventDeclarationNode => ShouldRemoveBraceForEventDeclaration(eventDeclarationNode, caretPosition),
@@ -793,11 +793,8 @@ internal sealed partial class AutomaticLineEnderCommandHandler
     /// <summary>
     /// Remove the braces if the BaseObjectCreationExpression has an empty Initializer.
     /// </summary>
-    private static bool ShouldRemoveBraceForObjectCreationExpression(BaseObjectCreationExpressionSyntax baseObjectCreationExpressionNode)
-    {
-        var initializer = baseObjectCreationExpressionNode.Initializer;
-        return initializer != null && initializer.Expressions.IsEmpty();
-    }
+    private static bool ShouldRemoveBraceForBaseObjectCreationExpression(BaseObjectCreationExpressionSyntax baseObjectCreationExpressionNode)
+        => baseObjectCreationExpressionNode.Initializer is { Expressions.Count: 0 };
 
     // Only do this when it is an accessor in property
     // Since it is illegal to have something like

--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
@@ -1970,6 +1970,43 @@ public sealed class AutomaticLineEnderTests : AbstractAutomaticLineEnderTests
             }
             """);
 
+    [WpfTheory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/80791")]
+    public void TestImplicitObjectCreationExpression(bool constructorParenthesis)
+    {
+        var firstResult = """
+            public class Bar
+            {
+                public void Bar2()
+                {
+                    Bar b = new()
+                    {
+                        $$
+                    };
+                }
+            }
+            """;
+        Test(firstResult, $$"""
+            public class Bar
+            {
+                public void Bar2()
+                {
+                    Bar b = new$${{(constructorParenthesis ? "($$)" : string.Empty)}}
+                }
+            }
+            """);
+        Test("""
+            public class Bar
+            {
+                public void Bar2()
+                {
+                    Bar b = new();
+                    $$
+                }
+            }
+            """, firstResult);
+    }
+
     [WpfFact]
     public void TestArrayInitializer1()
         => Test(
@@ -3161,55 +3198,6 @@ public sealed class AutomaticLineEnderTests : AbstractAutomaticLineEnderTests
                     fin$$ally$$
                     {
                     }
-                }
-            }
-            """);
-
-    [WpfFact]
-    public void TestObjectCreationExpressionWithMissingType()
-        => Test("""
-            public class Bar
-            {
-                public void Bar2()
-                {
-                    Bar b = new()
-                    {
-                        $$
-                    };
-                }
-            }
-            """,
-            """
-            public class Bar
-            {
-                public void Bar2()
-                {
-                    Bar b = new$$
-                }
-            }
-            """);
-
-    [WpfFact]
-    public void TestRemoveInitializerForImplicitObjectCreationExpression()
-        => Test("""
-            public class Bar
-            {
-                public void Bar2()
-                {
-                    Bar b = new();
-                    $$
-                }
-            }
-            """,
-            """
-            public class Bar
-            {
-                public void Bar2()
-                {
-                    Bar b = new()
-                    {
-                        $$
-                    };
                 }
             }
             """);


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/80791