### PR TITLE
Add support for automatically loading projects

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/LanguageServerTestComposition.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/LanguageServerTestComposition.cs
@@ -28,7 +28,8 @@ internal sealed class LanguageServerTestComposition
             CSharpDesignTimePath: null,
             ExtensionLogDirectory: string.Empty,
             ServerPipeName: null,
-            UseStdIo: false);
+            UseStdIo: false,
+            AutoLoadProjects: false);
         var extensionManager = ExtensionAssemblyManager.Create(serverConfiguration, loggerFactory);
         var assemblyLoader = new CustomExportAssemblyLoader(extensionManager, loggerFactory);
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/AutoLoadProjectsInitializer.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/AutoLoadProjectsInitializer.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.Threading;
 using Roslyn.LanguageServer.Protocol;
 
-namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.Razor;
+namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
 
 [Shared]
 [ExportCSharpVisualBasicStatelessLspService(typeof(AutoLoadProjectsInitializer))]
@@ -42,7 +42,7 @@ internal sealed class AutoLoadProjectsInitializer(
         var workspaceFolders = initializeParams.WorkspaceFolders;
         if (workspaceFolders is null || workspaceFolders.Length == 0)
         {
-            _logger.LogWarning("No workspace folders provided during initialization, could not auto load projects.");
+            _logger.LogWarning("No workspace folders provided during initialization; could not auto load projects.");
             return;
         }
 
@@ -66,7 +66,7 @@ internal sealed class AutoLoadProjectsInitializer(
             projectFiles.AddRange(Directory.EnumerateFiles(folderPath, "*.csproj", SearchOption.AllDirectories));
         }
 
-        _logger.LogInformation("Discovered {count} projects to auto load: {projects}", projectFiles.Count, string.Join($"{Environment.NewLine}    ", projectFiles));
+        _logger.LogInformation("Discovered {count} projects to auto load", projectFiles.Count);
 
         // We don't want to block initialization on loading projects - fire and forget.
         projectSystem.OpenProjectsAsync(projectFiles.ToImmutable()).ReportNonFatalErrorAsync().Forget();

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
@@ -106,7 +106,10 @@ static async Task RunAsync(ServerConfiguration serverConfiguration, Cancellation
     globalOptionService.SetGlobalOption(WorkspaceConfigurationOptionsStorage.SourceGeneratorExecution, SourceGeneratorExecutionPreference.Automatic);
 
     // The log file directory passed to us by VSCode might not exist yet, though its parent directory is guaranteed to exist.
-    Directory.CreateDirectory(serverConfiguration.ExtensionLogDirectory);
+    if (serverConfiguration.ExtensionLogDirectory is not null)
+    {
+        Directory.CreateDirectory(serverConfiguration.ExtensionLogDirectory);
+    }
 
     // Initialize the server configuration MEF exported value.
     exportProvider.GetExportedValue<ServerConfigurationFactory>().InitializeConfiguration(serverConfiguration);
@@ -290,14 +293,14 @@ static RootCommand CreateCommand()
         var devKitDependencyPath = parseResult.GetValue(devKitDependencyPathOption);
         var razorDesignTimePath = parseResult.GetValue(razorDesignTimePathOption);
         var csharpDesignTimePath = parseResult.GetValue(csharpDesignTimePathOption);
-        var extensionLogDirectory = parseResult.GetValue(extensionLogDirectoryOption) ?? Path.Combine(AppContext.BaseDirectory, "Logs");
+        var extensionLogDirectory = parseResult.GetValue(extensionLogDirectoryOption);
         var serverPipeName = parseResult.GetValue(serverPipeNameOption);
         var useStdIo = parseResult.GetValue(useStdIoOption);
         var autoLoadProjects = parseResult.GetValue(autoLoadProjectsOption);
 
         var serverConfiguration = new ServerConfiguration(
             LaunchDebugger: launchDebugger,
-            LogConfiguration: new LogConfiguration(logLevel),
+            LogConfiguration: new LogConfiguration(logLevel ?? LogLevel.Information),
             StarredCompletionsPath: starredCompletionsPath,
             TelemetryLevel: telemetryLevel,
             SessionId: sessionId,

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/ServerConfigurationFactory.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/ServerConfigurationFactory.cs
@@ -52,16 +52,16 @@ internal sealed record class ServerConfiguration(
     string? CSharpDesignTimePath,
     string? ServerPipeName,
     bool UseStdIo,
-    string ExtensionLogDirectory,
+    string? ExtensionLogDirectory,
     bool AutoLoadProjects);
 
 internal sealed class LogConfiguration
 {
     private int _currentLogLevel;
 
-    public LogConfiguration(LogLevel? initialLogLevel)
+    public LogConfiguration(LogLevel initialLogLevel)
     {
-        _currentLogLevel = (int)(initialLogLevel ?? LogLevel.Information);
+        _currentLogLevel = (int)(initialLogLevel);
     }
 
     public void UpdateLogLevel(LogLevel level)

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/RunTestsHandler.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/RunTestsHandler.cs
@@ -51,10 +51,11 @@ internal sealed class RunTestsHandler(DotnetCliHelper dotnetCliHelper, TestDisco
 
         var dotnetRootUser = Environment.GetEnvironmentVariable("DOTNET_ROOT_USER");
 
+        var testLogPath = serverConfiguration.ExtensionLogDirectory is not null ? Path.Combine(serverConfiguration.ExtensionLogDirectory, "testLogs", "vsTestLogs.txt") : null;
         // Instantiate the test platform wrapper.
         var vsTestConsoleWrapper = new VsTestConsoleWrapper(vsTestConsolePath, new ConsoleParameters
         {
-            LogFilePath = Path.Combine(serverConfiguration.ExtensionLogDirectory, "testLogs", "vsTestLogs.txt"),
+            LogFilePath = testLogPath,
             TraceLevel = GetTraceLevel(serverConfiguration),
             EnvironmentVariables = new()
             {


### PR DESCRIPTION
Adds support to search the workspace folders and automatically load projects when the server is started with a particular flag

Also makes some edits to the other parameters to make them optional for easier usage