### PR TITLE
Small optimization reducing repeated int.ToString calls in completion

### DIFF
--- a/src/Features/Core/Portable/Completion/Providers/SymbolCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/SymbolCompletionItem.cs
@@ -23,7 +23,7 @@ internal static class SymbolCompletionItem
 
     private static readonly Action<ImmutableArray<ISymbol>, ArrayBuilder<KeyValuePair<string, string>>> s_addSymbolEncoding = AddSymbolEncoding;
     private static readonly Action<ImmutableArray<ISymbol>, ArrayBuilder<KeyValuePair<string, string>>> s_addSymbolInfo = AddSymbolInfo;
-    private static (int, string) s_lastContextPositionInfo = (0, "0");
+    private static ContextPositionCache s_lastContextPositionInfo = new(0, "0");
 
     private const char ProjectSeparatorChar = ';';
 
@@ -234,14 +234,14 @@ internal static class SymbolCompletionItem
         var contextPositionData = s_lastContextPositionInfo;
 
         string contextPositionString;
-        if (contextPositionData.Item1 == contextPosition)
+        if (contextPositionData.Position == contextPosition)
         {
-            contextPositionString = contextPositionData.Item2;
+            contextPositionString = contextPositionData.PositionString;
         }
         else
         {
             contextPositionString = contextPosition.ToString();
-            s_lastContextPositionInfo = (contextPosition, contextPositionString);
+            s_lastContextPositionInfo = new ContextPositionCache(contextPosition, contextPositionString);
         }
 
         properties.Add(KeyValuePair.Create("ContextPosition", contextPositionString));
@@ -427,5 +427,11 @@ internal static class SymbolCompletionItem
         {
             return CompletionDescription.Empty;
         }
+    }
+
+    private sealed class ContextPositionCache(int position, string positionString)
+    {
+        public readonly int Position = position;
+        public readonly string PositionString = positionString;
     }
 }


### PR DESCRIPTION
SymbolCompletionItem.CreateWorker can be called thousands of times for each completion list, and in the scenarios I've tested, it passes in the same contextPosition for each call. We need this context position as a string to store in a properties collection, so previously the code always ToString'ed the position. This PR creates a simple single item cache that is used to commonly avoid this allocation.

Not a huge win, but it's 0.2% of total allocations in the trace I'm looking at.

<img width="1400" height="460" alt="image" src="https://github.com/user-attachments/assets/93a67b2f-0760-48eb-888c-675a7e440377" />
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/82765)