### PR TITLE
Move to using the VS2022 release image in CI

### DIFF
--- a/azure-pipelines-integration-lsp.yml
+++ b/azure-pipelines-integration-lsp.yml
@@ -53,12 +53,9 @@ parameters:
 - name: queueName
   displayName: Queue Name
   type: string
-  default: windows.vs2022preview.amd64.open
+  default: windows.vs2022.amd64.open
   values:
   - windows.vs2022.amd64.open
-  - windows.vs2022.scout.amd64.open
-  - windows.vs2022preview.amd64.open
-  - windows.vs2022preview.scout.amd64.open
 - name: timeout
   displayName: Timeout in Minutes
   type: number

--- a/azure-pipelines-integration-scouting.yml
+++ b/azure-pipelines-integration-scouting.yml
@@ -29,12 +29,9 @@ parameters:
 - name: queueName
   displayName: Queue Name
   type: string
-  default: windows.vs2022preview.scout.amd64.open
+  default: windows.vs2022.amd64.open
   values:
   - windows.vs2022.amd64.open
-  - windows.vs2022.scout.amd64.open
-  - windows.vs2022preview.amd64.open
-  - windows.vs2022preview.scout.amd64.open
 - name: timeout
   displayName: Timeout in Minutes
   type: number

--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -70,12 +70,9 @@ parameters:
 - name: queueName
   displayName: Queue Name
   type: string
-  default: windows.vs2022preview.scout.amd64.open
+  default: windows.vs2022.amd64.open
   values:
   - windows.vs2022.amd64.open
-  - windows.vs2022.scout.amd64.open
-  - windows.vs2022preview.amd64.open
-  - windows.vs2022preview.scout.amd64.open
 - name: timeout
   displayName: Timeout in Minutes
   type: number

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -141,7 +141,7 @@ extends:
         configFile: '$(Build.SourcesDirectory)/eng/TSAConfig.gdntsa'
     pool:
       name: $(DncEngInternalBuildPool)
-      image: windows.vs2022preview.scout.amd64
+      image: windows.vs2022.amd64
       os: windows
     customBuildTags:
     - ES365AIMigrationTooling

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,14 +56,6 @@ variables:
     ${{ else }}:
       value: NetCore1ESPool-Internal
 
-  - name: Vs2022PreviewQueueName
-    # As of 2025-06-12, the non-scouting queue does not have a new enough of an MSBuild to build Roslyn; use the scouting
-    # queue which is on 17.14. This likely can be removed by 2025-06-18 when the upgrade to 17.14 Preview 4 is scheduled to complete.
-    ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      value: windows.vs2022preview.scout.amd64.open
-    ${{ else }}:
-      value: windows.vs2022preview.scout.amd64
-
   - name: Vs2022RegularQueueName
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
       value: windows.vs2022.amd64.open


### PR DESCRIPTION
Makes the integration scouting redundant until we have vs2026 images.