### PR TITLE
Reduce allocations during analysis result creation.

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisResultBuilder.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisResultBuilder.cs
@@ -524,8 +524,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return new AnalysisResult(analyzers, localSyntaxDiagnostics, localSemanticDiagnostics, localAdditionalFileDiagnostics, nonLocalDiagnostics, analyzerTelemetryInfo);
         }
 
+        /// <summary>
+        /// Gets an immutable dictionary from the given local diagnostics map.
+        /// </summary>
+        /// <param name="analyzers">Limits the analyzers included. Is not modified.</param>
+        /// <param name="shouldInclude">Filter determining whether a diagnostic should be included</param>
+        /// <param name="localDiagnosticsOpt">Diagnostic map to operate on</param>
         private static ImmutableDictionary<TKey, ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<Diagnostic>>> GetImmutable<TKey>(
-            IReadOnlyCollection<DiagnosticAnalyzer> analyzers,
+            HashSet<DiagnosticAnalyzer> analyzers, // Will not be modified
             Func<Diagnostic, bool> shouldInclude,
             Dictionary<TKey, Dictionary<DiagnosticAnalyzer, ImmutableArray<Diagnostic>.Builder>>? localDiagnosticsOpt)
             where TKey : class
@@ -560,8 +566,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return builder.ToImmutable();
         }
 
+        /// <summary>
+        /// Gets an immutable dictionary from the given non-local diagnostics map.
+        /// </summary>
+        /// <param name="analyzers">Limits the analyzers included. Is not modified.</param>
+        /// <param name="shouldInclude">Filter determining whether a diagnostic should be included</param>
+        /// <param name="nonLocalDiagnosticsOpt">Diagnostic map to operate on</param>
         private static ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<Diagnostic>> GetImmutable(
-            IReadOnlyCollection<DiagnosticAnalyzer> analyzers,
+            HashSet<DiagnosticAnalyzer> analyzers,
             Func<Diagnostic, bool> shouldInclude,
             Dictionary<DiagnosticAnalyzer, ImmutableArray<Diagnostic>.Builder>? nonLocalDiagnosticsOpt)
         {


### PR DESCRIPTION
The local ImmutableHashSet usage in this method accounts for 0.9% of total allocations in the devhub process in the razor completion speedometer test. Local testing of mudblazor showed on average about 130 analyzers were added to this set per call. A standard HashSet is more efficient wrt memory usage and query performance than an ImmutableHashSet.

*** Previous allocations ***
<img width="1392" height="350" alt="image" src="https://github.com/user-attachments/assets/14331f92-73bb-4c01-a402-001fb0636831" />