### PR TITLE
Replace linear search with dictionary lookup in Workspace_Editor.GetOpenDocumentSourceTextContainer_NoLock

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -279,8 +279,8 @@ public abstract partial class Workspace
 
     private SourceTextContainer? GetOpenDocumentSourceTextContainer_NoLock(DocumentId documentId)
     {
-        // TODO: remove linear search
-        return _bufferToAssociatedDocumentsMap.Where(kvp => kvp.Value.Contains(documentId)).Select(kvp => kvp.Key).FirstOrDefault();
+        _documentToAssociatedBufferMap.TryGetValue(documentId, out var container);
+        return container;
     }
 
     internal bool TryGetOpenSourceGeneratedDocumentIdentity(DocumentId id, out (SourceGeneratedDocumentIdentity identity, DateTime generationDateTime) documentIdentity)


### PR DESCRIPTION
## Summary

- Replace O(n) LINQ scan over `_bufferToAssociatedDocumentsMap` with O(1) `_documentToAssociatedBufferMap.TryGetValue()` lookup in `GetOpenDocumentSourceTextContainer_NoLock`
- Remove the `// TODO: remove linear search` comment that has been present since the original 2014 open-source commit
- Both maps are maintained in sync (populated in `SignupForTextChanges` and `OnSourceGeneratedDocumentOpened`, removed in `ClearOpenDocument`), making this a safe substitution.

## Context

`GetOpenDocumentSourceTextContainer_NoLock` performs a reverse lookup — given a `DocumentId`, find its `SourceTextContainer`. The existing code iterates all entries in `_bufferToAssociatedDocumentsMap` using LINQ:

 ```csharp
  return _bufferToAssociatedDocumentsMap
      .Where(kvp => kvp.Value.Contains(documentId))
      .Select(kvp => kvp.Key)
      .FirstOrDefault();
```
A reverse-lookup dictionary _documentToAssociatedBufferMap (Dictionary<DocumentId, SourceTextContainer>) already exists and is kept in sync at every insertion and removal point. This PR simply uses it.

## Testing

- All workspace open/close/context tests pass (AdhocWorkspaceTests, WorkspaceTests, SolutionWithSourceGeneratorTests InProcess variants)
- Build completes with 0 warnings, 0 errors