### PR TITLE
Fix race in AbstractFormatEngine.GetChainedFormattingRules

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.cs
@@ -75,7 +75,7 @@ internal abstract partial class AbstractFormatEngine
     private static ChainedFormattingRules GetChainedFormattingRules(ImmutableArray<AbstractFormattingRule> formattingRules, SyntaxFormattingOptions options)
     {
         var lastRulesAndOptions = s_lastRulesAndOptions;
-        if (formattingRules != lastRulesAndOptions?.Item1 || options != s_lastRulesAndOptions?.Item2)
+        if (formattingRules != lastRulesAndOptions?.Item1 || options != lastRulesAndOptions?.Item2)
         {
             lastRulesAndOptions = Tuple.Create(formattingRules, options, new ChainedFormattingRules(formattingRules, options));
             s_lastRulesAndOptions = lastRulesAndOptions;


### PR DESCRIPTION
On a project with mixed whitespace settings, occasionally a document could be formatted (using dotnet-format) using the wrong settings.  This was caused by a race in GetChainedFormattingRules, when s_lastRulesAndOptions was written between the two reads.

I believe the second read was just a typo, so this change removes it.

Fixes: e97fcbe5131508400209a56ba8a76c05f3713319