### PR TITLE
Add .code-workspace files for all solutions

### DIFF
--- a/Compilers.code-workspace
+++ b/Compilers.code-workspace
@@ -1,0 +1,10 @@
+{
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "dotnet.defaultSolution": "Compilers.slnf"
+  }
+}

--- a/Ide.code-workspace
+++ b/Ide.code-workspace
@@ -1,0 +1,10 @@
+{
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "dotnet.defaultSolution": "Ide.slnf"
+  }
+}

--- a/Roslyn.code-workspace
+++ b/Roslyn.code-workspace
@@ -1,0 +1,10 @@
+{
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "dotnet.defaultSolution": "Roslyn.slnx"
+  }
+}


### PR DESCRIPTION
Allows to open a solution in VS Code from command line and Windows File Explorer:  e.g. `code Compilers.code-workspace` 