### PR TITLE
Adds a listener in the initialize handler for client process exit

### DIFF
--- a/src/LanguageServer/Protocol/Handler/ServerLifetime/InitializeHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/ServerLifetime/InitializeHandler.cs
@@ -24,14 +24,8 @@ internal sealed class InitializeHandler(ILspLogger logger) : ILspServiceRequestH
         var clientCapabilities = request.Capabilities;
         clientCapabilitiesManager.SetInitializeParams(request);
 
-        // If we are running in process with the client, then we don't need to listen for it to exit.
-        using var currentProcess = Process.GetCurrentProcess();
-        if (request.ProcessId is int clientProcessId
-            && clientProcessId != currentProcess.Id
-            && RoslynLanguageServer.TryRegisterClientProcessId(clientProcessId))
-        {
+        if (request.ProcessId is int clientProcessId && RoslynLanguageServer.TryRegisterClientProcessId(clientProcessId))
             logger.LogInformation("Monitoring client process {clientProcessId} for exit", clientProcessId);
-        }
 
         var capabilitiesProvider = context.GetRequiredLspService<ICapabilitiesProvider>();
         var serverCapabilities = capabilitiesProvider.GetCapabilities(clientCapabilities);

--- a/src/LanguageServer/Protocol/Handler/ServerLifetime/InitializeHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/ServerLifetime/InitializeHandler.cs
@@ -2,18 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Internal.Log;
-using Microsoft.CommonLanguageServerProtocol.Framework;
 using Roslyn.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler;
 
 [Method(Methods.InitializeName)]
-internal sealed class InitializeHandler(ILspLogger logger) : ILspServiceRequestHandler<InitializeParams, InitializeResult>
+internal sealed class InitializeHandler() : ILspServiceRequestHandler<InitializeParams, InitializeResult>
 {
     public bool MutatesSolutionState => true;
     public bool RequiresLSPSolution => false;
@@ -25,7 +23,7 @@ internal sealed class InitializeHandler(ILspLogger logger) : ILspServiceRequestH
         clientCapabilitiesManager.SetInitializeParams(request);
 
         if (request.ProcessId is int clientProcessId && RoslynLanguageServer.TryRegisterClientProcessId(clientProcessId))
-            logger.LogInformation("Monitoring client process {clientProcessId} for exit", clientProcessId);
+            context.Logger.LogInformation("Monitoring client process {clientProcessId} for exit", clientProcessId);
 
         var capabilitiesProvider = context.GetRequiredLspService<ICapabilitiesProvider>();
         var serverCapabilities = capabilitiesProvider.GetCapabilities(clientCapabilities);

--- a/src/LanguageServer/Protocol/Handler/ServerLifetime/InitializeHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/ServerLifetime/InitializeHandler.cs
@@ -24,7 +24,7 @@ internal sealed class InitializeHandler() : ILspServiceRequestHandler<Initialize
         var clientCapabilities = request.Capabilities;
         clientCapabilitiesManager.SetInitializeParams(request);
 
-        if (request.ProcessId.HasValue)
+        if (request.ProcessId.HasValue && request.ProcessId.Value != Process.GetCurrentProcess().Id)
         {
             // We were given a client process ID. Monitor that process and exit if it exits.
             _ = WaitForClientProcessExitAsync(request.ProcessId.Value);

--- a/src/LanguageServer/Protocol/Handler/ServerLifetime/InitializeHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/ServerLifetime/InitializeHandler.cs
@@ -25,7 +25,8 @@ internal sealed class InitializeHandler() : ILspServiceRequestHandler<Initialize
         clientCapabilitiesManager.SetInitializeParams(request);
 
         // If we are running in process with the client, then we don't need to listen for it to exit.
-        if (request.ProcessId.HasValue && request.ProcessId.Value != Process.GetCurrentProcess().Id)
+        using var currentProcess = Process.GetCurrentProcess();
+        if (request.ProcessId.HasValue && request.ProcessId.Value != currentProcess.Id)
         {
             // We were given a client process ID. Monitor that process and exit if it exits.
             _ = WaitForClientProcessExitAsync(request.ProcessId.Value);

--- a/src/LanguageServer/Protocol/Handler/ServerLifetime/InitializeHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/ServerLifetime/InitializeHandler.cs
@@ -2,18 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.CommonLanguageServerProtocol.Framework;
 using Roslyn.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler;
 
 [Method(Methods.InitializeName)]
-internal sealed class InitializeHandler() : ILspServiceRequestHandler<InitializeParams, InitializeResult>
+internal sealed class InitializeHandler(ILspLogger logger) : ILspServiceRequestHandler<InitializeParams, InitializeResult>
 {
     public bool MutatesSolutionState => true;
     public bool RequiresLSPSolution => false;
@@ -26,10 +26,11 @@ internal sealed class InitializeHandler() : ILspServiceRequestHandler<Initialize
 
         // If we are running in process with the client, then we don't need to listen for it to exit.
         using var currentProcess = Process.GetCurrentProcess();
-        if (request.ProcessId.HasValue && request.ProcessId.Value != currentProcess.Id)
+        if (request.ProcessId is int clientProcessId
+            && clientProcessId != currentProcess.Id
+            && RoslynLanguageServer.TryRegisterClientProcessId(clientProcessId))
         {
-            // We were given a client process ID. Monitor that process and exit if it exits.
-            _ = WaitForClientProcessExitAsync(request.ProcessId.Value);
+            logger.LogInformation("Monitoring client process {clientProcessId} for exit", clientProcessId);
         }
 
         var capabilitiesProvider = context.GetRequiredLspService<ICapabilitiesProvider>();
@@ -47,29 +48,5 @@ internal sealed class InitializeHandler() : ILspServiceRequestHandler<Initialize
         {
             Capabilities = serverCapabilities,
         };
-    }
-
-    static async Task WaitForClientProcessExitAsync(int clientProcessId)
-    {
-        try
-        {
-            var clientProcessExitTask = new TaskCompletionSource<bool>();
-
-            using var clientProcess = Process.GetProcessById(clientProcessId);
-            clientProcess.EnableRaisingEvents = true;
-            clientProcess.Exited += (sender, args) => clientProcessExitTask.SetResult(true);
-
-            if (!clientProcess.HasExited)
-            {
-                // Wait for the client process to exit.
-                await clientProcessExitTask.Task.ConfigureAwait(false);
-            }
-        }
-        finally
-        {
-            // The process didn't exist, exited, or we ran into
-            // issues checking whether the process had exited.
-            Process.GetCurrentProcess().Kill();
-        }
     }
 }

--- a/src/LanguageServer/Protocol/Handler/ServerLifetime/InitializeHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/ServerLifetime/InitializeHandler.cs
@@ -24,6 +24,7 @@ internal sealed class InitializeHandler() : ILspServiceRequestHandler<Initialize
         var clientCapabilities = request.Capabilities;
         clientCapabilitiesManager.SetInitializeParams(request);
 
+        // If we are running in process with the client, then we don't need to listen for it to exit.
         if (request.ProcessId.HasValue && request.ProcessId.Value != Process.GetCurrentProcess().Id)
         {
             // We were given a client process ID. Monitor that process and exit if it exits.

--- a/src/LanguageServer/Protocol/Handler/ServerLifetime/InitializeHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/ServerLifetime/InitializeHandler.cs
@@ -64,11 +64,11 @@ internal sealed class InitializeHandler() : ILspServiceRequestHandler<Initialize
                 await clientProcessExitTask.Task.ConfigureAwait(false);
             }
         }
-        catch (ArgumentException)
+        finally
         {
-            // The process has already exited or was never running.
+            // The process didn't exist, exited, or we ran into
+            // issues checking whether the process had exited.
+            Process.GetCurrentProcess().Kill();
         }
-
-        Process.GetCurrentProcess().Kill();
     }
 }

--- a/src/LanguageServer/Protocol/RoslynLanguageServer.cs
+++ b/src/LanguageServer/Protocol/RoslynLanguageServer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer;
 internal sealed class RoslynLanguageServer : SystemTextJsonLanguageServer<RequestContext>, IOnInitialized
 {
     private static int s_clientProcessId = -1;
-    private static readonly Lazy<int> s_currentProcessId = new(() => { using var process = Process.GetCurrentProcess(); return process.Id; });
+    private static readonly Lazy<int> s_currentProcessId = new(static () => { using var process = Process.GetCurrentProcess(); return process.Id; });
     public static int ServerProcessId => s_currentProcessId.Value;
 
     private readonly AbstractLspServiceProvider _lspServiceProvider;
@@ -129,7 +129,7 @@ internal sealed class RoslynLanguageServer : SystemTextJsonLanguageServer<Reques
         AddLazyService<AbstractTelemetryService>(lspServices => new TelemetryService(lspServices));
         AddLazyService<AbstractHandlerProvider>(_ => HandlerProvider);
         AddService<IInitializeManager>(new InitializeManager());
-        AddService<IMethodHandler>(new InitializeHandler(logger));
+        AddService<IMethodHandler>(new InitializeHandler());
         AddService<IMethodHandler>(new InitializedHandler());
         AddService<IOnInitialized>(this);
         AddService<ILanguageInfoProvider>(new LanguageInfoProvider());


### PR DESCRIPTION
Some clients send their process id via the initialize request. We can listen for their client process to exit then ensure we have also exited.