### PR TITLE
Disable draft insertions on main after VS snap

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -100,7 +100,7 @@
       "NonShipping"
     ],
     "vsBranch": "main",
-    "insertionCreateDraftPR": true,
+    "insertionCreateDraftPR": false,
     "insertionTitlePrefix": "[InsidersVNext]"
   }
 }


### PR DESCRIPTION
Post-VS-snap follow-up for the 18.6 snap: restore non-draft VS insertions on main now that the new VS branch is in place. Auto-generated by snap skill.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83032)