### PR TITLE
Fix ReflectionTypeLoadException in CodeStyleHostLanguageServices MEF composition

### DIFF
--- a/src/CodeStyle/Core/CodeFixes/Host/Mef/CodeStyleHostLanguageServices.cs
+++ b/src/CodeStyle/Core/CodeFixes/Host/Mef/CodeStyleHostLanguageServices.cs
@@ -11,6 +11,7 @@ using System.Composition;
 using System.Composition.Hosting;
 using System.Linq;
 using System.Reflection;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.PooledObjects;
 
@@ -45,6 +46,8 @@ internal sealed partial class CodeStyleHostLanguageServices : HostLanguageServic
             }
             catch (ReflectionTypeLoadException ex)
             {
+                FatalError.ReportNonFatalError(ex);
+
                 // Return only the types that were successfully loaded
                 return ex.Types.Where(t => t is not null);
             }


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2618500/ and https://github.com/dotnet/roslyn/issues/75005

`MefHostExportProvider.Create` was previously calling `WithAssemblies` which enumerates on `assembly.DefinedTypes` on each assembly, causing ReflectionTypeLoadExceptions to propagate up.

Changes to using `WithParts` and a helper that catches ReflectionTypeLoadExceptions and returns only successfully loaded types.