### PR TITLE
Fix small LookupResult pooling leak in NameofBinder.LookupSymbolsInSingleBinder

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/NameofBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/NameofBinder.cs
@@ -81,6 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var tmp = LookupResult.GetInstance();
                     _withTypeParametersBinder.LookupSymbolsInSingleBinder(tmp, name, arity, basesBeingResolved, options, originalBinder, diagnose, ref useSiteInfo);
                     result.MergeEqual(tmp);
+                    tmp.Free();
                 }
                 else
                 {


### PR DESCRIPTION

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/82764)