### PR TITLE
Fix incomplete migration of TopLevelStatement tests to VerifyCS pattern

### DIFF
--- a/src/Features/CSharp/Portable/SplitOrMergeIfStatements/CSharpIfLikeStatementGenerator.cs
+++ b/src/Features/CSharp/Portable/SplitOrMergeIfStatements/CSharpIfLikeStatementGenerator.cs
@@ -139,7 +139,7 @@ internal sealed class CSharpIfLikeStatementGenerator : IIfLikeStatementGenerator
             var elseIfStatement = (IfStatementSyntax)elseIfClause;
 
             var newElseIfStatement = elseIfStatement.WithElse(ifStatement.Else);
-            var newIfStatement = ifStatement.WithElse(ElseClause(newElseIfStatement));
+            var newIfStatement = ifStatement.WithElse(ElseClause(newElseIfStatement.WithLeadingTrivia(Space)));
 
             if (ifStatement.Else == null && ContainsEmbeddedIfStatement(ifStatement))
             {

--- a/src/Features/CSharpTest/SplitOrMergeIfStatements/SplitIntoConsecutiveIfStatementsTests.cs
+++ b/src/Features/CSharpTest/SplitOrMergeIfStatements/SplitIntoConsecutiveIfStatementsTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.SplitOrMergeIfStatements;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -1317,18 +1318,28 @@ public sealed class SplitIntoConsecutiveIfStatementsTests
 
     [Fact]
     public Task SplitIntoConsecutiveIfStatements_TopLevelStatement()
-        => TestInRegularAndScriptAsync(
-            """
-            if (a [||]|| b)
-            {
-            }
-            """,
-            """
-            if (a)
-            {
-            }
-            else if (b)
-            {
-            }
-            """);
+        => new VerifyCS.Test
+        {
+            TestCode = """
+                var a = true;
+                var b = true;
+
+                if (a [||]|| b)
+                {
+                }
+                """,
+            FixedCode = """
+                var a = true;
+                var b = true;
+
+                if (a)
+                {
+                }
+                else if (b)
+                {
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp9,
+            TestState = { OutputKind = OutputKind.ConsoleApplication }
+        }.RunAsync();
 }

--- a/src/Features/CSharpTest/SplitOrMergeIfStatements/SplitIntoNestedIfStatementsTests.cs
+++ b/src/Features/CSharpTest/SplitOrMergeIfStatements/SplitIntoNestedIfStatementsTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.SplitOrMergeIfStatements;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -767,18 +768,28 @@ public sealed class SplitIntoNestedIfStatementsTests
 
     [Fact]
     public Task SplitIntoNestedIfStatements_TopLevelStatement()
-        => TestInRegularAndScriptAsync(
-            """
-            if (a [||]&& b)
-            {
-            }
-            """,
-            """
-            if (a)
-            {
-                if (b)
+        => new VerifyCS.Test
+        {
+            TestCode = """
+                var a = true;
+                var b = true;
+
+                if (a [||]&& b)
                 {
                 }
-            }
-            """);
+                """,
+            FixedCode = """
+                var a = true;
+                var b = true;
+
+                if (a)
+                {
+                    if (b)
+                    {
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp9,
+            TestState = { OutputKind = OutputKind.ConsoleApplication }
+        }.RunAsync();
 }


### PR DESCRIPTION
The Split-if TopLevelStatement tests were still calling TestInRegularAndScriptAsync after the base class was removed in #82892.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83085)