### PR TITLE
Fix structure guideline anchor for initializer expressions with multi-line argument lists

### DIFF
--- a/src/EditorFeatures/CSharpTest/Structure/InitializerExpressionStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/InitializerExpressionStructureTests.cs
@@ -25,10 +25,10 @@ public sealed class InitializerExpressionStructureTests : AbstractCSharpSyntaxNo
                 {
                     void M()
                     {
-                        var v = {|hint:new Dictionary<int, int> {|textspan:$${
+                        {|hint:var v = new Dictionary<int, int> {|textspan:$${
                             { 1, 2 },
                             { 1, 2 },
-                        }|}|};
+                        }|};|}
                     }
                 }
                 """,
@@ -61,13 +61,32 @@ public sealed class InitializerExpressionStructureTests : AbstractCSharpSyntaxNo
                 {
                     void M()
                     {
-                        using var v = {|hint:new MailMessage(
+                        {|hint:using var v = new MailMessage(
                             fromAddress,
                             new MailAddress(member.Emails[0].Address))
                         {|textspan:$${
                             Subject = subject,
                             Body = plainBody
-                        }|}|};
+                        }|};|}
+                    }
+                }
+                """,
+            Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
+
+    [Fact]
+    public Task TestOuterInitializerWithMultiLineArgumentList_BraceOnSameLine()
+        => VerifyBlockSpansAsync(
+            """
+                class C
+                {
+                    void M()
+                    {
+                        {|hint:using var mailMessage = new MailMessage(
+                            DC.Data.FromEMailAddress,
+                            new MailAddress(member.Emails[0].Address)) {|textspan:$${
+                            Subject = subject,
+                            Body = plainBody
+                        }|};|}
                     }
                 }
                 """,

--- a/src/Features/CSharp/Portable/Structure/Providers/InitializerExpressionStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/InitializerExpressionStructureProvider.cs
@@ -56,16 +56,18 @@ internal sealed class InitializerExpressionStructureProvider : AbstractSyntaxNod
             //      }
             //
             // The collapsed textspan should be from the   {   to the   }
-            // Start at node.SpanStart (the open brace) rather than previousToken.Span.End
-            // so the editor's guideline heuristic picks the right column when the argument
-            // list spans multiple lines.
             //
-            // The hint span is the entire object creation for hover context.
+            // The hint span is the containing statement for hover context.
+
+            var containingStatement = node.FirstAncestorOrSelf<StatementSyntax>();
+            var hintSpan = containingStatement != null
+                ? containingStatement.Span
+                : node.Parent.Span;
 
             spans.Add(new BlockSpan(
                 isCollapsible: true,
                 textSpan: TextSpan.FromBounds(node.SpanStart, node.Span.End),
-                hintSpan: node.Parent.Span,
+                hintSpan: hintSpan,
                 type: BlockTypes.Expression));
         }
     }


### PR DESCRIPTION
Fixes: https://developercommunity.visualstudio.com/t/VS-Text-Editor-displays-vertical-lines-b/11039904
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2714731
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/82946)