### PR TITLE
Remove a hack in eng\targets\Imports.targets

### DIFF
--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -208,16 +208,6 @@
     </ItemGroup>
   </Target>
 
-  <!-- 
-    Count PublicAPIs as AdditionalFiles to get them to analyzers. This is working around
-    https://github.com/dotnet/project-system/issues/2160 where AdditionalFileItemNames
-    isn't fully supported yet in the new project system. Removal of this hack is tracked
-    by https://github.com/dotnet/roslyn/issues/19545. 
-  -->
-  <ItemGroup>
-    <AdditionalFiles Include="@(PublicAPI)" />
-  </ItemGroup>
-
   <ItemGroup>
     <!-- Include BannedSymbols covering all product projects -->
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\config\BannedSymbols.txt" Condition="'$(IsTestProject)' == 'false'" />


### PR DESCRIPTION
It appears we had a hack here to work around a CPS issue. Even though that issue isn't closed, it seems the scenario works at this point. Because a similar workaround exists in the NuGet package itself, there's no reason to duplicate it here, but it does cause warnings in dotnet watch.

Closes https://github.com/dotnet/roslyn/issues/19545