### PR TITLE
Fix IOException in ShadowCopyAnalyzerPathResolver by using overwrite:true in File.Copy

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/ShadowCopyAnalyzerPathResolverTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/ShadowCopyAnalyzerPathResolverTests.cs
@@ -105,4 +105,24 @@ public sealed class ShadowCopyAnalyzerPathResolverTests : IDisposable
             return filePath;
         }
     }
+
+    [Fact]
+    public void GetRealPath_DestinationAlreadyExists_ShouldNotThrow()
+    {
+        var analyzerPath = TempRoot.CreateDirectory().CreateFile("analyzer.dll").Path;
+        File.WriteAllText(analyzerPath, "content");
+
+        var sharedBaseDir = TempRoot.CreateDirectory().Path;
+        var resolver = new ShadowCopyAnalyzerPathResolver(sharedBaseDir);
+
+        var expectedShadowDir = Path.Combine(resolver.ShadowDirectory, "1");
+        var expectedShadowPath = Path.Combine(expectedShadowDir, "analyzer.dll");
+        Directory.CreateDirectory(expectedShadowDir);
+        File.WriteAllText(expectedShadowPath, "stale");
+
+        var actualShadowPath = resolver.GetResolvedAnalyzerPath(analyzerPath);
+
+        Assert.True(File.Exists(actualShadowPath));
+        Assert.Equal("content", File.ReadAllText(actualShadowPath));
+    }
 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerPathResolver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerPathResolver.cs
@@ -267,7 +267,7 @@ namespace Microsoft.CodeAnalysis
                 // emulates not having the shadow copy layer
                 if (File.Exists(originalPath))
                 {
-                    File.Copy(originalPath, shadowCopyPath);
+                    File.Copy(originalPath, shadowCopyPath, overwrite: true);
                     ClearReadOnlyFlagOnFile(new FileInfo(shadowCopyPath));
                 }
             }


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2668781