### PR TITLE
Fix mishandling of multiple output path changes in a single batch

### DIFF
--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/MetadataToProjectReferenceConversionTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/MetadataToProjectReferenceConversionTests.vb
@@ -417,6 +417,74 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             End Using
         End Function
 
+        <WpfFact>
+        <WorkItem("https://github.com/dotnet/roslyn/issues/79705")>
+        Public Async Function OutputPathChangesInSameBatchStartingAsMetadataReference() As Task
+            ' Scenario: project2 starts with a plain metadata reference to c:\project1.dll (no project has
+            ' that output path yet). Within a single batch on project1, the output path properties are set
+            ' so that c:\project1.dll is added, removed, and re-added as an output path. This causes the
+            ' metadata reference to be converted, unconverted, and reconverted.
+            Using environment = New TestEnvironment()
+                Dim project1 = Await environment.ProjectFactory.CreateAndAddToWorkspaceAsync(
+                    "project1", LanguageNames.CSharp, CancellationToken.None)
+
+                Dim project2 = Await environment.ProjectFactory.CreateAndAddToWorkspaceAsync(
+                    "project2", LanguageNames.CSharp, CancellationToken.None)
+
+                Const ReferencePath = "C:\project1.dll"
+                project2.AddMetadataReference(ReferencePath, MetadataReferenceProperties.Assembly)
+
+                Dim getProject2 = Function() environment.Workspace.CurrentSolution.GetProject(project2.Id)
+
+                Assert.Single(getProject2().MetadataReferences)
+                Assert.Empty(getProject2().ProjectReferences)
+
+                Using project1.CreateBatchScope()
+                    project1.OutputFilePath = ReferencePath
+                    project1.OutputFilePath = Nothing
+                    project1.OutputFilePath = ReferencePath
+                End Using
+
+                ' The metadata reference should have been converted to a project reference
+                Assert.Single(getProject2().ProjectReferences)
+                Assert.Empty(getProject2().MetadataReferences)
+            End Using
+        End Function
+
+        <WpfFact>
+        <WorkItem("https://github.com/dotnet/roslyn/issues/79705")>
+        Public Async Function OutputPathChangesInSameBatchStartingAsProjectReference() As Task
+            ' Scenario: project2 starts with a project reference to project1 (because project1 already has
+            ' output path c:\project1.dll). Within a single batch, project1's output path is removed and
+            ' re-added causing the reference to be unconverted to a metadata reference and then reconverted
+            ' back to a project reference within the same batch.
+            Using environment = New TestEnvironment()
+                Dim project1 = Await environment.ProjectFactory.CreateAndAddToWorkspaceAsync(
+                    "project1", LanguageNames.CSharp, CancellationToken.None)
+
+                Dim project2 = Await environment.ProjectFactory.CreateAndAddToWorkspaceAsync(
+                    "project2", LanguageNames.CSharp, CancellationToken.None)
+
+                Const ReferencePath = "C:\project1.dll"
+                project1.OutputFilePath = ReferencePath
+                project2.AddMetadataReference(ReferencePath, MetadataReferenceProperties.Assembly)
+
+                Dim getProject2 = Function() environment.Workspace.CurrentSolution.GetProject(project2.Id)
+
+                Assert.Single(getProject2().ProjectReferences)
+                Assert.Empty(getProject2().MetadataReferences)
+
+                Using project1.CreateBatchScope()
+                    project1.OutputFilePath = Nothing
+                    project1.OutputFilePath = ReferencePath
+                    project1.OutputFilePath = Nothing
+                End Using
+
+                Assert.Empty(getProject2().ProjectReferences)
+                Assert.Single(getProject2().MetadataReferences)
+            End Using
+        End Function
+
         ''' <summary>
         ''' Stress test that creates multiple threads which randomly create projects, add/remove
         ''' metadata references (including shared references and project output references),

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
@@ -427,21 +427,26 @@ internal sealed partial class ProjectSystemProjectFactory
     {
         Contract.ThrowIfFalse(_gate.CurrentCount == 0);
 
-        // Remove file watchers for any references we're no longer watching.
-        foreach (var reference in projectUpdateState.RemovedMetadataReferences)
-            FileWatchedPortableExecutableReferenceFactory.StopWatchingReference(reference.FilePath!, referenceToTrack: reference);
+        // WARNING: the lists in projectUpdateState.RemovedMetadataReference and AddedMetadataReferences may have duplicates across them;
+        // if a number of output paths change in a single batch for example, we might convert metadata references to project references and back
+        // within a single batch. To keep things simple, we should call StartWatchingReference before Stop, so that way we don't accidentally run the
+        // reference counts those maintain below zero.
 
         // Add file watchers for any references we are now watching.
         foreach (var reference in projectUpdateState.AddedMetadataReferences)
             FileWatchedPortableExecutableReferenceFactory.StartWatchingReference(reference.FilePath!);
 
         // Remove file watchers for any references we're no longer watching.
-        foreach (var referenceFullPath in projectUpdateState.RemovedAnalyzerReferences)
-            FileWatchedAnalyzerReferenceFactory.StopWatchingReference(referenceFullPath, referenceToTrack: null);
+        foreach (var reference in projectUpdateState.RemovedMetadataReferences)
+            FileWatchedPortableExecutableReferenceFactory.StopWatchingReference(reference.FilePath!, referenceToTrack: reference);
 
-        // Add file watchers for any references we are now watching.
+        // Add file watchers for any analyzers we are now watching.
         foreach (var referenceFullPath in projectUpdateState.AddedAnalyzerReferences)
             FileWatchedAnalyzerReferenceFactory.StartWatchingReference(referenceFullPath);
+
+        // Remove file watchers for any analyzers we're no longer watching.
+        foreach (var referenceFullPath in projectUpdateState.RemovedAnalyzerReferences)
+            FileWatchedAnalyzerReferenceFactory.StopWatchingReference(referenceFullPath, referenceToTrack: null);
 
         // Clear the state from the this update in preparation for the next.
         projectUpdateState = projectUpdateState.ClearIncrementalState();


### PR DESCRIPTION
If we had multiple output path changes in a single batch, we might try converting metadata references to project references and back multiple times. In that particular case, we were calling StopWatchingReference in the FileWatchedReferenceFactory for a reference we hadn't called StartWatchingReference for, and so if there were too many conversions we might end up running the reference count negative.

This may fix https://github.com/dotnet/roslyn/issues/79705, although I'm not entirely confident this particular edge case would actually happen in real projects, or if it does, why we'd be seeing the flakiness we're observing where it doesn't tend to reproduce again.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83121)