### PR TITLE
Skip ngen log publishing when not applying optprof

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -8,11 +8,24 @@ trigger:
 
 # Branches that trigger builds on PR
 pr:
-- main
-- main-vs-deps
-- release/*
-- features/*
-- demos/*
+  branches:
+    include:
+    - main
+    - main-vs-deps
+    - release/*
+    - features/*
+    - demos/*
+  paths:
+    exclude:
+      - docs/*
+      - eng/config/OptProf.json
+      - eng/config/PublishData.json
+      - eng/setup-pr-validation.ps1
+      - .vscode/*
+      - .github/*
+      - azure-pipelines-official.yml
+      - azure-pipelines-pr-validation.yml
+      - CODE-OF-CONDUCT.md
 
 jobs:
 - job: VS_Integration

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -145,7 +145,7 @@ extends:
 
                 - output: pipelineArtifact
                   displayName: "Publish Ngen Logs"
-                  condition: succeeded()
+                  condition: and(succeeded(), ${{ not(parameters.SkipApplyOptimizationData) }})
                   targetPath: '$(Build.SourcesDirectory)\artifacts\log\$(BuildConfiguration)\ngen'
                   artifactName: "NGen Logs"
                   publishLocation: Container

--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -95,7 +95,7 @@ extends:
 
                 - output: pipelineArtifact
                   displayName: "Publish Ngen Logs"
-                  condition: succeeded()
+                  condition: and(succeeded(), ${{ not(parameters.SkipApplyOptimizationData) }})
                   targetPath: '$(Build.SourcesDirectory)\artifacts\log\$(BuildConfiguration)\ngen'
                   artifactName: "NGen Logs"
                   publishLocation: Container

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,11 +8,24 @@ trigger:
 
 # Branches that trigger builds on PR
 pr:
-- main
-- main-vs-deps
-- release/*
-- features/*
-- demos/*
+  branches:
+    include:
+    - main
+    - main-vs-deps
+    - release/*
+    - features/*
+    - demos/*
+  paths:
+    exclude:
+      - docs/*
+      - eng/config/OptProf.json
+      - eng/config/PublishData.json
+      - eng/setup-pr-validation.ps1
+      - .vscode/*
+      - .github/*
+      - azure-pipelines-official.yml
+      - azure-pipelines-pr-validation.yml
+      - CODE-OF-CONDUCT.md
 
 # Windows Build and Test Jobs
 jobs:


### PR DESCRIPTION
Updated to match main. When we do not apply optprof we do not have logs to publish.