### PR TITLE
Add global.json for post-build scripts

### DIFF
--- a/eng/common/post-build/global.json
+++ b/eng/common/post-build/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.417",
+    "rollForward": "latestPatch"
+  }
+}

--- a/eng/common/templates-official/post-build/post-build.yml
+++ b/eng/common/templates-official/post-build/post-build.yml
@@ -268,6 +268,7 @@ stages:
       - task: UseDotNet@2
         inputs:
           version: 8.0.x
+          installationPath: $(Build.SourcesDirectory)/.dotnet
 
       - task: AzureCLI@2
         displayName: Publish Using Darc
@@ -282,3 +283,4 @@ stages:
             -WaitPublishingFinish true
             -ArtifactsPublishingAdditionalParameters '${{ parameters.artifactsPublishingAdditionalParameters }}'
             -SymbolPublishingAdditionalParameters '${{ parameters.symbolPublishingAdditionalParameters }}'
+          workingDirectory: $(Build.SourcesDirectory)/eng/common/post-build/

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -264,6 +264,7 @@ stages:
       - task: UseDotNet@2
         inputs:
           version: 8.0.x
+          installationPath: $(Build.SourcesDirectory)/.dotnet
 
       - task: AzureCLI@2
         displayName: Publish Using Darc
@@ -279,3 +280,5 @@ stages:
             -WaitPublishingFinish true
             -ArtifactsPublishingAdditionalParameters '${{ parameters.artifactsPublishingAdditionalParameters }}'
             -SymbolPublishingAdditionalParameters '${{ parameters.symbolPublishingAdditionalParameters }}'
+          workingDirectory: $(Build.SourcesDirectory)/eng/common/post-build/
+


### PR DESCRIPTION
Despite installing a dotnet 8 SDK, the darc tool installation was running under the .NET 6 SDK due to Roslyn's global.json. ([See failing run](https://dnceng.visualstudio.com/internal/internal%20Team/_build/results?buildId=2884394&view=logs&j=226748d0-f812-5437-d3f0-2dd291f5666e&t=b3ecf0d0-598d-5874-6547-0432d3f07f6b&l=57))

This PR adds a global.json just for running the post-build scripts and sets the working directory so the publish using darc scripts runs under it instead. ([See test run](https://dnceng.visualstudio.com/internal/internal%20Team/_build/results?buildId=2884857&view=logs&j=226748d0-f812-5437-d3f0-2dd291f5666e&t=b3ecf0d0-598d-5874-6547-0432d3f07f6b&l=55))