### PR TITLE
Allow for better parallelization with brokered services

### DIFF
--- a/src/Workspaces/Remote/Core/ServiceDescriptor.cs
+++ b/src/Workspaces/Remote/Core/ServiceDescriptor.cs
@@ -75,6 +75,10 @@ internal sealed class ServiceDescriptor : ServiceJsonRpcDescriptor
 
     protected override JsonRpcConnection CreateConnection(JsonRpc jsonRpc)
     {
+        // The default synchronization context set by the base type is NonConcurrentSynchronizationContext, which means that all incoming calls
+        // would be processed sequentially, at least up until their first await. We generally don't have services that expect ordering in that specific way, so
+        // disable that, especially since we want CPU-bound operations to happen in parallel.
+        jsonRpc.SynchronizationContext = null;
         jsonRpc.CancelLocallyInvokedMethodsWhenConnectionIsClosed = true;
         var connection = base.CreateConnection(jsonRpc);
         connection.LocalRpcTargetOptions = s_jsonRpcTargetOptions;


### PR DESCRIPTION
By default, there is a SynchronizationContext set that ensures that when dispatching new RPC requests, a new RPC requests is not dispatched until the previous request either finishes, or awaits to yield the thread. Although there are some cases where we do need behavior like that (LSP is the perfect example), we don't need that for brokered services.