### PR TITLE
[release/dev17.12] Include the PME service name for scheduled builds

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -34,16 +34,21 @@ pr:
       - docs/*
       - eng/config/OptProf.json
       - eng/config/PublishData.json
+      - eng/setup-pr-validation.ps1
+      - src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/README.md
       - .vscode/*
       - .github/*
       - .devcontainer/*
       - .git-blame-ignore-revs
       - .vsconfig
+      - azure-pipelines-compliance.yml
+      - azure-pipelines-integration-dartlab.yml
+      - azure-pipelines-integration-scouting.yml
+      - azure-pipelines-official.yml
+      - azure-pipelines-pr-validation.yml
       - CODE-OF-CONDUCT.md
       - CONTRIBUTING.md
       - README.md
-      - src/Compilers/*
-      - src/Features/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/README.md
 
 variables:
 - name: Codeql.Enabled

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -284,7 +284,7 @@ extends:
             zipSources: false
             feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
             # Set ConnectedPMEServiceName if the build is a CI build, otherwise it is not needed
-            ${{ if or(eq(variables['Build.Reason'], 'IndividualCI'), parameters.PMEOverride) }}:
+            ${{ if or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'Schedule'), parameters.PMEOverride) }}:
               ConnectedPMEServiceName: 248d384a-b39b-46e3-8ad5-c2c210d5e7ca
           condition: and(succeeded(), in('${{ parameters.SignType }}', 'test', 'real'))
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,13 +18,20 @@ pr:
   paths:
     exclude:
       - docs/*
+      - eng/config/OptProf.json
       - eng/config/PublishData.json
-      - src/Features/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/README.md
+      - eng/setup-pr-validation.ps1
+      - src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/README.md
       - .vscode/*
       - .github/*
       - .devcontainer/*
       - .git-blame-ignore-revs
       - .vsconfig
+      - azure-pipelines-compliance.yml
+      - azure-pipelines-integration-dartlab.yml
+      - azure-pipelines-integration-scouting.yml
+      - azure-pipelines-official.yml
+      - azure-pipelines-pr-validation.yml
       - CODE-OF-CONDUCT.md
       - CONTRIBUTING.md
       - README.md


### PR DESCRIPTION
Manual backport of https://github.com/dotnet/roslyn/pull/82105

Signing is failing for scheduled builds because we do not include the PME service name ([see run](https://dev.azure.com/dnceng/internal/internal%20Team/_build/results?buildId=2868326&view=logs&j=20fcf628-b65c-5865-625a-1cef81cda63b&t=9222df16-c5ca-5a8e-6729-493543112c66&l=58)).