### PR TITLE
[release/dev18.0] Update Microsoft.Build dependency of Metrics to a non-vulnerable version

### DIFF
--- a/src/RoslynAnalyzers/NuGet/Microsoft.CodeAnalysis.Metrics/Microsoft.CodeAnalysis.Metrics.Package.csproj
+++ b/src/RoslynAnalyzers/NuGet/Microsoft.CodeAnalysis.Metrics/Microsoft.CodeAnalysis.Metrics.Package.csproj
@@ -42,6 +42,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" VersionOverride="$(MicrosoftCodeAnalysisVersionForAnalyzers)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" VersionOverride="$(MicrosoftCodeAnalysisVersionForAnalyzers)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" VersionOverride="$(MicrosoftBuildTasksCoreVersionForMetrics)" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.Build" VersionOverride="$(MicrosoftBuildTasksCoreVersionForMetrics)" ExcludeAssets="Runtime" />
     <PackageReference Include="System.Text.Json" VersionOverride="$(SystemTextJsonVersionForMetrics)" />
 
     <PackageReference Include="SQLitePCLRaw.bundle_green" VersionOverride="$(SQLitePCLRawVersion)" ExcludeAssets="All" />

--- a/src/RoslynAnalyzers/Tools/Metrics.Legacy/Metrics.Legacy.csproj
+++ b/src/RoslynAnalyzers/Tools/Metrics.Legacy/Metrics.Legacy.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" VersionOverride="$(MicrosoftCodeAnalysisVersionForAnalyzers)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" VersionOverride="$(MicrosoftCodeAnalysisVersionForAnalyzers)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" VersionOverride="$(MicrosoftBuildTasksCoreVersionForMetrics)" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.Build" VersionOverride="$(MicrosoftBuildTasksCoreVersionForMetrics)" ExcludeAssets="Runtime" />
     <PackageReference Include="System.Text.Json" VersionOverride="$(SystemTextJsonVersionForMetrics)" />
 
     <PackageReference Include="SQLitePCLRaw.bundle_green" VersionOverride="$(SQLitePCLRawVersion)" ExcludeAssets="All" />

--- a/src/RoslynAnalyzers/Tools/Metrics/Metrics.csproj
+++ b/src/RoslynAnalyzers/Tools/Metrics/Metrics.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" VersionOverride="$(MicrosoftCodeAnalysisVersionForAnalyzers)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" VersionOverride="$(MicrosoftCodeAnalysisVersionForAnalyzers)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" VersionOverride="$(MicrosoftBuildTasksCoreVersionForMetrics)" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.Build" VersionOverride="$(MicrosoftBuildTasksCoreVersionForMetrics)" ExcludeAssets="Runtime" />
     <PackageReference Include="System.Text.Json" VersionOverride="$(SystemTextJsonVersionForMetrics)" />
 
     <PackageReference Include="SQLitePCLRaw.bundle_green" VersionOverride="$(SQLitePCLRawVersion)" ExcludeAssets="All" />


### PR DESCRIPTION
Should resolve https://dev.azure.com/dnceng/internal/_componentGovernance/dotnet-roslyn/alert/11734993?typeId=27538234&pipelinesTrackingFilter=0.

Validation: https://dev.azure.com/dnceng/internal/_build/results?buildId=2935780&view=results

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/82938)