### PR TITLE
Point release/insiders insertions to rel/insiders

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -99,7 +99,7 @@
       "Shipping",
       "NonShipping"
     ],
-    "vsBranch": "main",
+    "vsBranch": "rel/insiders",
     "insertionCreateDraftPR": false,
     "insertionTitlePrefix": "[Insiders]"
   }


### PR DESCRIPTION
Post-VS-snap follow-up for the 18.6 snap: now that VS has created rel/insiders, update the release/insiders insertion target accordingly. Auto-generated by snap skill.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83033)