### PR TITLE
Update the DevDivOptimization package version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -159,7 +159,7 @@ jobs:
     buildJobName: Build_Unix_Debug
     testArtifactName: Transport_Artifacts_Unix_Debug
     configuration: Debug
-    testArguments: --testCoreClr --helixQueueName OSX.13.Amd64.Open
+    testArguments: --testCoreClr --helixQueueName OSX.15.Amd64.Open
     queueName: Build.Ubuntu.2204.Amd64.Open
 
 # Build Correctness Jobs

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -83,7 +83,7 @@
     <MicrosoftCodeAnalysisAnalyzerUtilitiesVersion>3.3.0</MicrosoftCodeAnalysisAnalyzerUtilitiesVersion>
     <MicrosoftCodeAnalysisPerformanceSensitiveAnalyzersVersion>$(RoslynDiagnosticsNugetPackageVersion)</MicrosoftCodeAnalysisPerformanceSensitiveAnalyzersVersion>
     <MicrosoftCSharpVersion>4.3.0</MicrosoftCSharpVersion>
-    <MicrosoftDevDivOptimizationDataPowerShellVersion>1.0.339</MicrosoftDevDivOptimizationDataPowerShellVersion>
+    <MicrosoftDevDivOptimizationDataPowerShellVersion>1.0.865</MicrosoftDevDivOptimizationDataPowerShellVersion>
     <MicrosoftDiagnosticsRuntimeVersion>0.8.31-beta</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>1.0.35</MicrosoftDiagnosticsTracingTraceEventVersion>
     <MicrosoftDiaSymReaderVersion>1.3.0</MicrosoftDiaSymReaderVersion>

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -318,7 +318,7 @@ function GetIbcDropName() {
     }
 
     # Bring in the ibc tools
-    $packagePath = Join-Path (Get-PackageDir "Microsoft.DevDiv.Optimization.Data.PowerShell") "lib\net461"
+    $packagePath = Join-Path (Get-PackageDir "Microsoft.DevDiv.Optimization.Data.PowerShell") "lib\net472"
     Import-Module (Join-Path $packagePath "Optimization.Data.PowerShell.dll")
 
     # Find the matching drop

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/BinaryOperators.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/BinaryOperators.vb
@@ -58,7 +58,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
 
         End Sub
 
-        <Fact>
+        <ConditionalFact(GetType(WindowsOrLinuxOnly), Reason:="https://github.com/dotnet/roslyn/issues/77861")>
         Public Sub Test1_Date()
             ' test binary operator between Date value and another type data
             ' call ToString() on it defeat the purpose of these scenarios
@@ -379,7 +379,7 @@ False
 
         End Sub
 
-        <Fact>
+        <ConditionalFact(GetType(WindowsOrLinuxOnly), Reason:="https://github.com/dotnet/roslyn/issues/77861")>
         Public Sub Test5_DateConst()
             ' test binary operator between Date const and another type data
             ' call ToString() on it defeat the purpose of these scenarios


### PR DESCRIPTION
Backport of https://github.com/dotnet/roslyn/pull/70051

The old package had issues picking up newer optprof drop locations. 

[Test run](https://dev.azure.com/dnceng/internal/internal%20Team/_build/results?buildId=2891685&view=logs&j=20fcf628-b65c-5865-625a-1cef81cda63b&t=57a3a016-8c4d-5bd4-ed27-11d4fc0386e2&l=58) found a optprof drop but for the wrong branch because I didn't update publishdata. This is farther than it has gotten with the old package version.