### PR TITLE
Implement SynthesizedBackingFieldSymbolBase.TryGetFirstLocation

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedBackingFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedBackingFieldSymbol.cs
@@ -119,6 +119,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override ImmutableArray<Location> Locations
             => _property.Locations;
 
+        public override Location TryGetFirstLocation()
+            => _property.TryGetFirstLocation();
+
         public override RefKind RefKind => _property.RefKind;
 
         public override ImmutableArray<CustomModifier> RefCustomModifiers => _property.RefCustomModifiers;


### PR DESCRIPTION
This avoid the allocations done in the Symbol.TryGetFirstLocation usage of the Locations property.

This accounts for 0.7% of allocations in a scenario in the ComplietionInCohosting razor speedometer test.

<img width="1683" height="505" alt="image" src="https://github.com/user-attachments/assets/8b103bf1-5125-41e8-a41a-191067791806" />