### PR TITLE
Convert ComputeDocumentDiagnosticsAsync to a static method

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService_GetDiagnosticsForSpan.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService_GetDiagnosticsForSpan.cs
@@ -303,7 +303,7 @@ internal sealed partial class DiagnosticAnalyzerService
         static async Task ComputeDocumentDiagnosticsAsync(
             DiagnosticAnalyzerService service,
             TextDocument document,
-            CompilationWithAnalyzers compilationWithAnalyzers,
+            CompilationWithAnalyzers? compilationWithAnalyzers,
             bool logPerformanceInfo,
             ImmutableArray<DiagnosticAnalyzer> analyzers,
             AnalysisKind kind,


### PR DESCRIPTION
Small improvement, but this method is fairly heavily exercised. Each invocation of this method would create a closure and 3 delegate allocations, which copilot tells me is about ~200 bytes per call to ComputeDiagnosticsInProcessAsync. The scenario in the speedometer test shows the display class closure as about 0.3% of allocations.

<img width="1681" height="534" alt="image" src="https://github.com/user-attachments/assets/03c9b380-d8ed-4ea3-9933-11993fb421a1" />