### PR TITLE
Parallelize loading solution-level analyzers

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerWorkspaceFactory.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerWorkspaceFactory.cs
@@ -46,27 +46,23 @@ internal sealed class LanguageServerWorkspaceFactory
             .ToImmutableArray();
 
         // Create the workspace and set analyzer references for it
-        _logger.LogError("Start solution level analyzers 1: {Now}", DateTimeOffset.Now);
         var workspace = new LanguageServerWorkspace(hostServicesProvider.HostServices, WorkspaceKind.Host);
         var hostAnalyzerLoaderProvider = workspace.Services.GetRequiredService<IAnalyzerAssemblyLoaderProvider>();
-        var analyzerReferences = CreateSolutionLevelAnalyzerReferencesForWorkspace(hostAnalyzerLoaderProvider);
+        var analyzerReferences = CreateSolutionLevelAnalyzerReferences(hostAnalyzerLoaderProvider);
         workspace.SetCurrentSolution(s => s.WithAnalyzerReferences(analyzerReferences), WorkspaceChangeKind.SolutionChanged);
-        _logger.LogError("End solution level analyzers 1: {Now}", DateTimeOffset.Now);
 
         HostProjectFactory = new ProjectSystemProjectFactory(
             workspace, fileChangeWatcher, static (_, _) => Task.CompletedTask, _ => { },
             CancellationToken.None); // TODO: do we need to introduce a shutdown cancellation token for this?
         workspace.ProjectSystemProjectFactory = HostProjectFactory;
 
-        _logger.LogError("Start solution level analyzers 2: {Now}", DateTimeOffset.Now);
         // https://github.com/dotnet/roslyn/issues/78560: Move this workspace creation to 'FileBasedProgramsWorkspaceProviderFactory'.
-        // 'CreateSolutionLevelAnalyzerReferencesForWorkspace' needs to be broken out into its own service for us to be able to move this.
+        // 'CreateSolutionLevelAnalyzerReferences' needs to be broken out into its own service for us to be able to move this.
         var miscellaneousFilesWorkspace = new LanguageServerWorkspace(hostServicesProvider.HostServices, WorkspaceKind.MiscellaneousFiles);
         Contract.ThrowIfFalse(
             object.ReferenceEquals(hostAnalyzerLoaderProvider, miscellaneousFilesWorkspace.Services.GetRequiredService<IAnalyzerAssemblyLoaderProvider>()),
             "Expected same AnalyzerLoaderProvider to be used for both host and misc workspaces.");
         miscellaneousFilesWorkspace.SetCurrentSolution(s => s.WithAnalyzerReferences(analyzerReferences), WorkspaceChangeKind.SolutionChanged);
-        _logger.LogError("End solution level analyzers 2: {Now}", DateTimeOffset.Now);
 
         MiscellaneousFilesWorkspaceProjectFactory = new ProjectSystemProjectFactory(
             miscellaneousFilesWorkspace, fileChangeWatcher, static (_, _) => Task.CompletedTask, _ => { }, CancellationToken.None);
@@ -87,9 +83,8 @@ internal sealed class LanguageServerWorkspaceFactory
     public ProjectSystemHostInfo ProjectSystemHostInfo { get; }
     public ProjectTargetFrameworkManager TargetFrameworkManager { get; }
 
-    public ImmutableArray<AnalyzerFileReference> CreateSolutionLevelAnalyzerReferencesForWorkspace(IAnalyzerAssemblyLoaderProvider loaderProvider)
+    private ImmutableArray<AnalyzerFileReference> CreateSolutionLevelAnalyzerReferences(IAnalyzerAssemblyLoaderProvider loaderProvider)
     {
-        _logger.LogError("Start CreateSolutionLevelAnalyzerReferencesForWorkspace: {Now}", DateTimeOffset.Now);
         // Load all analyzers into a fresh shadow copied load context.  In the future, if we want to support reloading
         // of solution-level analyzer references, we should just need to listen for changes to those analyzer paths and
         // then call back into this method to update the solution accordingly.
@@ -112,7 +107,6 @@ internal sealed class LanguageServerWorkspaceFactory
             })
             .ToImmutableArray();
 
-        _logger.LogError("End CreateSolutionLevelAnalyzerReferencesForWorkspace: {Now}", DateTimeOffset.Now);
         return references;
     }
 }


### PR DESCRIPTION
I found this while investigating slow test perf in [`FileBasedProgramsWorkspaceTests`](https://github.com/dotnet/roslyn/blob/main/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/FileBasedProgramsWorkspaceTests.cs).

I used test case [`TestSemanticDiagnosticsNotEnabledWhenCoarseGrainedFlagDisabled(False)`](https://github.com/dotnet/roslyn/blob/53f6283d9ec8266a0cebafaeeb77611384c12738/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/FileBasedProgramsWorkspaceTests.cs#L252) as a reference. This test is not supposed to perform any design time builds, etc., so is expected to be "low cost" compared to many tests in this class.
- **Before the change, the test took ~9.6s** to run on my machine. (note that the simple right-click->run case takes double this due to needing to also run the case with `true` argument.)
- **After the change, the test took about ~2.8s** to run on my machine.
- To get the times I just right-clicked->ran the single test several times. Execution time variance didn't look significant. I think that when running the whole class, some of the work is amortized, as I was seeing ~1s execution times in that case.
- **"Real world" startup of the language server is also likely to benefit from this change.**
- Benefit appears to be specific to Windows. When I ran the same test on my mac, the before/after was more like 0.9s->1.0s (slight increase). It's possible that overhead of Windows-specific shadow copying and/or binary scanning is to blame here. On my Windows machine I do keep everything on a dev drive with async scanning etc turned on.

I was able to get some info using "Profile Test" in VS, and measuring "Async Activities". Unfortunately, it seems like the profiler doesn't have full ability to 'trace cause and effect', when, what we are essentially doing is sending a request into a stream, and another thread is reading it out. So, the information I got from the profiler, hinted at CreateTestLspServerAsync, and the Initialize request taking a long time specifically.

However, I wasn't able to get more details than that from the profiler data. Eventually I simply resorted to stepping thru the work the Initialize handler was doing, and literally just noticing when things 'felt slow', and finally sticking in `Log()` calls with timestamps to verify where the time was going. **It would be fantastic to work out how to do this better in the future.**

This is not great, and possibly represents me misusing the tools. But, in this case I was at least able to identify a major cause of the slowness. Creating an `AnalyzerFileReference` will cause us to crack the assembly file to get its name and stuff like that. Sometimes the wait time from that is significant. In practice there were ~45 analyzer DLLs to do this on. We were also doing essentially the exact same work back-to-back, so, sharing the resulting references array between host and misc workspaces, takes off ~0.5s from the test runtime.

<img width="1264" height="252" alt="image" src="https://github.com/user-attachments/assets/c50513b5-5c75-4ded-a47d-5dc0433efe62" />
