### PR TITLE
Avoid duplicate TFM in Microsoft.CodeAnalysis.ExternalAccess.Razor.Features.csproj

### DIFF
--- a/src/Tools/ExternalAccess/Razor/Features/Microsoft.CodeAnalysis.ExternalAccess.Razor.Features.csproj
+++ b/src/Tools/ExternalAccess/Razor/Features/Microsoft.CodeAnalysis.ExternalAccess.Razor.Features.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <RootNamespace>Microsoft.CodeAnalysis.ExternalAccess.Razor.Features</RootNamespace>
-    <TargetFrameworks>$(NetVS);netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>$(NetVSShared);netstandard2.0</TargetFrameworks>
     <Nullable>enable</Nullable>
 
     <!-- NuGet -->


### PR DESCRIPTION
Fixes this issue that appears when building Roslyn in VS:

<p><samp>
Error occurred while restoring NuGet packages: Invalid restore input. The original target frameworks value must match the aliases. Original target frameworks: net10.0;net10.0;netstandard2.0, aliases: net10.0;netstandard2.0. Input files: D:\GitHub\roslyn\src\Tools\ExternalAccess\Razor\Features\Microsoft.CodeAnalysis.ExternalAccess.Razor.Features.csproj.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/82705)