### PR TITLE
Fix a crash involving `[SetsRequiredMembers]` and required property using field keyword on a base type

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -795,10 +795,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return;
                 }
 
-                // If 'field' keyword is explicitly used by 'symbol', then use FlowAnalysisAnnotations from the backing field.
-                // Otherwise, use the FlowAnalysisAnnotations from the user-declared symbol (property or ordinary field).
-                var usesFieldKeyword = symbol is SourcePropertySymbolBase { UsesFieldKeyword: true };
-                var annotations = usesFieldKeyword ? field!.FlowAnalysisAnnotations : symbol.GetFlowAnalysisAnnotations();
+                // If we are considering the backing field for this check, and the field keyword is explicitly used by 'symbol', then use FlowAnalysisAnnotations from the backing field.
+                // Otherwise, use the FlowAnalysisAnnotations from 'symbol'.
+                var (usesFieldKeyword, annotations) = field != null && symbol is SourcePropertySymbolBase { UsesFieldKeyword: true }
+                    ? (true, field.FlowAnalysisAnnotations)
+                    : (false, symbol.GetFlowAnalysisAnnotations());
                 if ((annotations & FlowAnalysisAnnotations.AllowNull) != 0)
                 {
                     // We assume that if a member has AllowNull then the user


### PR DESCRIPTION
Closes #80504

We may analyze the state of a base property on exit, when it is required, and the constructor has SetsRequiredMembers. In this case we need to take care to ignore a backing field, even if the property uses the field keyword. This is because we want the analysis of the constructor in the subtype to behave similarly regardless of whether the base type comes from source or metadata.
