### PR TITLE
Reduce allocations in DocumentAnalysisExecutor ctor

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/Service/DocumentAnalysisExecutor.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/DocumentAnalysisExecutor.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.LanguageService;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Telemetry;
 using Microsoft.CodeAnalysis.Text;
@@ -50,10 +51,18 @@ internal sealed partial class DiagnosticAnalyzerService
             _logPerformanceInfo = logPerformanceInfo;
             _onAnalysisException = onAnalysisException;
 
-            var compilationBasedProjectAnalyzers = compilationWithAnalyzers?.Analyzers.ToImmutableHashSet();
-            _compilationBasedAnalyzersInAnalysisScope = compilationBasedProjectAnalyzers != null
-                ? analysisScope.Analyzers.WhereAsArray(compilationBasedProjectAnalyzers.Contains)
-                : [];
+            if (compilationWithAnalyzers is null || compilationWithAnalyzers.Analyzers.IsDefaultOrEmpty)
+            {
+                _compilationBasedAnalyzersInAnalysisScope = [];
+            }
+            else
+            {
+                using var _ = PooledHashSet<DiagnosticAnalyzer>.GetInstance(out var compilationBasedProjectAnalyzers);
+
+                compilationBasedProjectAnalyzers.AddRange(compilationWithAnalyzers.Analyzers);
+
+                _compilationBasedAnalyzersInAnalysisScope = analysisScope.Analyzers.WhereAsArray(compilationBasedProjectAnalyzers.Contains);
+            }
         }
 
         public DocumentAnalysisScope AnalysisScope { get; }


### PR DESCRIPTION
The DocumentAnalysisExecutor ctor call is accounting for about 5.4% of allocations in the html completion scenario in the razor CompletionInCohostingForComponents speedometer test. This PR removes the ImmutableHashSet usage (~4.2%) internal to the ctor and retrieves the HashSet it now uses as a temporary storage from the pool.

*** Previous ***
<img width="1040" height="261" alt="image" src="https://github.com/user-attachments/assets/2ee8a878-d8c1-4f9e-9eaa-3d675f4cb77c" />