### PR TITLE
Adds --clientProcessId option so server can shutdown when the parent does

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/LanguageServerTestComposition.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/LanguageServerTestComposition.cs
@@ -32,7 +32,7 @@ internal sealed class LanguageServerTestComposition
             UseStdIo: false,
             AutoLoadProjects: false,
             SourceGeneratorExecutionPreference: SourceGeneratorExecutionPreference.Balanced,
-            ParentProcessId: null);
+            ClientProcessId: null);
         var extensionManager = ExtensionAssemblyManager.Create(serverConfiguration, loggerFactory);
         var assemblyLoader = new CustomExportAssemblyLoader(extensionManager, loggerFactory);
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/LanguageServerTestComposition.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/LanguageServerTestComposition.cs
@@ -31,7 +31,8 @@ internal sealed class LanguageServerTestComposition
             ServerPipeName: null,
             UseStdIo: false,
             AutoLoadProjects: false,
-            SourceGeneratorExecutionPreference: SourceGeneratorExecutionPreference.Balanced);
+            SourceGeneratorExecutionPreference: SourceGeneratorExecutionPreference.Balanced,
+            ParentProcessId: null);
         var extensionManager = ExtensionAssemblyManager.Create(serverConfiguration, loggerFactory);
         var assemblyLoader = new CustomExportAssemblyLoader(extensionManager, loggerFactory);
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
@@ -162,6 +162,10 @@ static async Task RunAsync(ServerConfiguration serverConfiguration, Cancellation
             if (completedTask == clientProcessExitTask)
             {
                 logger.LogInformation("Client process {clientProcessId} exited, shutting down server", clientProcessId);
+
+                // With the client process exited, we cannot send logs or telemetry,
+                // so kill the server process immediately to ensure we exit in a timely manner.
+                Process.GetCurrentProcess().Kill();
             }
 
             // Await the task that completed to observe any exceptions.

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
@@ -380,9 +380,9 @@ static async Task WaitForParentProcessExitAsync(int parentProcessId, ILogger log
         var parentProcess = Process.GetProcessById(parentProcessId);
         await parentProcess.WaitForExitAsync();
     }
-    catch (ArgumentException)
+    catch (ArgumentException ex)
     {
         // The process has already exited or was never running.
-        logger.LogWarning("Parent process {parentProcessId} is not running", parentProcessId);
+        logger.LogWarning("Parent process {parentProcessId} is not running: {exceptionMessage}", parentProcessId, ex.Message);
     }
 }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
@@ -163,6 +163,9 @@ static async Task RunAsync(ServerConfiguration serverConfiguration, Cancellation
             {
                 logger.LogInformation("Parent process {parentProcessId} exited, shutting down server", parentProcessId);
             }
+
+            // Await the task that completed to observe any exceptions.
+            await completedTask;
         }
         else
         {
@@ -280,7 +283,7 @@ static RootCommand CreateCommand()
         DefaultValueFactory = _ => SourceGeneratorExecutionPreference.Automatic,
     };
 
-    var parentProcessIdOption = new Option<int?>("--process-id")
+    var parentProcessIdOption = new Option<int?>("--parentProcessId")
     {
         Description = "The process ID of the parent process. The server will terminate when the parent process exits.",
         Required = false,

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/ServerConfigurationFactory.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/ServerConfigurationFactory.cs
@@ -55,7 +55,8 @@ internal sealed record class ServerConfiguration(
     bool UseStdIo,
     string? ExtensionLogDirectory,
     bool AutoLoadProjects,
-    SourceGeneratorExecutionPreference SourceGeneratorExecutionPreference);
+    SourceGeneratorExecutionPreference SourceGeneratorExecutionPreference,
+    int? ParentProcessId);
 
 internal sealed class LogConfiguration
 {

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/ServerConfigurationFactory.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/ServerConfigurationFactory.cs
@@ -56,7 +56,7 @@ internal sealed record class ServerConfiguration(
     string? ExtensionLogDirectory,
     bool AutoLoadProjects,
     SourceGeneratorExecutionPreference SourceGeneratorExecutionPreference,
-    int? ParentProcessId);
+    int? ClientProcessId);
 
 internal sealed class LogConfiguration
 {


### PR DESCRIPTION
Adds an optional `--clientProcessId` option for passing the Roslyn LSP the parent process. When passed, the LSP will listen for the process to exit. On exit the language server will shutdown.