### PR TITLE
[release/dev16.11-vs-deps] Include the PME service name for scheduled builds

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -273,7 +273,7 @@ extends:
                   zipSources: false
                   feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
                   # Set ConnectedPMEServiceName if the build is a CI build, otherwise it is not needed
-                  ${{ if or(eq(variables['Build.Reason'], 'IndividualCI'), parameters.PMEOverride) }}:
+                  ${{ if or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'Schedule'), parameters.PMEOverride) }}:
                     ConnectedPMEServiceName: 248d384a-b39b-46e3-8ad5-c2c210d5e7ca
                 condition: and(succeeded(), in('${{ parameters.SignType }}', 'test', 'real'))
 


### PR DESCRIPTION
Manual backport of https://github.com/dotnet/roslyn/pull/82105

Signing is failing for scheduled builds because we do not include the PME service name ([see run](https://dev.azure.com/dnceng/internal/internal%20Team/_build/results?buildId=2868326&view=logs&j=20fcf628-b65c-5865-625a-1cef81cda63b&t=9222df16-c5ca-5a8e-6729-493543112c66&l=58)).