### PR TITLE
Fix embedded source decoding on big-endian architectures

### DIFF
--- a/src/Compilers/Test/Core/Metadata/MetadataReaderUtils.cs
+++ b/src/Compilers/Test/Core/Metadata/MetadataReaderUtils.cs
@@ -282,7 +282,7 @@ namespace Roslyn.Test.Utilities
                 return null;
             }
 
-            int uncompressedSize = BinaryPrimitives.ReadInt32LittleEndian(bytes.AsSpan().Slice(0));
+            int uncompressedSize = BinaryPrimitives.ReadInt32LittleEndian(bytes.AsSpan());
             var stream = new MemoryStream(bytes, sizeof(int), bytes.Length - sizeof(int));
 
             if (uncompressedSize != 0)


### PR DESCRIPTION
The test case `Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests.CommandLineTests.Embed_EndToEnd_Portable` fails on big-endian architectures because `MetadataReaderUtils.GetEmbeddedSource` incorrectly decodes embedded source payloads on big-endian architectures.

Portable PDB metadata is always little-endian, regardless of host architecture, so using BinaryPrimitives here fixes the test case.