### PR TITLE
Move inheritance margin logic to a features service

### DIFF
--- a/src/Features/CSharp/Portable/TypeHierarchy/CSharpTypeHierarchyService.cs
+++ b/src/Features/CSharp/Portable/TypeHierarchy/CSharpTypeHierarchyService.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.TypeHierarchy;
+
+namespace Microsoft.CodeAnalysis.CSharp.TypeHierarchy;
+
+[ExportLanguageService(typeof(ITypeHierarchyService), LanguageNames.CSharp), Shared]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class CSharpTypeHierarchyService() : AbstractTypeHierarchyService;

--- a/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.FindSymbols;
-using Microsoft.CodeAnalysis.FindSymbols.FindReferences;
 using Microsoft.CodeAnalysis.FindUsages;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -18,6 +17,7 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.SymbolMapping;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.TypeHierarchy;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.InheritanceMargin;
@@ -56,12 +56,19 @@ internal abstract partial class AbstractInheritanceMarginService
         }
 
         var solution = project.Solution;
+        var typeHierarchyService = project.GetRequiredLanguageService<ITypeHierarchyService>();
         using var _ = ArrayBuilder<InheritanceMarginItem>.GetInstance(out var builder);
         foreach (var (symbol, lineNumber) in symbolAndLineNumbers)
         {
             if (symbol is INamedTypeSymbol namedTypeSymbol)
             {
-                await AddInheritanceMemberItemsForNamedTypeAsync(solution, namedTypeSymbol, lineNumber, builder, cancellationToken).ConfigureAwait(false);
+                await AddInheritanceMemberItemsForNamedTypeAsync(
+                    solution,
+                    typeHierarchyService,
+                    namedTypeSymbol,
+                    lineNumber,
+                    builder,
+                    cancellationToken).ConfigureAwait(false);
             }
 
             if (symbol is IEventSymbol or IPropertySymbol or IMethodSymbol)
@@ -280,13 +287,14 @@ internal abstract partial class AbstractInheritanceMarginService
 
     private static async ValueTask AddInheritanceMemberItemsForNamedTypeAsync(
         Solution solution,
+        ITypeHierarchyService typeHierarchyService,
         INamedTypeSymbol memberSymbol,
         int lineNumber,
         ArrayBuilder<InheritanceMarginItem> builder,
         CancellationToken cancellationToken)
     {
         // Get all base types.
-        var allBaseSymbols = BaseTypeFinder.FindBaseTypesAndInterfaces(memberSymbol);
+        var allBaseSymbols = typeHierarchyService.GetBaseTypesAndInterfaces(memberSymbol);
 
         // Filter out
         // 1. System.Object. (otherwise margin would be shown for all classes)
@@ -300,9 +308,10 @@ internal abstract partial class AbstractInheritanceMarginService
             .WhereAsArray(symbol => !symbol.IsErrorType() && symbol.SpecialType is not (SpecialType.System_Object or SpecialType.System_ValueType or SpecialType.System_Enum));
 
         // Get all derived types
-        var allDerivedSymbols = await GetDerivedTypesAndImplementationsAsync(
-            solution,
+        var allDerivedSymbols = await typeHierarchyService.GetDerivedTypesAndImplementationsAsync(
             memberSymbol,
+            solution,
+            transitive: true,
             cancellationToken).ConfigureAwait(false);
 
         // Ensure the user won't be able to see symbol outside the solution for derived symbols.
@@ -670,38 +679,6 @@ internal abstract partial class AbstractInheritanceMarginService
         }
 
         return builder.ToImmutableAndClear();
-    }
-
-    /// <summary>
-    /// Get the derived interfaces and derived classes for <param name="typeSymbol"/>.
-    /// </summary>
-    private static async Task<ImmutableArray<INamedTypeSymbol>> GetDerivedTypesAndImplementationsAsync(
-        Solution solution,
-        INamedTypeSymbol typeSymbol,
-        CancellationToken cancellationToken)
-    {
-        if (typeSymbol.IsInterfaceType())
-        {
-            var allDerivedInterfaces = await SymbolFinder.FindDerivedInterfacesArrayAsync(
-                typeSymbol,
-                solution,
-                transitive: true,
-                cancellationToken: cancellationToken).ConfigureAwait(false);
-            var allImplementations = await SymbolFinder.FindImplementationsArrayAsync(
-                typeSymbol,
-                solution,
-                transitive: true,
-                cancellationToken: cancellationToken).ConfigureAwait(false);
-            return [.. allDerivedInterfaces, .. allImplementations];
-        }
-        else
-        {
-            return await SymbolFinder.FindDerivedClassesArrayAsync(
-                typeSymbol,
-                solution,
-                transitive: true,
-                cancellationToken: cancellationToken).ConfigureAwait(false);
-        }
     }
 
     /// <summary>

--- a/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
@@ -309,8 +309,8 @@ internal abstract partial class AbstractInheritanceMarginService
 
         // Get all derived types
         var allDerivedSymbols = await typeHierarchyService.GetDerivedTypesAndImplementationsAsync(
-            memberSymbol,
             solution,
+            memberSymbol,
             transitive: true,
             cancellationToken).ConfigureAwait(false);
 

--- a/src/Features/Core/Portable/TypeHierarchy/AbstractTypeHierarchyService.cs
+++ b/src/Features/Core/Portable/TypeHierarchy/AbstractTypeHierarchyService.cs
@@ -17,8 +17,8 @@ internal abstract class AbstractTypeHierarchyService : ITypeHierarchyService
         => BaseTypeFinder.FindBaseTypesAndInterfaces(typeSymbol);
 
     public async Task<ImmutableArray<INamedTypeSymbol>> GetDerivedTypesAndImplementationsAsync(
-        INamedTypeSymbol typeSymbol,
         Solution solution,
+        INamedTypeSymbol typeSymbol,
         bool transitive,
         CancellationToken cancellationToken)
     {

--- a/src/Features/Core/Portable/TypeHierarchy/AbstractTypeHierarchyService.cs
+++ b/src/Features/Core/Portable/TypeHierarchy/AbstractTypeHierarchyService.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.FindSymbols.FindReferences;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+
+namespace Microsoft.CodeAnalysis.TypeHierarchy;
+
+internal abstract class AbstractTypeHierarchyService : ITypeHierarchyService
+{
+    public ImmutableArray<INamedTypeSymbol> GetBaseTypesAndInterfaces(INamedTypeSymbol typeSymbol)
+        => BaseTypeFinder.FindBaseTypesAndInterfaces(typeSymbol);
+
+    public async Task<ImmutableArray<INamedTypeSymbol>> GetDerivedTypesAndImplementationsAsync(
+        INamedTypeSymbol typeSymbol,
+        Solution solution,
+        bool transitive,
+        CancellationToken cancellationToken)
+    {
+        if (typeSymbol.IsInterfaceType())
+        {
+            var allDerivedInterfaces = await SymbolFinder.FindDerivedInterfacesArrayAsync(
+                typeSymbol,
+                solution,
+                transitive: transitive,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+            var allImplementations = await SymbolFinder.FindImplementationsArrayAsync(
+                typeSymbol,
+                solution,
+                transitive: transitive,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+            return [.. allDerivedInterfaces, .. allImplementations];
+        }
+
+        return await SymbolFinder.FindDerivedClassesArrayAsync(
+            typeSymbol,
+            solution,
+            transitive: transitive,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Features/Core/Portable/TypeHierarchy/ITypeHierarchyService.cs
+++ b/src/Features/Core/Portable/TypeHierarchy/ITypeHierarchyService.cs
@@ -14,8 +14,8 @@ internal interface ITypeHierarchyService : ILanguageService
     ImmutableArray<INamedTypeSymbol> GetBaseTypesAndInterfaces(INamedTypeSymbol typeSymbol);
 
     Task<ImmutableArray<INamedTypeSymbol>> GetDerivedTypesAndImplementationsAsync(
-        INamedTypeSymbol typeSymbol,
         Solution solution,
+        INamedTypeSymbol typeSymbol,
         bool transitive,
         CancellationToken cancellationToken);
 }

--- a/src/Features/Core/Portable/TypeHierarchy/ITypeHierarchyService.cs
+++ b/src/Features/Core/Portable/TypeHierarchy/ITypeHierarchyService.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.CodeAnalysis.TypeHierarchy;
+
+internal interface ITypeHierarchyService : ILanguageService
+{
+    ImmutableArray<INamedTypeSymbol> GetBaseTypesAndInterfaces(INamedTypeSymbol typeSymbol);
+
+    Task<ImmutableArray<INamedTypeSymbol>> GetDerivedTypesAndImplementationsAsync(
+        INamedTypeSymbol typeSymbol,
+        Solution solution,
+        bool transitive,
+        CancellationToken cancellationToken);
+}

--- a/src/Features/Test/TypeHierarchy/TypeHierarchyServiceTests.cs
+++ b/src/Features/Test/TypeHierarchy/TypeHierarchyServiceTests.cs
@@ -78,8 +78,8 @@ public sealed class TypeHierarchyServiceTests
 
         var (document, service, symbol) = await GetTypeSymbolWithServiceAsync(workspace);
         var derivedTypes = await service.GetDerivedTypesAndImplementationsAsync(
-            symbol,
             document.Project.Solution,
+            symbol,
             transitive: true,
             CancellationToken.None);
 
@@ -145,8 +145,8 @@ public sealed class TypeHierarchyServiceTests
 
         var (document, service, symbol) = await GetTypeSymbolWithServiceAsync(workspace);
         var derivedTypes = await service.GetDerivedTypesAndImplementationsAsync(
-            symbol,
             document.Project.Solution,
+            symbol,
             transitive: true,
             CancellationToken.None);
         var derivedTypeNames = derivedTypes.Select(static t => t.Name).ToImmutableArray();

--- a/src/Features/Test/TypeHierarchy/TypeHierarchyServiceTests.cs
+++ b/src/Features/Test/TypeHierarchy/TypeHierarchyServiceTests.cs
@@ -1,0 +1,177 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.TypeHierarchy;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests.TypeHierarchy;
+
+[UseExportProvider]
+public sealed class TypeHierarchyServiceTests
+{
+    [Theory]
+    [InlineData(LanguageNames.CSharp)]
+    [InlineData(LanguageNames.VisualBasic)]
+    public async Task GetBaseTypesAndInterfacesAsync_ReturnsExpectedBaseTypes(string language)
+    {
+        using var workspace = CreateWorkspace(
+            language,
+            csharpMarkup: """
+                interface IRoot { }
+                class Base { }
+                class $$Derived : Base, IRoot { }
+                """,
+            vbMarkup: """
+                Interface IRoot
+                End Interface
+
+                Class Base
+                End Class
+
+                Class $$Derived
+                    Inherits Base
+                    Implements IRoot
+                End Class
+                """);
+
+        var (_, service, symbol) = await GetTypeSymbolWithServiceAsync(workspace);
+        var baseTypes = service.GetBaseTypesAndInterfaces(symbol);
+        var baseTypeNames = baseTypes.Select(static t => t.Name).ToImmutableArray();
+
+        Assert.Contains("Base", baseTypeNames);
+        Assert.Contains("IRoot", baseTypeNames);
+    }
+
+    [Theory]
+    [InlineData(LanguageNames.CSharp)]
+    [InlineData(LanguageNames.VisualBasic)]
+    public async Task GetDerivedTypesAndImplementationsAsync_ReturnsExpectedDerivedTypes(string language)
+    {
+        using var workspace = CreateWorkspace(
+            language,
+            csharpMarkup: """
+                class $$Base { }
+                class Mid : Base { }
+                class Derived : Mid { }
+                """,
+            vbMarkup: """
+                Class $$Base
+                End Class
+
+                Class Mid
+                    Inherits Base
+                End Class
+
+                Class Derived
+                    Inherits Mid
+                End Class
+                """);
+
+        var (document, service, symbol) = await GetTypeSymbolWithServiceAsync(workspace);
+        var derivedTypes = await service.GetDerivedTypesAndImplementationsAsync(
+            symbol,
+            document.Project.Solution,
+            transitive: true,
+            CancellationToken.None);
+
+        AssertEx.SetEqual(["Mid", "Derived"], derivedTypes.Select(static t => t.Name));
+    }
+
+    [Theory]
+    [InlineData(LanguageNames.CSharp)]
+    [InlineData(LanguageNames.VisualBasic)]
+    public async Task GetBaseTypesAndInterfacesAsync_ForInterface_ReturnsExpectedBaseInterfaces(string language)
+    {
+        using var workspace = CreateWorkspace(
+            language,
+            csharpMarkup: """
+                interface IRoot { }
+                interface $$IChild : IRoot { }
+                """,
+            vbMarkup: """
+                Interface IRoot
+                End Interface
+
+                Interface $$IChild
+                    Inherits IRoot
+                End Interface
+                """);
+
+        var (_, service, symbol) = await GetTypeSymbolWithServiceAsync(workspace);
+        var baseTypes = service.GetBaseTypesAndInterfaces(symbol);
+        var baseTypeNames = baseTypes.Select(static t => t.Name).ToImmutableArray();
+
+        Assert.Contains("IRoot", baseTypeNames);
+    }
+
+    [Theory]
+    [InlineData(LanguageNames.CSharp)]
+    [InlineData(LanguageNames.VisualBasic)]
+    public async Task GetDerivedTypesAndImplementationsAsync_ForInterface_ReturnsDerivedInterfacesAndImplementations(string language)
+    {
+        using var workspace = CreateWorkspace(
+            language,
+            csharpMarkup: """
+                interface $$IRoot { }
+                interface IChild : IRoot { }
+                class A : IRoot { }
+                class B : IChild { }
+                """,
+            vbMarkup: """
+                Interface $$IRoot
+                End Interface
+
+                Interface IChild
+                    Inherits IRoot
+                End Interface
+
+                Class A
+                    Implements IRoot
+                End Class
+
+                Class B
+                    Implements IChild
+                End Class
+                """);
+
+        var (document, service, symbol) = await GetTypeSymbolWithServiceAsync(workspace);
+        var derivedTypes = await service.GetDerivedTypesAndImplementationsAsync(
+            symbol,
+            document.Project.Solution,
+            transitive: true,
+            CancellationToken.None);
+        var derivedTypeNames = derivedTypes.Select(static t => t.Name).ToImmutableArray();
+
+        Assert.Contains("IChild", derivedTypeNames);
+        Assert.Contains("A", derivedTypeNames);
+        Assert.Contains("B", derivedTypeNames);
+    }
+
+    private static TestWorkspace CreateWorkspace(string language, string csharpMarkup, string vbMarkup)
+        => language switch
+        {
+            LanguageNames.CSharp => TestWorkspace.CreateCSharp(csharpMarkup),
+            LanguageNames.VisualBasic => TestWorkspace.CreateVisualBasic(vbMarkup),
+            _ => throw new System.ArgumentOutOfRangeException(nameof(language), language, message: null),
+        };
+
+    private static async Task<(Document Document, ITypeHierarchyService Service, INamedTypeSymbol TypeSymbol)> GetTypeSymbolWithServiceAsync(TestWorkspace workspace)
+    {
+        var hostDocument = workspace.DocumentWithCursor;
+        var document = workspace.CurrentSolution.GetRequiredDocument(hostDocument.Id);
+        var symbol = await SymbolFinder.FindSymbolAtPositionAsync(document, hostDocument.CursorPosition!.Value, cancellationToken: CancellationToken.None);
+        var typeSymbol = Assert.IsAssignableFrom<INamedTypeSymbol>(symbol);
+
+        var service = document.GetRequiredLanguageService<ITypeHierarchyService>();
+        return (document, service, typeSymbol);
+    }
+}

--- a/src/Features/VisualBasic/Portable/TypeHierarchy/VisualBasicTypeHierarchyService.vb
+++ b/src/Features/VisualBasic/Portable/TypeHierarchy/VisualBasicTypeHierarchyService.vb
@@ -1,0 +1,19 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Composition
+Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.TypeHierarchy
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.TypeHierarchy
+    <ExportLanguageService(GetType(ITypeHierarchyService), LanguageNames.VisualBasic), [Shared]>
+    Friend Class VisualBasicTypeHierarchyService
+        Inherits AbstractTypeHierarchyService
+
+        <ImportingConstructor>
+        <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
+        Public Sub New()
+        End Sub
+    End Class
+End Namespace


### PR DESCRIPTION
Create a TypeHierarchyService in the Features layer which can be used for both Inheritance Margin and the LSP TypeHierarchy handlers.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83001)