### PR TITLE
Clean up our newline-fixing extension methods

### DIFF
--- a/src/Compilers/Test/Core/FX/StringExtensions.cs
+++ b/src/Compilers/Test/Core/FX/StringExtensions.cs
@@ -10,28 +10,18 @@ namespace Roslyn.Test.Utilities
     {
         public static string NormalizeLineEndings(this string input)
         {
-            if (input.Contains("\n") && !input.Contains("\r\n"))
-            {
-                input = input.Replace("\n", "\r\n");
-            }
-
-            return input;
+            return input.ReplaceLineEndings("\r\n");
         }
+
+#if !NET6_0_OR_GREATER
 
         public static string ReplaceLineEndings(this string input)
         {
-#if NET6_0_OR_GREATER
-            return input.ReplaceLineEndings();
-#else
             return ReplaceLineEndings(input, Environment.NewLine);
-#endif
         }
 
         public static string ReplaceLineEndings(this string input, string replacementText)
         {
-#if NET6_0_OR_GREATER
-            return input.ReplaceLineEndings(replacementText);
-#else
             // First normalize to LF
             var lineFeedInput = input
                 .Replace("\r\n", "\n")
@@ -43,7 +33,8 @@ namespace Roslyn.Test.Utilities
 
             // Then normalize to the replacement text
             return lineFeedInput.Replace("\n", replacementText);
-#endif
         }
+
+#endif
     }
 }


### PR DESCRIPTION
No reason to define extension methods when they'll lose to the framework provided ones.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83043)