### PR TITLE
Skip unmappable source-generated document edits in rename

### DIFF
--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -2445,7 +2445,7 @@ public class GeneratedClass
                                 }
                             </Document>
                         </Project>
-                    </Workspace>, host)
+                    </Workspace>, host, GetType(TestRazorSourceGeneratedDocumentSpanMappingService))
 
                 Dim project = workspace.CurrentSolution.Projects.First().AddAnalyzerReference(New TestGeneratorReference(razorGenerator))
                 workspace.TryApplyChanges(project.Solution)

--- a/src/EditorFeatures/Test2/Rename/RenameTestHelpers.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameTestHelpers.vb
@@ -103,10 +103,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
         End Sub
 
 #Disable Warning IDE0060 ' Remove unused parameter - https://github.com/dotnet/roslyn/issues/45890
-    Public Function CreateWorkspaceWithWaiter(element As XElement, host As RenameTestHost, ParamArray additionalParts As Type()) As EditorTestWorkspace
+        Public Function CreateWorkspaceWithWaiter(element As XElement, host As RenameTestHost, ParamArray additionalParts As Type()) As EditorTestWorkspace
 #Enable Warning IDE0060 ' Remove unused parameter
-        Dim composition = If(additionalParts.Length = 0, s_composition, s_composition.AddParts(additionalParts))
-        Dim workspace = EditorTestWorkspace.CreateWorkspace(element, composition:=composition)
+            Dim composition = If(additionalParts.Length = 0, s_composition, s_composition.AddParts(additionalParts))
+            Dim workspace = EditorTestWorkspace.CreateWorkspace(element, composition:=composition)
             workspace.GetOpenDocumentIds().Select(Function(id) workspace.GetTestDocument(id).GetTextView()).ToList()
             Return workspace
         End Function

--- a/src/EditorFeatures/Test2/Rename/RenameTestHelpers.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameTestHelpers.vb
@@ -2,8 +2,13 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
+Imports System
+Imports System.Collections.Immutable
+Imports System.Composition
 Imports System.IO
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.Host
+Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 Imports Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
 Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
@@ -98,9 +103,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
         End Sub
 
 #Disable Warning IDE0060 ' Remove unused parameter - https://github.com/dotnet/roslyn/issues/45890
-        Public Function CreateWorkspaceWithWaiter(element As XElement, host As RenameTestHost) As EditorTestWorkspace
+    Public Function CreateWorkspaceWithWaiter(element As XElement, host As RenameTestHost, ParamArray additionalParts As Type()) As EditorTestWorkspace
 #Enable Warning IDE0060 ' Remove unused parameter
-            Dim workspace = EditorTestWorkspace.CreateWorkspace(element, composition:=s_composition)
+        Dim composition = If(additionalParts.Length = 0, s_composition, s_composition.AddParts(additionalParts))
+        Dim workspace = EditorTestWorkspace.CreateWorkspace(element, composition:=composition)
             workspace.GetOpenDocumentIds().Select(Function(id) workspace.GetTestDocument(id).GetTextView()).ToList()
             Return workspace
         End Function
@@ -135,5 +141,48 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
             Dim view = document.GetTextView()
             Return tagger.GetTags(view.TextBuffer.CurrentSnapshot.GetSnapshotSpanCollection())
         End Function
+
+        <ExportWorkspaceService(GetType(ISourceGeneratedDocumentSpanMappingService)), [Shared]>
+        <PartNotDiscoverable>
+        Friend NotInheritable Class TestRazorSourceGeneratedDocumentSpanMappingService
+            Implements ISourceGeneratedDocumentSpanMappingService
+
+            <ImportingConstructor>
+            <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
+            Public Sub New()
+            End Sub
+
+            Public Function CanMapSpans(sourceGeneratedDocument As SourceGeneratedDocument) As Boolean Implements ISourceGeneratedDocumentSpanMappingService.CanMapSpans
+                Return String.Equals(Path.GetFileName(sourceGeneratedDocument.FilePath), "generated_file.cs", StringComparison.OrdinalIgnoreCase)
+            End Function
+
+            Public Async Function GetMappedTextChangesAsync(oldDocument As SourceGeneratedDocument, newDocument As SourceGeneratedDocument, cancellationToken As CancellationToken) As Task(Of ImmutableArray(Of MappedTextChange)) Implements ISourceGeneratedDocumentSpanMappingService.GetMappedTextChangesAsync
+                If Not CanMapSpans(newDocument) Then
+                    Return ImmutableArray(Of MappedTextChange).Empty
+                End If
+
+                Dim changes = Await newDocument.GetTextChangesAsync(oldDocument, cancellationToken).ConfigureAwait(False)
+                Dim builder = ImmutableArray.CreateBuilder(Of MappedTextChange)(changes.Count)
+                For Each change In changes
+                    builder.Add(New MappedTextChange(newDocument.FilePath, change))
+                Next
+
+                Return builder.MoveToImmutable()
+            End Function
+
+            Public Async Function MapSpansAsync(document As SourceGeneratedDocument, spans As ImmutableArray(Of TextSpan), cancellationToken As CancellationToken) As Task(Of ImmutableArray(Of MappedSpanResult)) Implements ISourceGeneratedDocumentSpanMappingService.MapSpansAsync
+                If Not CanMapSpans(document) Then
+                    Return ImmutableArray(Of MappedSpanResult).Empty
+                End If
+
+                Dim sourceText = Await document.GetTextAsync(cancellationToken).ConfigureAwait(False)
+                Dim builder = ImmutableArray.CreateBuilder(Of MappedSpanResult)(spans.Length)
+                For Each span In spans
+                    builder.Add(New MappedSpanResult(document.FilePath, sourceText.Lines.GetLinePositionSpan(span), span))
+                Next
+
+                Return builder.MoveToImmutable()
+            End Function
+        End Class
     End Module
 End Namespace

--- a/src/LanguageServer/ProtocolUnitTests/Rename/RenameTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Rename/RenameTests.cs
@@ -331,11 +331,12 @@ public sealed class RenameTests(ITestOutputHelper testOutputHelper) : AbstractLa
 
         var renameLocation = testLspServer.GetLocations("caret").First();
         var renameValue = "RENAME";
+        // When the mapping service can't map spans, only the regular document edits should be returned.
+        // Source-generated document edits are dropped since the client can't open source-generated URIs.
         var expectedEdits = testLspServer.GetLocations("renamed").Select(location => new LSP.TextEdit() { NewText = renameValue, Range = location.Range });
-        var expectedGeneratedEdits = spans["renamed"].Select(span => new LSP.TextEdit() { NewText = renameValue, Range = ProtocolConversions.TextSpanToRange(span, generatedSourceText) });
 
         var results = await RunRenameAsync(testLspServer, CreateRenameParams(renameLocation, renameValue));
-        AssertJsonEquals(expectedEdits.Concat(expectedGeneratedEdits), ((TextDocumentEdit[])results.DocumentChanges).SelectMany(e => e.Edits));
+        AssertJsonEquals(expectedEdits, ((TextDocumentEdit[])results.DocumentChanges).SelectMany(e => e.Edits));
 
         Assert.False(service.DidMapEdits);
     }

--- a/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.ReferenceProcessing.cs
+++ b/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.ReferenceProcessing.cs
@@ -236,8 +236,9 @@ internal sealed partial class SymbolicRenameLocations
 
                 // If the location is in a source generated file, we won't rename it. Our assumption in this case is we
                 // have cascaded to this symbol from our original source symbol, and the generator will update this file
-                // based on the renamed symbol.
-                if (document is not SourceGeneratedDocument || document.IsRazorSourceGeneratedDocument())
+                // based on the renamed symbol. Razor source generated documents are an exception - we include them only
+                // when a span mapping service is available to map edits back to the original .razor files.
+                if (document is not SourceGeneratedDocument || CanMapSourceGeneratedDocument(solution, document))
                     results.Add(new RenameLocation(location, document.Id, isRenamableAccessor: isRenamableAccessor));
             }
         }
@@ -246,8 +247,9 @@ internal sealed partial class SymbolicRenameLocations
             ISymbol referencedSymbol, ISymbol originalSymbol, ReferenceLocation location, Solution solution, CancellationToken cancellationToken)
         {
             // We won't try to update references in source generated files; we'll assume the generator will rerun
-            // and produce an updated document with the new name.
-            if (location.Document is SourceGeneratedDocument && !location.Document.IsRazorSourceGeneratedDocument())
+            // and produce an updated document with the new name. Razor source generated documents are an exception -
+            // we include them only when a span mapping service is available to map edits back to the original files.
+            if (location.Document is SourceGeneratedDocument && !CanMapSourceGeneratedDocument(solution, location.Document))
                 return [];
 
             var shouldIncludeSymbol = await ShouldIncludeSymbolAsync(referencedSymbol, originalSymbol, solution, true, cancellationToken).ConfigureAwait(false);
@@ -431,6 +433,13 @@ internal sealed partial class SymbolicRenameLocations
                     renameLocations.Add(renameLocation);
                 }
             }
+        }
+
+        private static bool CanMapSourceGeneratedDocument(Solution solution, Document document)
+        {
+            return document is SourceGeneratedDocument sourceGeneratedDocument
+                && solution.Services.GetService<ISourceGeneratedDocumentSpanMappingService>() is { } mappingService
+                && mappingService.CanMapSpans(sourceGeneratedDocument);
         }
     }
 }


### PR DESCRIPTION
When Razor tooling is not available, we should not return renames in generated Razor files (like we don't return renames in regular generated files).

Related to https://github.com/dotnet/roslyn/issues/83078

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83080)