### PR TITLE
only publish roslyn-language-server in a single VMR leg

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <!-- When EnableDefaultRidSpecificArtifacts is true (dotnet/dotnet build), set the language server package
-       visibility to vertical so that only one leg (win-x64) publishes the RID-specific assets. -->
+       visibility to vertical so that only one leg (win-x64) publishes all the RID-specific tool packages. -->
   <ItemGroup Condition="'$(EnableDefaultRidSpecificArtifacts)' == 'true'">
     <Artifact Update="$(ArtifactsPackagesDir)**\roslyn-language-server.*.nupkg" Visibility="Vertical" />
   </ItemGroup>


### PR DESCRIPTION
Fix to unblock the VMR build.  For context, see https://github.com/dotnet/dotnet/issues/4694