### PR TITLE
Remove error reporting out of clasp and rely on host to report errors

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/LanguageServerHost.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/LanguageServerHost.cs
@@ -72,7 +72,7 @@ internal sealed class LanguageServerHost
             // The JsonRpc connection threw an exception.  This usually means the client disconnected unexpectedly while
             // the server was reading from it.  We don't need this to cause the process to crash and trigger watsons,
             // so we handle it and let the process exit.  The server handles the JSON RPC disconnect event and will
-            // report unexpected errors as NFW, so we have no need to report anything here.
+            // propagate unexpected errors through WaitForExitAsync.
         }
 
         await _roslynLanguageServer.WaitForExitAsync();

--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/ServerNotShutDownException.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/ServerNotShutDownException.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// This is consumed as 'generated' code in a source package and therefore requires an explicit nullable enable
+#nullable enable
+
+using System;
+
+namespace Microsoft.CommonLanguageServerProtocol.Framework;
+
+/// <summary>
+/// Thrown when an operation requires the language server to have been asked to shut down,
+/// but shutdown has not yet been initiated or completed.
+/// </summary>
+internal sealed class ServerNotShutDownException : InvalidOperationException
+{
+    public ServerNotShutDownException(string message)
+        : base(message)
+    {
+    }
+}


### PR DESCRIPTION
Fixes issue found by @davidwengier where we can't use FatalError in clasp (used by Razor/Webtools who do not have that type).

Also fixes issue where if the server encountered a queue error in VS, it could not be restarted as restart would throw.