### PR TITLE
Reduce allocations in MergedNamespaceDeclaration.addNamespacesToChildren

### DIFF
--- a/src/Compilers/CSharp/Portable/Declarations/MergedNamespaceDeclaration.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/MergedNamespaceDeclaration.cs
@@ -6,6 +6,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -178,6 +179,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 static void populateNamespaceCounts(ArrayBuilder<SingleNamespaceDeclaration> namespaces, PooledDictionary<string, int> namespaceCounts)
                 {
+                    Debug.Assert(namespaces.Count > 0);
+
                     var name = namespaces[0].Name;
                     var count = 0;
 
@@ -203,6 +206,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 static void populateNamespaceGroups(ArrayBuilder<SingleNamespaceDeclaration> namespaces, PooledDictionary<string, (SingleNamespaceDeclaration[] Declarations, int Index)> namespaceGroups, PooledDictionary<string, int> namespaceCounts)
                 {
+                    Debug.Assert(namespaces.Count > 0);
+
                     var name = namespaces[0].Name;
                     var declarations = new SingleNamespaceDeclaration[namespaceCounts[name]];
                     var index = 0;


### PR DESCRIPTION
Adds an extra pass to determine the number namespace declarations share the same name. This allows the code to exactly size the arrays used to populate the returned MergedNamespaceDeclaration. The old code suffered from the ArrayBuilders getting resized constantly (they would reach up to 1200 entries when opening Roslyn.sln) and then the ArrayBuilders would be thrown away because they exceeded the pooled size threshold.

There was a bit of extra care added in the third commit to reduce dictionary lookups and writes as otherwise the code (although less allocate-y) would take more CPU time.

Measurements taken from the Typing scenario in the CSharpEditingTests.ScrollingAndType speedometer test for the devenv process

| Version | Alloc (MB) | Alloc (%) | CPU (ms) | CPU (%) |
| --- | --- | --- | --- | --- |
| Original | 28.0 | 0.8 | 58 | 0.1 |
| Changed | 14.9 | 0.4 | 30 | 0.1 |