### PR TITLE
Fix suboptimal codegen for short or patterns in is-expressions

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsPatternOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsPatternOperator.cs
@@ -26,18 +26,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (canProduceLinearSequence(decisionDag.RootNode, whenTrueLabel: node.WhenTrueLabel, whenFalseLabel: node.WhenFalseLabel))
             {
                 // If we can build a linear test sequence `(e1 && e2 && e3)` for the dag, do so.
-                var isPatternRewriter = new IsPatternExpressionLinearLocalRewriter(node, this);
-                result = isPatternRewriter.LowerIsPatternAsLinearTestSequence(node, decisionDag, whenTrueLabel: node.WhenTrueLabel, whenFalseLabel: node.WhenFalseLabel);
-                isPatternRewriter.Free();
+                result = LowerIsPatternAsLinearSequence(node, decisionDag, whenTrueLabel: node.WhenTrueLabel, whenFalseLabel: node.WhenFalseLabel);
             }
             else if (IsFailureNode(decisionDag.RootNode, node.WhenFalseLabel))
             {
                 // If the given pattern always fails due to a constant input (see comments on BoundDecisionDag.SimplifyDecisionDagIfConstantInput),
                 // we build a linear test sequence with the whenTrue and whenFalse labels swapped and then negate the result, to keep the result a constant.
                 negated = !negated;
-                var isPatternRewriter = new IsPatternExpressionLinearLocalRewriter(node, this);
-                result = isPatternRewriter.LowerIsPatternAsLinearTestSequence(node, decisionDag, whenTrueLabel: node.WhenFalseLabel, whenFalseLabel: node.WhenTrueLabel);
-                isPatternRewriter.Free();
+                result = LowerIsPatternAsLinearSequence(node, decisionDag, whenTrueLabel: node.WhenFalseLabel, whenFalseLabel: node.WhenTrueLabel);
             }
             else if (canProduceLinearSequence(decisionDag.RootNode, whenTrueLabel: node.WhenFalseLabel, whenFalseLabel: node.WhenTrueLabel, maxTests: LinearSequenceMaxTests)
                      && !dagContainsBindings(decisionDag))
@@ -52,9 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // follows the "failure" branches, skipping BoundWhenDecisionDagNodes that contain variable
                 // bindings, which would leave captured variables uninitialized.
                 negated = !negated;
-                var isPatternRewriter = new IsPatternExpressionLinearLocalRewriter(node, this);
-                result = isPatternRewriter.LowerIsPatternAsLinearTestSequence(node, decisionDag, whenTrueLabel: node.WhenFalseLabel, whenFalseLabel: node.WhenTrueLabel);
-                isPatternRewriter.Free();
+                result = LowerIsPatternAsLinearSequence(node, decisionDag, whenTrueLabel: node.WhenFalseLabel, whenFalseLabel: node.WhenTrueLabel);
             }
             else
             {
@@ -74,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // linear tests with a single "golden" path to the true label and all other paths leading
             // to the false label?  This occurs with an is-pattern expression that uses no "or" or "not"
             // pattern forms.
-            // When maxTests is specified, the sequence is limited to at most that many test nodes.
+            // maxTests limits the number of BoundTestDecisionDagNode nodes in the sequence.
             static bool canProduceLinearSequence(
                 BoundDecisionDagNode node,
                 LabelSymbol whenTrueLabel,
@@ -108,6 +102,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
             }
+        }
+
+        private BoundExpression LowerIsPatternAsLinearSequence(
+            BoundIsPatternExpression node,
+            BoundDecisionDag decisionDag,
+            LabelSymbol whenTrueLabel,
+            LabelSymbol whenFalseLabel)
+        {
+            var rewriter = new IsPatternExpressionLinearLocalRewriter(node, this);
+            var result = rewriter.LowerIsPatternAsLinearTestSequence(node, decisionDag, whenTrueLabel, whenFalseLabel);
+            rewriter.Free();
+            return result;
         }
 
         /// <summary>
@@ -175,7 +181,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             foreach (var node in decisionDag.TopologicallySortedNodes)
             {
-                if (node is BoundWhenDecisionDagNode { Bindings.Length: > 0 })
+                if (node is BoundWhenDecisionDagNode { Bindings.IsEmpty: false })
                     return true;
             }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsPatternOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsPatternOperator.cs
@@ -39,7 +39,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 result = isPatternRewriter.LowerIsPatternAsLinearTestSequence(node, decisionDag, whenTrueLabel: node.WhenFalseLabel, whenFalseLabel: node.WhenTrueLabel);
                 isPatternRewriter.Free();
             }
-            else if (canProduceLinearSequence(decisionDag.RootNode, whenTrueLabel: node.WhenFalseLabel, whenFalseLabel: node.WhenTrueLabel, maxTests: LinearSequenceMaxTests))
+            else if (canProduceLinearSequence(decisionDag.RootNode, whenTrueLabel: node.WhenFalseLabel, whenFalseLabel: node.WhenTrueLabel, maxTests: LinearSequenceMaxTests)
+                     && !dagContainsBindings(decisionDag))
             {
                 // If we can build a short linear test sequence with the labels swapped, do so and negate the result.
                 // This handles `or` patterns like `is '/' or '\\'` by producing an inverted AND sequence
@@ -47,6 +48,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // unnecessary boolean temporaries and a SpillSequence.
                 // We limit this to short sequences because the general DAG lowering can use switch dispatch
                 // (binary search trees) which is more efficient for large `or` patterns.
+                // We exclude DAGs with bindings (e.g., `(B or C) and var x`) because the inverted traversal
+                // follows the "failure" branches, skipping BoundWhenDecisionDagNodes that contain variable
+                // bindings, which would leave captured variables uninitialized.
                 negated = !negated;
                 var isPatternRewriter = new IsPatternExpressionLinearLocalRewriter(node, this);
                 result = isPatternRewriter.LowerIsPatternAsLinearTestSequence(node, decisionDag, whenTrueLabel: node.WhenFalseLabel, whenFalseLabel: node.WhenTrueLabel);
@@ -161,6 +165,21 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (node is BoundWhenDecisionDagNode w)
                 node = w.WhenTrue;
             return node is BoundLeafDecisionDagNode l && l.Label == whenFalseLabel;
+        }
+
+        /// <summary>
+        /// Returns true if any node in the decision DAG contains variable bindings
+        /// (e.g., from <c>var</c> or declaration patterns).
+        /// </summary>
+        private static bool dagContainsBindings(BoundDecisionDag decisionDag)
+        {
+            foreach (var node in decisionDag.TopologicallySortedNodes)
+            {
+                if (node is BoundWhenDecisionDagNode { Bindings.Length: > 0 })
+                    return true;
+            }
+
+            return false;
         }
 
         private sealed class IsPatternExpressionLinearLocalRewriter : PatternLocalRewriter

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsPatternOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsPatternOperator.cs
@@ -12,6 +12,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal sealed partial class LocalRewriter
     {
+        /// <summary>
+        /// Maximum number of test nodes allowed in an inverted linear sequence for `or` patterns.
+        /// Beyond this threshold, the general DAG lowering with switch dispatch is preferred.
+        /// </summary>
+        private const int LinearSequenceMaxTests = 4;
+
         public override BoundNode VisitIsPatternExpression(BoundIsPatternExpression node)
         {
             BoundDecisionDag decisionDag = node.GetDecisionDagForLowering(_factory.Compilation);
@@ -28,8 +34,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // If the given pattern always fails due to a constant input (see comments on BoundDecisionDag.SimplifyDecisionDagIfConstantInput),
                 // we build a linear test sequence with the whenTrue and whenFalse labels swapped and then negate the result, to keep the result a constant.
-                // Note that the positive case will be handled by canProduceLinearSequence above, however, we avoid to produce a full inverted linear sequence here
-                // because we may be able to generate better code for a sequence of `or` patterns, using a switch dispatch, for example, which is done in the general rewriter.
+                negated = !negated;
+                var isPatternRewriter = new IsPatternExpressionLinearLocalRewriter(node, this);
+                result = isPatternRewriter.LowerIsPatternAsLinearTestSequence(node, decisionDag, whenTrueLabel: node.WhenFalseLabel, whenFalseLabel: node.WhenTrueLabel);
+                isPatternRewriter.Free();
+            }
+            else if (canProduceLinearSequence(decisionDag.RootNode, whenTrueLabel: node.WhenFalseLabel, whenFalseLabel: node.WhenTrueLabel, maxTests: LinearSequenceMaxTests))
+            {
+                // If we can build a short linear test sequence with the labels swapped, do so and negate the result.
+                // This handles `or` patterns like `is '/' or '\\'` by producing an inverted AND sequence
+                // (e.g., `!(x != '/' && x != '\\')`) instead of the general DAG lowering which introduces
+                // unnecessary boolean temporaries and a SpillSequence.
+                // We limit this to short sequences because the general DAG lowering can use switch dispatch
+                // (binary search trees) which is more efficient for large `or` patterns.
                 negated = !negated;
                 var isPatternRewriter = new IsPatternExpressionLinearLocalRewriter(node, this);
                 result = isPatternRewriter.LowerIsPatternAsLinearTestSequence(node, decisionDag, whenTrueLabel: node.WhenFalseLabel, whenFalseLabel: node.WhenTrueLabel);
@@ -53,11 +70,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             // linear tests with a single "golden" path to the true label and all other paths leading
             // to the false label?  This occurs with an is-pattern expression that uses no "or" or "not"
             // pattern forms.
+            // When maxTests is specified, the sequence is limited to at most that many test nodes.
             static bool canProduceLinearSequence(
                 BoundDecisionDagNode node,
                 LabelSymbol whenTrueLabel,
-                LabelSymbol whenFalseLabel)
+                LabelSymbol whenFalseLabel,
+                int maxTests = int.MaxValue)
             {
+                int testCount = 0;
                 while (true)
                 {
                     switch (node)
@@ -72,6 +92,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             node = e.Next;
                             break;
                         case BoundTestDecisionDagNode t:
+                            if (++testCount > maxTests)
+                                return false;
                             bool falseFail = IsFailureNode(t.WhenFalse, whenFalseLabel);
                             if (falseFail == IsFailureNode(t.WhenTrue, whenFalseLabel))
                                 return false;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
@@ -5505,23 +5505,18 @@ class C
             var compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
             compVerifier.VerifyIL("C.M1", """
 {
-  // Code size       26 (0x1a)
-  .maxstack  1
-  .locals init (bool V_0)
+  // Code size       21 (0x15)
+  .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  isinst     "int"
-  IL_0006:  brtrue.s   IL_0012
+  IL_0006:  brtrue.s   IL_0013
   IL_0008:  ldarg.0
   IL_0009:  isinst     "long"
-  IL_000e:  brtrue.s   IL_0012
-  IL_0010:  br.s       IL_0016
-  IL_0012:  ldc.i4.1
-  IL_0013:  stloc.0
-  IL_0014:  br.s       IL_0018
-  IL_0016:  ldc.i4.0
-  IL_0017:  stloc.0
-  IL_0018:  ldloc.0
-  IL_0019:  ret
+  IL_000e:  ldnull
+  IL_000f:  cgt.un
+  IL_0011:  br.s       IL_0014
+  IL_0013:  ldc.i4.1
+  IL_0014:  ret
 }
 """);
             compVerifier.VerifyIL("C.M2", """
@@ -5544,26 +5539,22 @@ class C
             compilation = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.RegularWithPatternCombinators);
             compilation.VerifyDiagnostics();
             compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
-            compVerifier.VerifyIL("C.M1", """
+            compVerifier.VerifyIL("C.M1", @"
 {
-  // Code size       24 (0x18)
-  .maxstack  1
-  .locals init (bool V_0)
+  // Code size       20 (0x14)
+  .maxstack  2
   IL_0000:  ldarg.0
-  IL_0001:  isinst     "int"
-  IL_0006:  brtrue.s   IL_0010
+  IL_0001:  isinst     ""int""
+  IL_0006:  brtrue.s   IL_0012
   IL_0008:  ldarg.0
-  IL_0009:  isinst     "long"
-  IL_000e:  brfalse.s  IL_0014
-  IL_0010:  ldc.i4.1
-  IL_0011:  stloc.0
-  IL_0012:  br.s       IL_0016
-  IL_0014:  ldc.i4.0
-  IL_0015:  stloc.0
-  IL_0016:  ldloc.0
-  IL_0017:  ret
+  IL_0009:  isinst     ""long""
+  IL_000e:  ldnull
+  IL_000f:  cgt.un
+  IL_0011:  ret
+  IL_0012:  ldc.i4.1
+  IL_0013:  ret
 }
-""");
+");
             compVerifier.VerifyIL("C.M2", @"
 {
   // Code size       20 (0x14)
@@ -5605,27 +5596,18 @@ class C
             var compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
             compVerifier.VerifyIL("C.M1", """
 {
-  // Code size       40 (0x28)
+  // Code size       29 (0x1d)
   .maxstack  1
-  .locals init (bool V_0)
   IL_0000:  ldarg.0
   IL_0001:  isinst     "int"
-  IL_0006:  brtrue.s   IL_0012
+  IL_0006:  brtrue.s   IL_0017
   IL_0008:  ldarg.0
   IL_0009:  isinst     "long"
-  IL_000e:  brtrue.s   IL_0012
-  IL_0010:  br.s       IL_0016
-  IL_0012:  ldc.i4.1
-  IL_0013:  stloc.0
-  IL_0014:  br.s       IL_0018
-  IL_0016:  ldc.i4.0
-  IL_0017:  stloc.0
-  IL_0018:  ldloc.0
-  IL_0019:  brtrue.s   IL_0022
-  IL_001b:  ldstr      "False"
-  IL_0020:  br.s       IL_0027
-  IL_0022:  ldstr      "True"
-  IL_0027:  ret
+  IL_000e:  brtrue.s   IL_0017
+  IL_0010:  ldstr      "False"
+  IL_0015:  br.s       IL_001c
+  IL_0017:  ldstr      "True"
+  IL_001c:  ret
 }
 """);
             compVerifier.VerifyIL("C.M2", """
@@ -5648,30 +5630,22 @@ class C
             compilation = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.RegularWithPatternCombinators);
             compilation.VerifyDiagnostics();
             compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
-            compVerifier.VerifyIL("C.M1", """
+            compVerifier.VerifyIL("C.M1", @"
 {
-  // Code size       37 (0x25)
+  // Code size       28 (0x1c)
   .maxstack  1
-  .locals init (bool V_0)
   IL_0000:  ldarg.0
-  IL_0001:  isinst     "int"
-  IL_0006:  brtrue.s   IL_0010
+  IL_0001:  isinst     ""int""
+  IL_0006:  brtrue.s   IL_0016
   IL_0008:  ldarg.0
-  IL_0009:  isinst     "long"
-  IL_000e:  brfalse.s  IL_0014
-  IL_0010:  ldc.i4.1
-  IL_0011:  stloc.0
-  IL_0012:  br.s       IL_0016
-  IL_0014:  ldc.i4.0
-  IL_0015:  stloc.0
-  IL_0016:  ldloc.0
-  IL_0017:  brtrue.s   IL_001f
-  IL_0019:  ldstr      "False"
-  IL_001e:  ret
-  IL_001f:  ldstr      "True"
-  IL_0024:  ret
+  IL_0009:  isinst     ""long""
+  IL_000e:  brtrue.s   IL_0016
+  IL_0010:  ldstr      ""False""
+  IL_0015:  ret
+  IL_0016:  ldstr      ""True""
+  IL_001b:  ret
 }
-""");
+");
             compVerifier.VerifyIL("C.M2", @"
 {
   // Code size       28 (0x1c)
@@ -6154,6 +6128,52 @@ class C
       IL_0016:  ldc.i4.0
       IL_0017:  ret
     }
+");
+        }
+
+        [Fact, WorkItem(80052, "https://github.com/dotnet/roslyn/issues/80052")]
+        public void IsPatternDisjunct_OrPatternInAndExpression()
+        {
+            // Regression test: `or` pattern used within `&&` should not introduce unnecessary bool temporaries.
+            var source = @"
+using System;
+class C
+{
+    static bool M1(int x, char c) => x > 0 && c is '/' or '\\';
+    static bool M2(int x, char c) => x > 0 && (c == '/' || c == '\\');
+    public static void Main()
+    {
+        Console.Write(M1(1, '/'));
+        Console.Write(M1(1, '\\'));
+        Console.Write(M1(1, 'a'));
+        Console.Write(M1(0, '/'));
+    }
+}";
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
+            compilation.VerifyDiagnostics();
+            var expectedOutput = @"TrueTrueFalseFalse";
+            var compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
+            // The `is '/' or '\\'` pattern should produce comparable IL to `c == '/' || c == '\\'`
+            // without introducing a bool temporary or SpillSequence.
+            compVerifier.VerifyIL("C.M1", @"
+{
+  // Code size       19 (0x13)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.0
+  IL_0002:  ble.s      IL_0011
+  IL_0004:  ldarg.1
+  IL_0005:  ldc.i4.s   47
+  IL_0007:  beq.s      IL_000f
+  IL_0009:  ldarg.1
+  IL_000a:  ldc.i4.s   92
+  IL_000c:  ceq
+  IL_000e:  ret
+  IL_000f:  ldc.i4.1
+  IL_0010:  ret
+  IL_0011:  ldc.i4.0
+  IL_0012:  ret
+}
 ");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
@@ -6175,6 +6175,26 @@ class C
   IL_0012:  ret
 }
 ");
+            compVerifier.VerifyIL("C.M2", @"
+{
+  // Code size       19 (0x13)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.0
+  IL_0002:  ble.s      IL_0011
+  IL_0004:  ldarg.1
+  IL_0005:  ldc.i4.s   47
+  IL_0007:  beq.s      IL_000f
+  IL_0009:  ldarg.1
+  IL_000a:  ldc.i4.s   92
+  IL_000c:  ceq
+  IL_000e:  ret
+  IL_000f:  ldc.i4.1
+  IL_0010:  ret
+  IL_0011:  ldc.i4.0
+  IL_0012:  ret
+}
+");
         }
 
         [Fact, WorkItem(46536, "https://github.com/dotnet/roslyn/issues/46536")]

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests.cs
@@ -8360,64 +8360,60 @@ and: False
 not: True")
                 .VerifyIL("C.Test", """
 {
-  // Code size      167 (0xa7)
+  // Code size      161 (0xa1)
   .maxstack  3
   .locals init (bool V_0)
   IL_0000:  nop
-  IL_0001:  ldarg.0
-  IL_0002:  ldstr      "string 1"
-  IL_0007:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
-  IL_000c:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
-  IL_0011:  brtrue.s   IL_0027
-  IL_0013:  ldarg.0
-  IL_0014:  ldstr      "string 2"
-  IL_0019:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
-  IL_001e:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
-  IL_0023:  brtrue.s   IL_0027
-  IL_0025:  br.s       IL_002b
-  IL_0027:  ldc.i4.1
-  IL_0028:  stloc.0
-  IL_0029:  br.s       IL_002d
-  IL_002b:  ldc.i4.0
-  IL_002c:  stloc.0
-  IL_002d:  ldstr      "or: "
-  IL_0032:  ldloca.s   V_0
-  IL_0034:  call       "string bool.ToString()"
-  IL_0039:  call       "string string.Concat(string, string)"
-  IL_003e:  call       "void System.Console.WriteLine(string)"
-  IL_0043:  nop
-  IL_0044:  ldstr      "and: "
-  IL_0049:  ldarg.0
-  IL_004a:  ldstr      "string 1"
-  IL_004f:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
-  IL_0054:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
-  IL_0059:  brfalse.s  IL_0067
-  IL_005b:  ldarga.s   V_0
-  IL_005d:  call       "int System.ReadOnlySpan<char>.Length.get"
-  IL_0062:  ldc.i4.7
-  IL_0063:  ceq
-  IL_0065:  br.s       IL_0068
-  IL_0067:  ldc.i4.0
-  IL_0068:  stloc.0
-  IL_0069:  ldloca.s   V_0
-  IL_006b:  call       "string bool.ToString()"
-  IL_0070:  call       "string string.Concat(string, string)"
-  IL_0075:  call       "void System.Console.WriteLine(string)"
-  IL_007a:  nop
-  IL_007b:  ldstr      "not: "
-  IL_0080:  ldarg.0
-  IL_0081:  ldstr      "string 1"
-  IL_0086:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
-  IL_008b:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
-  IL_0090:  ldc.i4.0
-  IL_0091:  ceq
-  IL_0093:  stloc.0
-  IL_0094:  ldloca.s   V_0
-  IL_0096:  call       "string bool.ToString()"
-  IL_009b:  call       "string string.Concat(string, string)"
-  IL_00a0:  call       "void System.Console.WriteLine(string)"
-  IL_00a5:  nop
-  IL_00a6:  ret
+  IL_0001:  ldstr      "or: "
+  IL_0006:  ldarg.0
+  IL_0007:  ldstr      "string 1"
+  IL_000c:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_0011:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
+  IL_0016:  brtrue.s   IL_002a
+  IL_0018:  ldarg.0
+  IL_0019:  ldstr      "string 2"
+  IL_001e:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_0023:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
+  IL_0028:  br.s       IL_002b
+  IL_002a:  ldc.i4.1
+  IL_002b:  stloc.0
+  IL_002c:  ldloca.s   V_0
+  IL_002e:  call       "string bool.ToString()"
+  IL_0033:  call       "string string.Concat(string, string)"
+  IL_0038:  call       "void System.Console.WriteLine(string)"
+  IL_003d:  nop
+  IL_003e:  ldstr      "and: "
+  IL_0043:  ldarg.0
+  IL_0044:  ldstr      "string 1"
+  IL_0049:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_004e:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
+  IL_0053:  brfalse.s  IL_0061
+  IL_0055:  ldarga.s   V_0
+  IL_0057:  call       "int System.ReadOnlySpan<char>.Length.get"
+  IL_005c:  ldc.i4.7
+  IL_005d:  ceq
+  IL_005f:  br.s       IL_0062
+  IL_0061:  ldc.i4.0
+  IL_0062:  stloc.0
+  IL_0063:  ldloca.s   V_0
+  IL_0065:  call       "string bool.ToString()"
+  IL_006a:  call       "string string.Concat(string, string)"
+  IL_006f:  call       "void System.Console.WriteLine(string)"
+  IL_0074:  nop
+  IL_0075:  ldstr      "not: "
+  IL_007a:  ldarg.0
+  IL_007b:  ldstr      "string 1"
+  IL_0080:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_0085:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
+  IL_008a:  ldc.i4.0
+  IL_008b:  ceq
+  IL_008d:  stloc.0
+  IL_008e:  ldloca.s   V_0
+  IL_0090:  call       "string bool.ToString()"
+  IL_0095:  call       "string string.Concat(string, string)"
+  IL_009a:  call       "void System.Console.WriteLine(string)"
+  IL_009f:  nop
+  IL_00a0:  ret
 }
 """);
         }
@@ -9970,64 +9966,60 @@ and: False
 not: True")
                 .VerifyIL("C.Test", """
 {
-  // Code size      167 (0xa7)
+  // Code size      161 (0xa1)
   .maxstack  3
   .locals init (bool V_0)
   IL_0000:  nop
-  IL_0001:  ldarg.0
-  IL_0002:  ldstr      "string 1"
-  IL_0007:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
-  IL_000c:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)"
-  IL_0011:  brtrue.s   IL_0027
-  IL_0013:  ldarg.0
-  IL_0014:  ldstr      "string 2"
-  IL_0019:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
-  IL_001e:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)"
-  IL_0023:  brtrue.s   IL_0027
-  IL_0025:  br.s       IL_002b
-  IL_0027:  ldc.i4.1
-  IL_0028:  stloc.0
-  IL_0029:  br.s       IL_002d
-  IL_002b:  ldc.i4.0
-  IL_002c:  stloc.0
-  IL_002d:  ldstr      "or: "
-  IL_0032:  ldloca.s   V_0
-  IL_0034:  call       "string bool.ToString()"
-  IL_0039:  call       "string string.Concat(string, string)"
-  IL_003e:  call       "void System.Console.WriteLine(string)"
-  IL_0043:  nop
-  IL_0044:  ldstr      "and: "
-  IL_0049:  ldarg.0
-  IL_004a:  ldstr      "string 1"
-  IL_004f:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
-  IL_0054:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)"
-  IL_0059:  brfalse.s  IL_0067
-  IL_005b:  ldarga.s   V_0
-  IL_005d:  call       "int System.Span<char>.Length.get"
-  IL_0062:  ldc.i4.7
-  IL_0063:  ceq
-  IL_0065:  br.s       IL_0068
-  IL_0067:  ldc.i4.0
-  IL_0068:  stloc.0
-  IL_0069:  ldloca.s   V_0
-  IL_006b:  call       "string bool.ToString()"
-  IL_0070:  call       "string string.Concat(string, string)"
-  IL_0075:  call       "void System.Console.WriteLine(string)"
-  IL_007a:  nop
-  IL_007b:  ldstr      "not: "
-  IL_0080:  ldarg.0
-  IL_0081:  ldstr      "string 1"
-  IL_0086:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
-  IL_008b:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)"
-  IL_0090:  ldc.i4.0
-  IL_0091:  ceq
-  IL_0093:  stloc.0
-  IL_0094:  ldloca.s   V_0
-  IL_0096:  call       "string bool.ToString()"
-  IL_009b:  call       "string string.Concat(string, string)"
-  IL_00a0:  call       "void System.Console.WriteLine(string)"
-  IL_00a5:  nop
-  IL_00a6:  ret
+  IL_0001:  ldstr      "or: "
+  IL_0006:  ldarg.0
+  IL_0007:  ldstr      "string 1"
+  IL_000c:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_0011:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)"
+  IL_0016:  brtrue.s   IL_002a
+  IL_0018:  ldarg.0
+  IL_0019:  ldstr      "string 2"
+  IL_001e:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_0023:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)"
+  IL_0028:  br.s       IL_002b
+  IL_002a:  ldc.i4.1
+  IL_002b:  stloc.0
+  IL_002c:  ldloca.s   V_0
+  IL_002e:  call       "string bool.ToString()"
+  IL_0033:  call       "string string.Concat(string, string)"
+  IL_0038:  call       "void System.Console.WriteLine(string)"
+  IL_003d:  nop
+  IL_003e:  ldstr      "and: "
+  IL_0043:  ldarg.0
+  IL_0044:  ldstr      "string 1"
+  IL_0049:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_004e:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)"
+  IL_0053:  brfalse.s  IL_0061
+  IL_0055:  ldarga.s   V_0
+  IL_0057:  call       "int System.Span<char>.Length.get"
+  IL_005c:  ldc.i4.7
+  IL_005d:  ceq
+  IL_005f:  br.s       IL_0062
+  IL_0061:  ldc.i4.0
+  IL_0062:  stloc.0
+  IL_0063:  ldloca.s   V_0
+  IL_0065:  call       "string bool.ToString()"
+  IL_006a:  call       "string string.Concat(string, string)"
+  IL_006f:  call       "void System.Console.WriteLine(string)"
+  IL_0074:  nop
+  IL_0075:  ldstr      "not: "
+  IL_007a:  ldarg.0
+  IL_007b:  ldstr      "string 1"
+  IL_0080:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_0085:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)"
+  IL_008a:  ldc.i4.0
+  IL_008b:  ceq
+  IL_008d:  stloc.0
+  IL_008e:  ldloca.s   V_0
+  IL_0090:  call       "string bool.ToString()"
+  IL_0095:  call       "string string.Concat(string, string)"
+  IL_009a:  call       "void System.Console.WriteLine(string)"
+  IL_009f:  nop
+  IL_00a0:  ret
 }
 """);
         }


### PR DESCRIPTION
## Summary

Fixes #80052
Relates to #59615, #55334

For short `or` patterns (≤4 tests), the compiler now uses an inverted linear test sequence instead of the general DAG lowering. This eliminates unnecessary boolean temporaries and `BoundSpillSequence` wrapping that caused IL bloat.

For example, `c is '/' or '\\'` now produces:
```
!(c != '/' && c != '\\')
```
instead of the general DAG path which created a bool temp with true/false assignments and gotos.

Large `or` patterns (5+ tests) continue to use the general DAG lowering with switch dispatch (binary search trees), which is more efficient at scale.

### IL size improvements

| Pattern | Before | After |
|---------|--------|-------|
| `o is int or long` (Debug) | 26 bytes | 21 bytes |
| `o is int or long` (Release) | 24 bytes | 20 bytes |
| `(o is int or long) ? "True" : "False"` (Debug) | 40 bytes | 29 bytes |
| `x > 0 && c is '/' or '\\'` (Release) | — | 19 bytes (no bool temp) |

### Why this approach vs previous attempts

This problem was previously addressed in PR #68694 (reverted in #69582) and PR #72273 (reverted in #72827 due to compiler crash #72753). Both previous attempts modified the **general DAG lowering** to avoid the result temp, which was fragile because it interacted with exception handler scopes (`await using`, try/finally), causing `NullReferenceException` in `ILBuilder.BlockedBranchDestinationSlow`.

This PR takes a fundamentally different approach:
- Does **not** modify the general DAG lowering at all
- Routes short `or` patterns to the **existing, well-tested linear rewriter** with swapped labels
- Adds a `maxTests` parameter to `canProduceLinearSequence` to limit the optimization to short sequences
- The linear rewriter doesn't use `SpillSequence` and doesn't interact with exception handler scopes, avoiding the crashes that killed previous attempts

### Changes

- `LocalRewriter_IsPatternOperator.cs`: Added inverted linear sequence path for short `or` patterns; added `maxTests` parameter to `canProduceLinearSequence`
- `PatternTests.cs`: Updated IL expectations for `IsPatternDisjunct_01` and `_02`; added new test `IsPatternDisjunct_OrPatternInAndExpression` for the exact scenario from #80052

## Test plan

- [x] All 6 `IsPatternDisjunct` tests pass (5 existing + 1 new)
- [x] `IsWarningSwitchEmit` passes (large `or` pattern still uses switch dispatch)
- [x] Full CodeGen test suite: 6245 passed, 0 failed
- [x] Full Emit test suite: 6986 passed, 0 failed
- [ ] Verify no regressions in Semantic test suite
- [ ] Verify the crash repro from #72753 (`is X or Y` inside `await using`) works correctly