### PR TITLE
Extensions: Optimize GetExtensionMembers

### DIFF
--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
@@ -34914,17 +34914,10 @@ static class E
 }
 """;
         var comp = CreateCompilation(src);
-#if DEBUG
-        comp.VerifyEmitDiagnostics(
-            // (1,4): error CS0121: The call is ambiguous between the following methods or properties: 'E.extension(string).M(object)' and 'E.extension(object).M(string)'
-            // "".M("");
-            Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("E.extension(string).M(object)", "E.extension(object).M(string)").WithLocation(1, 4));
-#else
         comp.VerifyEmitDiagnostics(
             // (1,4): error CS0121: The call is ambiguous between the following methods or properties: 'E.extension(object).M(string)' and 'E.extension(string).M(object)'
             // "".M("");
             Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("E.extension(object).M(string)", "E.extension(string).M(object)").WithLocation(1, 4));
-#endif
     }
 
     [Fact]
@@ -36747,7 +36740,7 @@ static class E
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "s.M");
         Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
-        AssertEx.SetEqual(["System.String E.<G>$C43E2675C7BBF9284AF22FB8A9BF0280.M()", "System.Action E.<G>$34505F560D9EACF86A87F3ED1F85E448.M { get; }"], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
+        AssertEx.SequenceEqual(["System.Action E.<G>$34505F560D9EACF86A87F3ED1F85E448.M { get; }", "System.String E.<G>$C43E2675C7BBF9284AF22FB8A9BF0280.M()"], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
     }
 
     [Fact]
@@ -36778,7 +36771,7 @@ static class E
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "string.M");
         Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
-        AssertEx.SetEqual(["System.String E.<G>$34505F560D9EACF86A87F3ED1F85E448.M()", "System.Action E.<G>$C43E2675C7BBF9284AF22FB8A9BF0280.M { get; }"], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
+        AssertEx.SequenceEqual(["System.Action E.<G>$C43E2675C7BBF9284AF22FB8A9BF0280.M { get; }", "System.String E.<G>$34505F560D9EACF86A87F3ED1F85E448.M()"], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
     }
 
     [Fact]
@@ -36812,7 +36805,7 @@ static class E
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "i.M");
         Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
-        AssertEx.SetEqual(["System.String E.<G>$2B406085AC5EBECC11B16BCD2A24DF4E.M()", "System.Action E.<G>$B5F2BFAFBDD4469288FE06B785D143CD.M { get; }"], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
+        AssertEx.SequenceEqual(["System.Action E.<G>$B5F2BFAFBDD4469288FE06B785D143CD.M { get; }", "System.String E.<G>$2B406085AC5EBECC11B16BCD2A24DF4E.M()"], model.GetSymbolInfo(memberAccess).CandidateSymbols.ToTestDisplayStrings());
     }
 
     [Fact]
@@ -37631,7 +37624,7 @@ static class E
         var tree = comp.SyntaxTrees.First();
         var model = comp.GetSemanticModel(tree);
         var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "s.M<string>");
-        AssertEx.SetEqual(["void E.<G>$34505F560D9EACF86A87F3ED1F85E448.M<System.String>()", "void E.<G>$8048A6C8BE30A622530249B904B537EB<System.String>.M()"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+        AssertEx.SequenceEqual(["void E.<G>$8048A6C8BE30A622530249B904B537EB<System.String>.M()", "void E.<G>$34505F560D9EACF86A87F3ED1F85E448.M<System.String>()"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
     }
 
     [Fact]
@@ -50263,19 +50256,11 @@ static class E
 """;
         var comp = CreateCompilation(src);
 
-#if DEBUG
-        var expectedDiagnostics = new[] {
-            // (2,4): error CS0121: The call is ambiguous between the following methods or properties: 'E.extension(string).M(object)' and 'E.extension(object).M(string)'
-            // "".M("");
-            Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("E.extension(string).M(object)", "E.extension(object).M(string)").WithLocation(2, 4)
-            };
-#else
         var expectedDiagnostics = new[] {
             // (2,4): error CS0121: The call is ambiguous between the following methods or properties: 'E.extension(object).M(string)' and 'E.extension(string).M(object)'
             // "".M("");
             Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("E.extension(object).M(string)", "E.extension(string).M(object)").WithLocation(2, 4)
             };
-#endif
 
         comp.VerifyEmitDiagnostics(expectedDiagnostics);
 
@@ -50315,19 +50300,11 @@ static class E
 """;
         var comp = CreateCompilation(src);
 
-#if DEBUG
-        var expectedDiagnostics = new[] {
-            // (3,3): error CS0121: The call is ambiguous between the following methods or properties: 'E.extension(string).M(object)' and 'E.extension(object).M(string)'
-            // s.M(s);
-            Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("E.extension(string).M(object)", "E.extension(object).M(string)").WithLocation(3, 3)
-            };
-#else
         var expectedDiagnostics = new[] {
             // (3,3): error CS0121: The call is ambiguous between the following methods or properties: 'E.extension(object).M(string)' and 'E.extension(string).M(object)'
             // s.M(s);
             Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("E.extension(object).M(string)", "E.extension(string).M(object)").WithLocation(3, 3)
             };
-#endif
 
         comp.VerifyEmitDiagnostics(expectedDiagnostics);
 

--- a/src/Compilers/Test/Utilities/CSharp/SymbolUtilities.cs
+++ b/src/Compilers/Test/Utilities/CSharp/SymbolUtilities.cs
@@ -135,10 +135,5 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             SymbolDisplayFormat format = GetDisplayFormat(includeNonNullable);
             return symbol.ToDisplayString(format);
         }
-
-        public static string[] ToDisplayStrings(this IEnumerable<ISymbol> symbols)
-        {
-            return symbols.Select(s => s.ToDisplayString()).ToArray();
-        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/81815

`GetTypeMembersUnordered()` allocates for PE named types and retargeting namespaces.
The changes:
- call `GetTypeMembers(name)` instead when looking for extension blocks (we know the name is "")
- cache the type members in retargeting namespaces

```
## 4.12 (4.14 is the same)

| Method                | Mean     | Error    | StdDev   | Gen0       | Gen1       | Allocated |
|---------------------- |---------:|---------:|---------:|-----------:|-----------:|----------:|
| ProcessAllSyntaxNodes | 954.4 ms | 18.89 ms | 21.00 ms | 44000.0000 | 10000.0000 | 695.15 MB |

## 5.0

| Method                | Mean    | Error    | StdDev   | Gen0        | Gen1       | Allocated |
|---------------------- |--------:|---------:|---------:|------------:|-----------:|----------:|
| ProcessAllSyntaxNodes | 5.744 s | 0.1115 s | 0.1768 s | 209000.0000 | 45000.0000 |   3.23 GB |

## main (including redesign of GetExtensionContainers->GetExtensionMembers in https://github.com/dotnet/roslyn/pull/80485 )

| Method                | Mean    | Error    | StdDev   | Gen0       | Gen1       | Allocated |
|---------------------- |--------:|---------:|---------:|-----------:|-----------:|----------:|
| ProcessAllSyntaxNodes | 1.787 s | 0.0342 s | 0.0714 s | 72000.0000 | 17000.0000 |   1.12 GB |


## after this PR

| Method                | Mean    | Error    | StdDev   | Gen0       | Gen1      | Allocated |
|---------------------- |--------:|---------:|---------:|-----------:|----------:|----------:|
| ProcessAllSyntaxNodes | 1.153 s | 0.0228 s | 0.0272 s | 24000.0000 | 5000.0000 | 382.31 MB |
```

I'm planning a follow-up to rename `MightContainExtensionMethods` and `TypesMightContainExtensionMethods`. I'll also explore factoring `GetExtensionMethods` and `GetExtensionMembers` together.

FWIW, here's the benchmark code:
<details>
  <summary>Click to expand</summary>
  
```
using BenchmarkDotNet.Running;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Configs;
using BenchmarkDotNet.Diagnosers;
using Microsoft.Build.Locator;
using Microsoft.CodeAnalysis;
using Microsoft.CodeAnalysis.MSBuild;

BenchmarkRunner.Run<SolutionSymbolBenchmark>();

[Config(typeof(SolutionSymbolBenchmarkConfig))]
public class SolutionSymbolBenchmark
{
    private const string SolutionPath = @"c:\src\nopCommerce\src\nopCommerce.sln";
    private const string MsbuildPath = @"C:\\Program Files\\Microsoft Visual Studio\\18\\Insiders\\MSBuild\\Current\\Bin";

    private sealed record DocumentContext(SemanticModel SemanticModel, SyntaxNode Root);

    private sealed class SolutionSymbolBenchmarkConfig : ManualConfig
    {
        public SolutionSymbolBenchmarkConfig()
        {
            AddDiagnoser(MemoryDiagnoser.Default);
            AddDiagnoser(new EventPipeProfiler(EventPipeProfile.CpuSampling));
        }
    }

    private readonly List<DocumentContext> _documents = new();
    private MSBuildWorkspace? _workspace;

    [GlobalSetup]
    public async Task GlobalSetupAsync()
    {
        Console.WriteLine($"Benchmark process PID: {Environment.ProcessId}");

        if (!File.Exists(SolutionPath))
        {
            throw new FileNotFoundException($"Solution not found at {SolutionPath}");
        }

        if (!MSBuildLocator.IsRegistered)
        {
            if (!Directory.Exists(MsbuildPath))
            {
                throw new DirectoryNotFoundException($"MSBuild path not found at {MsbuildPath}");
            }

            MSBuildLocator.RegisterMSBuildPath(MsbuildPath);
        }

        _workspace = MSBuildWorkspace.Create();

        var solution = await _workspace.OpenSolutionAsync(SolutionPath).ConfigureAwait(false);

        foreach (var document in solution.Projects.SelectMany(project => project.Documents))
        {
            if (!document.SupportsSyntaxTree)
            {
                continue;
            }

            var root = await document.GetSyntaxRootAsync().ConfigureAwait(false);
            if (root is null)
            {
                continue;
            }

            var semanticModel = await document.GetSemanticModelAsync().ConfigureAwait(false);
            if (semanticModel is null)
            {
                continue;
            }

            _documents.Add(new DocumentContext(semanticModel, root));
        }
    }

    [GlobalCleanup]
    public void GlobalCleanup()
    {
        _workspace?.Dispose();
        _documents.Clear();
    }

    [Benchmark]
    public int ProcessAllSyntaxNodes()
    {
        var symbolCount = 0;

        Parallel.ForEach(
            _documents,
            () => 0,
            (context, _, localCount) =>
            {
                foreach (var node in context.Root.DescendantNodesAndSelf())
                {
                    if (context.SemanticModel.GetSymbolInfo(node).Symbol is not null)
                    {
                        localCount++;
                    }
                }

                return localCount;
            },
            localCount => Interlocked.Add(ref symbolCount, localCount));

        return symbolCount;
    }
}
```
</details>
