### PR TITLE
[EE] Support pattern variables "obj is MyType myObj" for EE (Updated)

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -218,8 +218,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 typeName,
                 methodName,
                 this,
-                (EEMethodSymbol method, DiagnosticBag diags, out ImmutableArray<LocalSymbol> declaredLocals, out ResultProperties properties) =>
+                (EEMethodSymbol method, DiagnosticBag diags, out ImmutableArray<LocalSymbol> declaredLocals, out ResultProperties properties, out ImmutableArray<string> existingAliasNames) =>
                 {
+                    existingAliasNames = aliases.SelectAsArray(a => a.Name);
                     var binder = ExtendBinderChain(
                         syntax,
                         aliases,
@@ -255,8 +256,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 typeName,
                 methodName,
                 this,
-                (EEMethodSymbol method, DiagnosticBag diags, out ImmutableArray<LocalSymbol> declaredLocals, out ResultProperties properties) =>
+                (EEMethodSymbol method, DiagnosticBag diags, out ImmutableArray<LocalSymbol> declaredLocals, out ResultProperties properties, out ImmutableArray<string> existingAliasNames) =>
                 {
+                    existingAliasNames = aliases.SelectAsArray(a => a.Name);
                     var binder = ExtendBinderChain(
                         syntax,
                         aliases,
@@ -374,8 +376,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                                     container,
                                     methodName,
                                     syntax,
-                                    (EEMethodSymbol method, DiagnosticBag diags, out ImmutableArray<LocalSymbol> declaredLocals, out ResultProperties properties) =>
+                                    (EEMethodSymbol method, DiagnosticBag diags, out ImmutableArray<LocalSymbol> declaredLocals, out ResultProperties properties, out ImmutableArray<string> existingAliasNames) =>
                                     {
+                                        existingAliasNames = ImmutableArray<string>.Empty;
                                         declaredLocals = ImmutableArray<LocalSymbol>.Empty;
                                         var expression = new BoundLocal(syntax, local, constantValueOpt: null, type: local.Type);
                                         properties = default;
@@ -627,8 +630,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         private EEMethodSymbol GetLocalMethod(EENamedTypeSymbol container, string methodName, string localName, int localIndex)
         {
             var syntax = SyntaxFactory.IdentifierName(localName);
-            return CreateMethod(container, methodName, syntax, (EEMethodSymbol method, DiagnosticBag diagnostics, out ImmutableArray<LocalSymbol> declaredLocals, out ResultProperties properties) =>
+            return CreateMethod(container, methodName, syntax, (EEMethodSymbol method, DiagnosticBag diagnostics, out ImmutableArray<LocalSymbol> declaredLocals, out ResultProperties properties, out ImmutableArray<string> existingAliasNames) =>
             {
+                existingAliasNames = ImmutableArray<string>.Empty;
                 declaredLocals = ImmutableArray<LocalSymbol>.Empty;
 
                 int indexInside = localIndex - method.LocalsForBindingOutside.Length;
@@ -650,8 +654,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         private EEMethodSymbol GetParameterMethod(EENamedTypeSymbol container, string methodName, string parameterName, int parameterIndex)
         {
             var syntax = SyntaxFactory.IdentifierName(parameterName);
-            return CreateMethod(container, methodName, syntax, (EEMethodSymbol method, DiagnosticBag diagnostics, out ImmutableArray<LocalSymbol> declaredLocals, out ResultProperties properties) =>
+            return CreateMethod(container, methodName, syntax, (EEMethodSymbol method, DiagnosticBag diagnostics, out ImmutableArray<LocalSymbol> declaredLocals, out ResultProperties properties, out ImmutableArray<string> existingAliasNames) =>
             {
+                existingAliasNames = ImmutableArray<string>.Empty;
                 declaredLocals = ImmutableArray<LocalSymbol>.Empty;
                 var parameter = method.Parameters[parameterIndex];
                 var expression = new BoundParameter(syntax, parameter);
@@ -663,8 +668,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         private EEMethodSymbol GetThisMethod(EENamedTypeSymbol container, string methodName)
         {
             var syntax = SyntaxFactory.ThisExpression();
-            return CreateMethod(container, methodName, syntax, (EEMethodSymbol method, DiagnosticBag diagnostics, out ImmutableArray<LocalSymbol> declaredLocals, out ResultProperties properties) =>
+            return CreateMethod(container, methodName, syntax, (EEMethodSymbol method, DiagnosticBag diagnostics, out ImmutableArray<LocalSymbol> declaredLocals, out ResultProperties properties, out ImmutableArray<string> existingAliasNames) =>
             {
+                existingAliasNames = ImmutableArray<string>.Empty;
                 declaredLocals = ImmutableArray<LocalSymbol>.Empty;
                 var expression = new BoundThisReference(syntax, GetNonDisplayClassContainer(container.SubstitutedSourceType));
                 properties = default;
@@ -675,8 +681,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         private EEMethodSymbol GetTypeVariablesMethod(EENamedTypeSymbol container, string methodName, NamedTypeSymbol typeVariablesType)
         {
             var syntax = SyntaxFactory.IdentifierName(SyntaxFactory.MissingToken(SyntaxKind.IdentifierToken));
-            return CreateMethod(container, methodName, syntax, (EEMethodSymbol method, DiagnosticBag diagnostics, out ImmutableArray<LocalSymbol> declaredLocals, out ResultProperties properties) =>
+            return CreateMethod(container, methodName, syntax, (EEMethodSymbol method, DiagnosticBag diagnostics, out ImmutableArray<LocalSymbol> declaredLocals, out ResultProperties properties, out ImmutableArray<string> existingAliasNames) =>
             {
+                existingAliasNames = ImmutableArray<string>.Empty;
                 declaredLocals = ImmutableArray<LocalSymbol>.Empty;
                 var type = method.TypeMap.SubstituteNamedType(typeVariablesType);
                 var expression = new BoundObjectCreationExpression(syntax, type.InstanceConstructors[0]);

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/LocalDeclarationRewriter.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/LocalDeclarationRewriter.cs
@@ -20,13 +20,14 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             HashSet<LocalSymbol> declaredLocals,
             BoundStatement node,
             ImmutableArray<LocalSymbol> declaredLocalsArray,
+            ImmutableArray<string> existingAliasNames,
             DiagnosticBag diagnostics)
         {
             var builder = ArrayBuilder<BoundStatement>.GetInstance();
 
             foreach (var local in declaredLocalsArray)
             {
-                CreateLocal(compilation, declaredLocals, builder, local, node.Syntax, diagnostics);
+                CreateLocal(compilation, declaredLocals, builder, local, node.Syntax, existingAliasNames, diagnostics);
             }
 
             // Rewrite top-level declarations only.
@@ -91,8 +92,25 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             ArrayBuilder<BoundStatement> statements,
             LocalSymbol local,
             SyntaxNode syntax,
+            ImmutableArray<string> existingAliasNames,
             DiagnosticBag diagnostics)
         {
+            // If the local name already exists as a debugger alias (e.g., from a previous
+            // evaluation of the same expression), skip the CreateVariable call since the
+            // variable already exists at runtime. The local is still added to declaredLocals
+            // so that PlaceholderLocalRewriter rewrites it to GetVariableAddress.
+            if (!existingAliasNames.IsDefault)
+            {
+                foreach (var aliasName in existingAliasNames)
+                {
+                    if (aliasName == local.Name)
+                    {
+                        declaredLocals.Add(local);
+                        return;
+                    }
+                }
+            }
+
             // CreateVariable(Type type, string name)
             var method = PlaceholderLocalSymbol.GetIntrinsicMethod(compilation, ExpressionCompilerConstants.CreateVariableMethodName);
             if ((object)method == null)

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
@@ -24,7 +24,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         EEMethodSymbol method,
         DiagnosticBag diagnostics,
         out ImmutableArray<LocalSymbol> declaredLocals,
-        out ResultProperties properties);
+        out ResultProperties properties,
+        out ImmutableArray<string> existingAliasNames);
 
     /// <summary>
     /// Synthesized expression evaluation method.
@@ -481,7 +482,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         internal override void GenerateMethodBody(TypeCompilationState compilationState, BindingDiagnosticBag diagnostics)
         {
             ImmutableArray<LocalSymbol> declaredLocalsArray;
-            var body = _generateMethodBody(this, diagnostics.DiagnosticBag, out declaredLocalsArray, out _lazyResultProperties);
+            ImmutableArray<string> existingAliasNames;
+            var body = _generateMethodBody(this, diagnostics.DiagnosticBag, out declaredLocalsArray, out _lazyResultProperties, out existingAliasNames);
             var compilation = compilationState.Compilation;
 
             _lazyReturnType = TypeWithAnnotations.Create(CalculateReturnType(compilation, body));
@@ -520,6 +522,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                         declaredLocals,
                         body,
                         declaredLocalsArray,
+                        existingAliasNames,
                         diagnostics.DiagnosticBag);
 
                     // Verify local declaration names.
@@ -534,167 +537,192 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                         }
                     }
 
-                    // Rewrite references to placeholder "locals".
-                    body = (BoundStatement)PlaceholderLocalRewriter.Rewrite(compilation, declaredLocals, body, diagnostics.DiagnosticBag);
-
                     if (diagnostics.HasAnyErrors())
                     {
                         return;
+                    }
+
+                    var syntax = body.Syntax;
+                    var statementsBuilder = ArrayBuilder<BoundStatement>.GetInstance();
+                    statementsBuilder.Add(body);
+                    // Insert an implicit return statement if necessary.
+                    if (body.Kind != BoundKind.ReturnStatement)
+                    {
+                        statementsBuilder.Add(new BoundReturnStatement(syntax, RefKind.None, expressionOpt: null, @checked: false));
+                    }
+
+                    var localsSet = PooledHashSet<LocalSymbol>.GetInstance();
+                    try
+                    {
+                        var localsBuilder = ArrayBuilder<LocalSymbol>.GetInstance();
+                        foreach (var local in this.LocalsForBindingOutside)
+                        {
+                            Debug.Assert(!localsSet.Contains(local));
+                            localsBuilder.Add(local);
+                            localsSet.Add(local);
+                        }
+
+                        foreach (var local in this.LocalsForBindingInside)
+                        {
+                            Debug.Assert(!localsSet.Contains(local));
+                            localsBuilder.Add(local);
+                            localsSet.Add(local);
+                        }
+
+                        foreach (var local in this.Locals)
+                        {
+                            if (localsSet.Add(local))
+                            {
+                                localsBuilder.Add(local);
+                            }
+                        }
+
+                        // Add any expression-declared locals (pattern variables, out variables)
+                        // that are not already included in the block's locals.
+                        foreach (var local in declaredLocalsArray)
+                        {
+                            if (localsSet.Add(local))
+                            {
+                                localsBuilder.Add(local);
+                            }
+                        }
+
+                        // Collect PlaceholderLocalSymbol instances (e.g., ObjectAddressLocalSymbol
+                        // for @0x123) that are created dynamically during binding and are not part
+                        // of any pre-existing local collection. These must be declared in the block
+                        // to satisfy CheckLocalsDefined in LocalRewriter.
+                        var placeholderCollector = new PlaceholderLocalCollector(localsSet, localsBuilder);
+                        placeholderCollector.Visit(body);
+
+                        body = new BoundBlock(syntax, localsBuilder.ToImmutableAndFree(), statementsBuilder.ToImmutableAndFree()) { WasCompilerGenerated = true };
+
+                        Debug.Assert(!diagnostics.HasAnyErrors());
+                        Debug.Assert(!body.HasErrors);
+                        PipelinePhaseValidator.AssertAfterInitialBinding(body);
+
+                        body = LocalRewriter.Rewrite(
+                            compilation: this.DeclaringCompilation,
+                            method: this,
+                            methodOrdinal: _methodOrdinal,
+                            containingType: _container,
+                            statement: body,
+                            compilationState: compilationState,
+                            previousSubmissionFields: null,
+                            allowOmissionOfConditionalCalls: false,
+                            instrumentation: MethodInstrumentation.Empty,
+                            debugDocumentProvider: null,
+                            diagnostics: diagnostics,
+                            codeCoverageSpans: out ImmutableArray<SourceSpan> codeCoverageSpans,
+                            sawLambdas: out bool sawLambdas,
+                            sawLocalFunctions: out bool sawLocalFunctions,
+                            sawAwaitInExceptionHandler: out bool sawAwaitInExceptionHandler);
+
+                        Debug.Assert(!sawAwaitInExceptionHandler);
+                        Debug.Assert(codeCoverageSpans.IsEmpty);
+
+                        if (body.HasErrors)
+                        {
+                            return;
+                        }
+
+                        // Rewrite references to placeholder "locals" and declared locals.
+                        // This must run after LocalRewriter so that pattern variable BoundLocal
+                        // references created during pattern lowering are rewritten to
+                        // GetVariableAddress calls.
+                        body = (BoundStatement)PlaceholderLocalRewriter.Rewrite(compilation, declaredLocals, body, diagnostics.DiagnosticBag);
+
+                        if (diagnostics.HasAnyErrors())
+                        {
+                            return;
+                        }
+
+                        body = ExtensionMethodReferenceRewriter.Rewrite(body);
+
+                        if (body.HasErrors)
+                        {
+                            return;
+                        }
+
+                        // Variables may have been captured by lambdas in the original method
+                        // or in the expression, and we need to preserve the existing values of
+                        // those variables in the expression. This requires rewriting the variables
+                        // in the expression based on the closure classes from both the original
+                        // method and the expression, and generating a preamble that copies
+                        // values into the expression closure classes.
+                        //
+                        // Consider the original method:
+                        // static void M()
+                        // {
+                        //     int x, y, z;
+                        //     ...
+                        //     F(() => x + y);
+                        // }
+                        // and the expression in the EE: "F(() => x + z)".
+                        //
+                        // The expression is first rewritten using the closure class and local <1>
+                        // from the original method: F(() => <1>.x + z)
+                        // Then lambda rewriting introduces a new closure class that includes
+                        // the locals <1> and z, and a corresponding local <2>: F(() => <2>.<1>.x + <2>.z)
+                        // And a preamble is added to initialize the fields of <2>:
+                        //     <2> = new <>c__DisplayClass0();
+                        //     <2>.<1> = <1>;
+                        //     <2>.z = z;
+
+                        // Rewrite "this" and "base" references to parameter in this method.
+                        // Rewrite variables within body to reference existing display classes.
+                        body = (BoundStatement)CapturedVariableRewriter.Rewrite(
+                            this.GenerateThisReference,
+                            compilation.Conversions,
+                            _displayClassVariables,
+                            body,
+                            diagnostics.DiagnosticBag);
+
+                        if (body.HasErrors)
+                        {
+                            Debug.Assert(false, "Please add a test case capturing whatever caused this assert.");
+                            return;
+                        }
+
+                        if (diagnostics.HasAnyErrors())
+                        {
+                            return;
+                        }
+
+                        if (sawLambdas || sawLocalFunctions)
+                        {
+                            var closureDebugInfoBuilder = ArrayBuilder<EncClosureInfo>.GetInstance();
+                            var lambdaDebugInfoBuilder = ArrayBuilder<EncLambdaInfo>.GetInstance();
+                            var lambdaRuntimeRudeEditsBuilder = ArrayBuilder<LambdaRuntimeRudeEditInfo>.GetInstance();
+
+                            body = ClosureConversion.Rewrite(
+                                loweredBody: body,
+                                thisType: this.SubstitutedSourceMethod.ContainingType,
+                                thisParameter: _thisParameter,
+                                method: this,
+                                methodOrdinal: _methodOrdinal,
+                                substitutedSourceMethod: this.SubstitutedSourceMethod.OriginalDefinition,
+                                lambdaDebugInfoBuilder,
+                                lambdaRuntimeRudeEditsBuilder,
+                                closureDebugInfoBuilder,
+                                slotAllocator: null,
+                                compilationState: compilationState,
+                                diagnostics: diagnostics,
+                                assignLocals: localsSet);
+
+                            // we don't need this information:
+                            closureDebugInfoBuilder.Free();
+                            lambdaDebugInfoBuilder.Free();
+                            lambdaRuntimeRudeEditsBuilder.Free();
+                        }
+                    }
+                    finally
+                    {
+                        localsSet.Free();
                     }
                 }
                 finally
                 {
                     declaredLocals.Free();
-                }
-
-                var syntax = body.Syntax;
-                var statementsBuilder = ArrayBuilder<BoundStatement>.GetInstance();
-                statementsBuilder.Add(body);
-                // Insert an implicit return statement if necessary.
-                if (body.Kind != BoundKind.ReturnStatement)
-                {
-                    statementsBuilder.Add(new BoundReturnStatement(syntax, RefKind.None, expressionOpt: null, @checked: false));
-                }
-
-                var localsSet = PooledHashSet<LocalSymbol>.GetInstance();
-                try
-                {
-                    var localsBuilder = ArrayBuilder<LocalSymbol>.GetInstance();
-                    foreach (var local in this.LocalsForBindingOutside)
-                    {
-                        Debug.Assert(!localsSet.Contains(local));
-                        localsBuilder.Add(local);
-                        localsSet.Add(local);
-                    }
-
-                    foreach (var local in this.LocalsForBindingInside)
-                    {
-                        Debug.Assert(!localsSet.Contains(local));
-                        localsBuilder.Add(local);
-                        localsSet.Add(local);
-                    }
-
-                    foreach (var local in this.Locals)
-                    {
-                        if (localsSet.Add(local))
-                        {
-                            localsBuilder.Add(local);
-                        }
-                    }
-
-                    body = new BoundBlock(syntax, localsBuilder.ToImmutableAndFree(), statementsBuilder.ToImmutableAndFree()) { WasCompilerGenerated = true };
-
-                    Debug.Assert(!diagnostics.HasAnyErrors());
-                    Debug.Assert(!body.HasErrors);
-                    PipelinePhaseValidator.AssertAfterInitialBinding(body);
-
-                    body = LocalRewriter.Rewrite(
-                        compilation: this.DeclaringCompilation,
-                        method: this,
-                        methodOrdinal: _methodOrdinal,
-                        containingType: _container,
-                        statement: body,
-                        compilationState: compilationState,
-                        previousSubmissionFields: null,
-                        allowOmissionOfConditionalCalls: false,
-                        instrumentation: MethodInstrumentation.Empty,
-                        debugDocumentProvider: null,
-                        diagnostics: diagnostics,
-                        codeCoverageSpans: out ImmutableArray<SourceSpan> codeCoverageSpans,
-                        sawLambdas: out bool sawLambdas,
-                        sawLocalFunctions: out bool sawLocalFunctions,
-                        sawAwaitInExceptionHandler: out bool sawAwaitInExceptionHandler);
-
-                    Debug.Assert(!sawAwaitInExceptionHandler);
-                    Debug.Assert(codeCoverageSpans.IsEmpty);
-
-                    if (body.HasErrors)
-                    {
-                        return;
-                    }
-
-                    body = ExtensionMethodReferenceRewriter.Rewrite(body);
-
-                    if (body.HasErrors)
-                    {
-                        return;
-                    }
-
-                    // Variables may have been captured by lambdas in the original method
-                    // or in the expression, and we need to preserve the existing values of
-                    // those variables in the expression. This requires rewriting the variables
-                    // in the expression based on the closure classes from both the original
-                    // method and the expression, and generating a preamble that copies
-                    // values into the expression closure classes.
-                    //
-                    // Consider the original method:
-                    // static void M()
-                    // {
-                    //     int x, y, z;
-                    //     ...
-                    //     F(() => x + y);
-                    // }
-                    // and the expression in the EE: "F(() => x + z)".
-                    //
-                    // The expression is first rewritten using the closure class and local <1>
-                    // from the original method: F(() => <1>.x + z)
-                    // Then lambda rewriting introduces a new closure class that includes
-                    // the locals <1> and z, and a corresponding local <2>: F(() => <2>.<1>.x + <2>.z)
-                    // And a preamble is added to initialize the fields of <2>:
-                    //     <2> = new <>c__DisplayClass0();
-                    //     <2>.<1> = <1>;
-                    //     <2>.z = z;
-
-                    // Rewrite "this" and "base" references to parameter in this method.
-                    // Rewrite variables within body to reference existing display classes.
-                    body = (BoundStatement)CapturedVariableRewriter.Rewrite(
-                        this.GenerateThisReference,
-                        compilation.Conversions,
-                        _displayClassVariables,
-                        body,
-                        diagnostics.DiagnosticBag);
-
-                    if (body.HasErrors)
-                    {
-                        Debug.Assert(false, "Please add a test case capturing whatever caused this assert.");
-                        return;
-                    }
-
-                    if (diagnostics.HasAnyErrors())
-                    {
-                        return;
-                    }
-
-                    if (sawLambdas || sawLocalFunctions)
-                    {
-                        var closureDebugInfoBuilder = ArrayBuilder<EncClosureInfo>.GetInstance();
-                        var lambdaDebugInfoBuilder = ArrayBuilder<EncLambdaInfo>.GetInstance();
-                        var lambdaRuntimeRudeEditsBuilder = ArrayBuilder<LambdaRuntimeRudeEditInfo>.GetInstance();
-
-                        body = ClosureConversion.Rewrite(
-                            loweredBody: body,
-                            thisType: this.SubstitutedSourceMethod.ContainingType,
-                            thisParameter: _thisParameter,
-                            method: this,
-                            methodOrdinal: _methodOrdinal,
-                            substitutedSourceMethod: this.SubstitutedSourceMethod.OriginalDefinition,
-                            lambdaDebugInfoBuilder,
-                            lambdaRuntimeRudeEditsBuilder,
-                            closureDebugInfoBuilder,
-                            slotAllocator: null,
-                            compilationState: compilationState,
-                            diagnostics: diagnostics,
-                            assignLocals: localsSet);
-
-                        // we don't need this information:
-                        closureDebugInfoBuilder.Free();
-                        lambdaDebugInfoBuilder.Free();
-                        lambdaRuntimeRudeEditsBuilder.Free();
-                    }
-                }
-                finally
-                {
-                    localsSet.Free();
                 }
 
                 PipelinePhaseValidator.AssertAfterClosureConversion(body);
@@ -787,5 +815,33 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         }
 
         internal override int TryGetOverloadResolutionPriority() => 0;
+
+        /// <summary>
+        /// Walks the bound tree to collect <see cref="PlaceholderLocalSymbol"/> instances
+        /// referenced as <see cref="BoundLocal"/> nodes. These are created dynamically during
+        /// binding by <see cref="PlaceholderLocalBinder"/> (e.g., ObjectAddressLocalSymbol for
+        /// @0x123) and need to be declared in the enclosing block for correctness validation.
+        /// </summary>
+        private sealed class PlaceholderLocalCollector : BoundTreeWalkerWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
+        {
+            private readonly PooledHashSet<LocalSymbol> _localsSet;
+            private readonly ArrayBuilder<LocalSymbol> _localsBuilder;
+
+            internal PlaceholderLocalCollector(PooledHashSet<LocalSymbol> localsSet, ArrayBuilder<LocalSymbol> localsBuilder)
+            {
+                _localsSet = localsSet;
+                _localsBuilder = localsBuilder;
+            }
+
+            public override BoundNode VisitLocal(BoundLocal node)
+            {
+                if (node.LocalSymbol is PlaceholderLocalSymbol && _localsSet.Add(node.LocalSymbol))
+                {
+                    _localsBuilder.Add(node.LocalSymbol);
+                }
+
+                return base.VisitLocal(node);
+            }
+        }
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DeclarationTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DeclarationTests.cs
@@ -1747,7 +1747,8 @@ class C
             flags = resultProperties.Flags;
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/25702")]
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/25702")]
         public void PatternLocals_Assignment_01()
         {
             var source =
@@ -1780,13 +1781,12 @@ class C
                 context.CompileAssignment("x", "Test(x is int i)", out error, testData);
                 testData.GetMethodData("<>x.<>m0<T>").VerifyIL(
     @"{
-  // Code size       71 (0x47)
+  // Code size       67 (0x43)
   .maxstack  4
   .locals init (object V_0, //y
                 bool V_1,
                 object V_2,
-                System.Guid V_3,
-                int V_4)
+                System.Guid V_3)
   IL_0000:  ldtoken    ""int""
   IL_0005:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
   IL_000a:  ldstr      ""i""
@@ -1797,25 +1797,24 @@ class C
   IL_0019:  call       ""void Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.CreateVariable(System.Type, string, System.Guid, byte[])""
   IL_001e:  ldarg.0
   IL_001f:  isinst     ""int""
-  IL_0024:  brfalse.s  IL_003e
-  IL_0026:  ldarg.0
-  IL_0027:  unbox.any  ""int""
-  IL_002c:  stloc.s    V_4
-  IL_002e:  ldstr      ""i""
-  IL_0033:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
-  IL_0038:  ldloc.s    V_4
-  IL_003a:  stind.i4
-  IL_003b:  ldc.i4.1
-  IL_003c:  br.s       IL_003f
-  IL_003e:  ldc.i4.0
-  IL_003f:  call       ""object C.Test(bool)""
-  IL_0044:  starg.s    V_0
-  IL_0046:  ret
+  IL_0024:  brfalse.s  IL_003a
+  IL_0026:  ldstr      ""i""
+  IL_002b:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
+  IL_0030:  ldarg.0
+  IL_0031:  unbox.any  ""int""
+  IL_0036:  stind.i4
+  IL_0037:  ldc.i4.1
+  IL_0038:  br.s       IL_003b
+  IL_003a:  ldc.i4.0
+  IL_003b:  call       ""object C.Test(bool)""
+  IL_0040:  starg.s    V_0
+  IL_0042:  ret
 }");
             });
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/25702")]
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/25702")]
         public void PatternLocals_Assignment_02()
         {
             var source =
@@ -1848,13 +1847,12 @@ class C
                 context.CompileAssignment("x", "Test(x is string i)", out error, testData);
                 testData.GetMethodData("<>x.<>m0<T>").VerifyIL(
     @"{
-  // Code size       67 (0x43)
+  // Code size       73 (0x49)
   .maxstack  4
   .locals init (object V_0, //y
                 bool V_1,
                 object V_2,
-                System.Guid V_3,
-                string V_4)
+                System.Guid V_3)
   IL_0000:  ldtoken    ""string""
   IL_0005:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
   IL_000a:  ldstr      ""i""
@@ -1863,26 +1861,25 @@ class C
   IL_0017:  ldloc.3
   IL_0018:  ldnull
   IL_0019:  call       ""void Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.CreateVariable(System.Type, string, System.Guid, byte[])""
-  IL_001e:  ldarg.0
-  IL_001f:  isinst     ""string""
-  IL_0024:  stloc.s    V_4
-  IL_0026:  ldloc.s    V_4
-  IL_0028:  brfalse.s  IL_003a
-  IL_002a:  ldstr      ""i""
-  IL_002f:  call       ""string Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<string>(string)""
-  IL_0034:  ldloc.s    V_4
-  IL_0036:  stind.ref
-  IL_0037:  ldc.i4.1
-  IL_0038:  br.s       IL_003b
-  IL_003a:  ldc.i4.0
-  IL_003b:  call       ""object C.Test(bool)""
-  IL_0040:  starg.s    V_0
-  IL_0042:  ret
+  IL_001e:  ldstr      ""i""
+  IL_0023:  call       ""string Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<string>(string)""
+  IL_0028:  ldarg.0
+  IL_0029:  isinst     ""string""
+  IL_002e:  stind.ref
+  IL_002f:  ldstr      ""i""
+  IL_0034:  call       ""object Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetObjectByAlias(string)""
+  IL_0039:  castclass  ""string""
+  IL_003e:  ldnull
+  IL_003f:  cgt.un
+  IL_0041:  call       ""object C.Test(bool)""
+  IL_0046:  starg.s    V_0
+  IL_0048:  ret
 }");
             });
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/25702")]
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/25702")]
         public void PatternLocals_Assignment_03()
         {
             var source =
@@ -1945,7 +1942,8 @@ class C
             });
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/25702")]
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/25702")]
         public void PatternLocals_Assignment_04()
         {
             var source =
@@ -2004,7 +2002,8 @@ class C
             });
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/25702")]
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/25702")]
         public void PatternLocals_Assignment_05()
         {
             var source =
@@ -2037,44 +2036,40 @@ class C
                 context.CompileAssignment("x", "Test(x is int i)", out error, testData);
                 testData.GetMethodData("<>x.<>m0<T>").VerifyIL(
     @"{
-  // Code size       74 (0x4a)
+  // Code size       69 (0x45)
   .maxstack  4
   .locals init (object V_0, //y
                 bool V_1,
-                int? V_2,
-                int V_3,
-                object V_4,
-                System.Guid V_5,
-                int V_6)
+                object V_2,
+                System.Guid V_3)
   IL_0000:  ldtoken    ""int""
   IL_0005:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
   IL_000a:  ldstr      ""i""
-  IL_000f:  ldloca.s   V_5
+  IL_000f:  ldloca.s   V_3
   IL_0011:  initobj    ""System.Guid""
-  IL_0017:  ldloc.s    V_5
-  IL_0019:  ldnull
-  IL_001a:  call       ""void Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.CreateVariable(System.Type, string, System.Guid, byte[])""
-  IL_001f:  ldarga.s   V_0
-  IL_0021:  call       ""bool int?.HasValue.get""
-  IL_0026:  brfalse.s  IL_0041
-  IL_0028:  ldarga.s   V_0
-  IL_002a:  call       ""int int?.GetValueOrDefault()""
-  IL_002f:  stloc.s    V_6
-  IL_0031:  ldstr      ""i""
-  IL_0036:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
-  IL_003b:  ldloc.s    V_6
-  IL_003d:  stind.i4
-  IL_003e:  ldc.i4.1
-  IL_003f:  br.s       IL_0042
-  IL_0041:  ldc.i4.0
-  IL_0042:  call       ""int? C.Test(bool)""
-  IL_0047:  starg.s    V_0
-  IL_0049:  ret
+  IL_0017:  ldloc.3
+  IL_0018:  ldnull
+  IL_0019:  call       ""void Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.CreateVariable(System.Type, string, System.Guid, byte[])""
+  IL_001e:  ldarga.s   V_0
+  IL_0020:  call       ""bool int?.HasValue.get""
+  IL_0025:  brfalse.s  IL_003c
+  IL_0027:  ldstr      ""i""
+  IL_002c:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
+  IL_0031:  ldarga.s   V_0
+  IL_0033:  call       ""int int?.GetValueOrDefault()""
+  IL_0038:  stind.i4
+  IL_0039:  ldc.i4.1
+  IL_003a:  br.s       IL_003d
+  IL_003c:  ldc.i4.0
+  IL_003d:  call       ""int? C.Test(bool)""
+  IL_0042:  starg.s    V_0
+  IL_0044:  ret
 }");
             });
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/25702")]
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/25702")]
         public void PatternLocals_LocalDeclarationStatement_01()
         {
             var source =
@@ -2107,13 +2102,12 @@ class C
                 Assert.Equal(DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult, flags);
                 testData.GetMethodData("<>x.<>m0<T>").VerifyIL(
     @"{
-  // Code size      110 (0x6e)
+  // Code size      106 (0x6a)
   .maxstack  4
   .locals init (object V_0, //y
                 bool V_1,
                 object V_2,
-                System.Guid V_3,
-                int V_4)
+                System.Guid V_3)
   IL_0000:  ldtoken    ""int""
   IL_0005:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
   IL_000a:  ldstr      ""z""
@@ -2134,21 +2128,93 @@ class C
   IL_0041:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
   IL_0046:  ldarg.0
   IL_0047:  isinst     ""int""
-  IL_004c:  brfalse.s  IL_0066
-  IL_004e:  ldarg.0
-  IL_004f:  unbox.any  ""int""
-  IL_0054:  stloc.s    V_4
-  IL_0056:  ldstr      ""i""
-  IL_005b:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
-  IL_0060:  ldloc.s    V_4
-  IL_0062:  stind.i4
-  IL_0063:  ldc.i4.1
-  IL_0064:  br.s       IL_0067
-  IL_0066:  ldc.i4.0
-  IL_0067:  call       ""int C.Test(bool)""
-  IL_006c:  stind.i4
-  IL_006d:  ret
+  IL_004c:  brfalse.s  IL_0062
+  IL_004e:  ldstr      ""i""
+  IL_0053:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
+  IL_0058:  ldarg.0
+  IL_0059:  unbox.any  ""int""
+  IL_005e:  stind.i4
+  IL_005f:  ldc.i4.1
+  IL_0060:  br.s       IL_0063
+  IL_0062:  ldc.i4.0
+  IL_0063:  call       ""int C.Test(bool)""
+  IL_0068:  stind.i4
+  IL_0069:  ret
 }");
+            });
+        }
+
+        [ConditionalFact(typeof(IsRelease), Reason = "https://github.com/dotnet/roslyn/issues/25702")]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/25702")]
+        public void Conflict_PatternVariable_WithAlias()
+        {
+            var source =
+@"class C
+{
+    static void M(object x)
+    {
+    }
+}";
+            var compilation0 = CreateCompilation(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
+
+                // Simulate repeated evaluation: the first evaluation of "x is int myVar"
+                // creates a debugger variable "myVar". On the second evaluation, "myVar"
+                // is passed as an alias and CreateVariable should be skipped since
+                // the variable already exists at runtime.
+                var testData = new CompilationTestData();
+                context.CompileExpression(
+                    "x is int myVar",
+                    DkmEvaluationFlags.TreatAsExpression,
+                    ImmutableArray.Create(VariableAlias("myVar", typeof(int))),
+                    out error,
+                    testData);
+                Assert.Null(error);
+
+                // Verify that no CreateVariable call is emitted (only GetVariableAddress).
+                var il = testData.GetMethodData("<>x.<>m0").GetMethodIL();
+                Assert.DoesNotContain("CreateVariable", il);
+                Assert.Contains("GetVariableAddress", il);
+            });
+        }
+
+        [ConditionalFact(typeof(IsRelease), Reason = "https://github.com/dotnet/roslyn/issues/25702")]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/25702")]
+        public void Conflict_OutVar_WithAlias()
+        {
+            var source =
+@"class C
+{
+    static void F(out int x) { x = 1; }
+    static void M()
+    {
+    }
+}";
+            var compilation0 = CreateCompilation(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                string error;
+
+                // Simulate repeated evaluation: the first evaluation of "F(out var z)"
+                // creates a debugger variable "z". On the second evaluation, "z"
+                // is passed as an alias and CreateVariable should be skipped.
+                var testData = new CompilationTestData();
+                context.CompileExpression(
+                    "F(out var z)",
+                    DkmEvaluationFlags.None,
+                    ImmutableArray.Create(VariableAlias("z", typeof(int))),
+                    out error,
+                    testData);
+                Assert.Null(error);
+
+                // Verify that no CreateVariable call is emitted (only GetVariableAddress).
+                var il = testData.GetMethodData("<>x.<>m0").GetMethodIL();
+                Assert.DoesNotContain("CreateVariable", il);
+                Assert.Contains("GetVariableAddress", il);
             });
         }
 


### PR DESCRIPTION
## [EE] Support pattern variables "obj is MyType myObj" for EE

### Issue

While debugging, evaluating an expression like `obj is MyType myType` fails with "Internal error". The issue is due to `KeyNotFoundException` in `StackOptimizerPass1.RecordVarWrite` because pattern variable locals are not properly handled in the EE compilation pipeline.

Additionally, re-evaluating the same pattern expression a second time (e.g., in the Watch window) fails with "Variable already exists" because the debugger runtime persists the variable from the first evaluation.

### Root Cause

The EE compilation pipeline in `EEMethodSymbol.GenerateMethodBody` ran `PlaceholderLocalRewriter` **before** `LocalRewriter`. For out variables (`M(out int x)`), this worked because out-var lowering doesn't introduce intermediate temporaries. For pattern variables (`obj is int x`), `LocalRewriter` regenerates the decision DAG from scratch, creating **new** `BoundLocal(x)` references that `PlaceholderLocalRewriter` had already processed on the high-level tree. These fresh locals were never rewritten to debugger intrinsics, and because `declaredLocalsArray` (pattern/out variable locals) wasn't added to the synthesized `BoundBlock`, the stack optimizer crashed with `KeyNotFoundException`.

A secondary issue: `PlaceholderLocalSymbol` instances (e.g., `ObjectAddressLocalSymbol` for `@0x123`) are created dynamically during binding by `PlaceholderLocalBinder` and don't appear in any pre-existing local collection. After reordering the pipeline, `LocalRewriter`'s `CheckLocalsDefined` assertion detected these undeclared locals.

A third issue: on repeated evaluation, the debugger runtime already has the variable as an alias from the first evaluation, so calling `CreateVariable` again fails with "Variable already exists".

### Fix

**1. Pipeline reorder** (`EEMethodSymbol.cs`)
Move `PlaceholderLocalRewriter.Rewrite` to run **after** `LocalRewriter.Rewrite`. This ensures pattern lowering completes first (generating all `BoundLocal(x)` references in the lowered code), and then `PlaceholderLocalRewriter` correctly rewrites ALL those locals to `BoundPseudoVariable` nodes that generate proper `GetVariableAddress` intrinsics.

**2. Add `declaredLocalsArray` to block locals** (`EEMethodSymbol.cs`)
Add expression-declared locals (pattern variables, out variables) to the synthesized `BoundBlock`'s locals list so they are visible to `LocalRewriter` and codegen.

**3. Collect placeholder locals** (`EEMethodSymbol.cs`)
Add `PlaceholderLocalCollector` — a `BoundTreeWalker` — that walks the bound body before block construction to find all `BoundLocal` nodes referencing `PlaceholderLocalSymbol` instances (e.g., `ObjectAddressLocalSymbol` for `@0x123`). These are added to the block's locals to satisfy `CheckLocalsDefined` during lowering. They are still rewritten to method calls later by `PlaceholderLocalRewriter`.

**4. Skip duplicate `CreateVariable` on repeated evaluation** (`LocalDeclarationRewriter.cs`, `CompilationContext.cs`)
Thread `existingAliasNames` (the names of debugger aliases from prior evaluations) from `CompilationContext` through the delegate into `EEMethodSymbol.GenerateMethodBody` and into `LocalDeclarationRewriter.Rewrite`. In `CreateLocal`, if the declared local name already exists as a debugger alias, skip the `CreateVariable` call (the variable already exists at runtime) while still adding the local to `declaredLocals` so `PlaceholderLocalRewriter` rewrites it to `GetVariableAddress`.

### Files Changed

| File | Change |
|---|---|
| `EEMethodSymbol.cs` | Pipeline reorder, `declaredLocalsArray` in block locals, `PlaceholderLocalCollector`, thread `existingAliasNames` |
| `LocalDeclarationRewriter.cs` | Accept `existingAliasNames`, skip `CreateVariable` when alias already exists |
| `CompilationContext.cs` | Thread `existingAliasNames` through all `GenerateMethodBody` delegate signatures |
| `DeclarationTests.cs` | Updated IL baselines for 4 pattern-local tests, added 2 new repeat-evaluation tests |

### Differences from PR #82936

This PR takes a different approach from #82936 while solving the same core problem:

| Aspect | PR #82936 | This PR |
|---|---|---|
| Compiler changes | Adds `disablePatternVariableTempSharing` flag to `LocalRewriter` and `PatternLocalRewriter` (2 compiler files modified) | **None** — zero compiler changes |
| Repeat evaluation | Not addressed | Fixed — `CreateVariable` skipped when alias exists |
| IL codegen | Extra intermediate temps (e.g., `int V_4` for unboxed values) due to disabled temp sharing | No intermediate temps — pattern lowering shares temps directly with `GetVariableAddress`, producing tighter IL |
| New tests | None | `Conflict_PatternVariable_WithAlias` and `Conflict_OutVar_WithAlias` |
| Scope | 6 files (2 compiler + 4 EE) | 4 files (all EE) |

Both PRs share the same core fix (pipeline reorder, `declaredLocalsArray` in block locals, `PlaceholderLocalCollector`), but this PR avoids modifying the compiler's `LocalRewriter` API and additionally handles the repeated-evaluation scenario.

### Does VB need this?

No. VB doesn't have declaration patterns (`TypeOf x Is Program` doesn't declare an inline local). The VB expression evaluator never collects expression-declared locals. The fix only applies to the C# `EEMethodSymbol.cs` pipeline.

### Testing

- All 6 `PatternLocals_*` tests pass with updated IL baselines
- `EvaluateObjectAddress` passes (validates `PlaceholderLocalCollector`)
- `DuplicateDeclaration` and `DuplicateDeclarationInOutVar` pass
- `Conflict_PatternVariable_WithAlias` and `Conflict_OutVar_WithAlias` validate repeat evaluation (Release-only)
- Manually verified live debugging: `obj is MyType t` evaluates correctly on first and second evaluation
