### PR TITLE
Fix evaluations inside ref-returning methods

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
@@ -313,7 +313,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         public override RefKind RefKind
         {
-            get { return this.SubstitutedSourceMethod.RefKind; }
+            get { return RefKind.None; }
         }
 
         public override bool ReturnsVoid

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -793,6 +793,45 @@ class B : A
 }");
         }
 
+        /// <summary>
+        /// Evaluating expressions inside a ref-returning method should
+        /// produce a query method that returns by value, not by ref.
+        /// </summary>
+        [Fact]
+        public void EvaluateExpressionInRefReturningMethod()
+        {
+            var source =
+@"struct TestStruct
+{
+    public int Value;
+}
+class C
+{
+    static TestStruct _field;
+    ref readonly TestStruct GetValue(ulong id)
+    {
+        return ref _field;
+    }
+}";
+            var testData = Evaluate(
+                source,
+                OutputKind.DynamicallyLinkedLibrary,
+                methodName: "C.GetValue",
+                expr: "id");
+            var methodData = testData.GetMethodData("<>x.<>m0");
+            var method = (MethodSymbol)methodData.Method;
+            Assert.Equal(RefKind.None, method.RefKind);
+
+            testData = Evaluate(
+                source,
+                OutputKind.DynamicallyLinkedLibrary,
+                methodName: "C.GetValue",
+                expr: "id == 1");
+            methodData = testData.GetMethodData("<>x.<>m0");
+            method = (MethodSymbol)methodData.Method;
+            Assert.Equal(RefKind.None, method.RefKind);
+        }
+
         [Fact]
         public void EvaluateStaticMethodParameters()
         {


### PR DESCRIPTION
# Overview
After investigating this issue: https://developercommunity.visualstudio.com/t/Conditional-breakpoint-is-not-respecting/11063626

I determined that for evaluations inside `ref`-returning frames, the expression compiler would generate query method signatures indicating that the return type is `T&` (`ref T`), while the query method itself still returned `T` (as expected). 

In particular, this bug breaks breakpoint conditions in VS; typical conditions rely on comparisons, which return `Int32` and the debugger can make the implicit conversion from `Int32` to the method signature `bool` return type. In `ref`-returning methods, the debugger cannot make the implicit conversion when the signature indicates `bool&`.

# Details
Clearly this is an oversight on the C# expression compiler side; the VB EE already handles this correctly (EEMethodSymbol.vb)
```vb
Public Overrides ReadOnly Property ReturnsByRef As Boolean
    Get
        Return False
    End Get
End Property
```

The change is to make `EEMethodSymbol` not inherit `RefKind` and instead return `RefKind.None`.

# Testing
Added unit test; deployed changes to experimental instance and verified the linked original issue is fixed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83037)