### PR TITLE
Skip Marshal.GetExceptionPointers() in Mono as it is not supported

### DIFF
--- a/src/Test/PdbUtilities/EditAndContinue/EditAndContinueTest.cs
+++ b/src/Test/PdbUtilities/EditAndContinue/EditAndContinueTest.cs
@@ -207,11 +207,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         public void Dispose()
         {
             // If the test has thrown an exception, or the test host has crashed, we don't want to assert here
-            // or we'll hide it, so we need to do this dodgy looking thing. Skip in Mono as Marshal.GetExceptionPointers() isn't supported
-            if (!ExecutionConditionUtil.IsMonoCore){
-                var isInException = Marshal.GetExceptionPointers() != IntPtr.Zero;
-                Assert.True(isInException || _hasVerified, "No Verify call since the last AddGeneration call.");
-            }
+            // or we'll hide it, so we need to do this dodgy looking thing.
+            var isInException = ExecutionConditionUtil.IsMonoCore ? false : Marshal.GetExceptionPointers() != IntPtr.Zero;
+
+            Assert.True(isInException || _hasVerified, "No Verify call since the last AddGeneration call.");
             foreach (var disposable in _disposables)
             {
                 disposable.Dispose();


### PR DESCRIPTION
There are many tests cases like `Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests.EditAndContinueStateMachineTests.UpdateAsync_NoVariables` in `roslyn/src/Compilers/CSharp/Test/Emit2/Microsoft.CodeAnalysis.CSharp.Emit2.UnitTests.csproj` that fail with `System.PlatformNotSupportedException : Operation is not supported on this platform.`. This is arising from `Marshal.GetExceptionPointers()` as it not supported on Mono and stops the execution of the test. The condition is used to check if the test has thrown an exception or if the test host has crashed. This check could be skipped as it is not essential and could not replicate the same behavior on Mono.