### PR TITLE
Allow running roslyn insert tool on newer runtime

### DIFF
--- a/eng/pipelines/insert.yml
+++ b/eng/pipelines/insert.yml
@@ -225,3 +225,4 @@ steps:
     env:
       DevDivToken: ${{ parameters.devDivAzdoToken }}
       DncEngToken: ${{ parameters.dncEngAzdoToken }}
+      DOTNET_ROLL_FORWARD: Major


### PR DESCRIPTION
Should fix official builds failing with

```
You must install or update .NET to run this application.

App: D:\a\_work\1\s\.tools\roslyn-tools.exe
Architecture: x64
Framework: 'Microsoft.NETCore.App', version '9.0.0' (x64)
.NET location: C:\Program Files\dotnet\

The following frameworks were found:
  6.0.36 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  8.0.24 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  10.0.3 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]

The following frameworks for other architectures were found:
  x86
    6.0.36 at [C:\Program Files (x86)\dotnet\shared\Microsoft.NETCore.App]
    8.0.24 at [C:\Program Files (x86)\dotnet\shared\Microsoft.NETCore.App]
    10.0.3 at [C:\Program Files (x86)\dotnet\shared\Microsoft.NETCore.App]
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/82796)