### PR TITLE
Avoid unnecessary red node allocations in ReduceOneNodeOrTokenAsync by replacing .Single() with .First()

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Simplification/AbstractSimplificationService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Simplification/AbstractSimplificationService.cs
@@ -219,6 +219,8 @@ internal abstract class AbstractSimplificationService<
                                 ? nodeOrToken.Parent.ReplaceNode(nodeOrToken.AsNode()!, currentNodeOrToken.AsNode()!)
                                 : nodeOrToken.Parent.ReplaceToken(nodeOrToken.AsToken(), currentNodeOrToken.AsToken());
 
+                            Debug.Assert(replacedParent.ChildNodesAndTokens().Count(c => c.HasAnnotation(annotation)) == 1);
+
                             currentNodeOrToken = replacedParent
                                 .ChildNodesAndTokens()
                                 .First(c => c.HasAnnotation(annotation));


### PR DESCRIPTION
This pull request was generated by the VS Perf Rel AI Agent. Please review this AI-generated PR with extra care! For more information, visit our [wiki](https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/49206/PerfRel-Agent). Please share feedback with [TIP Insights](mailto:tipinsights@microsoft.com)

- **Issue:** `AbstractSimplificationService.ReduceOneNodeOrTokenAsync` uses `.Single()` on `ChildNodesAndTokens()` which forces enumeration of ALL children of a parent node to verify uniqueness, creating red syntax node wrappers (`ExpressionStatementSyntax`) for every child via `GetRedElement` → `CreateRed`, even after the matching annotated child has already been found.

  **Evidence:**
1. Stack trace shows allocation type `TypeAllocated!Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionStatementSyntax` (red node wrapper)
2. Source code at line 224 shows: `.ChildNodesAndTokens().Single(c => c.HasAnnotation(annotation))` which enumerates all remaining children after the match to verify uniqueness
3. The annotation is a freshly created `new SyntaxAnnotation()` which is guaranteed unique by construction (`_id` assigned via `Interlocked.Increment`), making the uniqueness check redundant
4. This code is in a triply-nested hot path: `Parallel.ForEachAsync` × `foreach reducers` × `do-while HasMoreWork`

  ```
  TypeAllocated!Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionStatementSyntax
  clr.dll!JIT_New
  microsoft.codeanalysis.csharp.dll!ExpressionStatementSyntax.CreateRed
  microsoft.codeanalysis.dll!SyntaxNode.GetRedElement
  microsoft.codeanalysis.dll!ChildSyntaxList.ItemInternal
  microsoft.codeanalysis.dll!ChildSyntaxList+EnumeratorImpl.get_Current
  microsoft.codeanalysis.workspaces.dll!System.Linq.Enumerable.Single[SyntaxNodeOrToken]
  microsoft.codeanalysis.workspaces.dll!AbstractSimplificationService.ReduceOneNodeOrTokenAsync
  ```


- **Issue type:** AVOID unnecessary full enumeration when searching for a guaranteed-unique element on hot path

- **Proposed fix:** Change `.Single()` to `.First()` on line 224 to stop enumeration at the first match instead of continuing through all remaining children.
The annotation is guaranteed unique by construction (`new SyntaxAnnotation()` assigns a unique `_id` via `Interlocked.Increment`), so `.First()` returns the same element as `.Single()`.
This is a minimal and safe fix that eliminates red node allocations for all children after the match while maintaining identical behavior.

[Best practices wiki](https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/24181/Garbage-collection-(GC))
[See related failure in PRISM](https://vsprismdev.azurewebsites.net/failure/?eventType=allocation&failureType=dualdirection&failureHash=d77cc10a-e6af-76f5-39e6-97e3bbf77813)
[ADO work item](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2822231)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/82711)