### PR TITLE
Updates build instructions for all copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,6 +12,7 @@
 ## Development Workflow
 
 **Building**:
+- Always set `DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE=1` before running any `dotnet` command to prevent workload update checks that require network access and can cause build failures in restricted environments
 - `build.sh` - Full solution build
 - `dotnet build Compilers.slnf` - Compiler-only build  
 - `dotnet msbuild <path to csproj> /t:UpdateXlf` - Update .xlf files when their corresponding .resx file is modified

--- a/.github/instructions/Compiler.instructions.md
+++ b/.github/instructions/Compiler.instructions.md
@@ -44,6 +44,9 @@ public class MyTests : CSharpTestBase
 ## Build & Test Workflows
 
 ### Essential Build Commands
+
+Always set `DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE=1` before running any `dotnet` command to prevent workload update checks that require network access and can cause build failures in restricted environments.
+
 ```powershell
 # Full build (use VS Code tasks when available)
 ./build.sh

--- a/.github/instructions/IDE.instructions.md
+++ b/.github/instructions/IDE.instructions.md
@@ -89,6 +89,8 @@ public sealed class MyAnalyzer : DiagnosticAnalyzer
 
 ## Essential Build & Test Commands
 
+Always set `DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE=1` before running any `dotnet` command to prevent workload update checks that require network access and can cause build failures in restricted environments.
+
 ```bash
 # Full build
 .build.sh


### PR DESCRIPTION
Adds an instruction to set the DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE before any dotnet command.