### PR TITLE
Fix Call Hierarchy missing interface implementation category for overrides

### DIFF
--- a/src/Features/Core/Portable/CallHierarchy/AbstractCallHierarchyService.cs
+++ b/src/Features/Core/Portable/CallHierarchy/AbstractCallHierarchyService.cs
@@ -125,15 +125,25 @@ internal abstract class AbstractCallHierarchyService : ICallHierarchyService
                     overriddenItemId));
             }
 
-            var implementedInterfaceMembers = await SymbolFinder.FindImplementedInterfaceMembersAsync(symbol, project.Solution, cancellationToken: cancellationToken).ConfigureAwait(false);
-            foreach (var implementedInterfaceMember in implementedInterfaceMembers)
+            // An override may not directly implement an interface member, but its base method
+            // might.  Walk the override chain so we still surface the "Calls To Interface
+            // Implementation" category for such overrides.
+            using var __ = PooledHashSet<CallHierarchyItemId>.GetInstance(out var seenInterfaces);
+            for (var current = symbol; current != null; current = current.GetOverriddenMember())
             {
-                if (!CallHierarchyItemId.TryCreate(implementedInterfaceMember, project, cancellationToken, out var interfaceItemId))
-                    continue;
+                var implementedInterfaceMembers = await SymbolFinder.FindImplementedInterfaceMembersAsync(current, project.Solution, cancellationToken: cancellationToken).ConfigureAwait(false);
+                foreach (var implementedInterfaceMember in implementedInterfaceMembers)
+                {
+                    if (!CallHierarchyItemId.TryCreate(implementedInterfaceMember, project, cancellationToken, out var interfaceItemId))
+                        continue;
 
-                descriptors.Add(new CallHierarchySearchDescriptor(
-                    CallHierarchyRelationshipKind.InterfaceImplementations,
-                    interfaceItemId));
+                    if (!seenInterfaces.Add(interfaceItemId))
+                        continue;
+
+                    descriptors.Add(new CallHierarchySearchDescriptor(
+                        CallHierarchyRelationshipKind.InterfaceImplementations,
+                        interfaceItemId));
+                }
             }
 
             if (symbol.IsImplementableMember())

--- a/src/VisualStudio/CSharp/Test/CallHierarchy/CSharpCallHierarchyTests.cs
+++ b/src/VisualStudio/CSharp/Test/CallHierarchy/CSharpCallHierarchyTests.cs
@@ -553,6 +553,49 @@ public sealed class CSharpCallHierarchyTests
     }
 
     [WpfFact]
+    public async Task Method_OverrideOfInterfaceImplementation()
+    {
+        var text = """
+            using System;
+
+            interface IFoo { void Bar(); }
+
+            class FooBase : IFoo
+            {
+                public virtual void Bar()
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            class Foo : FooBase
+            {
+                public override void B$$ar()
+                {
+                    base.Bar();
+                    Console.WriteLine("Bar");
+                }
+            }
+
+            class Program
+            {
+                void Main()
+                {
+                    IFoo foo = new Foo();
+                    foo.Bar();
+                }
+            }
+            """;
+        using var testState = CallHierarchyTestState.Create(text);
+        var root = await testState.GetRootAsync();
+        testState.VerifyRoot(root, "Foo.Bar()", [
+            string.Format(EditorFeaturesResources.Calls_To_0, "Bar"),
+            string.Format(EditorFeaturesResources.Calls_To_Base_Member_0, "FooBase.Bar()"),
+            string.Format(EditorFeaturesResources.Calls_To_Interface_Implementation_0, "IFoo.Bar()")]);
+        testState.VerifyResult(root, string.Format(EditorFeaturesResources.Calls_To_Interface_Implementation_0, "IFoo.Bar()"), ["Program.Main()"]);
+    }
+
+    [WpfFact]
     [WorkItem("https://github.com/dotnet/roslyn/issues/71068")]
     public async Task Method_ExcludeNameofReferencesWithoutMemberAccess()
     {


### PR DESCRIPTION
Fixes: https://developercommunity.visualstudio.com/t/Call-Hierarchy-not-finding-calls-to-over/11064394
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2853245/?view=edit
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83132)