### PR TITLE
Enable LSP agent tool in repo

### DIFF
--- a/.github/lsp.json
+++ b/.github/lsp.json
@@ -1,0 +1,19 @@
+{
+  "lspServers": {
+    "csharp": {
+      "command": "dotnet",
+      "args": [
+        "dnx",
+        "roslyn-language-server",
+        "--yes",
+        "--prerelease",
+        "--",
+        "--stdio",
+        "--autoLoadProjects"
+      ],
+      "fileExtensions": {
+        ".cs": "csharp"
+      }
+    }
+  }
+}

--- a/docs/roslyn-language-server-copilot-plugin.md
+++ b/docs/roslyn-language-server-copilot-plugin.md
@@ -4,6 +4,8 @@ The `roslyn-language-server` is a .NET tool that provides C# language intelligen
 
 ## Quick Start
 
+For this repository specifically, the equivalent Copilot CLI LSP configuration is already checked in at `.github/lsp.json`, and `.vscode/settings.json` points the server at `Roslyn.slnx`. That means opening this repo in Copilot CLI is enough to have the C# LSP configured automatically.
+
 ### Install the plugin
 
 In your agent (Copilot CLI, etc.), add the marketplace and install the `dotnet` plugin:


### PR DESCRIPTION
The goal is to make the LSP available to CCA
Follow-up to https://github.com/dotnet/roslyn/pull/82965
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83122)