### PR TITLE
Make the fetch of the VisualStudioWorkspace lazy in ObjectBrowser

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
@@ -98,11 +98,9 @@ internal sealed class CSharpPackage : AbstractPackage<CSharpPackage, CSharpLangu
     {
         Contract.ThrowIfFalse(JoinableTaskFactory.Context.IsOnMainThread);
 
-        var workspace = this.ComponentModel.GetService<VisualStudioWorkspace>();
-
         if (GetService(typeof(SVsObjectManager)) is IVsObjectManager2 objectManager)
         {
-            _libraryManager = new ObjectBrowserLibraryManager(this, ComponentModel, workspace);
+            _libraryManager = new ObjectBrowserLibraryManager(this, ComponentModel);
 
             if (ErrorHandler.Failed(objectManager.RegisterSimpleLibrary(_libraryManager, out _libraryManagerCookie)))
             {

--- a/src/VisualStudio/CSharp/Impl/ObjectBrowser/ObjectBrowserLibraryManager.cs
+++ b/src/VisualStudio/CSharp/Impl/ObjectBrowser/ObjectBrowserLibraryManager.cs
@@ -14,9 +14,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ObjectBrowser;
 
 internal sealed class ObjectBrowserLibraryManager(
     IServiceProvider serviceProvider,
-    IComponentModel componentModel,
-    VisualStudioWorkspace workspace) : AbstractObjectBrowserLibraryManager(
-        LanguageNames.CSharp, Guids.CSharpLibraryId, serviceProvider, componentModel, workspace)
+    IComponentModel componentModel) : AbstractObjectBrowserLibraryManager(
+        LanguageNames.CSharp, Guids.CSharpLibraryId, serviceProvider, componentModel)
 {
     internal override AbstractDescriptionBuilder CreateDescriptionBuilder(
         IVsObjectBrowserDescription3 description,

--- a/src/VisualStudio/Core/Def/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager.cs
+++ b/src/VisualStudio/Core/Def/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager.cs
@@ -29,7 +29,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
 
 internal abstract partial class AbstractObjectBrowserLibraryManager : AbstractLibraryManager, IDisposable
 {
-    internal readonly VisualStudioWorkspace Workspace;
+    private readonly Lazy<VisualStudioWorkspace> _workspace;
+
+    internal VisualStudioWorkspace Workspace => _workspace.Value;
 
     internal ILibraryService LibraryService => _libraryService.Value;
 
@@ -47,14 +49,21 @@ internal abstract partial class AbstractObjectBrowserLibraryManager : AbstractLi
         string languageName,
         Guid libraryGuid,
         IServiceProvider serviceProvider,
-        IComponentModel componentModel,
-        VisualStudioWorkspace workspace)
+        IComponentModel componentModel)
         : base(libraryGuid, componentModel, serviceProvider)
     {
         _languageName = languageName;
 
-        Workspace = workspace;
-        _workspaceChangedDisposer = Workspace.RegisterWorkspaceChangedHandler(OnWorkspaceChanged);
+        _workspace = new Lazy<VisualStudioWorkspace>(() =>
+        {
+            var workspace = ComponentModel.GetService<VisualStudioWorkspace>();
+
+            // We will now register for WorkspaceChanged now. Since that's used to invalidate previously cached results, there was no reason to be subscribed earlier
+            // since nothing could have observed the workspace. OnWorkspaceChanged could run during the rest of this Lazy<T> -- in that case it'll just wait
+            // for the Lazy to complete. If anything else is put after RegisterWorkspaceChangedHandler, think carefully about the potential ordering.
+            _workspaceChangedDisposer = workspace.RegisterWorkspaceChangedHandler(OnWorkspaceChanged);
+            return workspace;
+        });
 
         _libraryService = new Lazy<ILibraryService>(() => Workspace.Services.GetLanguageServices(_languageName).GetService<ILibraryService>());
     }

--- a/src/VisualStudio/Core/Test/ObjectBrowser/AbstractObjectBrowserTests.vb
+++ b/src/VisualStudio/Core/Test/ObjectBrowser/AbstractObjectBrowserTests.vb
@@ -45,7 +45,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ObjectBrowser
                 Dim mockComponentModel = New MockComponentModel(workspace.ExportProvider)
                 mockComponentModel.ProvideService(Of VisualStudioWorkspace)(vsWorkspace)
                 Dim mockServiceProvider = workspace.ExportProvider.GetExportedValue(Of MockServiceProvider)
-                Dim libraryManager = CreateLibraryManager(mockServiceProvider, mockComponentModel, vsWorkspace)
+                Dim libraryManager = CreateLibraryManager(mockServiceProvider, mockComponentModel)
 
                 result = New TestState(workspace, vsWorkspace, libraryManager)
             Finally
@@ -57,7 +57,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ObjectBrowser
             Return result
         End Function
 
-        Friend MustOverride Function CreateLibraryManager(serviceProvider As IServiceProvider, componentModel As IComponentModel, workspace As VisualStudioWorkspace) As AbstractObjectBrowserLibraryManager
+        Friend MustOverride Function CreateLibraryManager(serviceProvider As IServiceProvider, componentModel As IComponentModel) As AbstractObjectBrowserLibraryManager
 
         Friend Function ProjectNode(name As String) As NavInfoNodeDescriptor
             Return New NavInfoNodeDescriptor With {.Kind = ObjectListKind.Projects, .Name = name}

--- a/src/VisualStudio/Core/Test/ObjectBrowser/CSharp/ObjectBrowerTests.vb
+++ b/src/VisualStudio/Core/Test/ObjectBrowser/CSharp/ObjectBrowerTests.vb
@@ -21,8 +21,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ObjectBrowser.CSharp
             End Get
         End Property
 
-        Friend Overrides Function CreateLibraryManager(serviceProvider As IServiceProvider, componentModel As IComponentModel, workspace As VisualStudioWorkspace) As AbstractObjectBrowserLibraryManager
-            Return New ObjectBrowserLibraryManager(serviceProvider, componentModel, workspace)
+        Friend Overrides Function CreateLibraryManager(serviceProvider As IServiceProvider, componentModel As IComponentModel) As AbstractObjectBrowserLibraryManager
+            Return New ObjectBrowserLibraryManager(serviceProvider, componentModel)
         End Function
 
         <WpfFact>

--- a/src/VisualStudio/Core/Test/ObjectBrowser/VisualBasic/ObjectBrowerTests.vb
+++ b/src/VisualStudio/Core/Test/ObjectBrowser/VisualBasic/ObjectBrowerTests.vb
@@ -21,8 +21,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ObjectBrowser.Visual
             End Get
         End Property
 
-        Friend Overrides Function CreateLibraryManager(serviceProvider As IServiceProvider, componentModel As IComponentModel, workspace As VisualStudioWorkspace) As AbstractObjectBrowserLibraryManager
-            Return New ObjectBrowserLibraryManager(serviceProvider, componentModel, workspace)
+        Friend Overrides Function CreateLibraryManager(serviceProvider As IServiceProvider, componentModel As IComponentModel) As AbstractObjectBrowserLibraryManager
+            Return New ObjectBrowserLibraryManager(serviceProvider, componentModel)
         End Function
 
         <WpfFact>

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
@@ -90,13 +90,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
         End Sub
 
         Protected Overrides Sub RegisterObjectBrowserLibraryManager()
-            Dim workspace As VisualStudioWorkspace = ComponentModel.GetService(Of VisualStudioWorkspace)()
-
             Contract.ThrowIfFalse(JoinableTaskFactory.Context.IsOnMainThread)
 
             Dim objectManager = TryCast(GetService(GetType(SVsObjectManager)), IVsObjectManager2)
             If objectManager IsNot Nothing Then
-                Me._libraryManager = New ObjectBrowserLibraryManager(Me, ComponentModel, workspace)
+                Me._libraryManager = New ObjectBrowserLibraryManager(Me, ComponentModel)
 
                 If ErrorHandler.Failed(objectManager.RegisterSimpleLibrary(Me._libraryManager, Me._libraryManagerCookie)) Then
                     Me._libraryManagerCookie = 0

--- a/src/VisualStudio/VisualBasic/Impl/ObjectBrowser/ObjectBrowserLibraryManager.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ObjectBrowser/ObjectBrowserLibraryManager.vb
@@ -11,8 +11,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ObjectBrowser
     Friend NotInheritable Class ObjectBrowserLibraryManager
         Inherits AbstractObjectBrowserLibraryManager
 
-        Public Sub New(serviceProvider As IServiceProvider, componentModel As IComponentModel, workspace As VisualStudioWorkspace)
-            MyBase.New(LanguageNames.VisualBasic, Guids.VisualBasicLibraryId, serviceProvider, componentModel, workspace)
+        Public Sub New(serviceProvider As IServiceProvider, componentModel As IComponentModel)
+            MyBase.New(LanguageNames.VisualBasic, Guids.VisualBasicLibraryId, serviceProvider, componentModel)
         End Sub
 
         Friend Overrides Function CreateDescriptionBuilder(


### PR DESCRIPTION
This is one of the few remaining uses of MEF on the UI thread in our package initialization.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1812707