### PR TITLE
Add RegisterDeclarationOutput for two-phase source generation

### DIFF
--- a/docs/features/two-phase-source-generation.md
+++ b/docs/features/two-phase-source-generation.md
@@ -1,0 +1,229 @@
+# Two-Phase Source Generation
+
+## Summary
+
+This feature introduces a **declaration phase** to the incremental source generator pipeline, allowing generators to produce types and declarations that are visible to _other_ generators before their main source/implementation outputs run. This solves the long-standing problem that multiple source generators in the same project cannot see each other's output.
+
+Related: [dotnet/roslyn#81395](https://github.com/dotnet/roslyn/issues/81395)
+
+## Motivation
+
+Today, when multiple `IIncrementalGenerator` implementations are registered on the same project, each generator runs against the **original compilation** — none of them can see the types or source produced by any other generator. There is no defined ordering between generators, and the compiler makes no guarantee about execution order.
+
+This is a real limitation for generator ecosystems. Consider:
+
+- **Generator A** produces an `INotifyPropertyChanged` implementation with observable properties for classes annotated with `[ObservableProperty]`.
+- **Generator B** wants to discover all observable properties and generate data-binding glue code.
+
+Today, Generator B cannot see the types produced by Generator A. Users must resort to workarounds like multi-pass compilation, intermediate files, or tightly coupling generators.
+
+Roslyn already has a precedent for phased execution:
+
+| API | When it runs |
+|-----|-------------|
+| `RegisterPostInitializationOutput` | Before any pipeline execution; output is added to the compilation before generators run |
+| `RegisterSourceOutput` | Main pipeline execution |
+| `RegisterImplementationSourceOutput` | Main pipeline execution, but output is excluded from design-time builds |
+
+This feature adds a new phase between `PostInit` and `Source`:
+
+| API | Phase | Sees declarations? |
+|-----|-------|---------------------|
+| `RegisterPostInitializationOutput` | Phase 0 (pre-pipeline, constant) | N/A |
+| **`RegisterDeclarationOutput`** | **Phase 1 (declaration)** | No (original compilation only) |
+| `RegisterSourceOutput` | Phase 2 (source) | **No** (original compilation) |
+| `RegisterImplementationSourceOutput` | Phase 3 (implementation) | **Yes** (enriched compilation) |
+
+## Detailed Design
+
+### New Public API
+
+```csharp
+// New enum value
+public enum IncrementalGeneratorOutputKind
+{
+    // ... existing values ...
+    Declaration = 0b10000,   // = 16
+}
+
+// New methods on IncrementalGeneratorInitializationContext
+public void RegisterDeclarationOutput<TSource>(
+    IncrementalValueProvider<TSource> source,
+    Action<SourceProductionContext, TSource> action);
+
+public void RegisterDeclarationOutput<TSource>(
+    IncrementalValuesProvider<TSource> source,
+    Action<SourceProductionContext, TSource> action);
+
+// New constant
+public static class WellKnownGeneratorOutputs
+{
+    public const string DeclarationOutput = "DeclarationOutput";
+}
+```
+
+### Execution Model
+
+The `GeneratorDriver.RunGeneratorsCore` method now executes in three phases:
+
+```
+┌─────────────────────────────────────────────────┐
+│  Original Compilation (user source + PostInit)  │
+└──────────────────────┬──────────────────────────┘
+                       │
+        ┌──────────────▼──────────────┐
+        │       PHASE 1               │
+        │  Run Declaration outputs    │
+        │  for ALL generators         │
+        │  against original           │
+        │  compilation                │
+        └──────────────┬──────────────┘
+                       │
+        ┌──────────────▼──────────────┐
+        │  Enriched Compilation       │
+        │  = Original + all Phase 1   │
+        │    declaration trees        │
+        └──────────┬─────────┬────────┘
+                   │         │
+    ┌──────────────▼───┐ ┌───▼──────────────┐
+    │    PHASE 2       │ │    PHASE 3       │
+    │  Source + Host   │ │  Implementation  │
+    │  outputs against │ │  outputs against │
+    │  ORIGINAL        │ │  ENRICHED        │
+    │  compilation     │ │  compilation     │
+    └──────────────────┘ └─────────────────-┘
+```
+
+#### Phase 1 — Declaration
+
+1. For each generator, the driver checks whether any output nodes have `Kind == IncrementalGeneratorOutputKind.Declaration`.
+2. If so, a `DriverStateTable.Builder` is created against the **original compilation** (plus PostInit trees).
+3. Only `Declaration`-kind output nodes are executed via `UpdateOutputs`.
+4. The resulting source files are parsed into syntax trees and stored in `GeneratorState.DeclarationTrees`.
+5. All declaration trees from all generators are collected into a single list.
+
+#### Compilation Enrichment
+
+After Phase 1 completes for all generators, the driver calls:
+
+```csharp
+compilation = compilation.AddSyntaxTrees(allDeclarationTrees);
+```
+
+This produces an **enriched compilation** that contains the original source, PostInit trees, and all Phase 1 declaration trees.
+
+#### Phase 2 — Source and Host
+
+A `DriverStateTable.Builder` is created against the **original compilation** (without declaration trees). `Source` and `Host` outputs run here. These outputs do **not** see declaration trees from other generators — they see the same compilation as they would without the declaration feature.
+
+#### Phase 3 — Implementation
+
+A separate `DriverStateTable.Builder` is created against the **enriched compilation**. `Implementation` outputs run here. Because the compilation includes declaration trees, any generator's `CompilationProvider` in an `RegisterImplementationSourceOutput` callback will see types declared by other generators in Phase 1.
+
+This design is intentional: `RegisterSourceOutput` defines the **public API surface** visible at design time, while `RegisterImplementationSourceOutput` provides runtime implementation details. Cross-generator visibility belongs in the implementation phase to avoid design-time coupling between generators.
+
+### Key Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Phase 1 generators see only the original compilation | Prevents circular dependencies between declaration outputs. Generator A's declarations cannot depend on Generator B's declarations. |
+| Only Implementation outputs see Phase 1 declarations | `RegisterSourceOutput` defines the design-time API surface. Cross-generator visibility is intentionally limited to `RegisterImplementationSourceOutput` to avoid design-time coupling. |
+| Source and Host outputs see the original compilation | Ensures design-time builds are not affected by other generators' declarations. Source outputs remain deterministic and independent. |
+| Declaration outputs reuse `SourceOutputNode<T>` | Minimizes code duplication. The existing node infrastructure handles caching, cancellation, and step tracking. Only the `Kind` flag differs. |
+| Declaration trees are stored separately in `GeneratorState` | Allows independent tracking and the `WithDeclarationTrees()` update pattern, consistent with how `PostInitTrees` and `GeneratedTrees` are handled. |
+| Declaration trees are included in `GetRunResult()` | Ensures tooling and tests can observe all generated sources, including declarations. |
+
+### Impact on Existing Generators
+
+- **No breaking changes.** Generators that do not call `RegisterDeclarationOutput` behave identically to before. Phase 1 is a no-op if no generator has declaration outputs.
+- The `Declaration` output kind can be disabled via `GeneratorDriverOptions.DisabledOutputs`, consistent with how `Source` and `Implementation` can be disabled.
+- Existing `IncrementalGeneratorOutputKind` flag combinations continue to work as before.
+
+## Usage Example
+
+### Generator A: Produces observable property types (Phase 1)
+
+```csharp
+[Generator]
+public class ObservablePropertyGenerator : IIncrementalGenerator
+{
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        // Phase 1: Declare the generated types so other generators can see them
+        var classes = context.SyntaxProvider
+            .ForAttributeWithMetadataName("ObservablePropertyAttribute", ...);
+
+        context.RegisterDeclarationOutput(classes, (ctx, model) =>
+        {
+            // Emit the partial class with INotifyPropertyChanged
+            ctx.AddSource($"{model.ClassName}.g.cs", GenerateObservableClass(model));
+        });
+    }
+}
+```
+
+### Generator B: Consumes types from Generator A (Phase 3 — Implementation)
+
+```csharp
+[Generator]
+public class AutoBinderGenerator : IIncrementalGenerator
+{
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        // Phase 3 (Implementation): Can see types generated by ObservablePropertyGenerator
+        var observableTypes = context.CompilationProvider.Select((comp, ct) =>
+            comp.GetSymbolsWithName(s => true, SymbolFilter.Type)
+                .OfType<INamedTypeSymbol>()
+                .Where(t => t.Interfaces.Any(i => i.Name == "INotifyPropertyChanged"))
+                .ToList());
+
+        // Must use RegisterImplementationSourceOutput to see declaration outputs
+        context.RegisterImplementationSourceOutput(observableTypes, (ctx, types) =>
+        {
+            // Generate binding code for each observable type
+            ctx.AddSource("Bindings.g.cs", GenerateBindings(types));
+        });
+    }
+}
+```
+
+> **Note:** Using `RegisterSourceOutput` instead of `RegisterImplementationSourceOutput` would **not** see the types declared in Phase 1. This is by design — source outputs define the public API surface and should not depend on other generators' declarations.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/Compilers/Core/Portable/SourceGeneration/Nodes/IIncrementalGeneratorOutputNode.cs` | Added `Declaration = 0b10000` to `IncrementalGeneratorOutputKind` enum |
+| `src/Compilers/Core/Portable/SourceGeneration/WellKnownGeneratorOutputs.cs` | Added `DeclarationOutput` constant |
+| `src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs` | Updated `Debug.Assert` and step name to handle `Declaration` kind |
+| `src/Compilers/Core/Portable/SourceGeneration/IncrementalContexts.cs` | Added two `RegisterDeclarationOutput<TSource>()` overloads |
+| `src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs` | Added `DeclarationTrees` property, `WithDeclarationTrees()`, `RequiresDeclarationReparse()`; updated all constructors |
+| `src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs` | Two-phase execution in `RunGeneratorsCore`; updated `RunGeneratorsAndUpdateCompilation` and `GetRunResult` to include declaration trees |
+| `src/Compilers/Core/Portable/PublicAPI.Unshipped.txt` | 4 new public API entries |
+
+## Test Coverage
+
+10 new tests in `GeneratorDriverTests.cs`:
+
+| Test | What it validates |
+|------|-------------------|
+| `Declaration_Output_Is_Added_To_Compilation` | Single generator declares a type; the type exists in the output compilation |
+| `Declaration_Output_Visible_To_Other_Generator_Implementation_Output` | **Key test:** Generator 1 declares `GeneratedType` in Phase 1; Generator 2's `RegisterImplementationSourceOutput` sees it via `CompilationProvider` |
+| `Declaration_Output_Not_Visible_To_Other_Generator_Source_Output` | Generator 2's `RegisterSourceOutput` does **not** see Generator 1's Phase 1 declarations |
+| `Declaration_Output_Not_Visible_To_Own_Declaration_Output` | Phase 1 generators cannot see other Phase 1 generators' declarations (prevents cycles) |
+| `Declaration_And_Implementation_Same_Generator` | A single generator uses both `RegisterDeclarationOutput` and `RegisterImplementationSourceOutput` |
+| `Multiple_Generators_With_Declarations` | Three generators each declare types; each sees the others' declarations in `RegisterImplementationSourceOutput` |
+| `Declaration_Output_Can_Be_Disabled` | `Declaration` kind can be disabled via `GeneratorDriverOptions.DisabledOutputs` |
+| `Existing_Generators_Unaffected_By_Declaration_Phase` | Generators without declarations work identically |
+| `Declaration_Output_Tracked_In_Steps` | Step tracking includes declaration outputs |
+| `Declaration_Sources_Included_In_Run_Result` | `GetRunResult()` includes declaration sources |
+
+Additionally, the existing `Generator_Output_Kinds_Can_Be_Disabled` test was updated to include `Declaration` as an `[InlineData]` case.
+
+## Future Considerations
+
+- **Incremental caching**: Changes to declaration outputs should invalidate Phase 2 results. The current implementation re-runs both phases; a future optimization could track declaration tree identity to skip Phase 2 when declarations haven't changed.
+- **VB support**: `VisualBasicGeneratorDriver` should receive the same two-phase logic (currently only `CSharpGeneratorDriver` is affected via the shared `GeneratorDriver` base class).
+- **Performance**: The additional compilation creation (`AddSyntaxTrees`) in Phase 1 has a cost. For projects with many generators, profiling may be needed.
+- **IDE integration**: Design-time builds already understand `Implementation` vs `Source` for performance. Declaration outputs should be treated similarly to `Source` (included in design-time builds) since they define the API surface.
+- **Ordering within Phase 1**: Currently, Phase 1 generators run independently and cannot see each other's declarations. A future extension could introduce ordering hints or multiple declaration phases, but this significantly increases complexity.

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -3206,6 +3206,8 @@ class C { }
         [InlineData(IncrementalGeneratorOutputKind.Implementation | IncrementalGeneratorOutputKind.Host)]
         [InlineData(IncrementalGeneratorOutputKind.Source | IncrementalGeneratorOutputKind.Implementation | IncrementalGeneratorOutputKind.PostInit)]
         [InlineData(IncrementalGeneratorOutputKind.Source | IncrementalGeneratorOutputKind.Implementation | IncrementalGeneratorOutputKind.PostInit | IncrementalGeneratorOutputKind.Host)]
+        [InlineData(IncrementalGeneratorOutputKind.Source | IncrementalGeneratorOutputKind.Declaration)]
+        [InlineData(IncrementalGeneratorOutputKind.Source | IncrementalGeneratorOutputKind.Implementation | IncrementalGeneratorOutputKind.PostInit | IncrementalGeneratorOutputKind.Host | IncrementalGeneratorOutputKind.Declaration)]
         public void Generator_Output_Kinds_Can_Be_Disabled(IncrementalGeneratorOutputKind disabledOutput)
         {
             var source = @"
@@ -3222,6 +3224,7 @@ class C { }
                 ctx.RegisterSourceOutput(ctx.CompilationProvider, (context, ct) => context.AddSource("Source", ""));
                 ctx.RegisterImplementationSourceOutput(ctx.CompilationProvider, (context, ct) => context.AddSource("Implementation", ""));
                 ctx.RegisterHostOutput(ctx.CompilationOptionsProvider, (context, ct) => context.AddOutput("Host", ""));
+                ctx.RegisterDeclarationOutput(ctx.CompilationProvider, (context, ct) => context.AddSource("Declaration", ""));
             });
 
             GeneratorDriver driver = CSharpGeneratorDriver.Create(
@@ -4813,5 +4816,385 @@ class C { }
         }
 
 #pragma warning restore RSEXPERIMENTAL004 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+        #region Declaration Output Tests
+
+        [Fact]
+        public void Declaration_Output_Is_Added_To_Compilation()
+        {
+            var source = "class C { }";
+            var parseOptions = TestOptions.RegularPreview;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDllThrowing, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            var generator = new PipelineCallbackGenerator(ctx =>
+            {
+                ctx.RegisterDeclarationOutput(ctx.CompilationProvider, (spc, compilation) =>
+                {
+                    spc.AddSource("GeneratedType.decl.cs", "public class GeneratedType { public string Name { get; set; } }");
+                });
+            });
+
+            GeneratorDriver driver = CSharpGeneratorDriver.Create([generator.AsSourceGenerator()], parseOptions: parseOptions);
+            driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);
+
+            Assert.Empty(diagnostics);
+            var type = outputCompilation.GetTypeByMetadataName("GeneratedType");
+            Assert.NotNull(type);
+            var nameProperty = type.GetMembers("Name").Single();
+            Assert.Equal(SymbolKind.Property, nameProperty.Kind);
+        }
+
+        [Fact]
+        public void Declaration_Output_Visible_To_Other_Generator_Implementation_Output()
+        {
+            var source = "class C { }";
+            var parseOptions = TestOptions.RegularPreview;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDllThrowing, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            var generator1 = new PipelineCallbackGenerator(ctx =>
+            {
+                ctx.RegisterDeclarationOutput(ctx.CompilationProvider, (spc, compilation) =>
+                {
+                    spc.AddSource("GeneratedType.decl.cs", "public partial class GeneratedType { public string Name { get; set; } }");
+                });
+            });
+
+            bool generator2SawType = false;
+            var generator2 = new PipelineCallbackGenerator2(ctx =>
+            {
+                ctx.RegisterImplementationSourceOutput(ctx.CompilationProvider, (spc, compilation) =>
+                {
+                    // Implementation outputs should see declaration outputs from other generators
+                    var type = compilation.GetTypeByMetadataName("GeneratedType");
+                    if (type != null)
+                    {
+                        generator2SawType = true;
+                        spc.AddSource("Consumer.g.cs", "class Consumer { GeneratedType _field; }");
+                    }
+                });
+            });
+
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(
+                [generator1.AsSourceGenerator(), generator2.AsSourceGenerator()],
+                parseOptions: parseOptions);
+            driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);
+
+            Assert.Empty(diagnostics);
+            Assert.True(generator2SawType, "Generator2's implementation output should see GeneratedType from Generator1's declaration output");
+
+            // Verify both types exist in the output compilation
+            Assert.NotNull(outputCompilation.GetTypeByMetadataName("GeneratedType"));
+            Assert.NotNull(outputCompilation.GetTypeByMetadataName("Consumer"));
+        }
+
+        [Fact]
+        public void Declaration_Output_Not_Visible_To_Other_Generator_Source_Output()
+        {
+            var source = "class C { }";
+            var parseOptions = TestOptions.RegularPreview;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDllThrowing, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            var generator1 = new PipelineCallbackGenerator(ctx =>
+            {
+                ctx.RegisterDeclarationOutput(ctx.CompilationProvider, (spc, compilation) =>
+                {
+                    spc.AddSource("GeneratedType.decl.cs", "public class GeneratedType { }");
+                });
+            });
+
+            bool generator2SawType = false;
+            var generator2 = new PipelineCallbackGenerator2(ctx =>
+            {
+                ctx.RegisterSourceOutput(ctx.CompilationProvider, (spc, compilation) =>
+                {
+                    // Source outputs should NOT see declaration outputs from other generators
+                    var type = compilation.GetTypeByMetadataName("GeneratedType");
+                    generator2SawType = type != null;
+                    spc.AddSource("Consumer.g.cs", "class Consumer { }");
+                });
+            });
+
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(
+                [generator1.AsSourceGenerator(), generator2.AsSourceGenerator()],
+                parseOptions: parseOptions);
+            driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);
+
+            Assert.Empty(diagnostics);
+            Assert.False(generator2SawType, "Generator2's source output should NOT see declaration outputs");
+
+            // Both types should still be in the final output compilation
+            Assert.NotNull(outputCompilation.GetTypeByMetadataName("GeneratedType"));
+            Assert.NotNull(outputCompilation.GetTypeByMetadataName("Consumer"));
+        }
+
+        [Fact]
+        public void Declaration_Output_Not_Visible_To_Own_Declaration_Output()
+        {
+            var source = "class C { }";
+            var parseOptions = TestOptions.RegularPreview;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDllThrowing, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            bool generator2SawGenerator1DeclType = false;
+            var generator1 = new PipelineCallbackGenerator(ctx =>
+            {
+                ctx.RegisterDeclarationOutput(ctx.CompilationProvider, (spc, compilation) =>
+                {
+                    spc.AddSource("TypeA.decl.cs", "public class TypeA { }");
+                });
+            });
+
+            var generator2 = new PipelineCallbackGenerator2(ctx =>
+            {
+                ctx.RegisterDeclarationOutput(ctx.CompilationProvider, (spc, compilation) =>
+                {
+                    // During Phase 1, other generators' declaration outputs should NOT be visible
+                    var typeA = compilation.GetTypeByMetadataName("TypeA");
+                    generator2SawGenerator1DeclType = typeA != null;
+                    spc.AddSource("TypeB.decl.cs", "public class TypeB { }");
+                });
+            });
+
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(
+                [generator1.AsSourceGenerator(), generator2.AsSourceGenerator()],
+                parseOptions: parseOptions);
+            driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);
+
+            Assert.Empty(diagnostics);
+            Assert.False(generator2SawGenerator1DeclType, "Phase 1 outputs should not see other generators' Phase 1 outputs");
+
+            // Both declarations should be in the final compilation
+            Assert.NotNull(outputCompilation.GetTypeByMetadataName("TypeA"));
+            Assert.NotNull(outputCompilation.GetTypeByMetadataName("TypeB"));
+        }
+
+        [Fact]
+        public void Declaration_And_Implementation_Same_Generator()
+        {
+            var source = "class C { }";
+            var parseOptions = TestOptions.RegularPreview;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDllThrowing, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            var generator = new PipelineCallbackGenerator(ctx =>
+            {
+                ctx.RegisterDeclarationOutput(ctx.CompilationProvider, (spc, compilation) =>
+                {
+                    spc.AddSource("MyService.decl.cs", "public partial class MyService { partial void Execute(); }");
+                });
+
+                ctx.RegisterImplementationSourceOutput(ctx.CompilationProvider, (spc, compilation) =>
+                {
+                    spc.AddSource("MyService.impl.cs", "public partial class MyService { partial void Execute() { } }");
+                });
+            });
+
+            GeneratorDriver driver = CSharpGeneratorDriver.Create([generator.AsSourceGenerator()], parseOptions: parseOptions);
+            driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);
+
+            Assert.Empty(diagnostics);
+            var type = outputCompilation.GetTypeByMetadataName("MyService");
+            Assert.NotNull(type);
+            var methods = type.GetMembers("Execute");
+            Assert.NotEmpty(methods);
+        }
+
+        [Fact]
+        public void Multiple_Generators_With_Declarations()
+        {
+            var source = "class C { }";
+            var parseOptions = TestOptions.RegularPreview;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDllThrowing, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            bool gen1SawOthers = false, gen2SawOthers = false, gen3SawOthers = false;
+
+            var generator1 = new PipelineCallbackGenerator(ctx =>
+            {
+                ctx.RegisterDeclarationOutput(ctx.CompilationProvider, (spc, compilation) =>
+                {
+                    spc.AddSource("TypeA.decl.cs", "public class TypeA { }");
+                });
+                ctx.RegisterImplementationSourceOutput(ctx.CompilationProvider, (spc, compilation) =>
+                {
+                    gen1SawOthers = compilation.GetTypeByMetadataName("TypeB") != null
+                                 && compilation.GetTypeByMetadataName("TypeC") != null;
+                });
+            });
+
+            var generator2 = new PipelineCallbackGenerator2(ctx =>
+            {
+                ctx.RegisterDeclarationOutput(ctx.CompilationProvider, (spc, compilation) =>
+                {
+                    spc.AddSource("TypeB.decl.cs", "public class TypeB { }");
+                });
+                ctx.RegisterImplementationSourceOutput(ctx.CompilationProvider, (spc, compilation) =>
+                {
+                    gen2SawOthers = compilation.GetTypeByMetadataName("TypeA") != null
+                                 && compilation.GetTypeByMetadataName("TypeC") != null;
+                });
+            });
+
+            var generator3 = new PipelineCallbackGenerator3(ctx =>
+            {
+                ctx.RegisterDeclarationOutput(ctx.CompilationProvider, (spc, compilation) =>
+                {
+                    spc.AddSource("TypeC.decl.cs", "public class TypeC { }");
+                });
+                ctx.RegisterImplementationSourceOutput(ctx.CompilationProvider, (spc, compilation) =>
+                {
+                    gen3SawOthers = compilation.GetTypeByMetadataName("TypeA") != null
+                                 && compilation.GetTypeByMetadataName("TypeB") != null;
+                });
+            });
+
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(
+                [generator1.AsSourceGenerator(), generator2.AsSourceGenerator(), generator3.AsSourceGenerator()],
+                parseOptions: parseOptions);
+            driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);
+
+            Assert.Empty(diagnostics);
+            Assert.True(gen1SawOthers, "Generator1 implementation output should see TypeB and TypeC from other generators' declarations");
+            Assert.True(gen2SawOthers, "Generator2 implementation output should see TypeA and TypeC from other generators' declarations");
+            Assert.True(gen3SawOthers, "Generator3 implementation output should see TypeA and TypeB from other generators' declarations");
+        }
+
+        [Fact]
+        public void Declaration_Output_Can_Be_Disabled()
+        {
+            var source = "class C { }";
+            var parseOptions = TestOptions.RegularPreview;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDllThrowing, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            var generator = new PipelineCallbackGenerator(ctx =>
+            {
+                ctx.RegisterDeclarationOutput(ctx.CompilationProvider, (spc, compilation) =>
+                {
+                    spc.AddSource("GeneratedType.decl.cs", "public class GeneratedType { }");
+                });
+                ctx.RegisterSourceOutput(ctx.CompilationProvider, (spc, compilation) =>
+                {
+                    spc.AddSource("Other.g.cs", "class Other { }");
+                });
+            });
+
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(
+                generators: [generator.AsSourceGenerator()],
+                driverOptions: new GeneratorDriverOptions(IncrementalGeneratorOutputKind.Declaration),
+                parseOptions: parseOptions);
+            driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);
+
+            Assert.Empty(diagnostics);
+
+            // Declaration output should be disabled
+            Assert.Null(outputCompilation.GetTypeByMetadataName("GeneratedType"));
+
+            // Source output should still work
+            Assert.NotNull(outputCompilation.GetTypeByMetadataName("Other"));
+        }
+
+        [Fact]
+        public void Existing_Generators_Unaffected_By_Declaration_Phase()
+        {
+            var source = "class C { }";
+            var parseOptions = TestOptions.RegularPreview;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDllThrowing, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            var generator = new PipelineCallbackGenerator(ctx =>
+            {
+                ctx.RegisterSourceOutput(ctx.CompilationProvider, (spc, compilation) =>
+                {
+                    spc.AddSource("Generated.g.cs", "class Generated { }");
+                });
+            });
+
+            GeneratorDriver driver = CSharpGeneratorDriver.Create([generator.AsSourceGenerator()], parseOptions: parseOptions);
+            driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);
+
+            Assert.Empty(diagnostics);
+            Assert.NotNull(outputCompilation.GetTypeByMetadataName("Generated"));
+            outputCompilation.VerifyDiagnostics();
+
+            var runResult = driver.GetRunResult();
+            Assert.Single(runResult.Results);
+            Assert.Single(runResult.Results[0].GeneratedSources);
+        }
+
+        [Fact]
+        public void Declaration_Output_Tracked_In_Steps()
+        {
+            var source = "class C { }";
+            var parseOptions = TestOptions.RegularPreview;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDllThrowing, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            var generator = new PipelineCallbackGenerator(ctx =>
+            {
+                ctx.RegisterDeclarationOutput(ctx.CompilationProvider, (spc, compilation) =>
+                {
+                    spc.AddSource("GeneratedType.decl.cs", "public class GeneratedType { }");
+                });
+                ctx.RegisterSourceOutput(ctx.CompilationProvider, (spc, compilation) =>
+                {
+                    spc.AddSource("Other.g.cs", "class Other { }");
+                });
+            });
+
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(
+                [generator.AsSourceGenerator()],
+                parseOptions: parseOptions,
+                driverOptions: TestOptions.GeneratorDriverOptions);
+            driver = driver.RunGenerators(compilation);
+
+            var runResult = driver.GetRunResult();
+            var result = runResult.Results.Single();
+
+            // Source output tracked steps should still work
+            Assert.True(result.TrackedOutputSteps.ContainsKey(WellKnownGeneratorOutputs.SourceOutput),
+                "Source output should be tracked in steps");
+
+            // Declaration sources should appear in generated sources
+            Assert.Equal(2, result.GeneratedSources.Length);
+            Assert.Contains(result.GeneratedSources, s => s.HintName == "GeneratedType.decl.cs");
+        }
+
+        [Fact]
+        public void Declaration_Sources_Included_In_Run_Result()
+        {
+            var source = "class C { }";
+            var parseOptions = TestOptions.RegularPreview;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDllThrowing, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            var generator = new PipelineCallbackGenerator(ctx =>
+            {
+                ctx.RegisterDeclarationOutput(ctx.CompilationProvider, (spc, compilation) =>
+                {
+                    spc.AddSource("GeneratedType.decl.cs", "public class GeneratedType { }");
+                });
+                ctx.RegisterSourceOutput(ctx.CompilationProvider, (spc, compilation) =>
+                {
+                    spc.AddSource("Other.g.cs", "class Other { }");
+                });
+            });
+
+            GeneratorDriver driver = CSharpGeneratorDriver.Create([generator.AsSourceGenerator()], parseOptions: parseOptions);
+            driver = driver.RunGenerators(compilation);
+
+            var runResult = driver.GetRunResult();
+            var result = runResult.Results.Single();
+
+            // Both declaration and source outputs should be in GeneratedSources
+            Assert.Equal(2, result.GeneratedSources.Length);
+            Assert.Contains(result.GeneratedSources, s => s.HintName == "GeneratedType.decl.cs");
+            Assert.Contains(result.GeneratedSources, s => s.HintName == "Other.g.cs");
+        }
+
+        #endregion
     }
 }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -4,6 +4,10 @@ Microsoft.CodeAnalysis.Text.SourceHashAlgorithm.Sha512 = 4 -> Microsoft.CodeAnal
 Microsoft.CodeAnalysis.Emit.EmitDifferenceOptions.MethodImplEntriesSupported.init -> void
 Microsoft.CodeAnalysis.IMethodSymbol.ReduceExtensionMember(Microsoft.CodeAnalysis.ITypeSymbol! receiverType) -> Microsoft.CodeAnalysis.IMethodSymbol?
 Microsoft.CodeAnalysis.IPropertySymbol.ReduceExtensionMember(Microsoft.CodeAnalysis.ITypeSymbol! receiverType) -> Microsoft.CodeAnalysis.IPropertySymbol?
+Microsoft.CodeAnalysis.IncrementalGeneratorOutputKind.Declaration = 16 -> Microsoft.CodeAnalysis.IncrementalGeneratorOutputKind
+Microsoft.CodeAnalysis.IncrementalGeneratorInitializationContext.RegisterDeclarationOutput<TSource>(Microsoft.CodeAnalysis.IncrementalValueProvider<TSource> source, System.Action<Microsoft.CodeAnalysis.SourceProductionContext, TSource>! action) -> void
+Microsoft.CodeAnalysis.IncrementalGeneratorInitializationContext.RegisterDeclarationOutput<TSource>(Microsoft.CodeAnalysis.IncrementalValuesProvider<TSource> source, System.Action<Microsoft.CodeAnalysis.SourceProductionContext, TSource>! action) -> void
+Microsoft.CodeAnalysis.WellKnownGeneratorOutputs.DeclarationOutput = "DeclarationOutput" -> string!
 [RSEXPERIMENTAL006]Microsoft.CodeAnalysis.OperationKind.CollectionExpressionElementsPlaceholder = 129 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.Operations.ICollectionExpressionOperation.ConstructArguments.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.IOperation!>
 [RSEXPERIMENTAL006]Microsoft.CodeAnalysis.Operations.ICollectionExpressionElementsPlaceholderOperation

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -74,6 +74,7 @@ namespace Microsoft.CodeAnalysis
             foreach (var generatorState in state.GeneratorStates)
             {
                 trees.AddRange(generatorState.PostInitTrees.Select(t => t.Tree));
+                trees.AddRange(generatorState.DeclarationTrees.Select(t => t.Tree));
                 trees.AddRange(generatorState.GeneratedTrees.Select(t => t.Tree));
             }
             outputCompilation = compilation.AddSyntaxTrees(trees);
@@ -191,8 +192,12 @@ namespace Microsoft.CodeAnalysis
                     return default;
                 }
 
-                ArrayBuilder<GeneratedSourceResult> sources = ArrayBuilder<GeneratedSourceResult>.GetInstance(generatorState.PostInitTrees.Length + generatorState.GeneratedTrees.Length);
+                ArrayBuilder<GeneratedSourceResult> sources = ArrayBuilder<GeneratedSourceResult>.GetInstance(generatorState.PostInitTrees.Length + generatorState.DeclarationTrees.Length + generatorState.GeneratedTrees.Length);
                 foreach (var tree in generatorState.PostInitTrees)
+                {
+                    sources.Add(new GeneratedSourceResult(tree.Tree, tree.Text, tree.HintName));
+                }
+                foreach (var tree in generatorState.DeclarationTrees)
                 {
                     sources.Add(new GeneratedSourceResult(tree.Tree, tree.Text, tree.HintName));
                 }
@@ -306,9 +311,66 @@ namespace Microsoft.CodeAnalysis
             }
             constantSourcesBuilder.Free();
 
-            var syntaxStoreBuilder = _state.SyntaxStore.ToBuilder(compilation, syntaxInputNodes.ToImmutableAndFree(), _state.TrackIncrementalSteps, cancellationToken);
+            // === Phase 1: Run Declaration outputs for all generators ===
+            var syntaxInputNodesArray = syntaxInputNodes.ToImmutableAndFree();
+            var declarationTreesBuilder = ArrayBuilder<SyntaxTree>.GetInstance();
+            for (int i = 0; i < state.IncrementalGenerators.Length; i++)
+            {
+                var generatorState = stateBuilder[i];
+                if (shouldSkipGenerator(state.Generators[i]) || generatorState.OutputNodes.Length == 0)
+                {
+                    continue;
+                }
 
-            var driverStateBuilder = new DriverStateTable.Builder(compilation, _state, syntaxStoreBuilder, cancellationToken);
+                // Check if this generator has any declaration outputs
+                bool hasDeclarationOutputs = false;
+                foreach (var node in generatorState.OutputNodes)
+                {
+                    if (node.Kind == IncrementalGeneratorOutputKind.Declaration)
+                    {
+                        hasDeclarationOutputs = true;
+                        break;
+                    }
+                }
+
+                if (!hasDeclarationOutputs)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var declSyntaxStoreBuilder = _state.SyntaxStore.ToBuilder(compilation, syntaxInputNodesArray, _state.TrackIncrementalSteps, cancellationToken);
+                    var declDriverStateBuilder = new DriverStateTable.Builder(compilation, _state, declSyntaxStoreBuilder, cancellationToken);
+                    var declContext = UpdateOutputs(generatorState.OutputNodes, IncrementalGeneratorOutputKind.Declaration, new GeneratorRunStateTable.Builder(state.TrackIncrementalSteps), cancellationToken, declDriverStateBuilder);
+                    (var declSources, var declDiagnostics, var declRunStateTable, _) = declContext.ToImmutableAndFree();
+                    var declTrees = ParseAdditionalSources(state.Generators[i], declSources, cancellationToken);
+
+                    // Store declaration trees in the generator state
+                    stateBuilder[i] = generatorState.WithDeclarationTrees(declTrees);
+
+                    // Collect declaration trees for enriching the compilation
+                    declarationTreesBuilder.AddRange(declTrees.Select(t => t.Tree));
+                }
+                catch (UserFunctionException ufe) when (handleGeneratorException(compilation, MessageProvider, state.Generators[i], ufe.InnerException, isInit: false))
+                {
+                    stateBuilder[i] = SetGeneratorException(compilation, MessageProvider, generatorState, state.Generators[i], ufe.InnerException, diagnosticsBag, cancellationToken);
+                }
+            }
+
+            // Enrich the compilation with all declaration trees
+            bool hasDeclarations = declarationTreesBuilder.Count > 0;
+            var originalCompilation = compilation;
+            if (hasDeclarations)
+            {
+                compilation = compilation.AddSyntaxTrees(declarationTreesBuilder);
+            }
+            declarationTreesBuilder.Free();
+
+            // === Phase 2: Run Source and Host outputs against the ORIGINAL compilation ===
+            // Declaration outputs are only visible to Implementation outputs (Phase 3).
+            var syntaxStoreBuilder = _state.SyntaxStore.ToBuilder(originalCompilation, syntaxInputNodesArray, _state.TrackIncrementalSteps, cancellationToken);
+            var driverStateBuilder = new DriverStateTable.Builder(originalCompilation, _state, syntaxStoreBuilder, cancellationToken);
             for (int i = 0; i < state.IncrementalGenerators.Length; i++)
             {
                 var generatorState = stateBuilder[i];
@@ -320,20 +382,56 @@ namespace Microsoft.CodeAnalysis
                 using var generatorTimer = CodeAnalysisEventSource.Log.CreateSingleGeneratorRunTimer(state.Generators[i], (t) => t.Add(syntaxStoreBuilder.GetRuntimeAdjustment(stateBuilder[i].InputNodes)));
                 try
                 {
-                    // We do not support incremental step tracking for v1 generators, as the pipeline is implicitly defined.
-                    var context = UpdateOutputs(generatorState.OutputNodes, IncrementalGeneratorOutputKind.Source | IncrementalGeneratorOutputKind.Implementation | IncrementalGeneratorOutputKind.Host, new GeneratorRunStateTable.Builder(state.TrackIncrementalSteps), cancellationToken, driverStateBuilder);
+                    var context = UpdateOutputs(generatorState.OutputNodes, IncrementalGeneratorOutputKind.Source | IncrementalGeneratorOutputKind.Host, new GeneratorRunStateTable.Builder(state.TrackIncrementalSteps), cancellationToken, driverStateBuilder);
                     (var sources, var generatorDiagnostics, var generatorRunStateTable, var hostOutputs) = context.ToImmutableAndFree();
-                    generatorDiagnostics = FilterDiagnostics(compilation, generatorDiagnostics, driverDiagnostics: diagnosticsBag, cancellationToken);
+                    generatorDiagnostics = FilterDiagnostics(originalCompilation, generatorDiagnostics, driverDiagnostics: diagnosticsBag, cancellationToken);
 
                     stateBuilder[i] = generatorState.WithResults(ParseAdditionalSources(state.Generators[i], sources, cancellationToken), generatorDiagnostics, generatorRunStateTable.ExecutedSteps, generatorRunStateTable.OutputSteps, hostOutputs, generatorTimer.Elapsed);
                 }
-                catch (UserFunctionException ufe) when (handleGeneratorException(compilation, MessageProvider, state.Generators[i], ufe.InnerException, isInit: false))
+                catch (UserFunctionException ufe) when (handleGeneratorException(originalCompilation, MessageProvider, state.Generators[i], ufe.InnerException, isInit: false))
                 {
-                    stateBuilder[i] = SetGeneratorException(compilation, MessageProvider, generatorState, state.Generators[i], ufe.InnerException, diagnosticsBag, cancellationToken, runTime: generatorTimer.Elapsed);
+                    stateBuilder[i] = SetGeneratorException(originalCompilation, MessageProvider, generatorState, state.Generators[i], ufe.InnerException, diagnosticsBag, cancellationToken, runTime: generatorTimer.Elapsed);
                 }
             }
 
-            state = state.With(stateTable: driverStateBuilder.ToImmutable(), syntaxStore: syntaxStoreBuilder.ToImmutable(), generatorStates: stateBuilder.ToImmutableAndFree(), runTime: timer.Elapsed);
+            // === Phase 3: Run Implementation outputs against the ENRICHED compilation ===
+            // Implementation outputs can see declaration trees from all generators.
+            var implSyntaxStoreBuilder = _state.SyntaxStore.ToBuilder(compilation, syntaxInputNodesArray, _state.TrackIncrementalSteps, cancellationToken);
+            var implDriverStateBuilder = new DriverStateTable.Builder(compilation, _state, implSyntaxStoreBuilder, cancellationToken);
+            for (int i = 0; i < state.IncrementalGenerators.Length; i++)
+            {
+                var generatorState = stateBuilder[i];
+                if (shouldSkipGenerator(state.Generators[i]) || generatorState.OutputNodes.Length == 0)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var context = UpdateOutputs(generatorState.OutputNodes, IncrementalGeneratorOutputKind.Implementation, new GeneratorRunStateTable.Builder(state.TrackIncrementalSteps), cancellationToken, implDriverStateBuilder);
+                    (var implSources, var implDiagnostics, var implRunStateTable, _) = context.ToImmutableAndFree();
+                    implDiagnostics = FilterDiagnostics(compilation, implDiagnostics, driverDiagnostics: diagnosticsBag, cancellationToken);
+
+                    if (implSources.Length > 0 || implDiagnostics.Length > 0)
+                    {
+                        var implTrees = ParseAdditionalSources(state.Generators[i], implSources, cancellationToken);
+
+                        // Merge implementation results with the existing Source/Host results
+                        var mergedTrees = generatorState.GeneratedTrees.AddRange(implTrees);
+                        var mergedDiagnostics = generatorState.Diagnostics.AddRange(implDiagnostics);
+                        var mergedExecutedSteps = generatorState.ExecutedSteps.SetItems(implRunStateTable.ExecutedSteps);
+                        var mergedOutputSteps = generatorState.OutputSteps.SetItems(implRunStateTable.OutputSteps);
+
+                        stateBuilder[i] = generatorState.WithResults(mergedTrees, mergedDiagnostics, mergedExecutedSteps, mergedOutputSteps, generatorState.HostOutputs, generatorState.ElapsedTime);
+                    }
+                }
+                catch (UserFunctionException ufe) when (handleGeneratorException(compilation, MessageProvider, state.Generators[i], ufe.InnerException, isInit: false))
+                {
+                    stateBuilder[i] = SetGeneratorException(compilation, MessageProvider, generatorState, state.Generators[i], ufe.InnerException, diagnosticsBag, cancellationToken);
+                }
+            }
+
+            state = state.With(stateTable: implDriverStateBuilder.ToImmutable(), syntaxStore: implSyntaxStoreBuilder.ToImmutable(), generatorStates: stateBuilder.ToImmutableAndFree(), runTime: timer.Elapsed);
             return state;
 
             static bool handleGeneratorException(Compilation compilation, CommonMessageProvider messageProvider, ISourceGenerator sourceGenerator, Exception e, bool isInit)

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorState.cs
@@ -19,6 +19,7 @@ namespace Microsoft.CodeAnalysis
         /// A generator state that has been initialized but produced no results
         /// </summary>
         public static readonly GeneratorState Empty = new GeneratorState(ImmutableArray<GeneratedSyntaxTree>.Empty,
+                                                                         ImmutableArray<GeneratedSyntaxTree>.Empty,
                                                                          ImmutableArray<SyntaxInputNode>.Empty,
                                                                          ImmutableArray<IIncrementalGeneratorOutputNode>.Empty,
                                                                          ImmutableArray<GeneratedSyntaxTree>.Empty,
@@ -34,6 +35,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public GeneratorState(ImmutableArray<GeneratedSyntaxTree> postInitTrees, ImmutableArray<SyntaxInputNode> inputNodes, ImmutableArray<IIncrementalGeneratorOutputNode> outputNodes)
             : this(postInitTrees,
+                   ImmutableArray<GeneratedSyntaxTree>.Empty,
                    inputNodes,
                    outputNodes,
                    ImmutableArray<GeneratedSyntaxTree>.Empty,
@@ -48,6 +50,7 @@ namespace Microsoft.CodeAnalysis
 
         private GeneratorState(
             ImmutableArray<GeneratedSyntaxTree> postInitTrees,
+            ImmutableArray<GeneratedSyntaxTree> declarationTrees,
             ImmutableArray<SyntaxInputNode> inputNodes,
             ImmutableArray<IIncrementalGeneratorOutputNode> outputNodes,
             ImmutableArray<GeneratedSyntaxTree> generatedTrees,
@@ -60,6 +63,7 @@ namespace Microsoft.CodeAnalysis
         {
             this.Initialized = true;
             this.PostInitTrees = postInitTrees;
+            this.DeclarationTrees = declarationTrees;
             this.InputNodes = inputNodes;
             this.OutputNodes = outputNodes;
             this.GeneratedTrees = generatedTrees;
@@ -79,6 +83,7 @@ namespace Microsoft.CodeAnalysis
                                           TimeSpan elapsedTime)
         {
             return new GeneratorState(this.PostInitTrees,
+                                      this.DeclarationTrees,
                                       this.InputNodes,
                                       this.OutputNodes,
                                       generatedTrees,
@@ -93,6 +98,7 @@ namespace Microsoft.CodeAnalysis
         public GeneratorState WithError(Exception exception, Diagnostic error, TimeSpan elapsedTime)
         {
             return new GeneratorState(this.PostInitTrees,
+                                      this.DeclarationTrees,
                                       this.InputNodes,
                                       this.OutputNodes,
                                       ImmutableArray<GeneratedSyntaxTree>.Empty,
@@ -107,6 +113,8 @@ namespace Microsoft.CodeAnalysis
         internal bool Initialized { get; }
 
         internal ImmutableArray<GeneratedSyntaxTree> PostInitTrees { get; }
+
+        internal ImmutableArray<GeneratedSyntaxTree> DeclarationTrees { get; }
 
         internal ImmutableArray<SyntaxInputNode> InputNodes { get; }
 
@@ -127,5 +135,22 @@ namespace Microsoft.CodeAnalysis
         internal ImmutableDictionary<string, object> HostOutputs { get; }
 
         internal bool RequiresPostInitReparse(ParseOptions parseOptions) => PostInitTrees.Any(static (t, parseOptions) => t.Tree.Options != parseOptions, parseOptions);
+
+        internal bool RequiresDeclarationReparse(ParseOptions parseOptions) => DeclarationTrees.Any(static (t, parseOptions) => t.Tree.Options != parseOptions, parseOptions);
+
+        public GeneratorState WithDeclarationTrees(ImmutableArray<GeneratedSyntaxTree> declarationTrees)
+        {
+            return new GeneratorState(this.PostInitTrees,
+                                      declarationTrees,
+                                      this.InputNodes,
+                                      this.OutputNodes,
+                                      this.GeneratedTrees,
+                                      this.Diagnostics,
+                                      this.ExecutedSteps,
+                                      this.OutputSteps,
+                                      this.HostOutputs,
+                                      this.Exception,
+                                      this.ElapsedTime);
+        }
     }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/IncrementalContexts.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/IncrementalContexts.cs
@@ -130,6 +130,20 @@ namespace Microsoft.CodeAnalysis
         public void RegisterImplementationSourceOutput<TSource>(IncrementalValuesProvider<TSource> source, Action<SourceProductionContext, TSource> action) => RegisterSourceOutput(source.Node, action, IncrementalGeneratorOutputKind.Implementation, _sourceExtension);
 
         /// <summary>
+        /// Registers a declaration output that runs in Phase 1, before regular source outputs.
+        /// Declaration outputs from all generators are added to the compilation before Phase 2 runs,
+        /// allowing other generators to see the declared types in their source outputs.
+        /// </summary>
+        public void RegisterDeclarationOutput<TSource>(IncrementalValueProvider<TSource> source, Action<SourceProductionContext, TSource> action) => RegisterSourceOutput(source.Node, action, IncrementalGeneratorOutputKind.Declaration, _sourceExtension);
+
+        /// <summary>
+        /// Registers a declaration output that runs in Phase 1, before regular source outputs.
+        /// Declaration outputs from all generators are added to the compilation before Phase 2 runs,
+        /// allowing other generators to see the declared types in their source outputs.
+        /// </summary>
+        public void RegisterDeclarationOutput<TSource>(IncrementalValuesProvider<TSource> source, Action<SourceProductionContext, TSource> action) => RegisterSourceOutput(source.Node, action, IncrementalGeneratorOutputKind.Declaration, _sourceExtension);
+
+        /// <summary>
         /// Registers a callback that will be invoked once, before any other source generation occurs.
         /// This is typically used to add source code that should be available for subsequent generation steps, such as attribute definitions.
         /// Use <see cref="IncrementalGeneratorPostInitializationContext.AddEmbeddedAttributeDefinition"/> to add the EmbeddedAttribute which marks generated types as internal to the current assembly.

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/IIncrementalGeneratorOutputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/IIncrementalGeneratorOutputNode.cs
@@ -55,5 +55,10 @@ namespace Microsoft.CodeAnalysis
         /// or <see cref="IncrementalGeneratorInitializationContext.RegisterHostOutput{TSource}(IncrementalValuesProvider{TSource}, Action{HostOutputProductionContext, TSource})"/>
         /// </summary>
         Host = 0b1000,
+
+        /// <summary>
+        /// A declaration output that runs in Phase 1 and is visible to other generators in Phase 2.
+        /// </summary>
+        Declaration = 0b10000,
     }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis
             _source = source;
             _action = action;
 
-            Debug.Assert(outputKind == IncrementalGeneratorOutputKind.Source || outputKind == IncrementalGeneratorOutputKind.Implementation);
+            Debug.Assert(outputKind == IncrementalGeneratorOutputKind.Source || outputKind == IncrementalGeneratorOutputKind.Implementation || outputKind == IncrementalGeneratorOutputKind.Declaration);
             _outputKind = outputKind;
             _sourceExtension = sourceExtension;
         }
@@ -39,7 +39,12 @@ namespace Microsoft.CodeAnalysis
 
         public NodeStateTable<TOutput> UpdateStateTable(DriverStateTable.Builder graphState, NodeStateTable<TOutput>? previousTable, CancellationToken cancellationToken)
         {
-            string stepName = Kind == IncrementalGeneratorOutputKind.Source ? WellKnownGeneratorOutputs.SourceOutput : WellKnownGeneratorOutputs.ImplementationSourceOutput;
+            string stepName = Kind switch
+            {
+                IncrementalGeneratorOutputKind.Source => WellKnownGeneratorOutputs.SourceOutput,
+                IncrementalGeneratorOutputKind.Declaration => WellKnownGeneratorOutputs.DeclarationOutput,
+                _ => WellKnownGeneratorOutputs.ImplementationSourceOutput,
+            };
             var sourceTable = graphState.GetLatestStateTableForNode(_source);
             if (sourceTable.IsCached && previousTable is not null)
             {

--- a/src/Compilers/Core/Portable/SourceGeneration/WellKnownGeneratorOutputs.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/WellKnownGeneratorOutputs.cs
@@ -12,5 +12,7 @@ namespace Microsoft.CodeAnalysis
         public const string SourceOutput = nameof(SourceOutput);
 
         public const string ImplementationSourceOutput = nameof(ImplementationSourceOutput);
+
+        public const string DeclarationOutput = nameof(DeclarationOutput);
     }
 }

--- a/src/Compilers/Test/Core/SourceGeneration/TestGenerators.cs
+++ b/src/Compilers/Test/Core/SourceGeneration/TestGenerators.cs
@@ -186,6 +186,18 @@ namespace Roslyn.Test.Utilities.TestGenerators
         public void Initialize(IncrementalGeneratorInitializationContext context) => _registerPipelineCallback(context);
     }
 
+    internal sealed class PipelineCallbackGenerator3 : IIncrementalGenerator
+    {
+        private readonly Action<IncrementalGeneratorInitializationContext> _registerPipelineCallback;
+
+        public PipelineCallbackGenerator3(Action<IncrementalGeneratorInitializationContext> registerPipelineCallback)
+        {
+            _registerPipelineCallback = registerPipelineCallback;
+        }
+
+        public void Initialize(IncrementalGeneratorInitializationContext context) => _registerPipelineCallback(context);
+    }
+
     internal sealed class IncrementalAndSourceCallbackGenerator : CallbackGenerator, IIncrementalGenerator
     {
         private readonly Action<IncrementalGeneratorInitializationContext> _onInit;


### PR DESCRIPTION
## Summary

This PR introduces a **declaration phase** to the incremental source generator pipeline via a new `RegisterDeclarationOutput` API, allowing generators to produce types and declarations that are visible to *other* generators' `RegisterImplementationSourceOutput` callbacks.

Fixes #81395

## Motivation

Today, multiple `IIncrementalGenerator` implementations in the same project each run against the original compilation — none can see the types produced by other generators. This limits generator ecosystems where one generator produces types that another needs to consume.

## Design

The generator driver now executes in three phases:

| API | Phase | Sees declarations? |
|-----|-------|---------------------|
| `RegisterPostInitializationOutput` | Phase 0 (constant) | N/A |
| `RegisterDeclarationOutput` | Phase 1 (declaration) | No (original compilation) |
| `RegisterSourceOutput` | Phase 2 (source) | No (original compilation) |
| `RegisterImplementationSourceOutput` | Phase 3 (implementation) | **Yes** (enriched compilation) |

- **Phase 1**: Declaration outputs from all generators run against the original compilation
- **Enrichment**: All declaration trees are added to produce an enriched compilation
- **Phase 2**: Source + Host outputs run against the **original** compilation (unchanged behavior)
- **Phase 3**: Implementation outputs run against the **enriched** compilation (can see declarations from all generators)

This ensures `RegisterSourceOutput` (design-time API surface) remains independent, while `RegisterImplementationSourceOutput` (runtime details) gains cross-generator visibility.

## New Public API

```csharp
// New enum value
IncrementalGeneratorOutputKind.Declaration = 16

// New methods
void RegisterDeclarationOutput<TSource>(IncrementalValueProvider<TSource>, Action<SourceProductionContext, TSource>)
void RegisterDeclarationOutput<TSource>(IncrementalValuesProvider<TSource>, Action<SourceProductionContext, TSource>)

// New constant
WellKnownGeneratorOutputs.DeclarationOutput = "DeclarationOutput"
```

## Test Coverage

10 new tests covering:
- Declaration output added to compilation
- Cross-generator visibility via implementation output (**key test**)
- Source output does NOT see declarations (by design)
- Phase 1 isolation (no circular dependencies)
- Same-generator declaration + implementation
- Multi-generator scenarios (3 generators)
- Disabling declaration output kind
- Backward compatibility for existing generators
- Step tracking and run result inclusion

Full spec: [docs/features/two-phase-source-generation.md](docs/features/two-phase-source-generation.md)