### PR TITLE
Fix binding of explicit `this` in `nameof`

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <returns>True if a reference to "this" is available.</returns>
         internal bool HasThis(bool isExplicit, out bool inStaticContext)
         {
-            if (!isExplicit && IsInsideNameof && Compilation.IsFeatureEnabled(MessageID.IDS_FeatureInstanceMemberInNameof))
+            if (IsInsideNameof && Compilation.IsFeatureEnabled(MessageID.IDS_FeatureInstanceMemberInNameof))
             {
                 inStaticContext = false;
                 return true;
@@ -2578,8 +2578,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool inStaticContext;
             if (!HasThis(isExplicit: true, inStaticContext: out inStaticContext))
             {
-                //this error is returned in the field initializer case
-                Error(diagnostics, inStaticContext ? ErrorCode.ERR_ThisInStaticMeth : ErrorCode.ERR_ThisInBadContext, node);
+                if (IsInsideNameof)
+                {
+                    var nameofFeatureAvailable = CheckFeatureAvailability(node, MessageID.IDS_FeatureInstanceMemberInNameof, diagnostics);
+                    Debug.Assert(!nameofFeatureAvailable);
+                }
+                else
+                {
+                    //this error is returned in the field initializer case
+                    Error(diagnostics, inStaticContext ? ErrorCode.ERR_ThisInStaticMeth : ErrorCode.ERR_ThisInBadContext, node);
+                }
             }
             else
             {
@@ -2631,8 +2639,17 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (!HasThis(isExplicit: true, inStaticContext: out inStaticContext))
             {
-                //this error is returned in the field initializer case
-                Error(diagnostics, inStaticContext ? ErrorCode.ERR_BaseInStaticMeth : ErrorCode.ERR_BaseInBadContext, node.Token);
+                if (IsInsideNameof)
+                {
+                    var nameofFeatureAvailable = CheckFeatureAvailability(node, MessageID.IDS_FeatureInstanceMemberInNameof, diagnostics);
+                    Debug.Assert(!nameofFeatureAvailable);
+                }
+                else
+                {
+                    //this error is returned in the field initializer case
+                    Error(diagnostics, inStaticContext ? ErrorCode.ERR_BaseInStaticMeth : ErrorCode.ERR_BaseInBadContext, node.Token);
+                }
+
                 hasErrors = true;
             }
             else if ((object)baseType == null) // e.g. in System.Object

--- a/src/Compilers/CSharp/Portable/Binder/EarlyWellKnownAttributeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/EarlyWellKnownAttributeBinder.cs
@@ -139,6 +139,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.LessThanOrEqualExpression:
                 case SyntaxKind.InvocationExpression: //  To support nameof(); anything else will be a compile-time error
                 case SyntaxKind.ConditionalExpression: //  The ?: conditional operator.
+                // Allowed inside nameof()
+                case SyntaxKind.ThisExpression:
+                case SyntaxKind.BaseExpression:
                     return true;
 
                 default:


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/82251.