### PR TITLE
Unsafe evolution: allow unsafe property accessors

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/BinderFactory.BinderFactoryVisitor.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFactory.BinderFactoryVisitor.cs
@@ -316,7 +316,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             resultBinder = new InMethodBinder(accessor, resultBinder);
 
                             resultBinder = resultBinder.SetOrClearUnsafeRegionIfNecessary(
-                                modifiers: default,
+                                modifiers: parent.Modifiers,
                                 isIteratorBody: accessor.IsIterator);
                         }
                     }

--- a/src/Compilers/CSharp/Portable/Binder/ExecutableCodeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ExecutableCodeBinder.cs
@@ -131,9 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 diagnostics.Add(ErrorCode.ERR_VarargsIterator, errorLocation);
             }
 
-            if (((iterator as SourceMemberMethodSymbol)?.IsUnsafe == true
-                || (iterator as LocalFunctionSymbol)?.IsUnsafe == true
-                || ((iterator as SourcePropertyAccessorSymbol)?.AssociatedSymbol as SourcePropertySymbol)?.IsDeclaredUnsafe == true)
+            if (((iterator as SourceMemberMethodSymbol)?.IsUnsafe == true || (iterator as LocalFunctionSymbol)?.IsUnsafe == true)
                 && compilation.Options.AllowUnsafe) // Don't cascade
             {
                 MessageID.IDS_FeatureRefUnsafeInIteratorAsync.CheckFeatureAvailability(diagnostics, compilation, errorLocation);

--- a/src/Compilers/CSharp/Portable/Binder/ExecutableCodeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ExecutableCodeBinder.cs
@@ -131,7 +131,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 diagnostics.Add(ErrorCode.ERR_VarargsIterator, errorLocation);
             }
 
-            if (((iterator as SourceMemberMethodSymbol)?.IsUnsafe == true || (iterator as LocalFunctionSymbol)?.IsUnsafe == true)
+            if (((iterator as SourceMemberMethodSymbol)?.IsUnsafe == true
+                || (iterator as LocalFunctionSymbol)?.IsUnsafe == true
+                || ((iterator as SourcePropertyAccessorSymbol)?.AssociatedSymbol as SourcePropertySymbol)?.IsDeclaredUnsafe == true)
                 && compilation.Options.AllowUnsafe) // Don't cascade
             {
                 MessageID.IDS_FeatureRefUnsafeInIteratorAsync.CheckFeatureAvailability(diagnostics, compilation, errorLocation);

--- a/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
@@ -173,6 +173,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal sealed override bool HasSpecialName => InheritsBaseMethodAttributes && BaseMethod.HasSpecialName;
 
+        internal sealed override bool IsUnsafe => (DeclarationModifiers & DeclarationModifiers.Unsafe) != 0;
+
         // Synthesized methods created from a base method with [SkipLocalsInitAttribute] will also
         // skip locals init where applicable, even if the synthesized method does not inherit attributes.
         // Note that this doesn't affect BaseMethodWrapperSymbol for example because the implementation has no locals.

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
@@ -244,6 +244,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 ? flags.IsNullableAnalysisEnabled
                 : ((SourceMemberContainerTypeSymbol)ContainingType).IsNullableEnabledForConstructorsAndInitializers(IsStatic);
 
+        internal sealed override bool IsUnsafe => (DeclarationModifiers & DeclarationModifiers.Unsafe) != 0;
+
         protected override bool AllowRefOrOut
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
@@ -142,6 +142,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        internal sealed override bool IsUnsafe => (DeclarationModifiers & DeclarationModifiers.Unsafe) != 0;
+
         public override ImmutableArray<TypeParameterSymbol> TypeParameters
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDestructorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDestructorSymbol.cs
@@ -102,6 +102,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return 0; }
         }
 
+        internal sealed override bool IsUnsafe => (DeclarationModifiers & DeclarationModifiers.Unsafe) != 0;
+
         public override ImmutableArray<ParameterSymbol> Parameters
         {
             get { return ImmutableArray<ParameterSymbol>.Empty; }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventAccessorSymbol.cs
@@ -194,6 +194,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public sealed override ImmutableArray<TypeParameterConstraintKind> GetTypeParameterConstraintKinds()
             => ImmutableArray<TypeParameterConstraintKind>.Empty;
 
+        internal sealed override bool IsUnsafe => (DeclarationModifiers & DeclarationModifiers.Unsafe) != 0;
+
         internal Location Location
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -684,13 +684,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override bool IsUnsafe
-        {
-            get
-            {
-                return (this.DeclarationModifiers & DeclarationModifiers.Unsafe) != 0;
-            }
-        }
+        internal abstract override bool IsUnsafe { get; }
 
         public sealed override bool IsAsync
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -684,8 +684,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal abstract override bool IsUnsafe { get; }
-
         public sealed override bool IsAsync
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -684,7 +684,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal sealed override bool IsUnsafe
+        internal override bool IsUnsafe
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
@@ -94,7 +94,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool UseUpdatedEscapeRules => ContainingModule.UseUpdatedEscapeRules;
 
         /// <summary>
-        /// Whether the method has the <see langword="unsafe"/> keyword in its signature.
+        /// Whether the method is in an unsafe context.
+        /// For property/event accessors, this includes the containing property's unsafe modifier.
         /// Do not confuse with <see cref="CallerUnsafeMode"/>.
         /// </summary>
         internal abstract bool IsUnsafe { get; }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodOrUserDefinedOperatorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodOrUserDefinedOperatorSymbol.cs
@@ -171,6 +171,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        internal sealed override bool IsUnsafe => (DeclarationModifiers & DeclarationModifiers.Unsafe) != 0;
+
         protected abstract int GetParameterCountFromSyntax();
 
         public sealed override ImmutableArray<ParameterSymbol> Parameters

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -25,6 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private string _lazyName;
         private readonly bool _isAutoPropertyAccessor;
         private readonly bool _usesInit;
+        private readonly bool _declaredUnsafe;
 
         public static SourcePropertyAccessorSymbol CreateAccessorSymbol(
             NamedTypeSymbol containingType,
@@ -186,6 +187,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             _property = property;
             _isAutoPropertyAccessor = false;
+            _declaredUnsafe = false;
 
             CheckFeatureAvailabilityAndRuntimeSupport(syntax, location, hasBody: true, diagnostics: diagnostics);
             CheckModifiersForBody(location, diagnostics);
@@ -219,6 +221,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             _property = property;
             _isAutoPropertyAccessor = isAutoPropertyAccessor;
+            _declaredUnsafe = modifiers.Any(SyntaxKind.UnsafeKeyword);
             Debug.Assert(!_property.IsExpressionBodied, "Cannot have accessors in expression bodied lightweight properties");
             var hasAnyBody = hasBlockBody || hasExpressionBody;
             _usesInit = usesInit;
@@ -275,7 +278,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 #nullable disable
 
         private static DeclarationModifiers GetAccessorModifiers(DeclarationModifiers propertyModifiers) =>
-            propertyModifiers & ~(DeclarationModifiers.Indexer | DeclarationModifiers.ReadOnly | DeclarationModifiers.Unsafe);
+            propertyModifiers & ~(DeclarationModifiers.Indexer | DeclarationModifiers.ReadOnly);
 
         internal override ExecutableCodeBinder TryGetBodyBinder(BinderFactory binderFactoryOpt = null, bool ignoreAccessibility = false)
         {
@@ -881,7 +884,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics.Add(ErrorCode.ERR_PartialMemberReadOnlyDifference, implementationAccessor.GetFirstLocation());
             }
 
-            if (IsUnsafe != implementationAccessor.IsUnsafe)
+            if (_declaredUnsafe != implementationAccessor._declaredUnsafe)
             {
                 diagnostics.Add(ErrorCode.ERR_PartialMemberUnsafeDifference, implementationAccessor.GetFirstLocation());
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -529,6 +529,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             // Check that the set of modifiers is allowed
             var allowedModifiers = isExplicitInterfaceImplementation ? DeclarationModifiers.None : DeclarationModifiers.AccessibilityMask;
+            allowedModifiers |= DeclarationModifiers.Unsafe;
 
             if (containingType.IsStructType())
             {
@@ -545,6 +546,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             var mods = ModifierUtils.MakeAndCheckNonTypeMemberModifiers(isOrdinaryMethod: false, isForInterfaceMember: isInterface,
                                                                         modifiers, defaultAccess, allowedModifiers, location, diagnostics, out modifierErrors, out _);
+
+            if ((mods & DeclarationModifiers.Unsafe) != 0)
+            {
+                var syntax = modifiers.FirstOrDefault(SyntaxKind.UnsafeKeyword);
+                modifierErrors |= !MessageID.IDS_FeatureUnsafeEvolution.CheckFeatureAvailability(diagnostics, syntax);
+            }
 
             ModifierUtils.ReportDefaultInterfaceImplementationModifiers(hasBody, mods,
                                                                         defaultInterfaceImplementationModifiers,
@@ -872,6 +879,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (LocalDeclaredReadOnly != implementationAccessor.LocalDeclaredReadOnly)
             {
                 diagnostics.Add(ErrorCode.ERR_PartialMemberReadOnlyDifference, implementationAccessor.GetFirstLocation());
+            }
+
+            if (IsUnsafe != implementationAccessor.IsUnsafe)
+            {
+                diagnostics.Add(ErrorCode.ERR_PartialMemberUnsafeDifference, implementationAccessor.GetFirstLocation());
             }
 
             if (_usesInit != implementationAccessor._usesInit)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -25,7 +25,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private string _lazyName;
         private readonly bool _isAutoPropertyAccessor;
         private readonly bool _usesInit;
-        private readonly bool _declaredUnsafe;
 
         public static SourcePropertyAccessorSymbol CreateAccessorSymbol(
             NamedTypeSymbol containingType,
@@ -187,7 +186,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             _property = property;
             _isAutoPropertyAccessor = false;
-            _declaredUnsafe = false;
 
             CheckFeatureAvailabilityAndRuntimeSupport(syntax, location, hasBody: true, diagnostics: diagnostics);
             CheckModifiersForBody(location, diagnostics);
@@ -221,7 +219,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             _property = property;
             _isAutoPropertyAccessor = isAutoPropertyAccessor;
-            _declaredUnsafe = modifiers.Any(SyntaxKind.UnsafeKeyword);
             Debug.Assert(!_property.IsExpressionBodied, "Cannot have accessors in expression bodied lightweight properties");
             var hasAnyBody = hasBlockBody || hasExpressionBody;
             _usesInit = usesInit;
@@ -278,7 +275,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 #nullable disable
 
         private static DeclarationModifiers GetAccessorModifiers(DeclarationModifiers propertyModifiers) =>
-            propertyModifiers & ~(DeclarationModifiers.Indexer | DeclarationModifiers.ReadOnly);
+            propertyModifiers & ~(DeclarationModifiers.Indexer | DeclarationModifiers.ReadOnly | DeclarationModifiers.Unsafe);
 
         internal override ExecutableCodeBinder TryGetBodyBinder(BinderFactory binderFactoryOpt = null, bool ignoreAccessibility = false)
         {
@@ -464,6 +461,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Indicates whether this accessor itself has a 'readonly' modifier.
         /// </summary>
         internal bool LocalDeclaredReadOnly => (DeclarationModifiers & DeclarationModifiers.ReadOnly) != 0;
+
+        /// <summary>
+        /// Indicates whether this accessor itself has an 'unsafe' modifier.
+        /// </summary>
+        internal bool LocalDeclaredUnsafe => (DeclarationModifiers & DeclarationModifiers.Unsafe) != 0;
 
         /// <summary>
         /// Indicates whether this accessor is readonly due to reasons scoped to itself and its containing property.
@@ -884,7 +886,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics.Add(ErrorCode.ERR_PartialMemberReadOnlyDifference, implementationAccessor.GetFirstLocation());
             }
 
-            if (_declaredUnsafe != implementationAccessor._declaredUnsafe)
+            if (LocalDeclaredUnsafe != implementationAccessor.LocalDeclaredUnsafe)
             {
                 diagnostics.Add(ErrorCode.ERR_PartialMemberUnsafeDifference, implementationAccessor.GetFirstLocation());
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -275,7 +275,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 #nullable disable
 
         private static DeclarationModifiers GetAccessorModifiers(DeclarationModifiers propertyModifiers) =>
-            propertyModifiers & ~(DeclarationModifiers.Indexer | DeclarationModifiers.ReadOnly);
+            propertyModifiers & ~(DeclarationModifiers.Indexer | DeclarationModifiers.ReadOnly | DeclarationModifiers.Unsafe);
 
         internal override ExecutableCodeBinder TryGetBodyBinder(BinderFactory binderFactoryOpt = null, bool ignoreAccessibility = false)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -468,6 +468,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal bool LocalDeclaredUnsafe => (DeclarationModifiers & DeclarationModifiers.Unsafe) != 0;
 
         /// <summary>
+        /// Whether this accessor or its containing property has an 'unsafe' modifier.
+        /// </summary>
+        internal sealed override bool IsUnsafe => LocalDeclaredUnsafe || _property.HasUnsafeModifier;
+
+        /// <summary>
         /// Indicates whether this accessor is readonly due to reasons scoped to itself and its containing property.
         /// </summary>
         internal sealed override bool IsDeclaredReadOnly

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -771,7 +771,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics.Add(ErrorCode.ERR_PartialMemberReadOnlyDifference, implementation.GetFirstLocation());
             }
 
-            if (IsDeclaredUnsafe != implementation.IsDeclaredUnsafe && this.CompilationAllowsUnsafe()) // Don't cascade.
+            if (HasUnsafeModifier != implementation.HasUnsafeModifier && this.CompilationAllowsUnsafe()) // Don't cascade.
             {
                 diagnostics.Add(ErrorCode.ERR_PartialMemberUnsafeDifference, implementation.GetFirstLocation());
             }
@@ -821,11 +821,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private static BaseParameterListSyntax? GetParameterListSyntax(CSharpSyntaxNode syntax)
             => (syntax as IndexerDeclarationSyntax)?.ParameterList;
-
-        /// <summary>
-        /// Whether the property has the <see langword="unsafe"/> keyword in its signature.
-        /// </summary>
-        internal bool IsDeclaredUnsafe => (_modifiers & DeclarationModifiers.Unsafe) != 0;
 
         internal override CallerUnsafeMode CallerUnsafeMode
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -825,7 +825,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Whether the property has the <see langword="unsafe"/> keyword in its signature.
         /// </summary>
-        private bool IsDeclaredUnsafe => (_modifiers & DeclarationModifiers.Unsafe) != 0;
+        internal bool IsDeclaredUnsafe => (_modifiers & DeclarationModifiers.Unsafe) != 0;
 
         internal override CallerUnsafeMode CallerUnsafeMode
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
@@ -625,6 +625,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal bool HasReadOnlyModifier => (_modifiers & DeclarationModifiers.ReadOnly) != 0;
 
+        internal bool HasUnsafeModifier => (_modifiers & DeclarationModifiers.Unsafe) != 0;
+
 #nullable enable
         /// <summary>
         /// The method is called at the end of <see cref="SourcePropertySymbolBase"/> constructor.

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedPrimaryConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedPrimaryConstructor.cs
@@ -95,6 +95,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return ContainingType.IsNullableEnabledForConstructorsAndInitializers(IsStatic);
         }
 
+        internal sealed override bool IsUnsafe => (DeclarationModifiers & DeclarationModifiers.Unsafe) != 0;
+
         protected override bool IsWithinExpressionOrBlockBody(int position, out int offset)
         {
             offset = -1;

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSimpleProgramEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSimpleProgramEntryPointSymbol.cs
@@ -149,6 +149,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        internal sealed override bool IsUnsafe => (DeclarationModifiers & DeclarationModifiers.Unsafe) != 0;
+
         public override ImmutableArray<ParameterSymbol> Parameters
         {
             get

--- a/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests.cs
@@ -5452,60 +5452,147 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
     [Fact]
     public void Member_Property_Accessors_UnsafeKeyword()
     {
-        var source = """
+        CreateCompilation("""
             public class C
             {
-                public int P1 { unsafe get; set; }
-                public int P2 { get; unsafe set; }
-                public int P3 { unsafe get; unsafe set; }
-                public int P4 { unsafe get => 0; set { } }
-                public int P5 { get => 0; unsafe set { } }
+                public int P1 { unsafe get { int* p = null; return *p; } set { long* q = null; *q = value; } }
+                public int P2 { get { long* p = null; return (int)*p; } unsafe set { int* q = null; *q = value; } }
             }
-            """;
-
-        CreateCompilation(source, options: TestOptions.UnsafeReleaseDll)
-            .VerifyEmitDiagnostics();
+            """,
+            options: TestOptions.UnsafeReleaseDll)
+            .VerifyDiagnostics(
+            // (3,68): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //     public int P1 { unsafe get { int* p = null; return *p; } set { long* q = null; *q = value; } }
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "long*").WithLocation(3, 68),
+            // (3,85): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //     public int P1 { unsafe get { int* p = null; return *p; } set { long* q = null; *q = value; } }
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "q").WithLocation(3, 85),
+            // (4,27): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //     public int P2 { get { long* p = null; return (int)*p; } unsafe set { int* q = null; *q = value; } }
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "long*").WithLocation(4, 27),
+            // (4,56): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //     public int P2 { get { long* p = null; return (int)*p; } unsafe set { int* q = null; *q = value; } }
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "p").WithLocation(4, 56));
     }
 
     [Fact]
     public void Member_Property_Accessors_UnsafeKeyword_Partial()
     {
-        var source = """
+        CreateCompilation("""
             public partial class C
             {
                 public partial int P1 { unsafe get; set; }
-                public partial int P1 { unsafe get => 0; set { } }
+                public partial int P1 { unsafe get { int* p = null; return *p; } set { long* q = null; *q = value; } }
 
                 public partial int P2 { get; unsafe set; }
-                public partial int P2 { get => 0; unsafe set { } }
+                public partial int P2 { get { long* p = null; return (int)*p; } unsafe set { int* q = null; *q = value; } }
             }
-            """;
+            """,
+            options: TestOptions.UnsafeReleaseDll)
+            .VerifyDiagnostics(
+            // (4,76): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //     public partial int P1 { unsafe get { int* p = null; return *p; } set { long* q = null; *q = value; } }
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "long*").WithLocation(4, 76),
+            // (4,93): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //     public partial int P1 { unsafe get { int* p = null; return *p; } set { long* q = null; *q = value; } }
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "q").WithLocation(4, 93),
+            // (7,35): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //     public partial int P2 { get { long* p = null; return (int)*p; } unsafe set { int* q = null; *q = value; } }
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "long*").WithLocation(7, 35),
+            // (7,64): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //     public partial int P2 { get { long* p = null; return (int)*p; } unsafe set { int* q = null; *q = value; } }
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "p").WithLocation(7, 64));
 
-        CreateCompilation(source, options: TestOptions.UnsafeReleaseDll)
-            .VerifyEmitDiagnostics();
-
+        // Mismatch: definition has unsafe, implementation doesn't
         CreateCompilation("""
             partial class C
             {
                 public partial int P1 { unsafe get; set; }
-                public partial int P1 { get => 0; set { } }
+                public partial int P1 { get { int* p = null; return *p; } set { } }
             }
             """,
             options: TestOptions.UnsafeReleaseDll)
             .VerifyDiagnostics(
             // (4,29): error CS0764: Both partial member declarations must be unsafe or neither may be unsafe
-            //     public partial int P1 { get => 0; set { } }
-            Diagnostic(ErrorCode.ERR_PartialMemberUnsafeDifference, "get").WithLocation(4, 29));
+            //     public partial int P1 { get { int* p = null; return *p; } set { } }
+            Diagnostic(ErrorCode.ERR_PartialMemberUnsafeDifference, "get").WithLocation(4, 29),
+            // (4,35): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //     public partial int P1 { get { int* p = null; return *p; } set { } }
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(4, 35),
+            // (4,58): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //     public partial int P1 { get { int* p = null; return *p; } set { } }
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "p").WithLocation(4, 58));
 
+        // Property has unsafe on both, accessor inherits from property (no explicit accessor unsafe)
+        // Pointer operations work because property is unsafe
         CreateCompilation("""
             partial class C
             {
-                public partial int P1 { unsafe get; set; }
-                public partial int P1 { unsafe get => 0; set { } }
+                public unsafe partial int P { get; set; }
+                public unsafe partial int P { get { int* p = null; return *p; } set { int* q = null; *q = value; } }
             }
             """,
             options: TestOptions.UnsafeReleaseDll)
             .VerifyEmitDiagnostics();
+
+        // Both property and both accessors have unsafe - this is allowed
+        CreateCompilation("""
+            partial class C
+            {
+                public unsafe partial int P { unsafe get; set; }
+                public unsafe partial int P { unsafe get { int* p = null; return *p; } set { int* q = null; *q = value; } }
+            }
+            """,
+            options: TestOptions.UnsafeReleaseDll)
+            .VerifyEmitDiagnostics();
+
+        // Property has unsafe on both, but only one accessor has explicit unsafe - mismatch on accessor
+        CreateCompilation("""
+            partial class C
+            {
+                public unsafe partial int P { get; set; }
+                public unsafe partial int P { unsafe get => 0; set { } }
+            }
+            """,
+            options: TestOptions.UnsafeReleaseDll)
+            .VerifyDiagnostics(
+            // (4,42): error CS0764: Both partial member declarations must be unsafe or neither may be unsafe
+            //     public unsafe partial int P { unsafe get => 0; set { } }
+            Diagnostic(ErrorCode.ERR_PartialMemberUnsafeDifference, "get").WithLocation(4, 42));
+
+        // Property has unsafe on definition, implementation has unsafe on accessor - mismatch on both
+        CreateCompilation("""
+            partial class C
+            {
+                public unsafe partial int P { get; set; }
+                public partial int P { unsafe get => 0; set { } }
+            }
+            """,
+            options: TestOptions.UnsafeReleaseDll)
+            .VerifyDiagnostics(
+            // (4,24): error CS0764: Both partial member declarations must be unsafe or neither may be unsafe
+            //     public partial int P { unsafe get => 0; set { } }
+            Diagnostic(ErrorCode.ERR_PartialMemberUnsafeDifference, "P").WithLocation(4, 24),
+            // (4,35): error CS0764: Both partial member declarations must be unsafe or neither may be unsafe
+            //     public partial int P { unsafe get => 0; set { } }
+            Diagnostic(ErrorCode.ERR_PartialMemberUnsafeDifference, "get").WithLocation(4, 35));
+
+        // Property has unsafe on implementation, definition has unsafe on accessor - mismatch on both
+        CreateCompilation("""
+            partial class C
+            {
+                public partial int P { unsafe get; set; }
+                public unsafe partial int P { get => 0; set { } }
+            }
+            """,
+            options: TestOptions.UnsafeReleaseDll)
+            .VerifyDiagnostics(
+            // (4,31): error CS0764: Both partial member declarations must be unsafe or neither may be unsafe
+            //     public unsafe partial int P { get => 0; set { } }
+            Diagnostic(ErrorCode.ERR_PartialMemberUnsafeDifference, "P").WithLocation(4, 31),
+            // (4,35): error CS0764: Both partial member declarations must be unsafe or neither may be unsafe
+            //     public unsafe partial int P { get => 0; set { } }
+            Diagnostic(ErrorCode.ERR_PartialMemberUnsafeDifference, "get").WithLocation(4, 35));
     }
 
     [Fact]
@@ -5958,58 +6045,147 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
     [Fact]
     public void Member_Indexer_Accessors_UnsafeKeyword()
     {
-        var source = """
+        CreateCompilation("""
             public class C
             {
-                public int this[int i] { unsafe get => i; set { } }
-                public int this[int i, int j] { get => i + j; unsafe set { } }
-                public int this[int i, int j, int k] { unsafe get => i; unsafe set { } }
+                public int this[int i] { unsafe get { int* p = null; return *p; } set { long* q = null; *q = value; } }
+                public int this[int i, int j] { get { long* p = null; return (int)*p; } unsafe set { int* q = null; *q = value; } }
             }
-            """;
-
-        CreateCompilation(source, options: TestOptions.UnsafeReleaseDll)
-            .VerifyEmitDiagnostics();
+            """,
+            options: TestOptions.UnsafeReleaseDll)
+            .VerifyDiagnostics(
+            // (3,77): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //     public int this[int i] { unsafe get { int* p = null; return *p; } set { long* q = null; *q = value; } }
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "long*").WithLocation(3, 77),
+            // (3,94): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //     public int this[int i] { unsafe get { int* p = null; return *p; } set { long* q = null; *q = value; } }
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "q").WithLocation(3, 94),
+            // (4,43): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //     public int this[int i, int j] { get { long* p = null; return (int)*p; } unsafe set { int* q = null; *q = value; } }
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "long*").WithLocation(4, 43),
+            // (4,72): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //     public int this[int i, int j] { get { long* p = null; return (int)*p; } unsafe set { int* q = null; *q = value; } }
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "p").WithLocation(4, 72));
     }
 
     [Fact]
     public void Member_Indexer_Accessors_UnsafeKeyword_Partial()
     {
-        var source = """
+        CreateCompilation("""
             public partial class C
             {
                 public partial int this[int i] { unsafe get; set; }
-                public partial int this[int i] { unsafe get => i; set { } }
+                public partial int this[int i] { unsafe get { int* p = null; return *p; } set { long* q = null; *q = value; } }
 
                 public partial int this[int i, int j] { get; unsafe set; }
-                public partial int this[int i, int j] { get => i + j; unsafe set { } }
+                public partial int this[int i, int j] { get { long* p = null; return (int)*p; } unsafe set { int* q = null; *q = value; } }
             }
-            """;
+            """,
+            options: TestOptions.UnsafeReleaseDll)
+            .VerifyDiagnostics(
+            // (4,85): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //     public partial int this[int i] { unsafe get { int* p = null; return *p; } set { long* q = null; *q = value; } }
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "long*").WithLocation(4, 85),
+            // (4,102): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //     public partial int this[int i] { unsafe get { int* p = null; return *p; } set { long* q = null; *q = value; } }
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "q").WithLocation(4, 102),
+            // (7,51): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //     public partial int this[int i, int j] { get { long* p = null; return (int)*p; } unsafe set { int* q = null; *q = value; } }
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "long*").WithLocation(7, 51),
+            // (7,80): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //     public partial int this[int i, int j] { get { long* p = null; return (int)*p; } unsafe set { int* q = null; *q = value; } }
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "p").WithLocation(7, 80));
 
-        CreateCompilation(source, options: TestOptions.UnsafeReleaseDll)
-            .VerifyEmitDiagnostics();
-
+        // Mismatch: definition has unsafe, implementation doesn't
         CreateCompilation("""
             partial class C
             {
                 public partial int this[int i] { unsafe get; set; }
-                public partial int this[int i] { get => i; set { } }
+                public partial int this[int i] { get { int* p = null; return *p; } set { } }
             }
             """,
             options: TestOptions.UnsafeReleaseDll)
             .VerifyDiagnostics(
             // (4,38): error CS0764: Both partial member declarations must be unsafe or neither may be unsafe
-            //     public partial int this[int i] { get => i; set { } }
-            Diagnostic(ErrorCode.ERR_PartialMemberUnsafeDifference, "get").WithLocation(4, 38));
+            //     public partial int this[int i] { get { int* p = null; return *p; } set { } }
+            Diagnostic(ErrorCode.ERR_PartialMemberUnsafeDifference, "get").WithLocation(4, 38),
+            // (4,44): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //     public partial int this[int i] { get { int* p = null; return *p; } set { } }
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(4, 44),
+            // (4,67): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //     public partial int this[int i] { get { int* p = null; return *p; } set { } }
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "p").WithLocation(4, 67));
 
+        // Indexer has unsafe on both, accessor inherits from indexer (no explicit accessor unsafe)
+        // Pointer operations work because indexer is unsafe
         CreateCompilation("""
             partial class C
             {
-                public partial int this[int i] { unsafe get; set; }
-                public partial int this[int i] { unsafe get => i; set { } }
+                public unsafe partial int this[int i] { get; set; }
+                public unsafe partial int this[int i] { get { int* p = null; return *p; } set { int* q = null; *q = value; } }
             }
             """,
             options: TestOptions.UnsafeReleaseDll)
             .VerifyEmitDiagnostics();
+
+        // Both indexer and both accessors have unsafe - this is allowed
+        CreateCompilation("""
+            partial class C
+            {
+                public unsafe partial int this[int i] { unsafe get; set; }
+                public unsafe partial int this[int i] { unsafe get { int* p = null; return *p; } set { int* q = null; *q = value; } }
+            }
+            """,
+            options: TestOptions.UnsafeReleaseDll)
+            .VerifyEmitDiagnostics();
+
+        // Indexer has unsafe on both, but only one accessor has explicit unsafe - mismatch on accessor
+        CreateCompilation("""
+            partial class C
+            {
+                public unsafe partial int this[int i] { get; set; }
+                public unsafe partial int this[int i] { unsafe get => i; set { } }
+            }
+            """,
+            options: TestOptions.UnsafeReleaseDll)
+            .VerifyDiagnostics(
+            // (4,52): error CS0764: Both partial member declarations must be unsafe or neither may be unsafe
+            //     public unsafe partial int this[int i] { unsafe get => i; set { } }
+            Diagnostic(ErrorCode.ERR_PartialMemberUnsafeDifference, "get").WithLocation(4, 52));
+
+        // Indexer has unsafe on definition, implementation has unsafe on accessor - mismatch on both
+        CreateCompilation("""
+            partial class C
+            {
+                public unsafe partial int this[int i] { get; set; }
+                public partial int this[int i] { unsafe get => i; set { } }
+            }
+            """,
+            options: TestOptions.UnsafeReleaseDll)
+            .VerifyDiagnostics(
+            // (4,24): error CS0764: Both partial member declarations must be unsafe or neither may be unsafe
+            //     public partial int this[int i] { unsafe get => i; set { } }
+            Diagnostic(ErrorCode.ERR_PartialMemberUnsafeDifference, "this").WithLocation(4, 24),
+            // (4,45): error CS0764: Both partial member declarations must be unsafe or neither may be unsafe
+            //     public partial int this[int i] { unsafe get => i; set { } }
+            Diagnostic(ErrorCode.ERR_PartialMemberUnsafeDifference, "get").WithLocation(4, 45));
+
+        // Indexer has unsafe on implementation, definition has unsafe on accessor - mismatch on both
+        CreateCompilation("""
+            partial class C
+            {
+                public partial int this[int i] { unsafe get; set; }
+                public unsafe partial int this[int i] { get => i; set { } }
+            }
+            """,
+            options: TestOptions.UnsafeReleaseDll)
+            .VerifyDiagnostics(
+            // (4,31): error CS0764: Both partial member declarations must be unsafe or neither may be unsafe
+            //     public unsafe partial int this[int i] { get => i; set { } }
+            Diagnostic(ErrorCode.ERR_PartialMemberUnsafeDifference, "this").WithLocation(4, 31),
+            // (4,45): error CS0764: Both partial member declarations must be unsafe or neither may be unsafe
+            //     public unsafe partial int this[int i] { get => i; set { } }
+            Diagnostic(ErrorCode.ERR_PartialMemberUnsafeDifference, "get").WithLocation(4, 45));
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests.cs
@@ -6314,6 +6314,26 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
     }
 
     [Fact]
+    public void Member_Event_Accessors_UnsafeKeyword()
+    {
+        // unsafe on event accessors is not allowed (like other modifiers on event accessors)
+        CreateCompilation("""
+            public class C
+            {
+                public event System.Action E { unsafe add { int* p = null; } unsafe remove { int* p = null; } }
+            }
+            """,
+            options: TestOptions.UnsafeReleaseDll)
+            .VerifyDiagnostics(
+            // (3,36): error CS1609: Modifiers cannot be placed on event accessor declarations
+            //     public event System.Action E { unsafe add { int* p = null; } unsafe remove { int* p = null; } }
+            Diagnostic(ErrorCode.ERR_NoModifiersOnAccessor, "unsafe").WithLocation(3, 36),
+            // (3,66): error CS1609: Modifiers cannot be placed on event accessor declarations
+            //     public event System.Action E { unsafe add { int* p = null; } unsafe remove { int* p = null; } }
+            Diagnostic(ErrorCode.ERR_NoModifiersOnAccessor, "unsafe").WithLocation(3, 66));
+    }
+
+    [Fact]
     public void Member_Event_Override()
     {
         CompileAndVerifyUnsafe(

--- a/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests.cs
@@ -5450,6 +5450,91 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
     }
 
     [Fact]
+    public void Member_Property_Accessors_UnsafeKeyword()
+    {
+        var source = """
+            public class C
+            {
+                public int P1 { unsafe get; set; }
+                public int P2 { get; unsafe set; }
+                public int P3 { unsafe get; unsafe set; }
+                public int P4 { unsafe get => 0; set { } }
+                public int P5 { get => 0; unsafe set { } }
+            }
+            """;
+
+        CreateCompilation(source, options: TestOptions.UnsafeReleaseDll)
+            .VerifyEmitDiagnostics();
+    }
+
+    [Fact]
+    public void Member_Property_Accessors_UnsafeKeyword_Partial()
+    {
+        var source = """
+            public partial class C
+            {
+                public partial int P1 { unsafe get; set; }
+                public partial int P1 { unsafe get => 0; set { } }
+
+                public partial int P2 { get; unsafe set; }
+                public partial int P2 { get => 0; unsafe set { } }
+            }
+            """;
+
+        CreateCompilation(source, options: TestOptions.UnsafeReleaseDll)
+            .VerifyEmitDiagnostics();
+
+        CreateCompilation("""
+            partial class C
+            {
+                public partial int P1 { unsafe get; set; }
+                public partial int P1 { get => 0; set { } }
+            }
+            """,
+            options: TestOptions.UnsafeReleaseDll)
+            .VerifyDiagnostics(
+            // (4,29): error CS0764: Both partial member declarations must be unsafe or neither may be unsafe
+            //     public partial int P1 { get => 0; set { } }
+            Diagnostic(ErrorCode.ERR_PartialMemberUnsafeDifference, "get").WithLocation(4, 29));
+
+        CreateCompilation("""
+            partial class C
+            {
+                public partial int P1 { unsafe get; set; }
+                public partial int P1 { unsafe get => 0; set { } }
+            }
+            """,
+            options: TestOptions.UnsafeReleaseDll)
+            .VerifyEmitDiagnostics();
+    }
+
+    [Fact]
+    public void Member_Property_Accessors_UnsafeKeyword_LangVersion()
+    {
+        var source = """
+            public class C
+            {
+                public int P1 { unsafe get; set; }
+                public int P2 { get; unsafe set; }
+            }
+            """;
+
+        CreateCompilation(source, options: TestOptions.UnsafeReleaseDll)
+            .VerifyEmitDiagnostics();
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeReleaseDll)
+            .VerifyEmitDiagnostics();
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeReleaseDll)
+            .VerifyDiagnostics(
+            // (3,21): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     public int P1 { unsafe get; set; }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(3, 21),
+            // (4,26): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     public int P2 { get; unsafe set; }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(4, 26));
+    }
+
+    [Fact]
     public void Member_Property_Field()
     {
         CreateCompilation(
@@ -5868,6 +5953,89 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         CreateCompilation([lib, RequiresUnsafeAttributeDefinition], parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics(expectedDiagnostics);
         CreateCompilation([lib, RequiresUnsafeAttributeDefinition], parseOptions: TestOptions.RegularPreview).VerifyEmitDiagnostics(expectedDiagnostics);
+    }
+
+    [Fact]
+    public void Member_Indexer_Accessors_UnsafeKeyword()
+    {
+        var source = """
+            public class C
+            {
+                public int this[int i] { unsafe get => i; set { } }
+                public int this[int i, int j] { get => i + j; unsafe set { } }
+                public int this[int i, int j, int k] { unsafe get => i; unsafe set { } }
+            }
+            """;
+
+        CreateCompilation(source, options: TestOptions.UnsafeReleaseDll)
+            .VerifyEmitDiagnostics();
+    }
+
+    [Fact]
+    public void Member_Indexer_Accessors_UnsafeKeyword_Partial()
+    {
+        var source = """
+            public partial class C
+            {
+                public partial int this[int i] { unsafe get; set; }
+                public partial int this[int i] { unsafe get => i; set { } }
+
+                public partial int this[int i, int j] { get; unsafe set; }
+                public partial int this[int i, int j] { get => i + j; unsafe set { } }
+            }
+            """;
+
+        CreateCompilation(source, options: TestOptions.UnsafeReleaseDll)
+            .VerifyEmitDiagnostics();
+
+        CreateCompilation("""
+            partial class C
+            {
+                public partial int this[int i] { unsafe get; set; }
+                public partial int this[int i] { get => i; set { } }
+            }
+            """,
+            options: TestOptions.UnsafeReleaseDll)
+            .VerifyDiagnostics(
+            // (4,38): error CS0764: Both partial member declarations must be unsafe or neither may be unsafe
+            //     public partial int this[int i] { get => i; set { } }
+            Diagnostic(ErrorCode.ERR_PartialMemberUnsafeDifference, "get").WithLocation(4, 38));
+
+        CreateCompilation("""
+            partial class C
+            {
+                public partial int this[int i] { unsafe get; set; }
+                public partial int this[int i] { unsafe get => i; set { } }
+            }
+            """,
+            options: TestOptions.UnsafeReleaseDll)
+            .VerifyEmitDiagnostics();
+    }
+
+    [Fact]
+    public void Member_Indexer_Accessors_UnsafeKeyword_LangVersion()
+    {
+        var source = """
+            public class C
+            {
+                public int this[int i] { unsafe get => i; set { } }
+                public int this[int i, int j] { get => i + j; unsafe set { } }
+            }
+            """;
+
+        CreateCompilation(source, options: TestOptions.UnsafeReleaseDll)
+            .VerifyEmitDiagnostics();
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeReleaseDll)
+            .VerifyEmitDiagnostics();
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeReleaseDll)
+            .VerifyDiagnostics(
+            // (3,30): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     public int this[int i] { unsafe get => i; set { } }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(3, 30),
+            // (4,41): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     public int this[int i, int j] { get => i + j; unsafe set { } }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(4, 51));
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -2179,6 +2179,52 @@ unsafe class C
         }
 
         [Theory, CombinatorialData]
+        public void UnsafeContext_Property_Iterator_Signature_UnsafeAccessor(bool unsafeClass)
+        {
+            var code = $$"""
+                {{(unsafeClass ? "unsafe" : "")}} class C
+                {
+                    System.Collections.Generic.IEnumerable<int> P
+                    {
+                        unsafe get { yield break; }
+                        set { }
+                    }
+                }
+                """;
+
+            CreateCompilation(code, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+                // (5,9): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //         unsafe get { yield break; }
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(5, 9));
+
+            CreateCompilation(code, parseOptions: TestOptions.RegularPreview, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
+            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
+        }
+
+        [Theory, CombinatorialData]
+        public void UnsafeContext_Indexer_Iterator_Signature_UnsafeAccessor(bool unsafeClass)
+        {
+            var code = $$"""
+                {{(unsafeClass ? "unsafe" : "")}} class C
+                {
+                    System.Collections.Generic.IEnumerable<int> this[int x]
+                    {
+                        unsafe get { yield break; }
+                        set { }
+                    }
+                }
+                """;
+
+            CreateCompilation(code, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+                // (5,9): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //         unsafe get { yield break; }
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(5, 9));
+
+            CreateCompilation(code, parseOptions: TestOptions.RegularPreview, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
+            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
+        }
+
+        [Theory, CombinatorialData]
         public void UnsafeContext_LocalFunction_Signature_Unsafe(bool unsafeBlock, bool unsafeFunction)
         {
             if (!unsafeBlock && !unsafeFunction)


### PR DESCRIPTION
Test plan: https://github.com/dotnet/roslyn/issues/81207
Adding support for `unsafe` modifier on property accessors in preparation for letting the `unsafe` keyword denote *requires-unsafe* members instead of the `[RequiresUnsafe]` attribute.
Related speclet change: https://github.com/dotnet/csharplang/pull/10091

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83115)