### PR TITLE
Update package versions to match Razor

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -242,8 +242,8 @@
     <!--
       Testing.
     -->
-    <PackageVersion Include="BenchmarkDotNet" Version="0.13.5.2136" />
-    <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.5.2136" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.13.6" />
+    <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.6" />
     <PackageVersion Include="BasicUndo" Version="0.9.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="$(MicrosoftCodeAnalysisTestingVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="$(MicrosoftCodeAnalysisTestingVersion)" />

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -29,17 +29,17 @@
   -->
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
-    <PackageVersion Include="Microsoft.Build" Version="17.11.48" />
-    <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.48" />
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.11.48" />
-    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.48" />
+    <PackageVersion Include="Microsoft.Build" Version="17.15.0-preview-25357-08" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="17.15.0-preview-25357-08" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.15.0-preview-25357-08" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.15.0-preview-25357-08" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(TargetFramework)' != 'net472'">
-    <PackageVersion Include="Microsoft.Build" Version="17.11.48" />
-    <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.48" />
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.11.48" />
-    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.48" />
+    <PackageVersion Include="Microsoft.Build" Version="17.15.0-preview-25357-08" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="17.15.0-preview-25357-08" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.15.0-preview-25357-08" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.15.0-preview-25357-08" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(TargetFramework)' == 'net472'">
@@ -59,7 +59,7 @@
       Visual Studio
     -->
     <PackageVersion Include="Microsoft.VisualStudio.SDK" Version="18.0.2188-preview.1" />
-    <PackageVersion Include="Microsoft.Internal.VisualStudio.Shell.Framework" Version="18.0.1211-preview.1" />
+    <PackageVersion Include="Microsoft.Internal.VisualStudio.Shell.Framework" Version="18.0.2188-preview.1" />
     <PackageVersion Include="Microsoft.ServiceHub.Client" Version="4.6.3200" />
     <PackageVersion Include="Microsoft.VisualStudio.Extensibility.Sdk" Version="18.0.52-preview1" />
     <PackageVersion Include="Microsoft.VisualStudio.Extensibility" Version="18.0.52-preview1" />
@@ -81,8 +81,8 @@
     <PackageVersion Include="Microsoft.VisualStudio.Workspace.VSIntegration" Version="17.9.29-preview-0001" />
     <PackageVersion Include="Microsoft.VisualStudio.Copilot.Roslyn.SemanticSearch" Version="18.0.634-alpha" />
     <PackageVersion Include="VsWebSite.Interop" Version="8.0.50727" />
-    <PackageVersion Include="NuGet.VisualStudio" Version="6.0.0-preview.0.15" />
-    <PackageVersion Include="NuGet.VisualStudio.Contracts" Version="6.0.0-preview.0.15" />
+    <PackageVersion Include="NuGet.VisualStudio" Version="17.9.1" />
+    <PackageVersion Include="NuGet.VisualStudio.Contracts" Version="17.9.1" />
 
     <!-- TODO: Move these to the generate-vssdk-versions.csx-generated versions (https://github.com/dotnet/roslyn/issues/71691) -->
     <PackageVersion Include="Microsoft.VisualStudio.Text.Internal" Version="$(VisualStudioEditorPackagesVersion)" />
@@ -143,7 +143,7 @@
     <!--
       Language Server
     -->
-    <PackageVersion Include="Microsoft.VisualStudio.LanguageServer.Client.Implementation" Version="17.10.72-preview" />
+    <PackageVersion Include="Microsoft.VisualStudio.LanguageServer.Client.Implementation" Version="17.12.1-preview" />
     <PackageVersion Include="NuGet.ProjectModel" Version="6.8.0-rc.112" />
     <PackageVersion Include="Microsoft.TestPlatform.TranslationLayer" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="$(MicrosoftNETTestSdkVersion)" />
@@ -206,7 +206,7 @@
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafeVersion)" />
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="$(SystemSecurityCryptographyProtectedDataVersion)" />
     <PackageVersion Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsVersion)" />
-    <PackageVersion Include="System.Text.Encoding.CodePages" Version="8.0.0" />
+    <PackageVersion Include="System.Text.Encoding.CodePages" Version="9.0.0" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="$(SystemThreadingTasksDataflowVersion)" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
     <PackageVersion Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />
@@ -222,7 +222,7 @@
     <PackageVersion Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />
     <!-- Note: When updating SystemTextJsonVersion ensure that the version is no higher than what is used by MSBuild. -->
     <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
-    <PackageVersion Include="System.Threading.Channels" Version="8.0.0" />
+    <PackageVersion Include="System.Threading.Channels" Version="9.0.0" />
 
     <PackageVersion Include="Microsoft.IO.Redist" Version="$(MicrosoftIORedistVersion)" />
 
@@ -242,8 +242,8 @@
     <!--
       Testing.
     -->
-    <PackageVersion Include="BenchmarkDotNet" Version="0.13.0" />
-    <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.13.5.2136" />
+    <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.5.2136" />
     <PackageVersion Include="BasicUndo" Version="0.9.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="$(MicrosoftCodeAnalysisTestingVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="$(MicrosoftCodeAnalysisTestingVersion)" />
@@ -262,9 +262,8 @@
     <PackageVersion Include="Microsoft.VisualStudio.Diagnostics.PerformanceProvider" Version="17.8.36726" />
     <PackageVersion Include="System.Management" Version="7.0.0" />
     <PackageVersion Include="System.Drawing.Common" Version="10.0.1" />
-    <PackageVersion Include="NuGet.SolutionRestoreManager.Interop" Version="4.8.0" />
-    <PackageVersion Include="Moq" Version="4.10.1" />
-    <PackageVersion Include="System.CodeDom" Version="8.0.0" />
+    <PackageVersion Include="Moq" Version="4.18.4" />
+    <PackageVersion Include="System.CodeDom" Version="9.0.0" />
     <PackageVersion Include="InputSimulatorPlus" Version="1.0.7" />
     <PackageVersion Include="UIAComWrapper" Version="1.1.0.14" />
     <PackageVersion Include="DiffPlex" Version="1.7.2" />
@@ -304,8 +303,8 @@
     <PackageVersion Include="Microsoft.TeamFoundationServer.Client" Version="19.232.0-preview" />
     <PackageVersion Include="System.Data.SqlClient" Version="$(SystemDataSqlClientVersion)" />
     <!-- fix of vulnerability in 6.0.0 coming via Microsoft.TeamFoundationServer.Client -->
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.0" />
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="9.0.0" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.0" />
     <!--
       vs-extension-testing
     -->

--- a/src/Compilers/Core/Portable/Microsoft.CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/Microsoft.CodeAnalysis.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="System.Reflection.Metadata" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Condition="'$(TargetFramework)' == 'netstandard2.0'" VersionOverride="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <!-- Need to include the PerformanceSensitiveAttribute definition in source build, since we can't get it from the analyzer package. -->

--- a/src/EditorFeatures/Test/Workspaces/ClassificationTypeNamesTests.cs
+++ b/src/EditorFeatures/Test/Workspaces/ClassificationTypeNamesTests.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Castle.DynamicProxy.Internal;
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.Text.Classification;
@@ -22,7 +22,7 @@ public sealed class ClassificationTypeNamesTests
             .GetFields(BindingFlags.Static | BindingFlags.Public)
             .Select(f => new[] { f.Name, f.GetRawConstantValue() });
 
-    public static IEnumerable<object[]> AllClassificationTypeNames => typeof(ClassificationTypeNames).GetAllFields().Where(
+    public static IEnumerable<object[]> AllClassificationTypeNames => GetAllFields(typeof(ClassificationTypeNames)).Where(
         f => f.GetValue(null) is string value).Select(f => new[] { f.GetValue(null) });
 
     [Theory]
@@ -44,4 +44,15 @@ public sealed class ClassificationTypeNamesTests
     [Fact]
     public void AllTypeNamesContainsNoDuplicates()
         => Assert.Equal(ClassificationTypeNames.AllTypeNames.Distinct(), ClassificationTypeNames.AllTypeNames);
+
+    private static IEnumerable<FieldInfo> GetAllFields(Type type)
+    {
+        for (var currentType = type; currentType is not null; currentType = currentType.BaseType)
+        {
+            foreach (var field in currentType.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly))
+            {
+                yield return field;
+            }
+        }
+    }
 }

--- a/src/RoslynAnalyzers/Roslyn.Diagnostics.Analyzers/Roslyn.Diagnostics.Analyzers.md
+++ b/src/RoslynAnalyzers/Roslyn.Diagnostics.Analyzers/Roslyn.Diagnostics.Analyzers.md
@@ -81,7 +81,7 @@ Test exports should not be discoverable.
 |Category|RoslynDiagnosticsReliability|
 |Enabled|False|
 |Severity|Warning|
-|CodeFix|True|
+|CodeFix|False|
 ---
 
 ## RS0033: Importing constructor should be marked with 'ObsoleteAttribute'
@@ -105,7 +105,7 @@ Exported parts should be marked with 'ImportingConstructorAttribute'.
 |Category|RoslynDiagnosticsReliability|
 |Enabled|True|
 |Severity|Warning|
-|CodeFix|True|
+|CodeFix|False|
 ---
 
 ## RS0038: Prefer null literal
@@ -117,7 +117,7 @@ Use 'null' instead of 'default' for nullable types.
 |Category|RoslynDiagnosticsMaintainability|
 |Enabled|True|
 |Severity|Warning|
-|CodeFix|True|
+|CodeFix|False|
 ---
 
 ## RS0040: Defaultable types should have defaultable fields
@@ -165,7 +165,7 @@ Avoid the 'Opt' suffix in a nullable-enabled code.
 |Category|RoslynDiagnosticsDesign|
 |Enabled|True|
 |Severity|Warning|
-|CodeFix|True|
+|CodeFix|False|
 ---
 
 ## RS0049: Instance of TemporaryArray\<T>.AsRef() must be a 'using' variable
@@ -201,5 +201,5 @@ Primary constructor parameters should not be implicitly captured. Manually assig
 |Category|RoslynDiagnosticsPerformance|
 |Enabled|False|
 |Severity|Warning|
-|CodeFix|True|
+|CodeFix|False|
 ---

--- a/src/Tools/IdeCoreBenchmarks/IncrementalSourceGeneratorBenchmarks.cs
+++ b/src/Tools/IdeCoreBenchmarks/IncrementalSourceGeneratorBenchmarks.cs
@@ -26,7 +26,7 @@ namespace IdeCoreBenchmarks
 {
     // [GcServer(true)]
     [MemoryDiagnoser]
-    [SimpleJob(launchCount: 1, warmupCount: 0, targetCount: 0, invocationCount: 1, id: "QuickJob")]
+    [SimpleJob(launchCount: 1, warmupCount: 0, iterationCount: 0, invocationCount: 1, id: "QuickJob")]
     public class IncrementalSourceGeneratorBenchmarks
     {
         string _solutionPath;

--- a/src/Tools/IdeCoreBenchmarks/NavigateToBenchmarks.cs
+++ b/src/Tools/IdeCoreBenchmarks/NavigateToBenchmarks.cs
@@ -27,7 +27,7 @@ namespace IdeCoreBenchmarks
 {
     // [GcServer(true)]
     [MemoryDiagnoser]
-    [SimpleJob(launchCount: 1, warmupCount: 0, targetCount: 0, invocationCount: 1, id: "QuickJob")]
+    [SimpleJob(launchCount: 1, warmupCount: 0, iterationCount: 0, invocationCount: 1, id: "QuickJob")]
     public class NavigateToBenchmarks
     {
         string _solutionPath;

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/Microsoft.VisualStudio.LanguageServices.New.IntegrationTests.csproj
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/Microsoft.VisualStudio.LanguageServices.New.IntegrationTests.csproj
@@ -59,7 +59,6 @@
   <ItemGroup>
     <PackageReference Include="InputSimulatorPlus" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Styles" />
-    <PackageReference Include="NuGet.SolutionRestoreManager.Interop" />
     <PackageReference Include="System.IO.Hashing" />
     <PackageReference Include="UIAComWrapper" />
     <PackageReference Include="xunit.extensibility.core" />

--- a/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
@@ -29,6 +29,7 @@
          since it's now automatic, and Source Build will ensure we get a proper one automatically if we do nothing; if we reference the older version
          then source build may only give us a reference assembly would fail if we then try to actually run that output. -->
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Condition="'$(TargetFramework)' == 'netstandard2.0'" VersionOverride="8.0.0" />
     <PackageReference Include="System.IO.Pipelines" />
     <PackageReference Include="System.Threading.Channels" />
   </ItemGroup>

--- a/src/Workspaces/Remote/ServiceHub/Microsoft.CodeAnalysis.Remote.ServiceHub.csproj
+++ b/src/Workspaces/Remote/ServiceHub/Microsoft.CodeAnalysis.Remote.ServiceHub.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Telemetry" />
     <PackageReference Include="Microsoft.VisualStudio.RpcContracts" />
     <PackageReference Include="Microsoft.VisualStudio.Debugger.Contracts" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Condition="'$(TargetFramework)' == 'netstandard2.0'" VersionOverride="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <PublicAPI Include="PublicAPI.Shipped.txt" />


### PR DESCRIPTION
In advance of bringing the Razor repo into Roslyn, it makes sense to align on package versions. These are the version updates where Razor was ahead of Roslyn.

Razor side: https://github.com/dotnet/razor/pull/13028

Not sure if any of these will be contentious. At the very least, the update to Microsoft.VisualStudio.LanguageServer.Client.Implementation is required or actual product code in Razor won't compile.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83109)