### PR TITLE
No longer recommend 'this' inside nameof in an attribute

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/ThisKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/ThisKeywordRecommenderTests.cs
@@ -1217,9 +1217,11 @@ public sealed class ThisKeywordRecommenderTests : KeywordRecommenderTests
         => VerifyKeywordAsync(AddInsideMethod(
             @"ref int x = ref $$"));
 
-    [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/78979")]
+    [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/78979")]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/82251")]
     public Task TestInsideNameofInAttribute(bool isStatic)
-        => VerifyKeywordAsync($$"""
+        => VerifyAbsenceAsync($$"""
             public class Example
             {
                 private string _field;

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ThisKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ThisKeywordRecommender.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Linq;
 using System.Threading;
-using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -17,8 +15,7 @@ internal sealed class ThisKeywordRecommender() : AbstractSyntacticSingleKeywordR
     protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
         => IsInstanceExpressionOrStatement(context) ||
            IsThisParameterModifierContext(context) ||
-           IsConstructorInitializerContext(context) ||
-           IsNameofInsideAttributeContext(context);
+           IsConstructorInitializerContext(context);
 
     private static bool IsInstanceExpressionOrStatement(CSharpSyntaxContext context)
         => context.IsInstanceContext && (context.IsNonAttributeExpressionContext || context.IsStatementContext);
@@ -56,25 +53,6 @@ internal sealed class ThisKeywordRecommender() : AbstractSyntacticSingleKeywordR
         }
 
         return false;
-    }
-
-    private static bool IsNameofInsideAttributeContext(CSharpSyntaxContext context)
-    {
-        // Fascinatingly, the language supports [Attr(nameof(this.X))]
-
-        var token = context.TargetToken;
-        if (token.Kind() != SyntaxKind.OpenParenToken)
-            return false;
-
-        if (!context.IsNameOfContext)
-            return false;
-
-        var attribute = token.GetAncestor<AttributeSyntax>();
-        if (attribute is null)
-            return false;
-
-        var typeDeclaration = attribute.GetAncestor<TypeDeclarationSyntax>();
-        return typeDeclaration != null;
     }
 
     protected override bool ShouldPreselect(CSharpSyntaxContext context, CancellationToken cancellationToken)


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/issues/82251