### PR TITLE
Share FileSystemWatcher for directories across SimpleFileChangeWatcher contexts.

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/SimpleFileChangeWatcherTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/SimpleFileChangeWatcherTests.cs
@@ -1,0 +1,158 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.FileWatching;
+using Microsoft.CodeAnalysis.ProjectSystem;
+using Microsoft.CodeAnalysis.Test.Utilities;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests;
+
+public sealed class SimpleFileChangeWatcherTests : IDisposable
+{
+    private readonly TempRoot _tempRoot = new();
+
+    public void Dispose() => _tempRoot.Dispose();
+
+    [Fact]
+    public void CreateContext_WithExistingDirectory_CreatesSharedWatcher()
+    {
+        var tempDirectory = _tempRoot.CreateDirectory();
+        var watcher = new SimpleFileChangeWatcher();
+
+        using var context = watcher.CreateContext([new WatchedDirectory(tempDirectory.Path, extensionFilters: [])]);
+
+        Assert.Equal(1, SimpleFileChangeWatcher.TestAccessor.GetSharedDirectoryWatcherCount(watcher));
+    }
+
+    [Fact]
+    public void CreateContext_WithNonExistingDirectory_DoesNotCreateSharedWatcher()
+    {
+        var nonExistentPath = Path.Combine(_tempRoot.CreateDirectory().Path, "non-existent");
+        var watcher = new SimpleFileChangeWatcher();
+
+        using var context = watcher.CreateContext([new WatchedDirectory(nonExistentPath, extensionFilters: [])]);
+
+        Assert.Equal(0, SimpleFileChangeWatcher.TestAccessor.GetSharedDirectoryWatcherCount(watcher));
+    }
+
+    [Fact]
+    public void CreateMultipleContexts_SameDirectory_SharesWatcher()
+    {
+        var tempDirectory = _tempRoot.CreateDirectory();
+        var watcher = new SimpleFileChangeWatcher();
+
+        using var context1 = watcher.CreateContext([new WatchedDirectory(tempDirectory.Path, extensionFilters: [])]);
+        using var context2 = watcher.CreateContext([new WatchedDirectory(tempDirectory.Path, extensionFilters: [".cs"])]);
+
+        // Both contexts should share the same directory watcher
+        Assert.Equal(1, SimpleFileChangeWatcher.TestAccessor.GetSharedDirectoryWatcherCount(watcher));
+    }
+
+    [Fact]
+    public void CreateMultipleContexts_DifferentDirectories_CreatesSeparateWatchers()
+    {
+        var tempDirectory1 = _tempRoot.CreateDirectory();
+        var tempDirectory2 = _tempRoot.CreateDirectory();
+        var watcher = new SimpleFileChangeWatcher();
+
+        using var context1 = watcher.CreateContext([new WatchedDirectory(tempDirectory1.Path, extensionFilters: [])]);
+        using var context2 = watcher.CreateContext([new WatchedDirectory(tempDirectory2.Path, extensionFilters: [])]);
+
+        Assert.Equal(2, SimpleFileChangeWatcher.TestAccessor.GetSharedDirectoryWatcherCount(watcher));
+    }
+
+    [Fact]
+    public void DisposeContext_ReleasesSharedWatcher()
+    {
+        var tempDirectory = _tempRoot.CreateDirectory();
+        var watcher = new SimpleFileChangeWatcher();
+
+        var context = watcher.CreateContext([new WatchedDirectory(tempDirectory.Path, extensionFilters: [])]);
+        Assert.Equal(1, SimpleFileChangeWatcher.TestAccessor.GetSharedDirectoryWatcherCount(watcher));
+
+        context.Dispose();
+        Assert.Equal(0, SimpleFileChangeWatcher.TestAccessor.GetSharedDirectoryWatcherCount(watcher));
+    }
+
+    [Fact]
+    public void DisposeOneContext_WithTwoContextsSharingWatcher_KeepsWatcher()
+    {
+        var tempDirectory = _tempRoot.CreateDirectory();
+        var watcher = new SimpleFileChangeWatcher();
+
+        var context1 = watcher.CreateContext([new WatchedDirectory(tempDirectory.Path, extensionFilters: [])]);
+        var context2 = watcher.CreateContext([new WatchedDirectory(tempDirectory.Path, extensionFilters: [])]);
+        Assert.Equal(1, SimpleFileChangeWatcher.TestAccessor.GetSharedDirectoryWatcherCount(watcher));
+
+        context1.Dispose();
+        Assert.Equal(1, SimpleFileChangeWatcher.TestAccessor.GetSharedDirectoryWatcherCount(watcher));
+
+        context2.Dispose();
+        Assert.Equal(0, SimpleFileChangeWatcher.TestAccessor.GetSharedDirectoryWatcherCount(watcher));
+    }
+
+    [Fact]
+    public void EnqueueWatchingFile_InWatchedDirectory_ReturnsNoOpWatchedFile()
+    {
+        var tempDirectory = _tempRoot.CreateDirectory();
+        var tempFile = tempDirectory.CreateFile("test.cs");
+        var watcher = new SimpleFileChangeWatcher();
+
+        using var context = watcher.CreateContext([new WatchedDirectory(tempDirectory.Path, extensionFilters: [".cs"])]);
+        var watchedFile = context.EnqueueWatchingFile(tempFile.Path);
+
+        Assert.IsType<NoOpWatchedFile>(watchedFile);
+    }
+
+    [Fact]
+    public void EnqueueWatchingFile_OutsideWatchedDirectory_CreatesSharedWatcherForFileDirectory()
+    {
+        var watchedDirectory = _tempRoot.CreateDirectory();
+        var otherDirectory = _tempRoot.CreateDirectory();
+        var tempFile = otherDirectory.CreateFile("test.cs");
+        var watcher = new SimpleFileChangeWatcher();
+
+        using var context = watcher.CreateContext([new WatchedDirectory(watchedDirectory.Path, extensionFilters: [])]);
+        Assert.Equal(1, SimpleFileChangeWatcher.TestAccessor.GetSharedDirectoryWatcherCount(watcher));
+
+        using var watchedFile = context.EnqueueWatchingFile(tempFile.Path);
+
+        // Should create a shared watcher for the file's parent directory
+        Assert.Equal(2, SimpleFileChangeWatcher.TestAccessor.GetSharedDirectoryWatcherCount(watcher));
+    }
+
+    [Fact]
+    public void EnqueueWatchingFile_MultipleFilesInSameDirectory_SharesWatcher()
+    {
+        var watchedDirectory = _tempRoot.CreateDirectory();
+        var otherDirectory = _tempRoot.CreateDirectory();
+        var tempFile1 = otherDirectory.CreateFile("test1.cs");
+        var tempFile2 = otherDirectory.CreateFile("test2.cs");
+        var watcher = new SimpleFileChangeWatcher();
+
+        using var context = watcher.CreateContext([new WatchedDirectory(watchedDirectory.Path, extensionFilters: [])]);
+        Assert.Equal(1, SimpleFileChangeWatcher.TestAccessor.GetSharedDirectoryWatcherCount(watcher));
+
+        using var watchedFile1 = context.EnqueueWatchingFile(tempFile1.Path);
+        using var watchedFile2 = context.EnqueueWatchingFile(tempFile2.Path);
+
+        // Both individual files should share the same directory watcher
+        Assert.Equal(2, SimpleFileChangeWatcher.TestAccessor.GetSharedDirectoryWatcherCount(watcher));
+    }
+
+    [Fact]
+    public void FileChangeContext_GetSharedWatcherCount_ReturnsCorrectCount()
+    {
+        var tempDirectory1 = _tempRoot.CreateDirectory();
+        var tempDirectory2 = _tempRoot.CreateDirectory();
+        var watcher = new SimpleFileChangeWatcher();
+
+        using var context = watcher.CreateContext([
+            new WatchedDirectory(tempDirectory1.Path, extensionFilters: []),
+            new WatchedDirectory(tempDirectory2.Path, extensionFilters: [])
+        ]);
+
+        Assert.Equal(2, SimpleFileChangeWatcher.FileChangeContext.TestAccessor.GetSharedWatcherCount((SimpleFileChangeWatcher.FileChangeContext)context));
+    }
+}

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/SimpleFileChangeWatcher.FileChangeContext.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/SimpleFileChangeWatcher.FileChangeContext.cs
@@ -1,0 +1,118 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.ProjectSystem;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.FileWatching;
+
+/// <summary>
+/// A trivial implementation of <see cref="IFileChangeWatcher" /> that is built atop the framework <see cref="FileSystemWatcher" />. This is used if we can't
+/// use the LSP one.
+/// </summary>
+/// <remarks>
+/// This implementation is not remotely efficient, but is available as a fallback implementation. If this needs to regularly be used, then this should get some improvements.
+/// </remarks>
+internal sealed partial class SimpleFileChangeWatcher
+{
+    internal sealed class FileChangeContext : IFileChangeContext
+    {
+        private readonly SimpleFileChangeWatcher _owner;
+        private readonly ImmutableArray<WatchedDirectory> _watchedDirectories;
+        private readonly ConcurrentDictionary<string, SharedDirectoryWatcher> _sharedWatchers = new(s_stringComparer);
+
+        /// <summary>
+        /// The set of individual file paths being watched (outside of directory watches).
+        /// Maps file path to number of watchers for that file.
+        /// </summary>
+        private readonly ConcurrentDictionary<string, int> _individualWatchedFiles = new(s_stringComparer);
+
+        public FileChangeContext(ImmutableArray<WatchedDirectory> watchedDirectories, SimpleFileChangeWatcher owner)
+        {
+            _owner = owner;
+
+            var watchedDirectoriesBuilder = ImmutableArray.CreateBuilder<WatchedDirectory>(watchedDirectories.Length);
+
+            foreach (var watchedDirectory in watchedDirectories)
+            {
+                if (AcquireSharedWatcher(watchedDirectory.Path))
+                    watchedDirectoriesBuilder.Add(watchedDirectory);
+            }
+
+            _watchedDirectories = watchedDirectoriesBuilder.ToImmutable();
+        }
+
+        public event EventHandler<string>? FileChanged;
+
+        private bool AcquireSharedWatcher(string? directoryPath)
+        {
+            if (directoryPath == null || !Directory.Exists(directoryPath))
+                return false;
+
+            if (_sharedWatchers.ContainsKey(directoryPath))
+                return true;
+
+            var sharedWatcher = _owner.GetOrCreateSharedWatcher(directoryPath);
+            sharedWatcher.FileChanged += RaiseEvent;
+            _sharedWatchers.TryAdd(directoryPath, sharedWatcher);
+            return true;
+        }
+
+        private void RaiseEvent(object? sender, FileSystemEventArgs e)
+        {
+            if (!_watchedDirectories.IsEmpty &&
+                WatchedDirectory.FilePathCoveredByWatchedDirectories(_watchedDirectories, e.FullPath, StringComparison.Ordinal))
+            {
+                FileChanged?.Invoke(this, e.FullPath);
+            }
+            else if (_individualWatchedFiles.ContainsKey(e.FullPath))
+            {
+                FileChanged?.Invoke(this, e.FullPath);
+            }
+        }
+
+        public IWatchedFile EnqueueWatchingFile(string filePath)
+        {
+            // If this path is already covered by one of our directory watchers, nothing further to do
+            if (WatchedDirectory.FilePathCoveredByWatchedDirectories(_watchedDirectories, filePath, s_stringComparison))
+                return NoOpWatchedFile.Instance;
+
+            // Individual files are ref counted so we know when to stop watching them
+            _individualWatchedFiles.AddOrUpdate(filePath, 1, (_, count) => count + 1);
+
+            AcquireSharedWatcher(Path.GetDirectoryName(filePath));
+
+            return new IndividualWatchedFile(filePath, this);
+        }
+
+        private void StopWatchingFile(string filePath)
+        {
+            if (_individualWatchedFiles.AddOrUpdate(filePath, 0, (_, count) => count - 1) == 0)
+                _individualWatchedFiles.TryRemove(filePath, out _);
+        }
+
+        public void Dispose()
+        {
+            foreach (var (_, sharedWatcher) in _sharedWatchers)
+            {
+                sharedWatcher.FileChanged -= RaiseEvent;
+                _owner.ReleaseSharedWatcher(sharedWatcher);
+            }
+
+            _sharedWatchers.Clear();
+        }
+
+        private sealed class IndividualWatchedFile(string filePath, FileChangeContext context) : IWatchedFile
+        {
+            public void Dispose() => context.StopWatchingFile(filePath);
+        }
+
+        internal static class TestAccessor
+        {
+            public static int GetSharedWatcherCount(FileChangeContext context)
+                => context._sharedWatchers.Count;
+        }
+    }
+}

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/SimpleFileChangeWatcher.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/SimpleFileChangeWatcher.cs
@@ -2,135 +2,123 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
+using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.ProjectSystem;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.FileWatching;
 
 /// <summary>
-/// A trivial implementation of <see cref="IFileChangeWatcher" /> that is built atop the framework <see cref="FileSystemWatcher" />. This is used if we can't
+/// An implementation of <see cref="IFileChangeWatcher" /> that is built atop the framework <see cref="FileSystemWatcher" />. This is used if we can't
 /// use the LSP one.
 /// </summary>
 /// <remarks>
 /// This implementation is not remotely efficient, but is available as a fallback implementation. If this needs to regularly be used, then this should get some improvements.
 /// </remarks>
-internal sealed class SimpleFileChangeWatcher : IFileChangeWatcher
+internal sealed partial class SimpleFileChangeWatcher : IFileChangeWatcher
 {
+    private static readonly StringComparison s_stringComparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
+
+    private static readonly StringComparer s_stringComparer = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+        ? StringComparer.OrdinalIgnoreCase
+        : StringComparer.Ordinal;
+
+    /// <summary>
+    /// A dictionary mapping directory paths to shared watchers. This allows multiple <see cref="FileChangeContext"/>
+    /// instances watching the same directory to share a single <see cref="FileSystemWatcher"/>.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, SharedDirectoryWatcher> _sharedDirectoryWatchers = new();
+
     public IFileChangeContext CreateContext(ImmutableArray<WatchedDirectory> watchedDirectories)
-        => new FileChangeContext(watchedDirectories);
+        => new FileChangeContext(watchedDirectories, this);
 
-    private sealed class FileChangeContext : IFileChangeContext
+    /// <summary>
+    /// Gets or creates a shared watcher for the given directory path.
+    /// </summary>
+    private SharedDirectoryWatcher GetOrCreateSharedWatcher(string directoryPath)
     {
-        private readonly ImmutableArray<WatchedDirectory> _watchedDirectories;
-
-        /// <summary>
-        /// The directory watchers for the <see cref="_watchedDirectories"/>.
-        /// </summary>
-        private readonly ImmutableArray<FileSystemWatcher> _directoryFileSystemWatchers;
-        private readonly ConcurrentSet<IndividualWatchedFile> _individualWatchedFiles = [];
-
-        public FileChangeContext(ImmutableArray<WatchedDirectory> watchedDirectories)
-        {
-            var watchedDirectoriesBuilder = ImmutableArray.CreateBuilder<WatchedDirectory>(watchedDirectories.Length);
-            var watcherBuilder = ImmutableArray.CreateBuilder<FileSystemWatcher>(watchedDirectories.Length);
-
-            foreach (var watchedDirectory in watchedDirectories)
+        return _sharedDirectoryWatchers.AddOrUpdate(
+            directoryPath,
+            new SharedDirectoryWatcher(directoryPath),
+            (key, existingWatcher) =>
             {
-                // If the directory doesn't exist, we can't create a watcher for changes inside of it. In this case, we'll just skip this as a directory
-                // to watch; any requests for a watch within that directory will still create a one-off watcher for that specific file. That's not likely
-                // to be an issue in practice: directories that are missing would be things like global reference directories -- if it's not there, we
-                // probably won't ever see a watch for a file under there later anyways.
-                if (Directory.Exists(watchedDirectory.Path))
-                {
-                    var watcher = new FileSystemWatcher(watchedDirectory.Path);
-                    watcher.IncludeSubdirectories = true;
+                existingWatcher.AddRef();
+                return existingWatcher;
+            });
+    }
 
-                    foreach (var filter in watchedDirectory.ExtensionFilters)
-                        watcher.Filters.Add('*' + filter);
+    /// <summary>
+    /// Releases a reference to a shared watcher. When the reference count reaches zero, the watcher is disposed
+    /// and removed from the shared dictionary.
+    /// </summary>
+    private void ReleaseSharedWatcher(SharedDirectoryWatcher watcher)
+    {
+        if (watcher.Release())
+        {
+            _sharedDirectoryWatchers.TryRemove(watcher.DirectoryPath, out _);
+        }
+    }
 
-                    watcher.Changed += RaiseEvent;
-                    watcher.Created += RaiseEvent;
-                    watcher.Deleted += RaiseEvent;
-                    watcher.Renamed += RaiseEvent;
+    /// <summary>
+    /// A shared <see cref="FileSystemWatcher"/> that can be used by multiple <see cref="FileChangeContext"/> instances.
+    /// Uses reference counting to track how many contexts are using it. Does not use extension filters so it can be
+    /// shared across contexts with different filters.
+    /// </summary>
+    private sealed class SharedDirectoryWatcher
+    {
+        private readonly FileSystemWatcher _watcher;
+        private int _refCount = 1;
 
-                    watcher.EnableRaisingEvents = true;
+        public string DirectoryPath { get; }
 
-                    watchedDirectoriesBuilder.Add(watchedDirectory);
-                    watcherBuilder.Add(watcher);
-                }
-            }
+        public event EventHandler<FileSystemEventArgs>? FileChanged;
 
-            _watchedDirectories = watchedDirectoriesBuilder.ToImmutable();
-            _directoryFileSystemWatchers = watcherBuilder.ToImmutable();
+        public SharedDirectoryWatcher(string directoryPath)
+        {
+            DirectoryPath = directoryPath;
+
+            _watcher = new(directoryPath)
+            {
+                IncludeSubdirectories = true
+            };
+
+            _watcher.Changed += RaiseEvent;
+            _watcher.Created += RaiseEvent;
+            _watcher.Deleted += RaiseEvent;
+            _watcher.Renamed += RaiseEvent;
+
+            _watcher.EnableRaisingEvents = true;
         }
 
-        public event EventHandler<string>? FileChanged;
+        public void AddRef() => Interlocked.Increment(ref _refCount);
 
-        public IWatchedFile EnqueueWatchingFile(string filePath)
+        /// <summary>
+        /// Releases a reference.
+        /// </summary>
+        /// <returns>Returns true if the watcher should be removed from the shared dictionary (refcount reached zero).</returns>
+        public bool Release()
         {
-            // If this path is already covered by one of our directory watchers, nothing further to do
-            if (WatchedDirectory.FilePathCoveredByWatchedDirectories(_watchedDirectories, filePath, StringComparison.Ordinal))
-                return NoOpWatchedFile.Instance;
+            if (Interlocked.Decrement(ref _refCount) == 0)
+            {
+                _watcher.Dispose();
+                return true;
+            }
 
-            var individualWatchedFile = new IndividualWatchedFile(filePath, this);
-            _individualWatchedFiles.Add(individualWatchedFile);
-            return individualWatchedFile;
+            return false;
         }
 
         private void RaiseEvent(object sender, FileSystemEventArgs e)
         {
-            FileChanged?.Invoke(this, e.FullPath);
+            FileChanged?.Invoke(this, e);
         }
+    }
 
-        public void Dispose()
-        {
-            foreach (var directoryWatcher in _directoryFileSystemWatchers)
-                directoryWatcher.Dispose();
-        }
-
-        private sealed class IndividualWatchedFile : IWatchedFile
-        {
-            private readonly FileChangeContext _context;
-            private readonly FileSystemWatcher? _watcher;
-
-            public IndividualWatchedFile(string filePath, FileChangeContext context)
-            {
-                _context = context;
-
-                // We always must create a watch on an entire directory, so create that, filtered to the single file name
-                var directoryPath = Path.GetDirectoryName(filePath);
-
-                // TODO: support missing directories properly
-                if (Directory.Exists(directoryPath))
-                {
-                    _watcher = new FileSystemWatcher(directoryPath, Path.GetFileName(filePath));
-                    _watcher.IncludeSubdirectories = false;
-
-                    _watcher.Changed += _context.RaiseEvent;
-                    _watcher.Created += _context.RaiseEvent;
-                    _watcher.Deleted += _context.RaiseEvent;
-                    _watcher.Renamed += _context.RaiseEvent;
-
-                    _watcher.EnableRaisingEvents = true;
-                }
-                else
-                {
-                    _watcher = null;
-                }
-            }
-
-            public void Dispose()
-            {
-                if (_context._individualWatchedFiles.Remove(this) && _watcher != null)
-                {
-                    _watcher.Changed -= _context.RaiseEvent;
-                    _watcher.Created -= _context.RaiseEvent;
-                    _watcher.Deleted -= _context.RaiseEvent;
-                    _watcher.Renamed -= _context.RaiseEvent;
-                    _watcher.Dispose();
-                }
-            }
-        }
+    internal static class TestAccessor
+    {
+        public static int GetSharedDirectoryWatcherCount(SimpleFileChangeWatcher watcher)
+            => watcher._sharedDirectoryWatchers.Count;
     }
 }


### PR DESCRIPTION
With this change we only watch directories and we do not apply filters to the FileSystemWatchers. This means individual file watchers become directory watchers for their parent directory. Extension and file filtering are performed prior to raising the FileChanged event.