### PR TITLE
Only add reference counts on CodeLens elements that are supported

### DIFF
--- a/src/VisualStudio/CodeLens/ReferenceCodeLensProvider.cs
+++ b/src/VisualStudio/CodeLens/ReferenceCodeLensProvider.cs
@@ -67,13 +67,13 @@ internal sealed class ReferenceCodeLensProvider : IAsyncCodeLensDataPointProvide
     {
         if (descriptorContext != null && descriptorContext.ApplicableSpan.HasValue)
         {
-            // we allow all reference points. 
-            // engine will call this for all points our roslyn code lens (reference) tagger tagged.
-            return SpecializedTasks.True;
+            return IsSupportedCodeElement(descriptor.Kind) ? SpecializedTasks.True : SpecializedTasks.False;
         }
 
         return SpecializedTasks.False;
     }
+
+    private static bool IsSupportedCodeElement(CodeElementKinds kinds) => (kinds & CodeElementKinds.Type) != 0 || (kinds & CodeElementKinds.Member) != 0;
 
     public Task<IAsyncCodeLensDataPoint> CreateDataPointAsync(
         CodeLensDescriptor descriptor, CodeLensDescriptorContext descriptorContext, CancellationToken cancellationToken)
@@ -231,6 +231,10 @@ internal sealed class ReferenceCodeLensProvider : IAsyncCodeLensDataPointProvide
                         return FeaturesResources.type;
                     case CodeElementKinds.Property:
                         return FeaturesResources.property_;
+                    case CodeElementKinds.Field:
+                        return FeaturesResources.field;
+                    case CodeElementKinds.Event:
+                        return FeaturesResources.event_;
                     default:
                         // code lens engine will catch and ignore exception
                         // basically not showing data point


### PR DESCRIPTION
In the Tools for Unity team, we're working on a set of new features where we want to display CodeLens information on C# constructs that are Unity specific.

We're creating our own tagger for the `CSharp` content type and are tagging specific Unity constructs with `CodeElementKinds.Unspecified` that our OOP DataPoint provider picks up.

That's working nicely but the Roslyn ReferenceCodeLensProvider is kicking-in for any CodeLens tag in a `CSharp` document, showing an empty `- references` CodeLens tag.

In this PR I'm restricting the Visual Studio `ReferenceCodeLensProvider ` to be enabled only for CodeElementKinds that the VS CodeLens tagger knows how to semantically tag so it's not interfering with other taggers.
