### PR TITLE
Disable processing of source-generated documents in unit testing

### DIFF
--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/LegacySolutionEvents/UnitTestingLegacySolutionEventsListener.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/LegacySolutionEvents/UnitTestingLegacySolutionEventsListener.cs
@@ -45,10 +45,10 @@ internal sealed class UnitTestingLegacySolutionEventsListener : ILegacySolutionE
         return service.HasRegisteredAnalyzerProviders;
     }
 
-    public ValueTask OnWorkspaceChangedAsync(WorkspaceChangeEventArgs args, CancellationToken cancellationToken)
+    public ValueTask OnWorkspaceChangedAsync(WorkspaceChangeEventArgs args, bool processSourceGeneratedDocuments, CancellationToken cancellationToken)
     {
         var coordinator = GetCoordinator(args.NewSolution);
-        coordinator?.OnWorkspaceChanged(args);
+        coordinator?.OnWorkspaceChanged(args, processSourceGeneratedDocuments);
         return ValueTask.CompletedTask;
     }
 }

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/IUnitTestingWorkCoordinator.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/IUnitTestingWorkCoordinator.cs
@@ -6,5 +6,5 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.SolutionCrawler;
 
 internal interface IUnitTestingWorkCoordinator
 {
-    void OnWorkspaceChanged(WorkspaceChangeEventArgs args);
+    void OnWorkspaceChanged(WorkspaceChangeEventArgs args, bool processSourceGeneratedDocuments);
 }

--- a/src/Features/Core/Portable/LegacySolutionEvents/ILegacySolutionEventsAggregationService.cs
+++ b/src/Features/Core/Portable/LegacySolutionEvents/ILegacySolutionEventsAggregationService.cs
@@ -22,7 +22,7 @@ internal interface ILegacySolutionEventsAggregationService : IWorkspaceService
 {
     bool ShouldReportChanges(SolutionServices services);
 
-    ValueTask OnWorkspaceChangedAsync(WorkspaceChangeEventArgs args, CancellationToken cancellationToken);
+    ValueTask OnWorkspaceChangedAsync(WorkspaceChangeEventArgs args, bool processSourceGeneratedDocuments, CancellationToken cancellationToken);
 }
 
 [ExportWorkspaceService(typeof(ILegacySolutionEventsAggregationService)), Shared]
@@ -44,9 +44,9 @@ internal sealed class DefaultLegacySolutionEventsAggregationService(
         return false;
     }
 
-    public async ValueTask OnWorkspaceChangedAsync(WorkspaceChangeEventArgs args, CancellationToken cancellationToken)
+    public async ValueTask OnWorkspaceChangedAsync(WorkspaceChangeEventArgs args, bool processSourceGeneratedDocuments, CancellationToken cancellationToken)
     {
         foreach (var service in _eventsServices)
-            await service.Value.OnWorkspaceChangedAsync(args, cancellationToken).ConfigureAwait(false);
+            await service.Value.OnWorkspaceChangedAsync(args, processSourceGeneratedDocuments, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Features/Core/Portable/LegacySolutionEvents/ILegacySolutionEventsListener.cs
+++ b/src/Features/Core/Portable/LegacySolutionEvents/ILegacySolutionEventsListener.cs
@@ -16,5 +16,5 @@ namespace Microsoft.CodeAnalysis.LegacySolutionEvents;
 internal interface ILegacySolutionEventsListener
 {
     bool ShouldReportChanges(SolutionServices services);
-    ValueTask OnWorkspaceChangedAsync(WorkspaceChangeEventArgs args, CancellationToken cancellationToken);
+    ValueTask OnWorkspaceChangedAsync(WorkspaceChangeEventArgs args, bool processSourceGeneratedDocuments, CancellationToken cancellationToken);
 }

--- a/src/Features/Core/Portable/LegacySolutionEvents/IRemoteLegacySolutionEventsAggregationService.cs
+++ b/src/Features/Core/Portable/LegacySolutionEvents/IRemoteLegacySolutionEventsAggregationService.cs
@@ -21,5 +21,6 @@ internal interface IRemoteLegacySolutionEventsAggregationService
     /// <param name="kind"><inheritdoc cref="WorkspaceChangeEventArgs.Kind"/></param>
     /// <param name="projectId"><inheritdoc cref="WorkspaceChangeEventArgs.ProjectId"/></param>
     /// <param name="documentId"><inheritdoc cref="WorkspaceChangeEventArgs.DocumentId"/></param>
-    ValueTask OnWorkspaceChangedAsync(Checksum oldSolutionChecksum, Checksum newSolutionChecksum, WorkspaceChangeKind kind, ProjectId? projectId, DocumentId? documentId, CancellationToken cancellationToken);
+    /// <param name="processSourceGeneratedDocuments">Whether a change to a project should result in source-generated documents being refreshed.</param>
+    ValueTask OnWorkspaceChangedAsync(Checksum oldSolutionChecksum, Checksum newSolutionChecksum, WorkspaceChangeKind kind, ProjectId? projectId, DocumentId? documentId, bool processSourceGeneratedDocuments, CancellationToken cancellationToken);
 }

--- a/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerService.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerService.cs
@@ -9,4 +9,5 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler;
 internal sealed partial class SolutionCrawlerRegistrationService
 {
     internal static readonly Option2<bool> EnableSolutionCrawler = new("dotnet_enable_solution_crawler", defaultValue: true);
+    internal static readonly Option2<bool> ProcessRoslynSourceGeneratedFiles = new Option2<bool>("dotnet_process_roslyn_source_generated_files_in_solution_crawler", defaultValue: true);
 }

--- a/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
+++ b/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
@@ -43,6 +43,7 @@
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\ConcurrentLruCache.cs">
       <Link>Shared\ConcurrentLruCache.cs</Link>
     </Compile>
+    <Content Include="UnifiedSettings\roslynSettings.registration.json" IncludeInVSIX="true" CopyToOutputDirectory="PreserveNewest" />
     <Compile Update="VSPackage.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
+++ b/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
@@ -394,6 +394,7 @@ internal abstract class VisualStudioOptionStorage
         {"dotnet_enable_snippets", new LocalUserProfileStorage(@"Roslyn\Internal\OnOff\Features", "Snippets2")},
         {"dotnet_enable_syntactic_colorizer", new LocalUserProfileStorage(@"Roslyn\Internal\OnOff\Features", "Syntactic Colorizer")},
         {"dotnet_enable_solution_crawler", new LocalUserProfileStorage(@"Roslyn\Internal\SolutionCrawler", "Solution Crawler")},
+        {"dotnet_process_roslyn_source_generated_files_in_solution_crawler", new UnifiedSettingsManagerStorage("test.includeSourceGeneratedFilesInRealTimeDiscovery")},
         {"dotnet_colorize_json_patterns", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.ColorizeJsonPatterns")},
         {"dotnet_unsupported_detect_and_offer_editor_features_for_probable_json_strings", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.DetectAndOfferEditorFeaturesForProbableJsonStrings")},
         {"dotnet_highlight_related_json_components", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.HighlightRelatedJsonComponentsUnderCursor")},

--- a/src/VisualStudio/Core/Def/Options/VisualStudioUnifiedSettingsOptionPersister.cs
+++ b/src/VisualStudio/Core/Def/Options/VisualStudioUnifiedSettingsOptionPersister.cs
@@ -31,7 +31,9 @@ internal sealed class VisualStudioUnifiedSettingsOptionPersister : AbstractVisua
 
     private static void CheckStorageKeyAndType(string storageKey, [NotNull] Type? storageType)
     {
-        Contract.ThrowIfFalse(storageKey.StartsWith("languages"), "Need to update SubscribeToChanges in constructor to listen to changes to this key");
+        // HACK: We don't need to listen to changes to test.includeSourceGeneratedFilesInRealTimeDiscovery because we require a restart anyways, so just ignore it rather than
+        // worrying that we're watching it.
+        Contract.ThrowIfFalse(storageKey.StartsWith("languages") || storageKey == "test.includeSourceGeneratedFilesInRealTimeDiscovery", "Need to update SubscribeToChanges in constructor to listen to changes to this key");
 
         // Currently, these are the only types we expect.  This can be augmented in the future if we need to serialize
         // more kinds to unified settings backend.

--- a/src/VisualStudio/Core/Def/PackageRegistration.pkgdef
+++ b/src/VisualStudio/Core/Def/PackageRegistration.pkgdef
@@ -82,3 +82,10 @@
 "IsAsyncQueryable"=dword:00000001
 "IsCacheable"=dword:00000001
 "IsFreeThreaded"=dword:00000001
+
+// CacheTag value should be changed when registration file changes
+// See https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/39345/Manifest-Build-Deployment-and-Setup-Authoring-In-Depth?anchor=example-pkgdef-key for more infomation
+[$RootKey$\SettingsManifests\{6cf2e545-6109-4730-8883-cf43d7aec3e1}]
+@="Microsoft.VisualStudio.LanguageServices.Setup.RoslynPackage"
+"ManifestPath"="$PackageFolder$\UnifiedSettings\roslynSettings.registration.json"
+"CacheTag"=qword:ABE9BBF01CC8B289

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1906,4 +1906,8 @@ Additional information: {1}</value>
     <value>Warning {0} does not bind to type</value>
     <comment>{0} is a type name</comment>
   </data>
+  <data name="Include_Roslyn_source_generated_files" xml:space="preserve">
+    <value>Include Roslyn source-generated files</value>
+    <comment>Used in the unified settings registration for real-time test discovery</comment>
+  </data>
 </root>

--- a/src/VisualStudio/Core/Def/UnifiedSettings/roslynSettings.registration.json
+++ b/src/VisualStudio/Core/Def/UnifiedSettings/roslynSettings.registration.json
@@ -1,0 +1,18 @@
+﻿// NOTE:
+// When this file is changed. Please also update the cache tag under settings entry in src/VisualStudio/Core/Def/PackageRegistration.pkgdef
+// Otherwise your change might be ignored.
+// See https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/39345/Manifest-Build-Deployment-and-Setup-Authoring-In-Depth?anchor=example-pkgdef-key for more details
+{
+  "properties": {
+    "test.includeSourceGeneratedFilesInRealTimeDiscovery": {
+      "title": "@Include_Roslyn_source_generated_files;..\\Microsoft.VisualStudio.LanguageServices.dll",
+      "type": "boolean",
+      "default": true,
+      "enableWhen": "${config:test.realTimeDiscovery} == 'true'",
+      "alternateDefault": {
+        "flagName": "UnitTesting.DisableRoslynSourceGeneratedFiles",
+        "default": false
+      }
+    }
+  }
+}

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -572,6 +572,11 @@
         <target state="translated">V jiných operátorech</target>
         <note />
       </trans-unit>
+      <trans-unit id="Include_Roslyn_source_generated_files">
+        <source>Include Roslyn source-generated files</source>
+        <target state="new">Include Roslyn source-generated files</target>
+        <note>Used in the unified settings registration for real-time test discovery</note>
+      </trans-unit>
       <trans-unit id="Include_global_imports">
         <source>Include global imports</source>
         <target state="translated">Zahrnout globální importy</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -572,6 +572,11 @@
         <target state="translated">In anderen Operatoren</target>
         <note />
       </trans-unit>
+      <trans-unit id="Include_Roslyn_source_generated_files">
+        <source>Include Roslyn source-generated files</source>
+        <target state="new">Include Roslyn source-generated files</target>
+        <note>Used in the unified settings registration for real-time test discovery</note>
+      </trans-unit>
       <trans-unit id="Include_global_imports">
         <source>Include global imports</source>
         <target state="translated">Globale Importe einschließen</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -572,6 +572,11 @@
         <target state="translated">En otros operadores</target>
         <note />
       </trans-unit>
+      <trans-unit id="Include_Roslyn_source_generated_files">
+        <source>Include Roslyn source-generated files</source>
+        <target state="new">Include Roslyn source-generated files</target>
+        <note>Used in the unified settings registration for real-time test discovery</note>
+      </trans-unit>
       <trans-unit id="Include_global_imports">
         <source>Include global imports</source>
         <target state="translated">Incluir importaciones globales</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -572,6 +572,11 @@
         <target state="translated">Dans les autres opérateurs</target>
         <note />
       </trans-unit>
+      <trans-unit id="Include_Roslyn_source_generated_files">
+        <source>Include Roslyn source-generated files</source>
+        <target state="new">Include Roslyn source-generated files</target>
+        <note>Used in the unified settings registration for real-time test discovery</note>
+      </trans-unit>
       <trans-unit id="Include_global_imports">
         <source>Include global imports</source>
         <target state="translated">Inclure les importations globales</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -572,6 +572,11 @@
         <target state="translated">In altri operatori</target>
         <note />
       </trans-unit>
+      <trans-unit id="Include_Roslyn_source_generated_files">
+        <source>Include Roslyn source-generated files</source>
+        <target state="new">Include Roslyn source-generated files</target>
+        <note>Used in the unified settings registration for real-time test discovery</note>
+      </trans-unit>
       <trans-unit id="Include_global_imports">
         <source>Include global imports</source>
         <target state="translated">Includi importazioni globali</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -572,6 +572,11 @@
         <target state="translated">その他の演算子内で</target>
         <note />
       </trans-unit>
+      <trans-unit id="Include_Roslyn_source_generated_files">
+        <source>Include Roslyn source-generated files</source>
+        <target state="new">Include Roslyn source-generated files</target>
+        <note>Used in the unified settings registration for real-time test discovery</note>
+      </trans-unit>
       <trans-unit id="Include_global_imports">
         <source>Include global imports</source>
         <target state="translated">グローバル インポートを含める</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -572,6 +572,11 @@
         <target state="translated">기타 연산자</target>
         <note />
       </trans-unit>
+      <trans-unit id="Include_Roslyn_source_generated_files">
+        <source>Include Roslyn source-generated files</source>
+        <target state="new">Include Roslyn source-generated files</target>
+        <note>Used in the unified settings registration for real-time test discovery</note>
+      </trans-unit>
       <trans-unit id="Include_global_imports">
         <source>Include global imports</source>
         <target state="translated">전역 가져오기 포함</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -572,6 +572,11 @@
         <target state="translated">W innych operatorach</target>
         <note />
       </trans-unit>
+      <trans-unit id="Include_Roslyn_source_generated_files">
+        <source>Include Roslyn source-generated files</source>
+        <target state="new">Include Roslyn source-generated files</target>
+        <note>Used in the unified settings registration for real-time test discovery</note>
+      </trans-unit>
       <trans-unit id="Include_global_imports">
         <source>Include global imports</source>
         <target state="translated">Uwzględnij globalne importy</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -572,6 +572,11 @@
         <target state="translated">Em outros operadores</target>
         <note />
       </trans-unit>
+      <trans-unit id="Include_Roslyn_source_generated_files">
+        <source>Include Roslyn source-generated files</source>
+        <target state="new">Include Roslyn source-generated files</target>
+        <note>Used in the unified settings registration for real-time test discovery</note>
+      </trans-unit>
       <trans-unit id="Include_global_imports">
         <source>Include global imports</source>
         <target state="translated">Incluir as importações globais</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -572,6 +572,11 @@
         <target state="translated">В других операторах</target>
         <note />
       </trans-unit>
+      <trans-unit id="Include_Roslyn_source_generated_files">
+        <source>Include Roslyn source-generated files</source>
+        <target state="new">Include Roslyn source-generated files</target>
+        <note>Used in the unified settings registration for real-time test discovery</note>
+      </trans-unit>
       <trans-unit id="Include_global_imports">
         <source>Include global imports</source>
         <target state="translated">Включить глобальные директивы import</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -572,6 +572,11 @@
         <target state="translated">Diğer işleçlerde</target>
         <note />
       </trans-unit>
+      <trans-unit id="Include_Roslyn_source_generated_files">
+        <source>Include Roslyn source-generated files</source>
+        <target state="new">Include Roslyn source-generated files</target>
+        <note>Used in the unified settings registration for real-time test discovery</note>
+      </trans-unit>
       <trans-unit id="Include_global_imports">
         <source>Include global imports</source>
         <target state="translated">Genel içeri aktarmaları dahil et</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -572,6 +572,11 @@
         <target state="translated">在其他运算符中</target>
         <note />
       </trans-unit>
+      <trans-unit id="Include_Roslyn_source_generated_files">
+        <source>Include Roslyn source-generated files</source>
+        <target state="new">Include Roslyn source-generated files</target>
+        <note>Used in the unified settings registration for real-time test discovery</note>
+      </trans-unit>
       <trans-unit id="Include_global_imports">
         <source>Include global imports</source>
         <target state="translated">包括全局导入</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -572,6 +572,11 @@
         <target state="translated">其他運算子中</target>
         <note />
       </trans-unit>
+      <trans-unit id="Include_Roslyn_source_generated_files">
+        <source>Include Roslyn source-generated files</source>
+        <target state="new">Include Roslyn source-generated files</target>
+        <note>Used in the unified settings registration for real-time test discovery</note>
+      </trans-unit>
       <trans-unit id="Include_global_imports">
         <source>Include global imports</source>
         <target state="translated">包含全域匯入</target>

--- a/src/VisualStudio/Core/Test.Next/Roslyn.VisualStudio.Next.UnitTests.csproj
+++ b/src/VisualStudio/Core/Test.Next/Roslyn.VisualStudio.Next.UnitTests.csproj
@@ -65,6 +65,8 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="TestFiles\analyzer_input.csv" />
+    <EmbeddedResource Include="$(RepoRoot)\src\VisualStudio\Core\Def\UnifiedSettings\roslynSettings.registration.json" />
+    <EmbeddedResource Include="$(RepoRoot)\src\VisualStudio\Core\Def\PackageRegistration.pkgdef" Link="roslynPackageRegistration.pkgdef" />
     <EmbeddedResource Include="$(RepoRoot)\src\VisualStudio\VisualBasic\Impl\UnifiedSettings\visualBasicSettings.registration.json" />
     <EmbeddedResource Include="$(RepoRoot)\src\VisualStudio\VisualBasic\Impl\PackageRegistration.pkgdef" Link="visualBasicPackageRegistration.pkgdef" />
     <EmbeddedResource Include="$(RepoRoot)\src\VisualStudio\CSharp\Impl\UnifiedSettings\csharpSettings.registration.json" />

--- a/src/VisualStudio/Core/Test.Next/UnifiedSettings/UnifiedSettingsTests.cs
+++ b/src/VisualStudio/Core/Test.Next/UnifiedSettings/UnifiedSettingsTests.cs
@@ -269,6 +269,14 @@ public sealed class UnifiedSettingsTests
 
     #endregion
 
+    [Fact]
+    public async Task VerifyRoslynSettings()
+    {
+        using var registrationFileStream = typeof(UnifiedSettingsTests).GetTypeInfo().Assembly.GetManifestResourceStream("Roslyn.VisualStudio.Next.UnitTests.roslynSettings.registration.json");
+        using var streamReader = new StreamReader(registrationFileStream);
+        await VerifyTagAsync(streamReader.ReadToEnd(), "Roslyn.VisualStudio.Next.UnitTests.roslynPackageRegistration.pkgdef");
+    }
+
     #region Helpers
 
     private static async Task VerifyTagAsync(string registrationFile, string pkgdefFileName)

--- a/src/VisualStudio/Setup/Roslyn.VisualStudio.Setup.csproj
+++ b/src/VisualStudio/Setup/Roslyn.VisualStudio.Setup.csproj
@@ -200,7 +200,7 @@
     </ProjectReference>
     <ProjectReference Include="..\Core\Def\Microsoft.VisualStudio.LanguageServices.csproj">
       <Name>ServicesVisualStudio</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;PkgDefProjectOutputGroup;VsdConfigOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;PkgDefProjectOutputGroup;ContentFilesProjectOutputGroup;VsdConfigOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
       <PkgDefEntry>BindingRedirect</PkgDefEntry>
       <NgenPriority>2</NgenPriority>

--- a/src/Workspaces/Remote/ServiceHub/Services/LegacySolutionEvents/RemoteLegacySolutionEventsAggregationService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/LegacySolutionEvents/RemoteLegacySolutionEventsAggregationService.cs
@@ -39,6 +39,7 @@ internal sealed class RemoteLegacySolutionEventsAggregationService : BrokeredSer
         WorkspaceChangeKind kind,
         ProjectId? projectId,
         DocumentId? documentId,
+        bool processSourceGeneratedDocuments,
         CancellationToken cancellationToken)
     {
         return RunServiceAsync(oldSolutionChecksum, newSolutionChecksum,
@@ -46,7 +47,7 @@ internal sealed class RemoteLegacySolutionEventsAggregationService : BrokeredSer
             {
                 var aggregationService = oldSolution.Services.GetRequiredService<ILegacySolutionEventsAggregationService>();
                 await aggregationService.OnWorkspaceChangedAsync(
-                    new WorkspaceChangeEventArgs(kind, oldSolution, newSolution, projectId, documentId), cancellationToken).ConfigureAwait(false);
+                    new WorkspaceChangeEventArgs(kind, oldSolution, newSolution, projectId, documentId), processSourceGeneratedDocuments, cancellationToken).ConfigureAwait(false);
             }, cancellationToken);
     }
 }


### PR DESCRIPTION
While investigating a report of ServiceHub consuming a large amount of memory, I noticed the unit testing solution crawler queue was quite large, and (at least at the point of the dump) it was running source generators to add the source generated files to the queue. When chatting with the unit testing team, it's not clear that's really a scenario we need to support in the first place, so as a performance test we'd like to simply disable that.

This defines a new setting to disable this, and wires it up to a feature flag for us to experiment with this. The core code change is minimial -- most of this is defining a new roslyn setting that's not language specific, and passing the boolean around.