### PR TITLE
Add tests for inline regex options in conditional expression branches

### DIFF
--- a/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/RegularExpressions/CSharpRegexParserTests.cs
+++ b/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/RegularExpressions/CSharpRegexParserTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -41,11 +41,12 @@ public sealed partial class CSharpRegexParserTests
     }
 
     private void Test(
-        string stringText, string expected, RegexOptions options)
+        string stringText, string expected, RegexOptions options,
+        bool runtimeHasBug = false)
     {
-        var (tree, sourceText) = TryParseTree(stringText, options, conversionFailureOk: false);
+        var (tree, sourceText) = TryParseTree(stringText, options, conversionFailureOk: false, runtimeHasBug);
 
-        TryParseSubTrees(stringText, options);
+        TryParseSubTrees(stringText, options, runtimeHasBug);
 
         var actual = TreeToText(sourceText, tree)
             .Replace("&quot;", """
@@ -54,7 +55,7 @@ public sealed partial class CSharpRegexParserTests
         AssertEx.Equal(expected, actual);
     }
 
-    private void TryParseSubTrees(string stringText, RegexOptions options)
+    private void TryParseSubTrees(string stringText, RegexOptions options, bool runtimeHasBug = false)
     {
         // Trim the input from the right and make sure tree invariants hold
         var current = stringText;
@@ -67,7 +68,7 @@ public sealed partial class CSharpRegexParserTests
             current = current[..^2] + """
                 "
                 """;
-            TryParseTree(current, options, conversionFailureOk: true);
+            TryParseTree(current, options, conversionFailureOk: true, runtimeHasBug);
         }
 
         // Trim the input from the left and make sure tree invariants hold
@@ -91,7 +92,7 @@ public sealed partial class CSharpRegexParserTests
                     """ + current[2..];
             }
 
-            TryParseTree(current, options, conversionFailureOk: true);
+            TryParseTree(current, options, conversionFailureOk: true, runtimeHasBug);
         }
 
         for (var start = stringText[0] == '@' ? 2 : 1; start < stringText.Length - 1; start++)
@@ -100,7 +101,8 @@ public sealed partial class CSharpRegexParserTests
                 stringText[..start] +
                 stringText[(start + 1)..],
                 options,
-                conversionFailureOk: true);
+                conversionFailureOk: true,
+                runtimeHasBug);
         }
     }
 
@@ -120,7 +122,8 @@ public sealed partial class CSharpRegexParserTests
     }
 
     private (RegexTree, SourceText) TryParseTree(
-        string stringText, RegexOptions options, bool conversionFailureOk)
+        string stringText, RegexOptions options, bool conversionFailureOk,
+        bool runtimeHasBug = false)
     {
         var (token, tree, allChars) = JustParseTree(stringText, options, conversionFailureOk);
         if (tree == null)
@@ -140,6 +143,13 @@ public sealed partial class CSharpRegexParserTests
         }
         catch (ArgumentException ex)
         {
+            if (runtimeHasBug)
+            {
+                // The .NET runtime has a bug where it rejects this pattern. Our parser correctly
+                // accepts it. Skip runtime validation. See https://github.com/dotnet/runtime/issues/111633
+                return treeAndText;
+            }
+
             Assert.NotEmpty(tree.Diagnostics);
 
             // Ensure the diagnostic we emit is the same as the .NET one. Note: we can only

--- a/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/RegularExpressions/CSharpRegexParserTests_BasicTests.cs
+++ b/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/RegularExpressions/CSharpRegexParserTests_BasicTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -18301,6 +18301,369 @@ public sealed partial class CSharpRegexParserTests
               </CompilationUnit>
               <Captures>
                 <Capture Name="0" Span="[10..17)" Text="[-[:L:]" />
+              </Captures>
+            </Tree>
+            """, RegexOptions.None);
+
+    [Fact]
+    public void TestInlineOptionsInConditionalBranch_ExpressionConditional_YesBranch()
+        => Test("""
+            @"(?(cat)(?i)CAT|dog)"
+            """, """
+            <Tree>
+              <CompilationUnit>
+                <Sequence>
+                  <ConditionalExpressionGrouping>
+                    <OpenParenToken>(</OpenParenToken>
+                    <QuestionToken>?</QuestionToken>
+                    <SimpleGrouping>
+                      <OpenParenToken>(</OpenParenToken>
+                      <Sequence>
+                        <Text>
+                          <TextToken>cat</TextToken>
+                        </Text>
+                      </Sequence>
+                      <CloseParenToken>)</CloseParenToken>
+                    </SimpleGrouping>
+                    <Alternation>
+                      <Sequence>
+                        <SimpleOptionsGrouping>
+                          <OpenParenToken>(</OpenParenToken>
+                          <QuestionToken>?</QuestionToken>
+                          <OptionsToken>i</OptionsToken>
+                          <CloseParenToken>)</CloseParenToken>
+                        </SimpleOptionsGrouping>
+                        <Text>
+                          <TextToken>CAT</TextToken>
+                        </Text>
+                      </Sequence>
+                      <BarToken>|</BarToken>
+                      <Sequence>
+                        <Text>
+                          <TextToken>dog</TextToken>
+                        </Text>
+                      </Sequence>
+                    </Alternation>
+                    <CloseParenToken>)</CloseParenToken>
+                  </ConditionalExpressionGrouping>
+                </Sequence>
+                <EndOfFile />
+              </CompilationUnit>
+              <Captures>
+                <Capture Name="0" Span="[10..29)" Text="(?(cat)(?i)CAT|dog)" />
+              </Captures>
+            </Tree>
+            """, RegexOptions.None, runtimeHasBug: true);
+
+    [Fact]
+    public void TestInlineOptionsInConditionalBranch_ExpressionConditional_NoBranch()
+        => Test("""
+            @"(?(cat)cat|(?i)dog)"
+            """, """
+            <Tree>
+              <CompilationUnit>
+                <Sequence>
+                  <ConditionalExpressionGrouping>
+                    <OpenParenToken>(</OpenParenToken>
+                    <QuestionToken>?</QuestionToken>
+                    <SimpleGrouping>
+                      <OpenParenToken>(</OpenParenToken>
+                      <Sequence>
+                        <Text>
+                          <TextToken>cat</TextToken>
+                        </Text>
+                      </Sequence>
+                      <CloseParenToken>)</CloseParenToken>
+                    </SimpleGrouping>
+                    <Alternation>
+                      <Sequence>
+                        <Text>
+                          <TextToken>cat</TextToken>
+                        </Text>
+                      </Sequence>
+                      <BarToken>|</BarToken>
+                      <Sequence>
+                        <SimpleOptionsGrouping>
+                          <OpenParenToken>(</OpenParenToken>
+                          <QuestionToken>?</QuestionToken>
+                          <OptionsToken>i</OptionsToken>
+                          <CloseParenToken>)</CloseParenToken>
+                        </SimpleOptionsGrouping>
+                        <Text>
+                          <TextToken>dog</TextToken>
+                        </Text>
+                      </Sequence>
+                    </Alternation>
+                    <CloseParenToken>)</CloseParenToken>
+                  </ConditionalExpressionGrouping>
+                </Sequence>
+                <EndOfFile />
+              </CompilationUnit>
+              <Captures>
+                <Capture Name="0" Span="[10..29)" Text="(?(cat)cat|(?i)dog)" />
+              </Captures>
+            </Tree>
+            """, RegexOptions.None, runtimeHasBug: true);
+
+    [Fact]
+    public void TestInlineOptionsInConditionalBranch_NestedOptionsGroup()
+        => Test("""
+            @"(?(cat)(?i:CAT)|dog)"
+            """, """
+            <Tree>
+              <CompilationUnit>
+                <Sequence>
+                  <ConditionalExpressionGrouping>
+                    <OpenParenToken>(</OpenParenToken>
+                    <QuestionToken>?</QuestionToken>
+                    <SimpleGrouping>
+                      <OpenParenToken>(</OpenParenToken>
+                      <Sequence>
+                        <Text>
+                          <TextToken>cat</TextToken>
+                        </Text>
+                      </Sequence>
+                      <CloseParenToken>)</CloseParenToken>
+                    </SimpleGrouping>
+                    <Alternation>
+                      <Sequence>
+                        <NestedOptionsGrouping>
+                          <OpenParenToken>(</OpenParenToken>
+                          <QuestionToken>?</QuestionToken>
+                          <OptionsToken>i</OptionsToken>
+                          <ColonToken>:</ColonToken>
+                          <Sequence>
+                            <Text>
+                              <TextToken>CAT</TextToken>
+                            </Text>
+                          </Sequence>
+                          <CloseParenToken>)</CloseParenToken>
+                        </NestedOptionsGrouping>
+                      </Sequence>
+                      <BarToken>|</BarToken>
+                      <Sequence>
+                        <Text>
+                          <TextToken>dog</TextToken>
+                        </Text>
+                      </Sequence>
+                    </Alternation>
+                    <CloseParenToken>)</CloseParenToken>
+                  </ConditionalExpressionGrouping>
+                </Sequence>
+                <EndOfFile />
+              </CompilationUnit>
+              <Captures>
+                <Capture Name="0" Span="[10..30)" Text="(?(cat)(?i:CAT)|dog)" />
+              </Captures>
+            </Tree>
+            """, RegexOptions.None, runtimeHasBug: true);
+
+    [Fact]
+    public void TestInlineOptionsInConditionalBranch_LookaheadConditional()
+        => Test("""
+            @"(?(?=cat)(?i)CAT|dog)"
+            """, """
+            <Tree>
+              <CompilationUnit>
+                <Sequence>
+                  <ConditionalExpressionGrouping>
+                    <OpenParenToken>(</OpenParenToken>
+                    <QuestionToken>?</QuestionToken>
+                    <PositiveLookaheadGrouping>
+                      <OpenParenToken>(</OpenParenToken>
+                      <QuestionToken>?</QuestionToken>
+                      <EqualsToken>=</EqualsToken>
+                      <Sequence>
+                        <Text>
+                          <TextToken>cat</TextToken>
+                        </Text>
+                      </Sequence>
+                      <CloseParenToken>)</CloseParenToken>
+                    </PositiveLookaheadGrouping>
+                    <Alternation>
+                      <Sequence>
+                        <SimpleOptionsGrouping>
+                          <OpenParenToken>(</OpenParenToken>
+                          <QuestionToken>?</QuestionToken>
+                          <OptionsToken>i</OptionsToken>
+                          <CloseParenToken>)</CloseParenToken>
+                        </SimpleOptionsGrouping>
+                        <Text>
+                          <TextToken>CAT</TextToken>
+                        </Text>
+                      </Sequence>
+                      <BarToken>|</BarToken>
+                      <Sequence>
+                        <Text>
+                          <TextToken>dog</TextToken>
+                        </Text>
+                      </Sequence>
+                    </Alternation>
+                    <CloseParenToken>)</CloseParenToken>
+                  </ConditionalExpressionGrouping>
+                </Sequence>
+                <EndOfFile />
+              </CompilationUnit>
+              <Captures>
+                <Capture Name="0" Span="[10..31)" Text="(?(?=cat)(?i)CAT|dog)" />
+              </Captures>
+            </Tree>
+            """, RegexOptions.None, runtimeHasBug: true);
+
+    [Fact]
+    public void TestInlineOptionsInConditionalBranch_BackreferenceConditional()
+        => Test("""
+            @"(cat)?(?(1)(?i)dog|pig)"
+            """, """
+            <Tree>
+              <CompilationUnit>
+                <Sequence>
+                  <ZeroOrOneQuantifier>
+                    <SimpleGrouping>
+                      <OpenParenToken>(</OpenParenToken>
+                      <Sequence>
+                        <Text>
+                          <TextToken>cat</TextToken>
+                        </Text>
+                      </Sequence>
+                      <CloseParenToken>)</CloseParenToken>
+                    </SimpleGrouping>
+                    <QuestionToken>?</QuestionToken>
+                  </ZeroOrOneQuantifier>
+                  <ConditionalCaptureGrouping>
+                    <OpenParenToken>(</OpenParenToken>
+                    <QuestionToken>?</QuestionToken>
+                    <OpenParenToken>(</OpenParenToken>
+                    <NumberToken value="1">1</NumberToken>
+                    <CloseParenToken>)</CloseParenToken>
+                    <Alternation>
+                      <Sequence>
+                        <SimpleOptionsGrouping>
+                          <OpenParenToken>(</OpenParenToken>
+                          <QuestionToken>?</QuestionToken>
+                          <OptionsToken>i</OptionsToken>
+                          <CloseParenToken>)</CloseParenToken>
+                        </SimpleOptionsGrouping>
+                        <Text>
+                          <TextToken>dog</TextToken>
+                        </Text>
+                      </Sequence>
+                      <BarToken>|</BarToken>
+                      <Sequence>
+                        <Text>
+                          <TextToken>pig</TextToken>
+                        </Text>
+                      </Sequence>
+                    </Alternation>
+                    <CloseParenToken>)</CloseParenToken>
+                  </ConditionalCaptureGrouping>
+                </Sequence>
+                <EndOfFile />
+              </CompilationUnit>
+              <Captures>
+                <Capture Name="0" Span="[10..33)" Text="(cat)?(?(1)(?i)dog|pig)" />
+                <Capture Name="1" Span="[10..15)" Text="(cat)" />
+              </Captures>
+            </Tree>
+            """, RegexOptions.None, runtimeHasBug: true);
+
+    [Fact]
+    public void TestInlineOptionsInConditionalBranch_OptionsInTestExpression()
+        => Test("""
+            @"(?((?i)cat)CAT|dog)"
+            """, """
+            <Tree>
+              <CompilationUnit>
+                <Sequence>
+                  <ConditionalExpressionGrouping>
+                    <OpenParenToken>(</OpenParenToken>
+                    <QuestionToken>?</QuestionToken>
+                    <SimpleGrouping>
+                      <OpenParenToken>(</OpenParenToken>
+                      <Sequence>
+                        <SimpleOptionsGrouping>
+                          <OpenParenToken>(</OpenParenToken>
+                          <QuestionToken>?</QuestionToken>
+                          <OptionsToken>i</OptionsToken>
+                          <CloseParenToken>)</CloseParenToken>
+                        </SimpleOptionsGrouping>
+                        <Text>
+                          <TextToken>cat</TextToken>
+                        </Text>
+                      </Sequence>
+                      <CloseParenToken>)</CloseParenToken>
+                    </SimpleGrouping>
+                    <Alternation>
+                      <Sequence>
+                        <Text>
+                          <TextToken>CAT</TextToken>
+                        </Text>
+                      </Sequence>
+                      <BarToken>|</BarToken>
+                      <Sequence>
+                        <Text>
+                          <TextToken>dog</TextToken>
+                        </Text>
+                      </Sequence>
+                    </Alternation>
+                    <CloseParenToken>)</CloseParenToken>
+                  </ConditionalExpressionGrouping>
+                </Sequence>
+                <EndOfFile />
+              </CompilationUnit>
+              <Captures>
+                <Capture Name="0" Span="[10..29)" Text="(?((?i)cat)CAT|dog)" />
+              </Captures>
+            </Tree>
+            """, RegexOptions.None, runtimeHasBug: true);
+
+    [Fact]
+    public void TestInlineOptionsInConditionalBranch_OptionsAsTestExpression_Negative()
+        => Test("""
+            @"(?(?i)yes|no)"
+            """, """
+            <Tree>
+              <CompilationUnit>
+                <Sequence>
+                  <ConditionalExpressionGrouping>
+                    <OpenParenToken>(</OpenParenToken>
+                    <QuestionToken>?</QuestionToken>
+                    <SimpleGrouping>
+                      <OpenParenToken>(</OpenParenToken>
+                      <Sequence>
+                        <Text>
+                          <TextToken>?</TextToken>
+                        </Text>
+                        <Text>
+                          <TextToken>i</TextToken>
+                        </Text>
+                      </Sequence>
+                      <CloseParenToken>)</CloseParenToken>
+                    </SimpleGrouping>
+                    <Alternation>
+                      <Sequence>
+                        <Text>
+                          <TextToken>yes</TextToken>
+                        </Text>
+                      </Sequence>
+                      <BarToken>|</BarToken>
+                      <Sequence>
+                        <Text>
+                          <TextToken>no</TextToken>
+                        </Text>
+                      </Sequence>
+                    </Alternation>
+                    <CloseParenToken>)</CloseParenToken>
+                  </ConditionalExpressionGrouping>
+                </Sequence>
+                <EndOfFile />
+              </CompilationUnit>
+              <Diagnostics>
+                <Diagnostic Message="Unrecognized grouping construct" Span="[12..13)" Text="(" />
+                <Diagnostic Message="Quantifier '?' following nothing" Span="[13..14)" Text="?" />
+              </Diagnostics>
+              <Captures>
+                <Capture Name="0" Span="[10..23)" Text="(?(?i)yes|no)" />
               </Captures>
             </Tree>
             """, RegexOptions.None);


### PR DESCRIPTION
Adds tests matching the cases from dotnet/runtime#124699, which fixed a bug where the .NET runtime incorrectly rejected inline options like `(?i)` inside the yes/no branches of expression conditionals (e.g. `(?(test)(?i)yes|no)`). Roslyn's RegexParser already handled these patterns correctly due to its flag-based approach, so no parser changes are needed.

Adds a runtimeHasBug parameter to the test infrastructure so tests can pass even when the .NET runtime being tested against still has the bug (dotnet/runtime#111633).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/82834)