### PR TITLE
Enable CFSClean* policies for dotnet-roslyn-official pipeline (17.14)

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -103,6 +103,8 @@ variables:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    settings:
+      networkIsolationPolicy: Permissive, CFSClean, CFSClean2
     featureFlags:
       autoBaseline: true
       incrementalSDLBinaryAnalysis: false


### PR DESCRIPTION
Adds CFSClean and CFSClean2 network isolation policies.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/82828)