### PR TITLE
Reduce allocations in DocumentUri

### DIFF
--- a/src/LanguageServer/Protocol/Protocol/DocumentUri.cs
+++ b/src/LanguageServer/Protocol/Protocol/DocumentUri.cs
@@ -84,7 +84,7 @@ internal sealed record class DocumentUri
 
         // If we have parsed information for both URIs, compare the original strings for each.
         // This avoids allocations by avoiding realization of the UriString property
-        if (this._parsedUri.HasValue && otherUri._parsedUri.HasValue)
+        if (this._parsedUri.Value is not null && otherUri._parsedUri.Value is not null)
         {
             if (this._parsedUri.Value.OriginalString == otherUri._parsedUri.Value.OriginalString)
                 return true;


### PR DESCRIPTION
Perf numbers came back and weren't great -- no improvement. Looks like the call to AbsoluteUri moved to GetHashCode, and I'm not seeing a way to make that work given what the comments in that method indicate.

Going to close this out as I'm not seeing a path forward with it -- you win some, you lose some.

*** Original Description ***
Previously, the ctor taking in a Uri called Uri.AbsoluteUri to populate the UriString property. This shows as about 0.4% of all allocations in devenv in the TypingInWebforms ddrit test.

Instead, the ctor taking in a Uri will no longer set the field backing the UriString property, instead setting that field on demand when the UriString property is called.

This optimization only helps if a large number of DocumentUri instances are constructed but don't invoke the UriString property. Debugging through this, I see the vast majority of calls to the UriString property come through the Equals implementation. If we have _parsedUri fields, then we can short-circuit before calling the UriString property by checking the OriginalString of each parsed uri. In my testing, these are almost always equal, thus avoiding the call to UriString and the corresponding allocations.

*** Before allocations ***
<img width="1272" height="490" alt="image" src="https://github.com/user-attachments/assets/6bdafc90-43e9-47e1-861d-6b2d090c4f61" />
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/82763)