### PR TITLE
Don't format plain blocks as member declaration blocks in top level code

### DIFF
--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -12763,4 +12763,122 @@ public sealed class FormattingTests : CSharpFormattingTestBase
                 var v = [ null :  1  +  1 , ( x . y ) :  from   x    in   y    select  z ];
                 """);
 #endif
+
+    [Fact]
+    public Task StandaloneBlocksShouldNotCollapseWhenMethodBraceOptionIsOff()
+        => AssertFormatAsync(
+            expected: """
+                class C
+                {
+                    void M() {
+                        {
+                        }
+                        {
+                        }
+                    }
+                }
+                """,
+            code: """
+                class C
+                {
+                    void M()
+                    {
+                        {
+                        }
+                        {
+                        }
+                    }
+                }
+                """,
+            changedOptionSet: new OptionsCollection(LanguageNames.CSharp)
+            {
+                { NewLineBeforeOpenBrace, NewLineBeforeOpenBrace.DefaultValue.WithFlagValue(NewLineBeforeOpenBracePlacement.Methods, false) }
+            });
+
+    [Fact]
+    public Task StandaloneBlocksShouldNotCollapseWhenAllBraceOptionsOff()
+        => AssertFormatAsync(
+            expected: """
+                class C {
+                    void M() {
+                        {
+                        }
+                        {
+                        }
+                    }
+                }
+                """,
+            code: """
+                class C
+                {
+                    void M()
+                    {
+                        {
+                        }
+                        {
+                        }
+                    }
+                }
+                """,
+            changedOptionSet: new OptionsCollection(LanguageNames.CSharp)
+            {
+                { NewLineBeforeOpenBrace, NewLineBeforeOpenBracePlacement.None }
+            });
+
+    [Fact]
+    public Task TopLevelStandaloneBlocksShouldNotCollapseWhenMethodBraceOptionIsOff()
+        => AssertFormatAsync(
+            expected: """
+                {
+                }
+                {
+                }
+                """,
+            code: """
+                {
+                }
+                {
+                }
+                """,
+            changedOptionSet: new OptionsCollection(LanguageNames.CSharp)
+            {
+                { NewLineBeforeOpenBrace, NewLineBeforeOpenBrace.DefaultValue.WithFlagValue(NewLineBeforeOpenBracePlacement.Methods, false) }
+            });
+
+    [Fact]
+    public Task TopLevelStandaloneBlocksShouldNotCollapseWhenAllBraceOptionsOff()
+        => AssertFormatAsync(
+            expected: """
+                {
+                }
+                {
+                }
+                """,
+            code: """
+                {
+                }
+                {
+                }
+                """,
+            changedOptionSet: new OptionsCollection(LanguageNames.CSharp)
+            {
+                { NewLineBeforeOpenBrace, NewLineBeforeOpenBracePlacement.None }
+            });
+
+    [Fact]
+    public Task TopLevelLocalFunctionBraceStillFormatsWhenMethodBraceOptionIsOff()
+        => AssertFormatAsync(
+            expected: """
+                void M() {
+                }
+                """,
+            code: """
+                void M()
+                {
+                }
+                """,
+            changedOptionSet: new OptionsCollection(LanguageNames.CSharp)
+            {
+                { NewLineBeforeOpenBrace, NewLineBeforeOpenBrace.DefaultValue.WithFlagValue(NewLineBeforeOpenBracePlacement.Methods, false) }
+            });
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/NewLineUserSettingFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/NewLineUserSettingFormattingRule.cs
@@ -167,7 +167,7 @@ internal sealed class NewLineUserSettingFormattingRule : BaseFormattingRule
         // * { - in the member declaration context
         // In top-level code, everything is a GlobalStatementSyntax which inherits from MemberDeclarationSyntax,
         // but we don't want to format a plain open brace as though it's from a member declaration.
-        if (currentToken.IsKind(SyntaxKind.OpenBraceToken) && 
+        if (currentToken.IsKind(SyntaxKind.OpenBraceToken) &&
             currentTokenParentParent is MemberDeclarationSyntax and not GlobalStatementSyntax)
         {
             var option = currentTokenParentParent is BasePropertyDeclarationSyntax
@@ -371,7 +371,7 @@ internal sealed class NewLineUserSettingFormattingRule : BaseFormattingRule
         // * { - in the member declaration context
         // In top-level code, everything is a GlobalStatementSyntax which inherits from MemberDeclarationSyntax,
         // but we don't want to format a plain open brace as though it's from a member declaration.
-        if (currentToken.IsKind(SyntaxKind.OpenBraceToken) && 
+        if (currentToken.IsKind(SyntaxKind.OpenBraceToken) &&
             currentTokenParentParent is MemberDeclarationSyntax and not GlobalStatementSyntax)
         {
             var option = currentTokenParentParent is BasePropertyDeclarationSyntax

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/NewLineUserSettingFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/NewLineUserSettingFormattingRule.cs
@@ -165,7 +165,10 @@ internal sealed class NewLineUserSettingFormattingRule : BaseFormattingRule
         var currentTokenParentParent = currentToken.Parent.Parent;
 
         // * { - in the member declaration context
-        if (currentToken.IsKind(SyntaxKind.OpenBraceToken) && currentTokenParentParent is MemberDeclarationSyntax)
+        // In top-level code, everything is a GlobalStatementSyntax which inherits from MemberDeclarationSyntax,
+        // but we don't want to format a plain open brace as though it's from a member declaration.
+        if (currentToken.IsKind(SyntaxKind.OpenBraceToken) && 
+            currentTokenParentParent is MemberDeclarationSyntax and not GlobalStatementSyntax)
         {
             var option = currentTokenParentParent is BasePropertyDeclarationSyntax
                 ? _options.NewLines.HasFlag(NewLinePlacement.BeforeOpenBraceInProperties)
@@ -366,7 +369,10 @@ internal sealed class NewLineUserSettingFormattingRule : BaseFormattingRule
         var currentTokenParentParent = currentToken.Parent.Parent;
 
         // * { - in the member declaration context
-        if (currentToken.IsKind(SyntaxKind.OpenBraceToken) && currentTokenParentParent is MemberDeclarationSyntax)
+        // In top-level code, everything is a GlobalStatementSyntax which inherits from MemberDeclarationSyntax,
+        // but we don't want to format a plain open brace as though it's from a member declaration.
+        if (currentToken.IsKind(SyntaxKind.OpenBraceToken) && 
+            currentTokenParentParent is MemberDeclarationSyntax and not GlobalStatementSyntax)
         {
             var option = currentTokenParentParent is BasePropertyDeclarationSyntax
                 ? _options.NewLines.HasFlag(NewLinePlacement.BeforeOpenBraceInProperties)


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/12963

In top level code, plain blocks like this:

```
{
}
{
}
```

are being formatted like:

```
{
} {
}
```

This breaks Razor formatting for reasons that would probably surprise you.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/82976)