### PR TITLE
Add componentBuildProjectName to PR validation configuration

### DIFF
--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -352,6 +352,7 @@ extends:
             vsBranchName: ${{ parameters.VisualStudioBranchName }}
             titlePrefix: "[PR - #${{ parameters.PRNumber }}]"
             sourceBranch: $(ComponentBranchName)
+            componentBuildProjectName: $(System.TeamProject)
             publishDataURI: "https://raw.githubusercontent.com/dotnet/roslyn/$(ComponentBranchName)/eng/config/PublishData.json"
             queueSpeedometerValidation: true
             dropPath: '$(Pipeline.Workspace)\VSSetup'


### PR DESCRIPTION
Really the insert.yml should be defaulting this for us, but since the official.yml is passing it in, I will do that too. I need to have more time to really look at the insert.yml altogether.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/82803)