### PR TITLE
Update Microsoft.CodeAnalysis.Analyzers to a release version

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -162,8 +162,8 @@
       packages, when not in SourceBuild we will keep it untied to the MicrosoftCodeAnalysisAnalyzersVersion
       we use for other analyzers to ensure it stays on a release version.
     -->
-    <PackageVersion Condition="Condition="'$(DotNetBuildSourceOnly)' != 'true'" Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
-    <PackageVersion Condition="Condition="'$(DotNetBuildSourceOnly)' == 'true'" Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" />
+    <PackageVersion Condition="'$(DotNetBuildSourceOnly)' != 'true'" Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
+    <PackageVersion Condition="'$(DotNetBuildSourceOnly)' == 'true'" Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="$(MicrosoftCodeAnalysisNetAnalyzersVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="$(CodeStyleAnalyzerVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" Version="$(CodeStyleAnalyzerVersion)" />

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -159,10 +159,11 @@
 
     <!--
       Since the Microsoft.CodeAnalysis.Analyzers package is a public dependency of our NuGet
-      packages we will keep it untied to the RoslynDiagnosticsAnalyzersPackageVersion we use for
-      other analyzers to ensure it stays on a release version.
+      packages, when not in SourceBuild we will keep it untied to the MicrosoftCodeAnalysisAnalyzersVersion
+      we use for other analyzers to ensure it stays on a release version.
     -->
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" />
+    <PackageVersion Condition="Condition="'$(DotNetBuildSourceOnly)' != 'true'" Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
+    <PackageVersion Condition="Condition="'$(DotNetBuildSourceOnly)' == 'true'" Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="$(MicrosoftCodeAnalysisNetAnalyzersVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="$(CodeStyleAnalyzerVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" Version="$(CodeStyleAnalyzerVersion)" />

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -66,6 +66,11 @@ This file should be imported by eng/Versions.props
     <!-- dotnet-roslyn dependencies -->
     <MicrosoftCodeAnalysisVersion>$(MicrosoftCodeAnalysisPackageVersion)</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisAnalyzersVersion>$(MicrosoftCodeAnalysisAnalyzersPackageVersion)</MicrosoftCodeAnalysisAnalyzersVersion>
+    <!--
+      Since the Microsoft.CodeAnalysis.Analyzers package is a public dependency of our NuGet
+      packages we will keep it untied to the MicrosoftCodeAnalysisAnalyzersPackageVersion we use for
+      SourceBuild to ensure it stays on a release version.
+    -->
     <MicrosoftCodeAnalysisAnalyzersVersion Condition="Condition="'$(DotNetBuildSourceOnly)' != 'true'">5.3.0</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCodeAnalysisAnalyzerUtilitiesVersion>$(MicrosoftCodeAnalysisAnalyzerUtilitiesPackageVersion)</MicrosoftCodeAnalysisAnalyzerUtilitiesVersion>
     <MicrosoftNetCompilersToolsetVersion>$(MicrosoftNetCompilersToolsetPackageVersion)</MicrosoftNetCompilersToolsetVersion>

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -65,7 +65,8 @@ This file should be imported by eng/Versions.props
     <SystemCommandLineVersion>$(SystemCommandLinePackageVersion)</SystemCommandLineVersion>
     <!-- dotnet-roslyn dependencies -->
     <MicrosoftCodeAnalysisVersion>$(MicrosoftCodeAnalysisPackageVersion)</MicrosoftCodeAnalysisVersion>
-    <MicrosoftCodeAnalysisAnalyzersVersion>5.3.0</MicrosoftCodeAnalysisAnalyzersVersion>
+    <MicrosoftCodeAnalysisAnalyzersVersion>$(MicrosoftCodeAnalysisAnalyzersPackageVersion)</MicrosoftCodeAnalysisAnalyzersVersion>
+    <MicrosoftCodeAnalysisAnalyzersVersion Condition="Condition="'$(DotNetBuildSourceOnly)' != 'true'">5.3.0</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCodeAnalysisAnalyzerUtilitiesVersion>$(MicrosoftCodeAnalysisAnalyzerUtilitiesPackageVersion)</MicrosoftCodeAnalysisAnalyzerUtilitiesVersion>
     <MicrosoftNetCompilersToolsetVersion>$(MicrosoftNetCompilersToolsetPackageVersion)</MicrosoftNetCompilersToolsetVersion>
     <RoslynDiagnosticsAnalyzersVersion>$(RoslynDiagnosticsAnalyzersPackageVersion)</RoslynDiagnosticsAnalyzersVersion>

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -65,7 +65,7 @@ This file should be imported by eng/Versions.props
     <SystemCommandLineVersion>$(SystemCommandLinePackageVersion)</SystemCommandLineVersion>
     <!-- dotnet-roslyn dependencies -->
     <MicrosoftCodeAnalysisVersion>$(MicrosoftCodeAnalysisPackageVersion)</MicrosoftCodeAnalysisVersion>
-    <MicrosoftCodeAnalysisAnalyzersVersion>$(MicrosoftCodeAnalysisAnalyzersPackageVersion)</MicrosoftCodeAnalysisAnalyzersVersion>
+    <MicrosoftCodeAnalysisAnalyzersVersion>5.3.0</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCodeAnalysisAnalyzerUtilitiesVersion>$(MicrosoftCodeAnalysisAnalyzerUtilitiesPackageVersion)</MicrosoftCodeAnalysisAnalyzerUtilitiesVersion>
     <MicrosoftNetCompilersToolsetVersion>$(MicrosoftNetCompilersToolsetPackageVersion)</MicrosoftNetCompilersToolsetVersion>
     <RoslynDiagnosticsAnalyzersVersion>$(RoslynDiagnosticsAnalyzersPackageVersion)</RoslynDiagnosticsAnalyzersVersion>

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -66,12 +66,6 @@ This file should be imported by eng/Versions.props
     <!-- dotnet-roslyn dependencies -->
     <MicrosoftCodeAnalysisVersion>$(MicrosoftCodeAnalysisPackageVersion)</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisAnalyzersVersion>$(MicrosoftCodeAnalysisAnalyzersPackageVersion)</MicrosoftCodeAnalysisAnalyzersVersion>
-    <!--
-      Since the Microsoft.CodeAnalysis.Analyzers package is a public dependency of our NuGet
-      packages we will keep it untied to the MicrosoftCodeAnalysisAnalyzersPackageVersion we use for
-      SourceBuild to ensure it stays on a release version.
-    -->
-    <MicrosoftCodeAnalysisAnalyzersVersion Condition="Condition="'$(DotNetBuildSourceOnly)' != 'true'">5.3.0</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCodeAnalysisAnalyzerUtilitiesVersion>$(MicrosoftCodeAnalysisAnalyzerUtilitiesPackageVersion)</MicrosoftCodeAnalysisAnalyzerUtilitiesVersion>
     <MicrosoftNetCompilersToolsetVersion>$(MicrosoftNetCompilersToolsetPackageVersion)</MicrosoftNetCompilersToolsetVersion>
     <RoslynDiagnosticsAnalyzersVersion>$(RoslynDiagnosticsAnalyzersPackageVersion)</RoslynDiagnosticsAnalyzersVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <MajorVersion>5</MajorVersion>
     <MinorVersion>3</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
     <PreReleaseVersionLabel>2</PreReleaseVersionLabel>
     <PreReleaseVersionLabel Condition="'$(DotNetSignType)' == 'test'">$(PreReleaseVersionLabel)-test</PreReleaseVersionLabel>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>

--- a/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.sarif
+++ b/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.Analyzers",
-        "version": "5.3.0",
+        "version": "5.3.1",
         "language": "en-US"
       },
       "rules": {
@@ -724,7 +724,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.CSharp.Analyzers",
-        "version": "5.3.0",
+        "version": "5.3.1",
         "language": "en-US"
       },
       "rules": {
@@ -957,7 +957,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.VisualBasic.Analyzers",
-        "version": "5.3.0",
+        "version": "5.3.1",
         "language": "en-US"
       },
       "rules": {

--- a/src/RoslynAnalyzers/Microsoft.CodeAnalysis.BannedApiAnalyzers/Microsoft.CodeAnalysis.BannedApiAnalyzers.sarif
+++ b/src/RoslynAnalyzers/Microsoft.CodeAnalysis.BannedApiAnalyzers/Microsoft.CodeAnalysis.BannedApiAnalyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.BannedApiAnalyzers",
-        "version": "5.3.0",
+        "version": "5.3.1",
         "language": "en-US"
       },
       "rules": {
@@ -14,7 +14,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers",
-        "version": "5.3.0",
+        "version": "5.3.1",
         "language": "en-US"
       },
       "rules": {
@@ -77,7 +77,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.VisualBasic.BannedApiAnalyzers",
-        "version": "5.3.0",
+        "version": "5.3.1",
         "language": "en-US"
       },
       "rules": {

--- a/src/RoslynAnalyzers/PerformanceSensitiveAnalyzers/Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.sarif
+++ b/src/RoslynAnalyzers/PerformanceSensitiveAnalyzers/Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers",
-        "version": "5.3.0",
+        "version": "5.3.1",
         "language": "en-US"
       },
       "rules": {
@@ -184,7 +184,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers.CodeFixes",
-        "version": "5.3.0",
+        "version": "5.3.1",
         "language": "en-US"
       },
       "rules": {
@@ -193,7 +193,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers",
-        "version": "5.3.0",
+        "version": "5.3.1",
         "language": "en-US"
       },
       "rules": {

--- a/src/RoslynAnalyzers/PublicApiAnalyzers/Microsoft.CodeAnalysis.PublicApiAnalyzers.sarif
+++ b/src/RoslynAnalyzers/PublicApiAnalyzers/Microsoft.CodeAnalysis.PublicApiAnalyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.PublicApiAnalyzers",
-        "version": "5.3.0",
+        "version": "5.3.1",
         "language": "en-US"
       },
       "rules": {
@@ -460,7 +460,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.PublicApiAnalyzers.CodeFixes",
-        "version": "5.3.0",
+        "version": "5.3.1",
         "language": "en-US"
       },
       "rules": {

--- a/src/RoslynAnalyzers/Roslyn.Diagnostics.Analyzers/Roslyn.Diagnostics.Analyzers.sarif
+++ b/src/RoslynAnalyzers/Roslyn.Diagnostics.Analyzers/Roslyn.Diagnostics.Analyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Roslyn.Diagnostics.Analyzers",
-        "version": "5.3.0",
+        "version": "5.3.1",
         "language": "en-US"
       },
       "rules": {
@@ -157,7 +157,7 @@
     {
       "tool": {
         "name": "Roslyn.Diagnostics.CSharp.Analyzers",
-        "version": "5.3.0",
+        "version": "5.3.1",
         "language": "en-US"
       },
       "rules": {
@@ -300,7 +300,7 @@
     {
       "tool": {
         "name": "Roslyn.Diagnostics.VisualBasic.Analyzers",
-        "version": "5.3.0",
+        "version": "5.3.1",
         "language": "en-US"
       },
       "rules": {

--- a/src/RoslynAnalyzers/Text.Analyzers/Text.Analyzers.sarif
+++ b/src/RoslynAnalyzers/Text.Analyzers/Text.Analyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Humanizer",
-        "version": "5.3.0",
+        "version": "5.3.1",
         "language": "en-US"
       },
       "rules": {
@@ -14,7 +14,7 @@
     {
       "tool": {
         "name": "Text.Analyzers",
-        "version": "5.3.0",
+        "version": "5.3.1",
         "language": "en-US"
       },
       "rules": {
@@ -86,7 +86,7 @@
     {
       "tool": {
         "name": "Text.CSharp.Analyzers",
-        "version": "5.3.0",
+        "version": "5.3.1",
         "language": "en-US"
       },
       "rules": {
@@ -95,7 +95,7 @@
     {
       "tool": {
         "name": "Text.VisualBasic.Analyzers",
-        "version": "5.3.0",
+        "version": "5.3.1",
         "language": "en-US"
       },
       "rules": {


### PR DESCRIPTION
The Microsoft.CodeAnalysis.Analyzers package is a dependency of the Microsoft.CodeAnalysis packages. For the 5.3.0 release the analyzer dependency was set to a prerelease version. This is causing issues with users SBOM scanning as they cannot use prerelease packages in their deployed products. ([See comment](https://github.com/dotnet/roslyn/issues/82701#issuecomment-4044231262))
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/82719)