### PR TITLE
Change VS to ensure that LSP completions are sorted as intended.

### DIFF
--- a/src/LanguageServer/Protocol/Handler/Completion/CompletionResultFactory.cs
+++ b/src/LanguageServer/Protocol/Handler/Completion/CompletionResultFactory.cs
@@ -136,9 +136,16 @@ internal static class CompletionResultFactory
             // Now add data common to all hosts.
             lspItem.Data = completionItemResolveData;
 
+            if (!lspItem.Label.Equals(item.SortText, StringComparison.Ordinal))
+            {
+                lspItem.SortText = item.SortText;
+            }
+
             // Add sort text to ensure that items are sorted by their position in the list.
             // The max length of the list is 1000 items, so we only need 4 characters to represent the index.
-            lspItem.SortText = index.ToString("D4");
+            // lspItem.SortText needs to end with the item's SortText as the CompletionResolveHandler depends
+            // on that to properly resolve completion items.
+            lspItem.SortText = $"{index:D4}{lspItem.SortText}";
 
             if (!lspItem.Label.Equals(item.FilterText, StringComparison.Ordinal))
                 lspItem.FilterText = item.FilterText;

--- a/src/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -433,7 +433,7 @@ public sealed class CompletionTests : AbstractLanguageServerProtocolTests
         var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
 
         var expected = await CreateCompletionItemAsync(
-            label: "d", kind: LSP.CompletionItemKind.Text, tags: ["Text"], request: completionParams, document: document, sortText: "0000",
+            label: "d", kind: LSP.CompletionItemKind.Text, tags: ["Text"], request: completionParams, document: document, sortText: "00000000",
             labelDetails: new() { Description = "shortdate" }).ConfigureAwait(false);
 
         var results = await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
@@ -501,7 +501,7 @@ public sealed class CompletionTests : AbstractLanguageServerProtocolTests
 
         var expected = await CreateCompletionItemAsync(
             label: @"\A", kind: LSP.CompletionItemKind.Text, tags: ["Text"], request: completionParams, document: document, textEditText: @"\\A",
-            sortText: "0000", labelDetails: new() { Description = "startofstringonly" }).ConfigureAwait(false);
+            sortText: "00000000", labelDetails: new() { Description = "startofstringonly" }).ConfigureAwait(false);
 
         var results = await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
         AssertJsonEquals(expected, results.Items.First());
@@ -540,7 +540,7 @@ public sealed class CompletionTests : AbstractLanguageServerProtocolTests
 
         var expected = await CreateCompletionItemAsync(
             label: @"\A", kind: LSP.CompletionItemKind.Text, tags: ["Text"], request: completionParams, document: document,
-            sortText: "0000", vsResolveTextEditOnCommit: true, labelDetails: new() { Description = "startofstringonly" }).ConfigureAwait(false);
+            sortText: "00000000", vsResolveTextEditOnCommit: true, labelDetails: new() { Description = "startofstringonly" }).ConfigureAwait(false);
 
         var results = await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
         AssertJsonEquals(expected, results.Items.First());
@@ -579,7 +579,7 @@ public sealed class CompletionTests : AbstractLanguageServerProtocolTests
 
         var expected = await CreateCompletionItemAsync(
             label: @"\A", kind: LSP.CompletionItemKind.Text, tags: ["Text"], request: completionParams, document: document,
-            sortText: "0000", vsResolveTextEditOnCommit: true, labelDetails: new() { Description = "startofstringonly" }).ConfigureAwait(false);
+            sortText: "00000000", vsResolveTextEditOnCommit: true, labelDetails: new() { Description = "startofstringonly" }).ConfigureAwait(false);
 
         var results = await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
         AssertJsonEquals(expected, results.Items.First());
@@ -635,7 +635,7 @@ public sealed class CompletionTests : AbstractLanguageServerProtocolTests
 
         var expected = await CreateCompletionItemAsync(
             label: @"\A", kind: LSP.CompletionItemKind.Text, tags: ["Text"], request: completionParams, document: document, textEdit: textEdit,
-            sortText: "0000", labelDetails: new() { Description = "startofstringonly" }).ConfigureAwait(false);
+            sortText: "00000000", labelDetails: new() { Description = "startofstringonly" }).ConfigureAwait(false);
 
         var results = await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
         AssertJsonEquals(expected, results.Items.First());


### PR DESCRIPTION
This makes razor C# completions sort much more similarly to how C# completions sort in .cs files. (Note that we still have the nuint/null selection issue, that is covered by https://github.com/dotnet/razor/issues/12483 which is how I found this issue)

*** .cs behavior ***
<img width="653" height="521" alt="image" src="https://github.com/user-attachments/assets/28e338f8-bdcf-4694-8724-482b59daf374" />

*** old razor behavior ***
<img width="442" height="471" alt="image" src="https://github.com/user-attachments/assets/4729de85-f0fc-4fbc-8b91-1b4300577be1" />

*** new razor behavior ***
<img width="430" height="447" alt="image" src="https://github.com/user-attachments/assets/72aa5244-a7be-41b8-adf5-80d4785678d0" />
