### PR TITLE
Ref assemblies: add tests for internal members in private type

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -986,6 +986,7 @@ public class C
         [InlineData("public struct S { private int i; }", "public struct S { }", Match.Different)]
         [InlineData("private int i;", "", Match.RefOut)]
         [InlineData("public C() { }", "", Match.BothMetadataAndRefOut)]
+        [InlineData("private class C2 { internal void M() { } }", "private class C2 { }", Match.RefOut)]
         public void RefAssembly_InvariantToSomeChanges(string left, string right, Match expectedMatch)
         {
             string sourceTemplate = @"
@@ -1169,6 +1170,7 @@ public class D
         [Theory]
         [InlineData("internal void M() { }", "", Match.Different)]
         [InlineData("private protected void M() { }", "", Match.Different)]
+        [InlineData("private class C2 { internal void M() { } }", "private class C2 { }", Match.Different)]
         public void RefAssembly_InvariantToSomeChangesWithInternalsVisibleTo(string left, string right, Match expectedMatch)
         {
             string sourceTemplate = @"
@@ -2373,6 +2375,85 @@ public class C : I
                     new[] { "void C.I.E.add", "void C.I.E.remove", "C..ctor()", "event System.Action C.I.E" },
                     input.GetMember<NamedTypeSymbol>("C").GetMembers()
                         .Select(m => m.ToTestDisplayString()));
+            }
+        }
+
+        [Fact]
+        public void RefAssembly_VerifyInternalMembersOnPrivateNestedTypesWithIVT()
+        {
+            string source = """
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("FriendAssembly")]
+
+public class Outer
+{
+    private class Hidden
+    {
+        internal int Property
+        {
+            get { throw null; }
+        }
+
+        internal void Method()
+        {
+            throw null;
+        }
+    }
+}
+""";
+
+            var parseOptions = TestOptions.Regular.WithNoRefSafetyRulesAttribute();
+            CSharpCompilation comp = CreateEmptyCompilation(source, parseOptions: parseOptions, references: [MscorlibRef],
+                options: TestOptions.DebugDll.WithDeterministic(true));
+
+            // verify regular assembly
+            CompileAndVerify(comp, emitOptions: EmitOptions.Default, verify: Verification.Passes);
+
+            var realImage = comp.EmitToImageReference(EmitOptions.Default);
+            var compWithReal = CreateEmptyCompilation("", parseOptions: parseOptions, references: [MscorlibRef, realImage],
+                options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
+
+            verifyInternalMembersWereEmitted(compWithReal);
+
+            // verify metadata-only assembly
+            var emitMetadataOnly = EmitOptions.Default.WithEmitMetadataOnly(true);
+            CompileAndVerify(comp, emitOptions: emitMetadataOnly, verify: Verification.Passes);
+
+            var metadataImage = comp.EmitToImageReference(emitMetadataOnly);
+            var compWithMetadata = CreateEmptyCompilation("", parseOptions: parseOptions, references: [MscorlibRef, metadataImage],
+                options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
+
+            verifyInternalMembersWereEmitted(compWithMetadata);
+
+            // verify ref assembly
+            var emitRefOnly = EmitOptions.Default.WithEmitMetadataOnly(true).WithIncludePrivateMembers(false);
+            CompileAndVerify(comp, emitOptions: emitRefOnly, verify: Verification.Passes);
+
+            var refImage = comp.EmitToImageReference(emitRefOnly);
+            var compWithRef = CreateEmptyCompilation("", parseOptions: parseOptions, references: [MscorlibRef, refImage],
+                options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
+
+            verifyInternalMembersWereEmitted(compWithRef);
+
+            void verifyInternalMembersWereEmitted(CSharpCompilation input)
+            {
+                AssertEx.Equal(
+                    ["<Module>", "Outer"],
+                    input.SourceModule.GetReferencedAssemblySymbols().Last().GlobalNamespace.GetMembers().Select(m => m.ToDisplayString()));
+
+                var outer = input.GetMember<NamedTypeSymbol>("Outer");
+                var hidden = outer.GetTypeMembers("Hidden").Single();
+                var hiddenProperty = hidden.GetMembers("Property").OfType<PropertySymbol>().Single();
+                var hiddenMethod = hidden.GetMembers("Method").OfType<MethodSymbol>().Single();
+
+                Assert.Equal(Accessibility.Private, hidden.DeclaredAccessibility);
+
+                Assert.Equal(Accessibility.Internal, hiddenProperty.DeclaredAccessibility);
+                Assert.Equal(Accessibility.Internal, hiddenProperty.GetMethod.DeclaredAccessibility);
+                Assert.Null(hiddenProperty.SetMethod);
+
+                Assert.Equal(Accessibility.Internal, hiddenMethod.DeclaredAccessibility);
             }
         }
 


### PR DESCRIPTION
The logic in `ShouldImportMethod` and similar helpers use the metadata accessibility, so such members are imported. But I couldn't find direct ref assemblies test for this scenario.

For reference, feature [spec](https://github.com/dotnet/roslyn/blob/main/docs/features/refout.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83079)