### PR TITLE
Add missing buildQueueName parameter to scouting pipeline

### DIFF
--- a/azure-pipelines-integration-scouting.yml
+++ b/azure-pipelines-integration-scouting.yml
@@ -32,6 +32,14 @@ parameters:
   default: windows.vs2022.amd64.open
   values:
   - windows.vs2022.amd64.open
+  - windows.vs2026preview.scout.amd64.open
+- name: buildQueueName
+  displayName: Build Queue Name
+  type: string
+  default: windows.vs2026preview.scout.amd64.open
+  values:
+  - windows.vs2022.amd64.open
+  - windows.vs2026preview.scout.amd64.open
 - name: timeout
   displayName: Timeout in Minutes
   type: number
@@ -42,6 +50,7 @@ stages:
   parameters:
     poolName: ${{ parameters.poolName }}
     queueName: ${{ parameters.queueName }}
+    buildQueueName: ${{ parameters.buildQueueName }}
     timeout: ${{ parameters.timeout }}
     configuration: Debug
     testRuns:
@@ -56,6 +65,7 @@ stages:
   parameters:
     poolName: ${{ parameters.poolName }}
     queueName: ${{ parameters.queueName }}
+    buildQueueName: ${{ parameters.buildQueueName }}
     timeout: ${{ parameters.timeout }}
     configuration: Release
     testRuns:


### PR DESCRIPTION
Missed this in https://github.com/dotnet/roslyn/pull/82740.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/82901)