### PR TITLE
Add IAsyncDisposable support to IWorkspaceProjectContext

### DIFF
--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/AdditionalPropertiesTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/AdditionalPropertiesTests.cs
@@ -26,15 +26,14 @@ public sealed class AdditionalPropertiesTests
     [WpfFact]
     public async Task SetProperty_RootNamespace_CPS()
     {
-        using (var environment = new TestEnvironment())
-        using (var project = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test"))
-        {
-            Assert.Null(DefaultNamespaceOfSingleProject(environment));
+        using var environment = new TestEnvironment();
+        await using var project = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test");
 
-            var rootNamespace = "Foo.Bar";
-            project.SetProperty(BuildPropertyNames.RootNamespace, rootNamespace);
-            Assert.Equal(rootNamespace, DefaultNamespaceOfSingleProject(environment));
-        }
+        Assert.Null(DefaultNamespaceOfSingleProject(environment));
+
+        var rootNamespace = "Foo.Bar";
+        project.SetProperty(BuildPropertyNames.RootNamespace, rootNamespace);
+        Assert.Equal(rootNamespace, DefaultNamespaceOfSingleProject(environment));
 
         static string DefaultNamespaceOfSingleProject(TestEnvironment environment)
             => environment.Workspace.CurrentSolution.Projects.Single().DefaultNamespace;
@@ -53,7 +52,7 @@ public sealed class AdditionalPropertiesTests
         const LanguageVersion attemptedVersion = LanguageVersion.CSharp8;
 
         using var environment = new TestEnvironment(typeof(CSharpParseOptionsChangingService));
-        using var cpsProject = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test");
+        await using var cpsProject = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test");
         var project = environment.Workspace.CurrentSolution.Projects.Single();
         var oldParseOptions = (CSharpParseOptions)project.ParseOptions;
 
@@ -80,7 +79,7 @@ public sealed class AdditionalPropertiesTests
         const LanguageVersion attemptedVersion = LanguageVersion.CSharp8;
 
         using var environment = new TestEnvironment(typeof(CSharpParseOptionsChangingService));
-        using var cpsProject = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test");
+        await using var cpsProject = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test");
         var project = environment.Workspace.CurrentSolution.Projects.Single();
         var oldParseOptions = (CSharpParseOptions)project.ParseOptions;
 
@@ -124,7 +123,7 @@ public sealed class AdditionalPropertiesTests
         async Task TestCPSProject()
         {
             using var environment = new TestEnvironment();
-            using var cpsProject = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test");
+            await using var cpsProject = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test");
 
             cpsProject.SetProperty(BuildPropertyNames.RunAnalyzers, runAnalyzers);
             cpsProject.SetProperty(BuildPropertyNames.RunAnalyzersDuringLiveAnalysis, runAnalyzersDuringLiveAnalysis);
@@ -156,24 +155,23 @@ public sealed class AdditionalPropertiesTests
     [WpfFact]
     public async Task SetProperty_CompilerGeneratedFilesOutputPath_CPS()
     {
-        using (var environment = new TestEnvironment())
-        using (var project = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test"))
-        {
-            Assert.Null(environment.Workspace.CurrentSolution.Projects.Single().CompilationOutputInfo.GeneratedFilesOutputDirectory);
+        using var environment = new TestEnvironment();
+        await using var project = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test");
 
-            // relative path is relative to the project dir:
-            project.SetProperty(BuildPropertyNames.CompilerGeneratedFilesOutputPath, "generated");
-            AssertEx.AreEqual(
-                Path.Combine(Path.GetDirectoryName(project.ProjectFilePath), "generated"),
-                environment.Workspace.CurrentSolution.Projects.Single().CompilationOutputInfo.GeneratedFilesOutputDirectory);
+        Assert.Null(environment.Workspace.CurrentSolution.Projects.Single().CompilationOutputInfo.GeneratedFilesOutputDirectory);
 
-            var path = Path.Combine(TempRoot.Root, "generated");
-            project.SetProperty(BuildPropertyNames.CompilerGeneratedFilesOutputPath, path);
-            AssertEx.AreEqual(path, environment.Workspace.CurrentSolution.Projects.Single().CompilationOutputInfo.GeneratedFilesOutputDirectory);
+        // relative path is relative to the project dir:
+        project.SetProperty(BuildPropertyNames.CompilerGeneratedFilesOutputPath, "generated");
+        AssertEx.AreEqual(
+            Path.Combine(Path.GetDirectoryName(project.ProjectFilePath), "generated"),
+            environment.Workspace.CurrentSolution.Projects.Single().CompilationOutputInfo.GeneratedFilesOutputDirectory);
 
-            // empty path:
-            project.SetProperty(BuildPropertyNames.CompilerGeneratedFilesOutputPath, "");
-            Assert.Null(environment.Workspace.CurrentSolution.Projects.Single().CompilationOutputInfo.GeneratedFilesOutputDirectory);
-        }
+        var path = Path.Combine(TempRoot.Root, "generated");
+        project.SetProperty(BuildPropertyNames.CompilerGeneratedFilesOutputPath, path);
+        AssertEx.AreEqual(path, environment.Workspace.CurrentSolution.Projects.Single().CompilationOutputInfo.GeneratedFilesOutputDirectory);
+
+        // empty path:
+        project.SetProperty(BuildPropertyNames.CompilerGeneratedFilesOutputPath, "");
+        Assert.Null(environment.Workspace.CurrentSolution.Projects.Single().CompilationOutputInfo.GeneratedFilesOutputDirectory);
     }
 }

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/AnalyzersTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/AnalyzersTests.cs
@@ -30,7 +30,7 @@ public sealed class AnalyzersTests : TestBase
             </RuleSet>
             """);
         using var environment = new TestEnvironment();
-        using var project = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test");
+        await using var project = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test");
         var workspaceProject = environment.Workspace.CurrentSolution.Projects.Single();
         var options = (CSharpCompilationOptions)workspaceProject.CompilationOptions;
 
@@ -59,7 +59,7 @@ public sealed class AnalyzersTests : TestBase
             """);
 
         using var environment = new TestEnvironment();
-        using var project = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test");
+        await using var project = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test");
         // Verify SetRuleSetFile updates the ruleset.
         project.SetOptions([$"/ruleset:{ruleSetFile.Path}"]);
 
@@ -76,7 +76,7 @@ public sealed class AnalyzersTests : TestBase
         using var environment = new TestEnvironment();
         ProjectId projectId;
 
-        using (var project = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test"))
+        await using (var project = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test"))
         {
             project.SetOptions([$"/ruleset:{ruleSetFile.Path}"]);
 

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/CSharpCompilerOptionsTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/CSharpCompilerOptionsTests.cs
@@ -27,7 +27,7 @@ public sealed class CSharpCompilerOptionsTests : TestBase
     public async Task DocumentationModeSetToDiagnoseIfProducingDocFile_CPS()
     {
         using var environment = new TestEnvironment();
-        using var project = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test", commandLineArguments: @"/doc:DocFile.xml");
+        await using var project = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test", commandLineArguments: @"/doc:DocFile.xml");
         var parseOptions = environment.Workspace.CurrentSolution.Projects.Single().ParseOptions;
         Assert.Equal(DocumentationMode.Diagnose, parseOptions.DocumentationMode);
     }
@@ -36,7 +36,7 @@ public sealed class CSharpCompilerOptionsTests : TestBase
     public async Task DocumentationModeSetToParseIfNotProducingDocFile_CPS()
     {
         using var environment = new TestEnvironment();
-        using var project = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test", commandLineArguments: @"/doc:");
+        await using var project = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test", commandLineArguments: @"/doc:");
         var parseOptions = environment.Workspace.CurrentSolution.Projects.Single().ParseOptions;
         Assert.Equal(DocumentationMode.Parse, parseOptions.DocumentationMode);
     }
@@ -45,7 +45,7 @@ public sealed class CSharpCompilerOptionsTests : TestBase
     public async Task ProjectSettingsOptionAddAndRemove_CPS()
     {
         using var environment = new TestEnvironment();
-        using var project = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test", commandLineArguments: @"/warnaserror:CS1111");
+        await using var project = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test", commandLineArguments: @"/warnaserror:CS1111");
         var options = environment.GetUpdatedCompilationOptionOfSingleProject();
         Assert.Equal(expected: ReportDiagnostic.Error, actual: options.SpecificDiagnosticOptions["CS1111"]);
 
@@ -61,7 +61,7 @@ public sealed class CSharpCompilerOptionsTests : TestBase
         var initialBinPath = initialObjPath;
 
         using var environment = new TestEnvironment();
-        using var project = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test", commandLineArguments: $"/out:{initialObjPath}");
+        await using var project = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test", commandLineArguments: $"/out:{initialObjPath}");
         Assert.Equal(initialObjPath, project.CompilationOutputAssemblyFilePath);
         Assert.Equal(initialBinPath, project.BinOutputPath);
 
@@ -118,7 +118,7 @@ public sealed class CSharpCompilerOptionsTests : TestBase
         var initialGuid = Guid.NewGuid();
 
         using var environment = new TestEnvironment();
-        using IWorkspaceProjectContext projectContext = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test", initialGuid);
+        await using IWorkspaceProjectContext projectContext = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test", initialGuid);
         Assert.Equal(initialGuid, projectContext.Guid);
 
         var newGuid = Guid.NewGuid();
@@ -130,7 +130,7 @@ public sealed class CSharpCompilerOptionsTests : TestBase
     public async Task ProjectLastDesignTimeBuildSucceededSetter_CPS()
     {
         using var environment = new TestEnvironment();
-        using IWorkspaceProjectContext projectContext = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test");
+        await using IWorkspaceProjectContext projectContext = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test");
         Assert.True(projectContext.LastDesignTimeBuildSucceeded);
 
         projectContext.LastDesignTimeBuildSucceeded = false;
@@ -141,7 +141,7 @@ public sealed class CSharpCompilerOptionsTests : TestBase
     public async Task ProjectDisplayNameSetter_CPS()
     {
         using var environment = new TestEnvironment();
-        using IWorkspaceProjectContext project = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test");
+        await using IWorkspaceProjectContext project = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test");
         Assert.Equal("Test", project.DisplayName);
         var initialProjectFilePath = project.ProjectFilePath;
 
@@ -156,7 +156,7 @@ public sealed class CSharpCompilerOptionsTests : TestBase
     public async Task ProjectFilePathSetter_CPS()
     {
         using var environment = new TestEnvironment();
-        using IWorkspaceProjectContext project = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test");
+        await using IWorkspaceProjectContext project = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test");
         var initialProjectDisplayName = project.DisplayName;
         var initialProjectFilePath = project.ProjectFilePath;
         var newFilePath = Temp.CreateFile().Path;
@@ -178,7 +178,7 @@ public sealed class CSharpCompilerOptionsTests : TestBase
     public async Task ChecksumAlgorithm_CPS()
     {
         using var environment = new TestEnvironment();
-        using var cpsProject = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test");
+        await using var cpsProject = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test");
 
         Assert.Equal(SourceHashAlgorithms.Default, environment.Workspace.CurrentSolution.Projects.Single().State.ChecksumAlgorithm);
 
@@ -191,7 +191,7 @@ public sealed class CSharpCompilerOptionsTests : TestBase
     public async Task CompilerGeneratedFilesOutputPath_CPS()
     {
         using var environment = new TestEnvironment();
-        using var cpsProject = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test");
+        await using var cpsProject = await CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test");
 
         Assert.Null(environment.Workspace.CurrentSolution.Projects.Single().CompilationOutputInfo.GeneratedFilesOutputDirectory);
 

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/CSharpReferencesTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/CSharpReferencesTests.cs
@@ -83,10 +83,10 @@ public sealed class CSharpReferenceTests
         Assert.False(GetProject3ProjectReferences().Any(pr => pr.ProjectId == project2.Id));
         Assert.False(GetProject3MetadataReferences().Any(mr => mr.FilePath == metadaRefFilePath));
 
-        project1.Dispose();
-        project2.Dispose();
-        project4.Dispose();
-        project3.Dispose();
+        await project1.DisposeAsync();
+        await project2.DisposeAsync();
+        await project4.DisposeAsync();
+        await project3.DisposeAsync();
     }
 
     [WpfFact]
@@ -101,11 +101,11 @@ public sealed class CSharpReferenceTests
         Assert.Single(environment.Workspace.CurrentSolution.GetProject(project2.Id).AllProjectReferences);
 
         // Remove project1. project2's reference should have been converted back
-        project1.Dispose();
+        await project1.DisposeAsync();
         Assert.Empty(environment.Workspace.CurrentSolution.GetProject(project2.Id).AllProjectReferences);
         Assert.Single(environment.Workspace.CurrentSolution.GetProject(project2.Id).MetadataReferences);
 
-        project2.Dispose();
+        await project2.DisposeAsync();
     }
 
     [WpfFact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/461967")]
@@ -121,15 +121,15 @@ public sealed class CSharpReferenceTests
         // We should not have converted that to a project reference, because we would have no way to produce the compilation
         Assert.Empty(environment.Workspace.CurrentSolution.GetProject(project1.Id).AllProjectReferences);
 
-        project2.Dispose();
-        project1.Dispose();
+        await project2.DisposeAsync();
+        await project1.DisposeAsync();
     }
 
     [WpfFact]
     public async Task AddRemoveAnalyzerReference_CPS()
     {
         using var environment = new TestEnvironment();
-        using var project = await CreateCSharpCPSProjectAsync(environment, "project1");
+        await using var project = await CreateCSharpCPSProjectAsync(environment, "project1");
         // Add analyzer reference
         using var tempRoot = new TempRoot();
         var analyzerAssemblyFullPath = tempRoot.CreateFile().Path;

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/SourceFileHandlingTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/SourceFileHandlingTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -27,7 +27,7 @@ public sealed class SourceFileHandlingTests
     public async Task AddRemoveSourceFile_CPS()
     {
         using var environment = new TestEnvironment();
-        using var project = await CreateCSharpCPSProjectAsync(environment, "project1");
+        await using var project = await CreateCSharpCPSProjectAsync(environment, "project1");
         IEnumerable<Document> GetCurrentDocuments() => environment.Workspace.CurrentSolution.Projects.Single().Documents;
 
         Assert.Empty(GetCurrentDocuments());
@@ -46,7 +46,7 @@ public sealed class SourceFileHandlingTests
     public async Task AddRemoveAdditionalFile_CPS()
     {
         using var environment = new TestEnvironment();
-        using var project = await CreateCSharpCPSProjectAsync(environment, "project1");
+        await using var project = await CreateCSharpCPSProjectAsync(environment, "project1");
         IEnumerable<TextDocument> GetCurrentAdditionalDocuments() => environment.Workspace.CurrentSolution.Projects.Single().AdditionalDocuments;
         Assert.Empty(GetCurrentAdditionalDocuments());
 
@@ -64,7 +64,7 @@ public sealed class SourceFileHandlingTests
     public async Task ReorderSourceFiles_CPS()
     {
         using var environment = new TestEnvironment();
-        using var project = await CreateCSharpCPSProjectAsync(environment, "project1");
+        await using var project = await CreateCSharpCPSProjectAsync(environment, "project1");
         IEnumerable<Document> GetCurrentDocuments() => environment.Workspace.CurrentSolution.Projects.Single().Documents;
         VersionStamp GetVersion() => environment.Workspace.CurrentSolution.Projects.Single().Version;
 
@@ -114,7 +114,7 @@ public sealed class SourceFileHandlingTests
     public async Task ReorderSourceFilesBatch_CPS()
     {
         using var environment = new TestEnvironment();
-        using var project = await CreateCSharpCPSProjectAsync(environment, "project1");
+        await using var project = await CreateCSharpCPSProjectAsync(environment, "project1");
         IEnumerable<Document> GetCurrentDocuments() => environment.Workspace.CurrentSolution.Projects.Single().Documents;
 
         Assert.Empty(GetCurrentDocuments());
@@ -156,7 +156,7 @@ public sealed class SourceFileHandlingTests
     public async Task ReorderSourceFilesBatchWithReAdding_CPS()
     {
         using var environment = new TestEnvironment();
-        using var project = await CreateCSharpCPSProjectAsync(environment, "project1");
+        await using var project = await CreateCSharpCPSProjectAsync(environment, "project1");
         IEnumerable<Document> GetCurrentDocuments() => environment.Workspace.CurrentSolution.Projects.Single().Documents;
 
         Assert.Empty(GetCurrentDocuments());
@@ -210,7 +210,7 @@ public sealed class SourceFileHandlingTests
     public async Task ReorderSourceFilesBatchAddAfterReorder_CPS()
     {
         using var environment = new TestEnvironment();
-        using var project = await CreateCSharpCPSProjectAsync(environment, "project1");
+        await using var project = await CreateCSharpCPSProjectAsync(environment, "project1");
         IEnumerable<Document> GetCurrentDocuments() => environment.Workspace.CurrentSolution.Projects.Single().Documents;
 
         Assert.Empty(GetCurrentDocuments());
@@ -249,7 +249,7 @@ public sealed class SourceFileHandlingTests
     public async Task ReorderSourceFilesBatchRemoveAfterReorder_CPS()
     {
         using var environment = new TestEnvironment();
-        using var project = await CreateCSharpCPSProjectAsync(environment, "project1");
+        await using var project = await CreateCSharpCPSProjectAsync(environment, "project1");
         IEnumerable<Document> GetCurrentDocuments() => environment.Workspace.CurrentSolution.Projects.Single().Documents;
 
         Assert.Empty(GetCurrentDocuments());
@@ -288,7 +288,7 @@ public sealed class SourceFileHandlingTests
     public async Task ReorderSourceFilesExceptions_CPS()
     {
         using var environment = new TestEnvironment();
-        using var project = await CreateCSharpCPSProjectAsync(environment, "project1");
+        await using var project = await CreateCSharpCPSProjectAsync(environment, "project1");
         IEnumerable<Document> GetCurrentDocuments() => environment.Workspace.CurrentSolution.Projects.Single().Documents;
 
         Assert.Empty(GetCurrentDocuments());
@@ -322,7 +322,7 @@ public sealed class SourceFileHandlingTests
     public async Task ReorderSourceFilesBatchExceptions_CPS()
     {
         using var environment = new TestEnvironment();
-        using var project = await CreateCSharpCPSProjectAsync(environment, "project1");
+        await using var project = await CreateCSharpCPSProjectAsync(environment, "project1");
         IEnumerable<Document> GetCurrentDocuments() => environment.Workspace.CurrentSolution.Projects.Single().Documents;
 
         Assert.Empty(GetCurrentDocuments());
@@ -368,7 +368,7 @@ public sealed class SourceFileHandlingTests
     public async Task ReorderSourceFilesBatchExceptionRemoveFile_CPS()
     {
         using var environment = new TestEnvironment();
-        using var project = await CreateCSharpCPSProjectAsync(environment, "project1");
+        await using var project = await CreateCSharpCPSProjectAsync(environment, "project1");
         IEnumerable<Document> GetCurrentDocuments() => environment.Workspace.CurrentSolution.Projects.Single().Documents;
 
         Assert.Empty(GetCurrentDocuments());

--- a/src/VisualStudio/Core/Def/ProjectSystem/BrokeredService/WorkspaceProject.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/BrokeredService/WorkspaceProject.cs
@@ -25,7 +25,12 @@ internal sealed class WorkspaceProject : IWorkspaceProject
 
     public void Dispose()
     {
+        // Because this implementation needs to implement the contract for RpcMarshalable
+        // we have to implement IDisposable, so we don't have an alternative to implement
+        // at this point.
+#pragma warning disable CS0618 // Type or member is obsolete
         _project.Dispose();
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 
     [Obsolete($"Call the {nameof(AddAdditionalFilesAsync)} overload that takes {nameof(SourceFileInfo)}.")]

--- a/src/VisualStudio/Core/Def/ProjectSystem/CPS/IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/CPS/IWorkspaceProjectContext.cs
@@ -19,6 +19,10 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 /// </remarks>
 internal interface IWorkspaceProjectContext : IDisposable, IAsyncDisposable
 {
+    /// <inheritdoc cref="IDisposable.Dispose"/>
+    [Obsolete("Use DisposeAsync instead.")]
+    new void Dispose();
+
     // Project properties.
     string DisplayName { get; set; }
     string? ProjectFilePath { get; set; }

--- a/src/VisualStudio/Core/Def/ProjectSystem/CPS/IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/CPS/IWorkspaceProjectContext.cs
@@ -15,9 +15,9 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 /// Project context to initialize properties and items of a Workspace project created by <see cref="IWorkspaceProjectContextFactory"/>. 
 /// </summary>
 /// <remarks>
-/// <see cref="IDisposable.Dispose"/> is safe to call on instances of this type on any thread.
+/// All methods are safe to call from any thread.
 /// </remarks>
-internal interface IWorkspaceProjectContext : IDisposable
+internal interface IWorkspaceProjectContext : IDisposable, IAsyncDisposable
 {
     // Project properties.
     string DisplayName { get; set; }

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
@@ -242,6 +242,7 @@ internal sealed partial class CPSProject : IWorkspaceProjectContext
     public void AddAdditionalFile(string filePath, IEnumerable<string> folderNames, bool isInCurrentContext = true)
         => _projectSystemProject.AddAdditionalFile(filePath, folders: [.. folderNames]);
 
+    [Obsolete("Switch to using the DisposeAsync version of this API instead.")]
     public void Dispose()
     {
         if (Interlocked.CompareExchange(ref _disposed, value: 1, comparand: 0) != 0)

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
@@ -254,6 +254,18 @@ internal sealed partial class CPSProject : IWorkspaceProjectContext
         _projectSystemProject.RemoveFromWorkspace();
     }
 
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.CompareExchange(ref _disposed, value: 1, comparand: 0) != 0)
+        {
+            return;
+        }
+
+        _projectCodeModel?.OnProjectClosed();
+        _projectSystemProjectOptionsProcessor?.Dispose();
+        await _projectSystemProject.RemoveFromWorkspaceAsync().ConfigureAwait(false);
+    }
+
     public void AddAnalyzerReference(string referencePath)
         => _projectSystemProject.AddAnalyzerReference(referencePath);
 

--- a/src/VisualStudio/ExternalAccess/FSharp/VS/IFSharpWorkspaceProjectContextFactory.cs
+++ b/src/VisualStudio/ExternalAccess/FSharp/VS/IFSharpWorkspaceProjectContextFactory.cs
@@ -110,7 +110,9 @@ internal sealed class FSharpWorkspaceProjectContext : IFSharpWorkspaceProjectCon
     }
 
     public void Dispose()
+#pragma warning disable CS0618 // Type or member is obsolete
         => _vsProjectContext.Dispose();
+#pragma warning restore CS0618 // Type or member is obsolete
 
     public IVsLanguageServiceBuildErrorReporter2? BuildErrorReporter
         => _vsProjectContext as IVsLanguageServiceBuildErrorReporter2;

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
@@ -1362,8 +1362,14 @@ internal sealed partial class ProjectSystemProject
     #endregion
 
     public void RemoveFromWorkspace()
+        => RemoveFromWorkspaceMaybeAsync(useAsync: false).VerifyCompleted();
+
+    public ValueTask RemoveFromWorkspaceAsync()
+        => RemoveFromWorkspaceMaybeAsync(useAsync: true);
+
+    private async ValueTask RemoveFromWorkspaceMaybeAsync(bool useAsync)
     {
-        using (_gate.DisposableWait())
+        using (useAsync ? await _gate.DisposableWaitAsync().ConfigureAwait(false) : _gate.DisposableWait())
         {
             if (!_projectSystemProjectFactory.Workspace.CurrentSolution.ContainsProject(Id))
             {
@@ -1386,7 +1392,7 @@ internal sealed partial class ProjectSystemProject
         IReadOnlyList<MetadataReference>? remainingMetadataReferences = null;
         IReadOnlyList<AnalyzerReference>? remainingAnalyzerReferences = null;
 
-        _projectSystemProjectFactory.ApplyChangeToWorkspace(w =>
+        await _projectSystemProjectFactory.ApplyChangeToWorkspaceMaybeAsync(useAsync, w =>
         {
             // Acquire the remaining metadata references inside the workspace lock. This is critical
             // as another project being removed at the same time could result in project to project
@@ -1412,7 +1418,7 @@ internal sealed partial class ProjectSystemProject
             {
                 _projectSystemProjectFactory.Workspace.OnProjectRemoved(Id);
             }
-        });
+        }).ConfigureAwait(false);
 
         Contract.ThrowIfNull(remainingMetadataReferences);
         Contract.ThrowIfNull(remainingAnalyzerReferences);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/ValueTaskExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/ValueTaskExtensions.cs
@@ -17,6 +17,22 @@ internal static class ValueTaskExtensions
     /// calling it from a synchronous method where you know it should have completed synchronously. This is an easy
     /// way to assert that while silencing any compiler complaints.
     /// </remarks>
+    public static void VerifyCompleted(this ValueTask task, string message = "ValueTask should have already been completed")
+    {
+        Contract.ThrowIfFalse(task.IsCompleted, message);
+
+        // Propagate any exceptions that may have been thrown.
+        task.GetAwaiter().GetResult();
+    }
+
+    /// <summary>
+    /// Asserts the <see cref="ValueTask{TResult}"/> passed has already been completed.
+    /// </summary>
+    /// <remarks>
+    /// This is useful for a specific case: sometimes you might be calling an API that is "sometimes" async, and you're
+    /// calling it from a synchronous method where you know it should have completed synchronously. This is an easy
+    /// way to assert that while silencing any compiler complaints.
+    /// </remarks>
     public static T VerifyCompleted<T>(this ValueTask<T> task, string message = "ValueTask should have already been completed")
     {
         Contract.ThrowIfFalse(task.IsCompleted, message);


### PR DESCRIPTION
This is helpful if you're unloading a bunch of projects all at once, since this can result in contention on the global workspace lock.

Partially fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2653783. The other portion of the fix is also improve CancellationToken handling.