### PR TITLE
﻿Add Copilot skill for investigating VS integration test failures

### DIFF
--- a/.github/skills/integration-test-analysis/SKILL.md
+++ b/.github/skills/integration-test-analysis/SKILL.md
@@ -134,31 +134,28 @@ The script outputs human-readable console text followed by a structured JSON blo
     "exceptionFiles": ["01.15.40-CSharpTyping.TypingInPartialType-AggregateException.Activity.xml"],
     "screenshotFiles": ["StartingBuild.png", "01.15.40-Timeout.png"],
     "mefErrorFiles": [],
-    "vsixLogFiles": ["VSIXInstaller-xxx.log"]
-  },
-  "rootCause": {
-    "category": "assembly-load-failure",
-    "summary": "System.Runtime v10.0.0.0 not found in ServiceHub process",
-    "affectedServices": ["Solution Events", "Asset synchronization", "..."],
-    "errorCount": 147,
-    "primaryError": "Could not load file or assembly 'System.Runtime, Version=10.0.0.0'"
-  },
-  "recommendationHint": "ASSEMBLY_MISMATCH" | "TIMEOUT_HUNG_TEST" | "VSIX_INSTALL_FAILURE" | "MEF_COMPOSITION_ERROR" | "TEST_FAILURE" | "INVESTIGATE_ARTIFACTS"
+    "vsixLogFiles": ["VSIXInstaller-xxx.log"],
+    "parsedExceptions": [
+      {
+        "fileName": "01.15.40-CSharpTyping.TypingInPartialType-AggregateException.Activity.xml",
+        "testName": "CSharpTyping.TypingInPartialType",
+        "exceptionType": "AggregateException",
+        "rootCausePattern": "assembly-load-failure",
+        "primaryError": "Could not load file or assembly 'System.Runtime, Version=10.0.0.0'",
+        "totalErrors": 147,
+        "affectedFeatures": ["Solution Events", "Asset synchronization", "..."],
+        "errorSources": { "GlobalBrokeredServiceContainer": 80, "VisualStudioErrorReportingService": 67 },
+        "vsVersion": "17.14.0"
+      }
+    ],
+    "parsedMefErrors": [],
+    "parsedVsixLogs": [
+      { "fileName": "VSIXInstaller-xxx.log", "success": true, "errors": [] }
+    ]
+  }
 }
 [/INTEGRATION_TEST_SUMMARY]
 ```
-
-## Recommendation Hints
-
-| Hint | Meaning | Suggested Action |
-|------|---------|-----------------|
-| `ASSEMBLY_MISMATCH` | Assembly version not found in ServiceHub/VS process | Check TFM changes, verify .NET runtime on CI queue |
-| `TIMEOUT_HUNG_TEST` | Tests hung — first assembly never completed | Investigate which test assembly ran first, check for deadlocks |
-| `VSIX_INSTALL_FAILURE` | VSIX sideloading failed | Check VSIX installer log, verify VS instance state |
-| `MEF_COMPOSITION_ERROR` | MEF exports missing or failed | Check VSIX packaging, verify all assemblies are included |
-| `TEST_FAILURE` | Tests ran but some failed | Look at exception XMLs and screenshots for specific test failures |
-| `TIMEOUT_TESTS_RUNNING` | Tests were making progress but timed out | May need to increase timeout or investigate slow tests |
-| `INVESTIGATE_ARTIFACTS` | Couldn't determine root cause automatically | Download artifacts manually and inspect |
 
 ## Analysis Workflow for the Agent
 
@@ -175,7 +172,8 @@ pwsh -File .github/skills/integration-test-analysis/scripts/Get-IntegrationTestS
 ### Step 2: Analyze the Output
 - Read the human-readable output for the timeline and job status
 - Parse the `[INTEGRATION_TEST_SUMMARY]` JSON for structured data
-- If `rootCause` is populated, use it to explain the failure
+- Examine `artifacts.parsedExceptions`, `artifacts.parsedMefErrors`, and `artifacts.parsedVsixLogs` to understand what went wrong
+- Cross-reference job-level signals (e.g., `timedOut`, `testRunnerStatus`, `vsixInstallSuccess`) with the parsed artifact data to synthesize a root cause
 - If artifacts were too large to download, inform the user and suggest manual inspection
 
 ### Step 3: Cross-Reference

--- a/.github/skills/integration-test-analysis/SKILL.md
+++ b/.github/skills/integration-test-analysis/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: integration-test-analysis
+description: Investigate Visual Studio integration test failures from Azure DevOps builds. Use when investigating integration test timeouts, crashes, or failures in the roslyn-integration-CI pipeline. Also use when asked "why are integration tests failing", "integration test timeout", "VS integration tests", or given AzDO build URLs from the roslyn-integration-CI pipeline.
+---
+
+# Visual Studio Integration Test Failure Analysis
+
+Investigate Visual Studio integration test failures in the `roslyn-integration-CI` Azure DevOps pipeline. Downloads and analyzes published test artifacts including exception logs, screenshots, MEF errors, and VSIX installer logs.
+
+**Workflow**: Run the script with a BuildId → it fetches the build timeline, identifies failed/canceled integration test jobs, downloads the published test artifacts, and parses exception XMLs and error logs → read the structured output and `[INTEGRATION_TEST_SUMMARY]` JSON → synthesize root cause analysis. The script collects data; you generate the diagnosis.
+
+## When to Use This Skill
+
+Use this skill when:
+- Investigating failures or timeouts in the `roslyn-integration-CI` pipeline
+- A build URL points to `dev.azure.com/dnceng-public` with integration test jobs (`VS_Integration_*`)
+- Asked "why are integration tests timing out", "integration test failures", or "VS integration tests red"
+- You need to analyze exception Activity XML logs, screenshots, or MEF errors from integration test runs
+- Integration test jobs are canceled (usually due to timeout) and you need to understand why
+
+> ⚠️ This skill is specific to **Roslyn VS integration tests**. For general CI analysis (compiler tests, Helix failures, build errors), use the `ci-analysis` skill instead.
+
+## Quick Start
+
+```powershell
+# Analyze integration test failures by build ID
+pwsh -File .github/skills/integration-test-analysis/scripts/Get-IntegrationTestStatus.ps1 -BuildId 1354185
+
+# Analyze with verbose artifact download (downloads and parses exception XMLs)
+pwsh -File .github/skills/integration-test-analysis/scripts/Get-IntegrationTestStatus.ps1 -BuildId 1354185 -DownloadArtifacts
+
+# Limit artifact download size (default 200MB)
+pwsh -File .github/skills/integration-test-analysis/scripts/Get-IntegrationTestStatus.ps1 -BuildId 1354185 -DownloadArtifacts -MaxArtifactSizeMB 500
+```
+
+## Key Parameters
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `-BuildId` | Yes | — | Azure DevOps build ID from the roslyn-integration-CI pipeline |
+| `-DownloadArtifacts` | No | `$false` | Download and analyze published test artifacts (exception XMLs, screenshots, MEF errors) |
+| `-MaxArtifactSizeMB` | No | `200` | Maximum artifact size in MB to download. Artifacts larger than this are skipped with a warning |
+| `-Organization` | No | `dnceng-public` | Azure DevOps organization |
+| `-Project` | No | `public` | Azure DevOps project |
+
+## What the Script Does
+
+### Step 1: Build Timeline Analysis
+1. Fetches the build status and timeline from Azure DevOps
+2. Identifies integration test jobs (`VS_Integration_*`) and their status (succeeded/failed/canceled)
+3. Calculates job durations and detects timeouts (canceled jobs that ran close to the pipeline timeout limit)
+4. Extracts the pipeline timeout parameter for comparison
+
+### Step 2: Job Log Analysis
+For each failed or canceled integration test job:
+1. Fetches the "Run Integration Tests" step log
+2. Parses the test runner output to determine:
+   - How many test assemblies were running/queued/completed
+   - Which test assembly was running when the failure/timeout occurred
+   - VSIX installation status and timing
+   - The test runner command line (configuration, architecture, flags)
+
+### Step 3: Published Artifact Analysis (with `-DownloadArtifacts`)
+1. Lists all published artifacts and identifies test log artifacts matching the failing configuration
+2. Downloads artifacts within the size limit as ZIP files
+3. Extracts and analyzes key diagnostic files:
+
+| File Pattern | What It Contains |
+|-------------|-----------------|
+| `*.Activity.xml` | Exception logs per test — contains full stack traces, VS activity log entries |
+| `*.png` / `*.jpg` (in Screenshots/) | Screenshots taken during test execution — shows VS state at failure |
+| `*.png` / `*.jpg` (at root level) | Screenshots from timeouts — shows VS state when the job was killed |
+| `MEFErrors*.txt` | MEF composition errors — missing exports, failed service activation |
+| `VSIXInstaller*.log` | VSIX installation log — shows if Roslyn VSIX sideloading succeeded |
+| `ServiceHub*.log` | ServiceHub process logs — shows OOP service activation failures |
+| `StartingBuild.png` | Screenshot taken when the test harness first starts VS |
+
+### Step 4: Exception XML Parsing
+For each `*.Activity.xml` file found:
+1. Parses the XML structure to extract error entries
+2. Groups errors by source (e.g., `VisualStudioErrorReportingService`, `GlobalBrokeredServiceContainer`)
+3. Identifies the root cause error (e.g., assembly load failures, service activation failures)
+4. Extracts affected features and the common error pattern
+
+## Interpreting Results
+
+### Timeout Pattern (Most Common)
+When integration test jobs are **canceled** after ~150 minutes:
+- Check if the test runner was stuck at "1 running, N queued, 0 completed" — this means the **first test assembly hung**
+- Check if VSIX installation succeeded — VSIX install failures prevent tests from running
+- Look at timeout screenshots (root-level PNGs) to see the VS state when killed
+
+### Service Activation Failures
+When exception XMLs show `ServiceActivationFailedException`:
+- Look for the **inner exception** — usually an assembly load failure (e.g., `System.Runtime` version mismatch)
+- These cascade: one missing assembly breaks ALL remote Roslyn services
+- Check the assembly version being requested vs. what's available on the CI queue
+
+### MEF Composition Errors
+When `MEFErrors*.txt` files are present:
+- Missing exports indicate VSIX packaging issues
+- Failed imports indicate version mismatches between Roslyn components
+
+### VSIX Installation Failures
+When `VSIXInstaller*.log` shows errors:
+- `FileNotFoundException` during install — VS instance state is corrupted or locked
+- Exit code != 0 — the Roslyn VSIX didn't install properly, tests will fail or behave unexpectedly
+
+## Output Format
+
+The script outputs human-readable console text followed by a structured JSON block:
+
+```
+[INTEGRATION_TEST_SUMMARY]
+{
+  "buildId": 1354185,
+  "buildUrl": "https://dev.azure.com/...",
+  "buildResult": "failed",
+  "pipelineTimeout": 150,
+  "jobs": [
+    {
+      "name": "VS_Integration_Debug_64",
+      "result": "canceled",
+      "durationMinutes": 153.7,
+      "timedOut": true,
+      "configuration": "Debug",
+      "testRunnerStatus": "1 running, 3 queued, 0 completed",
+      "vsixInstallSuccess": true,
+      "lastTestActivity": "01:11:59"
+    }
+  ],
+  "artifacts": {
+    "downloaded": true,
+    "exceptionFiles": ["01.15.40-CSharpTyping.TypingInPartialType-AggregateException.Activity.xml"],
+    "screenshotFiles": ["StartingBuild.png", "01.15.40-Timeout.png"],
+    "mefErrorFiles": [],
+    "vsixLogFiles": ["VSIXInstaller-xxx.log"]
+  },
+  "rootCause": {
+    "category": "assembly-load-failure",
+    "summary": "System.Runtime v10.0.0.0 not found in ServiceHub process",
+    "affectedServices": ["Solution Events", "Asset synchronization", "..."],
+    "errorCount": 147,
+    "primaryError": "Could not load file or assembly 'System.Runtime, Version=10.0.0.0'"
+  },
+  "recommendationHint": "ASSEMBLY_MISMATCH" | "TIMEOUT_HUNG_TEST" | "VSIX_INSTALL_FAILURE" | "MEF_COMPOSITION_ERROR" | "TEST_FAILURE" | "INVESTIGATE_ARTIFACTS"
+}
+[/INTEGRATION_TEST_SUMMARY]
+```
+
+## Recommendation Hints
+
+| Hint | Meaning | Suggested Action |
+|------|---------|-----------------|
+| `ASSEMBLY_MISMATCH` | Assembly version not found in ServiceHub/VS process | Check TFM changes, verify .NET runtime on CI queue |
+| `TIMEOUT_HUNG_TEST` | Tests hung — first assembly never completed | Investigate which test assembly ran first, check for deadlocks |
+| `VSIX_INSTALL_FAILURE` | VSIX sideloading failed | Check VSIX installer log, verify VS instance state |
+| `MEF_COMPOSITION_ERROR` | MEF exports missing or failed | Check VSIX packaging, verify all assemblies are included |
+| `TEST_FAILURE` | Tests ran but some failed | Look at exception XMLs and screenshots for specific test failures |
+| `TIMEOUT_TESTS_RUNNING` | Tests were making progress but timed out | May need to increase timeout or investigate slow tests |
+| `INVESTIGATE_ARTIFACTS` | Couldn't determine root cause automatically | Download artifacts manually and inspect |
+
+## Analysis Workflow for the Agent
+
+### Step 0: Gather Context
+Before running the script:
+- Check the PR description and recent commits for clues (TFM changes, queue changes, new test additions)
+- Note the pipeline name — this skill is for `roslyn-integration-CI` only
+
+### Step 1: Run the Script
+```powershell
+pwsh -File .github/skills/integration-test-analysis/scripts/Get-IntegrationTestStatus.ps1 -BuildId <ID> -DownloadArtifacts
+```
+
+### Step 2: Analyze the Output
+- Read the human-readable output for the timeline and job status
+- Parse the `[INTEGRATION_TEST_SUMMARY]` JSON for structured data
+- If `rootCause` is populated, use it to explain the failure
+- If artifacts were too large to download, inform the user and suggest manual inspection
+
+### Step 3: Cross-Reference
+- Compare with PR changes — did a TFM change, queue change, or packaging change cause this?
+- Check if the same failure pattern exists in previous builds on the same PR
+- Look at the VS version on the queue vs. what the tests expect
+
+## References
+
+- [Integration Test Pipeline](../../azure-pipelines-integration.yml) — Pipeline YAML with queue and timeout parameters
+- [Integration Test Helix Template](../../eng/pipelines/test-integration-helix.yml) — Job template for integration tests
+- [ServiceHub Configuration](../../eng/targets/GenerateServiceHubConfigurationFiles.targets) — How ServiceHub services are configured
+- [Target Frameworks](../../eng/targets/TargetFrameworks.props) — TFM definitions (NetVS, NetRoslyn, etc.)

--- a/.github/skills/integration-test-analysis/references/artifact-structure.md
+++ b/.github/skills/integration-test-analysis/references/artifact-structure.md
@@ -1,0 +1,99 @@
+# Integration Test Artifact Structure
+
+## Published Artifact Naming
+
+Log artifacts from integration test runs follow this naming pattern:
+
+```
+{RunNumber}-Logs {Configuration} OOP64_{Bool} LspEditor_{Bool} {BuildNumber}
+```
+
+Examples:
+- `1-Logs Debug OOP64_True LspEditor_False 20260326.17`
+- `2-Logs Release OOP64_False LspEditor_False 20260326.17`
+
+The configuration (Debug/Release) in the artifact name matches the integration test job configuration:
+- `VS_Integration_Debug_64` → artifacts with "Debug" in the name
+- `VS_Integration_Release_32` → artifacts with "Release" in the name
+
+## Artifact Contents
+
+### Test Result Files
+
+| File Pattern | Description |
+|-------------|-------------|
+| `{HH.MM.SS}-{TestClass}.{TestMethod}-{ExceptionType}.Activity.xml` | Exception log with VS activity entries and full stack traces |
+| `{HH.MM.SS}-{TestClass}.{TestMethod}-{ExceptionType}.png` | Screenshot of VS at the time of the exception |
+| `Screenshots/{TestClass}.{TestMethod}/*.png` | Screenshots captured during test execution |
+| `MEFErrors*.txt` | MEF composition errors (missing exports, failed imports) |
+| `VSIXInstaller-{GUID}.log` | VSIX sideloading log |
+| `ServiceHub*.log` | ServiceHub OOP process logs |
+| `StartingBuild.png` | Screenshot taken when test harness first starts VS |
+
+### Root-Level Screenshots (Timeout Artifacts)
+
+When a test job times out, the test harness captures screenshots at the root directory level
+(not under `Screenshots/`). These show the state of Visual Studio when the pipeline killed the job.
+
+### Activity XML Structure
+
+```xml
+<entries>
+  <entry>
+    <record>1</record>
+    <time>2026/03/27 01:14:49.354</time>
+    <type>Information</type>
+    <source>VisualStudio</source>
+    <description>Microsoft Visual Studio 2026 version: 18.0.11518.184</description>
+  </entry>
+  <entry>
+    <record>721</record>
+    <time>2026/03/27 01:15:29.005</time>
+    <type>Error</type>
+    <source>VisualStudioErrorReportingService</source>
+    <description>Feature 'Solution Events' is currently unavailable due to an internal error.
+Microsoft.ServiceHub.Framework.ServiceActivationFailedException : ...</description>
+  </entry>
+</entries>
+```
+
+Key fields:
+- `<type>Error</type>` — Error entries contain the failure details
+- `<source>` — The VS component that reported the error
+- `<description>` — Full error message with stack trace
+
+### Common Error Sources
+
+| Source | Meaning |
+|--------|---------|
+| `VisualStudioErrorReportingService` | Roslyn feature failure (remote service activation, etc.) |
+| `GlobalBrokeredServiceContainer` | ServiceHub brokered service failure |
+| `Editor or Editor Extension` | Editor/extension crash (often ObjectDisposedException) |
+
+## Common Root Cause Patterns
+
+### Assembly Load Failure
+```
+Could not load file or assembly 'System.Runtime, Version=10.0.0.0'
+```
+- The ServiceHub process can't find a required .NET runtime assembly
+- Usually caused by TFM changes (e.g., `$(NetVS)` updated) without matching runtime on CI queue
+- Cascades to ALL remote Roslyn services
+
+### Service Activation Failure
+```
+ServiceActivationFailedException: Activating the "Microsoft.VisualStudio.LanguageServices.XxxCore64" service failed
+```
+- A specific Roslyn remote service can't be activated
+- Inner exception usually reveals the root cause (assembly load, MEF error, etc.)
+
+### MEF Composition Error
+- Missing `[Export]` attributes or version mismatches
+- Usually indicates VSIX packaging issues
+
+### VSIX Install Failure
+```
+Install Error : System.IO.FileNotFoundException: Unable to find the specified file
+```
+- VS instance state is corrupted or locked by another process
+- The Roslyn VSIX didn't sideload properly into the RoslynDev hive

--- a/.github/skills/integration-test-analysis/scripts/Get-IntegrationTestStatus.ps1
+++ b/.github/skills/integration-test-analysis/scripts/Get-IntegrationTestStatus.ps1
@@ -1,0 +1,913 @@
+<#
+.SYNOPSIS
+    Analyzes Visual Studio integration test failures from Azure DevOps builds.
+
+.DESCRIPTION
+    Fetches build timeline, job logs, and published test artifacts from the
+    roslyn-integration-CI pipeline. Parses exception Activity XMLs, screenshots,
+    MEF errors, and VSIX installer logs to identify root causes of integration
+    test failures and timeouts.
+
+.PARAMETER BuildId
+    Azure DevOps build ID to analyze.
+
+.PARAMETER DownloadArtifacts
+    Download and analyze published test artifacts (exception XMLs, screenshots, etc.).
+
+.PARAMETER MaxArtifactSizeMB
+    Maximum artifact size in MB to download. Artifacts larger than this are skipped.
+
+.PARAMETER Organization
+    Azure DevOps organization. Default: dnceng-public.
+
+.PARAMETER Project
+    Azure DevOps project. Default: public.
+
+.EXAMPLE
+    ./Get-IntegrationTestStatus.ps1 -BuildId 1354185
+    Analyze build timeline and job logs.
+
+.EXAMPLE
+    ./Get-IntegrationTestStatus.ps1 -BuildId 1354185 -DownloadArtifacts
+    Analyze build timeline, job logs, and download/parse test artifacts.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [int]$BuildId,
+
+    [Parameter()]
+    [switch]$DownloadArtifacts,
+
+    [Parameter()]
+    [int]$MaxArtifactSizeMB = 200,
+
+    [Parameter()]
+    [string]$Organization = "dnceng-public",
+
+    [Parameter()]
+    [string]$Project = "public"
+)
+
+$ErrorActionPreference = "Stop"
+
+#region Utility Functions
+
+function Write-Header([string]$text) {
+    Write-Host ""
+    Write-Host "=== $text ===" -ForegroundColor Cyan
+}
+
+function Write-Detail([string]$label, [string]$value) {
+    Write-Host "  ${label}: " -NoNewline -ForegroundColor Gray
+    Write-Host $value
+}
+
+function Write-ErrorLine([string]$text) {
+    Write-Host "  [ERROR] $text" -ForegroundColor Red
+}
+
+function Write-WarningLine([string]$text) {
+    Write-Host "  [WARNING] $text" -ForegroundColor Yellow
+}
+
+function Write-SuccessLine([string]$text) {
+    Write-Host "  [OK] $text" -ForegroundColor Green
+}
+
+#endregion
+
+#region Azure DevOps API Functions
+
+function Get-AzDOBuild {
+    param([int]$BuildId)
+    $uri = "https://dev.azure.com/$Organization/$Project/_apis/build/builds/${BuildId}?api-version=7.0"
+    Invoke-RestMethod -Uri $uri -Method Get -Headers @{ 'Accept' = 'application/json' }
+}
+
+function Get-AzDOTimeline {
+    param([int]$BuildId)
+    $uri = "https://dev.azure.com/$Organization/$Project/_apis/build/builds/${BuildId}/timeline?api-version=7.0"
+    Invoke-RestMethod -Uri $uri -Method Get -Headers @{ 'Accept' = 'application/json' }
+}
+
+function Get-AzDOLog {
+    param([int]$BuildId, [int]$LogId)
+    $uri = "https://dev.azure.com/$Organization/$Project/_apis/build/builds/${BuildId}/logs/${LogId}?api-version=7.0"
+    try {
+        $response = Invoke-WebRequest -Uri $uri -Method Get -Headers @{ 'Accept' = 'text/plain' }
+        return $response.Content
+    }
+    catch {
+        Write-WarningLine "Failed to fetch log $LogId : $($_.Exception.Message)"
+        return $null
+    }
+}
+
+function Get-AzDOArtifacts {
+    param([int]$BuildId)
+    $uri = "https://dev.azure.com/$Organization/$Project/_apis/build/builds/${BuildId}/artifacts?api-version=7.0"
+    $response = Invoke-RestMethod -Uri $uri -Method Get -Headers @{ 'Accept' = 'application/json' }
+    return $response.value
+}
+
+function Get-AzDOArtifactZip {
+    param([int]$BuildId, [string]$ArtifactName, [string]$OutputPath)
+    $encodedName = [uri]::EscapeDataString($ArtifactName)
+    $uri = "https://dev.azure.com/$Organization/$Project/_apis/build/builds/${BuildId}/artifacts?artifactName=${encodedName}&api-version=7.0&`$format=zip"
+    Invoke-WebRequest -Uri $uri -Method Get -OutFile $OutputPath
+}
+
+#endregion
+
+#region Log Parsing Functions
+
+function Parse-TestRunnerLog {
+    <#
+    .SYNOPSIS
+        Parses the "Run Integration Tests" step log to extract test runner status.
+    #>
+    param([string]$LogContent)
+
+    $result = @{
+        vsVersion = $null
+        vsixInstallSuccess = $true
+        vsixInstallErrors = @()
+        testRunnerCommandLine = $null
+        testRunnerStatus = $null
+        testRunnerStartTime = $null
+        cancelTime = $null
+        dotnetSdkVersion = $null
+        queueName = $null
+    }
+
+    $lines = $LogContent -split "`n"
+
+    foreach ($line in $lines) {
+        # VS version detection
+        if ($line -match 'Using VS Instance\s+\w+\s+\(([^)]+)\)\s+at\s+"([^"]+)"') {
+            $result.vsVersion = $matches[1]
+        }
+
+        # VSIX install error detection
+        if ($line -match 'VSIX installer failed with exit code:\s*(\d+)') {
+            $result.vsixInstallSuccess = $false
+            $result.vsixInstallErrors += "VSIX installer failed with exit code: $($matches[1])"
+        }
+        if ($line -match 'Install Error\s*:') {
+            $result.vsixInstallSuccess = $false
+            $result.vsixInstallErrors += ($line -replace '^\d{4}-\d{2}-\d{2}T[\d:.]+Z\s*', '').Trim()
+        }
+
+        # .NET SDK version
+        if ($line -match 'dotnet-install: Installed version is (.+)') {
+            $result.dotnetSdkVersion = $matches[1].Trim()
+        }
+
+        # Test runner command line
+        if ($line -match 'RunTests\.dll\s+(.+)') {
+            $result.testRunnerCommandLine = $matches[0].Trim()
+        }
+
+        # Test runner status line (e.g., "   1 running,  3 queued,  0 completed")
+        if ($line -match '(\d+)\s+running,\s*(\d+)\s+queued,\s*(\d+)\s+completed') {
+            $result.testRunnerStatus = "$($matches[1]) running, $($matches[2]) queued, $($matches[3]) completed"
+        }
+
+        # Test runner start time
+        if ($line -match '^(\d{4}-\d{2}-\d{2}T[\d:.]+Z).*RunTests\.dll') {
+            $result.testRunnerStartTime = $matches[1]
+        }
+
+        # Cancellation
+        if ($line -match '^(\d{4}-\d{2}-\d{2}T[\d:.]+Z).*The operation was canceled') {
+            $result.cancelTime = $matches[1]
+        }
+    }
+
+    return $result
+}
+
+function Parse-ExceptionActivityXml {
+    <#
+    .SYNOPSIS
+        Parses an integration test Activity.xml exception log for error details.
+    #>
+    param([string]$FilePath)
+
+    $result = @{
+        fileName = [System.IO.Path]::GetFileName($FilePath)
+        testName = $null
+        exceptionType = $null
+        vsVersion = $null
+        totalErrors = 0
+        errorSources = @{}
+        affectedFeatures = @()
+        primaryError = $null
+        rootCausePattern = $null
+    }
+
+    # Parse filename: {timestamp}-{TestClass}.{TestMethod}-{ExceptionType}.Activity.xml
+    $baseName = [System.IO.Path]::GetFileNameWithoutExtension([System.IO.Path]::GetFileNameWithoutExtension($FilePath))
+    if ($baseName -match '^[\d.]+\-(.+)\-([^-]+)$') {
+        $result.testName = $matches[1]
+        $result.exceptionType = $matches[2]
+    }
+
+    try {
+        $content = Get-Content $FilePath -Raw -ErrorAction Stop
+
+        # Extract VS version
+        if ($content -match 'Microsoft Visual Studio \d+ version:\s*([\d.]+)') {
+            $result.vsVersion = $matches[1]
+        }
+
+        # Count error entries
+        $errorMatches = [regex]::Matches($content, '<type>Error</type>')
+        $result.totalErrors = $errorMatches.Count
+
+        # Extract affected features
+        $featureMatches = [regex]::Matches($content, "Feature &apos;([^&]+)&apos;")
+        $result.affectedFeatures = @($featureMatches | ForEach-Object { $_.Groups[1].Value } | Sort-Object -Unique)
+
+        # Extract error sources
+        $sourceMatches = [regex]::Matches($content, '<type>Error</type>\s*\r?\n\s*<source>([^<]+)</source>')
+        foreach ($m in $sourceMatches) {
+            $source = $m.Groups[1].Value
+            if ($result.errorSources.ContainsKey($source)) {
+                $result.errorSources[$source]++
+            }
+            else {
+                $result.errorSources[$source] = 1
+            }
+        }
+
+        # Detect root cause patterns
+        if ($content -match "Could not load file or assembly &apos;([^&]+)&apos;") {
+            $result.rootCausePattern = "assembly-load-failure"
+            $result.primaryError = "Could not load file or assembly '$($matches[1])'"
+        }
+        elseif ($content -match 'ServiceActivationFailedException') {
+            $result.rootCausePattern = "service-activation-failure"
+            if ($content -match "Activating the &quot;([^&]+)&quot; service failed") {
+                $result.primaryError = "Service activation failed: $($matches[1])"
+            }
+        }
+        elseif ($content -match 'ObjectDisposedException') {
+            $result.rootCausePattern = "object-disposed"
+            $result.primaryError = "ObjectDisposedException in VS process"
+        }
+        elseif ($content -match 'TimeoutException') {
+            $result.rootCausePattern = "timeout"
+            $result.primaryError = "Operation timed out during test execution"
+        }
+    }
+    catch {
+        Write-WarningLine "Failed to parse $FilePath : $($_.Exception.Message)"
+    }
+
+    return $result
+}
+
+function Parse-MefErrors {
+    <#
+    .SYNOPSIS
+        Parses MEF error text files for composition failures.
+    #>
+    param([string]$FilePath)
+
+    $result = @{
+        fileName = [System.IO.Path]::GetFileName($FilePath)
+        errorCount = 0
+        errors = @()
+    }
+
+    try {
+        $content = Get-Content $FilePath -Raw -ErrorAction Stop
+        $lines = $content -split "`n" | Where-Object { $_.Trim() -ne '' }
+        $result.errorCount = $lines.Count
+
+        # Extract first few error summaries
+        $result.errors = @($lines | Select-Object -First 10 | ForEach-Object { $_.Trim().Substring(0, [Math]::Min(200, $_.Trim().Length)) })
+    }
+    catch {
+        Write-WarningLine "Failed to parse MEF errors from $FilePath : $($_.Exception.Message)"
+    }
+
+    return $result
+}
+
+function Parse-VsixInstallerLog {
+    <#
+    .SYNOPSIS
+        Parses VSIX installer log for installation errors.
+    #>
+    param([string]$FilePath)
+
+    $result = @{
+        fileName = [System.IO.Path]::GetFileName($FilePath)
+        success = $true
+        errors = @()
+        installedExtensions = @()
+    }
+
+    try {
+        $content = Get-Content $FilePath -ErrorAction Stop
+
+        foreach ($line in $content) {
+            if ($line -match 'Install Error') {
+                $result.success = $false
+                $result.errors += $line.Trim().Substring(0, [Math]::Min(300, $line.Trim().Length))
+            }
+            if ($line -match 'Successfully installed') {
+                $result.installedExtensions += $line.Trim()
+            }
+            if ($line -match 'failed with exit code') {
+                $result.success = $false
+                $result.errors += $line.Trim()
+            }
+        }
+    }
+    catch {
+        Write-WarningLine "Failed to parse VSIX log $FilePath : $($_.Exception.Message)"
+    }
+
+    return $result
+}
+
+#endregion
+
+#region Artifact Download & Analysis
+
+function Invoke-ArtifactAnalysis {
+    <#
+    .SYNOPSIS
+        Downloads and analyzes published test artifacts for a given build.
+    #>
+    param(
+        [int]$BuildId,
+        [array]$Artifacts,
+        [array]$FailedJobConfigs,
+        [int]$MaxSizeMB
+    )
+
+    $analysisResult = @{
+        downloaded = $false
+        exceptionFiles = @()
+        screenshotFiles = @()
+        mefErrorFiles = @()
+        vsixLogFiles = @()
+        serviceHubLogFiles = @()
+        parsedExceptions = @()
+        parsedMefErrors = @()
+        parsedVsixLogs = @()
+        skippedArtifacts = @()
+    }
+
+    # Find log artifacts matching failing configurations
+    $logArtifacts = @()
+    foreach ($artifact in $Artifacts) {
+        $name = $artifact.name
+        if ($name -notlike '*Logs*' -or $name -like '*Build*') {
+            continue
+        }
+
+        # Check if this artifact matches a failing configuration
+        $isRelevant = $false
+        foreach ($config in $FailedJobConfigs) {
+            if ($name -match $config) {
+                $isRelevant = $true
+                break
+            }
+        }
+        # If no specific configs, include all log artifacts
+        if ($FailedJobConfigs.Count -eq 0) {
+            $isRelevant = $true
+        }
+
+        if ($isRelevant) {
+            $sizeMB = [math]::Round([long]$artifact.resource.properties.artifactsize / 1MB, 1)
+            if ($sizeMB -gt $MaxSizeMB) {
+                Write-WarningLine "Artifact '$name' is ${sizeMB}MB (limit: ${MaxSizeMB}MB) — skipping download"
+                $analysisResult.skippedArtifacts += @{
+                    name  = $name
+                    sizeMB = $sizeMB
+                    reason = "Exceeds size limit of ${MaxSizeMB}MB"
+                }
+                continue
+            }
+            $logArtifacts += @{ artifact = $artifact; sizeMB = $sizeMB }
+        }
+    }
+
+    if ($logArtifacts.Count -eq 0) {
+        Write-WarningLine "No downloadable log artifacts found"
+        return $analysisResult
+    }
+
+    $tempBase = Join-Path ([System.IO.Path]::GetTempPath()) "roslyn-inttest-$BuildId"
+    if (Test-Path $tempBase) { Remove-Item -Recurse -Force $tempBase }
+    New-Item -ItemType Directory -Path $tempBase -Force | Out-Null
+
+    foreach ($entry in $logArtifacts) {
+        $artifact = $entry.artifact
+        $name = $artifact.name
+        $sizeMB = $entry.sizeMB
+        Write-Host "  Downloading '$name' (${sizeMB}MB)..." -ForegroundColor Gray
+
+        $zipPath = Join-Path $tempBase "$($name -replace '[^\w.-]', '_').zip"
+        $extractPath = Join-Path $tempBase ($name -replace '[^\w.-]', '_')
+
+        try {
+            Get-AzDOArtifactZip -BuildId $BuildId -ArtifactName $name -OutputPath $zipPath
+            Expand-Archive -Path $zipPath -DestinationPath $extractPath -Force
+            Remove-Item $zipPath -Force -ErrorAction SilentlyContinue
+            $analysisResult.downloaded = $true
+
+            # Scan extracted files
+            $allFiles = Get-ChildItem $extractPath -Recurse -File
+
+            # Exception Activity XMLs
+            $exceptionXmls = $allFiles | Where-Object { $_.Name -like '*.Activity.xml' }
+            foreach ($xml in $exceptionXmls) {
+                $analysisResult.exceptionFiles += $xml.Name
+                Write-Host "    Found exception log: $($xml.Name)" -ForegroundColor Yellow
+                $parsed = Parse-ExceptionActivityXml -FilePath $xml.FullName
+                $analysisResult.parsedExceptions += $parsed
+            }
+
+            # Screenshots
+            $screenshots = $allFiles | Where-Object { $_.Extension -in '.png', '.jpg', '.jpeg', '.bmp' }
+            foreach ($ss in $screenshots) {
+                $relPath = $ss.FullName.Substring($extractPath.Length + 1)
+                $analysisResult.screenshotFiles += $relPath
+                $inScreenshotsDir = $relPath -match '[\\/]Screenshots[\\/]'
+                if (-not $inScreenshotsDir) {
+                    Write-Host "    Found root-level screenshot (likely timeout): $($ss.Name)" -ForegroundColor Yellow
+                }
+            }
+
+            # MEF errors
+            $mefFiles = $allFiles | Where-Object { $_.Name -like 'MEFErrors*' }
+            foreach ($mef in $mefFiles) {
+                $analysisResult.mefErrorFiles += $mef.Name
+                Write-Host "    Found MEF error file: $($mef.Name)" -ForegroundColor Yellow
+                $parsed = Parse-MefErrors -FilePath $mef.FullName
+                $analysisResult.parsedMefErrors += $parsed
+            }
+
+            # VSIX installer logs
+            $vsixLogs = $allFiles | Where-Object { $_.Name -like 'VSIXInstaller*' }
+            foreach ($vl in $vsixLogs) {
+                $analysisResult.vsixLogFiles += $vl.Name
+                $parsed = Parse-VsixInstallerLog -FilePath $vl.FullName
+                $analysisResult.parsedVsixLogs += $parsed
+                if (-not $parsed.success) {
+                    Write-Host "    Found VSIX installer errors in: $($vl.Name)" -ForegroundColor Red
+                }
+            }
+
+            # ServiceHub logs
+            $shLogs = $allFiles | Where-Object { $_.Name -like 'ServiceHub*' -or $_.Name -like '*servicehub*' }
+            foreach ($sh in $shLogs) {
+                $analysisResult.serviceHubLogFiles += $sh.Name
+            }
+        }
+        catch {
+            Write-WarningLine "Failed to download/extract '$name': $($_.Exception.Message)"
+            $analysisResult.skippedArtifacts += @{
+                name   = $name
+                sizeMB = $sizeMB
+                reason = "Download/extract failed: $($_.Exception.Message)"
+            }
+        }
+    }
+
+    # Cleanup
+    try { Remove-Item -Recurse -Force $tempBase -ErrorAction SilentlyContinue } catch { }
+
+    return $analysisResult
+}
+
+#endregion
+
+#region Main Execution
+
+try {
+    Write-Header "Integration Test Analysis — Build $BuildId"
+    $buildUrl = "https://dev.azure.com/$Organization/$Project/_build/results?buildId=$BuildId&view=results"
+    Write-Detail "URL" $buildUrl
+
+    # Step 1: Fetch build status
+    Write-Header "Build Status"
+    $build = Get-AzDOBuild -BuildId $BuildId
+    Write-Detail "Status" "$($build.status) ($($build.result))"
+    Write-Detail "Pipeline" $build.definition.name
+    Write-Detail "Source Branch" $build.sourceBranch
+    Write-Detail "Start Time" $build.startTime
+    Write-Detail "Finish Time" $build.finishTime
+
+    if ($build.triggerInfo -and $build.triggerInfo.'pr.number') {
+        Write-Detail "PR" "#$($build.triggerInfo.'pr.number')"
+    }
+
+    # Step 2: Fetch timeline and analyze jobs
+    Write-Header "Job Timeline"
+    $timeline = Get-AzDOTimeline -BuildId $BuildId
+
+    $jobs = $timeline.records | Where-Object { $_.type -eq 'Job' }
+    $integrationJobs = @()
+    $buildJobs = @()
+
+    foreach ($job in $jobs) {
+        $durationMin = 'N/A'
+        if ($job.startTime -and $job.finishTime) {
+            $durationMin = [math]::Round(([datetime]$job.finishTime - [datetime]$job.startTime).TotalMinutes, 1)
+        }
+
+        $jobInfo = @{
+            name        = $job.name
+            result      = $job.result
+            durationMin = $durationMin
+            id          = $job.id
+            timedOut    = $false
+        }
+
+        if ($job.name -match 'VS_Integration') {
+            # Check if this was a timeout (canceled after running > 140 min)
+            if ($job.result -eq 'canceled' -and $durationMin -ne 'N/A' -and $durationMin -gt 140) {
+                $jobInfo.timedOut = $true
+            }
+            $integrationJobs += $jobInfo
+        }
+        else {
+            $buildJobs += $jobInfo
+        }
+    }
+
+    # Display build jobs
+    foreach ($j in $buildJobs) {
+        $color = if ($j.result -eq 'succeeded') { 'Green' } elseif ($j.result -eq 'failed') { 'Red' } else { 'Yellow' }
+        Write-Host "  $($j.name): " -NoNewline
+        Write-Host "$($j.result)" -ForegroundColor $color -NoNewline
+        Write-Host " ($($j.durationMin) min)"
+    }
+
+    # Display integration test jobs
+    Write-Host ""
+    foreach ($j in $integrationJobs) {
+        $color = if ($j.result -eq 'succeeded') { 'Green' } elseif ($j.result -eq 'failed') { 'Red' } else { 'Yellow' }
+        $suffix = if ($j.timedOut) { ' [TIMED OUT]' } else { '' }
+        Write-Host "  $($j.name): " -NoNewline
+        Write-Host "$($j.result)${suffix}" -ForegroundColor $color -NoNewline
+        Write-Host " ($($j.durationMin) min)"
+    }
+
+    # Step 3: Analyze logs for failed/canceled integration jobs
+    $failedOrCanceled = $integrationJobs | Where-Object { $_.result -ne 'succeeded' }
+    $jobAnalyses = @()
+
+    if ($failedOrCanceled.Count -gt 0) {
+        Write-Header "Integration Test Job Logs"
+
+        foreach ($job in $failedOrCanceled) {
+            Write-Host "`n  --- $($job.name) ---" -ForegroundColor Cyan
+
+            # Find "Run Integration Tests" step
+            $steps = $timeline.records | Where-Object { $_.parentId -eq $job.id }
+            $testStep = $steps | Where-Object { $_.name -eq 'Run Integration Tests' }
+
+            $jobAnalysis = @{
+                name              = $job.name
+                result            = $job.result
+                durationMinutes   = $job.durationMin
+                timedOut          = $job.timedOut
+                configuration     = if ($job.name -match 'Debug') { 'Debug' } else { 'Release' }
+                testRunnerStatus  = $null
+                vsixInstallSuccess = $null
+                vsVersion         = $null
+                dotnetSdkVersion  = $null
+                lastTestActivity  = $null
+            }
+
+            if ($testStep -and $testStep.log) {
+                $logContent = Get-AzDOLog -BuildId $BuildId -LogId $testStep.log.id
+                if ($logContent) {
+                    $parsed = Parse-TestRunnerLog -LogContent $logContent
+                    $jobAnalysis.testRunnerStatus = $parsed.testRunnerStatus
+                    $jobAnalysis.vsixInstallSuccess = $parsed.vsixInstallSuccess
+                    $jobAnalysis.vsVersion = $parsed.vsVersion
+                    $jobAnalysis.dotnetSdkVersion = $parsed.dotnetSdkVersion
+                    $jobAnalysis.lastTestActivity = $parsed.testRunnerStartTime
+
+                    Write-Detail "VS Version" ($parsed.vsVersion ?? "unknown")
+                    Write-Detail ".NET SDK" ($parsed.dotnetSdkVersion ?? "unknown")
+                    Write-Detail "VSIX Install" $(if ($parsed.vsixInstallSuccess) { "OK" } else { "FAILED" })
+                    if ($parsed.vsixInstallErrors.Count -gt 0) {
+                        foreach ($err in $parsed.vsixInstallErrors) {
+                            Write-ErrorLine $err
+                        }
+                    }
+                    Write-Detail "Test Runner Status" ($parsed.testRunnerStatus ?? "no status line found")
+
+                    if ($parsed.testRunnerStatus -and $parsed.testRunnerStatus -match '(\d+) running.*0 completed' -and $job.timedOut) {
+                        Write-ErrorLine "Tests HUNG: first test assembly never completed (ran for $($job.durationMin) min)"
+                    }
+
+                    if ($parsed.cancelTime) {
+                        Write-Detail "Canceled At" $parsed.cancelTime
+                    }
+                }
+            }
+            else {
+                Write-WarningLine "Could not find 'Run Integration Tests' step log"
+
+                # Check for other step errors
+                $failedSteps = $steps | Where-Object { $_.result -eq 'failed' }
+                foreach ($fs in $failedSteps) {
+                    Write-ErrorLine "Failed step: $($fs.name)"
+                    if ($fs.issues) {
+                        foreach ($issue in $fs.issues) {
+                            Write-ErrorLine "  $($issue.message)"
+                        }
+                    }
+                }
+            }
+
+            $jobAnalyses += $jobAnalysis
+        }
+    }
+
+    # Step 4: Artifact analysis
+    $artifactAnalysis = @{
+        downloaded        = $false
+        exceptionFiles    = @()
+        screenshotFiles   = @()
+        mefErrorFiles     = @()
+        vsixLogFiles      = @()
+        parsedExceptions  = @()
+        parsedMefErrors   = @()
+        parsedVsixLogs    = @()
+        skippedArtifacts  = @()
+    }
+
+    $artifacts = Get-AzDOArtifacts -BuildId $BuildId
+
+    if ($DownloadArtifacts -and $failedOrCanceled.Count -gt 0) {
+        Write-Header "Published Artifact Analysis"
+
+        # Determine which configurations failed
+        $failedConfigs = @()
+        foreach ($job in $failedOrCanceled) {
+            if ($job.name -match 'Debug') { $failedConfigs += 'Debug' }
+            if ($job.name -match 'Release') { $failedConfigs += 'Release' }
+        }
+        $failedConfigs = $failedConfigs | Sort-Object -Unique
+
+        Write-Host "  Looking for artifacts matching: $($failedConfigs -join ', ')"
+
+        $artifactAnalysis = Invoke-ArtifactAnalysis `
+            -BuildId $BuildId `
+            -Artifacts $artifacts `
+            -FailedJobConfigs $failedConfigs `
+            -MaxSizeMB $MaxArtifactSizeMB
+    }
+    elseif (-not $DownloadArtifacts -and $failedOrCanceled.Count -gt 0) {
+        Write-Header "Published Artifacts (not downloaded — use -DownloadArtifacts to analyze)"
+
+        $logArtifacts = $artifacts | Where-Object { $_.name -like '*Logs*' -and $_.name -notlike '*Build*' }
+        foreach ($a in $logArtifacts) {
+            $sizeMB = [math]::Round([long]$a.resource.properties.artifactsize / 1MB, 1)
+            Write-Host "  $($a.name) — ${sizeMB}MB"
+        }
+    }
+
+    # Step 5: Determine root cause
+    Write-Header "Root Cause Analysis"
+
+    $rootCause = @{
+        category         = $null
+        summary          = $null
+        affectedServices = @()
+        errorCount       = 0
+        primaryError     = $null
+    }
+    $recommendationHint = "INVESTIGATE_ARTIFACTS"
+
+    # Collect signals from all sources, then merge them into a single root cause.
+
+    # Signal A: Exception Activity XMLs from artifacts (highest detail — contain actual error info)
+    $exceptionSignal = $null
+    if ($artifactAnalysis.parsedExceptions.Count -gt 0) {
+        $firstException = $artifactAnalysis.parsedExceptions[0]
+        if ($firstException.rootCausePattern) {
+            $exceptionSignal = $firstException
+        }
+    }
+
+    # Signal B: Timeout / hung-test detection from job logs
+    $hungTests = @($jobAnalyses | Where-Object {
+        $_.timedOut -and $_.testRunnerStatus -and $_.testRunnerStatus -match '0 completed'
+    })
+    $timedOutWithProgress = @($jobAnalyses | Where-Object {
+        $_.timedOut -and $_.testRunnerStatus -and $_.testRunnerStatus -notmatch '0 completed'
+    })
+
+    # Signal C: VSIX install failure from job logs
+    $vsixFailedJobs = @($jobAnalyses | Where-Object { $_.vsixInstallSuccess -eq $false })
+
+    # Signal D: VSIX install failure from artifacts
+    $vsixFailedArtifacts = @($artifactAnalysis.parsedVsixLogs | Where-Object { -not $_.success })
+
+    # Signal E: MEF composition errors from artifacts
+    $hasMefErrors = $artifactAnalysis.parsedMefErrors.Count -gt 0
+
+    # --- Merge signals into root cause ---
+
+    # Best case: Exception XML explains WHY tests hung (e.g., assembly load failure causing timeout)
+    if ($exceptionSignal -and $hungTests.Count -gt 0) {
+        # Both an exception root cause AND a timeout — the exception explains the hang
+        if ($exceptionSignal.rootCausePattern -in 'assembly-load-failure', 'service-activation-failure') {
+            $rootCause.category = "assembly-load-failure"
+            $rootCause.summary = "Tests hung due to runtime mismatch: $($exceptionSignal.primaryError). All remote Roslyn services failed to activate, causing the test to wait indefinitely ($($hungTests[0].durationMinutes) min until timeout)."
+            $rootCause.affectedServices = $exceptionSignal.affectedFeatures
+            $rootCause.errorCount = $exceptionSignal.totalErrors
+            $rootCause.primaryError = $exceptionSignal.primaryError
+            $recommendationHint = "ASSEMBLY_MISMATCH"
+        }
+        else {
+            $rootCause.category = $exceptionSignal.rootCausePattern
+            $rootCause.summary = "Tests hung ($($hungTests[0].durationMinutes) min): $($exceptionSignal.primaryError)"
+            $rootCause.errorCount = $exceptionSignal.totalErrors
+            $rootCause.primaryError = $exceptionSignal.primaryError
+            $recommendationHint = "TEST_FAILURE"
+        }
+    }
+    # Exception XML without timeout
+    elseif ($exceptionSignal) {
+        if ($exceptionSignal.rootCausePattern -in 'assembly-load-failure', 'service-activation-failure') {
+            $rootCause.category = "assembly-load-failure"
+            $rootCause.summary = $exceptionSignal.primaryError
+            $rootCause.affectedServices = $exceptionSignal.affectedFeatures
+            $rootCause.errorCount = $exceptionSignal.totalErrors
+            $rootCause.primaryError = $exceptionSignal.primaryError
+            $recommendationHint = "ASSEMBLY_MISMATCH"
+        }
+        else {
+            $rootCause.category = $exceptionSignal.rootCausePattern
+            $rootCause.summary = $exceptionSignal.primaryError
+            $rootCause.errorCount = $exceptionSignal.totalErrors
+            $rootCause.primaryError = $exceptionSignal.primaryError
+            $recommendationHint = "TEST_FAILURE"
+        }
+    }
+    # Timeout without exception XML — check if we should hint at likely causes
+    elseif ($hungTests.Count -gt 0) {
+        $rootCause.category = "timeout-hung-test"
+        $rootCause.primaryError = "Test runner stuck at '$($hungTests[0].testRunnerStatus)' for $($hungTests[0].durationMinutes) minutes"
+
+        # Enrich with context: VSIX installed OK but tests hung → likely a runtime/service issue
+        $allVsixOk = ($jobAnalyses | Where-Object { $_.vsixInstallSuccess -eq $true }).Count -eq $jobAnalyses.Count
+        $dotnetSdk = ($jobAnalyses | Where-Object { $_.dotnetSdkVersion } | Select-Object -First 1).dotnetSdkVersion
+        $vsVer = ($jobAnalyses | Where-Object { $_.vsVersion } | Select-Object -First 1).vsVersion
+
+        if ($allVsixOk -and $dotnetSdk) {
+            $rootCause.summary = "Integration tests hung — first test assembly never completed. VSIX installed OK into VS $vsVer, but tests hung immediately. Built with .NET SDK $dotnetSdk — check that the VS ServiceHub process on this queue can load the matching System.Runtime assembly (the published test artifacts likely contain Activity XML exception logs with the specific assembly load failure)."
+            $recommendationHint = "TIMEOUT_HUNG_TEST"
+        }
+        else {
+            $rootCause.summary = "Integration tests hung — first test assembly never completed"
+            $recommendationHint = "TIMEOUT_HUNG_TEST"
+        }
+    }
+    # VSIX install failure from job logs
+    elseif ($vsixFailedJobs.Count -gt 0) {
+        $rootCause.category = "vsix-install-failure"
+        $rootCause.summary = "VSIX installation failed for $($vsixFailedJobs[0].name)"
+        $recommendationHint = "VSIX_INSTALL_FAILURE"
+    }
+    # VSIX install failure from artifacts
+    elseif ($vsixFailedArtifacts.Count -gt 0) {
+        $rootCause.category = "vsix-install-failure"
+        $firstError = if ($vsixFailedArtifacts[0].errors -and $vsixFailedArtifacts[0].errors.Count -gt 0) { $vsixFailedArtifacts[0].errors[0] } else { "Unknown VSIX install error" }
+        $rootCause.summary = "VSIX installation failed: $firstError"
+        $rootCause.primaryError = $firstError
+        $recommendationHint = "VSIX_INSTALL_FAILURE"
+    }
+    # MEF composition errors
+    elseif ($hasMefErrors) {
+        $rootCause.category = "mef-composition-error"
+        $totalMefErrors = ($artifactAnalysis.parsedMefErrors | Measure-Object -Property errorCount -Sum).Sum
+        $rootCause.summary = "$totalMefErrors MEF composition errors found"
+        $rootCause.errorCount = $totalMefErrors
+        $firstMefError = if ($artifactAnalysis.parsedMefErrors[0].errors -and $artifactAnalysis.parsedMefErrors[0].errors.Count -gt 0) { $artifactAnalysis.parsedMefErrors[0].errors[0] } else { "Unknown MEF error" }
+        $rootCause.primaryError = $firstMefError
+        $recommendationHint = "MEF_COMPOSITION_ERROR"
+    }
+    # Timeout with progress
+    elseif ($timedOutWithProgress.Count -gt 0) {
+        $rootCause.category = "timeout-slow-tests"
+        $rootCause.summary = "Tests were making progress but timed out"
+        $rootCause.primaryError = "Test runner was at '$($timedOutWithProgress[0].testRunnerStatus)' when canceled"
+        $recommendationHint = "TIMEOUT_TESTS_RUNNING"
+    }
+
+    # Display root cause
+    if ($rootCause.category) {
+        Write-Host "  Category: $($rootCause.category)" -ForegroundColor Red
+        Write-Host "  Summary: $($rootCause.summary)"
+        if ($rootCause.affectedServices.Count -gt 0) {
+            Write-Host "  Affected Services ($($rootCause.affectedServices.Count)):"
+            foreach ($svc in $rootCause.affectedServices | Select-Object -First 10) {
+                Write-Host "    - $svc" -ForegroundColor Yellow
+            }
+            if ($rootCause.affectedServices.Count -gt 10) {
+                Write-Host "    ... and $($rootCause.affectedServices.Count - 10) more" -ForegroundColor Gray
+            }
+        }
+        if ($rootCause.errorCount -gt 0) {
+            Write-Host "  Total Errors: $($rootCause.errorCount)"
+        }
+    }
+    else {
+        Write-WarningLine "Could not determine root cause automatically"
+        if (-not $DownloadArtifacts) {
+            Write-Host "  Tip: Re-run with -DownloadArtifacts to download and parse test artifacts" -ForegroundColor Gray
+        }
+    }
+
+    # Emit exception details
+    if ($artifactAnalysis.parsedExceptions.Count -gt 0) {
+        Write-Header "Exception Details"
+        foreach ($exc in $artifactAnalysis.parsedExceptions) {
+            Write-Host "  File: $($exc.fileName)" -ForegroundColor Yellow
+            if ($exc.testName) { Write-Detail "Test" $exc.testName }
+            if ($exc.exceptionType) { Write-Detail "Exception Type" $exc.exceptionType }
+            if ($exc.vsVersion) { Write-Detail "VS Version" $exc.vsVersion }
+            Write-Detail "Error Count" $exc.totalErrors
+            if ($exc.primaryError) { Write-Detail "Primary Error" $exc.primaryError }
+            if ($exc.affectedFeatures.Count -gt 0) {
+                Write-Detail "Affected Features" ($exc.affectedFeatures -join ', ')
+            }
+            if ($exc.errorSources.Count -gt 0) {
+                Write-Host "    Error Sources:"
+                foreach ($kvp in $exc.errorSources.GetEnumerator() | Sort-Object Value -Descending | Select-Object -First 5) {
+                    Write-Host "      $($kvp.Key): $($kvp.Value) errors"
+                }
+            }
+            Write-Host ""
+        }
+    }
+
+    # Step 6: Emit structured summary
+    $summary = [ordered]@{
+        buildId          = $BuildId
+        buildUrl         = $buildUrl
+        buildResult      = $build.result
+        pipeline         = $build.definition.name
+        sourceBranch     = $build.sourceBranch
+        pipelineTimeout  = 150
+        jobs             = @($jobAnalyses | ForEach-Object {
+                [ordered]@{
+                    name              = $_.name
+                    result            = $_.result
+                    durationMinutes   = $_.durationMinutes
+                    timedOut          = $_.timedOut
+                    configuration     = $_.configuration
+                    testRunnerStatus  = $_.testRunnerStatus
+                    vsixInstallSuccess = $_.vsixInstallSuccess
+                    vsVersion         = $_.vsVersion
+                    dotnetSdkVersion  = $_.dotnetSdkVersion
+                    lastTestActivity  = $_.lastTestActivity
+                }
+            })
+        artifacts = [ordered]@{
+            downloaded       = $artifactAnalysis.downloaded
+            exceptionFiles   = $artifactAnalysis.exceptionFiles
+            screenshotFiles  = $artifactAnalysis.screenshotFiles
+            mefErrorFiles    = $artifactAnalysis.mefErrorFiles
+            vsixLogFiles     = $artifactAnalysis.vsixLogFiles
+            skippedArtifacts = $artifactAnalysis.skippedArtifacts
+        }
+        rootCause = [ordered]@{
+            category         = $rootCause.category
+            summary          = $rootCause.summary
+            affectedServices = $rootCause.affectedServices
+            errorCount       = $rootCause.errorCount
+            primaryError     = $rootCause.primaryError
+        }
+        recommendationHint = $recommendationHint
+    }
+
+    Write-Host ""
+    Write-Host "[INTEGRATION_TEST_SUMMARY]"
+    Write-Host ($summary | ConvertTo-Json -Depth 5)
+    Write-Host "[/INTEGRATION_TEST_SUMMARY]"
+}
+catch {
+    Write-Host "FATAL ERROR: $($_.Exception.Message)" -ForegroundColor Red
+    Write-Host $_.ScriptStackTrace -ForegroundColor DarkGray
+    exit 1
+}
+
+#endregion

--- a/.github/skills/integration-test-analysis/scripts/Get-IntegrationTestStatus.ps1
+++ b/.github/skills/integration-test-analysis/scripts/Get-IntegrationTestStatus.ps1
@@ -494,6 +494,8 @@ function Invoke-ArtifactAnalysis {
 #region Main Execution
 
 try {
+    $pipelineTimeoutMinutes = 150
+
     Write-Header "Integration Test Analysis — Build $BuildId"
     $buildUrl = "https://dev.azure.com/$Organization/$Project/_build/results?buildId=$BuildId&view=results"
     Write-Detail "URL" $buildUrl
@@ -534,8 +536,8 @@ try {
         }
 
         if ($job.name -match 'VS_Integration') {
-            # Check if this was a timeout (canceled after running > 140 min)
-            if ($job.result -eq 'canceled' -and $durationMin -ne 'N/A' -and $durationMin -gt 140) {
+            # Check if this was a timeout (canceled after running close to the pipeline timeout)
+            if ($job.result -eq 'canceled' -and $durationMin -ne 'N/A' -and $durationMin -gt ($pipelineTimeoutMinutes - 10)) {
                 $jobInfo.timedOut = $true
             }
             $integrationJobs += $jobInfo
@@ -682,161 +684,7 @@ try {
         }
     }
 
-    # Step 5: Determine root cause
-    Write-Header "Root Cause Analysis"
-
-    $rootCause = @{
-        category         = $null
-        summary          = $null
-        affectedServices = @()
-        errorCount       = 0
-        primaryError     = $null
-    }
-    $recommendationHint = "INVESTIGATE_ARTIFACTS"
-
-    # Collect signals from all sources, then merge them into a single root cause.
-
-    # Signal A: Exception Activity XMLs from artifacts (highest detail — contain actual error info)
-    $exceptionSignal = $null
-    if ($artifactAnalysis.parsedExceptions.Count -gt 0) {
-        $firstException = $artifactAnalysis.parsedExceptions[0]
-        if ($firstException.rootCausePattern) {
-            $exceptionSignal = $firstException
-        }
-    }
-
-    # Signal B: Timeout / hung-test detection from job logs
-    $hungTests = @($jobAnalyses | Where-Object {
-        $_.timedOut -and $_.testRunnerStatus -and $_.testRunnerStatus -match '0 completed'
-    })
-    $timedOutWithProgress = @($jobAnalyses | Where-Object {
-        $_.timedOut -and $_.testRunnerStatus -and $_.testRunnerStatus -notmatch '0 completed'
-    })
-
-    # Signal C: VSIX install failure from job logs
-    $vsixFailedJobs = @($jobAnalyses | Where-Object { $_.vsixInstallSuccess -eq $false })
-
-    # Signal D: VSIX install failure from artifacts
-    $vsixFailedArtifacts = @($artifactAnalysis.parsedVsixLogs | Where-Object { -not $_.success })
-
-    # Signal E: MEF composition errors from artifacts
-    $hasMefErrors = $artifactAnalysis.parsedMefErrors.Count -gt 0
-
-    # --- Merge signals into root cause ---
-
-    # Best case: Exception XML explains WHY tests hung (e.g., assembly load failure causing timeout)
-    if ($exceptionSignal -and $hungTests.Count -gt 0) {
-        # Both an exception root cause AND a timeout — the exception explains the hang
-        if ($exceptionSignal.rootCausePattern -in 'assembly-load-failure', 'service-activation-failure') {
-            $rootCause.category = "assembly-load-failure"
-            $rootCause.summary = "Tests hung due to runtime mismatch: $($exceptionSignal.primaryError). All remote Roslyn services failed to activate, causing the test to wait indefinitely ($($hungTests[0].durationMinutes) min until timeout)."
-            $rootCause.affectedServices = $exceptionSignal.affectedFeatures
-            $rootCause.errorCount = $exceptionSignal.totalErrors
-            $rootCause.primaryError = $exceptionSignal.primaryError
-            $recommendationHint = "ASSEMBLY_MISMATCH"
-        }
-        else {
-            $rootCause.category = $exceptionSignal.rootCausePattern
-            $rootCause.summary = "Tests hung ($($hungTests[0].durationMinutes) min): $($exceptionSignal.primaryError)"
-            $rootCause.errorCount = $exceptionSignal.totalErrors
-            $rootCause.primaryError = $exceptionSignal.primaryError
-            $recommendationHint = "TEST_FAILURE"
-        }
-    }
-    # Exception XML without timeout
-    elseif ($exceptionSignal) {
-        if ($exceptionSignal.rootCausePattern -in 'assembly-load-failure', 'service-activation-failure') {
-            $rootCause.category = "assembly-load-failure"
-            $rootCause.summary = $exceptionSignal.primaryError
-            $rootCause.affectedServices = $exceptionSignal.affectedFeatures
-            $rootCause.errorCount = $exceptionSignal.totalErrors
-            $rootCause.primaryError = $exceptionSignal.primaryError
-            $recommendationHint = "ASSEMBLY_MISMATCH"
-        }
-        else {
-            $rootCause.category = $exceptionSignal.rootCausePattern
-            $rootCause.summary = $exceptionSignal.primaryError
-            $rootCause.errorCount = $exceptionSignal.totalErrors
-            $rootCause.primaryError = $exceptionSignal.primaryError
-            $recommendationHint = "TEST_FAILURE"
-        }
-    }
-    # Timeout without exception XML — check if we should hint at likely causes
-    elseif ($hungTests.Count -gt 0) {
-        $rootCause.category = "timeout-hung-test"
-        $rootCause.primaryError = "Test runner stuck at '$($hungTests[0].testRunnerStatus)' for $($hungTests[0].durationMinutes) minutes"
-
-        # Enrich with context: VSIX installed OK but tests hung → likely a runtime/service issue
-        $allVsixOk = ($jobAnalyses | Where-Object { $_.vsixInstallSuccess -eq $true }).Count -eq $jobAnalyses.Count
-        $dotnetSdk = ($jobAnalyses | Where-Object { $_.dotnetSdkVersion } | Select-Object -First 1).dotnetSdkVersion
-        $vsVer = ($jobAnalyses | Where-Object { $_.vsVersion } | Select-Object -First 1).vsVersion
-
-        if ($allVsixOk -and $dotnetSdk) {
-            $rootCause.summary = "Integration tests hung — first test assembly never completed. VSIX installed OK into VS $vsVer, but tests hung immediately. Built with .NET SDK $dotnetSdk — check that the VS ServiceHub process on this queue can load the matching System.Runtime assembly (the published test artifacts likely contain Activity XML exception logs with the specific assembly load failure)."
-            $recommendationHint = "TIMEOUT_HUNG_TEST"
-        }
-        else {
-            $rootCause.summary = "Integration tests hung — first test assembly never completed"
-            $recommendationHint = "TIMEOUT_HUNG_TEST"
-        }
-    }
-    # VSIX install failure from job logs
-    elseif ($vsixFailedJobs.Count -gt 0) {
-        $rootCause.category = "vsix-install-failure"
-        $rootCause.summary = "VSIX installation failed for $($vsixFailedJobs[0].name)"
-        $recommendationHint = "VSIX_INSTALL_FAILURE"
-    }
-    # VSIX install failure from artifacts
-    elseif ($vsixFailedArtifacts.Count -gt 0) {
-        $rootCause.category = "vsix-install-failure"
-        $firstError = if ($vsixFailedArtifacts[0].errors -and $vsixFailedArtifacts[0].errors.Count -gt 0) { $vsixFailedArtifacts[0].errors[0] } else { "Unknown VSIX install error" }
-        $rootCause.summary = "VSIX installation failed: $firstError"
-        $rootCause.primaryError = $firstError
-        $recommendationHint = "VSIX_INSTALL_FAILURE"
-    }
-    # MEF composition errors
-    elseif ($hasMefErrors) {
-        $rootCause.category = "mef-composition-error"
-        $totalMefErrors = ($artifactAnalysis.parsedMefErrors | Measure-Object -Property errorCount -Sum).Sum
-        $rootCause.summary = "$totalMefErrors MEF composition errors found"
-        $rootCause.errorCount = $totalMefErrors
-        $firstMefError = if ($artifactAnalysis.parsedMefErrors[0].errors -and $artifactAnalysis.parsedMefErrors[0].errors.Count -gt 0) { $artifactAnalysis.parsedMefErrors[0].errors[0] } else { "Unknown MEF error" }
-        $rootCause.primaryError = $firstMefError
-        $recommendationHint = "MEF_COMPOSITION_ERROR"
-    }
-    # Timeout with progress
-    elseif ($timedOutWithProgress.Count -gt 0) {
-        $rootCause.category = "timeout-slow-tests"
-        $rootCause.summary = "Tests were making progress but timed out"
-        $rootCause.primaryError = "Test runner was at '$($timedOutWithProgress[0].testRunnerStatus)' when canceled"
-        $recommendationHint = "TIMEOUT_TESTS_RUNNING"
-    }
-
-    # Display root cause
-    if ($rootCause.category) {
-        Write-Host "  Category: $($rootCause.category)" -ForegroundColor Red
-        Write-Host "  Summary: $($rootCause.summary)"
-        if ($rootCause.affectedServices.Count -gt 0) {
-            Write-Host "  Affected Services ($($rootCause.affectedServices.Count)):"
-            foreach ($svc in $rootCause.affectedServices | Select-Object -First 10) {
-                Write-Host "    - $svc" -ForegroundColor Yellow
-            }
-            if ($rootCause.affectedServices.Count -gt 10) {
-                Write-Host "    ... and $($rootCause.affectedServices.Count - 10) more" -ForegroundColor Gray
-            }
-        }
-        if ($rootCause.errorCount -gt 0) {
-            Write-Host "  Total Errors: $($rootCause.errorCount)"
-        }
-    }
-    else {
-        Write-WarningLine "Could not determine root cause automatically"
-        if (-not $DownloadArtifacts) {
-            Write-Host "  Tip: Re-run with -DownloadArtifacts to download and parse test artifacts" -ForegroundColor Gray
-        }
-    }
-
-    # Emit exception details
+    # Step 5: Emit parsed artifact details
     if ($artifactAnalysis.parsedExceptions.Count -gt 0) {
         Write-Header "Exception Details"
         foreach ($exc in $artifactAnalysis.parsedExceptions) {
@@ -866,7 +714,7 @@ try {
         buildResult      = $build.result
         pipeline         = $build.definition.name
         sourceBranch     = $build.sourceBranch
-        pipelineTimeout  = 150
+        pipelineTimeout  = $pipelineTimeoutMinutes
         jobs             = @($jobAnalyses | ForEach-Object {
                 [ordered]@{
                     name              = $_.name
@@ -888,15 +736,34 @@ try {
             mefErrorFiles    = $artifactAnalysis.mefErrorFiles
             vsixLogFiles     = $artifactAnalysis.vsixLogFiles
             skippedArtifacts = $artifactAnalysis.skippedArtifacts
+            parsedExceptions = @($artifactAnalysis.parsedExceptions | ForEach-Object {
+                    [ordered]@{
+                        fileName         = $_.fileName
+                        testName         = $_.testName
+                        exceptionType    = $_.exceptionType
+                        rootCausePattern = $_.rootCausePattern
+                        primaryError     = $_.primaryError
+                        totalErrors      = $_.totalErrors
+                        affectedFeatures = $_.affectedFeatures
+                        errorSources     = $_.errorSources
+                        vsVersion        = $_.vsVersion
+                    }
+                })
+            parsedMefErrors  = @($artifactAnalysis.parsedMefErrors | ForEach-Object {
+                    [ordered]@{
+                        fileName   = $_.fileName
+                        errorCount = $_.errorCount
+                        errors     = $_.errors
+                    }
+                })
+            parsedVsixLogs   = @($artifactAnalysis.parsedVsixLogs | ForEach-Object {
+                    [ordered]@{
+                        fileName = $_.fileName
+                        success  = $_.success
+                        errors   = $_.errors
+                    }
+                })
         }
-        rootCause = [ordered]@{
-            category         = $rootCause.category
-            summary          = $rootCause.summary
-            affectedServices = $rootCause.affectedServices
-            errorCount       = $rootCause.errorCount
-            primaryError     = $rootCause.primaryError
-        }
-        recommendationHint = $recommendationHint
     }
 
     Write-Host ""


### PR DESCRIPTION
Adds a new Copilot skill that analyzes roslyn-integration-CI pipeline failures:
- Fetches build timeline and identifies failed/canceled VS_Integration_* jobs
- Parses test runner logs for VSIX install status, test progress, and VS/.NET versions
- Downloads and analyzes published artifacts (exception XMLs, screenshots, MEF errors)
- Merges timeout + exception signals to identify root causes like runtime mismatches
- Outputs structured JSON summary for agent reasoning
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83002)