### PR TITLE
Modify SyntaxNode trivia search/walk methods to utilize green node checks

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeRemover.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeRemover.cs
@@ -431,7 +431,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                         _directivesToKeep.Clear();
                     }
 
-                    var directivesInSpan = node.DescendantTrivia(span, n => n.ContainsDirectives, descendIntoTrivia: true)
+                    var directivesInSpan = node.DescendantTrivia(span, descendIntoChildrenGreen: static n => n.ContainsDirectives, descendIntoChildrenRed: null, descendIntoTrivia: true)
                                                .Where(tr => tr.IsDirective)
                                                .Select(tr => (DirectiveTriviaSyntax)tr.GetStructure()!);
 

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNode.Iterators.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNode.Iterators.cs
@@ -8,7 +8,6 @@ using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -38,11 +37,15 @@ namespace Microsoft.CodeAnalysis
                 : DescendantNodesAndTokensOnly(span, descendIntoChildrenGreen, descendIntoChildrenRed, includeSelf);
         }
 
-        private IEnumerable<SyntaxTrivia> DescendantTriviaImpl(TextSpan span, Func<SyntaxNode, bool>? descendIntoChildren = null, bool descendIntoTrivia = false)
+        private IEnumerable<SyntaxTrivia> DescendantTriviaImpl(
+            TextSpan span,
+            Func<GreenNode, bool>? descendIntoChildrenGreen,
+            Func<SyntaxNode, bool>? descendIntoChildrenRed,
+            bool descendIntoTrivia = false)
         {
             return descendIntoTrivia
-                ? DescendantTriviaIntoTrivia(span, descendIntoChildren)
-                : DescendantTriviaOnly(span, descendIntoChildren);
+                ? DescendantTriviaIntoTrivia(span, descendIntoChildrenGreen, descendIntoChildrenRed)
+                : DescendantTriviaOnly(span, descendIntoChildrenGreen, descendIntoChildrenRed);
         }
 
         private static bool IsInSpan(in TextSpan span, TextSpan childSpan)
@@ -574,9 +577,12 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        private IEnumerable<SyntaxTrivia> DescendantTriviaOnly(TextSpan span, Func<SyntaxNode, bool>? descendIntoChildren)
+        private IEnumerable<SyntaxTrivia> DescendantTriviaOnly(
+            TextSpan span,
+            Func<GreenNode, bool>? descendIntoChildrenGreen,
+            Func<SyntaxNode, bool>? descendIntoChildrenRed)
         {
-            using (var stack = new ChildSyntaxListEnumeratorStack(this, descendIntoChildrenGreen: null, descendIntoChildren))
+            using (var stack = new ChildSyntaxListEnumeratorStack(this, descendIntoChildrenGreen, descendIntoChildrenRed))
             {
                 while (stack.IsNotEmpty)
                 {
@@ -612,9 +618,12 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        private IEnumerable<SyntaxTrivia> DescendantTriviaIntoTrivia(TextSpan span, Func<SyntaxNode, bool>? descendIntoChildren)
+        private IEnumerable<SyntaxTrivia> DescendantTriviaIntoTrivia(
+            TextSpan span,
+            Func<GreenNode, bool>? descendIntoChildrenGreen,
+            Func<SyntaxNode, bool>? descendIntoChildrenRed)
         {
-            using (var stack = new TwoEnumeratorListStack(this, descendIntoChildrenGreen: null, descendIntoChildren))
+            using (var stack = new TwoEnumeratorListStack(this, descendIntoChildrenGreen, descendIntoChildrenRed))
             {
                 while (stack.IsNotEmpty)
                 {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
@@ -1184,7 +1184,7 @@ recurse:
         /// </summary>
         public IEnumerable<SyntaxTrivia> DescendantTrivia(Func<SyntaxNode, bool>? descendIntoChildren = null, bool descendIntoTrivia = false)
         {
-            return DescendantTriviaImpl(this.FullSpan, descendIntoChildren, descendIntoTrivia);
+            return DescendantTriviaImpl(this.FullSpan, descendIntoChildrenGreen: null, descendIntoChildren, descendIntoTrivia);
         }
 
         /// <summary>
@@ -1192,7 +1192,30 @@ recurse:
         /// </summary>
         public IEnumerable<SyntaxTrivia> DescendantTrivia(TextSpan span, Func<SyntaxNode, bool>? descendIntoChildren = null, bool descendIntoTrivia = false)
         {
-            return DescendantTriviaImpl(span, descendIntoChildren, descendIntoTrivia);
+            return DescendantTriviaImpl(span, descendIntoChildrenGreen: null, descendIntoChildren, descendIntoTrivia);
+        }
+
+        /// <summary>
+        /// Get a list of all the trivia associated with the descendant nodes and tokens.
+        /// </summary>
+        internal IEnumerable<SyntaxTrivia> DescendantTrivia(
+            Func<GreenNode, bool>? descendIntoChildrenGreen,
+            Func<SyntaxNode, bool>? descendIntoChildrenRed,
+            bool descendIntoTrivia = false)
+        {
+            return DescendantTriviaImpl(this.FullSpan, descendIntoChildrenGreen, descendIntoChildrenRed, descendIntoTrivia);
+        }
+
+        /// <summary>
+        /// Get a list of all the trivia associated with the descendant nodes and tokens.
+        /// </summary>
+        internal IEnumerable<SyntaxTrivia> DescendantTrivia(
+            TextSpan span,
+            Func<GreenNode, bool>? descendIntoChildrenGreen,
+            Func<SyntaxNode, bool>? descendIntoChildrenRed,
+            bool descendIntoTrivia = false)
+        {
+            return DescendantTriviaImpl(span, descendIntoChildrenGreen, descendIntoChildrenRed, descendIntoTrivia);
         }
 
         #endregion
@@ -1328,7 +1351,7 @@ recurse:
         /// </summary>
         public IEnumerable<SyntaxTrivia> GetAnnotatedTrivia(string annotationKind)
         {
-            return this.DescendantTrivia(n => n.ContainsAnnotations, descendIntoTrivia: true)
+            return this.DescendantTrivia(descendIntoChildrenGreen: static n => n.ContainsAnnotations, descendIntoChildrenRed: null, descendIntoTrivia: true)
                        .Where(tr => tr.HasAnnotations(annotationKind));
         }
 
@@ -1337,7 +1360,7 @@ recurse:
         /// </summary>
         public IEnumerable<SyntaxTrivia> GetAnnotatedTrivia(params string[] annotationKinds)
         {
-            return this.DescendantTrivia(n => n.ContainsAnnotations, descendIntoTrivia: true)
+            return this.DescendantTrivia(descendIntoChildrenGreen: static n => n.ContainsAnnotations, descendIntoChildrenRed: null, descendIntoTrivia: true)
                        .Where(tr => tr.HasAnnotations(annotationKinds));
         }
 
@@ -1346,7 +1369,7 @@ recurse:
         /// </summary>
         public IEnumerable<SyntaxTrivia> GetAnnotatedTrivia(SyntaxAnnotation annotation)
         {
-            return this.DescendantTrivia(n => n.ContainsAnnotations, descendIntoTrivia: true)
+            return this.DescendantTrivia(descendIntoChildrenGreen: static n => n.ContainsAnnotations, descendIntoChildrenRed: null, descendIntoTrivia: true)
                        .Where(tr => tr.HasAnnotation(annotation));
         }
 

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrToken.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrToken.cs
@@ -869,7 +869,7 @@ namespace Microsoft.CodeAnalysis
         private static void GetDirectives<TDirective>(SyntaxNode node, Func<TDirective, bool>? filter, ref List<TDirective>? directives)
             where TDirective : SyntaxNode
         {
-            foreach (var trivia in node.DescendantTrivia(node => node.ContainsDirectives, descendIntoTrivia: true))
+            foreach (var trivia in node.DescendantTrivia(descendIntoChildrenGreen: static node => node.ContainsDirectives, descendIntoChildrenRed: null, descendIntoTrivia: true))
             {
                 GetDirectivesInTrivia(trivia, filter, ref directives);
             }

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxNodeRemover.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxNodeRemover.vb
@@ -298,7 +298,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax
                         Me._directivesToKeep.Clear()
                     End If
 
-                    Dim directivesInSpan = node.DescendantTrivia(span, Function(n) n.ContainsDirectives, descendIntoTrivia:=True) _
+                    Dim directivesInSpan = node.DescendantTrivia(span, descendIntoChildrenGreen:=Function(n) n.ContainsDirectives, descendIntoChildrenRed:=Nothing, descendIntoTrivia:=True) _
                                                .Where(Function(tr) tr.IsDirective) _
                                                .Select(Function(tr) DirectCast(tr.GetStructure(), DirectiveTriviaSyntax))
 


### PR DESCRIPTION
This is a simple extension on Cyrus's PR (https://github.com/dotnet/roslyn/pull/82816). 

This PR modifies the SyntaxNode trivia walks and searches to utilize the green node descend check, avoiding red node realization. Cyrus choose to not do this in his PR to limit the scope of changes in it.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/82893)