### PR TITLE
Fixers: Fix to add bounds checks and strip all boundary \r/\n chars

### DIFF
--- a/src/EditorFeatures/Test2/Copilot/RoslynProposalAdjusterTests.vb
+++ b/src/EditorFeatures/Test2/Copilot/RoslynProposalAdjusterTests.vb
@@ -853,6 +853,62 @@ class C
             Assert.Equal("ABC" & vbCrLf & "DEF", result.ToString())
         End Sub
 
+        <WpfFact>
+        Public Sub TestCSharp_FixLineEndingBoundaries_InsertAtEndOfFileThatEndsWithCr()
+            ' File ends with \r, insert "\nWorld" at the very end.
+            ' span.Start == originalText.Length, so the inner check must guard against
+            ' reading past the end.
+            Dim originalText = SourceText.From("Hello" & vbCr)
+            Dim changes = ImmutableArray.Create(
+                New TextChange(New TextSpan(6, 0), vbLf & "World"))
+
+            Dim fixed = AbstractCopilotProposalAdjusterService.TestAccessor.FixLineEndingBoundaries(originalText, changes)
+            Assert.Single(fixed)
+            ' The leading \n should be stripped to avoid creating \r\n at the boundary.
+            Assert.Equal(6, fixed(0).Span.Start)
+            Assert.Equal(6, fixed(0).Span.End)
+            Assert.Equal("World", fixed(0).NewText)
+
+            Dim result = originalText.WithChanges(fixed)
+            Assert.Equal("Hello" & vbCr & "World", result.ToString())
+        End Sub
+
+        <WpfFact>
+        Public Sub TestCSharp_FixLineEndingBoundaries_InsertAtStartOfFileThatStartsWithLf()
+            ' File starts with \n, insert "Hello\r" at position 0.
+            ' span.End == 0 initially, so the inner check must guard against
+            ' reading at position -1.
+            Dim originalText = SourceText.From(vbLf & "World")
+            Dim changes = ImmutableArray.Create(
+                New TextChange(New TextSpan(0, 0), "Hello" & vbCr))
+
+            Dim fixed = AbstractCopilotProposalAdjusterService.TestAccessor.FixLineEndingBoundaries(originalText, changes)
+            Assert.Single(fixed)
+            ' The trailing \r should be stripped to avoid creating \r\n at the boundary.
+            Assert.Equal(0, fixed(0).Span.Start)
+            Assert.Equal(0, fixed(0).Span.End)
+            Assert.Equal("Hello", fixed(0).NewText)
+
+            Dim result = originalText.WithChanges(fixed)
+            Assert.Equal("Hello" & vbLf & "World", result.ToString())
+        End Sub
+
+        <WpfFact>
+        Public Sub TestCSharp_FixLineEndingBoundaries_RepeatedTrailingCrBeforeLf()
+            ' newText ends with \r\r adjacent to \n.  Both trailing \r chars must be
+            ' stripped so the boundary doesn't form a \r\n pair.
+            Dim originalText = SourceText.From("AB" & vbLf & "CD")
+            Dim changes = ImmutableArray.Create(
+                New TextChange(New TextSpan(0, 2), "XY" & vbCr & vbCr))
+
+            Dim fixed = AbstractCopilotProposalAdjusterService.TestAccessor.FixLineEndingBoundaries(originalText, changes)
+            Assert.Single(fixed)
+            Assert.Equal("XY", fixed(0).NewText)
+
+            Dim result = originalText.WithChanges(fixed)
+            Assert.Equal("XY" & vbLf & "CD", result.ToString())
+        End Sub
+
 #End Region
 
 #Region "Visual Basic"

--- a/src/Features/Core/Portable/Copilot/IProposalAdjusterService.cs
+++ b/src/Features/Core/Portable/Copilot/IProposalAdjusterService.cs
@@ -178,21 +178,25 @@ internal abstract class AbstractCopilotProposalAdjusterService : ICopilotProposa
             var newText = change.NewText ?? "";
             var changed = false;
 
-            if (newText.Length > 0)
+            // Use a loop to handle cases where stripping one boundary character reveals
+            // another one (e.g., newText ends with "\r\r" adjacent to '\n').
+            while (newText.Length > 0)
             {
+                var fixedThisIteration = false;
+
                 if (newText[0] == '\n' &&
                     span.Start > 0 &&
                     originalText[span.Start - 1] == '\r')
                 {
                     // The replacement text would add a \n to a \r, changing the nature of the line break.
-                    if (originalText[span.Start] == '\n')
+                    if (span.Start < originalText.Length && originalText[span.Start] == '\n')
                     {
                         // The \n exists in the original text. There is no reason to replace it.
                         span = TextSpan.FromBounds(span.Start + 1, Math.Max(span.Start + 1, span.End));
                     }
 
                     newText = newText[1..];
-                    changed = true;
+                    fixedThisIteration = true;
                 }
 
                 if (newText.Length > 0 && newText[^1] == '\r' &&
@@ -200,15 +204,20 @@ internal abstract class AbstractCopilotProposalAdjusterService : ICopilotProposa
                     originalText[span.End] == '\n')
                 {
                     // The replacement text would add a \r to a \n, changing the nature of the line break.
-                    if (originalText[span.End - 1] == '\r')
+                    if (span.End > 0 && originalText[span.End - 1] == '\r')
                     {
                         // The \r already exists in the original text. There is no reason to replace it.
                         span = TextSpan.FromBounds(Math.Min(span.Start, span.End - 1), span.End - 1);
                     }
 
                     newText = newText[..^1];
-                    changed = true;
+                    fixedThisIteration = true;
                 }
+
+                changed = changed || fixedThisIteration;
+
+                if (!fixedThisIteration)
+                    break;
             }
 
             anyFixed = anyFixed || changed;


### PR DESCRIPTION
1. Missing bounds check when the edit span is at the end of the file
2. Missing bounds check when the edit span is at the start of the file
3. Only one \r or \n was stripped per change, repeated boundary chars (\r\r before \n) still formed invalid line breaks
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83098)