### PR TITLE
Use VS2026 for building integration tests

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -73,6 +73,14 @@ parameters:
   default: windows.vs2022.amd64.open
   values:
   - windows.vs2022.amd64.open
+  - windows.vs2026preview.scout.amd64.open
+- name: buildQueueName
+  displayName: Build Queue Name
+  type: string
+  default: windows.vs2026preview.scout.amd64.open
+  values:
+  - windows.vs2022.amd64.open
+  - windows.vs2026preview.scout.amd64.open
 - name: timeout
   displayName: Timeout in Minutes
   type: number
@@ -83,6 +91,7 @@ stages:
   parameters:
     poolName: ${{ parameters.poolName }}
     queueName: ${{ parameters.queueName }}
+    buildQueueName: ${{ parameters.buildQueueName }}
     timeout: ${{ parameters.timeout }}
     configuration: Debug
     testRuns:
@@ -98,6 +107,7 @@ stages:
   parameters:
     poolName: ${{ parameters.poolName }}
     queueName: ${{ parameters.queueName }}
+    buildQueueName: ${{ parameters.buildQueueName }}
     timeout: ${{ parameters.timeout }}
     configuration: Release
     testRuns:

--- a/eng/pipelines/test-integration-helix.yml
+++ b/eng/pipelines/test-integration-helix.yml
@@ -3,6 +3,8 @@ parameters:
     type: string
   - name: queueName
     type: string
+  - name: buildQueueName
+    type: string
   - name: configuration
     type: string
     default: 'Debug'
@@ -28,7 +30,7 @@ stages:
       configuration: ${{ parameters.configuration }}
       poolParameters: 
         name: ${{ parameters.poolName }}
-        demands: ImageOverride -equals ${{ parameters.queueName }}
+        demands: ImageOverride -equals ${{ parameters.buildQueueName }}
       restoreArguments: -msbuildEngine vs
       buildArguments: -msbuildEngine vs /p:Projects='"$(Build.Repository.LocalPath)\src\VisualStudio\IntegrationTest\IntegrationTestBuildProject.csproj"'
 


### PR DESCRIPTION
To fix this failure in https://github.com/dotnet/roslyn/pull/82735:

<p><samp>
eng\targets\Imports.targets(180,5): error MSB4233: (NETCORE_ENGINEERING_TELEMETRY=Build) The task "Microsoft.DotNet.Arcade.Sdk.CompareVersions" from assembly "C:\Users\cloudtest\.nuget\packages\microsoft.dotnet.arcade.sdk\10.0.0-beta.26160.1\tools\netframework\Microsoft.DotNet.Arcade.Sdk.dll" was specified to load with the .NET runtime, but this version of MSBuild does not support loading tasks with that runtime. To run .NET tasks, use "dotnet build" or Visual Studio 2026 or higher.  D:\a\_work\1\s\eng\targets\Imports.targets
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/82740)