### PR TITLE
Eagerly read additional text

### DIFF
--- a/src/Compilers/Core/Portable/AdditionalTextFile.cs
+++ b/src/Compilers/Core/Portable/AdditionalTextFile.cs
@@ -32,6 +32,7 @@ namespace Microsoft.CodeAnalysis
             _compiler = compiler;
             _diagnostics = SpecializedCollections.EmptyList<DiagnosticInfo>();
             _text = new Lazy<SourceText?>(ReadText);
+            _ = _text.Value;
         }
 
         private SourceText? ReadText()


### PR DESCRIPTION
The `AdditionalTextFile` lazily reads it's file contents. This means that issues reading the file, including problems like an illegal path name, are only noticed if an analyzer actually reads the file. This means a command line like the following may result in no diagnostics if an analyzer doesn't actually read the file. 

```
/additionalfile:a__c:\code\data.txt
```

Want to let this run through CI and see if this behavior is intenional and what issues it may reference.