### PR TITLE
Detect changes in non-Roslyn projects and report them as rude edits

### DIFF
--- a/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
+++ b/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
@@ -223,7 +223,7 @@ internal sealed class CommittedSolution(DebuggingSession debuggingSession, Solut
             return (null, DocumentState.DesignTimeOnly);
         }
 
-        if (!document.DocumentState.SupportsEditAndContinue())
+        if (document.DocumentState.IgnoreForEditAndContinue())
         {
             return (null, DocumentState.DesignTimeOnly);
         }

--- a/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
@@ -274,7 +274,8 @@ internal sealed class DebuggingSession : IDisposable
     /// </returns>
     internal Task<(Guid Mvid, Diagnostic? Error)> GetProjectModuleIdAsync(Project project, CancellationToken cancellationToken)
     {
-        Debug.Assert(project.SupportsEditAndContinue());
+        Debug.Assert(!project.IgnoreForEditAndContinue());
+
         // Note: Does not cache the result as the project may be rebuilt at any point in time.
         return Task.Run(ReadMvid, cancellationToken);
 

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticDescriptors.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticDescriptors.cs
@@ -165,8 +165,8 @@ internal static class EditAndContinueDiagnosticDescriptors
         AddRudeEdit(RudeEditKind.ChangingConstraints, nameof(FeaturesResources.Changing_constraints_of_0_requires_restarting_the_application));
         AddRudeEdit(RudeEditKind.ChangeImplicitMainReturnType, nameof(FeaturesResources.An_update_that_causes_the_return_type_of_implicit_main_to_change_requires_restarting_the_application));
         AddRudeEdit(RudeEditKind.RenamingNotSupportedByRuntime, nameof(FeaturesResources.Renaming_0_requires_restarting_the_application_because_it_is_not_supported_by_the_runtime));
-        AddRudeEdit(RudeEditKind.ChangingNonCustomAttribute, nameof(FeaturesResources.Changing_pseudo_custom_attribute_0_of_1_requires_restarting_th_application));
-        AddRudeEdit(RudeEditKind.ChangingNamespace, nameof(FeaturesResources.Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_th_application));
+        AddRudeEdit(RudeEditKind.ChangingNonCustomAttribute, nameof(FeaturesResources.Changing_pseudo_custom_attribute_0_of_1_requires_restarting_the_application));
+        AddRudeEdit(RudeEditKind.ChangingNamespace, nameof(FeaturesResources.Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_the_application));
         AddRudeEdit(RudeEditKind.ChangingSignatureNotSupportedByRuntime, nameof(FeaturesResources.Changing_the_signature_of_0_requires_restarting_the_application_because_it_is_not_supported_by_the_runtime));
         AddRudeEdit(RudeEditKind.DeleteNotSupportedByRuntime, nameof(FeaturesResources.Deleting_0_requires_restarting_the_application_because_is_not_supported_by_the_runtime));
         AddRudeEdit(RudeEditKind.UpdatingStateMachineMethodNotSupportedByRuntime, nameof(FeaturesResources.Updating_async_or_iterator_requires_restarting_the_application_because_is_not_supported_by_the_runtime));
@@ -198,6 +198,7 @@ internal static class EditAndContinueDiagnosticDescriptors
         AddGeneralDiagnostic(EditAndContinueErrorCode.UnableToReadSourceFileOrPdb, nameof(FeaturesResources.UnableToReadSourceFileOrPdb));
         AddGeneralDiagnostic(EditAndContinueErrorCode.AddingTypeRuntimeCapabilityRequired, nameof(FeaturesResources.ChangesRequiredSynthesizedType));
         AddGeneralDiagnostic(EditAndContinueErrorCode.UpdatingDocumentInStaleProject, nameof(FeaturesResources.Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2), DiagnosticSeverity.Warning, noEffect: true);
+        AddGeneralDiagnostic(EditAndContinueErrorCode.UpdatingUnsupportedProject, nameof(FeaturesResources.Changing_source_file_0_in_a_project_1_that_does_not_support_hot_reload_requires_restarting_the_application_2));
 
         // Project setting rude edits. Defines a distinct error code per setting to simplify telemetry tracking even though some errors share the same message.
 

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueErrorCode.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueErrorCode.cs
@@ -14,6 +14,7 @@ internal enum EditAndContinueErrorCode
     UnableToReadSourceFileOrPdb = 6,
     AddingTypeRuntimeCapabilityRequired = 7,
     UpdatingDocumentInStaleProject = 8,
+    UpdatingUnsupportedProject = 9,
 
     ChangingMultiVersionReferences = 98,
     ChangingReference = 99,

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueService.cs
@@ -135,9 +135,9 @@ internal sealed class EditAndContinueService : IEditAndContinueService
     {
         var documentTasks =
             from project in solution.Projects
-            where project.SupportsEditAndContinue()
+            where !project.IgnoreForEditAndContinue()
             from documentState in GetDocumentStates(project.State)
-            where documentState.SupportsEditAndContinue()
+            where !documentState.IgnoreForEditAndContinue()
             select documentState.GetTextAsync(cancellationToken).AsTask();
 
         _ = await Task.WhenAll(documentTasks).ConfigureAwait(false);

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -2682,10 +2682,10 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
   <data name="Move_static_members_to_another_type" xml:space="preserve">
     <value>Move static members to another type...</value>
   </data>
-  <data name="Changing_pseudo_custom_attribute_0_of_1_requires_restarting_th_application" xml:space="preserve">
+  <data name="Changing_pseudo_custom_attribute_0_of_1_requires_restarting_the_application" xml:space="preserve">
     <value>Changing pseudo-custom attribute '{0}' of {1} requires restarting the application</value>
   </data>
-  <data name="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_th_application" xml:space="preserve">
+  <data name="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_the_application" xml:space="preserve">
     <value>Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</value>
   </data>
   <data name="ChangesRequiredSynthesizedType" xml:space="preserve">
@@ -2693,6 +2693,12 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
   </data>
   <data name="Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2" xml:space="preserve">
     <value>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuit; {2}</value>
+  </data>
+  <data name="Changing_source_file_0_in_a_project_1_that_does_not_support_hot_reload_requires_restarting_the_application_2" xml:space="preserve">
+    <value>Changing source file '{0}' in a project '{1}' that does not support Hot Reload requires restarting the application; {2}</value>
+  </data>
+  <data name="_0_does_not_support_Hot_Reload" xml:space="preserve">
+    <value>{0} does not support Hot Reload.</value>
   </data>
   <data name="the_content_of_the_document_is_stale" xml:space="preserve">
     <value>the content of the document is stale.</value>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -460,9 +460,14 @@ Ujistěte se, že specifikátor tt použijete pro jazyky, pro které je nezbytn�
         <target state="translated">Změna nastavení projektu {0} z {1} na {2} vyžaduje restartování aplikace.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_pseudo_custom_attribute_0_of_1_requires_restarting_th_application">
+      <trans-unit id="Changing_pseudo_custom_attribute_0_of_1_requires_restarting_the_application">
         <source>Changing pseudo-custom attribute '{0}' of {1} requires restarting the application</source>
-        <target state="translated">Změna pseudovlastního atributu {0} u {1} vyžaduje restartování aplikace.</target>
+        <target state="new">Changing pseudo-custom attribute '{0}' of {1} requires restarting the application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_source_file_0_in_a_project_1_that_does_not_support_hot_reload_requires_restarting_the_application_2">
+        <source>Changing source file '{0}' in a project '{1}' that does not support Hot Reload requires restarting the application; {2}</source>
+        <target state="new">Changing source file '{0}' in a project '{1}' that does not support Hot Reload requires restarting the application; {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2">
@@ -470,9 +475,9 @@ Ujistěte se, že specifikátor tt použijete pro jazyky, pro které je nezbytn�
         <target state="translated">Změna zdrojového souboru {0} v zastaralém projektu {1} nemá žádný vliv, dokud projekt nebude znovu sestaven; {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_th_application">
+      <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_the_application">
         <source>Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</source>
-        <target state="translated">Změna nadřazeného oboru názvů {0} z {1} na {2} vyžaduje restartování aplikace.</target>
+        <target state="new">Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_the_declaration_scope_of_a_captured_variable_0_requires_restarting_the_application">
@@ -3168,6 +3173,11 @@ Pozitivní kontrolní výrazy zpětného vyhledávání s nulovou délkou se obv
       <trans-unit id="_0_dash_1">
         <source>{0} - {1}</source>
         <target state="translated">{0} - {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_does_not_support_Hot_Reload">
+        <source>{0} does not support Hot Reload.</source>
+        <target state="new">{0} does not support Hot Reload.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_expected">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -460,9 +460,14 @@ Stellen Sie sicher, dass Sie den Bezeichner "tt" für Sprachen verwenden, für d
         <target state="translated">Zum Ändern der Projekteinstellung „{0}“ von „{1}“ in „{2}“ muss die Anwendung neu gestartet werden.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_pseudo_custom_attribute_0_of_1_requires_restarting_th_application">
+      <trans-unit id="Changing_pseudo_custom_attribute_0_of_1_requires_restarting_the_application">
         <source>Changing pseudo-custom attribute '{0}' of {1} requires restarting the application</source>
-        <target state="translated">Das Ändern des pseudobenutzerdefinierten Attributs „{0}“ von {1} erfordert einen Neustart der Anwendung.</target>
+        <target state="new">Changing pseudo-custom attribute '{0}' of {1} requires restarting the application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_source_file_0_in_a_project_1_that_does_not_support_hot_reload_requires_restarting_the_application_2">
+        <source>Changing source file '{0}' in a project '{1}' that does not support Hot Reload requires restarting the application; {2}</source>
+        <target state="new">Changing source file '{0}' in a project '{1}' that does not support Hot Reload requires restarting the application; {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2">
@@ -470,9 +475,9 @@ Stellen Sie sicher, dass Sie den Bezeichner "tt" für Sprachen verwenden, für d
         <target state="translated">Das Ändern der Quelldatei „{0}“ in einem veralteten Projekt „{1}“ hat keine Wirkung, bis das Projekt neu erstellt wird; {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_th_application">
+      <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_the_application">
         <source>Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</source>
-        <target state="translated">Um den enthaltenden Namespace von "{0}" von "{1}" in "{2}" zu ändern, muss die Anwendung neu gestartet werden</target>
+        <target state="new">Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_the_declaration_scope_of_a_captured_variable_0_requires_restarting_the_application">
@@ -3168,6 +3173,11 @@ Positive Lookbehindassertionen mit Nullbreite werden normalerweise am Anfang reg
       <trans-unit id="_0_dash_1">
         <source>{0} - {1}</source>
         <target state="translated">{0} - {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_does_not_support_Hot_Reload">
+        <source>{0} does not support Hot Reload.</source>
+        <target state="new">{0} does not support Hot Reload.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_expected">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -460,9 +460,14 @@ Asegúrese de usar el especificador "tt" para los idiomas para los que es necesa
         <target state="translated">Cambiar el valor del proyecto “{0}” de “{1}” a “{2}” requiere reiniciar la aplicación.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_pseudo_custom_attribute_0_of_1_requires_restarting_th_application">
+      <trans-unit id="Changing_pseudo_custom_attribute_0_of_1_requires_restarting_the_application">
         <source>Changing pseudo-custom attribute '{0}' of {1} requires restarting the application</source>
-        <target state="translated">Para cambiar el atributo pseudo-personalizado "{0}" de {1} se requiere reiniciar la aplicación</target>
+        <target state="new">Changing pseudo-custom attribute '{0}' of {1} requires restarting the application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_source_file_0_in_a_project_1_that_does_not_support_hot_reload_requires_restarting_the_application_2">
+        <source>Changing source file '{0}' in a project '{1}' that does not support Hot Reload requires restarting the application; {2}</source>
+        <target state="new">Changing source file '{0}' in a project '{1}' that does not support Hot Reload requires restarting the application; {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2">
@@ -470,9 +475,9 @@ Asegúrese de usar el especificador "tt" para los idiomas para los que es necesa
         <target state="translated">Cambiar el archivo de origen “{0}” en un proyecto obsoleto {1} no tiene efecto hasta que se reconstruya el proyecto; {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_th_application">
+      <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_the_application">
         <source>Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</source>
-        <target state="translated">Para cambiar el espacio de nombres contenedor de '{0}' de '{1}' a '{2}' es necesario reiniciar la aplicación</target>
+        <target state="new">Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_the_declaration_scope_of_a_captured_variable_0_requires_restarting_the_application">
@@ -3168,6 +3173,11 @@ Las aserciones de búsqueda retrasada (lookbehind) positivas de ancho cero se us
       <trans-unit id="_0_dash_1">
         <source>{0} - {1}</source>
         <target state="translated">{0} - {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_does_not_support_Hot_Reload">
+        <source>{0} does not support Hot Reload.</source>
+        <target state="new">{0} does not support Hot Reload.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_expected">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -460,9 +460,14 @@ Veillez à utiliser le spécificateur "tt" pour les langues où il est nécessai
         <target state="translated">Le remplacement du paramètre de projet « {0} » de « {1} » par « {2} » nécessite le redémarrage de l’application.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_pseudo_custom_attribute_0_of_1_requires_restarting_th_application">
+      <trans-unit id="Changing_pseudo_custom_attribute_0_of_1_requires_restarting_the_application">
         <source>Changing pseudo-custom attribute '{0}' of {1} requires restarting the application</source>
-        <target state="translated">La modification de l’attribut pseudo-personnalisé « {0} » de {1} requiert le redémarrage de l’application</target>
+        <target state="new">Changing pseudo-custom attribute '{0}' of {1} requires restarting the application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_source_file_0_in_a_project_1_that_does_not_support_hot_reload_requires_restarting_the_application_2">
+        <source>Changing source file '{0}' in a project '{1}' that does not support Hot Reload requires restarting the application; {2}</source>
+        <target state="new">Changing source file '{0}' in a project '{1}' that does not support Hot Reload requires restarting the application; {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2">
@@ -470,9 +475,9 @@ Veillez à utiliser le spécificateur "tt" pour les langues où il est nécessai
         <target state="translated">La modification du fichier source « {0} » dans un projet obsolète « {1} » n’a aucun effet tant que le projet n’est pas reconstruit, {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_th_application">
+      <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_the_application">
         <source>Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</source>
-        <target state="translated">La modification de l’espace de noms conteneur de '{0}' de '{1}' en '{2}' nécessite le redémarrage de l’application</target>
+        <target state="new">Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_the_declaration_scope_of_a_captured_variable_0_requires_restarting_the_application">
@@ -3168,6 +3173,11 @@ Les assertions arrière positives de largeur nulle sont généralement utilisée
       <trans-unit id="_0_dash_1">
         <source>{0} - {1}</source>
         <target state="translated">{0} - {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_does_not_support_Hot_Reload">
+        <source>{0} does not support Hot Reload.</source>
+        <target state="new">{0} does not support Hot Reload.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_expected">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -460,9 +460,14 @@ Assicurarsi di usare l'identificatore "tt" per le lingue per le quali è necessa
         <target state="translated">La modifica dell'impostazione del progetto '{0}' da '{1}' a '{2}' richiede il riavvio dell'applicazione.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_pseudo_custom_attribute_0_of_1_requires_restarting_th_application">
+      <trans-unit id="Changing_pseudo_custom_attribute_0_of_1_requires_restarting_the_application">
         <source>Changing pseudo-custom attribute '{0}' of {1} requires restarting the application</source>
-        <target state="translated">Se si modifica l'attributo pseudo-personalizzato '{0}' di {1}, è necessario riavviare l'applicazione</target>
+        <target state="new">Changing pseudo-custom attribute '{0}' of {1} requires restarting the application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_source_file_0_in_a_project_1_that_does_not_support_hot_reload_requires_restarting_the_application_2">
+        <source>Changing source file '{0}' in a project '{1}' that does not support Hot Reload requires restarting the application; {2}</source>
+        <target state="new">Changing source file '{0}' in a project '{1}' that does not support Hot Reload requires restarting the application; {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2">
@@ -470,9 +475,9 @@ Assicurarsi di usare l'identificatore "tt" per le lingue per le quali è necessa
         <target state="translated">La modifica del file di origine '{0}' in un progetto non aggiornato '{1}' non ha alcun effetto finché il progetto non viene ricompilato; {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_th_application">
+      <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_the_application">
         <source>Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</source>
-        <target state="translated">Per modificare lo spazio dei nomi contenitore di '{0}' da '{1}' a '{2}' è necessario riavviare l'applicazione</target>
+        <target state="new">Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_the_declaration_scope_of_a_captured_variable_0_requires_restarting_the_application">
@@ -3168,6 +3173,11 @@ Le asserzioni lookbehind positive di larghezza zero vengono usate in genere all'
       <trans-unit id="_0_dash_1">
         <source>{0} - {1}</source>
         <target state="translated">{0} - {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_does_not_support_Hot_Reload">
+        <source>{0} does not support Hot Reload.</source>
+        <target state="new">{0} does not support Hot Reload.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_expected">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -460,9 +460,14 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">プロジェクト設定 '{0}' を '{1}' から '{2}' に変更するには、アプリケーションを再起動する必要があります。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_pseudo_custom_attribute_0_of_1_requires_restarting_th_application">
+      <trans-unit id="Changing_pseudo_custom_attribute_0_of_1_requires_restarting_the_application">
         <source>Changing pseudo-custom attribute '{0}' of {1} requires restarting the application</source>
-        <target state="translated">{0} の擬似カスタム属性 '{1}' を変更するには、アプリケーションを再起動する必要があります</target>
+        <target state="new">Changing pseudo-custom attribute '{0}' of {1} requires restarting the application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_source_file_0_in_a_project_1_that_does_not_support_hot_reload_requires_restarting_the_application_2">
+        <source>Changing source file '{0}' in a project '{1}' that does not support Hot Reload requires restarting the application; {2}</source>
+        <target state="new">Changing source file '{0}' in a project '{1}' that does not support Hot Reload requires restarting the application; {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2">
@@ -470,9 +475,9 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">古いプロジェクト '{1}' でソース ファイル '{0}' を変更しても、プロジェクトが再構築されるまで影響がありません。{2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_th_application">
+      <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_the_application">
         <source>Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</source>
-        <target state="translated">'{0}' の包含名前空間を '{1}' から '{2}' に変更するには、アプリケーションを再起動する必要があります</target>
+        <target state="new">Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_the_declaration_scope_of_a_captured_variable_0_requires_restarting_the_application">
@@ -3168,6 +3173,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="_0_dash_1">
         <source>{0} - {1}</source>
         <target state="translated">{0} - {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_does_not_support_Hot_Reload">
+        <source>{0} does not support Hot Reload.</source>
+        <target state="new">{0} does not support Hot Reload.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_expected">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -460,9 +460,14 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">프로젝트 설정 '{0}'을(를) '{1}'에서 '{2}'(으)로 변경하면 애플리케이션을 다시 시작해야 합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_pseudo_custom_attribute_0_of_1_requires_restarting_th_application">
+      <trans-unit id="Changing_pseudo_custom_attribute_0_of_1_requires_restarting_the_application">
         <source>Changing pseudo-custom attribute '{0}' of {1} requires restarting the application</source>
-        <target state="translated">{1}의 허위 사용자 지정 특성 '{0}'을(를) 변경하려면 애플리케이션을 다시 시작해야 합니다.</target>
+        <target state="new">Changing pseudo-custom attribute '{0}' of {1} requires restarting the application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_source_file_0_in_a_project_1_that_does_not_support_hot_reload_requires_restarting_the_application_2">
+        <source>Changing source file '{0}' in a project '{1}' that does not support Hot Reload requires restarting the application; {2}</source>
+        <target state="new">Changing source file '{0}' in a project '{1}' that does not support Hot Reload requires restarting the application; {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2">
@@ -470,9 +475,9 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">오래된 프로젝트 '{1}'에서 소스 파일 '{0}'을(를) 변경해도 프로젝트를 다시 빌드하기 전까지는 적용되지 않습니다. {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_th_application">
+      <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_the_application">
         <source>Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</source>
-        <target state="translated">'{0}'의 포함 네임스페이스를 '{1}'에서 '{2}'(으)로 변경하려면 애플리케이션을 다시 시작해야 합니다.</target>
+        <target state="new">Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_the_declaration_scope_of_a_captured_variable_0_requires_restarting_the_application">
@@ -3168,6 +3173,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="_0_dash_1">
         <source>{0} - {1}</source>
         <target state="translated">{0} - {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_does_not_support_Hot_Reload">
+        <source>{0} does not support Hot Reload.</source>
+        <target state="new">{0} does not support Hot Reload.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_expected">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -460,9 +460,14 @@ Pamiętaj, aby nie używać specyfikatora „tt” dla wszystkich języków, w k
         <target state="translated">Zmiana ustawienia projektu „{0}” z „{1}” na „{2}” wymaga ponownego uruchomienia aplikacji.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_pseudo_custom_attribute_0_of_1_requires_restarting_th_application">
+      <trans-unit id="Changing_pseudo_custom_attribute_0_of_1_requires_restarting_the_application">
         <source>Changing pseudo-custom attribute '{0}' of {1} requires restarting the application</source>
-        <target state="translated">Zmiana atrybutu pseudoniestandardowego elementu „{0}” z {1} wymaga ponownego uruchomienia aplikacji</target>
+        <target state="new">Changing pseudo-custom attribute '{0}' of {1} requires restarting the application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_source_file_0_in_a_project_1_that_does_not_support_hot_reload_requires_restarting_the_application_2">
+        <source>Changing source file '{0}' in a project '{1}' that does not support Hot Reload requires restarting the application; {2}</source>
+        <target state="new">Changing source file '{0}' in a project '{1}' that does not support Hot Reload requires restarting the application; {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2">
@@ -470,9 +475,9 @@ Pamiętaj, aby nie używać specyfikatora „tt” dla wszystkich języków, w k
         <target state="translated">Zmiana pliku źródłowego „{0}” w nieaktualnym projekcie „{1}” nie ma żadnego efektu, dopóki projekt nie zostanie przebudowany; {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_th_application">
+      <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_the_application">
         <source>Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</source>
-        <target state="translated">Zmiana zawierającej przestrzeni nazw „{0}” z „{1}” na „{2}” wymaga ponownego uruchomienia aplikacji</target>
+        <target state="new">Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_the_declaration_scope_of_a_captured_variable_0_requires_restarting_the_application">
@@ -3168,6 +3173,11 @@ Pozytywne asercje wsteczne o zerowej szerokości są zwykle używane na początk
       <trans-unit id="_0_dash_1">
         <source>{0} - {1}</source>
         <target state="translated">{0} - {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_does_not_support_Hot_Reload">
+        <source>{0} does not support Hot Reload.</source>
+        <target state="new">{0} does not support Hot Reload.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_expected">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -460,9 +460,14 @@ Verifique se o especificador "tt" foi usado para idiomas para os quais é necess
         <target state="translated">Alterar a configuração do projeto "{0}" de "{1}" para "{2}" requer a reinicialização do aplicativo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_pseudo_custom_attribute_0_of_1_requires_restarting_th_application">
+      <trans-unit id="Changing_pseudo_custom_attribute_0_of_1_requires_restarting_the_application">
         <source>Changing pseudo-custom attribute '{0}' of {1} requires restarting the application</source>
-        <target state="translated">Alterar o atributo pseudo-personalizado '{0}' de {1} requer o reinício do aplicativo</target>
+        <target state="new">Changing pseudo-custom attribute '{0}' of {1} requires restarting the application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_source_file_0_in_a_project_1_that_does_not_support_hot_reload_requires_restarting_the_application_2">
+        <source>Changing source file '{0}' in a project '{1}' that does not support Hot Reload requires restarting the application; {2}</source>
+        <target state="new">Changing source file '{0}' in a project '{1}' that does not support Hot Reload requires restarting the application; {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2">
@@ -470,9 +475,9 @@ Verifique se o especificador "tt" foi usado para idiomas para os quais é necess
         <target state="translated">Alterar o arquivo de origem '{0}' em um projeto obsoleto '{1}' não tem efeito até que o projeto seja reconstruído; {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_th_application">
+      <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_the_application">
         <source>Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</source>
-        <target state="translated">Alterar o namespace que o contém '{0}' de '{1}' para '{2}' requer a reinicialização do aplicativo</target>
+        <target state="new">Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_the_declaration_scope_of_a_captured_variable_0_requires_restarting_the_application">
@@ -3168,6 +3173,11 @@ As declarações de lookbehind positivas de largura zero normalmente são usadas
       <trans-unit id="_0_dash_1">
         <source>{0} - {1}</source>
         <target state="translated">{0} - {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_does_not_support_Hot_Reload">
+        <source>{0} does not support Hot Reload.</source>
+        <target state="new">{0} does not support Hot Reload.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_expected">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -460,9 +460,14 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">Чтобы изменить параметр проекта "{0}" с "{1}" на "{2}", необходимо перезапустить приложение.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_pseudo_custom_attribute_0_of_1_requires_restarting_th_application">
+      <trans-unit id="Changing_pseudo_custom_attribute_0_of_1_requires_restarting_the_application">
         <source>Changing pseudo-custom attribute '{0}' of {1} requires restarting the application</source>
-        <target state="translated">Для изменения псевдонастраиваемого атрибута "{0}" для {1} требуется перезапустить приложение.</target>
+        <target state="new">Changing pseudo-custom attribute '{0}' of {1} requires restarting the application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_source_file_0_in_a_project_1_that_does_not_support_hot_reload_requires_restarting_the_application_2">
+        <source>Changing source file '{0}' in a project '{1}' that does not support Hot Reload requires restarting the application; {2}</source>
+        <target state="new">Changing source file '{0}' in a project '{1}' that does not support Hot Reload requires restarting the application; {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2">
@@ -470,9 +475,9 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">Изменение исходного файла "{0}" в устаревшем проекте "{1}" вступит в силу только после повторной сборки проекта. {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_th_application">
+      <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_the_application">
         <source>Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</source>
-        <target state="translated">Чтобы изменить содержащее пространство имен "{0}" с "{1}" на "{2}", необходимо перезапустить приложение</target>
+        <target state="new">Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_the_declaration_scope_of_a_captured_variable_0_requires_restarting_the_application">
@@ -3168,6 +3173,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="_0_dash_1">
         <source>{0} - {1}</source>
         <target state="translated">{0} - {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_does_not_support_Hot_Reload">
+        <source>{0} does not support Hot Reload.</source>
+        <target state="new">{0} does not support Hot Reload.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_expected">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -460,9 +460,14 @@ AM ve PM arasındaki farkın korunmasının gerekli olduğu diller için "tt" be
         <target state="translated">'{1}' olan '{0}' proje ayarını '{2}' olarak değiştirmek için uygulamanın yeniden başlatılması gerekiyor.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_pseudo_custom_attribute_0_of_1_requires_restarting_th_application">
+      <trans-unit id="Changing_pseudo_custom_attribute_0_of_1_requires_restarting_the_application">
         <source>Changing pseudo-custom attribute '{0}' of {1} requires restarting the application</source>
-        <target state="translated">{1} öğesinin '{0}' sahte özel özniteliğinin değiştirilmesi, uygulamanın yeniden başlatılmasını gerektirir</target>
+        <target state="new">Changing pseudo-custom attribute '{0}' of {1} requires restarting the application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_source_file_0_in_a_project_1_that_does_not_support_hot_reload_requires_restarting_the_application_2">
+        <source>Changing source file '{0}' in a project '{1}' that does not support Hot Reload requires restarting the application; {2}</source>
+        <target state="new">Changing source file '{0}' in a project '{1}' that does not support Hot Reload requires restarting the application; {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2">
@@ -470,9 +475,9 @@ AM ve PM arasındaki farkın korunmasının gerekli olduğu diller için "tt" be
         <target state="translated">Eski bir projedeki ('{1}') kaynak dosyayı ,('{0}') değiştirmenin, proje yeniden derlenene kadar hiçbir etkisi olmaz; {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_th_application">
+      <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_the_application">
         <source>Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</source>
-        <target state="translated">'{1}' olan '{0}' kapsayan ad alanının '{2}' olarak değiştirilmesi, uygulamanın yeniden başlatılmasını gerektirir</target>
+        <target state="new">Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_the_declaration_scope_of_a_captured_variable_0_requires_restarting_the_application">
@@ -3168,6 +3173,11 @@ Sıfır genişlikli pozitif geri yönlü onaylamalar genellikle normal ifadeleri
       <trans-unit id="_0_dash_1">
         <source>{0} - {1}</source>
         <target state="translated">{0} - {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_does_not_support_Hot_Reload">
+        <source>{0} does not support Hot Reload.</source>
+        <target state="new">{0} does not support Hot Reload.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_expected">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -460,9 +460,14 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">将项目设置 ‘{0}’ 从 ‘{1}’ 更改为 ‘{2}’ 需要重启应用程序。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_pseudo_custom_attribute_0_of_1_requires_restarting_th_application">
+      <trans-unit id="Changing_pseudo_custom_attribute_0_of_1_requires_restarting_the_application">
         <source>Changing pseudo-custom attribute '{0}' of {1} requires restarting the application</source>
-        <target state="translated">更改 {1} 的伪自定义属性“{0}”需要重启应用程序</target>
+        <target state="new">Changing pseudo-custom attribute '{0}' of {1} requires restarting the application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_source_file_0_in_a_project_1_that_does_not_support_hot_reload_requires_restarting_the_application_2">
+        <source>Changing source file '{0}' in a project '{1}' that does not support Hot Reload requires restarting the application; {2}</source>
+        <target state="new">Changing source file '{0}' in a project '{1}' that does not support Hot Reload requires restarting the application; {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2">
@@ -470,9 +475,9 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">在重新生成项目之前，更改过时项目 "{1}" 中的源文件 "{0}" 将不起作用；{2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_th_application">
+      <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_the_application">
         <source>Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</source>
-        <target state="translated">将 '{0}' 的包含命名空间从 '{1}' 更改为'{2}' 需要重新启动应用程序</target>
+        <target state="new">Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_the_declaration_scope_of_a_captured_variable_0_requires_restarting_the_application">
@@ -3168,6 +3173,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="_0_dash_1">
         <source>{0} - {1}</source>
         <target state="translated">{0} - {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_does_not_support_Hot_Reload">
+        <source>{0} does not support Hot Reload.</source>
+        <target state="new">{0} does not support Hot Reload.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_expected">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -460,9 +460,14 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">將專案設定 '{0}' 從 '{1}' 變更為 '{2}' 需要重新啟動應用程式。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_pseudo_custom_attribute_0_of_1_requires_restarting_th_application">
+      <trans-unit id="Changing_pseudo_custom_attribute_0_of_1_requires_restarting_the_application">
         <source>Changing pseudo-custom attribute '{0}' of {1} requires restarting the application</source>
-        <target state="translated">變更 {1} 的虛擬自訂屬性 '{0}' 需要重新啟動應用程式</target>
+        <target state="new">Changing pseudo-custom attribute '{0}' of {1} requires restarting the application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_source_file_0_in_a_project_1_that_does_not_support_hot_reload_requires_restarting_the_application_2">
+        <source>Changing source file '{0}' in a project '{1}' that does not support Hot Reload requires restarting the application; {2}</source>
+        <target state="new">Changing source file '{0}' in a project '{1}' that does not support Hot Reload requires restarting the application; {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2">
@@ -470,9 +475,9 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">在專案重新建置之前，於過時的專案 '{1}' 中變更來源檔案 '{0}' 不會產生效果; {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_th_application">
+      <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_the_application">
         <source>Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</source>
-        <target state="translated">將包含的命名空間 '{0}' 從 '{1}' 變更為 '{2}' 需要重新啟動應用程式</target>
+        <target state="new">Changing the containing namespace of '{0}' from '{1}' to '{2}' requires restarting the application</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_the_declaration_scope_of_a_captured_variable_0_requires_restarting_the_application">
@@ -3168,6 +3173,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="_0_dash_1">
         <source>{0} - {1}</source>
         <target state="translated">{0} - {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_does_not_support_Hot_Reload">
+        <source>{0} does not support Hot Reload.</source>
+        <target state="new">{0} does not support Hot Reload.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_expected">

--- a/src/Features/ExternalAccess/HotReloadTest/HotReloadServiceTests.cs
+++ b/src/Features/ExternalAccess/HotReloadTest/HotReloadServiceTests.cs
@@ -16,6 +16,7 @@ using Microsoft.CodeAnalysis.ExternalAccess.HotReload.Api;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.UnitTests;
 using Roslyn.Test.Utilities;
 using Roslyn.Test.Utilities.TestGenerators;
 using Xunit;
@@ -293,9 +294,14 @@ public sealed class HotReloadServiceTests : EditAndContinueWorkspaceTestBase
             InspectDiagnostics(result.TransientDiagnostics));
     }
 
-    [Fact]
-    public async Task StaleSource()
+    [Theory]
+    [InlineData(LanguageNames.CSharp)]
+    [InlineData(NoCompilationConstants.LanguageName)]
+    public async Task StaleSource(string language)
     {
+        // When testing non-C# projects we compile the code using C# compiler but pretend it's not a C# assembly.
+        // The actual content of the assembly is irrelevant to the test as long as the PDB has correct document checksums.
+
         var source1 = "class C { void M() { System.Console.WriteLine(1); } }";
         var source2 = "class C { void M() { System.Console.WriteLine(2); } }";
         var source3 = "class C { void M() { System.Console.WriteLine(3); } }";
@@ -305,7 +311,7 @@ public sealed class HotReloadServiceTests : EditAndContinueWorkspaceTestBase
         using var workspace = CreateWorkspace(out var solution, out _);
 
         solution = solution.
-            AddTestProject("P", out var projectId).
+            AddTestProject("P", language: language, out var projectId).
             AddTestDocument(source: null, sourceFileA.Path, out var documentIdA).Project.Solution;
 
         EmitLibrary(projectId, source1, sourceFileA.Path, assemblyName: "Proj");
@@ -386,6 +392,34 @@ public sealed class HotReloadServiceTests : EditAndContinueWorkspaceTestBase
         AssertEx.Equal(
             [$"A: {generatedDoc.FilePath}: (0,26)-(0,42): Error ENC0023: {string.Format(FeaturesResources.Adding_an_abstract_0_or_overriding_an_inherited_0_requires_restarting_the_application, FeaturesResources.method)}"],
             InspectDiagnostics(result.TransientDiagnostics));
+    }
+
+    [Theory]
+    [InlineData(LanguageNames.VisualBasic)]
+    [InlineData(LanguageNames.CSharp)]
+    [InlineData(NoCompilationConstants.LanguageName)]
+    public async Task HydrateDocumentsAsync(string language)
+    {
+        var dir = Temp.CreateDirectory();
+        var sourceFileA = dir.CreateFile("A.nolang");
+
+        using var workspace = CreateWorkspace(out var solution, out _, [typeof(NoCompilationLanguageService)]);
+
+        solution = solution.
+            AddTestProject("P", language, out var projectId).
+            AddTestDocument(source: null, sourceFileA.Path, out var documentIdA).Project.Solution;
+
+        sourceFileA.WriteAllText("source", Encoding.UTF8);
+
+        var hotReload = new HotReloadService(workspace.Services, ["Baseline"]);
+
+        await hotReload.StartSessionAsync(solution, CancellationToken.None);
+
+        // text should be loaded from disk:
+        var document = solution.GetRequiredDocument(documentIdA);
+        document.TryGetText(out var text);
+        Assert.NotNull(text);
+        Assert.Equal("source", text.ToString());
     }
 }
 #endif

--- a/src/Workspaces/CoreTestUtilities/Microsoft.CodeAnalysis.Workspaces.Test.Utilities.csproj
+++ b/src/Workspaces/CoreTestUtilities/Microsoft.CodeAnalysis.Workspaces.Test.Utilities.csproj
@@ -65,6 +65,7 @@
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.LiveShare.UnitTests" />
     <InternalsVisibleTo Include="IdeBenchmarks" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.Razor.UnitTests" />
+    <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.HotReload.UnitTests"/>
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.CodeStyle.LegacyTestFramework.UnitTestUtilities" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Features.DiagnosticsTests.Utilities" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Features.Test.Utilities" />

--- a/src/Workspaces/MSBuild/Test/NetCoreTests.cs
+++ b/src/Workspaces/MSBuild/Test/NetCoreTests.cs
@@ -449,6 +449,10 @@ public sealed class NetCoreTests : MSBuildWorkspaceTestBase
         Assert.Empty(fsharpLib.AllProjectReferences);
         Assert.Contains(fsharpLib.MetadataReferences, r => r is PortableExecutableReference per && Path.GetFileName(per.FilePath) == "FSharp.Core.dll");
 
+        // enables Hot Reload to read PDB:
+        Assert.EndsWith(Path.Combine("obj", "Debug", "netstandard2.0", "fsharplib.dll"), fsharpLib.CompilationOutputInfo.AssemblyPath);
+
+        // enables Hot Reload to validate document checksums:
         var libraryFs = fsharpLib.Documents.Single(d => Path.GetFileName(d.FilePath) == "Library.fs");
         var text = await libraryFs.GetTextAsync();
 


### PR DESCRIPTION
Allows dotnet-watch to auto-restart app if a change is made in project whose compiler that doesn't support Hot Reload (e.g. F#).

This won't work in VS at the moment since we don't synchronize F# projects OOP and the project factory only initializes `CompilationOutputInfo` for Roslyn projects. Tracked by https://github.com/dotnet/roslyn/issues/82226