### PR TITLE
Reduce allocations in TextDocumentStates.AddRange

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentStates.cs
@@ -142,15 +142,13 @@ internal sealed class TextDocumentStates<TState>
 
     public TextDocumentStates<TState> AddRange(ImmutableArray<TState> states)
     {
-        using var pooledIds = SharedPools.Default<List<DocumentId>>().GetPooledObject();
-        var ids = pooledIds.Object;
+        using var _ = ArrayBuilder<DocumentId>.GetInstance(discardLargeInstances: false, out var ids);
 
-        foreach (var state in states)
-            ids.Add(state.Id);
+        ids.AddRange(states, static state => state.Id);
 
         return new(
             _ids.AddRange(ids),
-            States.AddRange(states.Select(state => KeyValuePair.Create(state.Id, state))),
+            States.AddRange(states.Select(static state => KeyValuePair.Create(state.Id, state))),
             filePathToDocumentIds: null);
     }
 


### PR DESCRIPTION
The states array passed into TextDocumentStates.AddRange are quite commonly larger than the SharedPoolExtensions.Threshold value of 512, causing that beautiful array to get GC'ed. Instead, explicitly use an ArrayBuilder that doesn't discard large objects. I'm not seeing a large amount of concurrency (I've seen at most five entries in the pool), so there isn't too much of a concern about holding onto these larger arrays.

This is currently accounting for about 34 MB (0.3%) of all devenv allocations in the CSharpEditingTests.ScrollingAndTyping speedometer test.

Will update with speedometer results when the test validation run completes.

*** Before ***
<img width="1668" height="549" alt="image" src="https://github.com/user-attachments/assets/27423a10-c903-4724-bddc-0b99e3489454" />
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/82806)

*** After ***
<img width="1157" height="296" alt="image" src="https://github.com/user-attachments/assets/15d5db1a-fe80-4b95-8caf-5c4707576450" />