### PR TITLE
PropertySymbol.IsReadOnly/IsWriteOnly: use helpers that compiler uses itself to check for existence of a setter/getter

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/PropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PropertySymbol.cs
@@ -166,8 +166,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                var property = (PropertySymbol)this.GetLeastOverriddenMember(this.ContainingType);
-                return (object)property.SetMethod == null;
+                return this.GetOwnOrInheritedSetMethod() is null;
             }
         }
 
@@ -178,8 +177,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                var property = (PropertySymbol)this.GetLeastOverriddenMember(this.ContainingType);
-                return (object)property.GetMethod == null;
+                return this.GetOwnOrInheritedGetMethod() is null;
             }
         }
 


### PR DESCRIPTION
GetOwnOrInheritedSetMethod/GetOwnOrInheritedGetMethod are used when compiler decides whether a read/write operations are possible for a property.

Fixes #82122