### PR TITLE
Only cache diagnostics for legacy projects

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
@@ -93,6 +93,10 @@ internal interface IDiagnosticAnalyzerService : IWorkspaceService
         DiagnosticKind diagnosticKind,
         CancellationToken cancellationToken);
 
+    /// <inheritdoc cref="HostDiagnosticAnalyzers.GetAllDiagnosticIds"/>
+    Task<ImmutableHashSet<string>> GetAllDiagnosticIdsAsync(
+        Solution solution, ProjectId? projectId, CancellationToken cancellationToken);
+
     /// <inheritdoc cref="HostDiagnosticAnalyzers.GetDiagnosticDescriptorsPerReference"/>
     Task<ImmutableDictionary<string, ImmutableArray<DiagnosticDescriptor>>> GetDiagnosticDescriptorsPerReferenceAsync(
         Solution solution, ProjectId? projectId, CancellationToken cancellationToken);

--- a/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
@@ -94,8 +94,8 @@ internal interface IDiagnosticAnalyzerService : IWorkspaceService
         CancellationToken cancellationToken);
 
     /// <inheritdoc cref="HostDiagnosticAnalyzers.GetAllDiagnosticIds"/>
-    Task<ImmutableHashSet<string>> GetAllDiagnosticIdsAsync(
-        Solution solution, ProjectId? projectId, CancellationToken cancellationToken);
+    Task<ImmutableDictionary<ProjectId, ImmutableHashSet<string>>> GetAllDiagnosticIdsAsync(
+        Solution solution, ImmutableArray<ProjectId> projectIds, CancellationToken cancellationToken);
 
     /// <inheritdoc cref="HostDiagnosticAnalyzers.GetDiagnosticDescriptorsPerReference"/>
     Task<ImmutableDictionary<string, ImmutableArray<DiagnosticDescriptor>>> GetDiagnosticDescriptorsPerReferenceAsync(

--- a/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService_RemoteOrLocalDispatcher.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService_RemoteOrLocalDispatcher.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -100,6 +99,27 @@ internal sealed partial class DiagnosticAnalyzerService : IDiagnosticAnalyzerSer
         }
 
         return builder.ToImmutableArray();
+    }
+
+    public async Task<ImmutableHashSet<string>> GetAllDiagnosticIdsAsync(
+        Solution solution, ProjectId? projectId, CancellationToken cancellationToken)
+    {
+        var client = await RemoteHostClient.TryGetClientAsync(solution.Services, cancellationToken).ConfigureAwait(false);
+        if (client is not null)
+        {
+            var list = await client.TryInvokeAsync<IRemoteDiagnosticAnalyzerService, ImmutableHashSet<string>>(
+                solution,
+                (service, solution, cancellationToken) => service.GetAllDiagnosticIdsAsync(
+                    solution, projectId, cancellationToken),
+                cancellationToken).ConfigureAwait(false);
+            if (!list.HasValue)
+                return [];
+
+            return list.Value;
+        }
+
+        return solution.SolutionState.Analyzers.GetAllDiagnosticIds(
+            this._analyzerInfoCache, solution.GetProject(projectId));
     }
 
     public async Task<ImmutableDictionary<string, ImmutableArray<DiagnosticDescriptor>>> GetDiagnosticDescriptorsPerReferenceAsync(

--- a/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService_RemoteOrLocalDispatcher.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService_RemoteOrLocalDispatcher.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Remote;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Diagnostics;
@@ -101,16 +102,16 @@ internal sealed partial class DiagnosticAnalyzerService : IDiagnosticAnalyzerSer
         return builder.ToImmutableArray();
     }
 
-    public async Task<ImmutableHashSet<string>> GetAllDiagnosticIdsAsync(
-        Solution solution, ProjectId? projectId, CancellationToken cancellationToken)
+    public async Task<ImmutableDictionary<ProjectId, ImmutableHashSet<string>>> GetAllDiagnosticIdsAsync(
+        Solution solution, ImmutableArray<ProjectId> projectIds, CancellationToken cancellationToken)
     {
         var client = await RemoteHostClient.TryGetClientAsync(solution.Services, cancellationToken).ConfigureAwait(false);
         if (client is not null)
         {
-            var list = await client.TryInvokeAsync<IRemoteDiagnosticAnalyzerService, ImmutableHashSet<string>>(
+            var list = await client.TryInvokeAsync<IRemoteDiagnosticAnalyzerService, ImmutableDictionary<ProjectId, ImmutableHashSet<string>>>(
                 solution,
                 (service, solution, cancellationToken) => service.GetAllDiagnosticIdsAsync(
-                    solution, projectId, cancellationToken),
+                    solution, projectIds, cancellationToken),
                 cancellationToken).ConfigureAwait(false);
             if (!list.HasValue)
                 return [];
@@ -118,8 +119,13 @@ internal sealed partial class DiagnosticAnalyzerService : IDiagnosticAnalyzerSer
             return list.Value;
         }
 
+        var builder = ImmutableArray.CreateBuilder<Project>();
+
+        foreach (var projectId in projectIds)
+            builder.Add(solution.GetRequiredProject(projectId));
+
         return solution.SolutionState.Analyzers.GetAllDiagnosticIds(
-            this._analyzerInfoCache, solution.GetProject(projectId));
+            this._analyzerInfoCache, builder.ToImmutable());
     }
 
     public async Task<ImmutableDictionary<string, ImmutableArray<DiagnosticDescriptor>>> GetDiagnosticDescriptorsPerReferenceAsync(

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CSharpHelpers.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CSharpHelpers.cs
@@ -15,7 +15,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.UnitTests;
-using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim;
 using Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim.Interop;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.CPS;
@@ -29,22 +28,10 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim;
 internal static class CSharpHelpers
 {
     public static CSharpProjectShim CreateCSharpProject(TestEnvironment environment, string projectName)
-    {
-        var projectBinPath = Path.GetTempPath();
-        var hierarchy = environment.CreateHierarchy(projectName, projectBinPath, projectRefPath: null, projectCapabilities: "CSharp");
-
-        return CreateCSharpProject(environment, projectName, hierarchy);
-    }
+        => Microsoft.VisualStudio.LanguageServices.UnitTests.CSharpHelpers.CSharpHelpers.CreateCSharpProject(environment, projectName);
 
     public static CSharpProjectShim CreateCSharpProject(TestEnvironment environment, string projectName, IVsHierarchy hierarchy)
-    {
-        return new CSharpProjectShim(
-            new MockCSharpProjectRoot(hierarchy),
-            projectSystemName: projectName,
-            hierarchy: hierarchy,
-            serviceProvider: environment.ServiceProvider,
-            threadingContext: environment.ThreadingContext);
-    }
+        => Microsoft.VisualStudio.LanguageServices.UnitTests.CSharpHelpers.CSharpHelpers.CreateCSharpProject(environment, projectName, hierarchy);
 
     public static Task<CPSProject> CreateCSharpCPSProjectAsync(TestEnvironment environment, string projectName, params string[] commandLineArguments)
     {
@@ -137,82 +124,6 @@ internal static class CSharpHelpers
             }
 
             return CSharpCommandLineParser.Default.Parse(arguments, baseDirectory, sdkDirectory);
-        }
-    }
-
-    private sealed class MockCSharpProjectRoot : ICSharpProjectRoot
-    {
-        private readonly IVsHierarchy _hierarchy;
-
-        public MockCSharpProjectRoot(IVsHierarchy hierarchy)
-        {
-            _hierarchy = hierarchy;
-        }
-
-        int ICSharpProjectRoot.BelongsToProject(string pszFileName)
-        {
-            throw new NotImplementedException();
-        }
-
-        string ICSharpProjectRoot.BuildPerConfigCacheFileName()
-        {
-            throw new NotImplementedException();
-        }
-
-        bool ICSharpProjectRoot.CanCreateFileCodeModel(string pszFile)
-        {
-            throw new NotImplementedException();
-        }
-
-        void ICSharpProjectRoot.ConfigureCompiler(ICSCompiler compiler, ICSInputSet inputSet, bool addSources)
-        {
-            throw new NotImplementedException();
-        }
-
-        object ICSharpProjectRoot.CreateFileCodeModel(string pszFile, ref Guid riid)
-        {
-            throw new NotImplementedException();
-        }
-
-        string ICSharpProjectRoot.GetActiveConfigurationName()
-        {
-            throw new NotImplementedException();
-        }
-
-        string ICSharpProjectRoot.GetFullProjectName()
-        {
-            throw new NotImplementedException();
-        }
-
-        int ICSharpProjectRoot.GetHierarchyAndItemID(string pszFile, out IVsHierarchy ppHier, out uint pItemID)
-        {
-            ppHier = _hierarchy;
-
-            // Each item should have it's own ItemID, but for simplicity we'll just hard-code a value of
-            // no particular significance.
-            pItemID = 42;
-
-            return VSConstants.S_OK;
-        }
-
-        void ICSharpProjectRoot.GetHierarchyAndItemIDOptionallyInProject(string pszFile, out IVsHierarchy ppHier, out uint pItemID, bool mustBeInProject)
-        {
-            throw new NotImplementedException();
-        }
-
-        string ICSharpProjectRoot.GetProjectLocation()
-        {
-            throw new NotImplementedException();
-        }
-
-        object ICSharpProjectRoot.GetProjectSite(ref Guid riid)
-        {
-            throw new NotImplementedException();
-        }
-
-        void ICSharpProjectRoot.SetProjectSite(ICSharpProjectSite site)
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject.cs
@@ -19,6 +19,7 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel;
 using Microsoft.VisualStudio.LanguageServices.Implementation.TaskList;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem.Legacy;
+using Microsoft.VisualStudio.LanguageServices.TaskList;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Roslyn.Utilities;
@@ -147,6 +148,9 @@ internal abstract partial class AbstractLegacyProject
         RefreshBinOutputPath();
 
         var projectHierarchyGuid = GetProjectIDGuid(hierarchy);
+
+        var diagnosticCache = workspaceImpl.Services.GetService<VisualStudioDiagnosticIdCache>();
+        diagnosticCache.RegisterProject(ProjectSystemProject.Id);
 
         _externalErrorReporter = new ProjectExternalErrorReporter(ProjectSystemProject.Id, projectHierarchyGuid, externalErrorReportingPrefix, language, workspaceImpl);
         _batchScopeCreator = componentModel.GetService<SolutionEventsBatchScopeCreator>();

--- a/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject.cs
@@ -149,7 +149,7 @@ internal abstract partial class AbstractLegacyProject
 
         var projectHierarchyGuid = GetProjectIDGuid(hierarchy);
 
-        var diagnosticCache = workspaceImpl.Services.GetService<VisualStudioDiagnosticIdCache>();
+        var diagnosticCache = workspaceImpl.Services.GetRequiredService<VisualStudioDiagnosticIdCache>();
         diagnosticCache.RegisterProject(ProjectSystemProject.Id);
 
         _externalErrorReporter = new ProjectExternalErrorReporter(ProjectSystemProject.Id, projectHierarchyGuid, externalErrorReportingPrefix, language, workspaceImpl);

--- a/src/VisualStudio/Core/Def/TaskList/ExternalErrorDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/TaskList/ExternalErrorDiagnosticUpdateSource.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Diagnostics;
@@ -20,7 +19,7 @@ using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Threading;
 using Microsoft.ServiceHub.Framework;
-using Microsoft.VisualStudio.Debugger.ComponentInterfaces;
+using Microsoft.VisualStudio.LanguageServices.TaskList;
 using Microsoft.VisualStudio.RpcContracts.DiagnosticManagement;
 using Microsoft.VisualStudio.RpcContracts.Utilities;
 using Microsoft.VisualStudio.Shell;
@@ -118,13 +117,13 @@ internal sealed class ExternalErrorDiagnosticUpdateSource : IDisposable
     /// for the given <paramref name="projectId"/> during the current build in progress.
     /// This API is only intended to be invoked from <see cref="ProjectExternalErrorReporter"/> while a build is in progress.
     /// </summary>
-    public async Task<bool> IsSupportedDiagnosticIdAsync(ProjectId projectId, string id, CancellationToken cancellationToken)
+    public bool IsUnsupportedDiagnosticId(ProjectId projectId, string id)
     {
         var state = GetBuildInProgressState();
         if (state is null)
-            return false;
+            return true;
 
-        return await state.IsSupportedDiagnosticIdAsync(projectId, id, cancellationToken).ConfigureAwait(false);
+        return state.IsUnsupportedDiagnosticId(projectId, id);
     }
 
     public void ClearErrors(ProjectId projectId)
@@ -324,42 +323,26 @@ internal sealed class ExternalErrorDiagnosticUpdateSource : IDisposable
 
     private sealed class InProgressState(Solution solution)
     {
-        /// <summary>
-        /// Map from project ID to all the possible analyzer diagnostic IDs that can be reported in the project.
-        /// </summary>
-        private ImmutableDictionary<ProjectId, AsyncLazy<ImmutableHashSet<string>>> _allDiagnosticIdMap = ImmutableDictionary<ProjectId, AsyncLazy<ImmutableHashSet<string>>>.Empty;
+        private readonly VisualStudioDiagnosticIdCache _diagnosticIdCache = solution.Workspace.Services.GetRequiredService<VisualStudioDiagnosticIdCache>();
 
         public Solution Solution { get; } = solution;
 
-        public async Task<bool> IsSupportedDiagnosticIdAsync(ProjectId projectId, string id, CancellationToken cancellationToken)
+        public bool IsUnsupportedDiagnosticId(ProjectId projectId, string id)
         {
-            var lazyIds = _allDiagnosticIdMap.TryGetValue(projectId, out var temp)
-                ? temp
-                : GetLazyIdsSlow();
-
-            var ids = await lazyIds.GetValueAsync(cancellationToken).ConfigureAwait(false);
-            return ids.Contains(id);
-
-            AsyncLazy<ImmutableHashSet<string>> GetLazyIdsSlow()
+            var project = Solution.GetProject(projectId);
+            if (project is null)
             {
-                return ImmutableInterlocked.GetOrAdd(ref _allDiagnosticIdMap, projectId, projectId => AsyncLazy.Create(async cancellationToken =>
-                {
-                    var project = Solution.GetProject(projectId);
-                    if (project == null)
-                    {
-                        // projectId no longer exist
-                        return [];
-                    }
-
-                    // set ids set
-                    var builder = ImmutableHashSet.CreateBuilder<string>();
-                    var service = this.Solution.Services.GetRequiredService<IDiagnosticAnalyzerService>();
-                    var descriptorMap = await service.GetDiagnosticDescriptorsPerReferenceAsync(project, cancellationToken).ConfigureAwait(false);
-                    builder.UnionWith(descriptorMap.Values.SelectMany(v => v.Select(d => d.Id)));
-
-                    return builder.ToImmutable();
-                }));
+                return true;
             }
+
+            if (_diagnosticIdCache.TryGetDiagnosticIds(projectId, out var supportedIds))
+            {
+                return !supportedIds.Contains(id);
+            }
+
+            // The cache hasn't been populated yet. We will report false because we do not know
+            // for certain that we do not support the diagnostic id.
+            return false;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/TaskList/ExternalErrorDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/TaskList/ExternalErrorDiagnosticUpdateSource.cs
@@ -40,6 +40,7 @@ internal sealed class ExternalErrorDiagnosticUpdateSource : IDisposable
 {
     private readonly Workspace _workspace;
     private readonly IServiceBroker _serviceBroker;
+    private readonly VisualStudioDiagnosticIdCache _diagnosticCache;
 
     /// <summary>
     /// Task queue to serialize all the work for errors reported by build.
@@ -68,6 +69,7 @@ internal sealed class ExternalErrorDiagnosticUpdateSource : IDisposable
         IThreadingContext threadingContext)
     {
         _workspace = workspace;
+        _diagnosticCache = workspace.Services.GetRequiredService<VisualStudioDiagnosticIdCache>();
 
         _serviceBroker = serviceBroker;
         _taskQueue = new AsyncBatchingWorkQueue<Func<CancellationToken, Task>>(
@@ -140,6 +142,10 @@ internal sealed class ExternalErrorDiagnosticUpdateSource : IDisposable
     /// </summary>
     internal void OnSolutionBuildStarted()
     {
+        // We want the diagnostic cache to be up-to-date when building so that we 
+        // can correctly report unsupported diagnostic ids back to VS.
+        _diagnosticCache.Refresh();
+
         _ = GetOrCreateInProgressState();
 
         _taskQueue.AddWork(async cancellationToken =>
@@ -316,24 +322,14 @@ internal sealed class ExternalErrorDiagnosticUpdateSource : IDisposable
             // We take current snapshot of solution when the state is first created. and through out this code, we use this snapshot.
             // Since we have no idea what actual snapshot of solution the out of proc build has picked up, it doesn't remove the race we can have
             // between build and diagnostic service, but this at least make us to consistent inside of our code.
-            _stateDoNotAccessDirectly ??= new InProgressState(_workspace.CurrentSolution);
+            _stateDoNotAccessDirectly ??= new InProgressState(_workspace.CurrentSolution, _diagnosticCache);
             return _stateDoNotAccessDirectly;
         }
     }
 
-    private sealed class InProgressState
+    private sealed class InProgressState(Solution solution, VisualStudioDiagnosticIdCache diagnosticIdCache)
     {
-        private readonly VisualStudioDiagnosticIdCache _diagnosticIdCache;
-
-        public InProgressState(Solution solution)
-        {
-            _diagnosticIdCache = solution.Workspace.Services.GetRequiredService<VisualStudioDiagnosticIdCache>();
-            _diagnosticIdCache.Refresh();
-
-            Solution = solution;
-        }
-
-        public Solution Solution { get; }
+        public Solution Solution { get; } = solution;
 
         public bool IsUnsupportedDiagnosticId(ProjectId projectId, string id)
         {
@@ -343,7 +339,7 @@ internal sealed class ExternalErrorDiagnosticUpdateSource : IDisposable
                 return true;
             }
 
-            if (_diagnosticIdCache.TryGetDiagnosticIds(projectId, out var supportedIds))
+            if (diagnosticIdCache.TryGetDiagnosticIds(projectId, out var supportedIds))
             {
                 return !supportedIds.Contains(id);
             }

--- a/src/VisualStudio/Core/Def/TaskList/ExternalErrorDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/TaskList/ExternalErrorDiagnosticUpdateSource.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -321,11 +321,19 @@ internal sealed class ExternalErrorDiagnosticUpdateSource : IDisposable
         }
     }
 
-    private sealed class InProgressState(Solution solution)
+    private sealed class InProgressState
     {
-        private readonly VisualStudioDiagnosticIdCache _diagnosticIdCache = solution.Workspace.Services.GetRequiredService<VisualStudioDiagnosticIdCache>();
+        private readonly VisualStudioDiagnosticIdCache _diagnosticIdCache;
 
-        public Solution Solution { get; } = solution;
+        public InProgressState(Solution solution)
+        {
+            _diagnosticIdCache = solution.Workspace.Services.GetRequiredService<VisualStudioDiagnosticIdCache>();
+            _diagnosticIdCache.Refresh();
+
+            Solution = solution;
+        }
+
+        public Solution Solution { get; }
 
         public bool IsUnsupportedDiagnosticId(ProjectId projectId, string id)
         {

--- a/src/VisualStudio/Core/Def/TaskList/ProjectExternalErrorReporter.cs
+++ b/src/VisualStudio/Core/Def/TaskList/ProjectExternalErrorReporter.cs
@@ -7,7 +7,6 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -200,21 +199,27 @@ internal sealed class ProjectExternalErrorReporter(
         int iEndColumn,
         string bstrFileName)
     {
-
         // make sure we have error id, otherwise, we simple don't support
         // this error
-        if (bstrErrorId == null)
+        if (string.IsNullOrEmpty(bstrErrorId))
         {
-            // record NFW to see who violates contract.
-            FatalError.ReportAndCatch(new Exception("errorId is null"));
-            return;
+            if (bstrErrorId is null)
+            {
+                // record NFW to see who violates contract.
+                FatalError.ReportAndCatch(new Exception("errorId is null"));
+            }
+
+            throw new NotImplementedException();
         }
 
-        if (!bstrErrorId.StartsWith(_errorCodePrefix))
-            return;
+        if (!bstrErrorId.StartsWith(_errorCodePrefix) &&
+            DiagnosticProvider.IsUnsupportedDiagnosticId(_projectId, bstrErrorId))
+        {
+            throw new NotImplementedException();
+        }
 
         if ((iEndLine >= 0 && iEndColumn >= 0) &&
-           ((iEndLine < iStartLine) ||
+            ((iEndLine < iStartLine) ||
             (iEndLine == iStartLine && iEndColumn < iStartColumn)))
         {
             throw new ArgumentException(ServicesVSResources.End_position_must_be_start_position);

--- a/src/VisualStudio/Core/Def/TaskList/VisualStudioDiagnosticIdCache.cs
+++ b/src/VisualStudio/Core/Def/TaskList/VisualStudioDiagnosticIdCache.cs
@@ -1,0 +1,126 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Collections;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.CodeAnalysis.Threading;
+
+namespace Microsoft.VisualStudio.LanguageServices.TaskList;
+
+[ExportWorkspaceServiceFactory(typeof(VisualStudioDiagnosticIdCache)), Shared]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class VisualStudioDiagnosticIdCacheFactory(
+    IThreadingContext threadingContext,
+    IAsynchronousOperationListenerProvider listenerProvider) : IWorkspaceServiceFactory
+{
+    public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
+    {
+        return new VisualStudioDiagnosticIdCache(
+            workspaceServices.Workspace,
+            threadingContext,
+            listenerProvider);
+    }
+}
+
+internal class VisualStudioDiagnosticIdCache : IWorkspaceService
+{
+    // This dictionary maps ProjectIds to a descriptor list.
+    private readonly ConcurrentDictionary<ProjectId, ImmutableHashSet<string>> _projectIdToDiagnosticIdsCache = [];
+    private readonly AsyncBatchingWorkQueue<ProjectId> _projectDescriptorRefreshQueue;
+
+    private readonly Workspace _workspace;
+    private readonly IDiagnosticAnalyzerService _analyzerService;
+    private readonly IAsynchronousOperationListener _listener;
+
+    public VisualStudioDiagnosticIdCache(
+        Workspace workspace,
+        IThreadingContext threadingContext,
+        IAsynchronousOperationListenerProvider listenerProvider)
+    {
+        _workspace = workspace;
+        _analyzerService = workspace.Services.GetRequiredService<IDiagnosticAnalyzerService>();
+        _listener = listenerProvider.GetListener(FeatureAttribute.DiagnosticService);
+
+        _projectDescriptorRefreshQueue = new AsyncBatchingWorkQueue<ProjectId>(
+            delay: DelayTimeSpan.Short,
+            processBatchAsync: RefreshCachedDiagnosticIdsAsync,
+            equalityComparer: EqualityComparer<ProjectId>.Default,
+            asyncListener: _listener,
+            cancellationToken: threadingContext.DisposalToken);
+
+        _workspace.RegisterWorkspaceChangedHandler(WorkspaceChanged);
+
+        foreach (var projectId in _workspace.CurrentSolution.ProjectIds)
+        {
+            _projectDescriptorRefreshQueue.AddWork(projectId);
+        }
+    }
+
+    public bool TryGetDiagnosticIds(ProjectId projectId, [NotNullWhen(returnValue: true)] out ImmutableHashSet<string>? diagnosticIds)
+        => _projectIdToDiagnosticIdsCache.TryGetValue(projectId, out diagnosticIds);
+
+    private void WorkspaceChanged(WorkspaceChangeEventArgs e)
+    {
+        var workspaceChanges = e.NewSolution.GetChanges(e.OldSolution);
+
+        foreach (var addedProject in workspaceChanges.GetAddedProjects())
+        {
+            _projectDescriptorRefreshQueue.AddWork(addedProject.Id);
+        }
+
+        foreach (var removedProject in workspaceChanges.GetRemovedProjects())
+        {
+            _projectDescriptorRefreshQueue.AddWork(removedProject.Id);
+        }
+
+        foreach (var projectChange in workspaceChanges.GetProjectChanges())
+        {
+            var oldProject = projectChange.OldProject;
+            var newProject = projectChange.NewProject;
+
+            var analyzersChanged = !oldProject.AnalyzerReferences.Equals(newProject.AnalyzerReferences);
+            if (analyzersChanged)
+            {
+                _projectDescriptorRefreshQueue.AddWork(projectChange.NewProject.Id);
+            }
+        }
+    }
+
+    private async ValueTask RefreshCachedDiagnosticIdsAsync(
+        ImmutableSegmentedList<ProjectId> projectIds,
+        CancellationToken cancellationToken)
+    {
+        foreach (var projectId in projectIds)
+        {
+            var project = _workspace.CurrentSolution.GetProject(projectId);
+            if (project == null)
+            {
+                _projectIdToDiagnosticIdsCache.TryRemove(projectId, out _);
+                continue;
+            }
+
+            var descriptorMap = await _analyzerService.GetDiagnosticDescriptorsPerReferenceAsync(
+                project.Solution,
+                project.Id,
+                cancellationToken).ConfigureAwait(false);
+
+            _projectIdToDiagnosticIdsCache[project.Id] = [.. descriptorMap.Values.SelectMany(static descriptors => descriptors.Select(descriptor => descriptor.Id))];
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/TaskList/VisualStudioDiagnosticIdCache.cs
+++ b/src/VisualStudio/Core/Def/TaskList/VisualStudioDiagnosticIdCache.cs
@@ -43,7 +43,12 @@ internal class VisualStudioDiagnosticIdCache : IWorkspaceService
     /// <summary>
     /// This dictionary maps ProjectIds to a set of DiagnosticIds.
     /// </summary>
-    private readonly ConcurrentDictionary<ProjectId, ImmutableHashSet<string>> _projectIdToDiagnosticIdsCache = [];
+    /// <remarks>
+    /// A project id being in the map means we are tracking changes for this project
+    /// and will update diagnostic ids when AnalyzerReferences change. A null value
+    /// means that we haven't computed the diagnostic ids for this project id yet.
+    /// </remarks>
+    private readonly ConcurrentDictionary<ProjectId, ImmutableHashSet<string>?> _projectIdToDiagnosticIdsCache = [];
     private readonly AsyncBatchingWorkQueue<ProjectId> _projectDescriptorRefreshQueue;
 
     private readonly Workspace _workspace;
@@ -74,11 +79,14 @@ internal class VisualStudioDiagnosticIdCache : IWorkspaceService
     /// </summary>
     public void RegisterProject(ProjectId projectId)
     {
+        // Ensure we have an entry for this projectId in case we get a workspace change event before
+        // we set it in RefreshCacheDiagnosticIdsAsync.
+        _projectIdToDiagnosticIdsCache.TryAdd(projectId, null);
         _projectDescriptorRefreshQueue.AddWork(projectId);
     }
 
     public bool TryGetDiagnosticIds(ProjectId projectId, [NotNullWhen(returnValue: true)] out ImmutableHashSet<string>? diagnosticIds)
-        => _projectIdToDiagnosticIdsCache.TryGetValue(projectId, out diagnosticIds);
+        => _projectIdToDiagnosticIdsCache.TryGetValue(projectId, out diagnosticIds) && diagnosticIds != null;
 
     private void WorkspaceChanged(WorkspaceChangeEventArgs e)
     {

--- a/src/VisualStudio/Core/Def/TaskList/VisualStudioDiagnosticIdCache.cs
+++ b/src/VisualStudio/Core/Def/TaskList/VisualStudioDiagnosticIdCache.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -127,12 +126,12 @@ internal class VisualStudioDiagnosticIdCache : IWorkspaceService
                 continue;
             }
 
-            var descriptorMap = await _analyzerService.GetDiagnosticDescriptorsPerReferenceAsync(
+            var list = await _analyzerService.GetAllDiagnosticIdsAsync(
                 project.Solution,
                 project.Id,
                 cancellationToken).ConfigureAwait(false);
 
-            _projectIdToDiagnosticIdsCache[project.Id] = [.. descriptorMap.Values.SelectMany(static descriptors => descriptors.Select(descriptor => descriptor.Id))];
+            _projectIdToDiagnosticIdsCache[project.Id] = list;
         }
     }
 

--- a/src/VisualStudio/Core/Def/TaskList/VisualStudioDiagnosticIdCache.cs
+++ b/src/VisualStudio/Core/Def/TaskList/VisualStudioDiagnosticIdCache.cs
@@ -19,6 +19,7 @@ using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Threading;
+using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Legacy;
 
 namespace Microsoft.VisualStudio.LanguageServices.TaskList;
 
@@ -40,7 +41,9 @@ internal sealed class VisualStudioDiagnosticIdCacheFactory(
 
 internal class VisualStudioDiagnosticIdCache : IWorkspaceService
 {
-    // This dictionary maps ProjectIds to a descriptor list.
+    /// <summary>
+    /// This dictionary maps ProjectIds to a set of DiagnosticIds.
+    /// </summary>
     private readonly ConcurrentDictionary<ProjectId, ImmutableHashSet<string>> _projectIdToDiagnosticIdsCache = [];
     private readonly AsyncBatchingWorkQueue<ProjectId> _projectDescriptorRefreshQueue;
 
@@ -65,11 +68,14 @@ internal class VisualStudioDiagnosticIdCache : IWorkspaceService
             cancellationToken: threadingContext.DisposalToken);
 
         _workspace.RegisterWorkspaceChangedHandler(WorkspaceChanged);
+    }
 
-        foreach (var projectId in _workspace.CurrentSolution.ProjectIds)
-        {
-            _projectDescriptorRefreshQueue.AddWork(projectId);
-        }
+    /// <summary>
+    /// We will only cache diagnostic ids for projects which have been registered by the <see cref="AbstractLegacyProject"/>.
+    /// </summary>
+    public void RegisterProject(ProjectId projectId)
+    {
+        _projectDescriptorRefreshQueue.AddWork(projectId);
     }
 
     public bool TryGetDiagnosticIds(ProjectId projectId, [NotNullWhen(returnValue: true)] out ImmutableHashSet<string>? diagnosticIds)
@@ -77,27 +83,33 @@ internal class VisualStudioDiagnosticIdCache : IWorkspaceService
 
     private void WorkspaceChanged(WorkspaceChangeEventArgs e)
     {
-        var workspaceChanges = e.NewSolution.GetChanges(e.OldSolution);
-
-        foreach (var addedProject in workspaceChanges.GetAddedProjects())
+        if (_projectIdToDiagnosticIdsCache.IsEmpty)
         {
-            _projectDescriptorRefreshQueue.AddWork(addedProject.Id);
+            return;
         }
+
+        var workspaceChanges = e.NewSolution.GetChanges(e.OldSolution);
 
         foreach (var removedProject in workspaceChanges.GetRemovedProjects())
         {
-            _projectDescriptorRefreshQueue.AddWork(removedProject.Id);
+            if (_projectIdToDiagnosticIdsCache.ContainsKey(removedProject.Id))
+            {
+                _projectDescriptorRefreshQueue.AddWork(removedProject.Id);
+            }
         }
 
         foreach (var projectChange in workspaceChanges.GetProjectChanges())
         {
-            var oldProject = projectChange.OldProject;
-            var newProject = projectChange.NewProject;
-
-            var analyzersChanged = !oldProject.AnalyzerReferences.Equals(newProject.AnalyzerReferences);
-            if (analyzersChanged)
+            if (_projectIdToDiagnosticIdsCache.ContainsKey(projectChange.ProjectId))
             {
-                _projectDescriptorRefreshQueue.AddWork(projectChange.NewProject.Id);
+                var oldProject = projectChange.OldProject;
+                var newProject = projectChange.NewProject;
+
+                var analyzersChanged = !oldProject.AnalyzerReferences.Equals(newProject.AnalyzerReferences);
+                if (analyzersChanged)
+                {
+                    _projectDescriptorRefreshQueue.AddWork(projectChange.NewProject.Id);
+                }
             }
         }
     }
@@ -122,5 +134,12 @@ internal class VisualStudioDiagnosticIdCache : IWorkspaceService
 
             _projectIdToDiagnosticIdsCache[project.Id] = [.. descriptorMap.Values.SelectMany(static descriptors => descriptors.Select(descriptor => descriptor.Id))];
         }
+    }
+
+    internal TestAccessor GetTestAccessor() => new(this);
+
+    internal readonly struct TestAccessor(VisualStudioDiagnosticIdCache diagnosticCache)
+    {
+        public int RegisteredProjectCount => diagnosticCache._projectIdToDiagnosticIdsCache.Count;
     }
 }

--- a/src/VisualStudio/Core/Def/TaskList/VisualStudioDiagnosticIdCache.cs
+++ b/src/VisualStudio/Core/Def/TaskList/VisualStudioDiagnosticIdCache.cs
@@ -44,7 +44,7 @@ internal class VisualStudioDiagnosticIdCache : IWorkspaceService
     /// This dictionary maps ProjectIds to a set of DiagnosticIds.
     /// </summary>
     /// <remarks>
-    /// A project id being in the map means we are tracking changes for this project
+    /// A <see cref="ProjectId" /> being in the map means we are tracking changes for this project
     /// and will update diagnostic ids when AnalyzerReferences change. A null value
     /// means that we haven't computed the diagnostic ids for this project id yet.
     /// </remarks>

--- a/src/VisualStudio/Core/Def/TaskList/VisualStudioDiagnosticIdCache.cs
+++ b/src/VisualStudio/Core/Def/TaskList/VisualStudioDiagnosticIdCache.cs
@@ -101,6 +101,9 @@ internal class VisualStudioDiagnosticIdCache : IWorkspaceService
         {
             if (_projectIdToDiagnosticIdsCache.ContainsKey(removedProject.Id))
             {
+                // Avoid a race condition where we remove a project here only for it to be added back
+                // by a refresh operation which is already in flight. Queue a refresh for this project 
+                // and remove it when refreshing.
                 _projectDescriptorRefreshQueue.AddWork(removedProject.Id);
             }
         }

--- a/src/VisualStudio/Core/Def/TaskList/VisualStudioDiagnosticIdCache.cs
+++ b/src/VisualStudio/Core/Def/TaskList/VisualStudioDiagnosticIdCache.cs
@@ -11,7 +11,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host;
@@ -49,10 +48,13 @@ internal class VisualStudioDiagnosticIdCache : IWorkspaceService
     /// means that we haven't computed the diagnostic ids for this project id yet.
     /// </remarks>
     private readonly ConcurrentDictionary<ProjectId, ImmutableHashSet<string>?> _projectIdToDiagnosticIdsCache = [];
-    private readonly AsyncBatchingWorkQueue<ProjectId> _projectDescriptorRefreshQueue;
+    private HashSet<ProjectId> _projectIdsToRefresh = [];
+    private Task _refreshTask = Task.CompletedTask;
+    private readonly object _gate = new();
 
     private readonly Workspace _workspace;
     private readonly IDiagnosticAnalyzerService _analyzerService;
+    private readonly IThreadingContext _threadingContext;
     private readonly IAsynchronousOperationListener _listener;
 
     public VisualStudioDiagnosticIdCache(
@@ -62,14 +64,8 @@ internal class VisualStudioDiagnosticIdCache : IWorkspaceService
     {
         _workspace = workspace;
         _analyzerService = workspace.Services.GetRequiredService<IDiagnosticAnalyzerService>();
+        _threadingContext = threadingContext;
         _listener = listenerProvider.GetListener(FeatureAttribute.DiagnosticService);
-
-        _projectDescriptorRefreshQueue = new AsyncBatchingWorkQueue<ProjectId>(
-            delay: DelayTimeSpan.Short,
-            processBatchAsync: RefreshCachedDiagnosticIdsAsync,
-            equalityComparer: EqualityComparer<ProjectId>.Default,
-            asyncListener: _listener,
-            cancellationToken: threadingContext.DisposalToken);
 
         _workspace.RegisterWorkspaceChangedHandler(WorkspaceChanged);
     }
@@ -82,7 +78,38 @@ internal class VisualStudioDiagnosticIdCache : IWorkspaceService
         // Ensure we have an entry for this projectId in case we get a workspace change event before
         // we set it in RefreshCacheDiagnosticIdsAsync.
         _projectIdToDiagnosticIdsCache.TryAdd(projectId, null);
-        _projectDescriptorRefreshQueue.AddWork(projectId);
+        _projectIdsToRefresh.Add(projectId);
+    }
+
+    public void Refresh()
+    {
+        lock (_gate)
+        {
+            _refreshTask = PerformRefreshAsync(_refreshTask);
+        }
+
+        return;
+
+        async Task PerformRefreshAsync(Task lastRefresh)
+        {
+            using var _ = _listener.BeginAsyncOperation(nameof(PerformRefreshAsync));
+
+            // Await the previous item in the task chain in a non-throwing fashion.  Regardless of whether that last
+            // task completed successfully or not, we want to move onto the next batch.
+            await lastRefresh.NoThrowAwaitableInternal(captureContext: false);
+
+            // If we were asked to shutdown, immediately transition to the canceled state without doing any more work.
+            if (_threadingContext.DisposalToken.IsCancellationRequested)
+                return;
+
+            var projectIdsToRefresh = Interlocked.Exchange(ref _projectIdsToRefresh, []);
+            if (projectIdsToRefresh.Count == 0)
+            {
+                return;
+            }
+
+            await RefreshCachedDiagnosticIdsAsync(projectIdsToRefresh, _threadingContext.DisposalToken).ConfigureAwait(false);
+        }
     }
 
     public bool TryGetDiagnosticIds(ProjectId projectId, [NotNullWhen(returnValue: true)] out ImmutableHashSet<string>? diagnosticIds)
@@ -104,7 +131,7 @@ internal class VisualStudioDiagnosticIdCache : IWorkspaceService
                 // Avoid a race condition where we remove a project here only for it to be added back
                 // by a refresh operation which is already in flight. Queue a refresh for this project 
                 // and remove it when refreshing.
-                _projectDescriptorRefreshQueue.AddWork(removedProject.Id);
+                _projectIdsToRefresh.Add(removedProject.Id);
             }
         }
 
@@ -118,17 +145,16 @@ internal class VisualStudioDiagnosticIdCache : IWorkspaceService
                 var analyzersChanged = !oldProject.AnalyzerReferences.Equals(newProject.AnalyzerReferences);
                 if (analyzersChanged)
                 {
-                    _projectDescriptorRefreshQueue.AddWork(projectChange.NewProject.Id);
+                    _projectIdsToRefresh.Add(projectChange.NewProject.Id);
                 }
             }
         }
     }
 
     private async ValueTask RefreshCachedDiagnosticIdsAsync(
-        ImmutableSegmentedList<ProjectId> projectIds,
+        IEnumerable<ProjectId> projectIds,
         CancellationToken cancellationToken)
     {
-        CodeAnalysis.Solution? solution = null;
         var builder = ImmutableArray.CreateBuilder<ProjectId>();
         foreach (var projectId in projectIds)
         {
@@ -139,7 +165,6 @@ internal class VisualStudioDiagnosticIdCache : IWorkspaceService
                 continue;
             }
 
-            solution ??= project.Solution;
             builder.Add(projectId);
         }
 
@@ -149,7 +174,7 @@ internal class VisualStudioDiagnosticIdCache : IWorkspaceService
         }
 
         var projectIdToDiagnosticIdsMap = await _analyzerService.GetAllDiagnosticIdsAsync(
-            solution!,
+            _workspace.CurrentSolution,
             builder.ToImmutable(),
             cancellationToken).ConfigureAwait(false);
 

--- a/src/VisualStudio/Core/Def/TaskList/VisualStudioDiagnosticIdCache.cs
+++ b/src/VisualStudio/Core/Def/TaskList/VisualStudioDiagnosticIdCache.cs
@@ -128,6 +128,8 @@ internal class VisualStudioDiagnosticIdCache : IWorkspaceService
         ImmutableSegmentedList<ProjectId> projectIds,
         CancellationToken cancellationToken)
     {
+        CodeAnalysis.Solution? solution = null;
+        var builder = ImmutableArray.CreateBuilder<ProjectId>();
         foreach (var projectId in projectIds)
         {
             var project = _workspace.CurrentSolution.GetProject(projectId);
@@ -137,12 +139,23 @@ internal class VisualStudioDiagnosticIdCache : IWorkspaceService
                 continue;
             }
 
-            var list = await _analyzerService.GetAllDiagnosticIdsAsync(
-                project.Solution,
-                project.Id,
-                cancellationToken).ConfigureAwait(false);
+            solution ??= project.Solution;
+            builder.Add(projectId);
+        }
 
-            _projectIdToDiagnosticIdsCache[project.Id] = list;
+        if (builder.Count == 0)
+        {
+            return;
+        }
+
+        var projectIdToDiagnosticIdsMap = await _analyzerService.GetAllDiagnosticIdsAsync(
+            solution!,
+            builder.ToImmutable(),
+            cancellationToken).ConfigureAwait(false);
+
+        foreach (var projectIdToDiagnosticIds in projectIdToDiagnosticIdsMap)
+        {
+            _projectIdToDiagnosticIdsCache[projectIdToDiagnosticIds.Key] = projectIdToDiagnosticIds.Value;
         }
     }
 

--- a/src/VisualStudio/Core/Def/TaskList/VisualStudioDiagnosticIdCache.cs
+++ b/src/VisualStudio/Core/Def/TaskList/VisualStudioDiagnosticIdCache.cs
@@ -16,7 +16,6 @@ using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
-using Microsoft.CodeAnalysis.Threading;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Legacy;
 
 namespace Microsoft.VisualStudio.LanguageServices.TaskList;
@@ -50,7 +49,8 @@ internal class VisualStudioDiagnosticIdCache : IWorkspaceService
     private readonly ConcurrentDictionary<ProjectId, ImmutableHashSet<string>?> _projectIdToDiagnosticIdsCache = [];
     private HashSet<ProjectId> _projectIdsToRefresh = [];
     private Task _refreshTask = Task.CompletedTask;
-    private readonly object _gate = new();
+    private readonly object _taskGate = new();
+    private readonly object _workGate = new();
 
     private readonly Workspace _workspace;
     private readonly IDiagnosticAnalyzerService _analyzerService;
@@ -75,34 +75,40 @@ internal class VisualStudioDiagnosticIdCache : IWorkspaceService
     /// </summary>
     public void RegisterProject(ProjectId projectId)
     {
-        // Ensure we have an entry for this projectId in case we get a workspace change event before
-        // we set it in RefreshCacheDiagnosticIdsAsync.
-        _projectIdToDiagnosticIdsCache.TryAdd(projectId, null);
-        _projectIdsToRefresh.Add(projectId);
+        lock (_workGate)
+        {
+            // Ensure we have an entry for this projectId in case we get a workspace change event before
+            // we set it in RefreshCacheDiagnosticIdsAsync.
+            _projectIdToDiagnosticIdsCache.TryAdd(projectId, null);
+            _projectIdsToRefresh.Add(projectId);
+        }
     }
 
     public void Refresh()
     {
-        lock (_gate)
+        lock (_taskGate)
         {
-            _refreshTask = PerformRefreshAsync(_refreshTask);
+            var refreshToken = _listener.BeginAsyncOperation(nameof(Refresh));
+            _refreshTask = _refreshTask.ContinueWith(_ => PerformRefreshAsync(refreshToken), CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default).Unwrap();
         }
 
         return;
 
-        async Task PerformRefreshAsync(Task lastRefresh)
+        async Task PerformRefreshAsync(IAsyncToken refreshToken)
         {
-            using var _ = _listener.BeginAsyncOperation(nameof(PerformRefreshAsync));
-
-            // Await the previous item in the task chain in a non-throwing fashion.  Regardless of whether that last
-            // task completed successfully or not, we want to move onto the next batch.
-            await lastRefresh.NoThrowAwaitableInternal(captureContext: false);
+            // The refresh operation begins in Refresh but does not complete until the method completes.
+            using var _ = refreshToken;
 
             // If we were asked to shutdown, immediately transition to the canceled state without doing any more work.
             if (_threadingContext.DisposalToken.IsCancellationRequested)
                 return;
 
-            var projectIdsToRefresh = Interlocked.Exchange(ref _projectIdsToRefresh, []);
+            HashSet<ProjectId> projectIdsToRefresh;
+            lock (_workGate)
+            {
+                projectIdsToRefresh = Interlocked.Exchange(ref _projectIdsToRefresh, []);
+            }
+
             if (projectIdsToRefresh.Count == 0)
             {
                 return;
@@ -117,35 +123,38 @@ internal class VisualStudioDiagnosticIdCache : IWorkspaceService
 
     private void WorkspaceChanged(WorkspaceChangeEventArgs e)
     {
-        if (_projectIdToDiagnosticIdsCache.IsEmpty)
+        lock (_workGate)
         {
-            return;
-        }
-
-        var workspaceChanges = e.NewSolution.GetChanges(e.OldSolution);
-
-        foreach (var removedProject in workspaceChanges.GetRemovedProjects())
-        {
-            if (_projectIdToDiagnosticIdsCache.ContainsKey(removedProject.Id))
+            if (_projectIdToDiagnosticIdsCache.IsEmpty)
             {
-                // Avoid a race condition where we remove a project here only for it to be added back
-                // by a refresh operation which is already in flight. Queue a refresh for this project 
-                // and remove it when refreshing.
-                _projectIdsToRefresh.Add(removedProject.Id);
+                return;
             }
-        }
 
-        foreach (var projectChange in workspaceChanges.GetProjectChanges())
-        {
-            if (_projectIdToDiagnosticIdsCache.ContainsKey(projectChange.ProjectId))
+            var workspaceChanges = e.NewSolution.GetChanges(e.OldSolution);
+
+            foreach (var removedProject in workspaceChanges.GetRemovedProjects())
             {
-                var oldProject = projectChange.OldProject;
-                var newProject = projectChange.NewProject;
-
-                var analyzersChanged = !oldProject.AnalyzerReferences.Equals(newProject.AnalyzerReferences);
-                if (analyzersChanged)
+                if (_projectIdToDiagnosticIdsCache.ContainsKey(removedProject.Id))
                 {
-                    _projectIdsToRefresh.Add(projectChange.NewProject.Id);
+                    // Avoid a race condition where we remove a project here only for it to be added back
+                    // by a refresh operation which is already in flight. Queue a refresh for this project 
+                    // and remove it when refreshing.
+                    _projectIdsToRefresh.Add(removedProject.Id);
+                }
+            }
+
+            foreach (var projectChange in workspaceChanges.GetProjectChanges())
+            {
+                if (_projectIdToDiagnosticIdsCache.ContainsKey(projectChange.ProjectId))
+                {
+                    var oldProject = projectChange.OldProject;
+                    var newProject = projectChange.NewProject;
+
+                    var analyzersChanged = !oldProject.AnalyzerReferences.Equals(newProject.AnalyzerReferences);
+                    if (analyzersChanged)
+                    {
+                        _projectIdsToRefresh.Add(projectChange.NewProject.Id);
+                    }
                 }
             }
         }
@@ -155,11 +164,11 @@ internal class VisualStudioDiagnosticIdCache : IWorkspaceService
         IEnumerable<ProjectId> projectIds,
         CancellationToken cancellationToken)
     {
+        var solution = _workspace.CurrentSolution;
         var builder = ImmutableArray.CreateBuilder<ProjectId>();
         foreach (var projectId in projectIds)
         {
-            var project = _workspace.CurrentSolution.GetProject(projectId);
-            if (project == null)
+            if (!solution.ContainsProject(projectId))
             {
                 _projectIdToDiagnosticIdsCache.TryRemove(projectId, out _);
                 continue;
@@ -174,7 +183,7 @@ internal class VisualStudioDiagnosticIdCache : IWorkspaceService
         }
 
         var projectIdToDiagnosticIdsMap = await _analyzerService.GetAllDiagnosticIdsAsync(
-            _workspace.CurrentSolution,
+            solution,
             builder.ToImmutable(),
             cancellationToken).ConfigureAwait(false);
 

--- a/src/VisualStudio/Core/Def/TaskList/VisualStudioDiagnosticIdCache.cs
+++ b/src/VisualStudio/Core/Def/TaskList/VisualStudioDiagnosticIdCache.cs
@@ -49,8 +49,7 @@ internal class VisualStudioDiagnosticIdCache : IWorkspaceService
     private readonly ConcurrentDictionary<ProjectId, ImmutableHashSet<string>?> _projectIdToDiagnosticIdsCache = [];
     private HashSet<ProjectId> _projectIdsToRefresh = [];
     private Task _refreshTask = Task.CompletedTask;
-    private readonly object _taskGate = new();
-    private readonly object _workGate = new();
+    private readonly object _gate = new();
 
     private readonly Workspace _workspace;
     private readonly IDiagnosticAnalyzerService _analyzerService;
@@ -75,7 +74,7 @@ internal class VisualStudioDiagnosticIdCache : IWorkspaceService
     /// </summary>
     public void RegisterProject(ProjectId projectId)
     {
-        lock (_workGate)
+        lock (_gate)
         {
             // Ensure we have an entry for this projectId in case we get a workspace change event before
             // we set it in RefreshCacheDiagnosticIdsAsync.
@@ -86,35 +85,24 @@ internal class VisualStudioDiagnosticIdCache : IWorkspaceService
 
     public void Refresh()
     {
-        lock (_taskGate)
+        lock (_gate)
         {
-            var refreshToken = _listener.BeginAsyncOperation(nameof(Refresh));
-            _refreshTask = _refreshTask.ContinueWith(_ => PerformRefreshAsync(refreshToken), CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default).Unwrap();
-        }
-
-        return;
-
-        async Task PerformRefreshAsync(IAsyncToken refreshToken)
-        {
-            // The refresh operation begins in Refresh but does not complete until the method completes.
-            using var _ = refreshToken;
-
-            // If we were asked to shutdown, immediately transition to the canceled state without doing any more work.
-            if (_threadingContext.DisposalToken.IsCancellationRequested)
-                return;
-
-            HashSet<ProjectId> projectIdsToRefresh;
-            lock (_workGate)
-            {
-                projectIdsToRefresh = Interlocked.Exchange(ref _projectIdsToRefresh, []);
-            }
+            var projectIdsToRefresh = _projectIdsToRefresh;
+            _projectIdsToRefresh = [];
 
             if (projectIdsToRefresh.Count == 0)
             {
                 return;
             }
 
-            await RefreshCachedDiagnosticIdsAsync(projectIdsToRefresh, _threadingContext.DisposalToken).ConfigureAwait(false);
+            var refreshToken = _listener.BeginAsyncOperation(nameof(Refresh));
+            _refreshTask = _refreshTask.ContinueWith(
+                async _ => await RefreshCachedDiagnosticIdsAsync(projectIdsToRefresh, _threadingContext.DisposalToken).ConfigureAwait(false),
+                _threadingContext.DisposalToken,
+                TaskContinuationOptions.None,
+                TaskScheduler.Default)
+                .Unwrap()
+                .CompletesAsyncOperation(refreshToken);
         }
     }
 
@@ -123,18 +111,18 @@ internal class VisualStudioDiagnosticIdCache : IWorkspaceService
 
     private void WorkspaceChanged(WorkspaceChangeEventArgs e)
     {
-        lock (_workGate)
+        if (_projectIdToDiagnosticIdsCache.IsEmpty)
         {
-            if (_projectIdToDiagnosticIdsCache.IsEmpty)
-            {
-                return;
-            }
+            return;
+        }
 
-            var workspaceChanges = e.NewSolution.GetChanges(e.OldSolution);
+        var workspaceChanges = e.NewSolution.GetChanges(e.OldSolution);
 
-            foreach (var removedProject in workspaceChanges.GetRemovedProjects())
+        foreach (var removedProject in workspaceChanges.GetRemovedProjects())
+        {
+            if (_projectIdToDiagnosticIdsCache.ContainsKey(removedProject.Id))
             {
-                if (_projectIdToDiagnosticIdsCache.ContainsKey(removedProject.Id))
+                lock (_gate)
                 {
                     // Avoid a race condition where we remove a project here only for it to be added back
                     // by a refresh operation which is already in flight. Queue a refresh for this project 
@@ -142,16 +130,19 @@ internal class VisualStudioDiagnosticIdCache : IWorkspaceService
                     _projectIdsToRefresh.Add(removedProject.Id);
                 }
             }
+        }
 
-            foreach (var projectChange in workspaceChanges.GetProjectChanges())
+        foreach (var projectChange in workspaceChanges.GetProjectChanges())
+        {
+            if (_projectIdToDiagnosticIdsCache.ContainsKey(projectChange.ProjectId))
             {
-                if (_projectIdToDiagnosticIdsCache.ContainsKey(projectChange.ProjectId))
-                {
-                    var oldProject = projectChange.OldProject;
-                    var newProject = projectChange.NewProject;
+                var oldProject = projectChange.OldProject;
+                var newProject = projectChange.NewProject;
 
-                    var analyzersChanged = !oldProject.AnalyzerReferences.Equals(newProject.AnalyzerReferences);
-                    if (analyzersChanged)
+                var analyzersChanged = !oldProject.AnalyzerReferences.Equals(newProject.AnalyzerReferences);
+                if (analyzersChanged)
+                {
+                    lock (_gate)
                     {
                         _projectIdsToRefresh.Add(projectChange.NewProject.Id);
                     }

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -5,7 +5,6 @@
 Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.CodeActions
 Imports Microsoft.CodeAnalysis.CommonDiagnosticAnalyzers
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Editor.[Shared].Utilities
@@ -35,9 +34,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
         Private Shared ReadOnly s_projectGuid As Guid = Guid.NewGuid()
 
         <WpfFact>
-        Public Async Function TestExternalDiagnostics_SupportedId() As Task
+        Public Async Function TestExternalDiagnostics_UnsupportedId() As Task
             Using workspace = EditorTestWorkspace.CreateCSharp(String.Empty, composition:=s_composition)
-                Dim waiter = workspace.GetService(Of AsynchronousOperationListenerProvider)().GetWaiter(FeatureAttribute.ErrorList)
+                Dim listener = workspace.GetService(Of AsynchronousOperationListenerProvider)()
+                Dim diagnosticWaiter = listener.GetWaiter(FeatureAttribute.DiagnosticService)
+                Dim errorListWaiter = listener.GetWaiter(FeatureAttribute.ErrorList)
                 Dim analyzer = New AnalyzerForErrorLogTest()
 
                 Dim analyzerReference = New TestAnalyzerReferenceByLanguage(
@@ -52,19 +53,23 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Using source = workspace.ExportProvider.GetExportedValue(Of ExternalErrorDiagnosticUpdateSource)()
 
                     Dim project = workspace.CurrentSolution.Projects.First()
-                    source.OnSolutionBuildStarted()
-                    Await waiter.ExpeditedWaitAsync()
 
-                    Assert.True(Await source.IsSupportedDiagnosticIdAsync(project.Id, "ID1", CancellationToken.None))
-                    Assert.False(Await source.IsSupportedDiagnosticIdAsync(project.Id, "CA1002", CancellationToken.None))
+                    source.OnSolutionBuildStarted()
+                    Await diagnosticWaiter.ExpeditedWaitAsync()
+                    Await errorListWaiter.ExpeditedWaitAsync()
+
+                    Assert.False(source.IsUnsupportedDiagnosticId(project.Id, "ID1"))
+                    Assert.True(source.IsUnsupportedDiagnosticId(project.Id, "CA1002"))
                 End Using
             End Using
         End Function
 
         <WpfFact>
-        Public Async Function TestExternalDiagnostics_SupportedIdFalseIfBuildNotStarted() As Task
+        Public Sub TestExternalDiagnostics_UnsupportedIdTrueIfBuildNotStarted()
             Using workspace = EditorTestWorkspace.CreateCSharp(String.Empty, composition:=s_composition)
-                Dim waiter = workspace.GetService(Of AsynchronousOperationListenerProvider)().GetWaiter(FeatureAttribute.ErrorList)
+                Dim listener = workspace.GetService(Of AsynchronousOperationListenerProvider)()
+                Dim diagnosticWaiter = listener.GetWaiter(FeatureAttribute.DiagnosticService)
+                Dim errorListWaiter = listener.GetWaiter(FeatureAttribute.ErrorList)
                 Dim analyzer = New AnalyzerForErrorLogTest()
 
                 Dim analyzerReference = New TestAnalyzerReferenceByLanguage(
@@ -80,11 +85,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
                     Dim project = workspace.CurrentSolution.Projects.First()
 
-                    Assert.False(Await source.IsSupportedDiagnosticIdAsync(project.Id, "ID1", CancellationToken.None))
-                    Assert.False(Await source.IsSupportedDiagnosticIdAsync(project.Id, "CA1002", CancellationToken.None))
+                    Assert.True(source.IsUnsupportedDiagnosticId(project.Id, "ID1"))
+                    Assert.True(source.IsUnsupportedDiagnosticId(project.Id, "CA1002"))
                 End Using
             End Using
-        End Function
+        End Sub
 
         <WpfFact>
         Public Async Function TestExternalDiagnosticsReported() As Task

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -15,6 +15,7 @@ Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
+Imports Microsoft.VisualStudio.LanguageServices.TaskList
 Imports Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.Mocks
 Imports Microsoft.VisualStudio.RpcContracts.DiagnosticManagement
 Imports Roslyn.Test.Utilities
@@ -50,12 +51,15 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
                 Dim vsWorkspace = workspace.ExportProvider.GetExportedValue(Of MockVisualStudioWorkspace)()
                 vsWorkspace.SetWorkspace(workspace)
-                Using source = workspace.ExportProvider.GetExportedValue(Of ExternalErrorDiagnosticUpdateSource)()
+                Dim diagnosticCache = vsWorkspace.Services.GetRequiredService(Of VisualStudioDiagnosticIdCache)()
 
+                Using source = workspace.ExportProvider.GetExportedValue(Of ExternalErrorDiagnosticUpdateSource)()
                     Dim project = workspace.CurrentSolution.Projects.First()
 
-                    source.OnSolutionBuildStarted()
+                    diagnosticCache.RegisterProject(project.Id)
                     Await diagnosticWaiter.ExpeditedWaitAsync()
+
+                    source.OnSolutionBuildStarted()
                     Await errorListWaiter.ExpeditedWaitAsync()
 
                     Assert.False(source.IsUnsupportedDiagnosticId(project.Id, "ID1"))

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -1,4 +1,4 @@
-' Licensed to the .NET Foundation under one or more agreements.
+﻿' Licensed to the .NET Foundation under one or more agreements.
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
@@ -38,29 +38,29 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
         Public Async Function TestExternalDiagnostics_UnsupportedId() As Task
             Using workspace = EditorTestWorkspace.CreateCSharp(String.Empty, composition:=s_composition)
                 Dim listener = workspace.GetService(Of AsynchronousOperationListenerProvider)()
-                Dim diagnosticWaiter = listener.GetWaiter(FeatureAttribute.DiagnosticService)
-                Dim errorListWaiter = listener.GetWaiter(FeatureAttribute.ErrorList)
-                Dim analyzer = New AnalyzerForErrorLogTest()
 
+                ' Create an analyzer and add it to the solution
+                Dim analyzer = New AnalyzerForErrorLogTest()
                 Dim analyzerReference = New TestAnalyzerReferenceByLanguage(
                     ImmutableDictionary(Of String, ImmutableArray(Of DiagnosticAnalyzer)).Empty.Add(LanguageNames.CSharp, ImmutableArray.Create(Of DiagnosticAnalyzer)(analyzer)))
-
                 workspace.TryApplyChanges(workspace.CurrentSolution.WithAnalyzerReferences({analyzerReference}))
-
-                Dim threadingContext = workspace.ExportProvider.GetExport(Of IThreadingContext).Value
 
                 Dim vsWorkspace = workspace.ExportProvider.GetExportedValue(Of MockVisualStudioWorkspace)()
                 vsWorkspace.SetWorkspace(workspace)
+
+                ' Get the diagnostic cache through the mock VS workspace otherwise it will not be the correct instance
                 Dim diagnosticCache = vsWorkspace.Services.GetRequiredService(Of VisualStudioDiagnosticIdCache)()
 
                 Using source = workspace.ExportProvider.GetExportedValue(Of ExternalErrorDiagnosticUpdateSource)()
                     Dim project = workspace.CurrentSolution.Projects.First()
 
+                    ' Registering the project with the diagnostic cache will allow it to be populated (this mimics AbstractLegeacyProject)
                     diagnosticCache.RegisterProject(project.Id)
-                    Await diagnosticWaiter.ExpeditedWaitAsync()
 
+                    ' Starting a build triggers the diagnostic id cache to refresh. Waiting on DiagnosticService ensures
+                    ' that they are populated.
                     source.OnSolutionBuildStarted()
-                    Await errorListWaiter.ExpeditedWaitAsync()
+                    Await listener.WaitAllAsync(workspace, {FeatureAttribute.DiagnosticService, FeatureAttribute.ErrorList})
 
                     Assert.False(source.IsUnsupportedDiagnosticId(project.Id, "ID1"))
                     Assert.True(source.IsUnsupportedDiagnosticId(project.Id, "CA1002"))
@@ -71,23 +71,25 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
         <WpfFact>
         Public Sub TestExternalDiagnostics_UnsupportedIdTrueIfBuildNotStarted()
             Using workspace = EditorTestWorkspace.CreateCSharp(String.Empty, composition:=s_composition)
-                Dim listener = workspace.GetService(Of AsynchronousOperationListenerProvider)()
-                Dim diagnosticWaiter = listener.GetWaiter(FeatureAttribute.DiagnosticService)
-                Dim errorListWaiter = listener.GetWaiter(FeatureAttribute.ErrorList)
+                ' Create an analyzer and add it to the solution
                 Dim analyzer = New AnalyzerForErrorLogTest()
-
                 Dim analyzerReference = New TestAnalyzerReferenceByLanguage(
                     ImmutableDictionary(Of String, ImmutableArray(Of DiagnosticAnalyzer)).Empty.Add(LanguageNames.CSharp, ImmutableArray.Create(Of DiagnosticAnalyzer)(analyzer)))
-
                 workspace.TryApplyChanges(workspace.CurrentSolution.WithAnalyzerReferences({analyzerReference}))
-
-                Dim threadingContext = workspace.ExportProvider.GetExport(Of IThreadingContext).Value
 
                 Dim vsWorkspace = workspace.ExportProvider.GetExportedValue(Of MockVisualStudioWorkspace)()
                 vsWorkspace.SetWorkspace(workspace)
-                Using source = workspace.ExportProvider.GetExportedValue(Of ExternalErrorDiagnosticUpdateSource)()
 
+                ' Get the diagnostic cache through the mock VS workspace otherwise it will not be the correct instance
+                Dim diagnosticCache = vsWorkspace.Services.GetRequiredService(Of VisualStudioDiagnosticIdCache)()
+
+                Using source = workspace.ExportProvider.GetExportedValue(Of ExternalErrorDiagnosticUpdateSource)()
                     Dim project = workspace.CurrentSolution.Projects.First()
+
+                    ' Registering the project with the diagnostic cache will allow it to be populated (this mimics AbstractLegeacyProject)
+                    diagnosticCache.RegisterProject(project.Id)
+
+                    ' By not starting a build the cache will not populate and we cannot say a diagnostic is unsupported.
 
                     Assert.True(source.IsUnsupportedDiagnosticId(project.Id, "ID1"))
                     Assert.True(source.IsUnsupportedDiagnosticId(project.Id, "CA1002"))

--- a/src/VisualStudio/Core/Test/Diagnostics/VisualStudioDiagnosticIdCacheTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/VisualStudioDiagnosticIdCacheTests.vb
@@ -1,0 +1,137 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Collections.Immutable
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.Serialization
+Imports Microsoft.CodeAnalysis.Shared.TestHooks
+Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Microsoft.VisualStudio.LanguageServices.TaskList
+Imports Roslyn.Test.Utilities
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
+
+    <[UseExportProvider]>
+    Public Class VisualStudioDiagnosticIdCacheTests
+        Private Shared ReadOnly s_composition As TestComposition = VisualStudioTestCompositions.LanguageServices
+
+        <Fact>
+        Public Async Function TestDiagnosticDescriptorCache_Populates() As Task
+            Using workspace = EditorTestWorkspace.CreateCSharp("class A { }", composition:=s_composition)
+                Dim listenerProvider = workspace.GetService(Of AsynchronousOperationListenerProvider)()
+
+                Dim analyzer = New DescriptorOnlyAnalyzer("CACHE001")
+                Dim analyzerReference = New AnalyzerImageReference(ImmutableArray.Create(Of DiagnosticAnalyzer)(analyzer))
+                SerializerService.TestAccessor.AddAnalyzerImageReference(analyzerReference)
+
+                Dim project = workspace.CurrentSolution.Projects.Single().AddAnalyzerReference(analyzerReference)
+                Assert.True(workspace.TryApplyChanges(project.Solution))
+
+                project = workspace.CurrentSolution.Projects.Single()
+                Dim service = workspace.Services.GetRequiredService(Of VisualStudioDiagnosticIdCache)()
+
+                Assert.False(service.TryGetDiagnosticIds(project.Id, Nothing))
+
+                ' Waiting for DiagnosticService to process should populate the cache.
+                Await listenerProvider.WaitAllAsync(workspace, {FeatureAttribute.Workspace, FeatureAttribute.DiagnosticService})
+
+                Dim diagnosticIds As ImmutableHashSet(Of String) = Nothing
+                Assert.True(service.TryGetDiagnosticIds(project.Id, diagnosticIds))
+
+                AssertEx.NotNull(diagnosticIds)
+                Assert.Contains("CACHE001", diagnosticIds)
+            End Using
+        End Function
+
+        <Fact>
+        Public Async Function TestDiagnosticDescriptorCache_RefreshesOnAnalyzerReferenceChange() As Task
+            Using workspace = EditorTestWorkspace.CreateCSharp("class A { }", composition:=s_composition)
+                Dim listenerProvider = workspace.GetService(Of AsynchronousOperationListenerProvider)()
+
+                Dim analyzer1 = New DescriptorOnlyAnalyzer("CACHE001")
+                Dim analyzerReference1 = New AnalyzerImageReference(ImmutableArray.Create(Of DiagnosticAnalyzer)(analyzer1))
+                SerializerService.TestAccessor.AddAnalyzerImageReference(analyzerReference1)
+
+                Dim project = workspace.CurrentSolution.Projects.Single().AddAnalyzerReference(analyzerReference1)
+                Assert.True(workspace.TryApplyChanges(project.Solution))
+
+                project = workspace.CurrentSolution.Projects.Single()
+                Dim service = workspace.Services.GetRequiredService(Of VisualStudioDiagnosticIdCache)()
+
+                Await listenerProvider.WaitAllAsync(workspace, {FeatureAttribute.Workspace, FeatureAttribute.DiagnosticService})
+
+                Dim initialDiagnosticIds As ImmutableHashSet(Of String) = Nothing
+                Assert.True(service.TryGetDiagnosticIds(project.Id, initialDiagnosticIds))
+                Assert.Contains("CACHE001", initialDiagnosticIds)
+
+                Dim analyzer2 = New DescriptorOnlyAnalyzer("CACHE002")
+                Dim analyzerReference2 = New AnalyzerImageReference(ImmutableArray.Create(Of DiagnosticAnalyzer)(analyzer2))
+                SerializerService.TestAccessor.AddAnalyzerImageReference(analyzerReference2)
+
+                project = workspace.CurrentSolution.Projects.Single().WithAnalyzerReferences({analyzerReference2})
+                Assert.True(workspace.TryApplyChanges(project.Solution))
+
+                Await listenerProvider.WaitAllAsync(workspace, {FeatureAttribute.Workspace, FeatureAttribute.DiagnosticService})
+
+                project = workspace.CurrentSolution.Projects.Single()
+                Dim refreshedDiagnosticIds As ImmutableHashSet(Of String) = Nothing
+                Assert.True(service.TryGetDiagnosticIds(project.Id, refreshedDiagnosticIds))
+
+                Assert.Contains("CACHE002", refreshedDiagnosticIds)
+                Assert.DoesNotContain("CACHE001", refreshedDiagnosticIds)
+            End Using
+        End Function
+
+        <Fact>
+        Public Async Function TestDiagnosticDescriptorCache_RemovesDeletedProjects() As Task
+            Using workspace = EditorTestWorkspace.CreateCSharp("class A { }", composition:=s_composition)
+                Dim listenerProvider = workspace.GetService(Of AsynchronousOperationListenerProvider)()
+
+                Dim analyzer = New DescriptorOnlyAnalyzer("CACHE001")
+                Dim analyzerReference = New AnalyzerImageReference(ImmutableArray.Create(Of DiagnosticAnalyzer)(analyzer))
+                SerializerService.TestAccessor.AddAnalyzerImageReference(analyzerReference)
+
+                Dim project = workspace.CurrentSolution.Projects.Single().AddAnalyzerReference(analyzerReference)
+                Assert.True(workspace.TryApplyChanges(project.Solution))
+
+                project = workspace.CurrentSolution.Projects.Single()
+                Dim projectId = project.Id
+                Dim service = workspace.Services.GetRequiredService(Of VisualStudioDiagnosticIdCache)()
+
+                Await listenerProvider.WaitAllAsync(workspace, {FeatureAttribute.Workspace, FeatureAttribute.DiagnosticService})
+
+                Assert.True(service.TryGetDiagnosticIds(projectId, Nothing))
+
+                Dim newSolution = workspace.CurrentSolution.RemoveProject(projectId)
+                Assert.True(workspace.TryApplyChanges(newSolution))
+
+                Await listenerProvider.WaitAllAsync(workspace, {FeatureAttribute.Workspace, FeatureAttribute.DiagnosticService})
+
+                Assert.False(service.TryGetDiagnosticIds(projectId, Nothing))
+            End Using
+        End Function
+
+        Private NotInheritable Class DescriptorOnlyAnalyzer
+            Inherits DiagnosticAnalyzer
+
+            Private ReadOnly _descriptor As DiagnosticDescriptor
+
+            Public Sub New(id As String)
+                _descriptor = New DiagnosticDescriptor(id, "title", "message", "category", DiagnosticSeverity.Warning, isEnabledByDefault:=True)
+            End Sub
+
+            Public Overrides ReadOnly Property SupportedDiagnostics As ImmutableArray(Of DiagnosticDescriptor)
+                Get
+                    Return ImmutableArray.Create(_descriptor)
+                End Get
+            End Property
+
+            Public Overrides Sub Initialize(context As AnalysisContext)
+            End Sub
+        End Class
+
+    End Class
+
+End Namespace

--- a/src/VisualStudio/Core/Test/Diagnostics/VisualStudioDiagnosticIdCacheTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/VisualStudioDiagnosticIdCacheTests.vb
@@ -9,6 +9,7 @@ Imports Microsoft.CodeAnalysis.Serialization
 Imports Microsoft.CodeAnalysis.Shared.TestHooks
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.VisualStudio.LanguageServices.TaskList
+Imports Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Framework
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
@@ -17,31 +18,58 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
     Public Class VisualStudioDiagnosticIdCacheTests
         Private Shared ReadOnly s_composition As TestComposition = VisualStudioTestCompositions.LanguageServices
 
+        <WpfFact>
+        Public Async Function LegacyProject_RegistersProjectWithCache() As Task
+            Using environment = New TestEnvironment()
+                Dim workspace = environment.Workspace
+                Dim diagnosticIdCache = workspace.Services.GetRequiredService(Of VisualStudioDiagnosticIdCache)()
+                Dim listenerProvider = environment.ExportProvider.GetExportedValue(Of AsynchronousOperationListenerProvider)()
+
+                ' There should be no registered projects in an empty workspace.
+                Assert.Equal(0, diagnosticIdCache.GetTestAccessor().RegisteredProjectCount)
+
+                ' Create a legacy project.
+                Dim csharpProject = CSharpHelpers.CreateCSharpProject(environment, "Test")
+                Dim project = workspace.CurrentSolution.Projects.Single()
+
+                ' The project should have been registered with the cache but it should be empty until diagnostics are fetched.
+                Assert.Equal(1, diagnosticIdCache.GetTestAccessor().RegisteredProjectCount)
+                Assert.False(diagnosticIdCache.TryGetDiagnosticIds(project.Id, Nothing))
+
+                ' Waiting for DiagnosticService to process should populate the cache.
+                Await listenerProvider.WaitAllAsync(workspace, {FeatureAttribute.DiagnosticService})
+
+                ' Cache should now be populated and contain the legacy project id.
+                Assert.True(diagnosticIdCache.TryGetDiagnosticIds(project.Id, Nothing))
+            End Using
+        End Function
+
         <Fact>
         Public Async Function TestDiagnosticDescriptorCache_Populates() As Task
             Using workspace = EditorTestWorkspace.CreateCSharp("class A { }", composition:=s_composition)
+                Dim diagnosticIdCache = workspace.Services.GetRequiredService(Of VisualStudioDiagnosticIdCache)()
                 Dim listenerProvider = workspace.GetService(Of AsynchronousOperationListenerProvider)()
 
+                ' Create an in memory analyzer.
                 Dim analyzer = New DescriptorOnlyAnalyzer("CACHE001")
                 Dim analyzerReference = New AnalyzerImageReference(ImmutableArray.Create(Of DiagnosticAnalyzer)(analyzer))
                 SerializerService.TestAccessor.AddAnalyzerImageReference(analyzerReference)
 
+                ' Add the analyzer reference to our project.
                 Dim project = workspace.CurrentSolution.Projects.Single().AddAnalyzerReference(analyzerReference)
                 Assert.True(workspace.TryApplyChanges(project.Solution))
-
                 project = workspace.CurrentSolution.Projects.Single()
-                Dim service = workspace.Services.GetRequiredService(Of VisualStudioDiagnosticIdCache)()
 
-                Assert.False(service.TryGetDiagnosticIds(project.Id, Nothing))
+                ' The cache should not contain the project until it is registered.
+                Assert.False(diagnosticIdCache.TryGetDiagnosticIds(project.Id, Nothing))
 
-                service.RegisterProject(project.Id)
-                ' Waiting for DiagnosticService to process should populate the cache.
+                ' Register the project with cache (this mimics what LegacyProjects do automatically) and for it to populate.
+                diagnosticIdCache.RegisterProject(project.Id)
                 Await listenerProvider.WaitAllAsync(workspace, {FeatureAttribute.DiagnosticService})
 
+                ' Cache should be populated and contain the diagnostic id from our analyzer.
                 Dim diagnosticIds As ImmutableHashSet(Of String) = Nothing
-                Assert.True(service.TryGetDiagnosticIds(project.Id, diagnosticIds))
-
-                AssertEx.NotNull(diagnosticIds)
+                Assert.True(diagnosticIdCache.TryGetDiagnosticIds(project.Id, diagnosticIds))
                 Assert.Contains("CACHE001", diagnosticIds)
             End Using
         End Function
@@ -49,38 +77,44 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
         <Fact>
         Public Async Function TestDiagnosticDescriptorCache_RefreshesOnAnalyzerReferenceChange() As Task
             Using workspace = EditorTestWorkspace.CreateCSharp("class A { }", composition:=s_composition)
+                Dim diagnosticIdCache = workspace.Services.GetRequiredService(Of VisualStudioDiagnosticIdCache)()
                 Dim listenerProvider = workspace.GetService(Of AsynchronousOperationListenerProvider)()
 
+                ' Create an in memory analyzer.
                 Dim analyzer1 = New DescriptorOnlyAnalyzer("CACHE001")
                 Dim analyzerReference1 = New AnalyzerImageReference(ImmutableArray.Create(Of DiagnosticAnalyzer)(analyzer1))
                 SerializerService.TestAccessor.AddAnalyzerImageReference(analyzerReference1)
 
+                ' Add the analyze reference to our project.
                 Dim project = workspace.CurrentSolution.Projects.Single().AddAnalyzerReference(analyzerReference1)
                 Assert.True(workspace.TryApplyChanges(project.Solution))
-
                 project = workspace.CurrentSolution.Projects.Single()
-                Dim service = workspace.Services.GetRequiredService(Of VisualStudioDiagnosticIdCache)()
-                service.RegisterProject(project.Id)
 
+                ' Register the project with cache (this mimics what LegacyProjects do automatically) and for it to populate.
+                diagnosticIdCache.RegisterProject(project.Id)
                 Await listenerProvider.WaitAllAsync(workspace, {FeatureAttribute.DiagnosticService})
 
+                ' Cache should be populated and contain the diagnostic id from our analyzer.
                 Dim initialDiagnosticIds As ImmutableHashSet(Of String) = Nothing
-                Assert.True(service.TryGetDiagnosticIds(project.Id, initialDiagnosticIds))
+                Assert.True(diagnosticIdCache.TryGetDiagnosticIds(project.Id, initialDiagnosticIds))
                 Assert.Contains("CACHE001", initialDiagnosticIds)
 
+                ' Create an in memory analyzer with a new diagnostic id.
                 Dim analyzer2 = New DescriptorOnlyAnalyzer("CACHE002")
                 Dim analyzerReference2 = New AnalyzerImageReference(ImmutableArray.Create(Of DiagnosticAnalyzer)(analyzer2))
                 SerializerService.TestAccessor.AddAnalyzerImageReference(analyzerReference2)
 
+                ' Replace the analyzer references with only the new one.
                 project = workspace.CurrentSolution.Projects.Single().WithAnalyzerReferences({analyzerReference2})
                 Assert.True(workspace.TryApplyChanges(project.Solution))
+                project = workspace.CurrentSolution.Projects.Single()
 
+                ' Wait for the workspace change event to propagate to the cache and for the cache to refresh.
                 Await listenerProvider.WaitAllAsync(workspace, {FeatureAttribute.Workspace, FeatureAttribute.DiagnosticService})
 
-                project = workspace.CurrentSolution.Projects.Single()
+                ' The cache should now contain the new diagnostic id but not the old one.
                 Dim refreshedDiagnosticIds As ImmutableHashSet(Of String) = Nothing
-                Assert.True(service.TryGetDiagnosticIds(project.Id, refreshedDiagnosticIds))
-
+                Assert.True(diagnosticIdCache.TryGetDiagnosticIds(project.Id, refreshedDiagnosticIds))
                 Assert.Contains("CACHE002", refreshedDiagnosticIds)
                 Assert.DoesNotContain("CACHE001", refreshedDiagnosticIds)
             End Using
@@ -89,31 +123,37 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
         <Fact>
         Public Async Function TestDiagnosticDescriptorCache_RemovesDeletedProjects() As Task
             Using workspace = EditorTestWorkspace.CreateCSharp("class A { }", composition:=s_composition)
+                Dim diagnosticIdCache = workspace.Services.GetRequiredService(Of VisualStudioDiagnosticIdCache)()
                 Dim listenerProvider = workspace.GetService(Of AsynchronousOperationListenerProvider)()
 
+                ' Create an in memory analyzer.
                 Dim analyzer = New DescriptorOnlyAnalyzer("CACHE001")
                 Dim analyzerReference = New AnalyzerImageReference(ImmutableArray.Create(Of DiagnosticAnalyzer)(analyzer))
                 SerializerService.TestAccessor.AddAnalyzerImageReference(analyzerReference)
 
+                ' Add the analyze reference to our project.
                 Dim project = workspace.CurrentSolution.Projects.Single().AddAnalyzerReference(analyzerReference)
                 Assert.True(workspace.TryApplyChanges(project.Solution))
-
                 project = workspace.CurrentSolution.Projects.Single()
-                Dim projectId = project.Id
-                Dim service = workspace.Services.GetRequiredService(Of VisualStudioDiagnosticIdCache)()
-                service.RegisterProject(projectId)
 
+                ' Register the project with cache (this mimics what LegacyProjects do automatically) and for it to populate.
+                diagnosticIdCache.RegisterProject(project.Id)
                 Await listenerProvider.WaitAllAsync(workspace, {FeatureAttribute.DiagnosticService})
 
-                Assert.True(service.TryGetDiagnosticIds(projectId, Nothing))
+                ' The cache should now contain the project and have one registered project.
+                Assert.True(diagnosticIdCache.TryGetDiagnosticIds(project.Id, Nothing))
+                Assert.Equal(1, diagnosticIdCache.GetTestAccessor().RegisteredProjectCount)
 
-                Dim newSolution = workspace.CurrentSolution.RemoveProject(projectId)
+                ' Remove the project from the workspace.
+                Dim newSolution = workspace.CurrentSolution.RemoveProject(project.Id)
                 Assert.True(workspace.TryApplyChanges(newSolution))
 
+                ' Wait for the workspace change event to propagate to the cache and for the cache to refresh.
                 Await listenerProvider.WaitAllAsync(workspace, {FeatureAttribute.Workspace, FeatureAttribute.DiagnosticService})
 
-                Assert.False(service.TryGetDiagnosticIds(projectId, Nothing))
-                Assert.Equal(0, service.GetTestAccessor().RegisteredProjectCount)
+                ' Ensure the cache no longer contains the project and it has been unregistered.
+                Assert.False(diagnosticIdCache.TryGetDiagnosticIds(project.Id, Nothing))
+                Assert.Equal(0, diagnosticIdCache.GetTestAccessor().RegisteredProjectCount)
             End Using
         End Function
 

--- a/src/VisualStudio/Core/Test/Diagnostics/VisualStudioDiagnosticIdCacheTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/VisualStudioDiagnosticIdCacheTests.vb
@@ -34,8 +34,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
                 Assert.False(service.TryGetDiagnosticIds(project.Id, Nothing))
 
+                service.RegisterProject(project.Id)
                 ' Waiting for DiagnosticService to process should populate the cache.
-                Await listenerProvider.WaitAllAsync(workspace, {FeatureAttribute.Workspace, FeatureAttribute.DiagnosticService})
+                Await listenerProvider.WaitAllAsync(workspace, {FeatureAttribute.DiagnosticService})
 
                 Dim diagnosticIds As ImmutableHashSet(Of String) = Nothing
                 Assert.True(service.TryGetDiagnosticIds(project.Id, diagnosticIds))
@@ -59,8 +60,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
                 project = workspace.CurrentSolution.Projects.Single()
                 Dim service = workspace.Services.GetRequiredService(Of VisualStudioDiagnosticIdCache)()
+                service.RegisterProject(project.Id)
 
-                Await listenerProvider.WaitAllAsync(workspace, {FeatureAttribute.Workspace, FeatureAttribute.DiagnosticService})
+                Await listenerProvider.WaitAllAsync(workspace, {FeatureAttribute.DiagnosticService})
 
                 Dim initialDiagnosticIds As ImmutableHashSet(Of String) = Nothing
                 Assert.True(service.TryGetDiagnosticIds(project.Id, initialDiagnosticIds))
@@ -99,8 +101,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 project = workspace.CurrentSolution.Projects.Single()
                 Dim projectId = project.Id
                 Dim service = workspace.Services.GetRequiredService(Of VisualStudioDiagnosticIdCache)()
+                service.RegisterProject(projectId)
 
-                Await listenerProvider.WaitAllAsync(workspace, {FeatureAttribute.Workspace, FeatureAttribute.DiagnosticService})
+                Await listenerProvider.WaitAllAsync(workspace, {FeatureAttribute.DiagnosticService})
 
                 Assert.True(service.TryGetDiagnosticIds(projectId, Nothing))
 
@@ -110,6 +113,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Await listenerProvider.WaitAllAsync(workspace, {FeatureAttribute.Workspace, FeatureAttribute.DiagnosticService})
 
                 Assert.False(service.TryGetDiagnosticIds(projectId, Nothing))
+                Assert.Equal(0, service.GetTestAccessor().RegisteredProjectCount)
             End Using
         End Function
 

--- a/src/VisualStudio/Core/Test/Diagnostics/VisualStudioDiagnosticIdCacheTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/VisualStudioDiagnosticIdCacheTests.vb
@@ -36,7 +36,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Assert.Equal(1, diagnosticIdCache.GetTestAccessor().RegisteredProjectCount)
                 Assert.False(diagnosticIdCache.TryGetDiagnosticIds(project.Id, Nothing))
 
-                ' Waiting for DiagnosticService to process should populate the cache.
+                ' Asking the cache to refresh and waiting for DiagnosticService to process should populate the cache.
+                diagnosticIdCache.Refresh()
                 Await listenerProvider.WaitAllAsync(workspace, {FeatureAttribute.DiagnosticService})
 
                 ' Cache should now be populated and contain the legacy project id.
@@ -63,8 +64,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 ' The cache should not contain the project until it is registered.
                 Assert.False(diagnosticIdCache.TryGetDiagnosticIds(project.Id, Nothing))
 
-                ' Register the project with cache (this mimics what LegacyProjects do automatically) and for it to populate.
+                ' Register the project with cache (this mimics what LegacyProjects do automatically) and request
+                ' the cache to refresh (this mimics what ExternalErrorDiagnosticUpdateSource does when a build is
+                ' started). Waiting for the DiagnosticService to process should populate the cache.
                 diagnosticIdCache.RegisterProject(project.Id)
+                diagnosticIdCache.Refresh()
                 Await listenerProvider.WaitAllAsync(workspace, {FeatureAttribute.DiagnosticService})
 
                 ' Cache should be populated and contain the diagnostic id from our analyzer.
@@ -90,8 +94,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Assert.True(workspace.TryApplyChanges(project.Solution))
                 project = workspace.CurrentSolution.Projects.Single()
 
-                ' Register the project with cache (this mimics what LegacyProjects do automatically) and for it to populate.
+                ' Register the project with cache (this mimics what LegacyProjects do automatically) and request
+                ' the cache to refresh (this mimics what ExternalErrorDiagnosticUpdateSource does when a build is
+                ' started). Waiting for the DiagnosticService to process should populate the cache.
                 diagnosticIdCache.RegisterProject(project.Id)
+                diagnosticIdCache.Refresh()
                 Await listenerProvider.WaitAllAsync(workspace, {FeatureAttribute.DiagnosticService})
 
                 ' Cache should be populated and contain the diagnostic id from our analyzer.
@@ -109,8 +116,12 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Assert.True(workspace.TryApplyChanges(project.Solution))
                 project = workspace.CurrentSolution.Projects.Single()
 
-                ' Wait for the workspace change event to propagate to the cache and for the cache to refresh.
-                Await listenerProvider.WaitAllAsync(workspace, {FeatureAttribute.Workspace, FeatureAttribute.DiagnosticService})
+                ' Wait for the workspace change event to propagate to the cache.
+                Await listenerProvider.WaitAllAsync(workspace, {FeatureAttribute.Workspace})
+
+                ' Request the cache to refresh and wait for the DiagnosticService to process should populate the cache.
+                diagnosticIdCache.Refresh()
+                Await listenerProvider.WaitAllAsync(workspace, {FeatureAttribute.DiagnosticService})
 
                 ' The cache should now contain the new diagnostic id but not the old one.
                 Dim refreshedDiagnosticIds As ImmutableHashSet(Of String) = Nothing
@@ -136,8 +147,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Assert.True(workspace.TryApplyChanges(project.Solution))
                 project = workspace.CurrentSolution.Projects.Single()
 
-                ' Register the project with cache (this mimics what LegacyProjects do automatically) and for it to populate.
+                ' Register the project with cache (this mimics what LegacyProjects do automatically) and request
+                ' the cache to refresh (this mimics what ExternalErrorDiagnosticUpdateSource does when a build is
+                ' started). Waiting for the DiagnosticService to process should populate the cache.
                 diagnosticIdCache.RegisterProject(project.Id)
+                diagnosticIdCache.Refresh()
                 Await listenerProvider.WaitAllAsync(workspace, {FeatureAttribute.DiagnosticService})
 
                 ' The cache should now contain the project and have one registered project.
@@ -148,8 +162,12 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Dim newSolution = workspace.CurrentSolution.RemoveProject(project.Id)
                 Assert.True(workspace.TryApplyChanges(newSolution))
 
-                ' Wait for the workspace change event to propagate to the cache and for the cache to refresh.
-                Await listenerProvider.WaitAllAsync(workspace, {FeatureAttribute.Workspace, FeatureAttribute.DiagnosticService})
+                ' Wait for the workspace change event to propagate to the cache.
+                Await listenerProvider.WaitAllAsync(workspace, {FeatureAttribute.Workspace})
+
+                ' Request the cache to refresh and wait for the DiagnosticService to process should populate the cache.
+                diagnosticIdCache.Refresh()
+                Await listenerProvider.WaitAllAsync(workspace, {FeatureAttribute.DiagnosticService})
 
                 ' Ensure the cache no longer contains the project and it has been unregistered.
                 Assert.False(diagnosticIdCache.TryGetDiagnosticIds(project.Id, Nothing))

--- a/src/VisualStudio/TestUtilities2/ProjectSystemShim/CSharpHelpers/CSharpHelpers.vb
+++ b/src/VisualStudio/TestUtilities2/ProjectSystemShim/CSharpHelpers/CSharpHelpers.vb
@@ -1,0 +1,32 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.IO
+Imports Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
+Imports Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Framework
+Imports Microsoft.VisualStudio.Shell.Interop
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CSharpHelpers
+
+    Friend Module CSharpHelpers
+
+        Public Function CreateCSharpProject(environment As TestEnvironment, projectName As String) As CSharpProjectShim
+            Dim projectBinPath = Path.GetTempPath()
+            Dim hierarchy = environment.CreateHierarchy(projectName, projectBinPath, projectRefPath:=Nothing, projectCapabilities:="CSharp")
+
+            Return CreateCSharpProject(environment, projectName, hierarchy)
+        End Function
+
+        Public Function CreateCSharpProject(environment As TestEnvironment, projectName As String, hierarchy As IVsHierarchy) As CSharpProjectShim
+            Return New CSharpProjectShim(
+                New MockCSharpProjectRoot(hierarchy),
+                projectSystemName:=projectName,
+                hierarchy:=hierarchy,
+                serviceProvider:=environment.ServiceProvider,
+                threadingContext:=environment.ThreadingContext)
+        End Function
+
+    End Module
+
+End Namespace

--- a/src/VisualStudio/TestUtilities2/ProjectSystemShim/CSharpHelpers/MockCSharpProjectRoot.vb
+++ b/src/VisualStudio/TestUtilities2/ProjectSystemShim/CSharpHelpers/MockCSharpProjectRoot.vb
@@ -1,0 +1,75 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim.Interop
+Imports Microsoft.VisualStudio.Shell.Interop
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CSharpHelpers
+
+    Friend NotInheritable Class MockCSharpProjectRoot
+        Implements ICSharpProjectRoot
+
+        Private ReadOnly _hierarchy As IVsHierarchy
+
+        Public Sub New(hierarchy As IVsHierarchy)
+            _hierarchy = hierarchy
+        End Sub
+
+        Private Function BelongsToProject(pszFileName As String) As Integer Implements ICSharpProjectRoot.BelongsToProject
+            Throw New NotImplementedException()
+        End Function
+
+        Private Function BuildPerConfigCacheFileName() As String Implements ICSharpProjectRoot.BuildPerConfigCacheFileName
+            Throw New NotImplementedException()
+        End Function
+
+        Private Function CanCreateFileCodeModel(pszFile As String) As Boolean Implements ICSharpProjectRoot.CanCreateFileCodeModel
+            Throw New NotImplementedException()
+        End Function
+
+        Private Sub ConfigureCompiler(compiler As ICSCompiler, inputSet As ICSInputSet, addSources As Boolean) Implements ICSharpProjectRoot.ConfigureCompiler
+            Throw New NotImplementedException()
+        End Sub
+
+        Private Function CreateFileCodeModel(pszFile As String, ByRef riid As Guid) As Object Implements ICSharpProjectRoot.CreateFileCodeModel
+            Throw New NotImplementedException()
+        End Function
+
+        Private Function GetActiveConfigurationName() As String Implements ICSharpProjectRoot.GetActiveConfigurationName
+            Throw New NotImplementedException()
+        End Function
+
+        Private Function GetFullProjectName() As String Implements ICSharpProjectRoot.GetFullProjectName
+            Throw New NotImplementedException()
+        End Function
+
+        Private Function GetHierarchyAndItemID(pszFile As String, ByRef ppHier As IVsHierarchy, ByRef pItemID As UInteger) As Integer Implements ICSharpProjectRoot.GetHierarchyAndItemID
+            ppHier = _hierarchy
+
+            ' Each item should have it's own ItemID, but for simplicity we'll just hard-code a value of
+            ' no particular significance.
+            pItemID = 42
+
+            Return VSConstants.S_OK
+        End Function
+
+        Private Sub GetHierarchyAndItemIDOptionallyInProject(pszFile As String, ByRef ppHier As IVsHierarchy, ByRef pItemID As UInteger, mustBeInProject As Boolean) Implements ICSharpProjectRoot.GetHierarchyAndItemIDOptionallyInProject
+            Throw New NotImplementedException()
+        End Sub
+
+        Private Function GetProjectLocation() As String Implements ICSharpProjectRoot.GetProjectLocation
+            Throw New NotImplementedException()
+        End Function
+
+        Private Function GetProjectSite(ByRef riid As Guid) As Object Implements ICSharpProjectRoot.GetProjectSite
+            Throw New NotImplementedException()
+        End Function
+
+        Private Sub SetProjectSite(site As ICSharpProjectSite) Implements ICSharpProjectRoot.SetProjectSite
+            Throw New NotImplementedException()
+        End Sub
+
+    End Class
+
+End Namespace

--- a/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
+++ b/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
@@ -5,7 +5,6 @@
 Imports System.ComponentModel.Composition
 Imports System.ComponentModel.Composition.Hosting
 Imports System.IO
-Imports System.Runtime.InteropServices
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Diagnostics
@@ -23,6 +22,7 @@ Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.CPS
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Legacy
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
+Imports Microsoft.VisualStudio.LanguageServices.TaskList
 Imports Microsoft.VisualStudio.LanguageServices.Telemetry
 Imports Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
 Imports Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
@@ -72,7 +72,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
                 GetType(OpenTextBufferProvider),
                 GetType(StubVsEditorAdaptersFactoryService),
                 GetType(ExternalErrorDiagnosticUpdateSource),
-                GetType(MockServiceBroker))
+                GetType(MockServiceBroker),
+                GetType(VisualStudioDiagnosticIdCacheFactory))
 
         Private ReadOnly _workspace As VisualStudioWorkspaceImpl
         Private ReadOnly _projectFilePaths As New List(Of String)

--- a/src/Workspaces/Core/Portable/Diagnostics/HostDiagnosticAnalyzers.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/HostDiagnosticAnalyzers.cs
@@ -75,6 +75,27 @@ internal sealed class HostDiagnosticAnalyzers
     public ImmutableDictionary<object, ImmutableArray<DiagnosticAnalyzer>> GetOrCreateHostDiagnosticAnalyzersPerReference(string language)
         => _hostDiagnosticAnalyzersPerLanguageMap.GetOrAdd(language, CreateHostDiagnosticAnalyzersAndBuildMap);
 
+    /// <summary>
+    /// Returns all the DiagnosticIds producible by the referenced DiagnosticAnalyzers.
+    /// </summary>
+    public ImmutableHashSet<string> GetAllDiagnosticIds(
+        DiagnosticAnalyzerInfoCache infoCache,
+        Project? project)
+    {
+        var descriptorsPerReference = GetDiagnosticDescriptorsPerReference(infoCache, project);
+
+        var builder = ImmutableHashSet.CreateBuilder<string>();
+        foreach (var descriptors in descriptorsPerReference.Values)
+        {
+            foreach (var descriptor in descriptors)
+            {
+                builder.Add(descriptor.Id);
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+
     public ImmutableDictionary<string, ImmutableArray<DiagnosticDescriptor>> GetDiagnosticDescriptorsPerReference(
         DiagnosticAnalyzerInfoCache infoCache,
         Project? project)

--- a/src/Workspaces/Core/Portable/Diagnostics/HostDiagnosticAnalyzers.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/HostDiagnosticAnalyzers.cs
@@ -78,22 +78,35 @@ internal sealed class HostDiagnosticAnalyzers
     /// <summary>
     /// Returns all the DiagnosticIds producible by the referenced DiagnosticAnalyzers.
     /// </summary>
-    public ImmutableHashSet<string> GetAllDiagnosticIds(
+    public ImmutableDictionary<ProjectId, ImmutableHashSet<string>> GetAllDiagnosticIds(
         DiagnosticAnalyzerInfoCache infoCache,
-        Project? project)
+        ImmutableArray<Project> projects)
     {
-        var descriptorsPerReference = GetDiagnosticDescriptorsPerReference(infoCache, project);
+        var builder = ImmutableDictionary.CreateBuilder<ProjectId, ImmutableHashSet<string>>();
 
-        var builder = ImmutableHashSet.CreateBuilder<string>();
-        foreach (var descriptors in descriptorsPerReference.Values)
+        foreach (var project in projects)
         {
-            foreach (var descriptor in descriptors)
-            {
-                builder.Add(descriptor.Id);
-            }
+            var diagnosticIds = GetAllDiagnosticIds(infoCache, project);
+            builder.Add(project.Id, diagnosticIds);
         }
 
         return builder.ToImmutable();
+
+        ImmutableHashSet<string> GetAllDiagnosticIds(DiagnosticAnalyzerInfoCache infoCache, Project project)
+        {
+            var descriptorsPerReference = GetDiagnosticDescriptorsPerReference(infoCache, project);
+
+            var diagnosticIdBuilder = ImmutableHashSet.CreateBuilder<string>();
+            foreach (var descriptors in descriptorsPerReference.Values)
+            {
+                foreach (var descriptor in descriptors)
+                {
+                    diagnosticIdBuilder.Add(descriptor.Id);
+                }
+            }
+
+            return diagnosticIdBuilder.ToImmutable();
+        }
     }
 
     public ImmutableDictionary<string, ImmutableArray<DiagnosticDescriptor>> GetDiagnosticDescriptorsPerReference(

--- a/src/Workspaces/Core/Portable/Diagnostics/IRemoteDiagnosticAnalyzerService.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/IRemoteDiagnosticAnalyzerService.cs
@@ -51,6 +51,9 @@ internal interface IRemoteDiagnosticAnalyzerService
     ValueTask<ImmutableArray<string>> GetCompilationEndDiagnosticDescriptorIdsAsync(
         Checksum solutionChecksum, CancellationToken cancellationToken);
 
+    ValueTask<ImmutableHashSet<string>> GetAllDiagnosticIdsAsync(
+        Checksum solutionChecksum, ProjectId? projectId, CancellationToken cancellationToken);
+
     ValueTask<ImmutableDictionary<string, ImmutableArray<DiagnosticDescriptorData>>> GetDiagnosticDescriptorsPerReferenceAsync(
         Checksum solutionChecksum, ProjectId? projectId, CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Core/Portable/Diagnostics/IRemoteDiagnosticAnalyzerService.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/IRemoteDiagnosticAnalyzerService.cs
@@ -51,8 +51,8 @@ internal interface IRemoteDiagnosticAnalyzerService
     ValueTask<ImmutableArray<string>> GetCompilationEndDiagnosticDescriptorIdsAsync(
         Checksum solutionChecksum, CancellationToken cancellationToken);
 
-    ValueTask<ImmutableHashSet<string>> GetAllDiagnosticIdsAsync(
-        Checksum solutionChecksum, ProjectId? projectId, CancellationToken cancellationToken);
+    ValueTask<ImmutableDictionary<ProjectId, ImmutableHashSet<string>>> GetAllDiagnosticIdsAsync(
+        Checksum solutionChecksum, ImmutableArray<ProjectId> projectIds, CancellationToken cancellationToken);
 
     ValueTask<ImmutableDictionary<string, ImmutableArray<DiagnosticDescriptorData>>> GetDiagnosticDescriptorsPerReferenceAsync(
         Checksum solutionChecksum, ProjectId? projectId, CancellationToken cancellationToken);

--- a/src/Workspaces/CoreTestUtilities/Workspaces/TestWorkspace`1.cs
+++ b/src/Workspaces/CoreTestUtilities/Workspaces/TestWorkspace`1.cs
@@ -339,6 +339,9 @@ public abstract partial class TestWorkspace<TDocument, TProject, TSolution> : Wo
             case ApplyChangesKind.RemoveDocument:
                 return KindSupportsAddRemoveDocument();
 
+            case ApplyChangesKind.RemoveProject:
+                return KindSupportsRemoveProject();
+
             case ApplyChangesKind.AddAdditionalDocument:
             case ApplyChangesKind.RemoveAdditionalDocument:
             case ApplyChangesKind.AddAnalyzerConfigDocument:
@@ -365,6 +368,15 @@ public abstract partial class TestWorkspace<TDocument, TProject, TSolution> : Wo
     }
 
     private bool KindSupportsAddRemoveDocument()
+        => _workspaceKind switch
+        {
+            WorkspaceKind.MiscellaneousFiles => false,
+            WorkspaceKind.Interactive => false,
+            WorkspaceKind.SemanticSearch => false,
+            _ => true
+        };
+
+    private bool KindSupportsRemoveProject()
         => _workspaceKind switch
         {
             WorkspaceKind.MiscellaneousFiles => false,

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
@@ -193,6 +193,23 @@ internal sealed class RemoteDiagnosticAnalyzerService(in BrokeredServiceBase.Ser
             cancellationToken);
     }
 
+    public ValueTask<ImmutableHashSet<string>> GetAllDiagnosticIdsAsync(
+        Checksum solutionChecksum,
+        ProjectId? projectId,
+        CancellationToken cancellationToken)
+    {
+        return RunWithSolutionAsync(
+            solutionChecksum,
+            async solution =>
+            {
+                var service = solution.Services.GetRequiredService<IDiagnosticAnalyzerService>();
+                var list = await service.GetAllDiagnosticIdsAsync(solution, projectId, cancellationToken).ConfigureAwait(false);
+                return list;
+
+            },
+            cancellationToken);
+    }
+
     public ValueTask<ImmutableDictionary<string, ImmutableArray<DiagnosticDescriptorData>>> GetDiagnosticDescriptorsPerReferenceAsync(
         Checksum solutionChecksum,
         ProjectId? projectId,

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
@@ -193,9 +193,9 @@ internal sealed class RemoteDiagnosticAnalyzerService(in BrokeredServiceBase.Ser
             cancellationToken);
     }
 
-    public ValueTask<ImmutableHashSet<string>> GetAllDiagnosticIdsAsync(
+    public ValueTask<ImmutableDictionary<ProjectId, ImmutableHashSet<string>>> GetAllDiagnosticIdsAsync(
         Checksum solutionChecksum,
-        ProjectId? projectId,
+        ImmutableArray<ProjectId> projectIds,
         CancellationToken cancellationToken)
     {
         return RunWithSolutionAsync(
@@ -203,7 +203,7 @@ internal sealed class RemoteDiagnosticAnalyzerService(in BrokeredServiceBase.Ser
             async solution =>
             {
                 var service = solution.Services.GetRequiredService<IDiagnosticAnalyzerService>();
-                var list = await service.GetAllDiagnosticIdsAsync(solution, projectId, cancellationToken).ConfigureAwait(false);
+                var list = await service.GetAllDiagnosticIdsAsync(solution, projectIds, cancellationToken).ConfigureAwait(false);
                 return list;
 
             },


### PR DESCRIPTION
We added a diagnostic id cache to answer whether a build error was supported by a particular project. This cache stored diagnostic ids for all projects in the solution. However it was only being used for legacy projects. This means we were doing too much work.

This PR changes the cache to only store diagnostic ids for registered projects and updates the AbstractLegacyProject to register new projects with the cache when they are created.