### PR TITLE
Fix race in event subscription in file watcher

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/DefaultFileChangeWatcher.FileChangeContext.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/DefaultFileChangeWatcher.FileChangeContext.cs
@@ -45,12 +45,16 @@ internal sealed partial class DefaultFileChangeWatcher
                     continue;
 
                 var rootWatcher = _owner.GetOrCreateSharedWatcher(rootPath);
-                AttachWatcher(this, rootWatcher);
                 fileSystemWatchersForWatchedDirectoriesBuilder.Add(rootWatcher);
             }
 
             _watchedDirectories = watchedDirectoryBuilder.ToImmutable();
             _fileSystemWatchersForWatchedDirectories = fileSystemWatchersForWatchedDirectoriesBuilder.ToImmutable();
+
+            // Attach watchers after fields are assigned to avoid race conditions where events
+            // fire before _watchedDirectories is initialized.
+            foreach (var rootWatcher in _fileSystemWatchersForWatchedDirectories)
+                AttachWatcher(this, rootWatcher);
         }
 
         public event EventHandler<string>? FileChanged;


### PR DESCRIPTION
```
2026-02-04T23:22:30.633Z [DEBUG] LSP csharp server for C:\Users\dabarbet\source\repos\aspire: [stderr] Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.FileWatching.DefaultFileChangeWatcher.FileChangeContext.Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.FileWatching.DefaultFileChangeWatcher.IEventRaiser.RaiseEvent(Object sender, FileSystemEventArgs e) in /_/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/DefaultFileChangeWatcher.FileChangeContext.cs:line 60
   at System.IO.FileSystemWatcher.NotifyFileSystemEventArgs(WatcherChangeTypes changeType, ReadOnlySpan`1 name)
   at System.IO.FileSystemWatcher.ParseEventBufferAndNotifyForEach(ReadOnlySpan`1 buffer)
   at System.IO.FileSystemWatcher.ReadDirectoryChangesCallback(UInt32 errorCode, UInt32 numBytes, AsyncReadState state)
   at System.IO.FileSystemWatcher.<>c.<StartRaisingEvents>b__84_0(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* overlappedPointer)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.ThreadPoolTypedWorkItemQueue.System.Threading.IThreadPoolWorkItem.Execute()
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()
   at System.Threading.Thread.StartCallback()
```