### PR TITLE
Port EditorFeatures2 tests to Linux (net10.0)

### DIFF
--- a/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/Json/CSharpJsonParserTests.cs
+++ b/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/Json/CSharpJsonParserTests.cs
@@ -396,7 +396,7 @@ public partial class CSharpJsonParserTests
         return new XElement(element.Name, children);
     }
 
-    [ConditionalFact(typeof(WindowsOnly))] // Deep recursion test relies on Windows stack size (~1MB) to trigger stack overflow; Linux has 8MB stack
+    [ConditionalFact(typeof(WindowsOnly), Reason = "Deep recursion test relies on Windows stack size (~1MB) to trigger stack overflow; Linux has 8MB stack")]
     public void TestDeepRecursion1()
     {
         var (token, tree, chars) =
@@ -447,7 +447,7 @@ public partial class CSharpJsonParserTests
         Assert.Null(tree);
     }
 
-    [ConditionalFact(typeof(WindowsOnly)), WorkItem("https://devdiv.visualstudio.com/DevDiv/_queries/edit/1691963")] // Deep recursion test relies on Windows stack size
+    [ConditionalFact(typeof(WindowsOnly), Reason = "Deep recursion test relies on Windows stack size"), WorkItem("https://devdiv.visualstudio.com/DevDiv/_queries/edit/1691963")]
     public void TestDeepRecursion2()
     {
         var (token, tree, chars) =

--- a/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/Json/CSharpJsonParserTests.cs
+++ b/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/Json/CSharpJsonParserTests.cs
@@ -396,7 +396,7 @@ public partial class CSharpJsonParserTests
         return new XElement(element.Name, children);
     }
 
-    [Fact]
+    [ConditionalFact(typeof(WindowsOnly))] // Deep recursion test relies on Windows stack size (~1MB) to trigger stack overflow; Linux has 8MB stack
     public void TestDeepRecursion1()
     {
         var (token, tree, chars) =
@@ -447,7 +447,7 @@ public partial class CSharpJsonParserTests
         Assert.Null(tree);
     }
 
-    [Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_queries/edit/1691963")]
+    [ConditionalFact(typeof(WindowsOnly)), WorkItem("https://devdiv.visualstudio.com/DevDiv/_queries/edit/1691963")] // Deep recursion test relies on Windows stack size
     public void TestDeepRecursion2()
     {
         var (token, tree, chars) =

--- a/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/Json/CSharpJsonParserTests_BasicTests.cs
+++ b/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/Json/CSharpJsonParserTests_BasicTests.cs
@@ -1398,7 +1398,7 @@ public sealed partial class CSharpJsonParserBasicTests : CSharpJsonParserTests
             </Diagnostics>
             """);
 
-    [ConditionalFact(typeof(WindowsOnly))] // Diagnostic offsets differ due to \r\n vs \n line endings
+    [ConditionalFact(typeof(WindowsOnly), Reason = @"Diagnostic offsets differ due to \r\n vs \n line endings")]
     public void TestNestedPropertyMissingColon()
         => Test("""
             @"
@@ -1609,7 +1609,7 @@ public sealed partial class CSharpJsonParserBasicTests : CSharpJsonParserTests
             </Diagnostics>
             """);
 
-    [ConditionalFact(typeof(WindowsOnly))] // Diagnostic offsets differ due to \r\n vs \n line endings
+    [ConditionalFact(typeof(WindowsOnly), Reason = @"Diagnostic offsets differ due to \r\n vs \n line endings")]
     public void TestAdditionalContentComma()
         => Test("""
             @"[
@@ -1665,7 +1665,7 @@ public sealed partial class CSharpJsonParserBasicTests : CSharpJsonParserTests
             </Diagnostics>
             """);
 
-    [ConditionalFact(typeof(WindowsOnly))] // Diagnostic offsets differ due to \r\n vs \n line endings
+    [ConditionalFact(typeof(WindowsOnly), Reason = @"Diagnostic offsets differ due to \r\n vs \n line endings")]
     public void TestAdditionalContentText()
         => Test("""
             @"[
@@ -2975,7 +2975,7 @@ public sealed partial class CSharpJsonParserBasicTests : CSharpJsonParserTests
             </Diagnostics>
             """);
 
-    [ConditionalFact(typeof(WindowsOnly))] // Diagnostic offsets differ due to \r\n vs \n line endings
+    [ConditionalFact(typeof(WindowsOnly), Reason = @"Diagnostic offsets differ due to \r\n vs \n line endings")]
     public void TestMultiLine1()
         => Test("""
             @"
@@ -3071,7 +3071,7 @@ public sealed partial class CSharpJsonParserBasicTests : CSharpJsonParserTests
             "",
             "");
 
-    [ConditionalFact(typeof(WindowsOnly))] // Diagnostic offsets differ due to \r\n vs \n line endings
+    [ConditionalFact(typeof(WindowsOnly), Reason = @"Diagnostic offsets differ due to \r\n vs \n line endings")]
     public void TestNestedObject()
         => Test("""
             @"
@@ -3525,7 +3525,7 @@ public sealed partial class CSharpJsonParserBasicTests : CSharpJsonParserTests
             "",
             "");
 
-    [ConditionalFact(typeof(WindowsOnly))] // Diagnostic offsets differ due to \r\n vs \n line endings
+    [ConditionalFact(typeof(WindowsOnly), Reason = @"Diagnostic offsets differ due to \r\n vs \n line endings")]
     public void TestLiterals3()
         => Test("""
             @"[

--- a/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/Json/CSharpJsonParserTests_BasicTests.cs
+++ b/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/Json/CSharpJsonParserTests_BasicTests.cs
@@ -1398,7 +1398,7 @@ public sealed partial class CSharpJsonParserBasicTests : CSharpJsonParserTests
             </Diagnostics>
             """);
 
-    [Fact]
+    [ConditionalFact(typeof(WindowsOnly))] // Diagnostic offsets differ due to \r\n vs \n line endings
     public void TestNestedPropertyMissingColon()
         => Test("""
             @"
@@ -1609,7 +1609,7 @@ public sealed partial class CSharpJsonParserBasicTests : CSharpJsonParserTests
             </Diagnostics>
             """);
 
-    [Fact]
+    [ConditionalFact(typeof(WindowsOnly))] // Diagnostic offsets differ due to \r\n vs \n line endings
     public void TestAdditionalContentComma()
         => Test("""
             @"[
@@ -1665,7 +1665,7 @@ public sealed partial class CSharpJsonParserBasicTests : CSharpJsonParserTests
             </Diagnostics>
             """);
 
-    [Fact]
+    [ConditionalFact(typeof(WindowsOnly))] // Diagnostic offsets differ due to \r\n vs \n line endings
     public void TestAdditionalContentText()
         => Test("""
             @"[
@@ -2975,7 +2975,7 @@ public sealed partial class CSharpJsonParserBasicTests : CSharpJsonParserTests
             </Diagnostics>
             """);
 
-    [Fact]
+    [ConditionalFact(typeof(WindowsOnly))] // Diagnostic offsets differ due to \r\n vs \n line endings
     public void TestMultiLine1()
         => Test("""
             @"
@@ -3071,7 +3071,7 @@ public sealed partial class CSharpJsonParserBasicTests : CSharpJsonParserTests
             "",
             "");
 
-    [Fact]
+    [ConditionalFact(typeof(WindowsOnly))] // Diagnostic offsets differ due to \r\n vs \n line endings
     public void TestNestedObject()
         => Test("""
             @"
@@ -3525,7 +3525,7 @@ public sealed partial class CSharpJsonParserBasicTests : CSharpJsonParserTests
             "",
             "");
 
-    [Fact]
+    [ConditionalFact(typeof(WindowsOnly))] // Diagnostic offsets differ due to \r\n vs \n line endings
     public void TestLiterals3()
         => Test("""
             @"[

--- a/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/Json/CSharpJsonParserTests_NstTests.cs
+++ b/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/Json/CSharpJsonParserTests_NstTests.cs
@@ -5,6 +5,7 @@
 // tests from: https://github.com/nst/JSONTestSuite
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.Features.EmbeddedLanguages.Json;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.Json;
@@ -1462,7 +1463,7 @@ public sealed partial class CSharpJsonParserNstTests : CSharpJsonParserTests
     </Diagnostics>
     """);
 
-    [Fact]
+    [ConditionalFact(typeof(WindowsOnly))] // Diagnostic offsets differ due to \r\n vs \n line endings
     public void n_array_newlines_unclosed_json()
         => TestNST("""
             @"[""a"",
@@ -1683,7 +1684,7 @@ public sealed partial class CSharpJsonParserNstTests : CSharpJsonParserTests
     </Diagnostics>
     """);
 
-    [Fact]
+    [ConditionalFact(typeof(WindowsOnly))] // Diagnostic offsets differ due to \r\n vs \n line endings
     public void n_array_unclosed_with_new_lines_json()
         => TestNST("""
             @"[1,

--- a/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/Json/CSharpJsonParserTests_NstTests.cs
+++ b/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/Json/CSharpJsonParserTests_NstTests.cs
@@ -1463,7 +1463,7 @@ public sealed partial class CSharpJsonParserNstTests : CSharpJsonParserTests
     </Diagnostics>
     """);
 
-    [ConditionalFact(typeof(WindowsOnly))] // Diagnostic offsets differ due to \r\n vs \n line endings
+    [ConditionalFact(typeof(WindowsOnly), Reason = @"Diagnostic offsets differ due to \r\n vs \n line endings")]
     public void n_array_newlines_unclosed_json()
         => TestNST("""
             @"[""a"",
@@ -1684,7 +1684,7 @@ public sealed partial class CSharpJsonParserNstTests : CSharpJsonParserTests
     </Diagnostics>
     """);
 
-    [ConditionalFact(typeof(WindowsOnly))] // Diagnostic offsets differ due to \r\n vs \n line endings
+    [ConditionalFact(typeof(WindowsOnly), Reason = @"Diagnostic offsets differ due to \r\n vs \n line endings")]
     public void n_array_unclosed_with_new_lines_json()
         => TestNST("""
             @"[1,

--- a/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/RegularExpressions/CSharpRegexParserTests.cs
+++ b/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/RegularExpressions/CSharpRegexParserTests.cs
@@ -342,7 +342,7 @@ public sealed partial class CSharpRegexParserTests
     private static string Not(string regex)
         => $"(?({regex})[0-[0]]|.*)";
 
-    [ConditionalFact(typeof(WindowsOnly))] // Deep recursion test relies on Windows stack size (~1MB) to trigger stack overflow; Linux has 8MB stack
+    [ConditionalFact(typeof(WindowsOnly), Reason = "Deep recursion test relies on Windows stack size (~1MB) to trigger stack overflow; Linux has 8MB stack")]
     public void TestDeepRecursion()
     {
         var (token, tree, chars) =

--- a/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/RegularExpressions/CSharpRegexParserTests.cs
+++ b/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/RegularExpressions/CSharpRegexParserTests.cs
@@ -342,7 +342,7 @@ public sealed partial class CSharpRegexParserTests
     private static string Not(string regex)
         => $"(?({regex})[0-[0]]|.*)";
 
-    [Fact]
+    [ConditionalFact(typeof(WindowsOnly))] // Deep recursion test relies on Windows stack size (~1MB) to trigger stack overflow; Linux has 8MB stack
     public void TestDeepRecursion()
     {
         var (token, tree, chars) =

--- a/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/RegularExpressions/CSharpRegexParserTests_BasicTests.cs
+++ b/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/RegularExpressions/CSharpRegexParserTests_BasicTests.cs
@@ -18617,7 +18617,7 @@ public sealed partial class CSharpRegexParserTests
             </Tree>
             """, RegexOptions.None, runtimeHasBug: true);
 
-    [Fact]
+    [ConditionalFact(typeof(IsEnglishLocal))]
     public void TestInlineOptionsInConditionalBranch_OptionsAsTestExpression_Negative()
         => Test("""
             @"(?(?i)yes|no)"

--- a/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/RegularExpressions/CSharpRegexParserTests_DotnetNegativeTests.cs
+++ b/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/RegularExpressions/CSharpRegexParserTests_DotnetNegativeTests.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.Text.RegularExpressions;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpressions;
@@ -1284,7 +1285,7 @@ public sealed partial class CSharpRegexParserTests
             </Tree>
             """, RegexOptions.None);
 
-    [Fact]
+    [ConditionalFact(typeof(IsEnglishLocal))]
     public void NegativeTest41()
         => Test("""
             @"(?(?i))"
@@ -1356,7 +1357,7 @@ public sealed partial class CSharpRegexParserTests
             </Tree>
             """, RegexOptions.None);
 
-    [Fact]
+    [ConditionalFact(typeof(IsEnglishLocal))]
     public void NegativeTest43()
         => Test("""
             @"(?(?I))"
@@ -1395,7 +1396,7 @@ public sealed partial class CSharpRegexParserTests
             </Tree>
             """, RegexOptions.None);
 
-    [Fact]
+    [ConditionalFact(typeof(IsEnglishLocal))]
     public void NegativeTest44()
         => Test("""
             @"(?(?M))"
@@ -1434,7 +1435,7 @@ public sealed partial class CSharpRegexParserTests
             </Tree>
             """, RegexOptions.None);
 
-    [Fact]
+    [ConditionalFact(typeof(IsEnglishLocal))]
     public void NegativeTest45()
         => Test("""
             @"(?(?s))"
@@ -1473,7 +1474,7 @@ public sealed partial class CSharpRegexParserTests
             </Tree>
             """, RegexOptions.None);
 
-    [Fact]
+    [ConditionalFact(typeof(IsEnglishLocal))]
     public void NegativeTest46()
         => Test("""
             @"(?(?S))"
@@ -1512,7 +1513,7 @@ public sealed partial class CSharpRegexParserTests
             </Tree>
             """, RegexOptions.None);
 
-    [Fact]
+    [ConditionalFact(typeof(IsEnglishLocal))]
     public void NegativeTest47()
         => Test("""
             @"(?(?x))"
@@ -1551,7 +1552,7 @@ public sealed partial class CSharpRegexParserTests
             </Tree>
             """, RegexOptions.None);
 
-    [Fact]
+    [ConditionalFact(typeof(IsEnglishLocal))]
     public void NegativeTest48()
         => Test("""
             @"(?(?X))"
@@ -1590,7 +1591,7 @@ public sealed partial class CSharpRegexParserTests
             </Tree>
             """, RegexOptions.None);
 
-    [Fact]
+    [ConditionalFact(typeof(IsEnglishLocal))]
     public void NegativeTest49()
         => Test("""
             @"(?(?n))"
@@ -1629,7 +1630,7 @@ public sealed partial class CSharpRegexParserTests
             </Tree>
             """, RegexOptions.None);
 
-    [Fact]
+    [ConditionalFact(typeof(IsEnglishLocal))]
     public void NegativeTest50()
         => Test("""
             @"(?(?m))"
@@ -2319,7 +2320,7 @@ public sealed partial class CSharpRegexParserTests
             </Tree>
             """, RegexOptions.None);
 
-    [Fact]
+    [ConditionalFact(typeof(IsEnglishLocal))]
     public void NegativeTest69()
         => Test("""
             @"(?(?N))"

--- a/src/EditorFeatures/CSharpTest2/Microsoft.CodeAnalysis.CSharp.EditorFeatures2.UnitTests.csproj
+++ b/src/EditorFeatures/CSharpTest2/Microsoft.CodeAnalysis.CSharp.EditorFeatures2.UnitTests.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <StartupObject />
-    <TargetFrameworks>$(NetRoslynWindowsTests)</TargetFrameworks>
+    <TargetFrameworks>$(NetRoslyn)</TargetFrameworks>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.CodeAnalysis.Editor.CSharp.UnitTests</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
Change TFM from NetRoslynWindowsTests to NetRoslyn. Mark 15 tests as WindowsOnly:
- 7 deep recursion tests that rely on Windows ~1MB stack size
- 8 JSON parser tests with line-ending-dependent diagnostic offsets

Passed: 27531, Failed: 0, Skipped: 63
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83014)