### PR TITLE
Preserve #: file-based app directives during formatting

### DIFF
--- a/src/Workspaces/CSharpTest/Formatting/FormattingTriviaTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTriviaTests.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -52,6 +53,32 @@ public sealed class FormattingEngineTriviaTests : CSharpFormattingTestBase
                 #line 1000
             #error
             """);
+
+    [Fact]
+    public Task FileBasedAppDirective()
+    {
+        var parseOptions = CSharpParseOptions.Default.WithFeatures([new KeyValuePair<string, string>("FileBasedProgram", "true")]);
+        return AssertNoFormattingChangesAsync("""
+            #:package Newtonsoft.Json@13.0.3
+
+            Console.WriteLine("Hello");
+            """, parseOptions: parseOptions);
+    }
+
+    [Fact]
+    public Task FileBasedAppDirective_WithLeadingWhitespace()
+    {
+        var parseOptions = CSharpParseOptions.Default.WithFeatures([new KeyValuePair<string, string>("FileBasedProgram", "true")]);
+        return AssertFormatAsync("""
+            #:package Newtonsoft.Json@13.0.3
+
+            Console.WriteLine("Hello");
+            """, """
+             #:package Newtonsoft.Json@13.0.3
+
+            Console.WriteLine("Hello");
+            """, parseOptions: parseOptions);
+    }
 
     [Fact]
     public Task Comment1()

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/StructuredTriviaFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/StructuredTriviaFormattingRule.cs
@@ -25,6 +25,16 @@ internal sealed class StructuredTriviaFormattingRule : BaseFormattingRule
     {
         if (previousToken.Parent is StructuredTriviaSyntax || currentToken.Parent is StructuredTriviaSyntax)
         {
+            // File-based app directives use IgnoredDirectiveTriviaSyntax, but their '#:' prefix and
+            // directive text are syntax-significant and must not be split by normal punctuation spacing.
+            if (previousToken.Parent is IgnoredDirectiveTriviaSyntax ignoredDirective &&
+                currentToken.Parent == previousToken.Parent &&
+                ((previousToken == ignoredDirective.HashToken && currentToken == ignoredDirective.ColonToken) ||
+                 (previousToken == ignoredDirective.ColonToken && currentToken == ignoredDirective.Content)))
+            {
+                return CreateAdjustSpacesOperation(space: 0, option: AdjustSpacesOption.ForceSpacesIfOnSingleLine);
+            }
+
             // this doesn't take care of all cases where tokens belong to structured trivia. this is only for cases we care
             if (previousToken.Kind() == SyntaxKind.HashToken && SyntaxFacts.IsPreprocessorKeyword(currentToken.Kind()))
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/StructuredTriviaFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/StructuredTriviaFormattingRule.cs
@@ -25,12 +25,11 @@ internal sealed class StructuredTriviaFormattingRule : BaseFormattingRule
     {
         if (previousToken.Parent is StructuredTriviaSyntax || currentToken.Parent is StructuredTriviaSyntax)
         {
-            // File-based app directives use IgnoredDirectiveTriviaSyntax, but their '#:' prefix and
-            // directive text are syntax-significant and must not be split by normal punctuation spacing.
-            if (previousToken.Parent is IgnoredDirectiveTriviaSyntax ignoredDirective &&
-                currentToken.Parent == previousToken.Parent &&
-                ((previousToken == ignoredDirective.HashToken && currentToken == ignoredDirective.ColonToken) ||
-                 (previousToken == ignoredDirective.ColonToken && currentToken == ignoredDirective.Content)))
+            // File-based app directives use a '#:' prefix inside structured trivia, and the directive
+            // text is syntax-significant and must not be split by normal punctuation spacing.
+            if (currentToken.Parent == previousToken.Parent &&
+                ((previousToken.Kind() == SyntaxKind.HashToken && currentToken.Kind() == SyntaxKind.ColonToken) ||
+                 (previousToken.Kind() == SyntaxKind.ColonToken && currentToken.Kind() == SyntaxKind.StringLiteralToken)))
             {
                 return CreateAdjustSpacesOperation(space: 0, option: AdjustSpacesOption.ForceSpacesIfOnSingleLine);
             }


### PR DESCRIPTION
Fix C# formatting for file-based app directives parsed as `IgnoredDirectiveTriviaSyntax`.

When the formatter touches a line like:

```csharp
 #:package Newtonsoft.Json@13.0.3
```

Roslyn was rewriting it to:

```csharp
# : package Newtonsoft.Json@13.0.3
```

That breaks file-based app syntax and causes downstream issues such as loss of project/file-based-app recognition and completion failures.

## Root cause

File-based app directives are represented as `IgnoredDirectiveTriviaSyntax`, but `StructuredTriviaFormattingRule` did not preserve spacing for the syntax-significant token sequence:

- `HashToken -> ColonToken`
- `ColonToken -> Content`

As a result, generic punctuation spacing rules inserted spaces around `:` once the directive line became eligible for formatting.

## Fix

Add a special-case in `StructuredTriviaFormattingRule` to force zero spaces for:

- `#` followed by `:`
- `:` followed by the directive content

inside `IgnoredDirectiveTriviaSyntax`.

## Tests

Added formatter coverage for file-based app directives:
- unchanged formatting for a normal `#:package ...` directive
- regression test showing that a directive with leading whitespace is normalized to valid `#:package ...` form instead of `# : package ...`

This should also fix this [vscode-csharp issue](https://github.com/dotnet/vscode-csharp/issues/8851)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/82996)