### PR TITLE
[DRAFT][EE] Support pattern variables "obj is MyType myObj" for EE

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.PatternLocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.PatternLocalRewriter.cs
@@ -575,7 +575,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // automaton is done with it (checked by the caller).
                         foreach (BoundPatternBinding binding in w.Bindings)
                         {
-                            if (binding.VariableAccess is BoundLocal l)
+                            if (binding.VariableAccess is BoundLocal l && !_localRewriter._disablePatternVariableTempSharing)
                             {
                                 Debug.Assert(l.LocalSymbol.DeclarationKind == LocalDeclarationKind.PatternVariable);
                                 _ = _tempAllocator.TrySetTemp(binding.TempContainingValue, binding.VariableAccess);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -25,6 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly SyntheticBoundNodeFactory _factory;
         private readonly SynthesizedSubmissionFields _previousSubmissionFields;
         private readonly bool _allowOmissionOfConditionalCalls;
+        private readonly bool _disablePatternVariableTempSharing;
         private LoweredDynamicOperationFactory _dynamicFactory;
         private bool _sawLambdas;
         private int _availableLocalFunctionOrdinal;
@@ -61,6 +62,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             SyntheticBoundNodeFactory factory,
             SynthesizedSubmissionFields previousSubmissionFields,
             bool allowOmissionOfConditionalCalls,
+            bool disablePatternVariableTempSharing,
             BindingDiagnosticBag diagnostics)
         {
             Debug.Assert(factory.InstrumentationState != null);
@@ -73,6 +75,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             _dynamicFactory = new LoweredDynamicOperationFactory(factory, containingMethodOrdinal);
             _previousSubmissionFields = previousSubmissionFields;
             _allowOmissionOfConditionalCalls = allowOmissionOfConditionalCalls;
+            _disablePatternVariableTempSharing = disablePatternVariableTempSharing;
             _topLevelMethodOrdinal = containingMethodOrdinal;
             _diagnostics = diagnostics;
             _rootStatement = rootStatement;
@@ -96,7 +99,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             out ImmutableArray<SourceSpan> codeCoverageSpans,
             out bool sawLambdas,
             out bool sawLocalFunctions,
-            out bool sawAwaitInExceptionHandler)
+            out bool sawAwaitInExceptionHandler,
+            bool disablePatternVariableTempSharing = false)
         {
             Debug.Assert(statement != null);
             Debug.Assert(compilationState != null);
@@ -141,7 +145,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // We don't want IL to differ based upon whether we write the PDB to a file/stream or not.
                 // Presence of sequence points in the tree affects final IL, therefore, we always generate them.
-                var localRewriter = new LocalRewriter(compilation, method, methodOrdinal, statement, containingType, factory, previousSubmissionFields, allowOmissionOfConditionalCalls, diagnostics);
+                var localRewriter = new LocalRewriter(compilation, method, methodOrdinal, statement, containingType, factory, previousSubmissionFields, allowOmissionOfConditionalCalls, disablePatternVariableTempSharing, diagnostics);
                 statement.CheckLocalsDefined();
                 var loweredStatement = localRewriter.VisitStatement(statement);
                 Debug.Assert(loweredStatement is { });

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
@@ -512,39 +512,41 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             try
             {
                 var declaredLocals = PooledHashSet<LocalSymbol>.GetInstance();
-                try
+                // For pure expression evaluations (body is a return statement), pattern
+                // variables are temporary to the single evaluation and should not be
+                // persisted via CreateVariable/GetVariableAddress. For assignments and
+                // declarations, pattern variables should be persisted as before.
+                // Pattern variables remain in declaredLocalsArray regardless so they are
+                // added to the block's Locals for CheckLocalsDefined and lowering.
+                var persistedLocalsArray = body is BoundReturnStatement
+                    ? declaredLocalsArray.WhereAsArray(
+                        static local => local.DeclarationKind != LocalDeclarationKind.PatternVariable)
+                    : declaredLocalsArray;
+                // Rewrite local declaration statement.
+                body = (BoundStatement)LocalDeclarationRewriter.Rewrite(
+                    compilation,
+                    declaredLocals,
+                    body,
+                    persistedLocalsArray,
+                    diagnostics.DiagnosticBag);
+
+                // Verify local declaration names.
+                foreach (var local in declaredLocals)
                 {
-                    // Rewrite local declaration statement.
-                    body = (BoundStatement)LocalDeclarationRewriter.Rewrite(
-                        compilation,
-                        declaredLocals,
-                        body,
-                        declaredLocalsArray,
-                        diagnostics.DiagnosticBag);
-
-                    // Verify local declaration names.
-                    foreach (var local in declaredLocals)
+                    Debug.Assert(local.Locations.Length > 0);
+                    var name = local.Name;
+                    if (name.StartsWith("$", StringComparison.Ordinal))
                     {
-                        Debug.Assert(local.Locations.Length > 0);
-                        var name = local.Name;
-                        if (name.StartsWith("$", StringComparison.Ordinal))
-                        {
-                            diagnostics.Add(ErrorCode.ERR_UnexpectedCharacter, local.GetFirstLocation(), name[0]);
-                            return;
-                        }
-                    }
-
-                    // Rewrite references to placeholder "locals".
-                    body = (BoundStatement)PlaceholderLocalRewriter.Rewrite(compilation, declaredLocals, body, diagnostics.DiagnosticBag);
-
-                    if (diagnostics.HasAnyErrors())
-                    {
+                        diagnostics.Add(ErrorCode.ERR_UnexpectedCharacter, local.GetFirstLocation(), name[0]);
+                        declaredLocals.Free();
                         return;
                     }
                 }
-                finally
+
+                if (diagnostics.HasAnyErrors())
                 {
                     declaredLocals.Free();
+                    return;
                 }
 
                 var syntax = body.Syntax;
@@ -582,11 +584,34 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                         }
                     }
 
+                    // Add locals declared by the expression itself (e.g., pattern variables
+                    // from 'is' expressions like "obj is MyType myObj"). These are not part
+                    // of the original method's locals but need to be in scope for lowering.
+                    foreach (var local in declaredLocalsArray)
+                    {
+                        if (localsSet.Add(local))
+                        {
+                            localsBuilder.Add(local);
+                        }
+                    }
+
+                    // Add placeholder locals (e.g., ObjectAddressLocalSymbol for @0x123,
+                    // ExceptionLocalSymbol for $exception) that appear in the bound tree.
+                    // These are created dynamically during binding by PlaceholderLocalBinder
+                    // and are not part of any predefined locals list. They need to be declared
+                    // in the block so that CheckLocalsDefined passes. They will later be
+                    // rewritten to method calls by PlaceholderLocalRewriter.
+                    var placeholderCollector = new PlaceholderLocalCollector(localsSet, localsBuilder);
+                    placeholderCollector.Visit(body);
+
                     body = new BoundBlock(syntax, localsBuilder.ToImmutableAndFree(), statementsBuilder.ToImmutableAndFree()) { WasCompilerGenerated = true };
 
                     Debug.Assert(!diagnostics.HasAnyErrors());
                     Debug.Assert(!body.HasErrors);
+
                     PipelinePhaseValidator.AssertAfterInitialBinding(body);
+
+                    bool hasDeclaredLocals = persistedLocalsArray.Length > 0;
 
                     body = LocalRewriter.Rewrite(
                         compilation: this.DeclaringCompilation,
@@ -603,12 +628,27 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                         codeCoverageSpans: out ImmutableArray<SourceSpan> codeCoverageSpans,
                         sawLambdas: out bool sawLambdas,
                         sawLocalFunctions: out bool sawLocalFunctions,
-                        sawAwaitInExceptionHandler: out bool sawAwaitInExceptionHandler);
+                        sawAwaitInExceptionHandler: out bool sawAwaitInExceptionHandler,
+                        disablePatternVariableTempSharing: hasDeclaredLocals);
 
                     Debug.Assert(!sawAwaitInExceptionHandler);
                     Debug.Assert(codeCoverageSpans.IsEmpty);
 
                     if (body.HasErrors)
+                    {
+                        return;
+                    }
+
+                    // Rewrite references to placeholder "locals" after local rewriting.
+                    // This must happen after LocalRewriter.Rewrite because the pattern lowering
+                    // needs the original BoundLocal nodes to generate correct binding assignments.
+                    // The disablePatternVariableTempSharing flag above prevents the lowering from
+                    // sharing pattern temps with the declared locals that will be rewritten here.
+                    body = (BoundStatement)PlaceholderLocalRewriter.Rewrite(compilation, declaredLocals, body, diagnostics.DiagnosticBag);
+
+                    declaredLocals.Free();
+
+                    if (diagnostics.HasAnyErrors())
                     {
                         return;
                     }
@@ -725,6 +765,35 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             catch (BoundTreeVisitor.CancelledByStackGuardException ex)
             {
                 ex.AddAnError(diagnostics);
+            }
+
+        }
+
+        /// <summary>
+        /// Walks the bound tree to collect <see cref="PlaceholderLocalSymbol"/> instances
+        /// referenced as <see cref="BoundLocal"/> nodes. These are created dynamically during
+        /// binding by <see cref="PlaceholderLocalBinder"/> (e.g., ObjectAddressLocalSymbol for
+        /// @0x123) and need to be declared in the enclosing block for correctness validation.
+        /// </summary>
+        private sealed class PlaceholderLocalCollector : BoundTreeWalkerWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
+        {
+            private readonly PooledHashSet<LocalSymbol> _localsSet;
+            private readonly ArrayBuilder<LocalSymbol> _localsBuilder;
+
+            internal PlaceholderLocalCollector(PooledHashSet<LocalSymbol> localsSet, ArrayBuilder<LocalSymbol> localsBuilder)
+            {
+                _localsSet = localsSet;
+                _localsBuilder = localsBuilder;
+            }
+
+            public override BoundNode VisitLocal(BoundLocal node)
+            {
+                if (node.LocalSymbol is PlaceholderLocalSymbol && _localsSet.Add(node.LocalSymbol))
+                {
+                    _localsBuilder.Add(node.LocalSymbol);
+                }
+
+                return base.VisitLocal(node);
             }
         }
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DeclarationTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DeclarationTests.cs
@@ -280,7 +280,7 @@ class C
             });
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/25702")]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/13159")]
         public void ExpressionLocals_ExpressionStatement_02()
         {
@@ -1747,7 +1747,8 @@ class C
             flags = resultProperties.Flags;
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/25702")]
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/25702")]
         public void PatternLocals_Assignment_01()
         {
             var source =
@@ -1815,7 +1816,8 @@ class C
             });
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/25702")]
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/25702")]
         public void PatternLocals_Assignment_02()
         {
             var source =
@@ -1882,7 +1884,8 @@ class C
             });
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/25702")]
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/25702")]
         public void PatternLocals_Assignment_03()
         {
             var source =
@@ -1945,7 +1948,8 @@ class C
             });
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/25702")]
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/25702")]
         public void PatternLocals_Assignment_04()
         {
             var source =
@@ -2004,7 +2008,8 @@ class C
             });
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/25702")]
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/25702")]
         public void PatternLocals_Assignment_05()
         {
             var source =
@@ -2037,44 +2042,43 @@ class C
                 context.CompileAssignment("x", "Test(x is int i)", out error, testData);
                 testData.GetMethodData("<>x.<>m0<T>").VerifyIL(
     @"{
-  // Code size       74 (0x4a)
+  // Code size       73 (0x49)
   .maxstack  4
   .locals init (object V_0, //y
                 bool V_1,
-                int? V_2,
-                int V_3,
-                object V_4,
-                System.Guid V_5,
-                int V_6)
+                object V_2,
+                System.Guid V_3,
+                int V_4)
   IL_0000:  ldtoken    ""int""
   IL_0005:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
   IL_000a:  ldstr      ""i""
-  IL_000f:  ldloca.s   V_5
+  IL_000f:  ldloca.s   V_3
   IL_0011:  initobj    ""System.Guid""
-  IL_0017:  ldloc.s    V_5
-  IL_0019:  ldnull
-  IL_001a:  call       ""void Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.CreateVariable(System.Type, string, System.Guid, byte[])""
-  IL_001f:  ldarga.s   V_0
-  IL_0021:  call       ""bool int?.HasValue.get""
-  IL_0026:  brfalse.s  IL_0041
-  IL_0028:  ldarga.s   V_0
-  IL_002a:  call       ""int int?.GetValueOrDefault()""
-  IL_002f:  stloc.s    V_6
-  IL_0031:  ldstr      ""i""
-  IL_0036:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
-  IL_003b:  ldloc.s    V_6
-  IL_003d:  stind.i4
-  IL_003e:  ldc.i4.1
-  IL_003f:  br.s       IL_0042
-  IL_0041:  ldc.i4.0
-  IL_0042:  call       ""int? C.Test(bool)""
-  IL_0047:  starg.s    V_0
-  IL_0049:  ret
+  IL_0017:  ldloc.3
+  IL_0018:  ldnull
+  IL_0019:  call       ""void Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.CreateVariable(System.Type, string, System.Guid, byte[])""
+  IL_001e:  ldarga.s   V_0
+  IL_0020:  call       ""bool int?.HasValue.get""
+  IL_0025:  brfalse.s  IL_0040
+  IL_0027:  ldarga.s   V_0
+  IL_0029:  call       ""int int?.GetValueOrDefault()""
+  IL_002e:  stloc.s    V_4
+  IL_0030:  ldstr      ""i""
+  IL_0035:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
+  IL_003a:  ldloc.s    V_4
+  IL_003c:  stind.i4
+  IL_003d:  ldc.i4.1
+  IL_003e:  br.s       IL_0041
+  IL_0040:  ldc.i4.0
+  IL_0041:  call       ""int? C.Test(bool)""
+  IL_0046:  starg.s    V_0
+  IL_0048:  ret
 }");
             });
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/25702")]
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/25702")]
         public void PatternLocals_LocalDeclarationStatement_01()
         {
             var source =


### PR DESCRIPTION
Issue:
- While debugging, evaluating an expression like "obj is MyType myType" fails with "Internal error".
- The issue is due to Roslyn Expression Compiler which throws
```
Exception thrown: 'System.Collections.Generic.KeyNotFoundException' in mscorlib.dll
DEBUGGER: [Error] EXCEPTION THROWN: IDkmClrExpressionCompiler.CompileExpression from class Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.ExpressionCompiler.dll!Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.CSharpExpressionCompiler -- System.Collections.Generic.KeyNotFoundException: The given key was not present in the dictionary.
DEBUGGER: [Error]    at System.ThrowHelper.ThrowKeyNotFoundException()
DEBUGGER: [Error]    at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.CodeGen.StackOptimizerPass1.RecordVarWrite(LocalSymbol local)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.CodeGen.StackOptimizerPass1.VisitAssignmentOperator(BoundAssignmentOperator node)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.CodeGen.StackOptimizerPass1.VisitExpressionCore(BoundExpression node, ExprContext context)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.CodeGen.StackOptimizerPass1.VisitExpression(BoundExpression node, ExprContext context)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.CodeGen.StackOptimizerPass1.VisitSequence(BoundSequence node)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.CodeGen.StackOptimizerPass1.VisitExpressionCore(BoundExpression node, ExprContext context)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.CodeGen.StackOptimizerPass1.VisitExpressionCoreWithStackGuard(BoundExpression node, ExprContext context)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.CodeGen.StackOptimizerPass1.VisitExpression(BoundExpression node, ExprContext context)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.CodeGen.StackOptimizerPass1.Visit(BoundNode node)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.CodeGen.StackOptimizerPass1.VisitReturnStatement(BoundReturnStatement node)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.CodeGen.StackOptimizerPass1.VisitSideEffect(BoundNode node)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.CodeGen.StackOptimizerPass1.Visit(BoundNode node)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.BoundTreeRewriter.DoVisitList[T](ImmutableArray`1 list)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.BoundTreeRewriter.VisitBlock(BoundBlock node)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.CodeGen.StackOptimizerPass1.VisitBlock(BoundBlock node)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.CodeGen.StackOptimizerPass1.VisitSideEffect(BoundNode node)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.CodeGen.StackOptimizerPass1.Visit(BoundNode node)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.BoundTreeRewriter.DoVisitList[T](ImmutableArray`1 list)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.BoundTreeRewriter.VisitBlock(BoundBlock node)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.CodeGen.StackOptimizerPass1.VisitBlock(BoundBlock node)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.CodeGen.StackOptimizerPass1.VisitSideEffect(BoundNode node)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.CodeGen.StackOptimizerPass1.Visit(BoundNode node)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.CodeGen.StackOptimizerPass1.Analyze(BoundNode node, Dictionary`2 locals, Boolean debugFriendly)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.CodeGen.Optimizer.Optimize(BoundStatement src, Boolean debugFriendly, HashSet`1& stackLocals)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.CodeGen.CodeGenerator..ctor(MethodSymbol method, BoundStatement boundBody, ILBuilder builder, PEModuleBuilder moduleBuilder, BindingDiagnosticBag diagnostics, OptimizationLevel optimizations, Boolean emittingPdb)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.MethodCompiler.GenerateMethodBody(PEModuleBuilder moduleBuilder, MethodSymbol method, Int32 methodOrdinal, BoundStatement block, ImmutableArray`1 lambdaDebugInfo, ImmutableArray`1 orderedLambdaRuntimeRudeEdits, ImmutableArray`1 closureDebugInfo, ImmutableArray`1 stateMachineStateDebugInfos, StateMachineTypeSymbol stateMachineTypeOpt, VariableSlotAllocator variableSlotAllocatorOpt, BindingDiagnosticBag diagnostics, DebugDocumentProvider debugDocumentProvider,...
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.MethodCompiler.CompileSynthesizedMethods(TypeCompilationState compilationState)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.MethodCompiler.CompileSynthesizedMethods(ImmutableArray`1 additionalTypes, BindingDiagnosticBag diagnostics)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.MethodCompiler.CompileMethodBodies(CSharpCompilation compilation, PEModuleBuilder moduleBeingBuiltOpt, Boolean emittingPdb, Boolean hasDeclarationErrors, Boolean emitMethodBodies, BindingDiagnosticBag diagnostics, Predicate`1 filterOpt, CancellationToken cancellationToken)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.CSharpCompilation.CompileMethods(CommonPEModuleBuilder moduleBuilder, Boolean emittingPdb, DiagnosticBag diagnostics, Predicate`1 filterOpt, CancellationToken cancellationToken)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.Compilation.Compile(CommonPEModuleBuilder moduleBuilder, Boolean emittingPdb, DiagnosticBag diagnostics, Predicate`1 filterOpt, CancellationToken cancellationToken)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.CompilationContext.TryCompileExpression(CSharpSyntaxNode syntax, String typeName, String methodName, ImmutableArray`1 aliases, CompilationTestData testData, DiagnosticBag diagnostics, CommonPEModuleBuilder& module, EEMethodSymbol& synthesizedMethod)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.EvaluationContext.CompileExpression(String expr, DkmEvaluationFlags compilationFlags, ImmutableArray`1 aliases, DiagnosticBag diagnostics, ResultProperties& resultProperties, CompilationTestData testData)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.ExpressionEvaluator.ExpressionCompiler.<>c__DisplayClass6_1.<Microsoft.VisualStudio.Debugger.ComponentInterfaces.IDkmClrExpressionCompiler.CompileExpression>b__1(EvaluationContextBase context, DiagnosticBag diagnostics)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.ExpressionEvaluator.ExpressionCompiler.TryCompileWithRetry[TResult](ImmutableArray`1 metadataBlocks, DiagnosticFormatter formatter, CreateContextDelegate createContext, CompileDelegate`1 compile, GetMetadataBytesPtrFunction getMetaDataBytesPtr, TResult& compileResult, String& errorMessage)
DEBUGGER: [Error]    at Microsoft.CodeAnalysis.ExpressionEvaluator.ExpressionCompiler.Microsoft.VisualStudio.Debugger.ComponentInterfaces.IDkmClrExpressionCompiler.CompileExpression(DkmLanguageExpression expression, DkmClrInstructionAddress instructionAddress, DkmInspectionContext inspectionContext, String& error, DkmCompiledClrInspectionQuery& result)
DEBUGGER: [Error]    at Microsoft.VisualStudio.Debugger.EntryPoint.IDkmClrExpressionCompiler_CompileExpression(IntPtr pvClassInfo, IntPtr Expression, IntPtr InstructionAddress, IntPtr InspectionContext, IntPtr& Error, IntPtr& Result)
```

Changes:
Used Debugger, Agent at the point of assert. Used Debugger Unit test agent to analyze unit test failures.

# Initial:
## Root Cause
The PlaceholderLocalRewriter was running before LocalRewriter (pattern lowering) in EEMethodSymbol.GenerateMethodBody. This caused pattern variable locals like i in x is int i to be rewritten by the PlaceholderLocalRewriter on the high-level bound tree. However, GetDecisionDagForLowering in the LocalRewriter regenerates the decision DAG from scratch using the original pattern, creating NEW BoundLocal(i) references that were never processed by PlaceholderLocalRewriter. The pattern lowering then shared these fresh BoundLocal(i) references with the temp allocator, causing the unbox.any result to be stored directly to the local variable (which was never rewritten to use debugger intrinsics), ultimately resulting in the value being discarded (pop) instead of stored via GetVariableAddress<int>.

## Fix
Move the PlaceholderLocalRewriter.Rewrite call from before LocalRewriter.Rewrite to after it in EEMethodSymbol.GenerateMethodBody. This ensures that pattern lowering completes first (generating all BoundLocal(i) references in the lowered pattern code), and then PlaceholderLocalRewriter correctly rewrites ALL those locals to BoundPseudoVariable nodes that generate proper debugger variable access intrinsics.

# PatternLocals_Assignment_01:
The test's expected IL was not updated after the change. The new codegen introduces an extra local (int V_4) to hold the unboxed value before copying it to the EE-managed variable address, which is the correct behavior. Fix: Updated the expected IL in the test to match the new (correct) code generation: •	Code size changed from 67 to 71 bytes
•	Added int V_4 to the locals
•	The unbox now stores to the temp local first (stloc.s V_4), then loads the variable address, loads the temp, and stores (ldloc.s V_4; stind.i4)

# EvaluateObjectAddress
## Hypothesis (Confirmed)
The test EvaluateObjectAddress failed because PlaceholderLocalSymbol instances (specifically ObjectAddressLocalSymbol for @0x123) were not declared in the BoundBlock's locals list. These locals are created dynamically during binding by PlaceholderLocalBinder.LookupSymbolsInSingleBinder when an expression references object addresses like @0x123. The CheckLocalsDefined() DEBUG assertion in LocalRewriter.Rewrite detected the undeclared local and threw an exception. Root ## Cause
In EEMethodSymbol.GenerateMethodBody, the BoundBlock at line 588 (now 596) was constructed with locals from LocalsForBindingOutside, LocalsForBindingInside, Locals, and declaredLocalsArray. However, ObjectAddressLocalSymbol instances are created on-the-fly during name lookup in PlaceholderLocalBinder and don't appear in any of these collections. They are bound as BoundLocal nodes in the tree, and the CheckLocalsDefined walker correctly flagged them as undeclared. Fix
Added a PlaceholderLocalCollector — a BoundTreeWalker nested within EEMethodSymbol — that walks the bound body statement before block construction to find all BoundLocal nodes referencing PlaceholderLocalSymbol instances. These are then added to the block's declared locals list. The placeholder locals are still later rewritten to method calls by PlaceholderLocalRewriter, so this only affects the correctness validation during lowering.

# PatternLocals_Assignment_05:
## Hypothesis (confirmed):
The compiler's nullable pattern matching lowering was optimized on this branch (dev/ramram/fixEEPatternVar), eliminating intermediate temporaries. Previously, x is int i where x is int? would generate intermediate int? V_2 and int V_3 locals during lowering. The new code generates the pattern match inline against the argument directly, producing fewer locals (5 instead of 7) and 1 byte less IL (73 vs 74 bytes).
## Fix applied
Updated the expected IL string in PatternLocals_Assignment_05 to match the new, more compact compiler output: •	Removed int? V_2 and int V_3 locals
•	Renumbered remaining locals (object V_2, System.Guid V_3, int V_4) •	Updated all IL offsets and local references accordingly •	Updated code size from 74 (0x4a) to 73 (0x49)

## Does VB need this?
the VB version does not need this fix. There are two reasons:
1.	VB doesn't have declaration patterns. VB has TypeOf x Is Program but that doesn't declare an inline local variable like C#'s x is Program program. The bug is specifically triggered by pattern variables introduced in expressions, which is a C#-only language feature.
2.	The VB delegate signature doesn't collect declared locals. The VB expression evaluator never collects expression-declared locals because the language doesn't support them. There's nothing to add to the block. The fix only needs to be applied to the C# EEMethodSymbol.cs file.

## Testing:
- Verified unit tests pass
- Manually verified that we are able to evaluate the new pattern variable expressions
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/82936)