### PR TITLE
Fix exception in `ExtractMethod` with `var` pattern in compound pattern

### DIFF
--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.cs
@@ -46,7 +46,7 @@ internal sealed partial class CSharpExtractMethodService
                 // existing local function instead of the overarching method.
                 var outermostCapturedVariable = analyzerResult.GetOutermostVariableToMoveIntoMethodDefinition();
                 var baseNode = outermostCapturedVariable != null
-                    ? outermostCapturedVariable.GetOriginalIdentifierToken(cancellationToken).Parent
+                    ? outermostCapturedVariable.GetIdentifierTokenAtDeclaration(document).Parent
                     : this.OriginalSelectionResult.GetOutermostCallSiteContainerToProcess(cancellationToken);
 
                 if (baseNode is CompilationUnitSyntax)

--- a/src/Features/CSharpTest/ExtractMethod/ExtractLocalFunctionTests.cs
+++ b/src/Features/CSharpTest/ExtractMethod/ExtractLocalFunctionTests.cs
@@ -5553,7 +5553,6 @@ class Program
             """, new(TestOptions.Regular, index: CodeActionIndex));
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/82031")]
-    [CompilerTrait(CompilerFeature.Patterns)]
     public Task TestVarPatternInCompoundPattern()
         => TestInRegularAndScriptAsync(
             """


### PR DESCRIPTION
Fix `InvalidOperationException` in Extract Method refactoring when selecting code containing a `var` pattern inside a compound pattern.

Fixes #82031 