### PR TITLE
Fix handling of added import trivia

### DIFF
--- a/src/Analyzers/CSharp/Tests/ImplementInterface/ImplementInterfaceCodeFixTests.cs
+++ b/src/Analyzers/CSharp/Tests/ImplementInterface/ImplementInterfaceCodeFixTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
@@ -11887,5 +11888,55 @@ class Goo : [|IComparable|]
              ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
              LanguageVersion = LanguageVersion.CSharp14,
              Options = { { FormattingOptions2.NewLine, "\n" } },
+         }.RunAsync();
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/82787")]
+    public Task FileLevelDirective_AddUsings()
+         => new VerifyCS.Test
+         {
+             TestCode = """
+                #:property Configuration=Release
+
+                using System.Collections;
+
+                class A : {|CS0535:I|}
+                {
+                }
+
+                interface I
+                {
+                    void M(System.DateTime dt, System.IO.FileInfo f);
+                }
+                """,
+             FixedCode = """
+                #:property Configuration=Release
+
+                using System;
+                using System.Collections;
+                using System.IO;
+
+                class A : I
+                {
+                    public void M(DateTime dt, FileInfo f)
+                    {
+                        throw new NotImplementedException();
+                    }
+                }
+
+                interface I
+                {
+                    void M(System.DateTime dt, System.IO.FileInfo f);
+                }
+                """,
+             SolutionTransforms =
+             {
+                static (solution, projectId) =>
+                {
+                    var project = solution.GetProject(projectId)!;
+                    var parseOptions = (CSharpParseOptions)project.ParseOptions!;
+                    return solution.WithProjectParseOptions(projectId,
+                        parseOptions.WithFeatures(parseOptions.Features.Append(new("FileBasedProgram", ""))));
+                },
+            },
          }.RunAsync();
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/AddImports/AddImportHelpers.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/AddImports/AddImportHelpers.cs
@@ -72,7 +72,7 @@ internal static class AddImportHelpers
                 // We added a new first-using.  Take the trivia on the existing first using
                 // And move it to the new using.
                 newImports[0] = newImports[0].WithLeadingTrivia(originalFirstUsing.GetLeadingTrivia());
-                newImports[originalFirstUsingCurrentIndex] = originalFirstUsing.WithoutLeadingTrivia();
+                newImports[originalFirstUsingCurrentIndex] = newImports[originalFirstUsingCurrentIndex].WithoutLeadingTrivia();
             }
 
             if (originalLastUsingCurrentIndex != newImports.Count - 1)
@@ -80,7 +80,7 @@ internal static class AddImportHelpers
                 // We added a new last-using.  Take the trailing trivia on the existing last using
                 // And move it to the new using.
                 newImports[^1] = newImports[^1].WithTrailingTrivia(originalLastUsing.GetTrailingTrivia());
-                newImports[originalLastUsingCurrentIndex] = originalLastUsing.WithoutTrailingTrivia();
+                newImports[originalLastUsingCurrentIndex] = newImports[originalLastUsingCurrentIndex].WithoutTrailingTrivia();
             }
 
             for (var i = 0; i < newImports.Count; i++)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/82787.

In AddImportHelpers.MoveTrivia, when there's only one existing import that needs both leading trivia moved (because a new import was added before it) and trailing trivia moved (because a new import was added after it), the two operations conflict:
1.	Line 75 correctly strips the leading trivia from newImports[originalFirstUsingCurrentIndex]
2.	Line 83 then overwrites the same index with originalLastUsing.WithoutTrailingTrivia(), where originalLastUsing is a captured reference to the original unmodified node. This restores the leading trivia that was just stripped in step 1.
This caused the IgnoredDirectiveTrivia (#:property Configuration=Release) to appear twice in the output — once on the new first using (correct), and once on the original using which should have had it removed.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/82788)