### PR TITLE
Update assembly versions in VS insertions

### DIFF
--- a/eng/pipelines/insert.yml
+++ b/eng/pipelines/insert.yml
@@ -176,6 +176,7 @@ steps:
         "--create-draft-pr", "$(Template.CreateDraftPR)"
         "--set-auto-complete", "$(Template.AutoComplete)"
         "--insert-toolset", "$(Template.InsertToolset)"
+        "--update-assembly-versions", "true"
         "--run-speedometer-in-validation", "${{ parameters.queueSpeedometerValidation }}"
         "--retain-inserted-build", "${{ parameters.retainInsertedBuild }}"
         "--reviewer-guid", "6c25b447-1d90-4840-8fde-d8b22cb8733e"


### PR DESCRIPTION
Without this we are not updating the assembly version in `/src/ProductData/AssemblyVersions.tt` and that leads to lots of ngen failures. See current insertions from main (and recent PR validation insertions based on main) since we snapped and changed the minor assembly version.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83016)