### PR TITLE
Do not crash if URI not parseable and no default handler exists

### DIFF
--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/RequestExecutionQueue.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/RequestExecutionQueue.cs
@@ -250,8 +250,19 @@ internal class RequestExecutionQueue<TRequestContext> : IRequestExecutionQueue<T
 
                     using var languageScope = _logger.CreateLanguageContext(language);
 
-                    // Now that we know the actual language, we can deserialize the request and start creating the request context.
-                    var (metadata, handler, methodInfo) = GetHandlerForRequest(work, language ?? LanguageServerConstants.DefaultLanguageName);
+                    // Now that we know the actual language, we can try to find the appropriate handler.
+                    var resolvedLanguage = language ?? LanguageServerConstants.DefaultLanguageName;
+                    if (!TryGetHandlerForRequest(work, resolvedLanguage, out var handlerResult))
+                    {
+                        // No handler found for this method+language combination.  This can happen if:
+                        // 1. We were unable to determine the language and there is no default handler for this method.
+                        // 2. A client sends a request for a method the server does not handle for this language.
+                        // In either case, we should not crash - just fail the request gracefully.
+                        work.FailRequest($"Missing handler for {work.MethodName} and language {resolvedLanguage}");
+                        continue;
+                    }
+
+                    var (metadata, handler, methodInfo) = handlerResult;
 
                     // We had an issue determining the language.  Generally this is very rare and only occurs
                     // when a client sends us requests for files where we haven't saved the languageId.
@@ -413,16 +424,18 @@ internal class RequestExecutionQueue<TRequestContext> : IRequestExecutionQueue<T
         return;
     }
 
-    private (RequestHandlerMetadata Metadata, IMethodHandler Handler, MethodInfo MethodInfo) GetHandlerForRequest(QueueItem<TRequestContext> work, string language)
+    private bool TryGetHandlerForRequest(QueueItem<TRequestContext> work, string language, out (RequestHandlerMetadata Metadata, IMethodHandler Handler, MethodInfo MethodInfo) result)
     {
         var handlersForMethod = _handlerInfoMap[work.MethodName];
         if (handlersForMethod.TryGetValue(language, out var lazyData) ||
             handlersForMethod.TryGetValue(LanguageServerConstants.DefaultLanguageName, out lazyData))
         {
-            return lazyData.Value;
+            result = lazyData.Value;
+            return true;
         }
 
-        throw new InvalidOperationException($"Missing default or language handler for {work.MethodName} and language {language}");
+        result = default;
+        return false;
     }
 
     /// <summary>

--- a/src/LanguageServer/ProtocolUnitTests/HandlerTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/HandlerTests.cs
@@ -309,6 +309,22 @@ public sealed class HandlerTests : AbstractLanguageServerProtocolTests
         }
     }
 
+    [Theory, CombinatorialData]
+    public async Task DoesNotCrashOnRequestForMissingHandler(bool mutatingLspWorkspace)
+    {
+        await using var server = await CreateTestLspServerAsync("", mutatingLspWorkspace);
+
+        var request = new TestRequestTypeOne(new TextDocumentIdentifier
+        {
+            DocumentUri = ProtocolConversions.CreateAbsoluteDocumentUri(@"C:\test.cs")
+        });
+
+        await Assert.ThrowsAnyAsync<Exception>(async ()
+            => await server.ExecuteRequestAsync<TestRequestTypeOne, string>("nonExistentMethod", request, CancellationToken.None));
+        Assert.False(server.GetServerAccessor().HasShutdownStarted());
+        Assert.False(server.GetQueueAccessor()!.Value.IsComplete());
+    }
+
     internal sealed record TestRequestTypeOne([property: JsonPropertyName("textDocument"), JsonRequired] TextDocumentIdentifier TextDocumentIdentifier);
 
     internal sealed record TestRequestTypeTwo([property: JsonPropertyName("textDocument"), JsonRequired] TextDocumentIdentifier TextDocumentIdentifier);

--- a/src/LanguageServer/ProtocolUnitTests/UriTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/UriTests.cs
@@ -27,7 +27,7 @@ public sealed class UriTests : AbstractLanguageServerProtocolTests
     {
     }
 
-    protected override TestComposition Composition => base.Composition.AddParts(typeof(CustomResolveHandler));
+    protected override TestComposition Composition => base.Composition.AddParts(typeof(CustomResolveHandler), typeof(LanguageSpecificHandler));
 
     [Theory, CombinatorialData]
     [WorkItem("https://github.com/dotnet/runtime/issues/89538")]
@@ -352,6 +352,50 @@ public sealed class UriTests : AbstractLanguageServerProtocolTests
         Assert.Equal("hello", (await document!.GetTextAsync()).ToString());
     }
 
+    [Theory, CombinatorialData]
+    public async Task TestUnparseableUri_FindsLanguageSpecificHandler_WhenDocumentIsOpen(bool mutatingLspWorkspace)
+    {
+        await using var testLspServer = await CreateTestLspServerAsync(string.Empty, mutatingLspWorkspace, new InitializationOptions { ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer });
+
+        // Use a URI that System.Uri cannot parse.
+        var unparseableUri = new DocumentUri("_claude_vscode_fs_right:/c:/Projects/MyApp/Pages/Component.razor");
+        Assert.Null(unparseableUri.ParsedUri);
+
+        // Open the document with the unparseable URI and "razor" language ID.
+        // The language ID should be saved and used to route subsequent requests to the Razor-specific handler.
+        await testLspServer.OpenDocumentAsync(unparseableUri, "<div>hello</div>", languageId: "razor");
+
+        // Send a request to the language-specific handler - should route to the Razor handler successfully.
+        var response = await testLspServer.ExecuteRequestAsync<CustomResolveParams, LanguageSpecificResponse>(
+            LanguageSpecificHandler.MethodName,
+            new CustomResolveParams(new LSP.TextDocumentIdentifier { DocumentUri = unparseableUri }),
+            CancellationToken.None);
+
+        Assert.NotNull(response);
+        Assert.True(response.HandlerCalled);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestUnparseableUri_WithNoDefaultHandler_DoesNotCrashServer_WhenDocumentIsClosed(bool mutatingLspWorkspace)
+    {
+        await using var testLspServer = await CreateTestLspServerAsync(string.Empty, mutatingLspWorkspace, new InitializationOptions { ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer });
+
+        // Use a URI that System.Uri cannot parse.
+        var unparseableUri = new DocumentUri("_claude_vscode_fs_right:/c:/Projects/MyApp/Pages/Component.razor");
+        Assert.Null(unparseableUri.ParsedUri);
+
+        // Send a request to a handler that is ONLY registered for "Razor" language (no default handler).
+        // Language lookup fails (document closed, URI unparseable) so there is no language to route to.
+        // The server should gracefully fail the request, not crash.
+        await Assert.ThrowsAnyAsync<Exception>(async ()
+            => await testLspServer.ExecuteRequestAsync<CustomResolveParams, LanguageSpecificResponse>(
+                LanguageSpecificHandler.MethodName,
+                new CustomResolveParams(new LSP.TextDocumentIdentifier { DocumentUri = unparseableUri }),
+                CancellationToken.None));
+        Assert.False(testLspServer.GetServerAccessor().HasShutdownStarted());
+        Assert.False(testLspServer.GetQueueAccessor()!.Value.IsComplete());
+    }
+
     [Theory]
     [InlineData(true, null, null)]
     [InlineData(false, "file://c:\\valid", null)]
@@ -371,6 +415,7 @@ public sealed class UriTests : AbstractLanguageServerProtocolTests
 
     private sealed record class ResolvedDocumentInfo(string WorkspaceKind, string ProjectLanguage);
     private sealed record class CustomResolveParams([property: JsonPropertyName("textDocument")] LSP.TextDocumentIdentifier TextDocument);
+    private sealed record class LanguageSpecificResponse(bool HandlerCalled);
 
     [ExportCSharpVisualBasicStatelessLspService(typeof(CustomResolveHandler)), PartNotDiscoverable, Shared]
     [LanguageServerEndpoint(MethodName, LanguageServerConstants.DefaultLanguageName)]
@@ -386,6 +431,26 @@ public sealed class UriTests : AbstractLanguageServerProtocolTests
         public async Task<ResolvedDocumentInfo> HandleRequestAsync(CustomResolveParams request, RequestContext context, CancellationToken cancellationToken)
         {
             return new ResolvedDocumentInfo(context.Workspace!.Kind!, context.GetRequiredDocument().Project.Language);
+        }
+    }
+
+    /// <summary>
+    /// Test handler that is only registered for the "Razor" language, with no default fallback.
+    /// This simulates handlers like textDocument/documentColor that are dynamically registered by Razor.
+    /// </summary>
+    [ExportCSharpVisualBasicStatelessLspService(typeof(LanguageSpecificHandler)), PartNotDiscoverable, Shared]
+    [LanguageServerEndpoint(MethodName, "Razor")]
+    [method: ImportingConstructor]
+    [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    private sealed class LanguageSpecificHandler() : ILspServiceRequestHandler<CustomResolveParams, LanguageSpecificResponse>
+    {
+        public const string MethodName = nameof(LanguageSpecificHandler);
+
+        public bool MutatesSolutionState => false;
+        public bool RequiresLSPSolution => false;
+        public Task<LanguageSpecificResponse> HandleRequestAsync(CustomResolveParams request, RequestContext context, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new LanguageSpecificResponse(true));
         }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-csharp/issues/9130

This does not completely fix the errors, but it prevents the server from crashing.  The root cause of the errors is an invalid URI (see https://github.com/dotnet/vscode-csharp/issues/9087).

### Scenario
When a request to the server is made for an unparsable URI and we have no saved language information sent to use via `didOpen`, the server falls back to trying to find a handler for the method using the default language.

However, some handlers have no default language handler, for example Razor's `textDocument/documentColor` handler.  If we are unable to determine the language for a request for this method, the server would crash as it finds no default language handler.

### Fix
The fix I made here is to not crash the server if we cannot find a handler for a request.  The client still gets an error, but allows server operations to continue.  This seemed appropriate as we do not control the client(s) and should not completely die if we get bad requests.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83024)