### PR TITLE
Fix async try-syntax assert in lock/using/fixed lowering

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FixedStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FixedStatement.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return _factory.Block(
                     localBuilder.ToImmutableAndFree(),
                     new BoundTryStatement(
-                        _factory.Syntax,
+                        node.Syntax,
                         _factory.Block(statementBuilder.ToImmutableAndFree()),
                         ImmutableArray<BoundCatchBlock>.Empty,
                         _factory.Block(cleanup)));

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_LockStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_LockStatement.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var expressionStatement = new BoundExpressionStatement(rewrittenArgument.Syntax, tempAssignment);
 
                 BoundStatement tryFinally = RewriteUsingStatementTryFinally(
-                    rewrittenArgument.Syntax,
+                    lockSyntax,
                     rewrittenArgument.Syntax,
                     tryBlock,
                     boundTemp,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
@@ -416,8 +416,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             // try { ... } finally { if (local != null) local.Dispose(); }
             // or
             // nullable or await variants
+            var trySyntax = SyntaxBindingUtilities.BindsToTryStatement(resourceSyntax) ? resourceSyntax : resourceTypeSyntax;
+
             BoundStatement tryFinally = new BoundTryStatement(
-                syntax: resourceSyntax,
+                syntax: trySyntax,
                 tryBlock: tryBlock,
                 catchBlocks: ImmutableArray<BoundCatchBlock>.Empty,
                 finallyBlockOpt: BoundBlock.SynthesizedNoLocals(resourceSyntax, finallyStatement));

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxBindingUtilities.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxBindingUtilities.cs
@@ -22,6 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                     or UsingStatementSyntax { Expression: not null }
                     or CommonForEachStatementSyntax
                     or TryStatementSyntax
+                    or FixedStatementSyntax
                     or LockStatementSyntax;
     }
 }

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/LockTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/LockTests.cs
@@ -2368,6 +2368,47 @@ public class LockTests : CSharpTestBase
             """);
     }
 
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/80996")]
+    public void AsyncMethod_LockMemberAccess_WithAwaitInFinally()
+    {
+        var source = """
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            class Holder
+            {
+                public Lock L = new();
+            }
+
+            class C
+            {
+                static async Task Main()
+                {
+                    var h = new Holder();
+
+                    if (System.Environment.TickCount < 0)
+                    {
+                        lock (h.L)
+                        {
+                        }
+                    }
+
+                    try
+                    {
+                    }
+                    finally
+                    {
+                        await Task.Yield();
+                    }
+                }
+            }
+            """;
+
+        var verifier = CompileAndVerify([source, LockTypeDefinition], options: TestOptions.DebugExe,
+            verify: Verification.FailsILVerify);
+        verifier.VerifyDiagnostics();
+    }
+
     [Fact]
     public void AsyncMethod_AwaitResource()
     {

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxBindingUtilitiesTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxBindingUtilitiesTests.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    public class SyntaxBindingUtilitiesTests
+    {
+        [Fact]
+        public void BindsToTryStatement_IncludesFixedAndStatementForms()
+        {
+            var fixedStatement = (FixedStatementSyntax)SyntaxFactory.ParseStatement("fixed (int* p = null) { }");
+            Assert.True(SyntaxBindingUtilities.BindsToTryStatement(fixedStatement));
+
+            var lockStatement = (LockStatementSyntax)SyntaxFactory.ParseStatement("lock (obj.Member) { }");
+            Assert.True(SyntaxBindingUtilities.BindsToTryStatement(lockStatement));
+            Assert.False(SyntaxBindingUtilities.BindsToTryStatement(lockStatement.Expression));
+
+            var usingStatement = (UsingStatementSyntax)SyntaxFactory.ParseStatement("using (obj.Member) { }");
+            Assert.True(SyntaxBindingUtilities.BindsToTryStatement(usingStatement));
+
+            var usingDeclaration = (LocalDeclarationStatementSyntax)SyntaxFactory.ParseStatement("using var x = obj.Member;");
+            var variableDeclarator = usingDeclaration.Declaration.Variables.Single();
+            Assert.True(SyntaxBindingUtilities.BindsToTryStatement(variableDeclarator));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This fixes a Debug-only assert in `AsyncExceptionHandlerRewriter` hit during an RDM Core replay compile.
Fixes https://github.com/dotnet/roslyn/issues/36797

The assertion was:

- `SyntaxBindingUtilities.BindsToTryStatement(tryStatementSyntax)`

## Trigger pattern

A real-world async method shape triggered this in RDM Core:

- async method containing `await` in a `finally`
- with a `lock` that lowers through the `using`-style lock path
- lock target expressed as member access (for example `lock (holder.Member)`)

In that path, synthesized `BoundTryStatement` nodes could carry expression syntax (`SimpleMemberAccessExpression`) instead of a statement syntax that `BindsToTryStatement` recognizes.

## Root cause

`AsyncExceptionHandlerRewriter` expects try-like bound nodes to be anchored to syntax forms that are valid for try/state-machine mapping. Some lowering paths were assigning syntax anchors too narrowly (or using ambient factory syntax), so the invariant failed in Debug builds.

## Fix

1. In fixed-statement lowering, anchor synthesized try syntax on `node.Syntax`.

2. In lock lowering (the `System.Threading.Lock` using-style path), pass `lock` statement syntax as the try anchor instead of lock argument expression syntax.

3. In using lowering, normalize try syntax anchor: use `resourceSyntax` when it binds to try, otherwise fall back to `resourceTypeSyntax`.

4. Extend `SyntaxBindingUtilities.BindsToTryStatement` to include `FixedStatementSyntax`.

## Tests

Added targeted regressions:

- `LockTests.AsyncMethod_LockMemberAccess_WithAwaitInFinally` (Emit3/Semantics)
- `SyntaxBindingUtilitiesTests.BindsToTryStatement_IncludesFixedAndStatementForms` (Syntax)

Also validated by running the `LockTests` class and broader Emit3 test sweep.

## Why this is safe

The change is syntactic anchoring/classification only (no semantic behavior changes in lowering algorithm). It preserves the existing invariant while ensuring synthesized try nodes use appropriate statement-level syntax forms.
