### PR TITLE
Add Signcheckexclusionsfile for Compiler.Test.Resources.dll

### DIFF
--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -1,0 +1,1 @@
+Microsoft.CodeAnalysis.Compiler.Test.Resources.dll


### PR DESCRIPTION
Per https://github.com/dotnet/arcade/blob/656bdecfc772fca7eba40c0c6983b58b21bbe4be/Documentation/Validation.md#what-do-i-do-if-an-issue-is-opened-in-my-repository, adding a SignCheckExclusionsFile.txt that contains the test dll to fix a signing error