### PR TITLE
Reimplement the DefaultFileChangeWatcher to be more precise with watches

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/DefaultFileChangeWatcherTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/DefaultFileChangeWatcherTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.FileWatching;
 using Microsoft.CodeAnalysis.ProjectSystem;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -688,6 +689,14 @@ public sealed class DefaultFileChangeWatcherTests : IDisposable
 
         // Now create the directory and the file
         Directory.CreateDirectory(nonExistentDir);
+
+        // On Linux, a directory watch is not recursive. This is implemented for us by the .NET Runtime -- when it sees a new directory
+        // created, it adds that directory to the existing watch list. This means however that in the case of a new directory created
+        // and then immediately creating a new file, there's not a guarantee the file change could be seen if the directory watch
+        // hasn't been processed yet.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            await Task.Delay(100);
+
         File.WriteAllText(filePath, "content");
 
         // The ancestor watcher should still pick up the event

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/DefaultFileChangeWatcherTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/DefaultFileChangeWatcherTests.cs
@@ -9,60 +9,106 @@ using Roslyn.Test.Utilities;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests;
 
-public sealed class SimpleFileChangeWatcherTests : IDisposable
+public sealed class DefaultFileChangeWatcherTests : IDisposable
 {
-    private readonly TimeSpan _fileChangeTimeout = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan s_fileChangeTimeout = TimeSpan.FromSeconds(1);
     private readonly TempRoot _tempRoot = new();
 
     public void Dispose() => _tempRoot.Dispose();
 
+    #region Watch Consolidation Tests
+
     [Fact]
-    public void CreateContext_WithEmptyDirectories_DoesNotAddRootWatcher()
+    public void CreateContext_WithEmptyDirectories_DoesNotAddWatchers()
     {
         var watcher = new DefaultFileChangeWatcher();
 
         using var context = watcher.CreateContext([]);
 
-        Assert.Empty(DefaultFileChangeWatcher.FileChangeContext.TestAccessor.GetRootFileWatchers((DefaultFileChangeWatcher.FileChangeContext)context));
+        // Empty directory lists should not register any shared watchers
+        Assert.Empty(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
     }
 
     [Fact]
-    public void CreateContext_WithExistingDirectory_AddsRootWatcher()
+    public void CreateContext_WithExistingDirectory_AddsDirectoryWatcher()
     {
         var tempDirectory = _tempRoot.CreateDirectory();
         var watcher = new DefaultFileChangeWatcher();
 
         using var context = watcher.CreateContext([new WatchedDirectory(tempDirectory.Path, extensionFilters: [])]);
 
-        Assert.Single(DefaultFileChangeWatcher.FileChangeContext.TestAccessor.GetRootFileWatchers((DefaultFileChangeWatcher.FileChangeContext)context));
+        // Watching one real directory should create one shared watcher
+        var watchedDirectory = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
+        Assert.Equal(tempDirectory.Path, watchedDirectory.path);
+        Assert.Empty(watchedDirectory.filters);
     }
 
     [Fact]
-    public void CreateContext_WithNonExistentDirectory_DoesNotAddRootWatcher()
+    public void CreateContext_WithNonExistentDirectory_WatchesAHigherLevel()
     {
         var nonExistentPath = Path.Combine(TempRoot.Root, "NonExistent", "Directory", Guid.NewGuid().ToString());
         var watcher = new DefaultFileChangeWatcher();
 
         using var context = watcher.CreateContext([new WatchedDirectory(nonExistentPath, extensionFilters: [])]);
 
-        Assert.Empty(DefaultFileChangeWatcher.FileChangeContext.TestAccessor.GetRootFileWatchers((DefaultFileChangeWatcher.FileChangeContext)context));
+        // A single watch should be created, but in this case it'd be the TempRoot.Root
+        var watchedDirectory = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
+        Assert.Equal(TempRoot.Root, watchedDirectory.path);
+        Assert.Empty(watchedDirectory.filters);
     }
 
     [Fact]
-    public void CreateContext_WithMultipleDirectories_OnSameRoot_CreatesOneRootWatcher()
+    public void CreateContext_WithContainedDirectory_ConsolidatesImmediately_ParentFirst()
     {
-        var rootDir = _tempRoot.CreateDirectory();
-        var subDir1 = rootDir.CreateDirectory("sub1");
-        var subDir2 = rootDir.CreateDirectory("sub2");
+        var root = _tempRoot.CreateDirectory();
+        var child = root.CreateDirectory("child");
         var watcher = new DefaultFileChangeWatcher();
 
-        // Both directories are under the same root
         using var context = watcher.CreateContext([
-            new WatchedDirectory(subDir1.Path, extensionFilters: []),
-            new WatchedDirectory(subDir2.Path, extensionFilters: [])
+            new WatchedDirectory(root.Path, extensionFilters: []),
+            new WatchedDirectory(child.Path, extensionFilters: [])
         ]);
 
-        Assert.Single(DefaultFileChangeWatcher.FileChangeContext.TestAccessor.GetRootFileWatchers((DefaultFileChangeWatcher.FileChangeContext)context));
+        // The child directory is covered by the parent directory watcher
+        var watchedDirectory = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
+        Assert.Equal(root.Path, watchedDirectory.path);
+        Assert.Empty(watchedDirectory.filters);
+    }
+
+    [Fact]
+    public void CreateContext_WithContainedDirectory_ConsolidatesImmediately_ChildFirst()
+    {
+        var root = _tempRoot.CreateDirectory();
+        var child = root.CreateDirectory("child");
+        var watcher = new DefaultFileChangeWatcher();
+
+        using var context = watcher.CreateContext([
+            new WatchedDirectory(child.Path, extensionFilters: []),
+            new WatchedDirectory(root.Path, extensionFilters: [])
+        ]);
+
+        // The child directory is covered by the parent directory watcher
+        var watchedDirectory = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
+        Assert.Equal(root.Path, watchedDirectory.path);
+        Assert.Empty(watchedDirectory.filters);
+    }
+
+    [Fact]
+    public void CreateContext_WithPartiallyCoveredChildDirectory_UsesSharedAncestorWatcher()
+    {
+        var root = _tempRoot.CreateDirectory();
+        var child = root.CreateDirectory("child");
+        var watcher = new DefaultFileChangeWatcher();
+
+        using var context = watcher.CreateContext([
+            new WatchedDirectory(root.Path, extensionFilters: [".cs"]),
+            new WatchedDirectory(child.Path, extensionFilters: [".vb"])
+        ]);
+
+        // Different filters still share the same underlying watcher for the directory tree
+        var watchedDirectory = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
+        Assert.Equal(root.Path, watchedDirectory.path);
+        AssertEx.SetEqual(watchedDirectory.filters, ["*.cs", "*.vb"]);
     }
 
     [Fact]
@@ -73,7 +119,7 @@ public sealed class SimpleFileChangeWatcherTests : IDisposable
         var watcher = new DefaultFileChangeWatcher();
 
         using var context = watcher.CreateContext([new WatchedDirectory(tempDirectory.Path, extensionFilters: [".cs"])]);
-        var watchedFile = context.EnqueueWatchingFile(filePath);
+        using var watchedFile = context.EnqueueWatchingFile(filePath);
 
         // When a file is already covered by a directory watch, it returns NoOpWatchedFile
         Assert.Same(NoOpWatchedFile.Instance, watchedFile);
@@ -95,19 +141,6 @@ public sealed class SimpleFileChangeWatcherTests : IDisposable
     }
 
     [Fact]
-    public void EnqueueWatchingFile_WithExtensionFilter_MatchingExtension_ReturnsNoOpWatcher()
-    {
-        var tempDirectory = _tempRoot.CreateDirectory();
-        var filePath = Path.Combine(tempDirectory.Path, "test.cs");
-        var watcher = new DefaultFileChangeWatcher();
-
-        using var context = watcher.CreateContext([new WatchedDirectory(tempDirectory.Path, extensionFilters: [".cs"])]);
-        using var watchedFile = context.EnqueueWatchingFile(filePath);
-
-        Assert.Same(NoOpWatchedFile.Instance, watchedFile);
-    }
-
-    [Fact]
     public void EnqueueWatchingFile_WithExtensionFilter_NonMatchingExtension_ReturnsIndividualWatcher()
     {
         var tempDirectory = _tempRoot.CreateDirectory();
@@ -120,6 +153,42 @@ public sealed class SimpleFileChangeWatcherTests : IDisposable
 
         // .txt file is not covered by .cs filter, so it gets an individual watcher
         Assert.NotSame(NoOpWatchedFile.Instance, watchedFile);
+    }
+
+    [Fact]
+    public void EnqueueWatchingFile_WatchesParentDirectory()
+    {
+        var tempDirectory = _tempRoot.CreateDirectory();
+        var filePath = Path.Combine(tempDirectory.Path, "test.cs");
+        var watcher = new DefaultFileChangeWatcher();
+
+        using var context = watcher.CreateContext([]);
+        using var watchedFile = context.EnqueueWatchingFile(filePath);
+
+        // The parent directory becomes watched when we enqueue a file directly
+        Assert.NotSame(NoOpWatchedFile.Instance, watchedFile);
+        var watchedDirectory = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
+        Assert.Equal(tempDirectory.Path, watchedDirectory.path);
+        Assert.Equal("*.cs", Assert.Single(watchedDirectory.filters));
+    }
+
+    [Fact]
+    public void EnqueueWatchingFile_MultipleFilesSameDirectory_UsesSingleWatcher()
+    {
+        var tempDirectory = _tempRoot.CreateDirectory();
+        var watcher = new DefaultFileChangeWatcher();
+        using var context = watcher.CreateContext([]);
+
+        using var watchedFile1 = context.EnqueueWatchingFile(Path.Combine(tempDirectory.Path, "a.cs"));
+        using var watchedFile2 = context.EnqueueWatchingFile(Path.Combine(tempDirectory.Path, "b.cs"));
+
+        // Multiple files in the same directory should share a single underlying watcher
+        Assert.NotSame(NoOpWatchedFile.Instance, watchedFile1);
+        Assert.NotSame(NoOpWatchedFile.Instance, watchedFile2);
+        var watchedDirectory = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
+
+        Assert.Equal(tempDirectory.Path, watchedDirectory.path);
+        Assert.Equal("*.cs", Assert.Single(watchedDirectory.filters));
     }
 
     [Fact]
@@ -162,8 +231,6 @@ public sealed class SimpleFileChangeWatcherTests : IDisposable
         var nonExistentPath = Path.Combine(TempRoot.Root, "NonExistent", "file.cs");
 
         using var context = watcher.CreateContext([]);
-
-        // Should not throw, though the file won't actually be watched until the directory exists
         using var watchedFile = context.EnqueueWatchingFile(nonExistentPath);
         Assert.NotNull(watchedFile);
     }
@@ -255,25 +322,95 @@ public sealed class SimpleFileChangeWatcherTests : IDisposable
         Assert.NotSame(NoOpWatchedFile.Instance, watcher2);
     }
 
+    [Fact]
+    public void Consolidate_Works()
+    {
+        var root = _tempRoot.CreateDirectory();
+        var pairBase = root.CreateDirectory("pair");
+        var pairA = pairBase.CreateDirectory("a");
+        var pairB = pairBase.CreateDirectory("b");
+        var other = root.CreateDirectory("other").CreateDirectory("x");
+
+        var watcher = new DefaultFileChangeWatcher(maxWatcherCount: 10);
+        using var context = watcher.CreateContext([]);
+
+        for (var i = 0; i < 10 - 2; i++)
+        {
+            var seed = root.CreateDirectory($"seed{i}");
+            context.EnqueueWatchingFile(Path.Combine(seed.Path, "seed.cs"));
+        }
+
+        context.EnqueueWatchingFile(Path.Combine(pairA.Path, "one.cs"));
+        context.EnqueueWatchingFile(Path.Combine(pairB.Path, "two.cs"));
+        context.EnqueueWatchingFile(Path.Combine(other.Path, "three.cs"));
+
+        var watchedPaths = DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher).ToArray();
+
+        // Consolidation should keep the active watcher count bounded
+        Assert.InRange(watchedPaths.Length, 1, 10);
+        Assert.All(watchedPaths, w => Assert.Contains("*.cs", w.filters));
+    }
+
+    [Fact]
+    public void DisposingAllContexts_WatcherCountReturnsToZero()
+    {
+        var root = _tempRoot.CreateDirectory();
+        var watcher = new DefaultFileChangeWatcher();
+
+        var context1 = watcher.CreateContext([new WatchedDirectory(root.Path, extensionFilters: [".cs"])]);
+        var context2 = watcher.CreateContext([new WatchedDirectory(root.Path, extensionFilters: [".vb"])]);
+
+        // Also add some individual file watches
+        var file1 = context1.EnqueueWatchingFile(Path.Combine(root.Path, "extra.txt"));
+        var file2 = context2.EnqueueWatchingFile(Path.Combine(root.Path, "extra2.log"));
+
+        Assert.NotEmpty(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
+
+        file1.Dispose();
+        file2.Dispose();
+        context1.Dispose();
+        context2.Dispose();
+
+        Assert.Empty(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
+    }
+
+    [Fact]
+    public void DisposingAllContexts_WatcherCountReturnsToZero_EvenIfFileWatchUndisposed()
+    {
+        var root = _tempRoot.CreateDirectory();
+        var watcher = new DefaultFileChangeWatcher();
+
+        var context = watcher.CreateContext([new WatchedDirectory(root.Path, extensionFilters: [".cs"])]);
+
+        // Also add an individual file watch that we will not dispose
+        _ = context.EnqueueWatchingFile(Path.Combine(root.Path, "extra.txt"));
+
+        Assert.NotEmpty(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
+
+        context.Dispose();
+
+        Assert.Empty(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
+    }
+
+    #endregion
+
     #region File System Event Tests
 
     /// <summary>
     /// Helper method to wait for a file change event with timeout.
     /// </summary>
-    private static async Task<bool> WaitForFileChangeAsync(Task fileChangeTask, TimeSpan timeout)
-    {
-        var completed = await Task.WhenAny(fileChangeTask, Task.Delay(timeout));
-        return completed == fileChangeTask;
-    }
-
-    private static async Task<bool> WaitForAllFileChangesAsync(Task[] fileChangeTasks, TimeSpan timeout)
+    private static async Task AssertAllChangesFire(FileChangeTask[] fileChangeTasks, TimeSpan timeout)
     {
         var delay = Task.Delay(timeout);
-        var completed = await Task.WhenAny(Task.WhenAll(fileChangeTasks), delay);
-        return completed != delay;
+        var completed = await Task.WhenAny(Task.WhenAll(fileChangeTasks.Select(t => t.Task)), delay);
+        if (completed == delay)
+        {
+            // At least one didn't fire, so assert which one it is
+            Assert.Empty(fileChangeTasks.Where(f => !f.Task.IsCompleted).Select(f => f.FilePath));
+        }
     }
 
-    private static Task ListenForFileChangeAsync(DefaultFileChangeWatcher.FileChangeContext context, string filePath)
+    private static FileChangeTask ListenForFileChangeAsync(IFileChangeContext context, string filePath)
     {
         var eventSource = new TaskCompletionSource();
 
@@ -283,26 +420,32 @@ public sealed class SimpleFileChangeWatcherTests : IDisposable
                 eventSource.TrySetResult();
         };
 
-        return eventSource.Task;
+        return new FileChangeTask(eventSource.Task, filePath);
     }
 
+    /// <summary>
+    /// Represents a wait for a single file change; includes the file path so failures are easy to understand which one didn't trigger.
+    /// </summary>
+    private sealed record FileChangeTask(Task Task, string FilePath);
+
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83180")]
-    public async Task FileCreated_InWatchedDirectory_RaisesFileChangedEvent()
+    public async Task FileCreated_InWatchedParentDirectory_RaisesFileChangedEvent()
     {
         var tempDirectory = _tempRoot.CreateDirectory();
         var filePath = Path.Combine(tempDirectory.Path, "created.cs");
         var watcher = new DefaultFileChangeWatcher();
 
-        using var context = watcher.CreateContext([new WatchedDirectory(tempDirectory.Path, extensionFilters: [])]);
-        var fileChangeTask = ListenForFileChangeAsync((DefaultFileChangeWatcher.FileChangeContext)context, filePath);
+        using var context = watcher.CreateContext([]);
+        var fileChangeTask = ListenForFileChangeAsync(context, filePath);
+
+        // Watch the specific file
+        context.EnqueueWatchingFile(filePath);
 
         // Create the file
         File.WriteAllText(filePath, "initial content");
 
         // Wait for the event
-        var eventFired = await WaitForFileChangeAsync(fileChangeTask, _fileChangeTimeout);
-
-        Assert.True(eventFired, "FileChanged event should fire when a file is created");
+        await AssertAllChangesFire([fileChangeTask], s_fileChangeTimeout);
     }
 
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83180")]
@@ -316,15 +459,13 @@ public sealed class SimpleFileChangeWatcherTests : IDisposable
         File.WriteAllText(filePath, "initial content");
 
         using var context = watcher.CreateContext([new WatchedDirectory(tempDirectory.Path, extensionFilters: [])]);
-        var fileChangeTask = ListenForFileChangeAsync((DefaultFileChangeWatcher.FileChangeContext)context, filePath);
+        var fileChangeTask = ListenForFileChangeAsync(context, filePath);
 
         // Modify the file
         File.WriteAllText(filePath, "modified content");
 
         // Wait for the event
-        var eventFired = await WaitForFileChangeAsync(fileChangeTask, _fileChangeTimeout);
-
-        Assert.True(eventFired, "FileChanged event should fire when a file is modified");
+        await AssertAllChangesFire([fileChangeTask], s_fileChangeTimeout);
     }
 
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83180")]
@@ -338,15 +479,13 @@ public sealed class SimpleFileChangeWatcherTests : IDisposable
         File.WriteAllText(filePath, "content to delete");
 
         using var context = watcher.CreateContext([new WatchedDirectory(tempDirectory.Path, extensionFilters: [])]);
-        var fileChangeTask = ListenForFileChangeAsync((DefaultFileChangeWatcher.FileChangeContext)context, filePath);
+        var fileChangeTask = ListenForFileChangeAsync(context, filePath);
 
         // Delete the file
         File.Delete(filePath);
 
         // Wait for the event
-        var eventFired = await WaitForFileChangeAsync(fileChangeTask, _fileChangeTimeout);
-
-        Assert.True(eventFired, "FileChanged event should fire when a file is deleted");
+        await AssertAllChangesFire([fileChangeTask], s_fileChangeTimeout);
     }
 
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83180")]
@@ -357,15 +496,13 @@ public sealed class SimpleFileChangeWatcherTests : IDisposable
         var watcher = new DefaultFileChangeWatcher();
 
         using var context = watcher.CreateContext([new WatchedDirectory(tempDirectory.Path, extensionFilters: [".cs"])]);
-        var fileChangeTask = ListenForFileChangeAsync((DefaultFileChangeWatcher.FileChangeContext)context, filePath);
+        var fileChangeTask = ListenForFileChangeAsync(context, filePath);
 
         // Create a .cs file (should match filter)
         File.WriteAllText(filePath, "content");
 
         // Wait for the event
-        var eventFired = await WaitForFileChangeAsync(fileChangeTask, _fileChangeTimeout);
-
-        Assert.True(eventFired, "FileChanged event should fire for files matching extension filter");
+        await AssertAllChangesFire([fileChangeTask], s_fileChangeTimeout);
     }
 
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83180")]
@@ -377,15 +514,15 @@ public sealed class SimpleFileChangeWatcherTests : IDisposable
 
         // Only watching for .cs files
         using var context = watcher.CreateContext([new WatchedDirectory(tempDirectory.Path, extensionFilters: [".cs"])]);
-        var fileChangeTask = ListenForFileChangeAsync((DefaultFileChangeWatcher.FileChangeContext)context, txtFilePath);
+        var fileChangeTask = ListenForFileChangeAsync(context, txtFilePath);
 
         // Create a .txt file (should not match filter)
         File.WriteAllText(txtFilePath, "content");
 
         // Wait a bit to ensure no event fires
-        await Task.Delay(_fileChangeTimeout);
+        await Task.Delay(s_fileChangeTimeout);
 
-        Assert.False(fileChangeTask.IsCompleted, "FileChanged event should NOT fire for files not matching extension filter");
+        Assert.False(fileChangeTask.Task.IsCompleted, "FileChanged event should NOT fire for files not matching extension filter");
     }
 
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83180")]
@@ -397,15 +534,13 @@ public sealed class SimpleFileChangeWatcherTests : IDisposable
         var watcher = new DefaultFileChangeWatcher();
 
         using var context = watcher.CreateContext([new WatchedDirectory(tempDirectory.Path, extensionFilters: [])]);
-        var fileChangeTask = ListenForFileChangeAsync((DefaultFileChangeWatcher.FileChangeContext)context, filePath);
+        var fileChangeTask = ListenForFileChangeAsync(context, filePath);
 
         // Create file in subdirectory
         File.WriteAllText(filePath, "nested content");
 
         // Wait for the event
-        var eventFired = await WaitForFileChangeAsync(fileChangeTask, _fileChangeTimeout);
-
-        Assert.True(eventFired, "FileChanged event should fire for files created in subdirectories");
+        await AssertAllChangesFire([fileChangeTask], s_fileChangeTimeout);
     }
 
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83180")]
@@ -417,7 +552,7 @@ public sealed class SimpleFileChangeWatcherTests : IDisposable
 
         // Create context without directory watches
         using var context = watcher.CreateContext([]);
-        var fileChangeTask = ListenForFileChangeAsync((DefaultFileChangeWatcher.FileChangeContext)context, filePath);
+        var fileChangeTask = ListenForFileChangeAsync(context, filePath);
 
         // Watch the specific file
         using var watchedFile = context.EnqueueWatchingFile(filePath);
@@ -426,9 +561,7 @@ public sealed class SimpleFileChangeWatcherTests : IDisposable
         File.WriteAllText(filePath, "individual file content");
 
         // Wait for the event
-        var eventFired = await WaitForFileChangeAsync(fileChangeTask, _fileChangeTimeout);
-
-        Assert.True(eventFired, "FileChanged event should fire for individually watched files");
+        await AssertAllChangesFire([fileChangeTask], s_fileChangeTimeout);
     }
 
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83180")]
@@ -446,15 +579,39 @@ public sealed class SimpleFileChangeWatcherTests : IDisposable
 
         // Watch the specific file
         using var watchedFile = context.EnqueueWatchingFile(filePath);
-        var fileChangeTask = ListenForFileChangeAsync((DefaultFileChangeWatcher.FileChangeContext)context, filePath);
+        var fileChangeTask = ListenForFileChangeAsync(context, filePath);
 
         // Modify the file
         File.WriteAllText(filePath, "modified content");
 
         // Wait for the event
-        var eventFired = await WaitForFileChangeAsync(fileChangeTask, _fileChangeTimeout);
+        await AssertAllChangesFire([fileChangeTask], s_fileChangeTimeout);
+    }
 
-        Assert.True(eventFired, "FileChanged event should fire when individually watched file is modified");
+    [Fact]
+    public async Task FileCreated_WithDifferentExtensionFiltersOnSameDirectory_RaisesForBothExtensions()
+    {
+        var tempDirectory = _tempRoot.CreateDirectory();
+        var csharpFilePath = Path.Combine(tempDirectory.Path, "created.cs");
+        var visualBasicFilePath = Path.Combine(tempDirectory.Path, "created.vb");
+        var watcher = new DefaultFileChangeWatcher();
+
+        using var context = watcher.CreateContext([
+            new WatchedDirectory(tempDirectory.Path, extensionFilters: [".cs"]),
+            new WatchedDirectory(tempDirectory.Path, extensionFilters: [".vb"])
+        ]);
+
+        var fileChangeTasks = new[]
+        {
+            ListenForFileChangeAsync(context, csharpFilePath),
+            ListenForFileChangeAsync(context, visualBasicFilePath),
+        };
+
+        // Create files matching both filters
+        File.WriteAllText(csharpFilePath, "csharp content");
+        File.WriteAllText(visualBasicFilePath, "visual basic content");
+
+        await AssertAllChangesFire(fileChangeTasks, s_fileChangeTimeout);
     }
 
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83180")]
@@ -465,8 +622,8 @@ public sealed class SimpleFileChangeWatcherTests : IDisposable
         var watcher = new DefaultFileChangeWatcher();
 
         using var context = watcher.CreateContext([]);
-
-        var fileChangeTask = ListenForFileChangeAsync((DefaultFileChangeWatcher.FileChangeContext)context, filePath);
+        var fileChangeContext = (DefaultFileChangeWatcher.FileChangeContext)context;
+        var fileChangeTask = ListenForFileChangeAsync(fileChangeContext, filePath);
 
         // Watch and then immediately dispose
         var watchedFile = context.EnqueueWatchingFile(filePath);
@@ -479,9 +636,9 @@ public sealed class SimpleFileChangeWatcherTests : IDisposable
         File.WriteAllText(filePath, "content after dispose");
 
         // Wait to see if any events fire
-        await Task.Delay(_fileChangeTimeout);
+        await Task.Delay(s_fileChangeTimeout);
 
-        Assert.False(fileChangeTask.IsCompleted, "FileChanged event should NOT fire after individual file watch is disposed");
+        Assert.False(fileChangeTask.Task.IsCompleted, "FileChanged event should NOT fire after individual file watch is disposed");
     }
 
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83180")]
@@ -499,11 +656,12 @@ public sealed class SimpleFileChangeWatcherTests : IDisposable
 
         var fileChangeTasks = new[]
         {
-            ListenForFileChangeAsync((DefaultFileChangeWatcher.FileChangeContext)context, file1),
-            ListenForFileChangeAsync((DefaultFileChangeWatcher.FileChangeContext)context, file2),
-            ListenForFileChangeAsync((DefaultFileChangeWatcher.FileChangeContext)context, file3)
+            ListenForFileChangeAsync(context, file1),
+            ListenForFileChangeAsync(context, file2),
+            ListenForFileChangeAsync(context, file3)
         };
 
+        // Create several files in sequence
         File.WriteAllText(file1, "content1");
         await Task.Delay(100); // Small delay between operations
         File.WriteAllText(file2, "content2");
@@ -511,13 +669,33 @@ public sealed class SimpleFileChangeWatcherTests : IDisposable
         File.WriteAllText(file3, "content3");
 
         // Wait for all events
-        var allEventsFired = await WaitForAllFileChangesAsync(fileChangeTasks, _fileChangeTimeout);
+        await AssertAllChangesFire(fileChangeTasks, s_fileChangeTimeout);
+    }
 
-        Assert.True(allEventsFired, "Should receive events for all file changes");
+    [Fact]
+    public async Task FileCreated_InNonExistentDirectory_RaisesEventAfterDirectoryCreated()
+    {
+        var root = _tempRoot.CreateDirectory();
+        var nonExistentDir = Path.Combine(root.Path, "not_yet_created");
+        var filePath = Path.Combine(nonExistentDir, "new_file.cs");
+        var watcher = new DefaultFileChangeWatcher();
+
+        using var context = watcher.CreateContext([]);
+        var fileChangeTask = ListenForFileChangeAsync(context, filePath);
+
+        // Watch the file whose directory doesn't exist yet; the watcher should be placed on an ancestor
+        using var watchedFile = context.EnqueueWatchingFile(filePath);
+
+        // Now create the directory and the file
+        Directory.CreateDirectory(nonExistentDir);
+        File.WriteAllText(filePath, "content");
+
+        // The ancestor watcher should still pick up the event
+        await AssertAllChangesFire([fileChangeTask], s_fileChangeTimeout);
     }
 
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83180")]
-    public async Task FileRenamed_InWatchedDirectory_FireEventForOriginalPath()
+    public async Task FileRenamed_InWatchedDirectory_FiresEventForOriginalPath()
     {
         var tempDirectory = _tempRoot.CreateDirectory();
         var originalPath = Path.Combine(tempDirectory.Path, "original.cs");
@@ -528,19 +706,16 @@ public sealed class SimpleFileChangeWatcherTests : IDisposable
         File.WriteAllText(originalPath, "content");
 
         using var context = watcher.CreateContext([new WatchedDirectory(tempDirectory.Path, extensionFilters: [])]);
-        var fileChangeTask = ListenForFileChangeAsync((DefaultFileChangeWatcher.FileChangeContext)context, originalPath);
+        var fileChangeTask = ListenForFileChangeAsync(context, originalPath);
 
         // Rename the file
         File.Move(originalPath, renamedPath);
 
-        // Wait for the event
-        var eventFired = await WaitForFileChangeAsync(fileChangeTask, _fileChangeTimeout);
-
-        Assert.True(eventFired, "FileChanged event should fire when a file is renamed");
+        await AssertAllChangesFire([fileChangeTask], s_fileChangeTimeout);
     }
 
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83180")]
-    public async Task FileRenamed_InWatchedDirectory_FireEventForRenamedPath()
+    public async Task FileRenamed_InWatchedDirectory_FiresEventForRenamedPath()
     {
         var tempDirectory = _tempRoot.CreateDirectory();
         var originalPath = Path.Combine(tempDirectory.Path, "original.cs");
@@ -551,15 +726,12 @@ public sealed class SimpleFileChangeWatcherTests : IDisposable
         File.WriteAllText(originalPath, "content");
 
         using var context = watcher.CreateContext([new WatchedDirectory(tempDirectory.Path, extensionFilters: [])]);
-        var fileChangeTask = ListenForFileChangeAsync((DefaultFileChangeWatcher.FileChangeContext)context, renamedPath);
+        var fileChangeTask = ListenForFileChangeAsync(context, renamedPath);
 
         // Rename the file
         File.Move(originalPath, renamedPath);
 
-        // Wait for the event
-        var eventFired = await WaitForFileChangeAsync(fileChangeTask, _fileChangeTimeout);
-
-        Assert.True(eventFired, "FileChanged event should fire when a file is renamed");
+        await AssertAllChangesFire([fileChangeTask], s_fileChangeTimeout);
     }
 
     #endregion
@@ -567,7 +739,7 @@ public sealed class SimpleFileChangeWatcherTests : IDisposable
     #region Shared Watcher Tests
 
     [Fact]
-    public void SharedWatcher_MultipleContexts_ShareSameRootWatcher()
+    public void SharedWatcher_MultipleContexts_ShareSameDirectoryWatcher()
     {
         var tempDirectory = _tempRoot.CreateDirectory();
         var watcher = new DefaultFileChangeWatcher();
@@ -575,12 +747,11 @@ public sealed class SimpleFileChangeWatcherTests : IDisposable
         using var context1 = watcher.CreateContext([new WatchedDirectory(tempDirectory.Path, extensionFilters: [])]);
         using var context2 = watcher.CreateContext([new WatchedDirectory(tempDirectory.Path, extensionFilters: [".cs"])]);
 
-        // Both contexts should have acquired 1 root path
-        Assert.Single(DefaultFileChangeWatcher.FileChangeContext.TestAccessor.GetRootFileWatchers((DefaultFileChangeWatcher.FileChangeContext)context1));
-        Assert.Single(DefaultFileChangeWatcher.FileChangeContext.TestAccessor.GetRootFileWatchers((DefaultFileChangeWatcher.FileChangeContext)context2));
-
-        // The watcher should only have 1 shared root watcher
-        Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedRootPaths(watcher));
+        // Both contexts should share the same underlying watcher entry and in this case the filters should be empty since that's needed to
+        // cover the directory that has empty filters
+        var watchedPath = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
+        Assert.Equal(tempDirectory.Path, watchedPath.path);
+        Assert.Empty(watchedPath.filters);
     }
 
     [Fact]
@@ -593,19 +764,21 @@ public sealed class SimpleFileChangeWatcherTests : IDisposable
         var context2 = watcher.CreateContext([new WatchedDirectory(tempDirectory.Path, extensionFilters: [".cs"])]);
 
         // Shared watcher should exist
-        Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedRootPaths(watcher));
+        var watchedPath = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
+        Assert.Equal(tempDirectory.Path, watchedPath.path);
 
         // Dispose context1
         context1.Dispose();
 
         // Shared watcher should still exist for context2
-        Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedRootPaths(watcher));
+        watchedPath = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
+        Assert.Equal(tempDirectory.Path, watchedPath.path);
 
         // Dispose context2
         context2.Dispose();
 
         // Now shared watcher should be disposed
-        Assert.Empty(DefaultFileChangeWatcher.TestAccessor.GetWatchedRootPaths(watcher));
+        Assert.Empty(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
     }
 
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83180")]
@@ -620,17 +793,15 @@ public sealed class SimpleFileChangeWatcherTests : IDisposable
 
         var fileChangeTasks = new[]
         {
-            ListenForFileChangeAsync((DefaultFileChangeWatcher.FileChangeContext)context1, filePath),
-            ListenForFileChangeAsync((DefaultFileChangeWatcher.FileChangeContext)context2, filePath)
+            ListenForFileChangeAsync(context1, filePath),
+            ListenForFileChangeAsync(context2, filePath)
         };
 
         // Create file
         File.WriteAllText(filePath, "content");
 
         // Both contexts should receive the event
-        var allEventsFired = await WaitForAllFileChangesAsync(fileChangeTasks, _fileChangeTimeout);
-
-        Assert.True(allEventsFired, "Both contexts should have received FileChanged events");
+        await AssertAllChangesFire(fileChangeTasks, s_fileChangeTimeout);
     }
 
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83180")]
@@ -644,7 +815,7 @@ public sealed class SimpleFileChangeWatcherTests : IDisposable
         using var context2 = watcher.CreateContext([new WatchedDirectory(tempDirectory.Path, extensionFilters: [".cs"])]);
 
         var context1Events = new List<string>();
-        var context2Received = ListenForFileChangeAsync((DefaultFileChangeWatcher.FileChangeContext)context2, filePath);
+        var context2Received = ListenForFileChangeAsync(context2, filePath);
 
         context1.FileChanged += (sender, path) => context1Events.Add(path);
 
@@ -655,9 +826,7 @@ public sealed class SimpleFileChangeWatcherTests : IDisposable
         File.WriteAllText(filePath, "content");
 
         // Only context2 should receive the event
-        var context2ReceivedEvent = await WaitForFileChangeAsync(context2Received, _fileChangeTimeout);
-
-        Assert.True(context2ReceivedEvent, "Context 2 should receive FileChanged event");
+        await AssertAllChangesFire([context2Received], s_fileChangeTimeout);
         Assert.DoesNotContain(filePath, context1Events);
     }
 
@@ -671,12 +840,13 @@ public sealed class SimpleFileChangeWatcherTests : IDisposable
         var context1 = watcher.CreateContext([new WatchedDirectory(tempDirectory.Path, extensionFilters: [])]);
         context1.Dispose();
 
-        Assert.Empty(DefaultFileChangeWatcher.TestAccessor.GetWatchedRootPaths(watcher));
+        Assert.Empty(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
 
         // Create new context - should create a new watcher
         using var context2 = watcher.CreateContext([new WatchedDirectory(tempDirectory.Path, extensionFilters: [])]);
 
-        Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedRootPaths(watcher));
+        var watchedPath = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
+        Assert.Equal(tempDirectory.Path, watchedPath.path);
     }
 
     #endregion

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/DefaultFileChangeWatcherTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/DefaultFileChangeWatcherTests.cs
@@ -764,6 +764,22 @@ public sealed class DefaultFileChangeWatcherTests : IDisposable
     }
 
     [Fact]
+    public void SharedWatcher_MultipleContexts_ShareSameDirectoryWatcherEvenIfExtraSlashes()
+    {
+        var tempDirectory = _tempRoot.CreateDirectory();
+        var watcher = new DefaultFileChangeWatcher();
+
+        using var context1 = watcher.CreateContext([new WatchedDirectory(tempDirectory.Path, extensionFilters: [])]);
+        string pathWithExtraSeparators = tempDirectory.Path.Replace(Path.DirectorySeparatorChar.ToString(), Path.DirectorySeparatorChar.ToString() + Path.DirectorySeparatorChar);
+        using var context2 = watcher.CreateContext([new WatchedDirectory(pathWithExtraSeparators, extensionFilters: [])]);
+
+        // Both contexts should share the same underlying watcher entry
+        var watchedPath = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
+        Assert.Equal(tempDirectory.Path, watchedPath.path);
+        Assert.Empty(watchedPath.filters);
+    }
+
+    [Fact]
     public void SharedWatcher_DisposingOneContext_KeepsWatcherForOther()
     {
         var tempDirectory = _tempRoot.CreateDirectory();

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/DefaultFileChangeWatcher.FileChangeContext.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/DefaultFileChangeWatcher.FileChangeContext.cs
@@ -5,142 +5,165 @@
 using System.Collections.Immutable;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.ProjectSystem;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.FileWatching;
 
 internal sealed partial class DefaultFileChangeWatcher
 {
-    /// <summary>
-    /// A file change context that tracks watched directories and files.
-    /// </summary>
-    /// <remarks>
-    /// Each context tracks which root watchers it has acquired, subscribing to their events
-    /// and unsubscribing when disposed. It also tracks individual files being watched outside
-    /// of directory watches.
-    /// </remarks>
-    internal sealed class FileChangeContext : IFileChangeContext, IEventRaiser
+    internal sealed class FileChangeContext : IFileChangeContext
     {
         private readonly DefaultFileChangeWatcher _owner;
+
+        /// <summary>
+        /// A monitor lock held for code touching <see cref="_explicitlyWatchedFiles"/>, and <see cref="_watchedDirectoriesWatches"/> during disposal. It is not expected to be held
+        /// when calling into <see cref="_owner"/>, but that shouldn't really be necessary given the simplicitly of this type.
+        /// </summary>
+        private readonly object _gate = new();
+
         private readonly ImmutableArray<WatchedDirectory> _watchedDirectories;
-        private readonly ImmutableArray<IReferenceCountedDisposable<ICacheEntry<string, FileSystemWatcher>>> _fileSystemWatchersForWatchedDirectories;
-        private bool _disposed = false;
+
+        /// <summary>
+        /// The actual watches created for each watch in <see cref="_watchedDirectories"/>.
+        /// </summary>
+        private readonly List<IDisposable> _watchedDirectoriesWatches;
+
+        /// <summary>
+        /// A map from a file path to the number of times <see cref="EnqueueWatchingFile(string)"/> was called for that file path, and the IDisposable for the
+        /// return from <see cref="DefaultFileChangeWatcher.AcquireDirectoryWatch(WatchedDirectory, FileChangeContext)"/> when it was called for the first time.
+        /// </summary>
+        private readonly Dictionary<string, (int count, IDisposable directoryWatch)> _explicitlyWatchedFiles = new(s_pathStringComparer);
+
+        private bool _disposed;
 
         public FileChangeContext(DefaultFileChangeWatcher owner, ImmutableArray<WatchedDirectory> watchedDirectories)
         {
             _owner = owner;
+            _watchedDirectories = watchedDirectories;
 
-            var watchedRootPaths = new HashSet<string>(s_pathStringComparer);
-            var fileSystemWatchersForWatchedDirectoriesBuilder = ImmutableArray.CreateBuilder<IReferenceCountedDisposable<ICacheEntry<string, FileSystemWatcher>>>();
-            var watchedDirectoryBuilder = ImmutableArray.CreateBuilder<WatchedDirectory>(watchedDirectories.Length);
-            foreach (var watchedDirectory in watchedDirectories)
-            {
-                if (!Directory.Exists(watchedDirectory.Path))
-                    continue;
-
-                watchedDirectoryBuilder.Add(watchedDirectory);
-
-                var rootPath = Path.GetPathRoot(watchedDirectory.Path)!;
-                if (!watchedRootPaths.Add(rootPath))
-                    continue;
-
-                var rootWatcher = _owner.GetOrCreateSharedWatcher(rootPath);
-                fileSystemWatchersForWatchedDirectoriesBuilder.Add(rootWatcher);
-            }
-
-            _watchedDirectories = watchedDirectoryBuilder.ToImmutable();
-            _fileSystemWatchersForWatchedDirectories = fileSystemWatchersForWatchedDirectoriesBuilder.ToImmutable();
-
-            // Attach watchers after fields are assigned to avoid race conditions where events
-            // fire before _watchedDirectories is initialized.
-            foreach (var rootWatcher in _fileSystemWatchersForWatchedDirectories)
-                AttachWatcher(this, rootWatcher);
+            // Acquire the directory watches for each directory; it's important this happens last in the constructor since events
+            // could get notified immediatly after the directory is watched.
+            _watchedDirectoriesWatches = new List<IDisposable>(_watchedDirectories.Length);
+            foreach (var watchedDirectory in _watchedDirectories)
+                _watchedDirectoriesWatches.Add(_owner.AcquireDirectoryWatch(watchedDirectory, this));
         }
 
         public event EventHandler<string>? FileChanged;
 
-        void IEventRaiser.RaiseEvent(object? sender, FileSystemEventArgs e)
-        {
-            if (_watchedDirectories.IsEmpty)
-                return;
-
-            if (WatchedDirectory.FilePathCoveredByWatchedDirectories(_watchedDirectories, e.FullPath, s_pathStringComparison))
-            {
-                FileChanged?.Invoke(this, e.FullPath);
-
-                // On Windows we only get a renamed event instead of separate delete/create events, so also raise
-                // a change event for the old file path.
-                if (e is RenamedEventArgs re && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                    FileChanged?.Invoke(this, re.OldFullPath);
-            }
-        }
-
         public IWatchedFile EnqueueWatchingFile(string filePath)
         {
-            // If this path is already covered by one of our directory watchers, nothing further to do
             if (WatchedDirectory.FilePathCoveredByWatchedDirectories(_watchedDirectories, filePath, s_pathStringComparison))
                 return NoOpWatchedFile.Instance;
 
-            // If this path doesn't have a valid root, we can't watch it
-            var rootPath = Path.GetPathRoot(filePath);
-            if (string.IsNullOrEmpty(rootPath) || !Directory.Exists(rootPath))
+            var parentDirectory = Path.GetDirectoryName(filePath);
+            if (parentDirectory is null)
                 return NoOpWatchedFile.Instance;
 
-            var rootWatcher = _owner.GetOrCreateSharedWatcher(rootPath);
-            return new IndividualWatchedFile(this, filePath, rootWatcher);
+            lock (_gate)
+            {
+
+                if (_explicitlyWatchedFiles.TryGetValue(filePath, out var countAndWatcher))
+                {
+                    _explicitlyWatchedFiles[filePath] = countAndWatcher with { count = countAndWatcher.count + 1 };
+                }
+                else
+                {
+                    var extension = Path.GetExtension(filePath);
+                    var directoryWatchToken = _owner.AcquireDirectoryWatch(new WatchedDirectory(parentDirectory, extensionFilters: string.IsNullOrEmpty(extension) ? [] : [extension]), this);
+                    countAndWatcher = (count: 1, directoryWatchToken);
+                    _explicitlyWatchedFiles.Add(filePath, countAndWatcher);
+                }
+            }
+
+            return new ExplicitlyWatchedFile(this, filePath);
+
+        }
+
+        /// <summary>
+        /// Routes a filesystem event to this context when the changed path matches one of the context's watched
+        /// directories or explicitly watched files.
+        /// </summary>
+        internal void OnFileSystemEvent(FileSystemEventArgs e)
+        {
+            bool shouldRaiseForNewPath;
+            bool shouldRaiseForOldPath = false;
+
+            lock (_gate)
+            {
+                if (_disposed)
+                    return;
+
+                shouldRaiseForNewPath = ShouldRaiseForPath_NoLock(e.FullPath);
+
+                if (e is RenamedEventArgs renamedEventArgs && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    shouldRaiseForOldPath = ShouldRaiseForPath_NoLock(renamedEventArgs.OldFullPath);
+            }
+
+            if (shouldRaiseForNewPath)
+                FileChanged?.Invoke(this, e.FullPath);
+
+            if (shouldRaiseForOldPath)
+                FileChanged?.Invoke(this, ((RenamedEventArgs)e).OldFullPath);
+        }
+
+        /// <summary>
+        /// Returns <see langword="true"/> when this context is interested in notifications for <paramref name="filePath"/>.
+        /// </summary>
+        private bool ShouldRaiseForPath_NoLock(string filePath)
+            => _explicitlyWatchedFiles.ContainsKey(filePath) ||
+               WatchedDirectory.FilePathCoveredByWatchedDirectories(_watchedDirectories, filePath, s_pathStringComparison);
+
+        /// <summary>
+        /// Removes one explicit file watch registration when a returned <see cref="IWatchedFile"/> is disposed.
+        /// </summary>
+        private void RemoveExplicitlyWatchedFile(string filePath)
+        {
+            lock (_gate)
+            {
+                // If it's already not in that dictionary, then the entire context might have already been disposed
+                if (!_explicitlyWatchedFiles.TryGetValue(filePath, out var countAndWatcher))
+                    return;
+
+                if (countAndWatcher.count == 1)
+                {
+                    countAndWatcher.directoryWatch.Dispose();
+                    _explicitlyWatchedFiles.Remove(filePath);
+                }
+                else
+                {
+                    _explicitlyWatchedFiles[filePath] = countAndWatcher with { count = countAndWatcher.count - 1 };
+                }
+            }
         }
 
         public void Dispose()
         {
-            if (Interlocked.Exchange(ref _disposed, true) == false)
+            if (Interlocked.Exchange(ref _disposed, true))
+                return;
+
+            List<IDisposable> watches;
+
+            lock (_gate)
             {
-                foreach (var rootWatcher in _fileSystemWatchersForWatchedDirectories)
-                    DetachAndDisposeWatcher(this, rootWatcher);
+                watches = [.. _watchedDirectoriesWatches, .. _explicitlyWatchedFiles.Values.Select(v => v.directoryWatch)];
+                _watchedDirectoriesWatches.Clear();
+                _explicitlyWatchedFiles.Clear();
             }
+
+            foreach (var watch in watches)
+                watch.Dispose();
         }
 
-        private sealed class IndividualWatchedFile : IWatchedFile, IEventRaiser
+        private sealed class ExplicitlyWatchedFile(FileChangeContext context, string filePath) : IWatchedFile
         {
-            private readonly FileChangeContext _context;
-            private readonly string _filePath;
-            private readonly IReferenceCountedDisposable<ICacheEntry<string, FileSystemWatcher>> _watcher;
-            private bool _disposed = false;
-
-            public IndividualWatchedFile(FileChangeContext context, string filePath, IReferenceCountedDisposable<ICacheEntry<string, FileSystemWatcher>> watcher)
-            {
-                _context = context;
-                _filePath = filePath;
-                _watcher = watcher;
-
-                AttachWatcher(this, _watcher);
-            }
-
-            void IEventRaiser.RaiseEvent(object? sender, FileSystemEventArgs e)
-            {
-                if (e.FullPath.Equals(_filePath, s_pathStringComparison))
-                {
-                    _context.FileChanged?.Invoke(this, e.FullPath);
-                }
-                else if (e is RenamedEventArgs re && RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
-                    re.OldFullPath.Equals(_filePath, s_pathStringComparison))
-                {
-                    // On Windows we only get a renamed event instead of separate delete/create events, so check
-                    // whether the old file path matches.
-                    _context.FileChanged?.Invoke(this, re.OldFullPath);
-                }
-            }
+            private bool _disposed;
 
             public void Dispose()
             {
-                if (Interlocked.Exchange(ref _disposed, true) == false)
-                    DetachAndDisposeWatcher(this, _watcher);
-            }
-        }
+                if (Interlocked.Exchange(ref _disposed, true))
+                    return;
 
-        internal static class TestAccessor
-        {
-            public static ImmutableArray<IReferenceCountedDisposable<ICacheEntry<string, FileSystemWatcher>>> GetRootFileWatchers(FileChangeContext context)
-                => context._fileSystemWatchersForWatchedDirectories;
+                context.RemoveExplicitlyWatchedFile(filePath);
+            }
         }
     }
 }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/DefaultFileChangeWatcher.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/DefaultFileChangeWatcher.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.ProjectSystem;
 using Roslyn.Utilities;
@@ -14,9 +15,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.FileWatching;
 /// use the LSP one.
 /// </summary>
 /// <remarks>
-/// This implementation creates one <see cref="FileSystemWatcher"/> per root drive and uses filtering to route file
-/// change events to the appropriate watchers. The watchers are shared between all <see cref="FileChangeContext"/>
-/// instances and are disposed when all contexts using them have been disposed.
+/// This implementation creates FileSystemWatchers for each directory being watched, reusing watchers where possible, and trying to consolidate watchers to stay under a
+/// maximum.
 /// </remarks>
 internal sealed partial class DefaultFileChangeWatcher : IFileChangeWatcher
 {
@@ -27,44 +27,430 @@ internal sealed partial class DefaultFileChangeWatcher : IFileChangeWatcher
         ? StringComparison.OrdinalIgnoreCase
         : StringComparison.Ordinal;
 
-    private readonly ReferenceCountedDisposableCache<string, FileSystemWatcher> _sharedRootWatchers = new(s_pathStringComparer);
+    /// <summary>
+    /// A monitor to be held for all manipulations to the entire tree structure. For now, no effort is made to to reduce locking with something more fine-grained, since the
+    /// primary goal of this implementation is to ensure we're respecting operating system limits. The only unsynchronized action that does not acquire this lock is the actual
+    /// reporting of file changes; since <see cref="DirectoryNode.ActiveContexts"/> is an ImmutableArray we can enumerate it safely.
+    /// </summary>
+    private readonly object _gate = new object();
+    private readonly Dictionary<string, DirectoryNode> _roots = new(s_pathStringComparer);
+    private readonly int _maxWatcherCount;
+    private int _currentWatcherCount = 0;
+
+    /// <param name="maxWatcherCount">The maxiumum number of watchers to create. Note this technically a soft limit -- it might be the case that we simply have to create more if we have to create
+    /// a number of watchers for different drives or roots. For example, if the limit is 10 and we have to watch files on 11 different drives, we'll have no choice but to exceed our limit.</param>
+    public DefaultFileChangeWatcher(int maxWatcherCount = 1000)
+    {
+        _maxWatcherCount = maxWatcherCount;
+    }
 
     public IFileChangeContext CreateContext(ImmutableArray<WatchedDirectory> watchedDirectories)
         => new FileChangeContext(this, watchedDirectories);
 
-    private IReferenceCountedDisposable<ICacheEntry<string, FileSystemWatcher>> GetOrCreateSharedWatcher(string rootPath)
+    private IDisposable AcquireDirectoryWatch(WatchedDirectory watchedDirectory, FileChangeContext fileChangeContext)
     {
-        var rootWatcher = _sharedRootWatchers.GetOrCreate<object?>(rootPath, static (key, _) => new FileSystemWatcher(key), arg: null);
-        rootWatcher.Target.Value.IncludeSubdirectories = true;
-        rootWatcher.Target.Value.EnableRaisingEvents = true;
-        return rootWatcher;
+        var watchedDirectoryPath = watchedDirectory.Path.AsSpan();
+
+        lock (_gate)
+        {
+            // First create the node that represents the root of the path we're trying to watch.
+            var root = Path.GetPathRoot(watchedDirectoryPath);
+
+            if (!_roots.GetAlternateLookup<ReadOnlySpan<char>>().TryGetValue(root, out var node))
+            {
+                var rootString = root.ToString();
+                node = new DirectoryNode { Path = rootString, Parent = null };
+                _roots.Add(rootString, node);
+            }
+
+            // We're now going to navigate our tree to create a full set of nodes for this path.
+            bool parentAlreadyHadFileWatch = false;
+            var pathRelativeToRoot = watchedDirectoryPath[root.Length..];
+            foreach (var pathComponentRange in pathRelativeToRoot.SplitAny([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar]))
+            {
+                var pathComponent = pathRelativeToRoot[pathComponentRange];
+
+                // Empty component, just ignore it
+                if (pathComponent.Length == 0)
+                    continue;
+
+                if (node.Watcher is not null)
+                {
+                    if (!parentAlreadyHadFileWatch)
+                    {
+                        // We already have a watcher on this node, so we can just reuse it, but need to ensure filters are good enough to include us
+                        ExpandFiltersToCover(node.Watcher.Filters, watchedDirectory.ExtensionFilters.SelectAsArray(static extension => '*' + extension));
+                        node.ActiveContexts = node.ActiveContexts.Add(fileChangeContext);
+                    }
+
+                    parentAlreadyHadFileWatch = true;
+                }
+
+                if (!node.Children.GetAlternateLookup<ReadOnlySpan<char>>().TryGetValue(pathComponent, out var childNode))
+                {
+                    childNode = new DirectoryNode { Path = watchedDirectoryPath[0..(root.Length + pathComponentRange.End.Value)].ToString(), Parent = node };
+                    node.Children.Add(pathComponent.ToString(), childNode);
+                }
+
+                // Before we move to the child, we want to record that we'll have an active context below this one.
+                node.ActiveContextsRecursiveCount++;
+                node = childNode;
+            }
+
+            if (!parentAlreadyHadFileWatch)
+            {
+                if (node.Watcher is not null)
+                {
+                    // We already have a watcher on this node, so we can just reuse it, but need to ensure filters are good enough to include us
+                    ExpandFiltersToCover(node.Watcher.Filters, watchedDirectory.ExtensionFilters.SelectAsArray(static extension => '*' + extension));
+                    node.ActiveContexts = node.ActiveContexts.Add(fileChangeContext);
+                }
+                else
+                {
+                    // We will have to create a file watch for this directory and we have nothing to cover it; walk back up until we find a directory to watch.
+                    // Ideally it'll just the final one we created, but since we can't watch an non-existent directory we might have to walk back a bit.
+                    var parentNodeForWatch = node;
+                    while (parentNodeForWatch is not null)
+                    {
+                        if (Directory.Exists(parentNodeForWatch.Path))
+                        {
+                            parentNodeForWatch.CreateNewFileWatcher(watchedDirectory.ExtensionFilters.SelectAsArray(static extension => '*' + extension));
+                            _currentWatcherCount++;
+
+                            // It's possible this is a watch higher up than a directory we've previously watched, so consolidate any further children
+                            var allActiveContextsBuilder = parentNodeForWatch.ActiveContexts.ToBuilder();
+                            allActiveContextsBuilder.Capacity = parentNodeForWatch.ActiveContextsRecursiveCount - parentNodeForWatch.ActiveContexts.Length + 1;
+                            allActiveContextsBuilder.Add(fileChangeContext);
+
+                            IList<string>? filters = parentNodeForWatch.Watcher.Filters;
+
+                            RemoveWatchersFromChildrenForConsolidation_NoLock(parentNodeForWatch, ref filters, allActiveContextsBuilder);
+
+                            Contract.ThrowIfFalse(filters == parentNodeForWatch.Watcher.Filters, "We should have been updating the existing list of filters.");
+
+                            parentNodeForWatch.ActiveContexts = allActiveContextsBuilder.ToImmutable();
+                            break;
+                        }
+                        else
+                        {
+                            parentNodeForWatch = parentNodeForWatch.Parent;
+                        }
+                    }
+
+                    // We've now added a new watcher; if we're above our limit then we need to consolidate
+                    FindBestNodeToConsolidateAndConsolidateIt_NoLock();
+                }
+            }
+
+            node.ActiveContextsRecursiveCount++;
+
+            return new DirectoryWatch(this, node, fileChangeContext);
+        }
     }
 
-    private static void AttachWatcher(IEventRaiser eventRaiser, IReferenceCountedDisposable<ICacheEntry<string, FileSystemWatcher>> watcher)
+    private void ReleaseWatch(DirectoryNode node, FileChangeContext fileChangeContext)
     {
-        watcher.Target.Value.Changed += eventRaiser.RaiseEvent;
-        watcher.Target.Value.Created += eventRaiser.RaiseEvent;
-        watcher.Target.Value.Deleted += eventRaiser.RaiseEvent;
-        watcher.Target.Value.Renamed += eventRaiser.RaiseEvent;
+        lock (_gate)
+        {
+            var current = node;
+            while (current is not null)
+            {
+                Contract.ThrowIfFalse(current.ActiveContextsRecursiveCount > 0);
+                current.ActiveContextsRecursiveCount--;
+
+                // If this node's ActiveContexts contains the context, remove it; this is necessary to check at all levels since we might have moved it up
+                // if we consolidated.
+                current.ActiveContexts = current.ActiveContexts.Remove(fileChangeContext);
+
+                // If this node is no longer needed, then we can clean it up
+                if (current.ActiveContextsRecursiveCount == 0)
+                {
+                    Contract.ThrowIfFalse(current.ActiveContexts.IsDefaultOrEmpty);
+                    Contract.ThrowIfFalse(current.Children.Count == 0, "If we have no active contexts, we should have no children as well.");
+
+                    if (current.Watcher is not null)
+                    {
+                        current.DisposeWatcher();
+                        _currentWatcherCount--;
+                    }
+
+                    // Prune this node from its parent if it's now completely empty (no watcher, no contexts, no children).
+                    if (current.Parent is not null)
+                    {
+                        // Find and remove from parent's Children dictionary.
+                        foreach (var (key, value) in current.Parent.Children)
+                        {
+                            if (ReferenceEquals(value, current))
+                            {
+                                current.Parent.Children.Remove(key);
+                                break;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        // This is a root node; remove it from _roots.
+                        Contract.ThrowIfFalse(_roots.Remove(current.Path));
+                    }
+                }
+
+                current = current.Parent;
+            }
+        }
     }
 
-    private static void DetachAndDisposeWatcher(IEventRaiser eventRaiser, IReferenceCountedDisposable<ICacheEntry<string, FileSystemWatcher>> watcher)
+    private void FindBestNodeToConsolidateAndConsolidateIt_NoLock()
     {
-        watcher.Target.Value.Changed -= eventRaiser.RaiseEvent;
-        watcher.Target.Value.Created -= eventRaiser.RaiseEvent;
-        watcher.Target.Value.Deleted -= eventRaiser.RaiseEvent;
-        watcher.Target.Value.Renamed -= eventRaiser.RaiseEvent;
-        watcher.Dispose();
+        Contract.ThrowIfFalse(Monitor.IsEntered(_gate));
+
+        if (_currentWatcherCount < _maxWatcherCount)
+            return;
+
+        // Find the root with the most watchers; that's where the biggest win would be
+        var nodeToConsolidate = _roots.Values.MaxBy(static r => r.ActiveWatchersRecursiveCount);
+
+        Contract.ThrowIfNull(nodeToConsolidate, "Why are we consolidating when we have no watchers?");
+
+        if (nodeToConsolidate.ActiveWatchersRecursiveCount == 1)
+        {
+            // Well, this means each watcher we have is on a different drive, so we can't actually consolidate.
+            return;
+        }
+
+        // Let's look at the children -- is there any child of this node that is worth consolidating to keep our watches precise?
+        while (true)
+        {
+            var childToConsolidate = nodeToConsolidate.Children.Values.MaxBy(static r => r.ActiveWatchersRecursiveCount);
+
+            if (childToConsolidate is not null && childToConsolidate.ActiveWatchersRecursiveCount > 1)
+            {
+                // Sure, let's do this instead, but we'll keep recursing further
+                nodeToConsolidate = childToConsolidate;
+            }
+            else
+            {
+                // Nope nothing more precise, so we found it
+                IList<string>? filters = null;
+                var activeContexts = ImmutableArray.CreateBuilder<FileChangeContext>(initialCapacity: nodeToConsolidate.ActiveContextsRecursiveCount);
+
+                RemoveWatchersFromChildrenForConsolidation_NoLock(nodeToConsolidate, ref filters, activeContexts);
+
+                Contract.ThrowIfNull(filters, "We knew we had at least one watcher to consolidate, so we should have consolidated it's filters.");
+                Contract.ThrowIfTrue(activeContexts.Count == 0, "We had at least one watcher to consolidate, and that should have had at least one context listening.");
+                nodeToConsolidate.CreateNewFileWatcher(filters.ToImmutableArray());
+                nodeToConsolidate.ActiveContexts = activeContexts.ToImmutable();
+                _currentWatcherCount++;
+                break;
+            }
+        }
+
+        // And now assert we're back under our limit
+        Contract.ThrowIfFalse(_currentWatcherCount <= _maxWatcherCount);
     }
 
-    internal interface IEventRaiser
+    /// <summary>
+    /// Recursively removes the watchers from the given node's children and all it's descendants, and updates the list of filters and activeContexts
+    /// a consolidated node should have.
+    /// </summary>
+    /// <param name="filters">
+    /// The list of filters. Our convention is an empty list of filters means the entire directory is being watched,
+    /// but we need a different value to indicate that we haven't found a watcher at all yet and we should use it's filters when we find it.
+    /// </param>
+    private void RemoveWatchersFromChildrenForConsolidation_NoLock(DirectoryNode node, ref IList<string>? filters, ImmutableArray<FileChangeContext>.Builder activeContexts)
     {
-        void RaiseEvent(object? sender, FileSystemEventArgs e);
+        Contract.ThrowIfFalse(Monitor.IsEntered(_gate));
+
+        foreach (var child in node.Children.Values)
+        {
+            if (child.Watcher is not null)
+            {
+                // We're going to get rid of this child's watcher; we'll transfer all filters up and also transfer up the active contexts
+                // that are listening. That now means those other contexts will also get notified, but it's up for them to do final filtering
+                // to ensure they only react to the files they care about. Doing this now means we can avoid traversing the tree on each
+                // event to know which contexts to notify. This might be a bad tradeoff -- preserving the original structure would potentially
+                // mean we can filter events better by parsing the file paths out and more quickly navigating our tree structure.
+                if (filters is null)
+                {
+                    filters = new List<string>(child.Watcher.Filters);
+                }
+                else
+                {
+                    ExpandFiltersToCover(filters, [.. child.Watcher.Filters]);
+                }
+
+                activeContexts.AddRange(child.ActiveContexts);
+                child.ActiveContexts = ImmutableArray<FileChangeContext>.Empty;
+                child.DisposeWatcher();
+                _currentWatcherCount--;
+            }
+            else if (child.ActiveWatchersRecursiveCount > 0)
+            {
+                RemoveWatchersFromChildrenForConsolidation_NoLock(child, ref filters, activeContexts);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Represents a single directory in the directory tree structure.
+    /// </summary>
+    private sealed class DirectoryNode
+    {
+        public required string Path { get; init; }
+
+        /// <summary>
+        /// The parent directory, or null if this is the root of a drive.
+        /// </summary>
+        public required DirectoryNode? Parent { get; init; }
+        public Dictionary<string, DirectoryNode> Children { get; } = new Dictionary<string, DirectoryNode>(s_pathStringComparer);
+
+        /// <summary>
+        /// The watcher for this directory, if we have one.
+        /// </summary>
+        public FileSystemWatcher? Watcher { get; private set; }
+
+        /// <summary>
+        /// The set of contexts that are subscribed to this location. In the case of consolidation, these contexts are moved towards the directory with the actual watch
+        /// so we can avoid having to recursively enumerate the tree each time we have to fire an event. This is immutable so firing events can be done without taking a lock;
+        /// see <see cref="_gate"/>'s comments for the overall threading model here.
+        /// </summary>
+        public ImmutableArray<FileChangeContext> ActiveContexts { get; set; } = ImmutableArray<FileChangeContext>.Empty;
+
+        /// <summary>
+        /// The total number of <see cref="ActiveContexts"/> in this node and all child nodes.
+        /// </summary>
+        public int ActiveContextsRecursiveCount { get; set; }
+
+        /// <summary>
+        /// The total number of <see cref="Watcher"/> in this node and all child nodes.
+        /// </summary>
+        public int ActiveWatchersRecursiveCount { get; private set; }
+
+        [MemberNotNull(nameof(Watcher))]
+        public void CreateNewFileWatcher(ImmutableArray<string> filters)
+        {
+            Contract.ThrowIfTrue(Watcher is not null);
+            Contract.ThrowIfFalse(ActiveContexts.IsEmpty);
+
+            Watcher = new FileSystemWatcher(Path);
+            Watcher.Filters.AddRange(filters);
+
+            Watcher.Created += OnFileSystemWatcherEvent;
+            Watcher.Changed += OnFileSystemWatcherEvent;
+            Watcher.Renamed += OnFileSystemWatcherEvent;
+            Watcher.Deleted += OnFileSystemWatcherEvent;
+
+            Watcher.IncludeSubdirectories = true;
+            Watcher.EnableRaisingEvents = true;
+
+            UpdateActiveWatchersRecursiveCountIncludingAllParents(delta: 1);
+        }
+
+        private void UpdateActiveWatchersRecursiveCountIncludingAllParents(int delta)
+        {
+            var node = this;
+            while (node is not null)
+            {
+                node.ActiveWatchersRecursiveCount += delta;
+                Contract.ThrowIfTrue(node.ActiveWatchersRecursiveCount < 0);
+                node = node.Parent;
+            }
+        }
+
+        public void DisposeWatcher()
+        {
+            // Assert here, usually because the caller already had checked this since it had other logic
+            Contract.ThrowIfNull(Watcher);
+            Contract.ThrowIfTrue(ActiveContexts.Length > 0);
+
+            Watcher.Dispose();
+            Watcher = null;
+
+            UpdateActiveWatchersRecursiveCountIncludingAllParents(delta: -1);
+        }
+
+        private void OnFileSystemWatcherEvent(object sender, FileSystemEventArgs e)
+        {
+            var activeContexts = ActiveContexts;
+            foreach (var activeContext in activeContexts)
+                activeContext.OnFileSystemEvent(e);
+        }
+    }
+
+    private sealed class DirectoryWatch : IDisposable
+    {
+        /// <summary>
+        /// The parent object; mutable and nullable so we can set it to null when we're disposed to ensure an accidental double-dispose doesn't break anything.
+        /// </summary>
+        private DefaultFileChangeWatcher? _owner;
+        private readonly DirectoryNode _node;
+        private readonly FileChangeContext _fileChangeContext;
+
+        public DirectoryWatch(DefaultFileChangeWatcher owner, DirectoryNode node, FileChangeContext fileChangeContext)
+        {
+            _owner = owner;
+            _node = node;
+            _fileChangeContext = fileChangeContext;
+        }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _owner, value: null) is { } owner)
+            {
+                owner.ReleaseWatch(_node, _fileChangeContext);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Merges the list of filters in <paramref name="newFilters"/> into <paramref name="watcherFilters"/>. The convention is an empty list
+    /// means everything, so if either list is empty, the result is an empty list. Otherwise, we merge the two lists and remove duplicates.
+    /// </summary>
+    private static void ExpandFiltersToCover(ICollection<string> watcherFilters, IEnumerable<string> newFilters)
+    {
+        // If we're already watching everything, can just be done
+        if (watcherFilters.Count == 0)
+            return;
+
+        bool hadAFilter = false;
+
+        foreach (var newFilter in newFilters)
+        {
+            hadAFilter = true;
+            if (!watcherFilters.Contains(newFilter))
+                watcherFilters.Add(newFilter);
+        }
+
+        if (!hadAFilter)
+            watcherFilters.Clear();
     }
 
     internal static class TestAccessor
     {
-        public static IEnumerable<string> GetWatchedRootPaths(DefaultFileChangeWatcher watcher)
-            => ReferenceCountedDisposableCache<string, FileSystemWatcher>.TestAccessor.GetCacheKeys(watcher._sharedRootWatchers);
+        public static IEnumerable<(string path, ImmutableArray<string> filters)> GetWatchedDirectories(DefaultFileChangeWatcher watcher)
+        {
+            var paths = new List<(string path, ImmutableArray<string> filters)>(capacity: watcher._currentWatcherCount);
+
+            int currentWatcherCountPerRoots = 0;
+
+            foreach (var root in watcher._roots.Values)
+            {
+                currentWatcherCountPerRoots += root.ActiveWatchersRecursiveCount;
+                AddWatchedDirectoryPaths(root);
+            }
+
+            Contract.ThrowIfTrue(paths.Count != watcher._currentWatcherCount, $"{nameof(watcher._currentWatcherCount)} is out of sync with the actual number of watchers.");
+            Contract.ThrowIfTrue(currentWatcherCountPerRoots != watcher._currentWatcherCount, $"{nameof(watcher._currentWatcherCount)} is out of sync with the actual number of watchers in the roots.");
+
+            return paths;
+
+            void AddWatchedDirectoryPaths(DirectoryNode node)
+            {
+                if (node.Watcher is not null)
+                    paths.Add((node.Path, node.Watcher.Filters.ToImmutableArray()));
+
+                foreach (var child in node.Children.Values)
+                    AddWatchedDirectoryPaths(child);
+            }
+        }
     }
 }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/DelegatingFileChangeWatcher.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/DelegatingFileChangeWatcher.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Immutable;
 using System.Composition;
+using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServer.LanguageServer;
 using Microsoft.CodeAnalysis.ProjectSystem;
@@ -38,7 +39,10 @@ internal sealed class DelegatingFileChangeWatcher(
                 return new LspFileChangeWatcher(instance, asynchronousOperationListenerProvider);
 
             loggerFactory.CreateLogger<DelegatingFileChangeWatcher>().LogWarning("We are unable to use LSP file watching; falling back to our in-process watcher.");
-            return new DefaultFileChangeWatcher();
+
+            // On non-Windows platforms, the number of inotify handles is limited, so we'll want to be more aggressive with reducing it.
+            // TODO: we could read the inotify limit and set this dynamically, since some newer kernels have a higher default.
+            return new DefaultFileChangeWatcher(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 10_000 : 50);
         });
 
     public IFileChangeContext CreateContext(ImmutableArray<WatchedDirectory> watchedDirectories)

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/FileWatchedPortableExecutableReferenceFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/FileWatchedPortableExecutableReferenceFactory.cs
@@ -102,14 +102,6 @@ internal sealed class FileWatchedReferenceFactory<TReference>
                 referenceDirectories.Add("/usr/local/share/dotnet/packs");
             }
 
-            // Also watch the NuGet restore path; we don't do this (yet) on Windows due to potential concerns about
-            // whether this creates additional overhead responding to changes during a restore. TODO: remove this
-            // condition
-            if (!PlatformInformation.IsWindows)
-            {
-                referenceDirectories.Add(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages"));
-            }
-
             return referenceDirectories.SelectAsArray(static d => new WatchedDirectory(d, [".dll"]));
         }
     }


### PR DESCRIPTION
Our current implementation of DefaultFileChangeWatcher works around a limitation of .NET's FileSystemWatcher in a very aggressive manner. In .NET 10 and earlier, FileSystemWatcher will create a single inotify handle for each watch you create -- since those tend to be limited on Unix OSes, we had to be careful to not make too many of them. The workaround was just to create one watcher on each drive root, but this isn't ideal because:

1. On Unix, the implementation still has to recursively watch each directory, which means we're expensively watching your entire drive
2. This is just generally going to mean we're watching far more than we should.

This replaces implementations which a smarter approach that instead tries to be smart and watch only what we need, but starts consolidating watchers once we have to many of them. The approach here still tries to be simple, so there's a few things it's right now trying not to do:

1. We're not doing any find-grained locking on the data structure where we are tracking what we are and aren't watching, so there may be more lock contention than we'd like.

2. When watches are removed, we don't try to unconsolidate again. We do still track when all the watched directories are removed we will remove the watchers entirely, but we don't try to minimize what we're watching in the middle of it. This is practically because the only large-scale removal of watches is generally going to be unload of projects, which isn't a terribly interesting case since by the end we will have just removed everything.