### PR TITLE
Add LSP TypeHierarchy Support

### DIFF
--- a/src/Features/Core/Portable/GoToBase/FindBaseHelpers.cs
+++ b/src/Features/Core/Portable/GoToBase/FindBaseHelpers.cs
@@ -18,7 +18,7 @@ internal static class FindBaseHelpers
                 TypeKind: TypeKind.Class or TypeKind.Interface or TypeKind.Struct,
             } namedTypeSymbol)
         {
-            var result = BaseTypeFinder.FindBaseTypesAndInterfaces(namedTypeSymbol).CastArray<ISymbol>();
+            var result = BaseTypeFinder.FindBaseTypesAndInterfaces(namedTypeSymbol, transitive: true).CastArray<ISymbol>();
             return result;
         }
 

--- a/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
@@ -294,7 +294,7 @@ internal abstract partial class AbstractInheritanceMarginService
         CancellationToken cancellationToken)
     {
         // Get all base types.
-        var allBaseSymbols = typeHierarchyService.GetBaseTypesAndInterfaces(memberSymbol);
+        var allBaseSymbols = typeHierarchyService.GetBaseTypesAndInterfaces(memberSymbol, transitive: true);
 
         // Filter out
         // 1. System.Object. (otherwise margin would be shown for all classes)

--- a/src/Features/Core/Portable/TypeHierarchy/AbstractTypeHierarchyService.cs
+++ b/src/Features/Core/Portable/TypeHierarchy/AbstractTypeHierarchyService.cs
@@ -13,8 +13,8 @@ namespace Microsoft.CodeAnalysis.TypeHierarchy;
 
 internal abstract class AbstractTypeHierarchyService : ITypeHierarchyService
 {
-    public ImmutableArray<INamedTypeSymbol> GetBaseTypesAndInterfaces(INamedTypeSymbol typeSymbol)
-        => BaseTypeFinder.FindBaseTypesAndInterfaces(typeSymbol);
+    public ImmutableArray<INamedTypeSymbol> GetBaseTypesAndInterfaces(INamedTypeSymbol typeSymbol, bool transitive)
+        => BaseTypeFinder.FindBaseTypesAndInterfaces(typeSymbol, transitive);
 
     public async Task<ImmutableArray<INamedTypeSymbol>> GetDerivedTypesAndImplementationsAsync(
         Solution solution,

--- a/src/Features/Core/Portable/TypeHierarchy/ITypeHierarchyService.cs
+++ b/src/Features/Core/Portable/TypeHierarchy/ITypeHierarchyService.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.TypeHierarchy;
 
 internal interface ITypeHierarchyService : ILanguageService
 {
-    ImmutableArray<INamedTypeSymbol> GetBaseTypesAndInterfaces(INamedTypeSymbol typeSymbol);
+    ImmutableArray<INamedTypeSymbol> GetBaseTypesAndInterfaces(INamedTypeSymbol typeSymbol, bool transitive);
 
     Task<ImmutableArray<INamedTypeSymbol>> GetDerivedTypesAndImplementationsAsync(
         Solution solution,

--- a/src/Features/Test/TypeHierarchy/TypeHierarchyServiceTests.cs
+++ b/src/Features/Test/TypeHierarchy/TypeHierarchyServiceTests.cs
@@ -44,7 +44,7 @@ public sealed class TypeHierarchyServiceTests
                 """);
 
         var (_, service, symbol) = await GetTypeSymbolWithServiceAsync(workspace);
-        var baseTypes = service.GetBaseTypesAndInterfaces(symbol);
+        var baseTypes = service.GetBaseTypesAndInterfaces(symbol, transitive: true);
         var baseTypeNames = baseTypes.Select(static t => t.Name).ToImmutableArray();
 
         Assert.Contains("Base", baseTypeNames);
@@ -107,7 +107,7 @@ public sealed class TypeHierarchyServiceTests
                 """);
 
         var (_, service, symbol) = await GetTypeSymbolWithServiceAsync(workspace);
-        var baseTypes = service.GetBaseTypesAndInterfaces(symbol);
+        var baseTypes = service.GetBaseTypesAndInterfaces(symbol, transitive: true);
         var baseTypeNames = baseTypes.Select(static t => t.Name).ToImmutableArray();
 
         Assert.Contains("IRoot", baseTypeNames);

--- a/src/LanguageServer/Protocol/DefaultCapabilitiesProvider.cs
+++ b/src/LanguageServer/Protocol/DefaultCapabilitiesProvider.cs
@@ -86,6 +86,7 @@ internal sealed class DefaultCapabilitiesProvider : ICapabilitiesProvider
         capabilities.FoldingRangeProvider = true;
         capabilities.SelectionRangeProvider = true;
         capabilities.CallHierarchyProvider = true;
+        capabilities.TypeHierarchyProvider = true;
         capabilities.ExecuteCommandProvider = new ExecuteCommandOptions() { Commands = [] };
         capabilities.TextDocumentSync = new TextDocumentSyncOptions
         {

--- a/src/LanguageServer/Protocol/Handler/TypeHierarchy/PrepareTypeHierarchyHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/TypeHierarchy/PrepareTypeHierarchyHandler.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.LanguageServer.Protocol;
+using LSP = Roslyn.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler.TypeHierarchy;
+
+[ExportCSharpVisualBasicStatelessLspService(typeof(PrepareTypeHierarchyHandler)), Shared]
+[Method(LSP.Methods.PrepareTypeHierarchyName)]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class PrepareTypeHierarchyHandler() : ILspServiceDocumentRequestHandler<LSP.TypeHierarchyPrepareParams, LSP.TypeHierarchyItem[]?>
+{
+    public bool MutatesSolutionState => false;
+
+    public bool RequiresLSPSolution => true;
+
+    public TextDocumentIdentifier GetTextDocumentIdentifier(LSP.TypeHierarchyPrepareParams request)
+        => request.TextDocument;
+
+    public async Task<LSP.TypeHierarchyItem[]?> HandleRequestAsync(LSP.TypeHierarchyPrepareParams request, RequestContext context, CancellationToken cancellationToken)
+    {
+        var document = context.GetRequiredDocument();
+        var solution = document.Project.Solution;
+        var position = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(request.Position), cancellationToken).ConfigureAwait(false);
+        var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+
+        var symbol = await SymbolFinder.FindSymbolAtPositionAsync(semanticModel, position, solution.Services, includeType: true, cancellationToken).ConfigureAwait(false);
+        var typeSymbol = GetTargetTypeSymbol(symbol);
+        if (typeSymbol == null)
+            return null;
+
+        var item = await TypeHierarchyHelpers.CreateItemAsync(typeSymbol, solution, preferredDocumentId: document.Id, cancellationToken).ConfigureAwait(false);
+        return item == null ? null : [item];
+    }
+
+    private static INamedTypeSymbol? GetTargetTypeSymbol(ISymbol? symbol)
+        => symbol switch
+        {
+            INamedTypeSymbol namedTypeSymbol => namedTypeSymbol,
+            IMethodSymbol methodSymbol when methodSymbol.MethodKind is MethodKind.Constructor or MethodKind.StaticConstructor => methodSymbol.ContainingType,
+            { ContainingType: not null } containingTypeSymbol => containingTypeSymbol.ContainingType,
+            _ => null,
+        };
+}

--- a/src/LanguageServer/Protocol/Handler/TypeHierarchy/TypeHierarchyHelpers.cs
+++ b/src/LanguageServer/Protocol/Handler/TypeHierarchy/TypeHierarchyHelpers.cs
@@ -1,0 +1,115 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+using LSP = Roslyn.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler.TypeHierarchy;
+
+internal static class TypeHierarchyHelpers
+{
+    public static TypeHierarchyResolveData GetResolveData(LSP.TypeHierarchyItem item)
+    {
+        Contract.ThrowIfNull(item.Data);
+        var resolveData = JsonSerializer.Deserialize<TypeHierarchyResolveData>((JsonElement)item.Data, ProtocolConversions.LspJsonSerializerOptions);
+        Contract.ThrowIfNull(resolveData, "Missing data for type hierarchy request");
+        return resolveData;
+    }
+
+    public static async Task<INamedTypeSymbol?> GetTypeSymbolAsync(
+        LSP.TypeHierarchyItem item,
+        Solution solution,
+        CancellationToken cancellationToken)
+    {
+        var resolveData = GetResolveData(item);
+        var project = solution.GetProject(resolveData.GetProjectId());
+        if (project == null)
+            return null;
+
+        var compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
+        if (compilation == null)
+            return null;
+
+        var symbol = SymbolKey.ResolveString(resolveData.SymbolKeyData, compilation, cancellationToken: cancellationToken).GetAnySymbol();
+        return symbol as INamedTypeSymbol;
+    }
+
+    public static async Task<LSP.TypeHierarchyItem?> CreateItemAsync(
+        INamedTypeSymbol symbol,
+        Solution solution,
+        CancellationToken cancellationToken)
+        => await CreateItemAsync(symbol, solution, preferredDocumentId: null, cancellationToken).ConfigureAwait(false);
+
+    public static async Task<LSP.TypeHierarchyItem?> CreateItemAsync(
+        INamedTypeSymbol symbol,
+        Solution solution,
+        DocumentId? preferredDocumentId,
+        CancellationToken cancellationToken)
+    {
+        var sourceInfo = await TryGetSourceInfoAsync(symbol, solution, preferredDocumentId, cancellationToken).ConfigureAwait(false);
+        if (sourceInfo == null)
+            return null;
+
+        var (document, declarationSpan, selectionSpan) = sourceInfo.Value;
+        var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
+
+        var name = symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+        var detail = symbol.ContainingNamespace?.IsGlobalNamespace == true
+            ? null
+            : symbol.ContainingNamespace?.ToDisplayString();
+
+        return new LSP.TypeHierarchyItem
+        {
+            Name = name,
+            Kind = ProtocolConversions.GlyphToSymbolKind(symbol.GetGlyph()),
+            Detail = detail,
+            Uri = document.GetURI(),
+            Range = ProtocolConversions.TextSpanToRange(declarationSpan, text),
+            SelectionRange = ProtocolConversions.TextSpanToRange(selectionSpan, text),
+            Data = new TypeHierarchyResolveData(
+                SymbolKey.CreateString(symbol, cancellationToken),
+                document.Project.Id.Id,
+                ProtocolConversions.DocumentToTextDocumentIdentifier(document)),
+        };
+    }
+
+    private static async Task<(Document Document, TextSpan DeclarationSpan, TextSpan SelectionSpan)?> TryGetSourceInfoAsync(
+        INamedTypeSymbol symbol,
+        Solution solution,
+        DocumentId? preferredDocumentId,
+        CancellationToken cancellationToken)
+    {
+        (Document Document, TextSpan DeclarationSpan, TextSpan SelectionSpan)? fallbackSourceInfo = null;
+
+        foreach (var syntaxReference in symbol.DeclaringSyntaxReferences)
+        {
+            var document = solution.GetDocument(syntaxReference.SyntaxTree);
+            if (document == null)
+                continue;
+
+            var syntax = await syntaxReference.GetSyntaxAsync(cancellationToken).ConfigureAwait(false);
+            var declarationSpan = syntax.Span;
+            var selectionSpan = symbol.Locations.FirstOrDefault(location =>
+                location.IsInSource &&
+                location.SourceTree == syntax.SyntaxTree &&
+                declarationSpan.Contains(location.SourceSpan))?.SourceSpan ?? declarationSpan;
+
+            var sourceInfo = (document, declarationSpan, selectionSpan);
+
+            // Prefer a declaration in the request document when possible, but
+            // fall back to any source declaration when the symbol is declared elsewhere.
+            if (preferredDocumentId == null || document.Id == preferredDocumentId)
+                return sourceInfo;
+
+            fallbackSourceInfo ??= sourceInfo;
+        }
+
+        return fallbackSourceInfo;
+    }
+}

--- a/src/LanguageServer/Protocol/Handler/TypeHierarchy/TypeHierarchyResolveData.cs
+++ b/src/LanguageServer/Protocol/Handler/TypeHierarchy/TypeHierarchyResolveData.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Roslyn.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler.TypeHierarchy;
+
+internal sealed record TypeHierarchyResolveData(
+    string SymbolKeyData,
+    Guid ProjectGuid,
+    TextDocumentIdentifier TextDocument) : DocumentResolveData(TextDocument)
+{
+    public ProjectId GetProjectId()
+        => ProjectId.CreateFromSerialized(ProjectGuid);
+}

--- a/src/LanguageServer/Protocol/Handler/TypeHierarchy/TypeHierarchySubtypesHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/TypeHierarchy/TypeHierarchySubtypesHandler.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.TypeHierarchy;
+using Roslyn.LanguageServer.Protocol;
+using LSP = Roslyn.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler.TypeHierarchy;
+
+[ExportCSharpVisualBasicStatelessLspService(typeof(TypeHierarchySubtypesHandler)), Shared]
+[Method(LSP.Methods.TypeHierarchySubtypesName)]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class TypeHierarchySubtypesHandler() : ILspServiceDocumentRequestHandler<LSP.TypeHierarchySubtypesParams, LSP.TypeHierarchyItem[]?>
+{
+    public bool MutatesSolutionState => false;
+
+    public bool RequiresLSPSolution => true;
+
+    public TextDocumentIdentifier GetTextDocumentIdentifier(LSP.TypeHierarchySubtypesParams request)
+        => TypeHierarchyHelpers.GetResolveData(request.Item).TextDocument;
+
+    public async Task<LSP.TypeHierarchyItem[]?> HandleRequestAsync(LSP.TypeHierarchySubtypesParams request, RequestContext context, CancellationToken cancellationToken)
+    {
+        var document = context.GetRequiredDocument();
+        var solution = document.Project.Solution;
+        var typeSymbol = await TypeHierarchyHelpers.GetTypeSymbolAsync(request.Item, solution, cancellationToken).ConfigureAwait(false);
+        if (typeSymbol == null)
+            return null;
+
+        var service = document.GetRequiredLanguageService<ITypeHierarchyService>();
+        var derivedTypes = await service.GetDerivedTypesAndImplementationsAsync(solution, typeSymbol, transitive: false, cancellationToken).ConfigureAwait(false);
+
+        using var _ = ArrayBuilder<LSP.TypeHierarchyItem>.GetInstance(out var items);
+        foreach (var derivedType in derivedTypes)
+        {
+            var item = await TypeHierarchyHelpers.CreateItemAsync(derivedType, solution, cancellationToken).ConfigureAwait(false);
+            if (item != null)
+                items.Add(item);
+        }
+
+        return items.ToArray();
+    }
+}

--- a/src/LanguageServer/Protocol/Handler/TypeHierarchy/TypeHierarchySupertypesHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/TypeHierarchy/TypeHierarchySupertypesHandler.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.TypeHierarchy;
+using Roslyn.LanguageServer.Protocol;
+using LSP = Roslyn.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler.TypeHierarchy;
+
+[ExportCSharpVisualBasicStatelessLspService(typeof(TypeHierarchySupertypesHandler)), Shared]
+[Method(LSP.Methods.TypeHierarchySupertypesName)]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class TypeHierarchySupertypesHandler() : ILspServiceDocumentRequestHandler<LSP.TypeHierarchySupertypesParams, LSP.TypeHierarchyItem[]?>
+{
+    public bool MutatesSolutionState => false;
+
+    public bool RequiresLSPSolution => true;
+
+    public TextDocumentIdentifier GetTextDocumentIdentifier(LSP.TypeHierarchySupertypesParams request)
+        => TypeHierarchyHelpers.GetResolveData(request.Item).TextDocument;
+
+    public async Task<LSP.TypeHierarchyItem[]?> HandleRequestAsync(LSP.TypeHierarchySupertypesParams request, RequestContext context, CancellationToken cancellationToken)
+    {
+        var document = context.GetRequiredDocument();
+        var solution = document.Project.Solution;
+        var typeSymbol = await TypeHierarchyHelpers.GetTypeSymbolAsync(request.Item, solution, cancellationToken).ConfigureAwait(false);
+        if (typeSymbol == null)
+            return null;
+
+        var service = document.GetRequiredLanguageService<ITypeHierarchyService>();
+        var baseTypes = service.GetBaseTypesAndInterfaces(typeSymbol, transitive: false);
+
+        using var _ = ArrayBuilder<LSP.TypeHierarchyItem>.GetInstance(out var items);
+        foreach (var baseType in baseTypes)
+        {
+            var item = await TypeHierarchyHelpers.CreateItemAsync(baseType, solution, cancellationToken).ConfigureAwait(false);
+            if (item != null)
+                items.Add(item);
+        }
+
+        return items.ToArray();
+    }
+}

--- a/src/LanguageServer/Protocol/Protocol/Navigation/TypeHierarchySupertypesParams.cs
+++ b/src/LanguageServer/Protocol/Protocol/Navigation/TypeHierarchySupertypesParams.cs
@@ -10,7 +10,7 @@ namespace Roslyn.LanguageServer.Protocol;
 /// <summary>
 /// The params sent in a 'typeHierarchy/supertypes' request.
 /// <para>
-/// See the <see href="https://microsoft.github.io/language-server-protocol/specifications/specification-current/#typeHierarchySubtypesParams">Language Server Protocol specification</see> for additional information.
+/// See the <see href="https://microsoft.github.io/language-server-protocol/specifications/specification-current/#typeHierarchySupertypesParams">Language Server Protocol specification</see> for additional information.
 /// </para>
 /// </summary>
 /// <remarks>Since LSP 3.17</remarks>

--- a/src/LanguageServer/Protocol/Protocol/ServerCapabilities.cs
+++ b/src/LanguageServer/Protocol/Protocol/ServerCapabilities.cs
@@ -253,7 +253,7 @@ internal class ServerCapabilities
     /// <remarks>Since LSP 3.17</remarks>
     [JsonPropertyName("typeHierarchyProvider")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public SumType<bool, TypeHierarchyOptions, TypeHierarchyRegistrationOptions>? TypeHierarchyProvider { get; init; }
+    public SumType<bool, TypeHierarchyOptions, TypeHierarchyRegistrationOptions>? TypeHierarchyProvider { get; set; }
 
     /// <summary>
     /// The server provides inline values.

--- a/src/LanguageServer/ProtocolUnitTests/TypeHierarchy/TypeHierarchyTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/TypeHierarchy/TypeHierarchyTests.cs
@@ -1,0 +1,437 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Roslyn.Test.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+using LSP = Roslyn.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.TypeHierarchy;
+
+public sealed class TypeHierarchyTests(ITestOutputHelper testOutputHelper) : AbstractLanguageServerProtocolTests(testOutputHelper)
+{
+    [Theory, CombinatorialData]
+    public async Task TestPrepareTypeHierarchyReturnsTypeItem(bool mutatingLspWorkspace)
+    {
+        var markup = """
+            class {|definition:C|}
+            {
+                void {|caret:|}M()
+                {
+                }
+            }
+            """;
+
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
+
+        var preparedItem = Assert.Single(await RunPrepareTypeHierarchyAsync(testLspServer, testLspServer.GetLocations("caret").Single()));
+        var definition = testLspServer.GetLocations("definition").Single();
+
+        AssertEqualsItem(preparedItem, "C", definition);
+        Assert.NotNull(preparedItem.Data);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestPrepareTypeHierarchyReturnsTypeItemForCrossDocumentReference(bool mutatingLspWorkspace)
+    {
+        var markups = new[]
+        {
+            """
+            class User
+            {
+                {|caret:|}C field;
+            }
+            """,
+            """
+            class {|definition:C|}
+            {
+            }
+            """,
+        };
+
+        await using var testLspServer = await CreateTestLspServerAsync(markups, mutatingLspWorkspace);
+
+        var preparedItem = Assert.Single(await RunPrepareTypeHierarchyAsync(testLspServer, testLspServer.GetLocations("caret").Single()));
+        var definition = testLspServer.GetLocations("definition").Single();
+
+        AssertEqualsItem(preparedItem, "C", definition);
+        Assert.NotNull(preparedItem.Data);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestPrepareTypeHierarchyReturnsContainingTypeFromConstructor(bool mutatingLspWorkspace)
+    {
+        var markup = """
+            class {|definition:C|}
+            {
+                {|caret:|}C()
+                {
+                }
+            }
+            """;
+
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
+
+        var preparedItem = Assert.Single(await RunPrepareTypeHierarchyAsync(testLspServer, testLspServer.GetLocations("caret").Single()));
+        var definition = testLspServer.GetLocations("definition").Single();
+
+        AssertEqualsItem(preparedItem, "C", definition);
+        Assert.NotNull(preparedItem.Data);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestPrepareTypeHierarchyReturnsContainingTypeFromStaticConstructor(bool mutatingLspWorkspace)
+    {
+        var markup = """
+            class {|definition:C|}
+            {
+                static {|caret:|}C()
+                {
+                }
+            }
+            """;
+
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
+
+        var preparedItem = Assert.Single(await RunPrepareTypeHierarchyAsync(testLspServer, testLspServer.GetLocations("caret").Single()));
+        var definition = testLspServer.GetLocations("definition").Single();
+
+        AssertEqualsItem(preparedItem, "C", definition);
+        Assert.NotNull(preparedItem.Data);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestPrepareTypeHierarchyPrefersRequestDocumentForPartialType(bool mutatingLspWorkspace)
+    {
+        var markups = new[]
+        {
+            """
+            partial class {|definitionInFirst:C|}
+            {
+            }
+            """,
+            """
+            partial class {|definitionInSecond:C|}
+            {
+                void M()
+                {
+                    {|caret:|}C c;
+                }
+            }
+            """,
+        };
+
+        await using var testLspServer = await CreateTestLspServerAsync(markups, mutatingLspWorkspace);
+
+        var preparedItem = Assert.Single(await RunPrepareTypeHierarchyAsync(testLspServer, testLspServer.GetLocations("caret").Single()));
+        var preferredDefinition = testLspServer.GetLocations("definitionInSecond").Single();
+
+        AssertEqualsItem(preparedItem, "C", preferredDefinition);
+        Assert.NotNull(preparedItem.Data);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestPrepareTypeHierarchyReturnsContainingTypeForLocalVariableSymbol(bool mutatingLspWorkspace)
+    {
+        var markup = """
+            class {|definition:C|}
+            {
+                void M()
+                {
+                    int {|caret:local|} = 0;
+                }
+            }
+            """;
+
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
+
+        var preparedItem = Assert.Single(await RunPrepareTypeHierarchyAsync(testLspServer, testLspServer.GetLocations("caret").Single()));
+        var definition = testLspServer.GetLocations("definition").Single();
+
+        AssertEqualsItem(preparedItem, "C", definition);
+        Assert.NotNull(preparedItem.Data);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestPrepareTypeHierarchyReturnsNullForNamespaceSymbol(bool mutatingLspWorkspace)
+    {
+        var markup = """
+            namespace {|caret:N|}
+            {
+                class C
+                {
+                }
+            }
+            """;
+
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
+
+        var preparedItems = await RunPrepareTypeHierarchyAsync(testLspServer, testLspServer.GetLocations("caret").Single());
+        Assert.Empty(preparedItems);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestPrepareTypeHierarchyReturnsNullForKeywordPosition(bool mutatingLspWorkspace)
+    {
+        var markup = """
+            class C
+            {
+                void M()
+                {
+                    {|caret:if|} (true)
+                    {
+                    }
+                }
+            }
+            """;
+
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
+
+        var preparedItems = await RunPrepareTypeHierarchyAsync(testLspServer, testLspServer.GetLocations("caret").Single());
+        Assert.Empty(preparedItems);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestTypeHierarchySupertypesReturnsBaseAndInterface(bool mutatingLspWorkspace)
+    {
+        var markups = new[]
+        {
+            """
+            interface {|interfaceDef:IRoot|}
+            {
+            }
+            """,
+            """
+            class {|baseDef:Base|}
+            {
+            }
+            """,
+            """
+            class {|derivedDef:Derived|} : Base, IRoot
+            {
+                void {|caret:|}M()
+                {
+                }
+            }
+            """,
+        };
+
+        await using var testLspServer = await CreateTestLspServerAsync(markups, mutatingLspWorkspace);
+
+        var preparedItem = Assert.Single(await RunPrepareTypeHierarchyAsync(testLspServer, testLspServer.GetLocations("caret").Single()));
+        var supertypes = await RunSupertypesAsync(testLspServer, preparedItem);
+
+        var baseDefinition = testLspServer.GetLocations("baseDef").Single();
+        var interfaceDefinition = testLspServer.GetLocations("interfaceDef").Single();
+
+        Assert.Equal(2, supertypes.Length);
+        AssertContainsItem(supertypes, "Base", baseDefinition);
+        AssertContainsItem(supertypes, "IRoot", interfaceDefinition);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestTypeHierarchySubtypesReturnsDerivedInterfaceAndImplementation(bool mutatingLspWorkspace)
+    {
+        var markups = new[]
+        {
+            """
+            interface {|rootDef:IRoot|}
+            {
+            }
+            """,
+            """
+            interface {|childDef:IChild|} : {|caret:|}IRoot
+            {
+            }
+            """,
+            """
+            class {|directImplDef:DirectImplementation|} : IRoot
+            {
+            }
+            """,
+            """
+            class {|implDef:Implementation|} : IChild
+            {
+            }
+            """,
+        };
+
+        await using var testLspServer = await CreateTestLspServerAsync(markups, mutatingLspWorkspace);
+
+        var preparedItem = Assert.Single(await RunPrepareTypeHierarchyAsync(testLspServer, testLspServer.GetLocations("caret").Single()));
+        var subtypes = await RunSubtypesAsync(testLspServer, preparedItem);
+
+        var childDefinition = testLspServer.GetLocations("childDef").Single();
+        var directImplementationDefinition = testLspServer.GetLocations("directImplDef").Single();
+
+        Assert.Equal(2, subtypes.Length);
+        AssertContainsItem(subtypes, "IChild", childDefinition);
+        AssertContainsItem(subtypes, "DirectImplementation", directImplementationDefinition);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestTypeHierarchySupertypesReturnsOnlyImmediateSupertypes(bool mutatingLspWorkspace)
+    {
+        var markups = new[]
+        {
+            """
+            interface {|topInterfaceDef:ITop|}
+            {
+            }
+            """,
+            """
+            interface {|midInterfaceDef:IMid|} : ITop
+            {
+            }
+            """,
+            """
+            class {|baseDef:Base|} : IMid
+            {
+            }
+            """,
+            """
+            class {|midDef:Mid|} : Base
+            {
+            }
+            """,
+            """
+            class {|derivedDef:Derived|} : Mid
+            {
+                void {|caret:|}M()
+                {
+                }
+            }
+            """,
+        };
+
+        await using var testLspServer = await CreateTestLspServerAsync(markups, mutatingLspWorkspace);
+
+        var preparedItem = Assert.Single(await RunPrepareTypeHierarchyAsync(testLspServer, testLspServer.GetLocations("caret").Single()));
+        var supertypes = await RunSupertypesAsync(testLspServer, preparedItem);
+
+        var midDefinition = testLspServer.GetLocations("midDef").Single();
+        var baseDefinition = testLspServer.GetLocations("baseDef").Single();
+        var midInterfaceDefinition = testLspServer.GetLocations("midInterfaceDef").Single();
+        var topInterfaceDefinition = testLspServer.GetLocations("topInterfaceDef").Single();
+
+        var midItem = Assert.Single(supertypes);
+        AssertEqualsItem(midItem, "Mid", midDefinition);
+
+        var midSupertypes = await RunSupertypesAsync(testLspServer, midItem);
+        var baseItem = Assert.Single(midSupertypes);
+        AssertEqualsItem(baseItem, "Base", baseDefinition);
+
+        var baseSupertypes = await RunSupertypesAsync(testLspServer, baseItem);
+        var midInterfaceItem = Assert.Single(baseSupertypes);
+        AssertEqualsItem(midInterfaceItem, "IMid", midInterfaceDefinition);
+
+        var midInterfaceSupertypes = await RunSupertypesAsync(testLspServer, midInterfaceItem);
+        var topInterfaceItem = Assert.Single(midInterfaceSupertypes);
+        AssertEqualsItem(topInterfaceItem, "ITop", topInterfaceDefinition);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestTypeHierarchySubtypesReturnsOnlyImmediateSubtypes(bool mutatingLspWorkspace)
+    {
+        var markups = new[]
+        {
+            """
+            interface {|rootDef:IRoot|}
+            {
+            }
+            """,
+            """
+            interface {|childDef:IChild|} : {|caret:|}IRoot
+            {
+            }
+            """,
+            """
+            interface {|grandchildDef:IGrandChild|} : IChild
+            {
+            }
+            """,
+            """
+            class {|directImplDef:DirectImplementation|} : IRoot
+            {
+            }
+            """,
+            """
+            class {|indirectImplDef:IndirectImplementation|} : IGrandChild
+            {
+            }
+            """,
+        };
+
+        await using var testLspServer = await CreateTestLspServerAsync(markups, mutatingLspWorkspace);
+
+        var preparedItem = Assert.Single(await RunPrepareTypeHierarchyAsync(testLspServer, testLspServer.GetLocations("caret").Single()));
+        var subtypes = await RunSubtypesAsync(testLspServer, preparedItem);
+
+        var childDefinition = testLspServer.GetLocations("childDef").Single();
+        var directImplementationDefinition = testLspServer.GetLocations("directImplDef").Single();
+        var grandchildDefinition = testLspServer.GetLocations("grandchildDef").Single();
+        var indirectImplementationDefinition = testLspServer.GetLocations("indirectImplDef").Single();
+
+        Assert.Equal(2, subtypes.Length);
+        AssertContainsItem(subtypes, "IChild", childDefinition);
+        AssertContainsItem(subtypes, "DirectImplementation", directImplementationDefinition);
+
+        var childItem = Assert.Single(subtypes, static item => item.Name == "IChild");
+        var childSubtypes = await RunSubtypesAsync(testLspServer, childItem);
+        var grandchildItem = Assert.Single(childSubtypes);
+        AssertEqualsItem(grandchildItem, "IGrandChild", grandchildDefinition);
+
+        var grandchildSubtypes = await RunSubtypesAsync(testLspServer, grandchildItem);
+        var indirectImplementationItem = Assert.Single(grandchildSubtypes);
+        AssertEqualsItem(indirectImplementationItem, "IndirectImplementation", indirectImplementationDefinition);
+    }
+
+    private static void AssertContainsItem(LSP.TypeHierarchyItem[] items, string expectedName, LSP.Location expectedDefinition)
+    {
+        var item = Assert.Single(items, i => i.Name == expectedName);
+        AssertEqualsItem(item, expectedName, expectedDefinition);
+    }
+
+    private static void AssertEqualsItem(LSP.TypeHierarchyItem item, string expectedName, LSP.Location expectedDefinition)
+    {
+        Assert.Equal(expectedName, item.Name);
+        Assert.Equal(expectedDefinition.DocumentUri, item.Uri);
+        Assert.Equal(0, CompareRange(expectedDefinition.Range, item.SelectionRange));
+    }
+
+    private static async Task<LSP.TypeHierarchyItem[]> RunPrepareTypeHierarchyAsync(TestLspServer testLspServer, LSP.Location caret)
+        => await testLspServer.ExecuteRequestAsync<LSP.TypeHierarchyPrepareParams, LSP.TypeHierarchyItem[]?>(
+            LSP.Methods.PrepareTypeHierarchyName,
+            new LSP.TypeHierarchyPrepareParams
+            {
+                TextDocument = CreateTextDocumentIdentifier(caret.DocumentUri),
+                Position = caret.Range.Start,
+            },
+            CancellationToken.None) ?? [];
+
+    private static async Task<LSP.TypeHierarchyItem[]> RunSupertypesAsync(TestLspServer testLspServer, LSP.TypeHierarchyItem item)
+        => await testLspServer.ExecuteRequestAsync<LSP.TypeHierarchySupertypesParams, LSP.TypeHierarchyItem[]?>(
+            LSP.Methods.TypeHierarchySupertypesName,
+            new LSP.TypeHierarchySupertypesParams
+            {
+                TextDocument = CreateTextDocumentIdentifier(item.Uri),
+                Position = item.SelectionRange.Start,
+                Item = item,
+            },
+            CancellationToken.None) ?? [];
+
+    private static async Task<LSP.TypeHierarchyItem[]> RunSubtypesAsync(TestLspServer testLspServer, LSP.TypeHierarchyItem item)
+        => await testLspServer.ExecuteRequestAsync<LSP.TypeHierarchySubtypesParams, LSP.TypeHierarchyItem[]?>(
+            LSP.Methods.TypeHierarchySubtypesName,
+            new LSP.TypeHierarchySubtypesParams
+            {
+                TextDocument = CreateTextDocumentIdentifier(item.Uri),
+                Position = item.SelectionRange.Start,
+                Item = item,
+            },
+            CancellationToken.None) ?? [];
+}

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/BaseTypeFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/BaseTypeFinder.cs
@@ -11,8 +11,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols.FindReferences;
 
 internal static partial class BaseTypeFinder
 {
-    public static ImmutableArray<INamedTypeSymbol> FindBaseTypesAndInterfaces(INamedTypeSymbol type)
-        => FindBaseTypes(type).AddRange(type.AllInterfaces);
+    public static ImmutableArray<INamedTypeSymbol> FindBaseTypesAndInterfaces(INamedTypeSymbol type, bool transitive)
+        => FindBaseTypes(type, transitive).AddRange(transitive ? type.AllInterfaces : type.Interfaces);
 
     public static ImmutableArray<ISymbol> FindOverriddenAndImplementedMembers(
         ISymbol symbol, Solution solution, CancellationToken cancellationToken)
@@ -36,7 +36,7 @@ internal static partial class BaseTypeFinder
         void AddOverrides(bool allowLooseMatch)
         {
             // The type scenario. Iterate over all base classes to find overridden and hidden (new/Shadows) methods.
-            foreach (var type in FindBaseTypes(symbol.ContainingType))
+            foreach (var type in FindBaseTypes(symbol.ContainingType, transitive: true))
             {
                 foreach (var member in type.GetMembers(symbol.Name))
                 {
@@ -77,8 +77,14 @@ internal static partial class BaseTypeFinder
         }
     }
 
-    private static ImmutableArray<INamedTypeSymbol> FindBaseTypes(INamedTypeSymbol type)
+    private static ImmutableArray<INamedTypeSymbol> FindBaseTypes(INamedTypeSymbol type, bool transitive)
     {
+        if (type.BaseType == null)
+            return [];
+
+        if (!transitive)
+            return [type.BaseType];
+
         var typesBuilder = ArrayBuilder<INamedTypeSymbol>.GetInstance();
 
         var currentType = type.BaseType;


### PR DESCRIPTION
Implements the following LSP APIs:
- `textDocument/prepareTypeHierarchy`
- `typeHierarchy/supertypes`
- `typeHierarchy/subtypes`

Builds on https://github.com/dotnet/roslyn/pull/83001

Resolves https://github.com/dotnet/roslyn/issues/83008

https://github.com/user-attachments/assets/22131e46-3740-46c9-8213-0771ff38aa2a


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83011)