### PR TITLE
Fix incorrect version check for collection expression arguments support in IDE0028

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
@@ -86,7 +86,7 @@ internal sealed class CSharpUseCollectionInitializerAnalyzer : AbstractUseCollec
             return true;
 
         // See if we can specialize a single argument, by potentially spreading it, or dropping it entirely if redundant.
-        var supportsWithArgument = _objectCreationExpression.SyntaxTree.Options.LanguageVersion().IsCSharp14OrAbove();
+        var supportsWithArgument = _objectCreationExpression.SyntaxTree.Options.LanguageVersion().IsCSharp15OrAbove();
         if (TrySpecializeSingleArgument(out mayChangeSemantics))
             return true;
 
@@ -104,7 +104,7 @@ internal sealed class CSharpUseCollectionInitializerAnalyzer : AbstractUseCollec
             return false;
         }
 
-        // Otherwise, if we're in C#14 or above, we can use the 'with(args)' argument trivially.
+        // Otherwise, if we're in C#15 or above, we can use the 'with(args)' argument trivially.
         if (supportsWithArgument)
         {
             preMatches.Add(new(argumentList, UseSpread: false, UseKeyValue: false));


### PR DESCRIPTION
I couldn't find an issue for this, but this seems to be a trivial fix to me.

IDE0028 (`Collection initialization can be simplified`) analyzer wrongly assumes that the collection expression arguments feature (i.e., `with()` in collection initializers) is supported in C# 14. As far as I understand, that feature was recently included in .NET 11/C# 15 Preview 1, so a check for C# 15 seems more appropriate.

Without this change, IDE0028 suggests the following fix while targeting C# 14:

```csharp
// Before
class Test
{
    public List<string> A = new(1);
}

// After
class Test
{
    public List<string> A = [with(1)];
}
```

Which results in `The feature 'collection expression arguments' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version. [CS8652]` error.