### PR TITLE
Unsafe evolution: make pointers safe regardless of memory safety rules version

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 11.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 11.md
@@ -215,7 +215,7 @@ object with(object a, object b) { ... }
 ***Introduced in Visual Studio 2026 version 18.7***
 
 In a future C# version (currently in `langversion:preview`), pointer types (e.g., `int*`, `delegate*<void>`) no longer require an unsafe context.
-Only pointer operations (dereference, member access via `->`, element access, etc.) require unsafe.
+Only pointer indirection operations (dereference, member access via `->`, element access, etc.) require unsafe.
 This is part of the [unsafe evolution](https://github.com/dotnet/csharplang/issues/9704) feature.
 
 Because pointer types are now legal in safe contexts, overload resolution may consider candidates that were previously excluded. This can cause new ambiguity errors:

--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 11.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 11.md
@@ -209,3 +209,77 @@ items = [with(x, y), z];  // C# 14: call to with() method; C# 15: error args not
 items = [@with(x, y), z]; // call to with() method
 object with(object a, object b) { ... }
 ```
+
+## Pointer types no longer require an unsafe context
+
+***Introduced in Visual Studio 2026 version 18.7***
+
+In a future C# version (currently in `langversion:preview`), pointer types (e.g., `int*`, `delegate*<void>`) no longer require an unsafe context.
+Only pointer operations (dereference, member access via `->`, element access, etc.) require unsafe.
+This is part of the [unsafe evolution](https://github.com/dotnet/csharplang/issues/9704) feature.
+
+Because pointer types are now legal in safe contexts, overload resolution may consider candidates that were previously excluded. This can cause new ambiguity errors:
+
+```cs
+using System;
+
+class Program
+{
+    static void Main()
+    {
+        M(x => { }); // C# 14: prints "2"; C# preview: error CS0121 (ambiguous)
+    }
+
+    static void M(F1 f) { Console.WriteLine(1); }
+    static void M(F2 f) { Console.WriteLine(2); }
+}
+
+unsafe delegate void F1(int* x);
+delegate void F2(int x);
+```
+
+Previously, the lambda `x => { }` could not convert to `F1` in a safe context because `int*` required an unsafe context, so only `M(F2)` was applicable.
+Now that `int*` is legal in safe contexts, the lambda is convertible to both delegates, producing an ambiguity error.
+
+If your code is impacted by the ambiguity change, add explicit parameter types to the lambda to disambiguate:
+
+```cs
+M((int x) => { }); // Resolves to M(F2)
+```
+
+## Uninitialized `stackalloc` inside `SkipLocalsInit` requires an unsafe context
+
+***Introduced in Visual Studio 2026 version 18.7***
+
+In a future C# version (currently in `langversion:preview`), a `stackalloc` expression without an initializer inside a method marked with `[SkipLocalsInit]` now requires an unsafe context, even when the target type is `Span<T>`.
+This is because `SkipLocalsInit` prevents zero-initialization of the allocated memory, making it possible to read uninitialized data - a memory safety concern.
+This is part of the [unsafe evolution](https://github.com/dotnet/csharplang/issues/9704) feature.
+
+```cs
+[System.Runtime.CompilerServices.SkipLocalsInit]
+void M()
+{
+    Span<int> a = stackalloc int[5];           // previously ok, now error CS9361
+    Span<int> b = stackalloc int[] { 1, 2 };   // ok (has initializer)
+    Span<int> c = stackalloc int[2] { 1, 2 };  // ok (has initializer)
+}
+```
+
+If your code is impacted, you can either:
+- Add an `unsafe` block around the `stackalloc`:
+  ```cs
+  [SkipLocalsInit]
+  void M()
+  {
+      Span<int> a;
+      unsafe { a = stackalloc int[5]; }
+  }
+  ```
+- Or provide an initializer so the memory is fully initialized:
+  ```cs
+  [SkipLocalsInit]
+  void M()
+  {
+      Span<int> a = stackalloc int[5] { 0, 0, 0, 0, 0 };
+  }
+  ```

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Unsafe.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Unsafe.cs
@@ -102,6 +102,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void ReportDiagnosticsIfUnsafeMemberAccess<T>(DiagnosticBag diagnostics, Symbol symbol, T arg, Func<T, Location?> location, bool forConstructorConstraint, ReadOnlySpan<object> additionalArgs = default)
         {
+            if (!this.Compilation.SourceModule.UseUpdatedMemorySafetyRules)
+            {
+                return;
+            }
+
             var callerUnsafeMode = symbol.CallerUnsafeMode;
             if (callerUnsafeMode != CallerUnsafeMode.None)
             {
@@ -246,15 +251,25 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else if (!this.InUnsafeRegion)
             {
+                var featureDiag = MessageID.IDS_FeatureUnsafeEvolution.GetFeatureAvailabilityDiagnosticInfo(this.Compilation);
+
                 if (disallowedUnder is MemorySafetyRules.Legacy)
                 {
                     Debug.Assert(customErrorCode is null && customArgs is null);
 
-                    if (this.Compilation.SourceModule.UseUpdatedMemorySafetyRules)
+                    // Feature available: pointer types are safe.
+                    if (featureDiag is null)
                     {
-                        return MessageID.IDS_FeatureUnsafeEvolution.GetFeatureAvailabilityDiagnosticInfo(this.Compilation);
+                        return null;
                     }
 
+                    // Feature not available but opted in: report feature availability error.
+                    if (this.Compilation.SourceModule.UseUpdatedMemorySafetyRules)
+                    {
+                        return featureDiag;
+                    }
+
+                    // Legacy rules.
                     return ((object?)sizeOfTypeOpt == null)
                         ? new CSDiagnosticInfo(ErrorCode.ERR_UnsafeNeeded)
                         : new CSDiagnosticInfo(ErrorCode.ERR_SizeofUnsafe, sizeOfTypeOpt);
@@ -262,10 +277,16 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 Debug.Assert(disallowedUnder is MemorySafetyRules.Updated);
 
+                // Feature available: pointer operations are unsafe.
+                if (featureDiag is null)
+                {
+                    return new CSDiagnosticInfo(customErrorCode ?? ErrorCode.ERR_UnsafeOperation, customArgs ?? []);
+                }
+
+                // Feature not available but opted in: report feature availability error.
                 if (this.Compilation.SourceModule.UseUpdatedMemorySafetyRules)
                 {
-                    return MessageID.IDS_FeatureUnsafeEvolution.GetFeatureAvailabilityDiagnosticInfo(this.Compilation)
-                        ?? new CSDiagnosticInfo(customErrorCode ?? ErrorCode.ERR_UnsafeOperation, customArgs ?? []);
+                    return featureDiag;
                 }
 
                 // This location is disallowed only under updated memory safety rules which are not enabled.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Unsafe.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Unsafe.cs
@@ -31,11 +31,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        internal void ReportDiagnosticsIfUnsafeMemberAccess(DiagnosticBag diagnostics, Symbol symbol, SyntaxNodeOrToken node)
-        {
-            ReportDiagnosticsIfUnsafeMemberAccess(diagnostics, symbol, node, static node => node.GetLocation());
-        }
-
         internal void ReportDiagnosticsIfUnsafeMemberAccess(DiagnosticBag diagnostics, Symbol symbol, Location? location)
         {
             ReportDiagnosticsIfUnsafeMemberAccess(diagnostics, symbol, location, static l => l);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Unsafe.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Unsafe.cs
@@ -43,6 +43,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void ReportDiagnosticsIfUnsafeMemberAccess<T>(DiagnosticBag diagnostics, Symbol symbol, T arg, Func<T, Location?> location)
         {
+            if (!this.Compilation.SourceModule.UseUpdatedMemorySafetyRules)
+            {
+                return;
+            }
+
             ReportDiagnosticsIfUnsafeMemberAccess(diagnostics, symbol, arg, location, forConstructorConstraint: false);
 
             if (ShouldCheckConstraints)
@@ -102,10 +107,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void ReportDiagnosticsIfUnsafeMemberAccess<T>(DiagnosticBag diagnostics, Symbol symbol, T arg, Func<T, Location?> location, bool forConstructorConstraint, ReadOnlySpan<object> additionalArgs = default)
         {
-            if (!this.Compilation.SourceModule.UseUpdatedMemorySafetyRules)
-            {
-                return;
-            }
+            Debug.Assert(this.Compilation.SourceModule.UseUpdatedMemorySafetyRules);
 
             var callerUnsafeMode = symbol.CallerUnsafeMode;
             if (callerUnsafeMode != CallerUnsafeMode.None)

--- a/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests.cs
@@ -37,7 +37,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CSharpCompilationOptions? optionsDll = null,
         TargetFramework targetFramework = TargetFramework.Standard,
         DiagnosticDescription[]? expectedDiagnosticsWhenReferencingLegacyLib = null,
-        DiagnosticDescription[]? expectedDiagnosticsForLegacyCaller = null)
+        DiagnosticDescription[]? expectedDiagnosticsForLegacyCaller = null,
+        DiagnosticDescription[]? expectedDiagnosticsWithOldLangVersion = null)
     {
         optionsDll ??= TestOptions.UnsafeReleaseDll;
         var optionsExe = optionsDll.WithOutputKind(OutputKind.ConsoleApplication);
@@ -49,6 +50,21 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             parseOptions: parseOptions,
             options: optionsExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(expectedDiagnostics);
+
+        CreateCompilation([lib, caller, .. additionalSources],
+            targetFramework: targetFramework,
+            parseOptions: TestOptions.RegularNext,
+            options: optionsExe.WithUpdatedMemorySafetyRules())
+            .VerifyDiagnostics(expectedDiagnostics);
+
+        if (expectedDiagnosticsWithOldLangVersion is { })
+        {
+            CreateCompilation([lib, caller, .. additionalSources],
+                targetFramework: targetFramework,
+                parseOptions: TestOptions.Regular14,
+                options: optionsExe.AddSpecificDiagnosticOptions(GetIdForErrorCode(ErrorCode.WRN_RequiresUnsafeAttributeLegacyRules), ReportDiagnostic.Suppress))
+                .VerifyDiagnostics(expectedDiagnosticsWithOldLangVersion);
+        }
 
         var libUpdated = CompileAndVerify([lib, .. additionalSources],
             targetFramework: targetFramework,
@@ -822,7 +838,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(1, 1),
         };
 
-        CreateCompilation(source, options: TestOptions.ReleaseExe.WithAllowUnsafe(allowUnsafe)).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, options: TestOptions.ReleaseExe.WithAllowUnsafe(allowUnsafe)).VerifyEmitDiagnostics();
 
         CreateCompilation(source,
             parseOptions: TestOptions.Regular14,
@@ -830,7 +846,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         CreateCompilation(source,
             parseOptions: TestOptions.RegularNext,
-            options: TestOptions.ReleaseExe.WithAllowUnsafe(allowUnsafe)).VerifyDiagnostics(expectedDiagnostics);
+            options: TestOptions.ReleaseExe.WithAllowUnsafe(allowUnsafe)).VerifyEmitDiagnostics();
 
         CreateCompilation(source, options: TestOptions.ReleaseExe.WithAllowUnsafe(allowUnsafe).WithUpdatedMemorySafetyRules()).VerifyEmitDiagnostics();
 
@@ -892,10 +908,18 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             }
             """;
 
-        CreateCompilation(source, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(
+        CreateCompilation(source,
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(
             // (6,9): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             //         int* p = null;
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(6, 9));
+
+        CreateCompilation(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.UnsafeReleaseExe).VerifyEmitDiagnostics();
+
+        CreateCompilation(source, options: TestOptions.UnsafeReleaseExe).VerifyEmitDiagnostics();
 
         CreateCompilation(source, options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules()).VerifyEmitDiagnostics();
 
@@ -988,7 +1012,11 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "X").WithLocation(2, 1),
         };
 
-        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyEmitDiagnostics();
+
+        CreateCompilation(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.ReleaseExe).VerifyEmitDiagnostics();
 
         CreateCompilation(source,
             parseOptions: TestOptions.Regular14,
@@ -1060,7 +1088,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             int y = *x;
             """;
 
-        CreateCompilation(source, options: TestOptions.ReleaseExe.WithAllowUnsafe(allowUnsafe))
+        CreateCompilation(source,
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.ReleaseExe.WithAllowUnsafe(allowUnsafe))
             .VerifyDiagnostics(
             // (1,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             // int* x = null;
@@ -1075,6 +1105,14 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             // int y = *x;
             Diagnostic(ErrorCode.ERR_UnsafeOperation, "*").WithLocation(2, 9),
         };
+
+        CreateCompilation(source, options: TestOptions.ReleaseExe.WithAllowUnsafe(allowUnsafe))
+            .VerifyDiagnostics(expectedDiagnostics);
+
+        CreateCompilation(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.ReleaseExe.WithAllowUnsafe(allowUnsafe))
+            .VerifyDiagnostics(expectedDiagnostics);
 
         CreateCompilation(source,
             options: TestOptions.ReleaseExe.WithAllowUnsafe(allowUnsafe).WithUpdatedMemorySafetyRules())
@@ -1118,7 +1156,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             }
             """;
 
-        CreateCompilation(source, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(
+        CreateCompilation(source,
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics(
             // (6,9): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             //         int* p = null;
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(6, 9),
@@ -1132,6 +1173,14 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             //         int y = *p;
             Diagnostic(ErrorCode.ERR_UnsafeOperation, "*").WithLocation(7, 17),
         };
+
+        CreateCompilation(source, options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics(expectedDiagnostics);
+
+        CreateCompilation(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics(expectedDiagnostics);
 
         CreateCompilation(source, options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(expectedDiagnostics);
@@ -1249,7 +1298,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             string s = x->ToString();
             """;
 
-        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+        CreateCompilation(source,
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(
             // (1,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             // int* x = null;
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(1, 1),
@@ -1263,6 +1315,14 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             // string s = x->ToString();
             Diagnostic(ErrorCode.ERR_UnsafeOperation, "->").WithLocation(2, 13),
         };
+
+        CreateCompilation(source, options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(expectedDiagnostics);
+
+        CreateCompilation(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(expectedDiagnostics);
 
         CreateCompilation(source, options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(expectedDiagnostics);
@@ -1356,7 +1416,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             string s = (*x).ToString();
             """;
 
-        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+        CreateCompilation(source,
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(
             // (1,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             // int* x = null;
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(1, 1),
@@ -1370,6 +1433,14 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             // string s = (*x).ToString();
             Diagnostic(ErrorCode.ERR_UnsafeOperation, "*").WithLocation(2, 13),
         };
+
+        CreateCompilation(source, options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(expectedDiagnostics);
+
+        CreateCompilation(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(expectedDiagnostics);
 
         CreateCompilation(source, options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(expectedDiagnostics);
@@ -1430,7 +1501,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             int y = x[1];
             """;
 
-        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+        CreateCompilation(source,
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(
             // (1,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             // int* x = null;
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(1, 1),
@@ -1450,6 +1524,14 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             // int y = x[1];
             Diagnostic(ErrorCode.ERR_UnsafeOperation, "[").WithLocation(3, 10),
         };
+
+        CreateCompilation(source, options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(expectedDiagnostics);
+
+        CreateCompilation(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(expectedDiagnostics);
 
         CreateCompilation(source, options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(expectedDiagnostics);
@@ -1491,7 +1573,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             int y = x[2, 3];
             """;
 
-        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+        CreateCompilation(source,
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(
             // (1,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             // int* x = null;
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(1, 1),
@@ -1517,6 +1602,14 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             // int y = x[2, 3];
             Diagnostic(ErrorCode.ERR_PtrIndexSingle, "x[2, 3]").WithLocation(3, 9),
         };
+
+        CreateCompilation(source, options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(expectedDiagnostics);
+
+        CreateCompilation(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(expectedDiagnostics);
 
         CreateCompilation(source, options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(expectedDiagnostics);
@@ -1558,7 +1651,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             _ = x[1];
             """;
 
-        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+        CreateCompilation(source,
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(
             // (1,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             // int*[] x = [];
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(1, 1),
@@ -1580,6 +1676,12 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             // (3,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             // _ = x[1];
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "_ = x[1]").WithLocation(3, 1));
+
+        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyEmitDiagnostics();
+
+        CreateCompilation(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.ReleaseExe).VerifyEmitDiagnostics();
 
         CreateCompilation(source, options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules()).VerifyEmitDiagnostics();
 
@@ -1625,7 +1727,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             _ = x[1];
             """;
 
-        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+        CreateCompilation(source,
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(
             // (1,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             // delegate*<void> x = null;
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "delegate*").WithLocation(1, 1),
@@ -1651,6 +1756,14 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             // _ = x[1];
             Diagnostic(ErrorCode.ERR_BadIndexLHS, "x[1]").WithArguments("delegate*<void>").WithLocation(3, 5),
         };
+
+        CreateCompilation(source, options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(expectedDiagnostics);
+
+        CreateCompilation(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(expectedDiagnostics);
 
         CreateCompilation(source, options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(expectedDiagnostics);
@@ -1726,7 +1839,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "delegate*").WithLocation(1, 1),
         };
 
-        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyEmitDiagnostics();
 
         CreateCompilation(source,
             parseOptions: TestOptions.Regular14,
@@ -1801,11 +1914,15 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "X").WithLocation(2, 1),
         };
 
-        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics();
 
         CreateCompilation(source,
             parseOptions: TestOptions.Regular14,
             options: TestOptions.ReleaseExe).VerifyDiagnostics(expectedDiagnostics);
+
+        CreateCompilation(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.ReleaseExe).VerifyDiagnostics();
 
         // https://github.com/dotnet/roslyn/issues/77389
         expectedDiagnostics = PlatformInformation.IsWindows
@@ -1900,7 +2017,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             string s = x();
             """;
 
-        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+        CreateCompilation(source,
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(
             // (1,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             // delegate*<string> x = null;
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "delegate*").WithLocation(1, 1),
@@ -1914,6 +2034,14 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             // string s = x();
             Diagnostic(ErrorCode.ERR_UnsafeOperation, "x()").WithLocation(2, 12),
         };
+
+        CreateCompilation(source, options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(expectedDiagnostics);
+
+        CreateCompilation(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(expectedDiagnostics);
 
         CreateCompilation(source, options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(expectedDiagnostics);
@@ -1971,7 +2099,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             string s = x();
             """;
 
-        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+        CreateCompilation(source,
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(
             // (1,11): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             // using X = delegate*<string>;
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "delegate*").WithLocation(1, 11),
@@ -1988,6 +2119,14 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             // string s = x();
             Diagnostic(ErrorCode.ERR_UnsafeOperation, "x()").WithLocation(3, 12),
         };
+
+        CreateCompilation(source, options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(expectedDiagnostics);
+
+        CreateCompilation(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(expectedDiagnostics);
 
         CreateCompilation(source, options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(expectedDiagnostics);
@@ -2032,11 +2171,15 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "&x").WithLocation(2, 10),
         };
 
-        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyEmitDiagnostics();
 
         CreateCompilation(source,
             parseOptions: TestOptions.Regular14,
             options: TestOptions.ReleaseExe).VerifyDiagnostics(expectedDiagnostics);
+
+        CreateCompilation(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.ReleaseExe).VerifyEmitDiagnostics();
 
         CreateCompilation(source, options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules()).VerifyEmitDiagnostics();
 
@@ -2066,7 +2209,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             int* p = &x;
             """;
 
-        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+        CreateCompilation(source,
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(
             // (2,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             // int* p = &x;
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(2, 1),
@@ -2080,6 +2226,14 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             // int* p = &x;
             Diagnostic(ErrorCode.ERR_InvalidAddrOp, "x").WithLocation(2, 11),
         };
+
+        CreateCompilation(source, options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(expectedDiagnostics);
+
+        CreateCompilation(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(expectedDiagnostics);
 
         CreateCompilation(source, options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(expectedDiagnostics);
@@ -2165,11 +2319,15 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "&x").WithLocation(6, 25),
         };
 
-        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyEmitDiagnostics();
 
         CreateCompilation(source,
             parseOptions: TestOptions.Regular14,
             options: TestOptions.ReleaseExe).VerifyDiagnostics(expectedDiagnostics);
+
+        CreateCompilation(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.ReleaseExe).VerifyEmitDiagnostics();
 
         CreateCompilation(source, options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules()).VerifyEmitDiagnostics();
 
@@ -2222,11 +2380,15 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(5, 16),
         };
 
-        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyEmitDiagnostics();
 
         CreateCompilation(source,
             parseOptions: TestOptions.Regular14,
             options: TestOptions.ReleaseExe).VerifyDiagnostics(expectedDiagnostics);
+
+        CreateCompilation(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.ReleaseExe).VerifyEmitDiagnostics();
 
         CreateCompilation(source, options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules()).VerifyEmitDiagnostics();
 
@@ -2256,7 +2418,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             fixed (int* p = &x) { }
             """;
 
-        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+        CreateCompilation(source,
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(
             // (2,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             // fixed (int* p = &x) { }
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "fixed (int* p = &x) { }").WithLocation(2, 1),
@@ -2273,6 +2438,14 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             // fixed (int* p = &x) { }
             Diagnostic(ErrorCode.ERR_FixedNotNeeded, "&x").WithLocation(2, 17),
         };
+
+        CreateCompilation(source, options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(expectedDiagnostics);
+
+        CreateCompilation(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(expectedDiagnostics);
 
         CreateCompilation(source, options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(expectedDiagnostics);
@@ -2385,11 +2558,15 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "p2").WithLocation(5, 14),
         };
 
-        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyEmitDiagnostics();
 
         CreateCompilation(source,
             parseOptions: TestOptions.Regular14,
             options: TestOptions.ReleaseExe).VerifyDiagnostics(expectedDiagnostics);
+
+        CreateCompilation(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.ReleaseExe).VerifyEmitDiagnostics();
 
         CreateCompilation(source, options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules()).VerifyEmitDiagnostics();
 
@@ -2445,13 +2622,22 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             struct S;
             """;
 
-        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+        CreateCompilation(source,
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(
             // (2,5): error CS0233: 'nint' does not have a predefined size, therefore sizeof can only be used in an unsafe context
             // _ = sizeof(nint);
             Diagnostic(ErrorCode.ERR_SizeofUnsafe, "sizeof(nint)").WithArguments("nint").WithLocation(2, 5),
             // (3,5): error CS0233: 'S' does not have a predefined size, therefore sizeof can only be used in an unsafe context
             // _ = sizeof(S);
             Diagnostic(ErrorCode.ERR_SizeofUnsafe, "sizeof(S)").WithArguments("S").WithLocation(3, 5));
+
+        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyEmitDiagnostics();
+
+        CreateCompilation(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.ReleaseExe).VerifyEmitDiagnostics();
 
         CreateCompilation(source, options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules()).VerifyEmitDiagnostics();
 
@@ -2487,7 +2673,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             }
             """;
 
-        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+        CreateCompilation(source,
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(
             // (2,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             // int* p = s.y;
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(2, 1),
@@ -2507,6 +2696,14 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             // int z = s.x[100];
             Diagnostic(ErrorCode.ERR_UnsafeOperation, "[").WithLocation(3, 12),
         };
+
+        CreateCompilation(source, options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(expectedDiagnostics);
+
+        CreateCompilation(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.ReleaseExe)
+            .VerifyDiagnostics(expectedDiagnostics);
 
         CreateCompilation(source, options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(expectedDiagnostics);
@@ -2594,7 +2791,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             }
             """;
 
-        CreateCompilationWithSpan(source, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(
+        CreateCompilationWithSpan(source,
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics(
             // (1,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             // int* x = stackalloc int[3];
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(1, 1),
@@ -2614,6 +2814,14 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             //     System.Span<int> e = stackalloc int[3] { 1, 2 };
             Diagnostic(ErrorCode.ERR_ArrayInitializerIncorrectLength, "stackalloc int[3] { 1, 2 }").WithArguments("3").WithLocation(11, 26),
         };
+
+        CreateCompilationWithSpan(source, options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics(expectedDiagnostics);
+
+        CreateCompilationWithSpan(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics(expectedDiagnostics);
 
         CreateCompilationWithSpan(source, options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(expectedDiagnostics);
@@ -3190,7 +3398,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 // delegate*<void> p1 = &C.M;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "&C.M").WithArguments("C.M()").WithLocation(1, 22),
             ],
-            expectedDiagnosticsForLegacyCaller:
+            expectedDiagnosticsWithOldLangVersion:
             [
                 // (1,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // delegate*<void> p1 = &C.M;
@@ -4866,7 +5074,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 // fixed (int* p = new C2()) { }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "new C2()").WithArguments("C2.GetPinnableReference()").WithLocation(2, 17),
             ],
-            expectedDiagnosticsForLegacyCaller:
+            expectedDiagnosticsWithOldLangVersion:
             [
                 // (1,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // fixed (int* p = new C1()) { }
@@ -6955,9 +7163,27 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             [libRef],
             options: TestOptions.UnsafeReleaseExe)
             .VerifyDiagnostics(
+            // (2,12): error CS9360: This operation may only be used in an unsafe context
+            // string s = c.F();
+            Diagnostic(ErrorCode.ERR_UnsafeOperation, "c.F()").WithLocation(2, 12));
+
+        CreateCompilation(source,
+            [libRef],
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics(
             // (2,12): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             // string s = c.F();
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "c.F()").WithLocation(2, 12));
+
+        CreateCompilation(source,
+            [libRef],
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics(
+            // (2,12): error CS9360: This operation may only be used in an unsafe context
+            // string s = c.F();
+            Diagnostic(ErrorCode.ERR_UnsafeOperation, "c.F()").WithLocation(2, 12));
 
         static Symbol getFunctionPointerType(ModuleSymbol module)
         {
@@ -7011,6 +7237,12 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "C.M()").WithArguments("C.M()").WithLocation(5, 14),
             ],
             expectedDiagnosticsForLegacyCaller:
+            [
+                // (4,14): error CS9360: This operation may only be used in an unsafe context
+                //     int F1 = *default(int*);
+                Diagnostic(ErrorCode.ERR_UnsafeOperation, "*").WithLocation(4, 14),
+            ],
+            expectedDiagnosticsWithOldLangVersion:
             [
                 // (4,15): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     int F1 = *default(int*);
@@ -7080,13 +7312,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CreateCompilation(source,
             [libRef],
             options: TestOptions.UnsafeReleaseExe)
-            .VerifyDiagnostics(
-            // (3,6): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // c.M2(null);
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "null").WithLocation(3, 6),
-            // (3,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // c.M2(null);
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "c.M2(null)").WithLocation(3, 1));
+            .VerifyDiagnostics();
     }
 
     [Theory, CombinatorialData]
@@ -7138,10 +7364,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CreateCompilation(source,
             [libRef],
             options: TestOptions.UnsafeReleaseExe)
-            .VerifyDiagnostics(
-            // (3,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // c.M2(null);
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "c.M2(null)").WithLocation(3, 1));
+            .VerifyDiagnostics();
     }
 
     [Theory, CombinatorialData]
@@ -7282,22 +7505,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CreateCompilation(source,
             [libRef],
             options: TestOptions.UnsafeReleaseExe)
-            .VerifyDiagnostics(
-            // (2,5): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // new int*[0].M2();
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(2, 5),
-            // (2,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // new int*[0].M2();
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "new int*[0]").WithLocation(2, 1),
-            // (2,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // new int*[0].M2();
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "new int*[0].M2()").WithLocation(2, 1),
-            // (4,6): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // E.M2(null);
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "null").WithLocation(4, 6),
-            // (4,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // E.M2(null);
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "E.M2(null)").WithLocation(4, 1));
+            .VerifyDiagnostics();
     }
 
     [Theory, CombinatorialData]
@@ -7361,22 +7569,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CreateCompilation(source,
             [libRef],
             options: TestOptions.UnsafeReleaseExe)
-            .VerifyDiagnostics(
-            // (2,5): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // new int*[0].M2();
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(2, 5),
-            // (2,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // new int*[0].M2();
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "new int*[0]").WithLocation(2, 1),
-            // (2,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // new int*[0].M2();
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "new int*[0].M2()").WithLocation(2, 1),
-            // (4,6): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // E.M2(null);
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "null").WithLocation(4, 6),
-            // (4,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // E.M2(null);
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "E.M2(null)").WithLocation(4, 1));
+            .VerifyDiagnostics();
     }
 
     [Theory, CombinatorialData]
@@ -7521,16 +7714,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CreateCompilation(source,
             [libRef],
             options: TestOptions.UnsafeReleaseExe)
-            .VerifyDiagnostics(
-            // (2,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // i.M1();
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "i.M1()").WithLocation(2, 1),
-            // (7,12): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            //     public int* M1() => null;
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(7, 12),
-            // (13,5): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            //     int* I.M1() => null;
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(13, 5));
+            .VerifyDiagnostics();
     }
 
     [Theory, CombinatorialData]
@@ -7585,37 +7769,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CreateCompilation(source,
             [libRef],
             options: TestOptions.UnsafeReleaseExe)
-            .VerifyDiagnostics(
-            // (5,21): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // public class C1 : I<int*[]>
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(5, 21),
-            // (11,21): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // public class C2 : I<int*[]>
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(11, 21),
-            // (23,21): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // public class C4 : I<int*[]>
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(23, 21),
-            // (17,21): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // public class C3 : I<int*[]>
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(17, 21),
-            // (7,12): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            //     public int*[] M1() => null;
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(7, 12),
-            // (13,14): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            //     int*[] I<int*[]>.M1() => null;
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(13, 14),
-            // (14,12): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            //     void I<int*[]>.M2() { }
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(14, 12),
-            // (13,5): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            //     int*[] I<int*[]>.M1() => null;
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(13, 5),
-            // (1,3): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // I<int*[]> i = new C1();
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(1, 3),
-            // (2,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // i.M1();
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "i.M1()").WithLocation(2, 1));
+            .VerifyDiagnostics();
     }
 
     [Theory, CombinatorialData]
@@ -7671,16 +7825,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CreateCompilation(source,
             [libRef],
             options: TestOptions.UnsafeReleaseExe)
-            .VerifyDiagnostics(
-            // (3,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // c.P2 = c.P2;
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "c.P2").WithLocation(3, 1),
-            // (3,8): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // c.P2 = c.P2;
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "c.P2").WithLocation(3, 8),
-            // (3,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // c.P2 = c.P2;
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "c.P2 = c.P2").WithLocation(3, 1));
+            .VerifyDiagnostics();
     }
 
     [Theory, CombinatorialData]
@@ -7752,31 +7897,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CreateCompilation(source,
             [libRef],
             options: TestOptions.UnsafeReleaseExe)
-            .VerifyDiagnostics(
-            // (3,5): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // new int*[0].P2 = new int*[0].P2;
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(3, 5),
-            // (3,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // new int*[0].P2 = new int*[0].P2;
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "new int*[0]").WithLocation(3, 1),
-            // (3,22): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // new int*[0].P2 = new int*[0].P2;
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(3, 22),
-            // (3,18): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // new int*[0].P2 = new int*[0].P2;
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "new int*[0]").WithLocation(3, 18),
-            // (5,10): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // E.get_P2(null); E.set_P2(null, 0);
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "null").WithLocation(5, 10),
-            // (5,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // E.get_P2(null); E.set_P2(null, 0);
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "E.get_P2(null)").WithLocation(5, 1),
-            // (5,26): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // E.get_P2(null); E.set_P2(null, 0);
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "null").WithLocation(5, 26),
-            // (5,17): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // E.get_P2(null); E.set_P2(null, 0);
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "E.set_P2(null, 0)").WithLocation(5, 17));
+            .VerifyDiagnostics();
     }
 
     [Theory, CombinatorialData]
@@ -7837,16 +7958,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CreateCompilation(source,
             [libRef],
             options: TestOptions.UnsafeReleaseExe)
-            .VerifyDiagnostics(
-            // (4,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // c2[0] = c2[0];
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "c2[0]").WithLocation(4, 1),
-            // (4,9): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // c2[0] = c2[0];
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "c2[0]").WithLocation(4, 9),
-            // (4,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // c2[0] = c2[0];
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "c2[0] = c2[0]").WithLocation(4, 1));
+            .VerifyDiagnostics();
     }
 
     [Theory, CombinatorialData]
@@ -7898,10 +8010,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CreateCompilation(source,
             [libRef],
             options: TestOptions.UnsafeReleaseExe)
-            .VerifyDiagnostics(
-            // (3,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // c.E2 += null;
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "c.E2").WithLocation(3, 1));
+            .VerifyDiagnostics();
     }
 
     [Theory, CombinatorialData]
@@ -7949,13 +8058,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CreateCompilation(source,
             [libRef],
             options: TestOptions.UnsafeReleaseExe)
-            .VerifyDiagnostics(
-            // (2,5): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // _ = new C(null);
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "new C(null)").WithLocation(2, 5),
-            // (2,11): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            // _ = new C(null);
-            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "null").WithLocation(2, 11));
+            .VerifyDiagnostics();
     }
 
     [Theory, CombinatorialData]
@@ -8151,10 +8254,18 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 expectedNoAttributeInSource: ["C.M"]);
         }
 
-        CreateCompilation(getLibSource("extern")).VerifyDiagnostics(
+        CreateCompilation(getLibSource("extern")).VerifyDiagnostics();
+
+        CreateCompilation(getLibSource("extern"),
+            parseOptions: TestOptions.Regular14)
+            .VerifyDiagnostics(
             // (4,19): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             //     public extern int* M();
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(4, 19));
+
+        CreateCompilation(getLibSource("extern"),
+            parseOptions: TestOptions.RegularNext)
+            .VerifyDiagnostics();
 
         // When compiling the lib under legacy rules, extern members are not unsafe, but members with pointers are.
         var libLegacy = CreateCompilation(
@@ -8745,10 +8856,18 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 expectedNoAttributeInSource: ["C.P", "C.set_P"]);
         }
 
-        CreateCompilation(getLibSource("extern")).VerifyDiagnostics(
+        CreateCompilation(getLibSource("extern")).VerifyDiagnostics();
+
+        CreateCompilation(getLibSource("extern"),
+            parseOptions: TestOptions.Regular14)
+            .VerifyDiagnostics(
             // (4,19): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             //     public extern int* P { set; }
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(4, 19));
+
+        CreateCompilation(getLibSource("extern"),
+            parseOptions: TestOptions.RegularNext)
+            .VerifyDiagnostics();
 
         // When compiling the lib under legacy rules, extern members are not unsafe, but members with pointers are.
         var libLegacy = CreateCompilation(
@@ -8945,10 +9064,18 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 expectedNoAttributeInSource: unsafeSymbols);
         }
 
-        CreateCompilation(getLibSource("extern")).VerifyDiagnostics(
+        CreateCompilation(getLibSource("extern")).VerifyDiagnostics();
+
+        CreateCompilation(getLibSource("extern"),
+            parseOptions: TestOptions.Regular14)
+            .VerifyDiagnostics(
             // (4,19): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-            //     public extern int* P { set; }
+            //     public extern int* this[int i] { get; set; }
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(4, 19));
+
+        CreateCompilation(getLibSource("extern"),
+            parseOptions: TestOptions.RegularNext)
+            .VerifyDiagnostics();
 
         // When compiling the lib under legacy rules, extern members are not unsafe, but members with pointers are.
         var libLegacy = CreateCompilation(
@@ -9311,10 +9438,18 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 expectedNoAttributeInSource: ["C..ctor"]);
         }
 
-        CreateCompilation(getLibSource("extern")).VerifyDiagnostics(
+        CreateCompilation(getLibSource("extern")).VerifyDiagnostics();
+
+        CreateCompilation(getLibSource("extern"),
+            parseOptions: TestOptions.Regular14)
+            .VerifyDiagnostics(
             // (4,21): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             //     public extern C(int* p);
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(4, 21));
+
+        CreateCompilation(getLibSource("extern"),
+            parseOptions: TestOptions.RegularNext)
+            .VerifyDiagnostics();
 
         // When compiling the lib under legacy rules, extern members are not unsafe, but members with pointers are.
         var libLegacy = CreateCompilation(
@@ -9481,10 +9616,18 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 expectedNoAttributeInSource: ["C.op_AdditionAssignment"]);
         }
 
-        CreateCompilation([getLibSource("extern"), CompilerFeatureRequiredAttribute]).VerifyDiagnostics(
+        CreateCompilation([getLibSource("extern"), CompilerFeatureRequiredAttribute]).VerifyDiagnostics();
+
+        CreateCompilation([getLibSource("extern"), CompilerFeatureRequiredAttribute],
+            parseOptions: TestOptions.Regular14)
+            .VerifyDiagnostics(
             // (4,36): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             //     public extern void operator +=(int* p);
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(4, 36));
+
+        CreateCompilation([getLibSource("extern"), CompilerFeatureRequiredAttribute],
+            parseOptions: TestOptions.RegularNext)
+            .VerifyDiagnostics();
 
         // When compiling the lib under legacy rules, extern members are not unsafe, but members with pointers are.
         var libLegacy = CreateCompilation(

--- a/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests.cs
@@ -2637,6 +2637,126 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
     }
 
     [Fact]
+    public void Pointer_Fixed_ManagedType()
+    {
+        var source = """
+            class C
+            {
+                static string x;
+                static void Main()
+                {
+                    fixed (string* p1 = &x) { }
+                    unsafe { fixed (string* p2 = &x) { } }
+                }
+            }
+            """;
+
+        CreateCompilationWithSpan(source,
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics(
+            // (6,9): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //         fixed (string* p1 = &x) { }
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "fixed (string* p1 = &x) { }").WithLocation(6, 9),
+            // (6,16): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //         fixed (string* p1 = &x) { }
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "string*").WithLocation(6, 16),
+            // (6,16): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            //         fixed (string* p1 = &x) { }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "string*").WithArguments("string").WithLocation(6, 16),
+            // (6,29): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            //         fixed (string* p1 = &x) { }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "&x").WithArguments("string").WithLocation(6, 29),
+            // (6,29): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //         fixed (string* p1 = &x) { }
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "&x").WithLocation(6, 29),
+            // (6,29): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            //         fixed (string* p1 = &x) { }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "&x").WithArguments("string").WithLocation(6, 29),
+            // (7,25): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            //         unsafe { fixed (string* p2 = &x) { } }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "string*").WithArguments("string").WithLocation(7, 25),
+            // (7,38): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            //         unsafe { fixed (string* p2 = &x) { } }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "&x").WithArguments("string").WithLocation(7, 38),
+            // (7,38): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            //         unsafe { fixed (string* p2 = &x) { } }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "&x").WithArguments("string").WithLocation(7, 38));
+
+        var expectedDiagnostics = new[]
+        {
+             // (6,16): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            //         fixed (string* p1 = &x) { }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "string*").WithArguments("string").WithLocation(6, 16),
+            // (6,29): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            //         fixed (string* p1 = &x) { }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "&x").WithArguments("string").WithLocation(6, 29),
+            // (6,29): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            //         fixed (string* p1 = &x) { }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "&x").WithArguments("string").WithLocation(6, 29),
+            // (7,25): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            //         unsafe { fixed (string* p2 = &x) { } }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "string*").WithArguments("string").WithLocation(7, 25),
+            // (7,38): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            //         unsafe { fixed (string* p2 = &x) { } }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "&x").WithArguments("string").WithLocation(7, 38),
+            // (7,38): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            //         unsafe { fixed (string* p2 = &x) { } }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "&x").WithArguments("string").WithLocation(7, 38),
+        };
+
+        CreateCompilationWithSpan(source, options: TestOptions.UnsafeReleaseExe)
+            .VerifyEmitDiagnostics(expectedDiagnostics);
+
+        CreateCompilationWithSpan(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyEmitDiagnostics(expectedDiagnostics);
+
+        CreateCompilationWithSpan(source, options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
+            .VerifyEmitDiagnostics(expectedDiagnostics);
+
+        CreateCompilationWithSpan(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
+            .VerifyEmitDiagnostics(expectedDiagnostics);
+
+        CreateCompilationWithSpan(source,
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
+            .VerifyDiagnostics(
+            // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
+            Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
+            // (6,9): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //         fixed (string* p1 = &x) { }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "fixed (string* p1 = &x) { }").WithArguments("updated memory safety rules").WithLocation(6, 9),
+            // (6,16): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //         fixed (string* p1 = &x) { }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "string*").WithArguments("updated memory safety rules").WithLocation(6, 16),
+            // (6,16): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            //         fixed (string* p1 = &x) { }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "string*").WithArguments("string").WithLocation(6, 16),
+            // (6,29): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            //         fixed (string* p1 = &x) { }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "&x").WithArguments("string").WithLocation(6, 29),
+            // (6,29): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //         fixed (string* p1 = &x) { }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "&x").WithArguments("updated memory safety rules").WithLocation(6, 29),
+            // (6,29): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            //         fixed (string* p1 = &x) { }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "&x").WithArguments("string").WithLocation(6, 29),
+            // (7,25): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            //         unsafe { fixed (string* p2 = &x) { } }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "string*").WithArguments("string").WithLocation(7, 25),
+            // (7,38): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            //         unsafe { fixed (string* p2 = &x) { } }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "&x").WithArguments("string").WithLocation(7, 38),
+            // (7,38): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            //         unsafe { fixed (string* p2 = &x) { } }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "&x").WithArguments("string").WithLocation(7, 38));
+    }
+
+    [Fact]
     public void Pointer_Arithmetic_SafeContext()
     {
         var source = """
@@ -2780,6 +2900,71 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             // (3,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             // _ = sizeof(S);
             Diagnostic(ErrorCode.ERR_FeatureInPreview, "sizeof(S)").WithArguments("updated memory safety rules").WithLocation(3, 5));
+    }
+
+    [Fact]
+    public void SizeOf_ManagedType()
+    {
+        var source = """
+            _ = sizeof(string);
+            unsafe { _ = sizeof(string); }
+            """;
+
+        CreateCompilationWithSpan(source,
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics(
+            // (1,5): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            // _ = sizeof(string);
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "sizeof(string)").WithArguments("string").WithLocation(1, 5),
+            // (1,5): error CS0233: 'string' does not have a predefined size, therefore sizeof can only be used in an unsafe context
+            // _ = sizeof(string);
+            Diagnostic(ErrorCode.ERR_SizeofUnsafe, "sizeof(string)").WithArguments("string").WithLocation(1, 5),
+            // (2,14): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            // unsafe { _ = sizeof(string); }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "sizeof(string)").WithArguments("string").WithLocation(2, 14));
+
+        var expectedDiagnostics = new[]
+        {
+            // (1,5): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            // _ = sizeof(string);
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "sizeof(string)").WithArguments("string").WithLocation(1, 5),
+            // (2,14): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            // unsafe { _ = sizeof(string); }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "sizeof(string)").WithArguments("string").WithLocation(2, 14),
+        };
+
+        CreateCompilationWithSpan(source, options: TestOptions.UnsafeReleaseExe)
+            .VerifyEmitDiagnostics(expectedDiagnostics);
+
+        CreateCompilationWithSpan(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyEmitDiagnostics(expectedDiagnostics);
+
+        CreateCompilationWithSpan(source, options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
+            .VerifyEmitDiagnostics(expectedDiagnostics);
+
+        CreateCompilationWithSpan(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
+            .VerifyEmitDiagnostics(expectedDiagnostics);
+
+        CreateCompilationWithSpan(source,
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
+            .VerifyDiagnostics(
+            // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
+            Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
+            // (1,5): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            // _ = sizeof(string);
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "sizeof(string)").WithArguments("string").WithLocation(1, 5),
+            // (1,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            // _ = sizeof(string);
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "sizeof(string)").WithArguments("updated memory safety rules").WithLocation(1, 5),
+            // (2,14): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            // unsafe { _ = sizeof(string); }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "sizeof(string)").WithArguments("string").WithLocation(2, 14));
     }
 
     [Fact]
@@ -3024,6 +3209,74 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
     }
 
     [Fact]
+    public void StackAlloc_ManagedType()
+    {
+        var source = """
+            unsafe { System.Span<string> x = stackalloc string[5]; }
+            unsafe { string* y = stackalloc[] { "a" }; }
+            M();
+
+            [System.Runtime.CompilerServices.SkipLocalsInit]
+            void M()
+            {
+                System.Span<string> a = stackalloc string[5];
+            }
+
+            namespace System.Runtime.CompilerServices
+            {
+                public class SkipLocalsInitAttribute : Attribute;
+            }
+            """;
+
+        var expectedDiagnostics = new[]
+        {
+            // (1,45): error CS0208: Cannot take the address of, get the size of, or declare a pointer to a managed type ('string')
+            // unsafe { System.Span<string> x = stackalloc string[5]; }
+            Diagnostic(ErrorCode.ERR_ManagedAddr, "string").WithArguments("string").WithLocation(1, 45),
+            // (2,10): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            // unsafe { string* y = stackalloc[] { "a" }; }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "string*").WithArguments("string").WithLocation(2, 10),
+            // (2,22): error CS0208: Cannot take the address of, get the size of, or declare a pointer to a managed type ('string')
+            // unsafe { string* y = stackalloc[] { "a" }; }
+            Diagnostic(ErrorCode.ERR_ManagedAddr, @"stackalloc[] { ""a"" }").WithArguments("string").WithLocation(2, 22),
+            // (8,40): error CS0208: Cannot take the address of, get the size of, or declare a pointer to a managed type ('string')
+            //     System.Span<string> a = stackalloc string[5];
+            Diagnostic(ErrorCode.ERR_ManagedAddr, "string").WithArguments("string").WithLocation(8, 40),
+        };
+
+        CreateCompilationWithSpan(source,
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyEmitDiagnostics(expectedDiagnostics);
+
+        CreateCompilationWithSpan(source, options: TestOptions.UnsafeReleaseExe)
+            .VerifyEmitDiagnostics(expectedDiagnostics);
+
+        CreateCompilationWithSpan(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyEmitDiagnostics(expectedDiagnostics);
+
+        CreateCompilationWithSpan(source, options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
+            .VerifyEmitDiagnostics(expectedDiagnostics);
+
+        CreateCompilationWithSpan(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
+            .VerifyEmitDiagnostics(expectedDiagnostics);
+
+        CreateCompilationWithSpan(source,
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
+            .VerifyDiagnostics(
+            [
+                // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
+                Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
+                .. expectedDiagnostics,
+            ]);
+    }
+
+    [Fact]
     public void StackAlloc_Lambda()
     {
         var source = """
@@ -3115,6 +3368,115 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             // (12,22): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
             // unsafe delegate void D();
             Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "D").WithLocation(12, 22));
+    }
+
+    [Fact]
+    public void UnsafeDeclarations_PointerToManagedType()
+    {
+        var source = """
+            _ = new X<string*[]>();
+            unsafe { _ = new X<string*[]>(); }
+
+            class C
+            {
+                void M1(X<string*[]> x) { }
+                unsafe void M2(X<string*[]> x) { }
+            }
+
+            class X<T>;
+            """;
+
+        CreateCompilationWithSpan(source,
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics(
+            // (1,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // _ = new X<string*[]>();
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "_ = new X<string*[]>()").WithLocation(1, 1),
+            // (1,5): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // _ = new X<string*[]>();
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "new X<string*[]>()").WithLocation(1, 5),
+            // (1,11): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // _ = new X<string*[]>();
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "string*").WithLocation(1, 11),
+            // (1,11): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            // _ = new X<string*[]>();
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "string*").WithArguments("string").WithLocation(1, 11),
+            // (2,20): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            // unsafe { _ = new X<string*[]>(); }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "string*").WithArguments("string").WithLocation(2, 20),
+            // (6,15): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //     void M1(X<string*[]> x) { }
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "string*").WithLocation(6, 15),
+            // (6,26): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            //     void M1(X<string*[]> x) { }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "x").WithArguments("string").WithLocation(6, 26),
+            // (7,33): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            //     unsafe void M2(X<string*[]> x) { }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "x").WithArguments("string").WithLocation(7, 33));
+
+        var expectedDiagnostics = new[]
+        {
+            // (1,11): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            // _ = new X<string*[]>();
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "string*").WithArguments("string").WithLocation(1, 11),
+            // (2,20): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            // unsafe { _ = new X<string*[]>(); }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "string*").WithArguments("string").WithLocation(2, 20),
+            // (6,26): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            //     void M1(X<string*[]> x) { }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "x").WithArguments("string").WithLocation(6, 26),
+            // (7,33): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            //     unsafe void M2(X<string*[]> x) { }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "x").WithArguments("string").WithLocation(7, 33),
+        };
+
+        CreateCompilationWithSpan(source, options: TestOptions.UnsafeReleaseExe)
+            .VerifyEmitDiagnostics(expectedDiagnostics);
+
+        CreateCompilationWithSpan(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyEmitDiagnostics(expectedDiagnostics);
+
+        CreateCompilationWithSpan(source, options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
+            .VerifyEmitDiagnostics(expectedDiagnostics);
+
+        CreateCompilationWithSpan(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
+            .VerifyEmitDiagnostics(expectedDiagnostics);
+
+        CreateCompilationWithSpan(source,
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
+            .VerifyDiagnostics(
+            // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
+            Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
+            // (1,1): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            // _ = new X<string*[]>();
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "_ = new X<string*[]>()").WithArguments("updated memory safety rules").WithLocation(1, 1),
+            // (1,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            // _ = new X<string*[]>();
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "new X<string*[]>()").WithArguments("updated memory safety rules").WithLocation(1, 5),
+            // (1,11): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            // _ = new X<string*[]>();
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "string*").WithArguments("updated memory safety rules").WithLocation(1, 11),
+            // (1,11): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            // _ = new X<string*[]>();
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "string*").WithArguments("string").WithLocation(1, 11),
+            // (2,20): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            // unsafe { _ = new X<string*[]>(); }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "string*").WithArguments("string").WithLocation(2, 20),
+            // (6,15): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     void M1(X<string*[]> x) { }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "string*").WithArguments("updated memory safety rules").WithLocation(6, 15),
+            // (6,26): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            //     void M1(X<string*[]> x) { }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "x").WithArguments("string").WithLocation(6, 26),
+            // (7,33): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            //     unsafe void M2(X<string*[]> x) { }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "x").WithArguments("string").WithLocation(7, 33));
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests.cs
@@ -2293,6 +2293,129 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
     }
 
     [Fact]
+    public void Pointer_AddressOfManaged_SafeContext()
+    {
+        var source = """
+            string s;
+            string* p = &s;
+            """;
+
+        var expectedDiagnostics = new[]
+        {
+            // (2,1): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            // string* p = &s;
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "string*").WithArguments("string").WithLocation(2, 1),
+            // (2,13): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            // string* p = &s;
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "&s").WithArguments("string").WithLocation(2, 13),
+        };
+
+        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyEmitDiagnostics(expectedDiagnostics);
+
+        CreateCompilation(source,
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.ReleaseExe).VerifyDiagnostics(
+            // (2,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // string* p = &s;
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "string*").WithLocation(2, 1),
+            // (2,1): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            // string* p = &s;
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "string*").WithArguments("string").WithLocation(2, 1),
+            // (2,13): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // string* p = &s;
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "&s").WithLocation(2, 13),
+            // (2,13): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            // string* p = &s;
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "&s").WithArguments("string").WithLocation(2, 13));
+
+        CreateCompilation(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.ReleaseExe).VerifyEmitDiagnostics(expectedDiagnostics);
+
+        CreateCompilation(source, options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules()).VerifyEmitDiagnostics(expectedDiagnostics);
+
+        CreateCompilation(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules()).VerifyEmitDiagnostics(expectedDiagnostics);
+
+        CreateCompilation(source,
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules())
+            .VerifyDiagnostics(
+            // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
+            Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
+            // (2,1): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            // string* p = &s;
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "string*").WithArguments("updated memory safety rules").WithLocation(2, 1),
+            // (2,1): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            // string* p = &s;
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "string*").WithArguments("string").WithLocation(2, 1),
+            // (2,13): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            // string* p = &s;
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "&s").WithArguments("updated memory safety rules").WithLocation(2, 13),
+            // (2,13): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            // string* p = &s;
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "&s").WithArguments("string").WithLocation(2, 13));
+    }
+
+    [Fact]
+    public void Pointer_AddressOfManaged_UnsafeContext()
+    {
+        var source = """
+            string s;
+            unsafe { string* p = &s; }
+            """;
+
+        var expectedWarnings = new[]
+        {
+            // (2,10): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            // unsafe { string* p = &s; }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "string*").WithArguments("string").WithLocation(2, 10),
+            // (2,22): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            // unsafe { string* p = &s; }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "&s").WithArguments("string").WithLocation(2, 22),
+        };
+
+        var expectedDiagnostics = new[]
+        {
+            // (2,1): error CS0227: Unsafe code may only appear if compiling with /unsafe
+            // unsafe { string* p = &s; }
+            Diagnostic(ErrorCode.ERR_IllegalUnsafe, "unsafe").WithLocation(2, 1),
+            // (2,10): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            // unsafe { string* p = &s; }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "string*").WithArguments("string").WithLocation(2, 10),
+            // (2,22): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            // unsafe { string* p = &s; }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "&s").WithArguments("string").WithLocation(2, 22),
+        };
+
+        CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+
+        CreateCompilation(source, options: TestOptions.UnsafeReleaseExe).VerifyEmitDiagnostics(expectedWarnings);
+
+        CreateCompilation(source, options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules())
+            .VerifyDiagnostics(expectedDiagnostics);
+
+        CreateCompilation(source, options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules()).VerifyEmitDiagnostics(expectedWarnings);
+
+        CreateCompilation(source,
+            parseOptions: TestOptions.RegularNext,
+            options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules()).VerifyEmitDiagnostics(expectedWarnings);
+
+        CreateCompilation(source,
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules()).VerifyEmitDiagnostics(
+            // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
+            Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
+            // (2,10): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            // unsafe { string* p = &s; }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "string*").WithArguments("string").WithLocation(2, 10),
+            // (2,22): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
+            // unsafe { string* p = &s; }
+            Diagnostic(ErrorCode.WRN_ManagedAddr, "&s").WithArguments("string").WithLocation(2, 22));
+    }
+
+    [Fact]
     public void Pointer_Fixed_SafeContext()
     {
         var source = """
@@ -7311,6 +7434,24 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         CreateCompilation(source,
             [libRef],
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics(
+            // (3,6): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // c.M2(null);
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "null").WithLocation(3, 6),
+            // (3,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // c.M2(null);
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "c.M2(null)").WithLocation(3, 1));
+
+        CreateCompilation(source,
+            [libRef],
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics();
+
+        CreateCompilation(source,
+            [libRef],
+            parseOptions: TestOptions.RegularNext,
             options: TestOptions.UnsafeReleaseExe)
             .VerifyDiagnostics();
     }
@@ -7363,6 +7504,21 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         CreateCompilation(source,
             [libRef],
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics(
+            // (3,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // c.M2(null);
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "c.M2(null)").WithLocation(3, 1));
+
+        CreateCompilation(source,
+            [libRef],
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics();
+
+        CreateCompilation(source,
+            [libRef],
+            parseOptions: TestOptions.RegularNext,
             options: TestOptions.UnsafeReleaseExe)
             .VerifyDiagnostics();
     }
@@ -7504,6 +7660,33 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         CreateCompilation(source,
             [libRef],
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics(
+            // (2,5): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // new int*[0].M2();
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(2, 5),
+            // (2,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // new int*[0].M2();
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "new int*[0]").WithLocation(2, 1),
+            // (2,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // new int*[0].M2();
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "new int*[0].M2()").WithLocation(2, 1),
+            // (4,6): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // E.M2(null);
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "null").WithLocation(4, 6),
+            // (4,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // E.M2(null);
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "E.M2(null)").WithLocation(4, 1));
+
+        CreateCompilation(source,
+            [libRef],
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics();
+
+        CreateCompilation(source,
+            [libRef],
+            parseOptions: TestOptions.RegularNext,
             options: TestOptions.UnsafeReleaseExe)
             .VerifyDiagnostics();
     }
@@ -7568,6 +7751,33 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         CreateCompilation(source,
             [libRef],
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics(
+            // (2,5): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // new int*[0].M2();
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(2, 5),
+            // (2,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // new int*[0].M2();
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "new int*[0]").WithLocation(2, 1),
+            // (2,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // new int*[0].M2();
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "new int*[0].M2()").WithLocation(2, 1),
+            // (4,6): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // E.M2(null);
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "null").WithLocation(4, 6),
+            // (4,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // E.M2(null);
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "E.M2(null)").WithLocation(4, 1));
+
+        CreateCompilation(source,
+            [libRef],
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics();
+
+        CreateCompilation(source,
+            [libRef],
+            parseOptions: TestOptions.RegularNext,
             options: TestOptions.UnsafeReleaseExe)
             .VerifyDiagnostics();
     }
@@ -7713,6 +7923,27 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         CreateCompilation(source,
             [libRef],
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics(
+            // (2,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // i.M1();
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "i.M1()").WithLocation(2, 1),
+            // (7,12): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //     public int* M1() => null;
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(7, 12),
+            // (13,5): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //     int* I.M1() => null;
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(13, 5));
+
+        CreateCompilation(source,
+            [libRef],
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics();
+
+        CreateCompilation(source,
+            [libRef],
+            parseOptions: TestOptions.RegularNext,
             options: TestOptions.UnsafeReleaseExe)
             .VerifyDiagnostics();
     }
@@ -7768,6 +7999,48 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         CreateCompilation(source,
             [libRef],
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics(
+            // (5,21): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // public class C1 : I<int*[]>
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(5, 21),
+            // (11,21): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // public class C2 : I<int*[]>
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(11, 21),
+            // (23,21): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // public class C4 : I<int*[]>
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(23, 21),
+            // (17,21): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // public class C3 : I<int*[]>
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(17, 21),
+            // (7,12): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //     public int*[] M1() => null;
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(7, 12),
+            // (13,14): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //     int*[] I<int*[]>.M1() => null;
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(13, 14),
+            // (14,12): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //     void I<int*[]>.M2() { }
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(14, 12),
+            // (13,5): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            //     int*[] I<int*[]>.M1() => null;
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(13, 5),
+            // (1,3): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // I<int*[]> i = new C1();
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(1, 3),
+            // (2,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // i.M1();
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "i.M1()").WithLocation(2, 1));
+
+        CreateCompilation(source,
+            [libRef],
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics();
+
+        CreateCompilation(source,
+            [libRef],
+            parseOptions: TestOptions.RegularNext,
             options: TestOptions.UnsafeReleaseExe)
             .VerifyDiagnostics();
     }
@@ -7824,6 +8097,27 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         CreateCompilation(source,
             [libRef],
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics(
+            // (3,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // c.P2 = c.P2;
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "c.P2").WithLocation(3, 1),
+            // (3,8): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // c.P2 = c.P2;
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "c.P2").WithLocation(3, 8),
+            // (3,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // c.P2 = c.P2;
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "c.P2 = c.P2").WithLocation(3, 1));
+
+        CreateCompilation(source,
+            [libRef],
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics();
+
+        CreateCompilation(source,
+            [libRef],
+            parseOptions: TestOptions.RegularNext,
             options: TestOptions.UnsafeReleaseExe)
             .VerifyDiagnostics();
     }
@@ -7896,6 +8190,42 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         CreateCompilation(source,
             [libRef],
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics(
+            // (3,5): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // new int*[0].P2 = new int*[0].P2;
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(3, 5),
+            // (3,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // new int*[0].P2 = new int*[0].P2;
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "new int*[0]").WithLocation(3, 1),
+            // (3,22): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // new int*[0].P2 = new int*[0].P2;
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(3, 22),
+            // (3,18): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // new int*[0].P2 = new int*[0].P2;
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "new int*[0]").WithLocation(3, 18),
+            // (5,10): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // E.get_P2(null); E.set_P2(null, 0);
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "null").WithLocation(5, 10),
+            // (5,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // E.get_P2(null); E.set_P2(null, 0);
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "E.get_P2(null)").WithLocation(5, 1),
+            // (5,26): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // E.get_P2(null); E.set_P2(null, 0);
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "null").WithLocation(5, 26),
+            // (5,17): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // E.get_P2(null); E.set_P2(null, 0);
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "E.set_P2(null, 0)").WithLocation(5, 17));
+
+        CreateCompilation(source,
+            [libRef],
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics();
+
+        CreateCompilation(source,
+            [libRef],
+            parseOptions: TestOptions.RegularNext,
             options: TestOptions.UnsafeReleaseExe)
             .VerifyDiagnostics();
     }
@@ -7957,6 +8287,27 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         CreateCompilation(source,
             [libRef],
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics(
+            // (4,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // c2[0] = c2[0];
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "c2[0]").WithLocation(4, 1),
+            // (4,9): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // c2[0] = c2[0];
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "c2[0]").WithLocation(4, 9),
+            // (4,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // c2[0] = c2[0];
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "c2[0] = c2[0]").WithLocation(4, 1));
+
+        CreateCompilation(source,
+            [libRef],
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics();
+
+        CreateCompilation(source,
+            [libRef],
+            parseOptions: TestOptions.RegularNext,
             options: TestOptions.UnsafeReleaseExe)
             .VerifyDiagnostics();
     }
@@ -8009,6 +8360,21 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         CreateCompilation(source,
             [libRef],
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics(
+            // (3,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // c.E2 += null;
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "c.E2").WithLocation(3, 1));
+
+        CreateCompilation(source,
+            [libRef],
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics();
+
+        CreateCompilation(source,
+            [libRef],
+            parseOptions: TestOptions.RegularNext,
             options: TestOptions.UnsafeReleaseExe)
             .VerifyDiagnostics();
     }
@@ -8057,6 +8423,24 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         CreateCompilation(source,
             [libRef],
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics(
+            // (2,5): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // _ = new C(null);
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "new C(null)").WithLocation(2, 5),
+            // (2,11): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+            // _ = new C(null);
+            Diagnostic(ErrorCode.ERR_UnsafeNeeded, "null").WithLocation(2, 11));
+
+        CreateCompilation(source,
+            [libRef],
+            options: TestOptions.UnsafeReleaseExe)
+            .VerifyDiagnostics();
+
+        CreateCompilation(source,
+            [libRef],
+            parseOptions: TestOptions.RegularNext,
             options: TestOptions.UnsafeReleaseExe)
             .VerifyDiagnostics();
     }

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -1720,6 +1720,7 @@ class C
             // - [ ] update the feature status page
             // - [ ] update all the tests that call this canary
             // - [ ] replace all references to C# "Next" (such as `TestOptions.RegularNext` or `LanguageVersionFacts.CSharpNext`) with the new version and fix failing tests
+            // - [ ] replace references to C# "preview" in breaking change docs
             // - [ ] update _MaxAvailableLangVersion cap (a relevant test should break when new version is introduced)
             // - [ ] update the "UpgradeProject" codefixer
             // - [ ] Remove the `ExperimentalUrl` section from any entries for language features being shipped in Syntax.xml and OperationInterfaces.xml, and rerun the generator

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -11506,8 +11506,15 @@ class C<T> {}
                 // [A(default(B<delegate*<void>[]>.E))]
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "delegate*").WithLocation(11, 14));
 
-            CreateCompilation(source).VerifyEmitDiagnostics();
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics();
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (11,2): error CS8911: Using a function pointer type in this context is not supported.
+                // [A(default(B<delegate*<void>[]>.E))]
+                Diagnostic(ErrorCode.ERR_FunctionPointerTypesInAttributeNotSupported, "A(default(B<delegate*<void>[]>.E))").WithLocation(11, 2),
+            };
+
+            CreateCompilation(source).VerifyEmitDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Theory, CombinatorialData, WorkItem(65594, "https://github.com/dotnet/roslyn/issues/65594")]
@@ -11567,8 +11574,15 @@ class C<T> {}
                 // [A<object>(default(B<delegate*<void>[]>.E))]
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "delegate*").WithLocation(11, 22));
 
-            CreateCompilation(source).VerifyEmitDiagnostics();
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics();
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (11,2): error CS8911: Using a function pointer type in this context is not supported.
+                // [A<object>(default(B<delegate*<void>[]>.E))]
+                Diagnostic(ErrorCode.ERR_FunctionPointerTypesInAttributeNotSupported, "A<object>(default(B<delegate*<void>[]>.E))").WithLocation(11, 2),
+            };
+
+            CreateCompilation(source).VerifyEmitDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Theory, CombinatorialData, WorkItem(65594, "https://github.com/dotnet/roslyn/issues/65594")]
@@ -12084,8 +12098,15 @@ class C<T> {}
                 // [A<object>(B<delegate*<void>[]>.C)]
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "delegate*").WithLocation(12, 14));
 
-            CreateCompilation(source).VerifyEmitDiagnostics();
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics();
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (12,2): error CS8911: Using a function pointer type in this context is not supported.
+                // [A<object>(B<delegate*<void>[]>.C)]
+                Diagnostic(ErrorCode.ERR_FunctionPointerTypesInAttributeNotSupported, "A<object>(B<delegate*<void>[]>.C)").WithLocation(12, 2),
+            };
+
+            CreateCompilation(source).VerifyEmitDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Theory, CombinatorialData, WorkItem(65594, "https://github.com/dotnet/roslyn/issues/65594")]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -11498,13 +11498,16 @@ class C<T> {}
                 class C { }
                 """;
 
-            CreateCompilation(source).VerifyEmitDiagnostics(
+            CreateCompilation(source, parseOptions: TestOptions.Regular14).VerifyEmitDiagnostics(
                 // (11,4): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // [A(default(B<delegate*<void>[]>.E))]
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "default(B<delegate*<void>[]>.E)").WithLocation(11, 4),
                 // (11,14): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // [A(default(B<delegate*<void>[]>.E))]
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "delegate*").WithLocation(11, 14));
+
+            CreateCompilation(source).VerifyEmitDiagnostics();
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics();
         }
 
         [Theory, CombinatorialData, WorkItem(65594, "https://github.com/dotnet/roslyn/issues/65594")]
@@ -11526,10 +11529,16 @@ class C<T> {}
                 """;
 
             // https://github.com/dotnet/roslyn/issues/48765 tracks enabling support for this scenario.
-            CreateCompilation(source, options: TestOptions.UnsafeDebugDll).VerifyEmitDiagnostics(
+            var expectedDiagnostics = new[]
+            {
                 // (11,2): error CS8911: Using a function pointer type in this context is not supported.
                 // [A(default(B<delegate*<void>[]>.E))]
-                Diagnostic(ErrorCode.ERR_FunctionPointerTypesInAttributeNotSupported, "A(default(B<delegate*<void>[]>.E))").WithLocation(11, 2));
+                Diagnostic(ErrorCode.ERR_FunctionPointerTypesInAttributeNotSupported, "A(default(B<delegate*<void>[]>.E))").WithLocation(11, 2),
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll).VerifyEmitDiagnostics(expectedDiagnostics);
+            CreateCompilation(source, options: TestOptions.UnsafeDebugDll).VerifyEmitDiagnostics(expectedDiagnostics);
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll).VerifyEmitDiagnostics(expectedDiagnostics);
         }
 
         [Theory, CombinatorialData, WorkItem(65594, "https://github.com/dotnet/roslyn/issues/65594")]
@@ -11550,13 +11559,16 @@ class C<T> {}
                 class C { }
                 """;
 
-            CreateCompilation(source).VerifyEmitDiagnostics(
+            CreateCompilation(source, parseOptions: TestOptions.Regular14).VerifyEmitDiagnostics(
                 // (11,12): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // [A<object>(default(B<delegate*<void>[]>.E))]
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "default(B<delegate*<void>[]>.E)").WithLocation(11, 12),
                 // (11,22): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // [A<object>(default(B<delegate*<void>[]>.E))]
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "delegate*").WithLocation(11, 22));
+
+            CreateCompilation(source).VerifyEmitDiagnostics();
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics();
         }
 
         [Theory, CombinatorialData, WorkItem(65594, "https://github.com/dotnet/roslyn/issues/65594")]
@@ -11627,11 +11639,14 @@ class C<T> {}
                 unsafe class C { }
                 """;
 
-            CreateCompilation(source, options: TestOptions.UnsafeDebugDll).VerifyEmitDiagnostics(
+            CreateCompilation(source, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll).VerifyEmitDiagnostics(
                 // (3,16): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     public A(B<delegate*<void>[]>.E e) { }
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "delegate*").WithLocation(3, 16)
                 );
+
+            CreateCompilation(source, options: TestOptions.UnsafeDebugDll).VerifyEmitDiagnostics();
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll).VerifyEmitDiagnostics();
         }
 
         [Theory, CombinatorialData, WorkItem(65594, "https://github.com/dotnet/roslyn/issues/65594")]
@@ -11690,11 +11705,14 @@ class C<T> {}
                 class C { }
                 """;
 
-            CreateCompilation(source, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(
+            CreateCompilation(source, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(
                 // (11,4): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // [A(default)]
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "default").WithLocation(11, 4)
                 );
+
+            CreateCompilation(source, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics();
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics();
         }
 
         [Theory, CombinatorialData, WorkItem(65594, "https://github.com/dotnet/roslyn/issues/65594")]
@@ -12055,7 +12073,7 @@ class C<T> {}
                 class C { }
                 """;
 
-            CreateCompilation(source).VerifyEmitDiagnostics(
+            CreateCompilation(source, parseOptions: TestOptions.Regular14).VerifyEmitDiagnostics(
                 // (12,12): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // [A<object>(B<delegate*<void>[]>.C)]
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "B<delegate*<void>[]>").WithLocation(12, 12),
@@ -12065,6 +12083,9 @@ class C<T> {}
                 // (12,14): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // [A<object>(B<delegate*<void>[]>.C)]
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "delegate*").WithLocation(12, 14));
+
+            CreateCompilation(source).VerifyEmitDiagnostics();
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics();
         }
 
         [Theory, CombinatorialData, WorkItem(65594, "https://github.com/dotnet/roslyn/issues/65594")]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/FixedSizeBufferTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/FixedSizeBufferTests.cs
@@ -367,7 +367,7 @@ class Program
 }
 ";
 
-            CreateCompilation(source, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+            CreateCompilation(source, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
                 // (14,34): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //         System.Console.WriteLine(s.x[3]);
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "s.x").WithLocation(14, 34),
@@ -375,6 +375,9 @@ class Program
                 //         System.Console.WriteLine(a[0].x[3]);
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "a[0].x").WithLocation(18, 34)
                 );
+
+            CreateCompilation(source, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/FixedSizeBufferTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/FixedSizeBufferTests.cs
@@ -376,8 +376,18 @@ class Program
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "a[0].x").WithLocation(18, 34)
                 );
 
-            CreateCompilation(source, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (14,37): error CS9229: Unsafe code may not appear in this context
+                //         System.Console.WriteLine(s.x[3]);
+                Diagnostic(ErrorCode.ERR_UnsafeOperation, "[").WithLocation(14, 37),
+                // (18,40): error CS9229: Unsafe code may not appear in this context
+                //         System.Console.WriteLine(a[0].x[3]);
+                Diagnostic(ErrorCode.ERR_UnsafeOperation, "[").WithLocation(18, 40)
+            };
+
+            CreateCompilation(source, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
@@ -87,7 +87,7 @@ class C
     }
 }
 ";
-            var comp = CreateCompilation(text, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(text, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (4,12): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     void M(int* param)
@@ -99,6 +99,9 @@ class C
                 //         M(param);
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "param").WithLocation(6, 11)
                 );
+
+            CreateCompilation(text, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics();
+            CreateCompilation(text, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics();
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67330")]
@@ -113,7 +116,7 @@ class C
     }
 }
 ";
-            var comp = CreateCompilation(text, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(text, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (4,12): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     void M(int*[] param)
@@ -125,6 +128,9 @@ class C
                 //         M(param);
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "param").WithLocation(6, 11)
                 );
+
+            CreateCompilation(text, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics();
+            CreateCompilation(text, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics();
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67330")]
@@ -139,7 +145,7 @@ class C<T>
     }
 }
 ";
-            var comp = CreateCompilation(text, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(text, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (4,14): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     void M(C<int*[]>[] param)
@@ -151,6 +157,9 @@ class C<T>
                 //         M(param);
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "param").WithLocation(6, 11)
                 );
+
+            CreateCompilation(text, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics();
+            CreateCompilation(text, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics();
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67330")]
@@ -165,7 +174,7 @@ class C
     }
 }
 ";
-            var comp = CreateCompilation(text, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(text, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (4,7): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     C(int* param)
@@ -177,6 +186,9 @@ class C
                 //         new C(param);
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "param").WithLocation(6, 15)
                 );
+
+            CreateCompilation(text, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics();
+            CreateCompilation(text, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics();
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67330")]
@@ -191,7 +203,7 @@ class C
     }
 }
 ";
-            var comp = CreateCompilation(text, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(text, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (4,7): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     C(int*[] param)
@@ -203,6 +215,9 @@ class C
                 //         new C(param);
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "param").WithLocation(6, 15)
                 );
+
+            CreateCompilation(text, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics();
+            CreateCompilation(text, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics();
         }
 
         [Fact]
@@ -11074,7 +11089,7 @@ False", verify: Verification.Skipped);
         [InlineData("delegate*<T>")]
         public void CompareToNullInPatternOutsideUnsafe(string pointerType)
         {
-            var comp = CreateCompilation($@"
+            var source = $@"
 var c = default(S<int>);
 _ = c.Field is null;
 unsafe struct S<T> where T : unmanaged
@@ -11082,13 +11097,15 @@ unsafe struct S<T> where T : unmanaged
 #pragma warning disable CS0649 // Field is unassigned
     public {pointerType} Field;
 }}
-", options: TestOptions.UnsafeReleaseExe);
-
-            comp.VerifyDiagnostics(
+";
+            CreateCompilation(source, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(
                 // (3,5): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // _ = c.Field is null;
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "c.Field").WithLocation(3, 5)
             );
+
+            CreateCompilation(source, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics();
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics();
         }
 
         #endregion Pointer comparison tests
@@ -11672,7 +11689,7 @@ class D
     }
 }
 """;
-            var comp = CreateCompilation(source, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (6,21): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //         var lam1 = (int* ptr) => ptr; // 1
@@ -11711,6 +11728,9 @@ class D
                 //         var lam4 = (C<delegate*<void>[]> a) => a; // 4
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "a").WithLocation(18, 48)
                 );
+
+            CreateCompilation(source, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics();
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics();
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67330")]
@@ -11743,7 +11763,7 @@ class D
     }
 }
 """;
-            var comp = CreateCompilation(source, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (11,17): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //         return (ptr) => ptr; // 1
@@ -11770,6 +11790,9 @@ class D
                 //         return (a) => a; // 4
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "a").WithLocation(23, 23)
                 );
+
+            CreateCompilation(source, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics();
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
@@ -11633,7 +11633,17 @@ unsafe delegate void F1(int* x);
 delegate void F2(int x);
 ";
 
-            CompileAndVerify(text, options: TestOptions.UnsafeReleaseExe, expectedOutput: @"2", verify: Verification.Passes);
+            CompileAndVerify(text, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeReleaseExe, expectedOutput: @"2", verify: Verification.Passes);
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (8,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.Goo(F1)' and 'Program.Goo(F2)'
+                //         Goo(x => { });
+                Diagnostic(ErrorCode.ERR_AmbigCall, "Goo").WithArguments("Program.Goo(F1)", "Program.Goo(F2)").WithLocation(8, 9)
+            };
+
+            CreateCompilation(text, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilation(text, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Fact]
@@ -11659,9 +11669,19 @@ unsafe delegate void F1(C<int*[]> x);
 delegate void F2(int x);
 ";
 
-            var comp = CreateCompilation(text, options: TestOptions.UnsafeDebugExe);
+            var comp = CreateCompilation(text, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugExe);
             comp.VerifyDiagnostics();
             CompileAndVerify(comp, expectedOutput: "2");
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (10,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.M(F1)' and 'Program.M(F2)'
+                //         M(x => { });
+                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("Program.M(F1)", "Program.M(F2)").WithLocation(10, 9)
+            };
+
+            CreateCompilation(text, options: TestOptions.UnsafeDebugExe).VerifyDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilation(text, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugExe).VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67330")]

--- a/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
@@ -1412,7 +1412,10 @@ unsafe class Program
             };
 
             CreateCompilation(source, options: TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.Regular13, targetFramework: TargetFramework.Net70).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source, options: TestOptions.UnsafeReleaseDll, targetFramework: TargetFramework.Net70).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source, options: TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.Regular14, targetFramework: TargetFramework.Net70).VerifyDiagnostics(expectedDiagnostics);
+
+            CreateCompilation(source, options: TestOptions.UnsafeReleaseDll, targetFramework: TargetFramework.Net70).VerifyDiagnostics();
+            CreateCompilation(source, options: TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.RegularNext, targetFramework: TargetFramework.Net70).VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit3/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Attributes/AttributeTests.cs
@@ -10172,7 +10172,7 @@ class C
     unsafe static D M1() => new D(F);
     static D M2() => new D(F);
 }";
-            var comp = CreateCompilation(source, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (7,35): warning CS0612: 'C.F()' is obsolete
                 //     unsafe static D M1() => new D(F);
@@ -10181,6 +10181,21 @@ class C
                 //     static D M2() => new D(F);
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "F").WithLocation(8, 28)
             );
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (7,35): warning CS0612: 'C.F()' is obsolete
+                //     unsafe static D M1() => new D(F);
+                Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "F").WithArguments("C.F()").WithLocation(7, 35),
+                // (8,28): warning CS0612: 'C.F()' is obsolete
+                //     static D M2() => new D(F);
+                Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "F").WithArguments("C.F()").WithLocation(8, 28),
+            };
+
+            comp = CreateCompilation(source, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(expectedPreviewDiagnostics);
+            comp = CreateCompilation(source, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Fact]
@@ -10210,7 +10225,7 @@ namespace System.Runtime.InteropServices
         public string EntryPoint;
     }
 }";
-            var comp = CreateCompilation(source, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (8,35): error CS8902: 'C.F()' is attributed with 'UnmanagedCallersOnly' and cannot be converted to a delegate type. Obtain a function pointer to this method.
                 //     unsafe static D M1() => new D(F);
@@ -10219,6 +10234,21 @@ namespace System.Runtime.InteropServices
                 //     static D M2() => new D(F);
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "F").WithLocation(9, 28)
             );
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (8,35): error CS8902: 'C.F()' is attributed with 'UnmanagedCallersOnly' and cannot be converted to a delegate type. Obtain a function pointer to this method.
+                //     unsafe static D M1() => new D(F);
+                Diagnostic(ErrorCode.ERR_UnmanagedCallersOnlyMethodsCannotBeConvertedToDelegate, "F").WithArguments("C.F()").WithLocation(8, 35),
+                // (9,28): error CS8902: 'C.F()' is attributed with 'UnmanagedCallersOnly' and cannot be converted to a delegate type. Obtain a function pointer to this method.
+                //     static D M2() => new D(F);
+                Diagnostic(ErrorCode.ERR_UnmanagedCallersOnlyMethodsCannotBeConvertedToDelegate, "F").WithArguments("C.F()").WithLocation(9, 28),
+            };
+
+            comp = CreateCompilation(source, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(expectedPreviewDiagnostics);
+            comp = CreateCompilation(source, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Fact]
@@ -10833,7 +10863,7 @@ class C2 { }
 [Attr<TypedReference>] // 3
 class C3 { }
 ";
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular14);
             comp.VerifyDiagnostics(
                 // (5,7): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // [Attr<int*>] // 1
@@ -10850,6 +10880,22 @@ class C3 { }
                 // (11,7): error CS0306: The type 'TypedReference' may not be used as a type argument
                 // [Attr<TypedReference>] // 3
                 Diagnostic(ErrorCode.ERR_BadTypeArgument, "TypedReference").WithArguments("System.TypedReference").WithLocation(11, 7));
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (5,7): error CS0306: The type 'int*' may not be used as a type argument
+                // [Attr<int*>] // 1
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "int*").WithArguments("int*").WithLocation(5, 7),
+                // (8,7): error CS0306: The type 'delegate*<int, void>' may not be used as a type argument
+                // [Attr<delegate*<int, void>>] // 2
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "delegate*<int, void>").WithArguments("delegate*<int, void>").WithLocation(8, 7),
+                // (11,7): error CS0306: The type 'TypedReference' may not be used as a type argument
+                // [Attr<TypedReference>] // 3
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "TypedReference").WithArguments("System.TypedReference").WithLocation(11, 7),
+            };
+
+            CreateCompilation(source).VerifyDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Fact]
@@ -10894,11 +10940,16 @@ class Attr<T> : Attribute { }
 [Attr<int*[]>] // 1
 class C1 { }
 ";
-            var comp = CreateCompilation(source, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (5,7): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // [Attr<int*[]>] // 1
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(5, 7));
+
+            comp = CreateCompilation(source, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
+            comp = CreateCompilation(source, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
 
             comp = CreateCompilation(source, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.Regular12);
             comp.VerifyDiagnostics(
@@ -11575,11 +11626,16 @@ class A<T> : System.Attribute
 {
 }
 ";
-            var comp = CreateCompilation(source, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (2,4): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // [A<int*[]>] // 1
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(2, 4));
+
+            comp = CreateCompilation(source, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
+            comp = CreateCompilation(source, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/68370")]

--- a/src/Compilers/CSharp/Test/Emit3/PartialEventsAndConstructorsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/PartialEventsAndConstructorsTests.cs
@@ -3090,7 +3090,7 @@ public sealed class PartialEventsAndConstructorsTests : CSharpTestBase
                 partial event System.Action F { add { int* p = null; } remove { } }
             }
             """;
-        CreateCompilation(source, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+        CreateCompilation(source, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
             // (8,15): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             //     partial C(int* p) { }
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(8, 15),
@@ -3100,6 +3100,9 @@ public sealed class PartialEventsAndConstructorsTests : CSharpTestBase
             // (10,43): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             //     partial event System.Action F { add { int* p = null; } remove { } }
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(10, 43));
+
+        CreateCompilation(source, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
@@ -45738,13 +45738,18 @@ partial class Program
                             }
                             """;
 
-            var comp3 = CreateCompilation(source3, references: [comp1Ref], options: TestOptions.UnsafeDebugExe);
+            var comp3 = CreateCompilation(source3, references: [comp1Ref], parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugExe);
 
             comp3.VerifyDiagnostics(
                 // (5,24): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //         Overloads.Test([2, 3]);
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "[2, 3]").WithLocation(5, 24)
                 );
+
+            comp3 = CreateCompilation(source3, references: [comp1Ref], options: TestOptions.UnsafeDebugExe);
+            comp3.VerifyDiagnostics();
+            comp3 = CreateCompilation(source3, references: [comp1Ref], parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugExe);
+            comp3.VerifyDiagnostics();
         }
 
         [Fact]
@@ -45818,7 +45823,7 @@ partial class Program
                             }
                             """;
 
-            var comp3 = CreateCompilation(source3, references: [comp1Ref], options: TestOptions.UnsafeDebugExe);
+            var comp3 = CreateCompilation(source3, references: [comp1Ref], parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugExe);
 
             comp3.VerifyDiagnostics(
                 // (5,25): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
@@ -45828,6 +45833,11 @@ partial class Program
                 //         Overloads.Test([2, 3]);
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "3").WithLocation(5, 28)
                 );
+
+            comp3 = CreateCompilation(source3, references: [comp1Ref], options: TestOptions.UnsafeDebugExe);
+            comp3.VerifyDiagnostics();
+            comp3 = CreateCompilation(source3, references: [comp1Ref], parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugExe);
+            comp3.VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
@@ -20076,11 +20076,16 @@ unsafe static class E
     }
 }
 """;
-        var comp = CreateCompilation(source, options: TestOptions.UnsafeDebugExe);
+        var comp = CreateCompilation(source, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugExe);
         comp.VerifyEmitDiagnostics(
             // (1,7): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             // D d = object.M;
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "object.M").WithLocation(1, 7));
+
+        comp = CreateCompilation(source, options: TestOptions.UnsafeDebugExe);
+        comp.VerifyEmitDiagnostics();
+        comp = CreateCompilation(source, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugExe);
+        comp.VerifyEmitDiagnostics();
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ParamsCollectionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ParamsCollectionTests.cs
@@ -13535,7 +13535,7 @@ class Program
 }
 """;
 
-            var comp4 = CreateCompilation(source4, references: [comp1Ref, comp3.ToMetadataReference()], options: TestOptions.ReleaseExe);
+            var comp4 = CreateCompilation(source4, references: [comp1Ref, comp3.ToMetadataReference()], parseOptions: TestOptions.Regular14, options: TestOptions.ReleaseExe);
             comp4.VerifyEmitDiagnostics(
                 // (5,9): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //         Params.Test();
@@ -13547,6 +13547,11 @@ class Program
                 //         Params.Test(2, 3);
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "Params.Test(2, 3)").WithLocation(7, 9)
                 );
+
+            comp4 = CreateCompilation(source4, references: [comp1Ref, comp3.ToMetadataReference()], options: TestOptions.ReleaseExe);
+            comp4.VerifyEmitDiagnostics();
+            comp4 = CreateCompilation(source4, references: [comp1Ref, comp3.ToMetadataReference()], parseOptions: TestOptions.RegularNext, options: TestOptions.ReleaseExe);
+            comp4.VerifyEmitDiagnostics();
 
             string source5 = """
 class Program
@@ -13636,7 +13641,7 @@ class Program
 }
 """;
 
-            var comp4 = CreateCompilation(source4, references: [comp1Ref, comp3.ToMetadataReference()], options: TestOptions.ReleaseExe);
+            var comp4 = CreateCompilation(source4, references: [comp1Ref, comp3.ToMetadataReference()], parseOptions: TestOptions.Regular14, options: TestOptions.ReleaseExe);
             comp4.VerifyEmitDiagnostics(
                 // (6,21): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //         Params.Test(1);
@@ -13648,6 +13653,11 @@ class Program
                 //         Params.Test(2, 3);
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "3").WithLocation(7, 24)
                 );
+
+            comp4 = CreateCompilation(source4, references: [comp1Ref, comp3.ToMetadataReference()], options: TestOptions.ReleaseExe);
+            comp4.VerifyEmitDiagnostics();
+            comp4 = CreateCompilation(source4, references: [comp1Ref, comp3.ToMetadataReference()], parseOptions: TestOptions.RegularNext, options: TestOptions.ReleaseExe);
+            comp4.VerifyEmitDiagnostics();
 
             string source5 = """
 class Program

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/PrimaryConstructorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/PrimaryConstructorTests.cs
@@ -22114,7 +22114,7 @@ class C1(int* x)
     public int X => *x;
 }
 ";
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDll);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular14, options: TestOptions.ReleaseDll);
             comp.VerifyDiagnostics(
                 // (2,11): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // struct S1(int* x)
@@ -22129,6 +22129,21 @@ class C1(int* x)
                 //     public int X => *x;
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "x").WithLocation(9, 22)
                 );
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (4,21): error CS9360: This operation may only be used in an unsafe context
+                //     public int X => *x;
+                Diagnostic(ErrorCode.ERR_UnsafeOperation, "*").WithLocation(4, 21),
+                // (9,21): error CS9360: This operation may only be used in an unsafe context
+                //     public int X => *x;
+                Diagnostic(ErrorCode.ERR_UnsafeOperation, "*").WithLocation(9, 21),
+            };
+
+            comp = CreateCompilation(source, options: TestOptions.ReleaseDll);
+            comp.VerifyDiagnostics(expectedPreviewDiagnostics);
+            comp = CreateCompilation(source, parseOptions: TestOptions.RegularNext, options: TestOptions.ReleaseDll);
+            comp.VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_ISizeOfExpression.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_ISizeOfExpression.cs
@@ -66,17 +66,18 @@ ISizeOfOperation (OperationKind.SizeOf, Type: System.Int32, IsInvalid) (Syntax: 
             };
 
             VerifyOperationTreeAndDiagnosticsForTest<SizeOfExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.Regular14);
+            string expectedPreviewOperationTree = @"
+ISizeOfOperation (OperationKind.SizeOf, Type: System.Int32) (Syntax: 'sizeof(C)')
+  TypeOperand: C
+";
             var expectedPreviewDiagnostics = new[]
             {
-                // (2,1): hidden CS8019: Unnecessary using directive.
-                // using System;
-                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System;").WithLocation(2, 1),
                 // (8,23): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('C')
                 //         i = /*<bind>*/sizeof(C)/*</bind>*/;
                 Diagnostic(ErrorCode.WRN_ManagedAddr, "sizeof(C)").WithArguments("C").WithLocation(8, 23),
             };
-            CreateCompilation(source).VerifyDiagnostics(expectedPreviewDiagnostics);
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedPreviewDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<SizeOfExpressionSyntax>(source, expectedPreviewOperationTree, expectedPreviewDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<SizeOfExpressionSyntax>(source, expectedPreviewOperationTree, expectedPreviewDiagnostics, parseOptions: TestOptions.RegularNext);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
@@ -134,15 +135,12 @@ ISizeOfOperation (OperationKind.SizeOf, Type: System.Int32, IsInvalid) (Syntax: 
             VerifyOperationTreeAndDiagnosticsForTest<SizeOfExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.Regular14);
             var expectedPreviewDiagnostics = new[]
             {
-                // (2,1): hidden CS8019: Unnecessary using directive.
-                // using System;
-                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System;").WithLocation(2, 1),
                 // (8,30): error CS0246: The type or namespace name 'UndefinedType' could not be found (are you missing a using directive or an assembly reference?)
                 //         i = /*<bind>*/sizeof(UndefinedType)/*</bind>*/;
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "UndefinedType").WithArguments("UndefinedType").WithLocation(8, 30),
             };
-            CreateCompilation(source).VerifyDiagnostics(expectedPreviewDiagnostics);
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedPreviewDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<SizeOfExpressionSyntax>(source, expectedOperationTree, expectedPreviewDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<SizeOfExpressionSyntax>(source, expectedOperationTree, expectedPreviewDiagnostics, parseOptions: TestOptions.RegularNext);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
@@ -176,15 +174,12 @@ ISizeOfOperation (OperationKind.SizeOf, Type: System.Int32, IsInvalid) (Syntax: 
             VerifyOperationTreeAndDiagnosticsForTest<SizeOfExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.Regular14);
             var expectedPreviewDiagnostics = new[]
             {
-                // (2,1): hidden CS8019: Unnecessary using directive.
-                // using System;
-                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System;").WithLocation(2, 1),
                 // (8,30): error CS0118: 'i' is a variable but is used like a type
                 //         i = /*<bind>*/sizeof(i)/*</bind>*/;
                 Diagnostic(ErrorCode.ERR_BadSKknown, "i").WithArguments("i", "variable", "type").WithLocation(8, 30),
             };
-            CreateCompilation(source).VerifyDiagnostics(expectedPreviewDiagnostics);
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedPreviewDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<SizeOfExpressionSyntax>(source, expectedOperationTree, expectedPreviewDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<SizeOfExpressionSyntax>(source, expectedOperationTree, expectedPreviewDiagnostics, parseOptions: TestOptions.RegularNext);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
@@ -231,24 +226,21 @@ IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'sizeof(M
             VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.Regular14);
             var expectedPreviewDiagnostics = new[]
             {
-                // (2,1): hidden CS8019: Unnecessary using directive.
-                // using System;
-                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System;").WithLocation(2, 1),
                 // (8,32): error CS1026: ) expected
-                //         i = /*<bind>*/sizeof(M2()/*</bind>*/);                
+                //         i = /*<bind>*/sizeof(M2()/*</bind>*/);
                 Diagnostic(ErrorCode.ERR_CloseParenExpected, "(").WithLocation(8, 32),
                 // (8,45): error CS1002: ; expected
-                //         i = /*<bind>*/sizeof(M2()/*</bind>*/);                
+                //         i = /*<bind>*/sizeof(M2()/*</bind>*/);
                 Diagnostic(ErrorCode.ERR_SemicolonExpected, ")").WithLocation(8, 45),
                 // (8,45): error CS1513: } expected
-                //         i = /*<bind>*/sizeof(M2()/*</bind>*/);                
+                //         i = /*<bind>*/sizeof(M2()/*</bind>*/);
                 Diagnostic(ErrorCode.ERR_RbraceExpected, ")").WithLocation(8, 45),
                 // (8,30): error CS0246: The type or namespace name 'M2' could not be found (are you missing a using directive or an assembly reference?)
-                //         i = /*<bind>*/sizeof(M2()/*</bind>*/);                
+                //         i = /*<bind>*/sizeof(M2()/*</bind>*/);
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "M2").WithArguments("M2").WithLocation(8, 30),
             };
-            CreateCompilation(source).VerifyDiagnostics(expectedPreviewDiagnostics);
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedPreviewDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(source, expectedOperationTree, expectedPreviewDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(source, expectedOperationTree, expectedPreviewDiagnostics, parseOptions: TestOptions.RegularNext);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
@@ -282,15 +274,12 @@ ISizeOfOperation (OperationKind.SizeOf, Type: System.Int32, IsInvalid) (Syntax: 
             VerifyOperationTreeAndDiagnosticsForTest<SizeOfExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.Regular14);
             var expectedPreviewDiagnostics = new[]
             {
-                // (2,1): hidden CS8019: Unnecessary using directive.
-                // using System;
-                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System;").WithLocation(2, 1),
                 // (8,30): error CS1031: Type expected
                 //         i = /*<bind>*/sizeof()/*</bind>*/;
                 Diagnostic(ErrorCode.ERR_TypeExpected, ")").WithLocation(8, 30),
             };
-            CreateCompilation(source).VerifyDiagnostics(expectedPreviewDiagnostics);
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedPreviewDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<SizeOfExpressionSyntax>(source, expectedOperationTree, expectedPreviewDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<SizeOfExpressionSyntax>(source, expectedOperationTree, expectedPreviewDiagnostics, parseOptions: TestOptions.RegularNext);
         }
 
         [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_ISizeOfExpression.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_ISizeOfExpression.cs
@@ -65,7 +65,18 @@ ISizeOfOperation (OperationKind.SizeOf, Type: System.Int32, IsInvalid) (Syntax: 
                 Diagnostic(ErrorCode.ERR_SizeofUnsafe, "sizeof(C)").WithArguments("C").WithLocation(8, 23)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<SizeOfExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<SizeOfExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.Regular14);
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using System;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System;").WithLocation(2, 1),
+                // (8,23): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('C')
+                //         i = /*<bind>*/sizeof(C)/*</bind>*/;
+                Diagnostic(ErrorCode.WRN_ManagedAddr, "sizeof(C)").WithArguments("C").WithLocation(8, 23),
+            };
+            CreateCompilation(source).VerifyDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
@@ -120,7 +131,18 @@ ISizeOfOperation (OperationKind.SizeOf, Type: System.Int32, IsInvalid) (Syntax: 
                 Diagnostic(ErrorCode.ERR_SizeofUnsafe, "sizeof(UndefinedType)").WithArguments("UndefinedType").WithLocation(8, 23)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<SizeOfExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<SizeOfExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.Regular14);
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using System;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System;").WithLocation(2, 1),
+                // (8,30): error CS0246: The type or namespace name 'UndefinedType' could not be found (are you missing a using directive or an assembly reference?)
+                //         i = /*<bind>*/sizeof(UndefinedType)/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "UndefinedType").WithArguments("UndefinedType").WithLocation(8, 30),
+            };
+            CreateCompilation(source).VerifyDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
@@ -151,7 +173,18 @@ ISizeOfOperation (OperationKind.SizeOf, Type: System.Int32, IsInvalid) (Syntax: 
                 Diagnostic(ErrorCode.ERR_SizeofUnsafe, "sizeof(i)").WithArguments("i").WithLocation(8, 23)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<SizeOfExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<SizeOfExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.Regular14);
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using System;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System;").WithLocation(2, 1),
+                // (8,30): error CS0118: 'i' is a variable but is used like a type
+                //         i = /*<bind>*/sizeof(i)/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_BadSKknown, "i").WithArguments("i", "variable", "type").WithLocation(8, 30),
+            };
+            CreateCompilation(source).VerifyDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
@@ -195,7 +228,27 @@ IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'sizeof(M
                 Diagnostic(ErrorCode.ERR_SizeofUnsafe, "sizeof(M2").WithArguments("M2").WithLocation(8, 23)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.Regular14);
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using System;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System;").WithLocation(2, 1),
+                // (8,32): error CS1026: ) expected
+                //         i = /*<bind>*/sizeof(M2()/*</bind>*/);                
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "(").WithLocation(8, 32),
+                // (8,45): error CS1002: ; expected
+                //         i = /*<bind>*/sizeof(M2()/*</bind>*/);                
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, ")").WithLocation(8, 45),
+                // (8,45): error CS1513: } expected
+                //         i = /*<bind>*/sizeof(M2()/*</bind>*/);                
+                Diagnostic(ErrorCode.ERR_RbraceExpected, ")").WithLocation(8, 45),
+                // (8,30): error CS0246: The type or namespace name 'M2' could not be found (are you missing a using directive or an assembly reference?)
+                //         i = /*<bind>*/sizeof(M2()/*</bind>*/);                
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "M2").WithArguments("M2").WithLocation(8, 30),
+            };
+            CreateCompilation(source).VerifyDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
@@ -226,7 +279,18 @@ ISizeOfOperation (OperationKind.SizeOf, Type: System.Int32, IsInvalid) (Syntax: 
                 Diagnostic(ErrorCode.ERR_SizeofUnsafe, "sizeof()").WithArguments("?").WithLocation(8, 23)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<SizeOfExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<SizeOfExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.Regular14);
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using System;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System;").WithLocation(2, 1),
+                // (8,30): error CS1031: Type expected
+                //         i = /*<bind>*/sizeof()/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_TypeExpected, ")").WithLocation(8, 30),
+            };
+            CreateCompilation(source).VerifyDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_StackAllocArrayCreationAndInitializer.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_StackAllocArrayCreationAndInitializer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_StackAllocArrayCreationAndInitializer.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_StackAllocArrayCreationAndInitializer.cs
@@ -1,10 +1,11 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 #nullable disable
 
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -36,7 +37,9 @@ IOperation:  (OperationKind.None, Type: System.Int32*, IsInvalid) (Syntax: 'stac
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "stackalloc int[1]").WithLocation(6, 27)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.Regular14);
+            CreateCompilation(source).VerifyDiagnostics();
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
         }
 
         [Fact]
@@ -64,7 +67,9 @@ IOperation:  (OperationKind.None, Type: M*, IsInvalid) (Syntax: 'stackalloc M[1]
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "stackalloc M[1]").WithLocation(8, 27)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.Regular14);
+            CreateCompilation(source).VerifyDiagnostics();
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
         }
 
         [Fact]
@@ -93,7 +98,9 @@ IOperation:  (OperationKind.None, Type: M*, IsInvalid) (Syntax: 'stackalloc M[di
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "stackalloc M[dimension]").WithLocation(9, 27)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.Regular14);
+            CreateCompilation(source).VerifyDiagnostics();
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
         }
 
         [Fact]
@@ -121,7 +128,9 @@ IOperation:  (OperationKind.None, Type: M*, IsInvalid) (Syntax: 'stackalloc M[di
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "stackalloc M[dimension]").WithLocation(8, 27)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.Regular14);
+            CreateCompilation(source).VerifyDiagnostics();
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
         }
 
         [Fact]
@@ -152,7 +161,9 @@ IOperation:  (OperationKind.None, Type: M*, IsInvalid) (Syntax: 'stackalloc M[di
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "stackalloc M[dimension]").WithLocation(8, 27)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.Regular14);
+            CreateCompilation(source).VerifyDiagnostics();
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
         }
 
         [Fact]
@@ -183,7 +194,9 @@ IOperation:  (OperationKind.None, Type: M*, IsInvalid) (Syntax: 'stackalloc  ...
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "stackalloc M[(int)dimension]").WithLocation(8, 27)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.Regular14);
+            CreateCompilation(source).VerifyDiagnostics();
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
         }
 
         [Fact]
@@ -210,7 +223,9 @@ IOperation:  (OperationKind.None, Type: System.Int32*, IsInvalid) (Syntax: 'stac
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "stackalloc int[] { 42 }").WithLocation(6, 27)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.Regular14);
+            CreateCompilation(source).VerifyDiagnostics();
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
         }
 
         [Fact]
@@ -237,7 +252,9 @@ IOperation:  (OperationKind.None, Type: System.Int32*, IsInvalid) (Syntax: 'stac
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "stackalloc int[1] { 42 }").WithLocation(6, 27)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.Regular14);
+            CreateCompilation(source).VerifyDiagnostics();
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
         }
 
         [Fact]
@@ -323,7 +340,9 @@ IOperation:  (OperationKind.None, Type: M*, IsInvalid) (Syntax: 'stackalloc  ...
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "stackalloc M[] { new M() }").WithLocation(8, 27)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.Regular14);
+            CreateCompilation(source).VerifyDiagnostics();
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
         }
 
         [Fact]
@@ -355,7 +374,9 @@ IOperation:  (OperationKind.None, Type: M*, IsInvalid) (Syntax: 'stackalloc[] { 
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "stackalloc[] { new M() }").WithLocation(8, 27)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<ImplicitStackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<ImplicitStackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.Regular14);
+            CreateCompilation(source).VerifyDiagnostics();
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
         }
 
         [Fact]
@@ -455,7 +476,9 @@ IOperation:  (OperationKind.None, Type: System.Int32*, IsInvalid) (Syntax: 'stac
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "stackalloc[] { 2, a, default }").WithLocation(7, 27)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<ImplicitStackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<ImplicitStackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.Regular14);
+            CreateCompilation(source).VerifyDiagnostics();
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
         }
 
         [Fact]
@@ -509,7 +532,9 @@ IOperation:  (OperationKind.None, Type: System.Int32*, IsInvalid) (Syntax: 'stac
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "stackalloc int[] { 1 }").WithLocation(6, 27)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.Regular14);
+            CreateCompilation(source).VerifyDiagnostics();
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
         }
 
         [Fact]
@@ -541,7 +566,15 @@ IOperation:  (OperationKind.None, Type: System.Int32*, IsInvalid) (Syntax: 'stac
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "stackalloc int[b]").WithLocation(6, 27)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.Regular14);
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (6,42): error CS0266: Cannot implicitly convert type 'object' to 'int'. An explicit conversion exists (are you missing a cast?)
+                //         var a = /*<bind>*/stackalloc int[b]/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "b").WithArguments("object", "int").WithLocation(6, 42),
+            };
+            CreateCompilation(source).VerifyDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Fact]
@@ -572,7 +605,9 @@ IOperation:  (OperationKind.None, Type: System.Int32*, IsInvalid) (Syntax: 'stac
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "stackalloc int[M()]").WithLocation(6, 27)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.Regular14);
+            CreateCompilation(source).VerifyDiagnostics();
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
         }
 
         [Fact]
@@ -606,7 +641,9 @@ IOperation:  (OperationKind.None, Type: System.Int32*, IsInvalid) (Syntax: 'stac
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "stackalloc int[(int)M()]").WithLocation(6, 27)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.Regular14);
+            CreateCompilation(source).VerifyDiagnostics();
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
         }
 
         [Fact]
@@ -704,7 +741,15 @@ IOperation:  (OperationKind.None, Type: System.Int32*, IsInvalid) (Syntax: 'stac
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "stackalloc int[0.0]").WithLocation(6, 27)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.Regular14);
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (6,42): error CS0266: Cannot implicitly convert type 'double' to 'int'. An explicit conversion exists (are you missing a cast?)
+                //         var a = /*<bind>*/stackalloc int[0.0]/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "0.0").WithArguments("double", "int").WithLocation(6, 42),
+            };
+            CreateCompilation(source).VerifyDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedPreviewDiagnostics);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTests.cs
@@ -727,7 +727,7 @@ class Test
     async static Task M3(int*[] i) { await Task.Yield(); } // 3
     async static Task M4(delegate*<void>[] i) { await Task.Yield(); } // 4
 }";
-            CreateCompilationWithMscorlib461(source, null, TestOptions.UnsafeReleaseDll)
+            CreateCompilationWithMscorlib461(source, null, TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.Regular14)
                 .VerifyDiagnostics(
                     // (6,45): error CS4004: Cannot await in an unsafe context
                     //     unsafe async static Task M1(int*[] i) { await Task.Yield(); } // 1
@@ -742,6 +742,21 @@ class Test
                     //     async static Task M4(delegate*<void>[] i) { await Task.Yield(); } // 4
                     Diagnostic(ErrorCode.ERR_UnsafeNeeded, "delegate*").WithLocation(9, 26)
                     );
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (6,45): error CS4004: Cannot await in an unsafe context
+                //     unsafe async static Task M1(int*[] i) { await Task.Yield(); } // 1
+                Diagnostic(ErrorCode.ERR_AwaitInUnsafeContext, "await Task.Yield()").WithLocation(6, 45),
+                // (7,56): error CS4004: Cannot await in an unsafe context
+                //     unsafe async static Task M2(delegate*<void>[] i) { await Task.Yield(); } // 2
+                Diagnostic(ErrorCode.ERR_AwaitInUnsafeContext, "await Task.Yield()").WithLocation(7, 56)
+            };
+
+            CreateCompilationWithMscorlib461(source, null, TestOptions.UnsafeReleaseDll)
+                .VerifyDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilationWithMscorlib461(source, null, TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.RegularNext)
+                .VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/GlobalUsingDirectiveTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/GlobalUsingDirectiveTests.cs
@@ -5060,10 +5060,14 @@ class C
 }
 ";
 
-            CreateCompilation(new[] { source1, source2 }, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            CreateCompilation(new[] { source1, source2 }, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.Regular14).VerifyDiagnostics(
                 // (4,5): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     X Goo() => default;
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "X").WithLocation(4, 5));
+
+            CreateCompilation(new[] { source1, source2 }, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics();
+
+            CreateCompilation(new[] { source1, source2 }, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
         }
 
         [Fact]
@@ -5079,10 +5083,14 @@ class C
 }
 ";
 
-            CreateCompilation(new[] { source1, source2 }, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            CreateCompilation(new[] { source1, source2 }, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.Regular14).VerifyDiagnostics(
                 // (2,18): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // global using X = int*;
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(2, 18));
+
+            CreateCompilation(new[] { source1, source2 }, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics();
+
+            CreateCompilation(new[] { source1, source2 }, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ImplicitObjectCreationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ImplicitObjectCreationTests.cs
@@ -2795,7 +2795,7 @@ class C
     }
 }
 ";
-            var comp = CreateCompilation(source, options: TestOptions.DebugExe);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular14, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
                 // (6,20): error CS1031: Type expected
                 //         _ = sizeof(new());
@@ -2819,6 +2819,33 @@ class C
                 //         _ = sizeof(new());
                 Diagnostic(ErrorCode.ERR_ImplicitObjectCreationNoTargetType, "new()").WithArguments("new()").WithLocation(6, 20)
                 );
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (6,20): error CS1031: Type expected
+                //         _ = sizeof(new());
+                Diagnostic(ErrorCode.ERR_TypeExpected, "new").WithLocation(6, 20),
+                // (6,20): error CS1026: ) expected
+                //         _ = sizeof(new());
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "new").WithLocation(6, 20),
+                // (6,20): error CS1002: ; expected
+                //         _ = sizeof(new());
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "new").WithLocation(6, 20),
+                // (6,25): error CS1002: ; expected
+                //         _ = sizeof(new());
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, ")").WithLocation(6, 25),
+                // (6,25): error CS1513: } expected
+                //         _ = sizeof(new());
+                Diagnostic(ErrorCode.ERR_RbraceExpected, ")").WithLocation(6, 25),
+                // (6,20): error CS8754: There is no target type for 'new()'
+                //         _ = sizeof(new());
+                Diagnostic(ErrorCode.ERR_ImplicitObjectCreationNoTargetType, "new()").WithArguments("new()").WithLocation(6, 20),
+            };
+
+            comp = CreateCompilation(source, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics(expectedPreviewDiagnostics);
+            comp = CreateCompilation(source, parseOptions: TestOptions.RegularNext, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -8260,7 +8260,7 @@ public class MyAttribute : System.Attribute
         [Fact]
         public void TypeParameterScope_InParameterAttributeSizeOf()
         {
-            var comp = CreateCompilation(@"
+            var source = @"
 class C
 {
     void M()
@@ -8277,7 +8277,8 @@ public class MyAttribute : System.Attribute
 {
     public MyAttribute(int i) { }
 }
-");
+";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular14);
             comp.VerifyDiagnostics(
                 // (8,36): error CS0233: 'TParameter' does not have a predefined size, therefore sizeof can only be used in an unsafe context
                 //         void local<TParameter>([My(sizeof(TParameter))] int i) where TParameter : unmanaged => throw null;
@@ -8289,6 +8290,19 @@ public class MyAttribute : System.Attribute
 
             VerifyTParameter(comp, 0, "void local<TParameter>(System.Int32 i)");
             VerifyTParameter(comp, 1, "void C.M2<TParameter>(System.Int32 i)");
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (8,36): error CS0182: An attribute argument must be a constant expression, typeof expression or array creation expression of an attribute parameter type
+                //         void local<TParameter>([My(sizeof(TParameter))] int i) where TParameter : unmanaged => throw null;
+                Diagnostic(ErrorCode.ERR_BadAttributeArgument, "sizeof(TParameter)").WithLocation(8, 36),
+                // (11,29): error CS0182: An attribute argument must be a constant expression, typeof expression or array creation expression of an attribute parameter type
+                //     void M2<TParameter>([My(sizeof(TParameter))] int i) where TParameter : unmanaged => throw null;
+                Diagnostic(ErrorCode.ERR_BadAttributeArgument, "sizeof(TParameter)").WithLocation(11, 29),
+            };
+
+            CreateCompilation(source).VerifyDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -2433,7 +2433,28 @@ class C
             };
 
             CreateCompilation(src, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.Regular13.WithFeature(Feature.RunNullableAnalysis, "never")).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(src, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularPreview.WithFeature(Feature.RunNullableAnalysis, "never")).VerifyDiagnostics(expectedDiagnostics);
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (8,37): error CS1637: Iterators cannot have pointer type parameters
+                //         IEnumerable<int> Local(int* a) { yield break; }
+                Diagnostic(ErrorCode.ERR_UnsafeIteratorArgType, "a").WithLocation(8, 37),
+                // (17,41): error CS1637: Iterators cannot have pointer type parameters
+                //             IEnumerable<int> Local(int* x) { yield break; }
+                Diagnostic(ErrorCode.ERR_UnsafeIteratorArgType, "x").WithLocation(17, 41),
+                // (27,37): error CS1637: Iterators cannot have pointer type parameters
+                //         IEnumerable<int> Local(int* a) { yield break; }
+                Diagnostic(ErrorCode.ERR_UnsafeIteratorArgType, "a").WithLocation(27, 37),
+                // (33,44): error CS1637: Iterators cannot have pointer type parameters
+                //     public unsafe IEnumerable<int> M4(int* a)
+                Diagnostic(ErrorCode.ERR_UnsafeIteratorArgType, "a").WithLocation(33, 44),
+                // (37,45): error CS1637: Iterators cannot have pointer type parameters
+                //                 IEnumerable<int> Local(int* b) { yield break; }
+                Diagnostic(ErrorCode.ERR_UnsafeIteratorArgType, "b").WithLocation(37, 45)
+            };
+
+            CreateCompilation(src, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularPreview.WithFeature(Feature.RunNullableAnalysis, "never")).VerifyDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilation(src, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularNext.WithFeature(Feature.RunNullableAnalysis, "never")).VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Fact]
@@ -4780,7 +4801,7 @@ class C
         [WorkItem(13172, "https://github.com/dotnet/roslyn/issues/13172")]
         public void InheritUnsafeContext()
         {
-            var comp = CreateCompilationWithMscorlib46(@"
+            var source = @"
 using System;
 using System.Threading.Tasks;
 class C
@@ -4844,7 +4865,8 @@ unsafe class D
             var _ = Local();
         }
     }
-}", options: TestOptions.UnsafeDebugDll);
+}";
+            var comp = CreateCompilationWithMscorlib46(source, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.Regular14);
             comp.VerifyDiagnostics(
                 // (11,29): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //             return (IntPtr)(void*)null;
@@ -4864,6 +4886,27 @@ unsafe class D
                 // (33,13): error CS4004: Cannot await in an unsafe context
                 //             await Task.Delay(2);
                 Diagnostic(ErrorCode.ERR_AwaitInUnsafeContext, "await Task.Delay(2)").WithLocation(33, 13));
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (47,13): error CS4004: Cannot await in an unsafe context
+                //             await Task.Delay(3);
+                Diagnostic(ErrorCode.ERR_AwaitInUnsafeContext, "await Task.Delay(3)").WithLocation(47, 13),
+                // (22,17): error CS4004: Cannot await in an unsafe context
+                //                 await Task.Delay(1);
+                Diagnostic(ErrorCode.ERR_AwaitInUnsafeContext, "await Task.Delay(1)").WithLocation(22, 17),
+                // (59,17): error CS4004: Cannot await in an unsafe context
+                //                 await Task.Delay(4);
+                Diagnostic(ErrorCode.ERR_AwaitInUnsafeContext, "await Task.Delay(4)").WithLocation(59, 17),
+                // (33,13): error CS4004: Cannot await in an unsafe context
+                //             await Task.Delay(2);
+                Diagnostic(ErrorCode.ERR_AwaitInUnsafeContext, "await Task.Delay(2)").WithLocation(33, 13)
+            };
+
+            CreateCompilationWithMscorlib46(source, options: TestOptions.UnsafeDebugDll)
+                .VerifyDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilationWithMscorlib46(source, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularNext)
+                .VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Fact, WorkItem(16167, "https://github.com/dotnet/roslyn/issues/16167")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
@@ -4404,7 +4404,10 @@ unsafe class Program
             };
 
             CreateCompilation(source, options: TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.Regular13).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source, options: TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.Regular14).VerifyDiagnostics(expectedDiagnostics);
+
+            CreateCompilation(source, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
+            CreateCompilation(source, options: TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -749,7 +749,7 @@ class C
     }
 }
 ";
-            var comp = CreateCompilation(source, options: TestOptions.UnsafeReleaseDll, targetFramework: TargetFramework.Net70);
+            var comp = CreateCompilation(source, options: TestOptions.UnsafeReleaseDll, targetFramework: TargetFramework.Net70, parseOptions: TestOptions.Regular14);
             comp.VerifyEmitDiagnostics(
                 // (14,9): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //         S* s, // 1
@@ -773,6 +773,28 @@ class C
                 //         C* c) // 7
                 Diagnostic(ErrorCode.WRN_ManagedAddr, "c").WithArguments("C").WithLocation(23, 12)
                 );
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (15,13): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('S2')
+                //         S2* s2, // 2, 3
+                Diagnostic(ErrorCode.WRN_ManagedAddr, "s2").WithArguments("S2").WithLocation(15, 13),
+                // (16,12): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('C')
+                //         C* c) // 4, 5
+                Diagnostic(ErrorCode.WRN_ManagedAddr, "c").WithArguments("C").WithLocation(16, 12),
+                // (22,13): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('S2')
+                //         S2* s2, // 6
+                Diagnostic(ErrorCode.WRN_ManagedAddr, "s2").WithArguments("S2").WithLocation(22, 13),
+                // (23,12): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('C')
+                //         C* c) // 7
+                Diagnostic(ErrorCode.WRN_ManagedAddr, "c").WithArguments("C").WithLocation(23, 12)
+            };
+
+            comp = CreateCompilation(source, options: TestOptions.UnsafeReleaseDll, targetFramework: TargetFramework.Net70);
+            comp.VerifyEmitDiagnostics(expectedPreviewDiagnostics);
+
+            comp = CreateCompilation(source, options: TestOptions.UnsafeReleaseDll, targetFramework: TargetFramework.Net70, parseOptions: TestOptions.RegularNext);
+            comp.VerifyEmitDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Fact]
@@ -1025,7 +1047,7 @@ class C
     }
 }
 ";
-            var comp = CreateCompilation(source, options: TestOptions.UnsafeReleaseDll, targetFramework: TargetFramework.Net70);
+            var comp = CreateCompilation(source, options: TestOptions.UnsafeReleaseDll, targetFramework: TargetFramework.Net70, parseOptions: TestOptions.Regular14);
             comp.VerifyEmitDiagnostics(
                 // (13,12): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     void M(void* p)
@@ -1079,6 +1101,28 @@ class C
                 //         _ = (C*)p; // 5
                 Diagnostic(ErrorCode.WRN_ManagedAddr, "C*").WithArguments("C").WithLocation(24, 14)
                 );
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (16,14): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('S2')
+                //         _ = (S2*)p; // 2
+                Diagnostic(ErrorCode.WRN_ManagedAddr, "S2*").WithArguments("S2").WithLocation(16, 14),
+                // (17,14): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('C')
+                //         _ = (C*)p; // 3
+                Diagnostic(ErrorCode.WRN_ManagedAddr, "C*").WithArguments("C").WithLocation(17, 14),
+                // (23,14): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('S2')
+                //         _ = (S2*)p; // 4
+                Diagnostic(ErrorCode.WRN_ManagedAddr, "S2*").WithArguments("S2").WithLocation(23, 14),
+                // (24,14): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('C')
+                //         _ = (C*)p; // 5
+                Diagnostic(ErrorCode.WRN_ManagedAddr, "C*").WithArguments("C").WithLocation(24, 14)
+            };
+
+            comp = CreateCompilation(source, options: TestOptions.UnsafeReleaseDll, targetFramework: TargetFramework.Net70);
+            comp.VerifyEmitDiagnostics(expectedPreviewDiagnostics);
+
+            comp = CreateCompilation(source, options: TestOptions.UnsafeReleaseDll, targetFramework: TargetFramework.Net70, parseOptions: TestOptions.RegularNext);
+            comp.VerifyEmitDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Fact]
@@ -1259,7 +1303,7 @@ unsafe class C2
     }
 }
 ";
-            var comp = CreateCompilation(source, options: TestOptions.UnsafeReleaseDll, targetFramework: TargetFramework.Net70);
+            var comp = CreateCompilation(source, options: TestOptions.UnsafeReleaseDll, targetFramework: TargetFramework.Net70, parseOptions: TestOptions.Regular14);
             comp.VerifyEmitDiagnostics(
                 // (15,17): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //         var x = &s; // 1
@@ -1286,6 +1330,34 @@ unsafe class C2
                 //         var x = &s; // 5
                 Diagnostic(ErrorCode.ERR_FixedNeeded, "&s").WithLocation(39, 17)
                 );
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (19,17): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('S2')
+                //         var x = &s; // 2
+                Diagnostic(ErrorCode.WRN_ManagedAddr, "&s").WithArguments("S2").WithLocation(19, 17),
+                // (23,17): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('S2')
+                //         var x = &s; // 3
+                Diagnostic(ErrorCode.WRN_ManagedAddr, "&s").WithArguments("S2").WithLocation(23, 17),
+                // (23,17): error CS0212: You can only take the address of an unfixed expression inside of a fixed statement initializer
+                //         var x = &s; // 3
+                Diagnostic(ErrorCode.ERR_FixedNeeded, "&s").WithLocation(23, 17),
+                // (35,17): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('S2')
+                //         var x = &s; // 4
+                Diagnostic(ErrorCode.WRN_ManagedAddr, "&s").WithArguments("S2").WithLocation(35, 17),
+                // (39,17): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('S2')
+                //         var x = &s; // 5
+                Diagnostic(ErrorCode.WRN_ManagedAddr, "&s").WithArguments("S2").WithLocation(39, 17),
+                // (39,17): error CS0212: You can only take the address of an unfixed expression inside of a fixed statement initializer
+                //         var x = &s; // 5
+                Diagnostic(ErrorCode.ERR_FixedNeeded, "&s").WithLocation(39, 17)
+            };
+
+            comp = CreateCompilation(source, options: TestOptions.UnsafeReleaseDll, targetFramework: TargetFramework.Net70);
+            comp.VerifyEmitDiagnostics(expectedPreviewDiagnostics);
+
+            comp = CreateCompilation(source, options: TestOptions.UnsafeReleaseDll, targetFramework: TargetFramework.Net70, parseOptions: TestOptions.RegularNext);
+            comp.VerifyEmitDiagnostics(expectedPreviewDiagnostics);
 
             source = @"
 ref struct S2

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -8630,7 +8630,7 @@ public class MyClass
    }
 }
 ";
-            CreateCompilation(text).VerifyDiagnostics(
+            CreateCompilation(text, parseOptions: TestOptions.Regular14).VerifyDiagnostics(
                 // (16,27): error CS0233: 'S' does not have a predefined size, therefore sizeof can only be used in an unsafe context (consider using System.Runtime.InteropServices.Marshal.SizeOf)
                 //         Console.WriteLine(sizeof(S));   // CS0233
                 Diagnostic(ErrorCode.ERR_SizeofUnsafe, "sizeof(S)").WithArguments("S"),
@@ -8638,6 +8638,15 @@ public class MyClass
                 // (15,11): warning CS0219: The variable 'myS' is assigned but its value is never used
                 //         S myS = new S();
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "myS").WithArguments("myS"));
+
+            var expectedDiagnostics = new[]
+            {
+                // (15,11): warning CS0219: The variable 'myS' is assigned but its value is never used
+                //         S myS = new S();
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "myS").WithArguments("myS")
+            };
+            CreateCompilation(text).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(text, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -16167,7 +16167,7 @@ class Test
 }
 ";
 
-            CreateCompilation(text, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(
+            CreateCompilation(text, options: TestOptions.UnsafeReleaseExe, parseOptions: TestOptions.Regular14).VerifyDiagnostics(
                 // (13,30): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //         System.Console.Write(inst.field.buffer[0]);
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "inst.field.buffer").WithLocation(13, 30),
@@ -16175,6 +16175,20 @@ class Test
                 //         return (field.buffer[0] = 7);   // OK
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "field.buffer").WithLocation(20, 17)
                  );
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (13,47): error CS9360: This operation may only be used in an unsafe context
+                //         System.Console.Write(inst.field.buffer[0]);
+                Diagnostic(ErrorCode.ERR_UnsafeOperation, "[").WithLocation(13, 47),
+                // (20,29): error CS9360: This operation may only be used in an unsafe context
+                //         return (field.buffer[0] = 7);   // OK
+                Diagnostic(ErrorCode.ERR_UnsafeOperation, "[").WithLocation(20, 29)
+            };
+
+            CreateCompilation(text, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedPreviewDiagnostics);
+
+            CreateCompilation(text, options: TestOptions.UnsafeReleaseExe, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StackAllocInitializerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StackAllocInitializerTests.cs
@@ -1494,7 +1494,7 @@ class Test
         [Fact]
         public void StackAllocSyntaxProducesUnsafeErrorInSafeCode()
         {
-            CreateCompilation(@"
+            var source = @"
 class Test
 {
     void M()
@@ -1503,7 +1503,8 @@ class Test
         var x2 = stackalloc int [ ] { 1, 2, 3 };
         var x3 = stackalloc     [ ] { 1, 2, 3 };
     }
-}", options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+}";
+            CreateCompilation(source, options: TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.Regular14).VerifyDiagnostics(
                 // (6,18): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //         var x1 = stackalloc int [3] { 1, 2, 3 };
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "stackalloc int [3] { 1, 2, 3 }").WithLocation(6, 18),
@@ -1514,6 +1515,9 @@ class Test
                 //         var x3 = stackalloc     [ ] { 1, 2, 3 };
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "stackalloc     [ ] { 1, 2, 3 }").WithLocation(8, 18)
                 );
+
+            CreateCompilation(source, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
+            CreateCompilation(source, options: TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
         }
 
         [Fact]
@@ -1817,7 +1821,7 @@ unsafe public class Test
         [Fact]
         public void StackAllocWithDynamic()
         {
-            CreateCompilation(@"
+            var source = @"
 class Program
 {
     static void Main()
@@ -1827,7 +1831,8 @@ class Program
         var d2 = stackalloc dynamic [ ] { d };
         var d3 = stackalloc         [ ] { d };
     }
-}").VerifyDiagnostics(
+}";
+            CreateCompilation(source, parseOptions: TestOptions.Regular14).VerifyDiagnostics(
                 // (7,29): error CS0208: Cannot take the address of, get the size of, or declare a pointer to a managed type ('dynamic')
                 //         var d1 = stackalloc dynamic [3] { d };
                 Diagnostic(ErrorCode.ERR_ManagedAddr, "dynamic").WithArguments("dynamic").WithLocation(7, 29),
@@ -1844,6 +1849,25 @@ class Program
                 //         var d3 = stackalloc         [ ] { d };
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "stackalloc         [ ] { d }").WithLocation(9, 18)
                 );
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (7,29): error CS0208: Cannot take the address of, get the size of, or declare a pointer to a managed type ('dynamic')
+                //         var d1 = stackalloc dynamic [3] { d };
+                Diagnostic(ErrorCode.ERR_ManagedAddr, "dynamic").WithArguments("dynamic").WithLocation(7, 29),
+                // (7,18): error CS0847: An array initializer of length '3' is expected
+                //         var d1 = stackalloc dynamic [3] { d };
+                Diagnostic(ErrorCode.ERR_ArrayInitializerIncorrectLength, "stackalloc dynamic [3] { d }").WithArguments("3").WithLocation(7, 18),
+                // (8,29): error CS0208: Cannot take the address of, get the size of, or declare a pointer to a managed type ('dynamic')
+                //         var d2 = stackalloc dynamic [ ] { d };
+                Diagnostic(ErrorCode.ERR_ManagedAddr, "dynamic").WithArguments("dynamic").WithLocation(8, 29),
+                // (9,18): error CS0208: Cannot take the address of, get the size of, or declare a pointer to a managed type ('dynamic')
+                //         var d3 = stackalloc         [ ] { d };
+                Diagnostic(ErrorCode.ERR_ManagedAddr, "stackalloc         [ ] { d }").WithArguments("dynamic").WithLocation(9, 18)
+            };
+
+            CreateCompilation(source).VerifyDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StackAllocSpanExpressionsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StackAllocSpanExpressionsTests.cs
@@ -402,17 +402,21 @@ class Test
         [Fact]
         public void StackAllocSyntaxProducesUnsafeErrorInSafeCode()
         {
-            CreateCompilation(@"
+            var source = @"
 class Test
 {
     void M()
     {
         var x = stackalloc int[10];
     }
-}", options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+}";
+            CreateCompilation(source, options: TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.Regular14).VerifyDiagnostics(
                 // (6,17): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //         var x = stackalloc int[10];
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "stackalloc int[10]").WithLocation(6, 17));
+
+            CreateCompilation(source, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
+            CreateCompilation(source, options: TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -396,7 +396,7 @@ unsafe class C
             };
 
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Fact]
@@ -444,7 +444,7 @@ unsafe class C
             };
 
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Fact]
@@ -491,7 +491,7 @@ unsafe class C
             };
 
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Fact]
@@ -675,7 +675,7 @@ unsafe class C
             };
 
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Fact]
@@ -753,7 +753,7 @@ unsafe class C
             };
 
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         // Should behave equivalently to Iterator_UnsafeBlock_Async_02.
@@ -811,7 +811,7 @@ unsafe class C
             };
             CreateCompilation(code, parseOptions: TestOptions.Regular12, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseExe, expectedDiagnostics);
         }
 
         [Fact]
@@ -935,7 +935,7 @@ unsafe class C
             };
 
             CreateCompilation(code, options: TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.Regular13).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Fact]
@@ -963,7 +963,7 @@ unsafe class C
             };
 
             CreateCompilation(code, options: TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.Regular13).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Fact]
@@ -1014,7 +1014,7 @@ unsafe class C
             };
 
             CreateCompilation(code, options: TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.Regular13).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Fact]
@@ -1042,7 +1042,7 @@ unsafe class C
             };
 
             CreateCompilation(code, options: TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.Regular13).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Fact]
@@ -1074,7 +1074,7 @@ unsafe class C
             };
 
             CreateCompilation(code, options: TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.Regular13).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Fact]
@@ -1106,7 +1106,7 @@ unsafe class C
             };
 
             CreateCompilation(code, options: TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.Regular13).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/73280")]
@@ -1137,7 +1137,7 @@ unsafe class C
             };
 
             CreateCompilation(code, options: TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.Regular13).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Theory, CombinatorialData]
@@ -1179,7 +1179,7 @@ unsafe class C
 
             CreateCompilation(code, parseOptions: TestOptions.Regular12, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Theory, CombinatorialData]
@@ -1227,7 +1227,7 @@ unsafe class C
 
             CreateCompilation(code, parseOptions: TestOptions.Regular12, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Fact]
@@ -1292,7 +1292,7 @@ unsafe class C
 
             CreateCompilation(code, parseOptions: TestOptions.Regular12, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Fact]
@@ -1388,7 +1388,7 @@ unsafe class C
             };
 
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Theory, CombinatorialData]
@@ -1414,7 +1414,7 @@ unsafe class C
             };
 
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Theory, CombinatorialData]
@@ -1462,7 +1462,7 @@ unsafe class C
 
             CreateCompilation(code, parseOptions: TestOptions.Regular12, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Theory, CombinatorialData]
@@ -1510,7 +1510,7 @@ unsafe class C
 
             CreateCompilation(code, parseOptions: TestOptions.Regular12, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Fact]
@@ -1575,7 +1575,7 @@ unsafe class C
 
             CreateCompilation(code, parseOptions: TestOptions.Regular12, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Fact]
@@ -1633,7 +1633,7 @@ unsafe class C
             };
 
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Theory, CombinatorialData]
@@ -1683,7 +1683,7 @@ unsafe class C
 
             CreateCompilation(code, parseOptions: TestOptions.Regular12, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Theory, CombinatorialData]
@@ -1736,7 +1736,7 @@ unsafe class C
 
             CreateCompilation(code, parseOptions: TestOptions.Regular12, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Fact]
@@ -1804,7 +1804,7 @@ unsafe class C
 
             CreateCompilation(code, parseOptions: TestOptions.Regular12, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Fact]
@@ -1876,7 +1876,7 @@ unsafe class C
             };
 
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Fact]
@@ -1904,7 +1904,7 @@ unsafe class C
             };
 
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Theory, CombinatorialData]
@@ -1954,7 +1954,7 @@ unsafe class C
 
             CreateCompilation(code, parseOptions: TestOptions.Regular12, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Theory, CombinatorialData]
@@ -2007,7 +2007,7 @@ unsafe class C
 
             CreateCompilation(code, parseOptions: TestOptions.Regular12, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Fact]
@@ -2075,7 +2075,7 @@ unsafe class C
 
             CreateCompilation(code, parseOptions: TestOptions.Regular12, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Fact]
@@ -2147,7 +2147,7 @@ unsafe class C
             };
 
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Fact]
@@ -2175,7 +2175,7 @@ unsafe class C
             };
 
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll, expectedDiagnostics);
         }
 
         [Theory, CombinatorialData]
@@ -2216,7 +2216,7 @@ unsafe class C
 
             CreateCompilation(code, parseOptions: TestOptions.Regular12, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseExe, expectedDiagnostics);
         }
 
         [Theory, CombinatorialData]
@@ -2263,7 +2263,7 @@ unsafe class C
 
             CreateCompilation(code, parseOptions: TestOptions.Regular12, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseExe, expectedDiagnostics);
         }
 
         [Fact]
@@ -2328,7 +2328,7 @@ unsafe class C
 
             CreateCompilation(code, parseOptions: TestOptions.Regular12, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseExe, expectedDiagnostics);
         }
 
         [Fact]
@@ -2386,7 +2386,7 @@ unsafe class C
             };
 
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseExe, expectedDiagnostics);
         }
 
         [Fact]
@@ -2423,7 +2423,7 @@ unsafe class C
 
             CreateCompilation(code, parseOptions: TestOptions.Regular12, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseExe, expectedDiagnostics);
         }
 
         [Fact]
@@ -2463,7 +2463,7 @@ unsafe class C
 
             CreateCompilation(code, parseOptions: TestOptions.Regular12, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseExe, expectedDiagnostics);
         }
 
         [Fact]
@@ -2488,7 +2488,7 @@ unsafe class C
 
             CreateCompilation(code, parseOptions: TestOptions.Regular12, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseExe, expectedDiagnostics);
         }
 
         [Fact]
@@ -2516,7 +2516,7 @@ unsafe class C
 
             CreateCompilation(code, parseOptions: TestOptions.Regular12, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseExe, expectedDiagnostics);
         }
 
         [Fact]
@@ -2551,7 +2551,7 @@ unsafe class C
             ];
 
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseExe, expectedDiagnostics);
         }
 
         [Fact]
@@ -2576,7 +2576,7 @@ unsafe class C
 
             CreateCompilation(code, parseOptions: TestOptions.Regular12, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(code, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseExe, expectedDiagnostics);
         }
 
         [Fact]
@@ -2953,7 +2953,16 @@ unsafe class C<T>
                     // (8,30): error CS0306: The type 'int*' may not be used as a type argument
                     //     unsafe void Test(C<int*> c) { }
                     Diagnostic(ErrorCode.ERR_BadTypeArgument, "c").WithArguments("int*"),
-                });
+                },
+                expectedWithoutUnsafePreview:
+                [
+                    // (3,24): error CS0306: The type 'int*' may not be used as a type argument
+                    //      void Test(I<int*> i);
+                    Diagnostic(ErrorCode.ERR_BadTypeArgument, "i").WithArguments("int*").WithLocation(3, 24),
+                    // (8,24): error CS0306: The type 'int*' may not be used as a type argument
+                    //      void Test(C<int*> c) { }
+                    Diagnostic(ErrorCode.ERR_BadTypeArgument, "c").WithArguments("int*").WithLocation(8, 24)
+                ]);
         }
 
         [Fact]
@@ -3162,7 +3171,8 @@ unsafe class C<T>
                 Diagnostic(ErrorCode.ERR_DefaultValueMustBeConstant, "Unsafe()").WithArguments("p")
             };
 
-            CompareUnsafeDiagnostics(template, expectedWithoutUnsafe, expectedWithUnsafe);
+            CompareUnsafeDiagnostics(template, expectedWithoutUnsafe, expectedWithUnsafe,
+                expectedWithoutUnsafePreview: expectedWithUnsafe);
         }
 
         [Fact]
@@ -3179,7 +3189,7 @@ unsafe class C<T>
 ";
 
             var withoutUnsafe = string.Format(template, "", "");
-            CreateCompilation(withoutUnsafe, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+            CreateCompilation(withoutUnsafe, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
                 // CONSIDER: We should probably suppress CS0214 (like Dev10 does) because it's
                 // confusing, but we don't have a good way to do so, because we don't know that
                 // the method is an iterator until we bind the body and we certainly don't want
@@ -3187,6 +3197,13 @@ unsafe class C<T>
 
                 // (4,59): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*"),
+                // (4,64): error CS1637: Iterators cannot have pointer type parameters
+                Diagnostic(ErrorCode.ERR_UnsafeIteratorArgType, "p"));
+
+            CreateCompilation(withoutUnsafe, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+                // (4,64): error CS1637: Iterators cannot have pointer type parameters
+                Diagnostic(ErrorCode.ERR_UnsafeIteratorArgType, "p"));
+            CreateCompilation(withoutUnsafe, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
                 // (4,64): error CS1637: Iterators cannot have pointer type parameters
                 Diagnostic(ErrorCode.ERR_UnsafeIteratorArgType, "p"));
 
@@ -3247,11 +3264,14 @@ unsafe class C<T>
 ";
 
             var withoutUnsafe = string.Format(template, "", "");
-            CreateCompilation(withoutUnsafe, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+            CreateCompilation(withoutUnsafe, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
                 // (4,59): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //      System.Collections.Generic.IEnumerable<int> Iterator(int*[] p)
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(4, 59)
                 );
+
+            CreateCompilation(withoutUnsafe, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
+            CreateCompilation(withoutUnsafe, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
 
             var withUnsafeOnType = string.Format(template, "unsafe", "");
             CreateCompilation(withUnsafeOnType, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
@@ -3934,7 +3954,13 @@ class Container<T> {{ }}
                 // (2,2): error CS0181: Attribute constructor parameter 'a' has type 'int*[]', which is not a valid attribute parameter type
                 // [A]
                 Diagnostic(ErrorCode.ERR_BadAttributeParamType, "A").WithArguments("a", "int*[]")
-                });
+                },
+                expectedWithoutUnsafePreview:
+                [
+                // (2,2): error CS0181: Attribute constructor parameter 'a' has type 'int*[]', which is not a valid attribute parameter type
+                // [A]
+                Diagnostic(ErrorCode.ERR_BadAttributeParamType, "A").WithArguments("a", "int*[]")
+                ]);
         }
 
         [WorkItem(544938, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544938")]
@@ -3967,7 +3993,13 @@ class Container<T> {{ }}
                 // (2,2): error CS0181: Attribute constructor parameter 'p' has type 'int*', which is not a valid attribute parameter type
                 // [A]
                 Diagnostic(ErrorCode.ERR_BadAttributeParamType, "A").WithArguments("p", "int*")
-                });
+                },
+                expectedWithoutUnsafePreview:
+                [
+                // (2,2): error CS0181: Attribute constructor parameter 'p' has type 'int*', which is not a valid attribute parameter type
+                // [A]
+                Diagnostic(ErrorCode.ERR_BadAttributeParamType, "A").WithArguments("p", "int*")
+                ]);
         }
 
         [WorkItem(544938, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544938")]
@@ -4161,15 +4193,30 @@ class Container<T> {{ }}
 
         private static void CompareUnsafeDiagnostics(string template, params DiagnosticDescription[] expectedWithoutUnsafe)
         {
-            CompareUnsafeDiagnostics(template, expectedWithoutUnsafe, new DiagnosticDescription[0]);
+            // In preview langversion, pointer types and sizeof are safe,
+            // so filter out ERR_UnsafeNeeded and ERR_SizeofUnsafe for preview expected diagnostics.
+            var expectedWithoutUnsafePreview = Array.FindAll(expectedWithoutUnsafe,
+                d => !d.Code.Equals((int)ErrorCode.ERR_UnsafeNeeded) && !d.Code.Equals((int)ErrorCode.ERR_SizeofUnsafe));
+            CompareUnsafeDiagnostics(template, expectedWithoutUnsafe, expectedWithUnsafe: [], expectedWithoutUnsafePreview: expectedWithoutUnsafePreview);
         }
 
-        private static void CompareUnsafeDiagnostics(string template, DiagnosticDescription[] expectedWithoutUnsafe, DiagnosticDescription[] expectedWithUnsafe)
+        private static void CompareUnsafeDiagnostics(string template, DiagnosticDescription[] expectedWithoutUnsafe, DiagnosticDescription[] expectedWithUnsafe, DiagnosticDescription[] expectedWithoutUnsafePreview = null)
         {
             // NOTE: ERR_UnsafeNeeded is not affected by the presence/absence of the /unsafe flag.
             var withoutUnsafe = string.Format(template, "", "");
-            CreateCompilation(withoutUnsafe).VerifyDiagnostics(expectedWithoutUnsafe);
-            CreateCompilation(withoutUnsafe, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedWithoutUnsafe);
+
+            // With old langversion, pointer types require unsafe context.
+            CreateCompilation(withoutUnsafe, parseOptions: TestOptions.Regular14).VerifyDiagnostics(expectedWithoutUnsafe);
+            CreateCompilation(withoutUnsafe, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedWithoutUnsafe);
+
+            // With preview langversion, pointer types are safe.
+            var previewExpected = expectedWithoutUnsafePreview ?? expectedWithoutUnsafe;
+            CreateCompilation(withoutUnsafe).VerifyDiagnostics(previewExpected);
+            CreateCompilation(withoutUnsafe, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(previewExpected);
+
+            // RegularNext should match preview behavior.
+            CreateCompilation(withoutUnsafe, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(previewExpected);
+            CreateCompilation(withoutUnsafe, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(previewExpected);
 
             var withUnsafeOnType = string.Format(template, "unsafe", "");
             CreateCompilation(withUnsafeOnType, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedWithUnsafe);
@@ -4179,6 +4226,19 @@ class Container<T> {{ }}
 
             var withUnsafeOnTypeAndMembers = string.Format(template, "unsafe", "unsafe");
             CreateCompilation(withUnsafeOnTypeAndMembers, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedWithUnsafe);
+        }
+
+        /// <summary>
+        /// Tests that diagnostics are reported with old langversion and correctly filtered in preview.
+        /// In preview, pointer types and sizeof are safe, so ERR_UnsafeNeeded and ERR_SizeofUnsafe are filtered.
+        /// </summary>
+        private static void VerifyUnsafeContextDiagnostics(string code, CSharpCompilationOptions options, DiagnosticDescription[] expectedDiagnostics, DiagnosticDescription[] expectedPreviewDiagnostics = null)
+        {
+            expectedPreviewDiagnostics ??= Array.FindAll(expectedDiagnostics,
+                d => !d.Code.Equals((int)ErrorCode.ERR_UnsafeNeeded) && !d.Code.Equals((int)ErrorCode.ERR_SizeofUnsafe));
+            CreateCompilation(code, parseOptions: TestOptions.Regular14, options: options).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(code, options: options).VerifyDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilation(code, parseOptions: TestOptions.RegularNext, options: options).VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [WorkItem(544097, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544097")]
@@ -10455,7 +10515,10 @@ struct S
 
             CreateCompilation(text, parseOptions: TestOptions.Regular12).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(text, parseOptions: TestOptions.Regular13).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(text).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(text, parseOptions: TestOptions.Regular14).VerifyDiagnostics(expectedDiagnostics);
+
+            CreateCompilation(text).VerifyDiagnostics();
+            CreateCompilation(text, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
         }
 
         [Fact]
@@ -10558,7 +10621,7 @@ class Program
     int F1 = sizeof(null);
 }
 ";
-            CreateCompilation(text, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+            CreateCompilation(text, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
                 // (4,21): error CS1031: Type expected
                 //     int F1 = sizeof(null);
                 Diagnostic(ErrorCode.ERR_TypeExpected, "null"),
@@ -10571,6 +10634,21 @@ class Program
                 // (4,14): error CS0233: '?' does not have a predefined size, therefore sizeof can only be used in an unsafe context (consider using System.Runtime.InteropServices.Marshal.SizeOf)
                 //     int F1 = sizeof(null);
                 Diagnostic(ErrorCode.ERR_SizeofUnsafe, "sizeof(").WithArguments("?"));
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (4,21): error CS1031: Type expected
+                //     int F1 = sizeof(null);
+                Diagnostic(ErrorCode.ERR_TypeExpected, "null"),
+                // (4,21): error CS1026: ) expected
+                //     int F1 = sizeof(null);
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "null"),
+                // (4,21): error CS1003: Syntax error, ',' expected
+                //     int F1 = sizeof(null);
+                Diagnostic(ErrorCode.ERR_SyntaxError, "null").WithArguments(","),
+            };
+            CreateCompilation(text, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilation(text, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         #endregion sizeof diagnostic tests
@@ -10828,7 +10906,10 @@ struct S
 
             CreateCompilation(text, parseOptions: TestOptions.Regular12).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(text, parseOptions: TestOptions.Regular13).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(text).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(text, parseOptions: TestOptions.Regular14).VerifyDiagnostics(expectedDiagnostics);
+
+            CreateCompilation(text).VerifyDiagnostics();
+            CreateCompilation(text, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
         }
 
         [Fact]
@@ -11786,7 +11867,11 @@ public unsafe class B : A
     public override T* M<T>() => throw null!;
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics();
         }
 
@@ -12713,7 +12798,11 @@ namespace Interop
         public PROPVARIANT* pElems;
     }
 }";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics();
         }
 
@@ -12727,14 +12816,21 @@ class C
 {
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.DebugDll);
-            comp.VerifyDiagnostics(
+            var expectedDiagnostics = new[]
+            {
                 // (2,1): hidden CS8019: Unnecessary using directive.
                 // using unsafe X = int*;
                 Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using unsafe X = int*;").WithLocation(2, 1),
                 // (2,7): error CS0227: Unsafe code may only appear if compiling with /unsafe
                 // using unsafe X = int*;
-                Diagnostic(ErrorCode.ERR_IllegalUnsafe, "unsafe").WithLocation(2, 7));
+                Diagnostic(ErrorCode.ERR_IllegalUnsafe, "unsafe").WithLocation(2, 7),
+            };
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.DebugDll);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+            comp = CreateCompilation(csharp, options: TestOptions.DebugDll);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.DebugDll);
+            comp.VerifyDiagnostics(expectedDiagnostics);
         }
 
         [Fact]
@@ -12747,14 +12843,21 @@ class C
 {
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.DebugDll);
-            comp.VerifyDiagnostics(
+            var expectedDiagnostics = new[]
+            {
                 // (2,1): hidden CS8019: Unnecessary using directive.
                 // using unsafe X = int;
                 Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using unsafe X = int;").WithLocation(2, 1),
                 // (2,7): error CS0227: Unsafe code may only appear if compiling with /unsafe
                 // using unsafe X = int;
-                Diagnostic(ErrorCode.ERR_IllegalUnsafe, "unsafe").WithLocation(2, 7));
+                Diagnostic(ErrorCode.ERR_IllegalUnsafe, "unsafe").WithLocation(2, 7),
+            };
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.DebugDll);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+            comp = CreateCompilation(csharp, options: TestOptions.DebugDll);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.DebugDll);
+            comp.VerifyDiagnostics(expectedDiagnostics);
         }
 
         [Fact]
@@ -12878,7 +12981,7 @@ class C
     unsafe void N2(Y y) { }
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (3,11): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // using Y = int*;
@@ -12889,6 +12992,11 @@ class C
                 // (10,13): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     void N1(Y y) { }
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "Y").WithLocation(10, 13));
+
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
         }
 
         [Fact]
@@ -12901,7 +13009,7 @@ namespace N
     using Y = X;
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (5,5): hidden CS8019: Unnecessary using directive.
                 //     using Y = X;
@@ -12909,6 +13017,17 @@ namespace N
                 // (5,15): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     using Y = X;
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "X").WithLocation(5, 15));
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (5,5): hidden CS8019: Unnecessary using directive.
+                //     using Y = X;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using Y = X;").WithLocation(5, 5),
+            };
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(expectedPreviewDiagnostics);
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Fact]
@@ -12921,11 +13040,18 @@ namespace N
     using unsafe Y = X;
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
-            comp.VerifyDiagnostics(
+            var expectedDiagnostics = new[]
+            {
                 // (5,5): hidden CS8019: Unnecessary using directive.
                 //     using unsafe Y = X;
-                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using unsafe Y = X;").WithLocation(5, 5));
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using unsafe Y = X;").WithLocation(5, 5),
+            };
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(expectedDiagnostics);
         }
 
         [Fact]
@@ -12939,7 +13065,7 @@ class C
     void M(int* x) { }
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (2,1): hidden CS8019: Unnecessary using directive.
                 // using X = int*;
@@ -12950,6 +13076,17 @@ class C
                 // (6,12): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     void M(int* x) { }
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(6, 12));
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using X = int*;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using X = int*;").WithLocation(2, 1),
+            };
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(expectedPreviewDiagnostics);
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Fact]
@@ -12963,14 +13100,21 @@ class C
     unsafe void M((X x1, X x2) t) { }
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
-            comp.VerifyDiagnostics(
+            var expectedDiagnostics = new[]
+            {
                 // (6,32): error CS0306: The type 'int*' may not be used as a type argument
                 //     unsafe void M((X x1, X x2) t) { }
                 Diagnostic(ErrorCode.ERR_BadTypeArgument, "t").WithArguments("int*").WithLocation(6, 32),
                 // (6,32): error CS0306: The type 'int*' may not be used as a type argument
                 //     unsafe void M((X x1, X x2) t) { }
-                Diagnostic(ErrorCode.ERR_BadTypeArgument, "t").WithArguments("int*").WithLocation(6, 32));
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "t").WithArguments("int*").WithLocation(6, 32),
+            };
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(expectedDiagnostics);
         }
 
         [Fact]
@@ -12984,7 +13128,11 @@ class C
     unsafe void M(X[] t) { }
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics();
         }
 
@@ -12999,11 +13147,16 @@ class C
     void M(X[] t) { }
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (6,12): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     void M(X[] t) { }
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "X").WithLocation(6, 12));
+
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
         }
 
         [Fact]
@@ -13012,11 +13165,18 @@ class C
             var csharp = @"
 using unsafe X = int*[];
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
-            comp.VerifyDiagnostics(
+            var expectedDiagnostics = new[]
+            {
                 // (2,1): hidden CS8019: Unnecessary using directive.
                 // using unsafe X = int*[];
-                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using unsafe X = int*[];").WithLocation(2, 1));
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using unsafe X = int*[];").WithLocation(2, 1),
+            };
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(expectedDiagnostics);
         }
 
         [Fact]
@@ -13025,7 +13185,7 @@ using unsafe X = int*[];
             var csharp = @"
 using X = int*[];
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (2,1): hidden CS8019: Unnecessary using directive.
                 // using X = int*[];
@@ -13033,6 +13193,17 @@ using X = int*[];
                 // (2,11): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // using X = int*[];
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(2, 11));
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using X = int*[];
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using X = int*[];").WithLocation(2, 1),
+            };
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(expectedPreviewDiagnostics);
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Fact]
@@ -13047,11 +13218,16 @@ class C
     unsafe void M2(X t) { }
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (6,13): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     void M1(X t) { }
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "X").WithLocation(6, 13));
+
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
         }
 
         [Fact]
@@ -13066,11 +13242,16 @@ class C
     unsafe void M2(X t) { }
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (6,13): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     void M1(X t) { }
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "X").WithLocation(6, 13));
+
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
         }
 
         [Fact]
@@ -13084,7 +13265,11 @@ class C
     void ThisMethodIsNotUnsafe(X x) { }
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics();
         }
 
@@ -13099,11 +13284,18 @@ class C
     void ThisMethodIsNotUnsafe(X x) { }
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.DebugDll);
-            comp.VerifyDiagnostics(
+            var expectedDiagnostics = new[]
+            {
                 // (2,7): error CS0227: Unsafe code may only appear if compiling with /unsafe
                 // using unsafe X = int;
-                Diagnostic(ErrorCode.ERR_IllegalUnsafe, "unsafe").WithLocation(2, 7));
+                Diagnostic(ErrorCode.ERR_IllegalUnsafe, "unsafe").WithLocation(2, 7),
+            };
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.DebugDll);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+            comp = CreateCompilation(csharp, options: TestOptions.DebugDll);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.DebugDll);
+            comp.VerifyDiagnostics(expectedDiagnostics);
         }
 
         [Fact]
@@ -13118,11 +13310,16 @@ class C
     unsafe void M2(X x) { }
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (6,13): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     void M1(X x) { }
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "X").WithLocation(6, 13));
+
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
         }
 
         [Fact]
@@ -13137,7 +13334,7 @@ class C
     unsafe void M2(X x) { }
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (2,11): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // using X = delegate*<int,int>;
@@ -13145,6 +13342,11 @@ class C
                 // (6,13): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     void M1(X x) { }
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "X").WithLocation(6, 13));
+
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
         }
 
         [Fact]
@@ -13158,7 +13360,7 @@ class C
     void M(int* x) { }
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (2,1): hidden CS8019: Unnecessary using directive.
                 // using X = delegate*<int,int>;
@@ -13169,6 +13371,17 @@ class C
                 // (6,12): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     void M(int* x) { }
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(6, 12));
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using X = delegate*<int,int>;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using X = delegate*<int,int>;").WithLocation(2, 1),
+            };
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(expectedPreviewDiagnostics);
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Fact]
@@ -13184,7 +13397,7 @@ class C
     void M3(X[] t) { }
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (6,33): error CS0306: The type 'delegate*<int, int>' may not be used as a type argument
                 //     unsafe void M1((X x1, X x2) t) { }
@@ -13195,6 +13408,20 @@ class C
                 // (8,13): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     void M3(X[] t) { }
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "X").WithLocation(8, 13));
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (6,33): error CS0306: The type 'delegate*<int, int>' may not be used as a type argument
+                //     unsafe void M1((X x1, X x2) t) { }
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "t").WithArguments("delegate*<int, int>").WithLocation(6, 33),
+                // (6,33): error CS0306: The type 'delegate*<int, int>' may not be used as a type argument
+                //     unsafe void M1((X x1, X x2) t) { }
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "t").WithArguments("delegate*<int, int>").WithLocation(6, 33),
+            };
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(expectedPreviewDiagnostics);
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Fact]
@@ -13204,7 +13431,7 @@ class C
 using unsafe X = delegate*<int,int>[];
 using Y = delegate*<int,int>[];
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (2,1): hidden CS8019: Unnecessary using directive.
                 // using unsafe X = delegate*<int,int>[];
@@ -13215,6 +13442,20 @@ using Y = delegate*<int,int>[];
                 // (3,11): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // using Y = delegate*<int,int>[];
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "delegate*").WithLocation(3, 11));
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using unsafe X = delegate*<int,int>[];
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using unsafe X = delegate*<int,int>[];").WithLocation(2, 1),
+                // (3,1): hidden CS8019: Unnecessary using directive.
+                // using Y = delegate*<int,int>[];
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using Y = delegate*<int,int>[];").WithLocation(3, 1),
+            };
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(expectedPreviewDiagnostics);
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Fact]
@@ -13229,11 +13470,16 @@ class C
     unsafe void M2(X t) { }
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (6,13): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     void M1(X t) { }
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "X").WithLocation(6, 13));
+
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
         }
 
         [Fact]
@@ -13248,59 +13494,80 @@ class C
     unsafe void M2(X t) { }
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (6,13): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     void M1(X t) { }
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "X").WithLocation(6, 13));
+
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
         }
 
         [Fact]
         public void UsingAlias_Multiple()
         {
-            CreateCompilation("""
+            var src1 = """
                 #pragma warning disable CS8019 // unnecessary using
                 using unsafe X = System.Collections.Generic.List<int*[]>;
                 using Y = System.Collections.Generic.List<long*[]>;
-                """,
-                options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+                """;
+            CreateCompilation(src1,
+                parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
                 // (3,43): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // using Y = System.Collections.Generic.List<long*[]>;
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "long*").WithLocation(3, 43));
 
-            CreateCompilation("""
+            CreateCompilation(src1, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
+            CreateCompilation(src1, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
+
+            var src2 = """
                 #pragma warning disable CS8019 // unnecessary using
                 using X = System.Collections.Generic.List<int*[]>;
                 using unsafe Y = System.Collections.Generic.List<long*[]>;
-                """,
-                options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+                """;
+            CreateCompilation(src2,
+                parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
                 // (2,43): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // using X = System.Collections.Generic.List<int*[]>;
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(2, 43));
+
+            CreateCompilation(src2, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
+            CreateCompilation(src2, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/82426")]
         public void UsingStatic_Multiple()
         {
-            CreateCompilation("""
+            var src1 = """
                 #pragma warning disable CS8019 // unnecessary using
                 using static unsafe System.Collections.Generic.List<int*[]>;
                 using static System.Collections.Generic.List<long*[]>;
-                """,
-                options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+                """;
+            CreateCompilation(src1,
+                parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
                 // (3,46): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // using static System.Collections.Generic.List<long*[]>;
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "long*").WithLocation(3, 46));
 
-            CreateCompilation("""
+            CreateCompilation(src1, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
+            CreateCompilation(src1, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
+
+            var src2 = """
                 #pragma warning disable CS8019 // unnecessary using
                 using static System.Collections.Generic.List<int*[]>;
                 using static unsafe System.Collections.Generic.List<long*[]>;
-                """,
-                options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+                """;
+            CreateCompilation(src2,
+                parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
                 // (2,46): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // using static System.Collections.Generic.List<int*[]>;
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(2, 46));
+
+            CreateCompilation(src2, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
+            CreateCompilation(src2, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
         }
 
         [Fact]
@@ -13314,7 +13581,7 @@ unsafe struct S
     X x;
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (6,7): warning CS0169: The field 'S.x' is never used
                 //     X x;
@@ -13324,6 +13591,8 @@ unsafe struct S
 
             // Try again with a fresh compilation, without having done anything to pull on this type.
             comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            Assert.Equal(ManagedKind.Unmanaged, comp.GlobalNamespace.GetMember<NamedTypeSymbol>("S").ManagedKindNoUseSiteDiagnostics);
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
             Assert.Equal(ManagedKind.Unmanaged, comp.GlobalNamespace.GetMember<NamedTypeSymbol>("S").ManagedKindNoUseSiteDiagnostics);
         }
 
@@ -13349,7 +13618,7 @@ class C
 }
 
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (6,7): warning CS0169: The field 'S.x' is never used
                 //     X x;
@@ -13359,6 +13628,8 @@ class C
 
             // Try again with a fresh compilation, without having done anything to pull on this type.
             comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            Assert.Equal(ManagedKind.Unmanaged, comp.GlobalNamespace.GetMember<NamedTypeSymbol>("S").ManagedKindNoUseSiteDiagnostics);
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
             Assert.Equal(ManagedKind.Unmanaged, comp.GlobalNamespace.GetMember<NamedTypeSymbol>("S").ManagedKindNoUseSiteDiagnostics);
         }
 
@@ -13549,11 +13820,23 @@ using X = System.Collections.Generic.List<int*[]>;
                 // using X = System.Collections.Generic.List<int*[]>;
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(2, 43)
             };
-            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularPreview);
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.Regular14);
             comp.VerifyDiagnostics(expected);
 
-            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularPreview);
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14);
             comp.VerifyDiagnostics(expected);
+
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyDiagnostics(expectedCSharp11);
+
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyDiagnostics(expectedCSharp11);
+
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularNext);
+            comp.VerifyDiagnostics(expectedCSharp11);
+
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext);
+            comp.VerifyDiagnostics(expectedCSharp11);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67281")]
@@ -13591,11 +13874,23 @@ class C
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "X").WithLocation(6, 12)
             };
 
-            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularPreview);
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.Regular14);
             comp.VerifyDiagnostics(expected);
 
-            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularPreview);
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14);
             comp.VerifyDiagnostics(expected);
+
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyDiagnostics();
+
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyDiagnostics();
+
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularNext);
+            comp.VerifyDiagnostics();
+
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext);
+            comp.VerifyDiagnostics();
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67281")]
@@ -13611,22 +13906,29 @@ class C
     }
 }
 ";
+            var illegalUnsafe = new[]
+            {
+                // (6,17): error CS0227: Unsafe code may only appear if compiling with /unsafe
+                //     unsafe void M(X x)
+                Diagnostic(ErrorCode.ERR_IllegalUnsafe, "M").WithLocation(6, 17),
+            };
+            var unsafeNeeded = new[]
+            {
+                // (2,43): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+                // using X = System.Collections.Generic.List<int*[]>;
+                Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(2, 43),
+            };
+
             var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.Regular11);
             comp.VerifyDiagnostics();
 
             comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular11);
-            comp.VerifyDiagnostics(
-                // (6,17): error CS0227: Unsafe code may only appear if compiling with /unsafe
-                //     unsafe void M(X x)
-                Diagnostic(ErrorCode.ERR_IllegalUnsafe, "M").WithLocation(6, 17));
+            comp.VerifyDiagnostics(illegalUnsafe);
 
-            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularPreview);
-            comp.VerifyDiagnostics(
-                // (2,43): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-                // using X = System.Collections.Generic.List<int*[]>;
-                Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(2, 43));
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.Regular14);
+            comp.VerifyDiagnostics(unsafeNeeded);
 
-            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularPreview);
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14);
             comp.VerifyDiagnostics(
                 // (2,43): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // using X = System.Collections.Generic.List<int*[]>;
@@ -13634,6 +13936,18 @@ class C
                 // (6,17): error CS0227: Unsafe code may only appear if compiling with /unsafe
                 //     unsafe void M(X x)
                 Diagnostic(ErrorCode.ERR_IllegalUnsafe, "M").WithLocation(6, 17));
+
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyDiagnostics();
+
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyDiagnostics(illegalUnsafe);
+
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularNext);
+            comp.VerifyDiagnostics();
+
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext);
+            comp.VerifyDiagnostics(illegalUnsafe);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67281")]
@@ -13770,8 +14084,14 @@ class C
             comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.Regular12);
             comp.VerifyDiagnostics(expected);
 
-            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularPreview);
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.Regular14);
             comp.VerifyDiagnostics(expected);
+
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyDiagnostics();
+
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularNext);
+            comp.VerifyDiagnostics();
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67281")]
@@ -13915,8 +14235,14 @@ class C
             comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.Regular12);
             comp.VerifyDiagnostics(expected);
 
-            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularPreview);
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.Regular14);
             comp.VerifyDiagnostics(expected);
+
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyDiagnostics();
+
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.RegularNext);
+            comp.VerifyDiagnostics();
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67281")]
@@ -14017,7 +14343,11 @@ class PointerImpl : IPointerTest
     }
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyEmitDiagnostics();
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyEmitDiagnostics();
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
             comp.VerifyEmitDiagnostics();
         }
 
@@ -14043,9 +14373,14 @@ class PointerImpl : IPointerTest
     }
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyEmitDiagnostics(
                 );
+
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyEmitDiagnostics();
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -14070,9 +14405,14 @@ class PointerImpl : IPointerTest
     }
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyEmitDiagnostics(
                 );
+
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyEmitDiagnostics();
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -14098,7 +14438,12 @@ class PointerImpl : IPointerTest
     }
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyEmitDiagnostics();
+
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyEmitDiagnostics();
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
             comp.VerifyEmitDiagnostics();
         }
 
@@ -14180,12 +14525,17 @@ class PointerImpl : IPointerTest
     }
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyEmitDiagnostics(
                 // (14,16): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     void ITest<void*[]>.Method()
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "void*").WithLocation(14, 16)
                 );
+
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyEmitDiagnostics();
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -14210,12 +14560,17 @@ class PointerImpl : IPointerTest
     }
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyEmitDiagnostics(
                 // (14,15): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     int ITest<void*[]>.P1
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "void*").WithLocation(14, 15)
                 );
+
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyEmitDiagnostics();
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -14240,12 +14595,17 @@ class PointerImpl : IPointerTest
     }
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyEmitDiagnostics(
                 // (14,15): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     int ITest<void*[]>.this[int i]
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "void*").WithLocation(14, 15)
                 );
+
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyEmitDiagnostics();
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -14271,12 +14631,17 @@ class PointerImpl : IPointerTest
     }
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             comp.VerifyEmitDiagnostics(
                 // (14,31): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     event System.Action ITest<void*[]>.E1
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "void*").WithLocation(14, 31)
                 );
+
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyEmitDiagnostics();
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -14301,7 +14666,7 @@ class PointerImpl : IPointerTest
     }
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll, targetFramework: TargetFramework.NetCoreApp);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll, targetFramework: TargetFramework.NetCoreApp);
             comp.VerifyEmitDiagnostics(
                 // (14,18): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     static ITest<void*[]> ITest<void*[]>.operator-(ITest<void*[]> x)
@@ -14313,6 +14678,11 @@ class PointerImpl : IPointerTest
                 //     static ITest<void*[]> ITest<void*[]>.operator-(ITest<void*[]> x)
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "void*").WithLocation(14, 58)
                 );
+
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll, targetFramework: TargetFramework.NetCoreApp);
+            comp.VerifyEmitDiagnostics();
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll, targetFramework: TargetFramework.NetCoreApp);
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -14337,7 +14707,7 @@ class PointerImpl : IPointerTest
     }
 }
 ";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll, targetFramework: TargetFramework.NetCoreApp);
+            var comp = CreateCompilation(csharp, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll, targetFramework: TargetFramework.NetCoreApp);
             comp.VerifyEmitDiagnostics(
                 // (4,39): error CS0552: 'ITest<T>.implicit operator int(ITest<T>)': user-defined conversions to or from an interface are not allowed
                 //     abstract static implicit operator int(ITest<T> x);
@@ -14349,6 +14719,17 @@ class PointerImpl : IPointerTest
                 //     static implicit ITest<void*[]>.operator int(ITest<void*[]> x)
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "void*").WithLocation(14, 55)
                 );
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (4,39): error CS0552: 'ITest<T>.implicit operator int(ITest<T>)': user-defined conversions to or from an interface are not allowed
+                //     abstract static implicit operator int(ITest<T> x);
+                Diagnostic(ErrorCode.ERR_ConversionWithInterface, "int").WithArguments("ITest<T>.implicit operator int(ITest<T>)").WithLocation(4, 39),
+            };
+            comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll, targetFramework: TargetFramework.NetCoreApp);
+            comp.VerifyEmitDiagnostics(expectedPreviewDiagnostics);
+            comp = CreateCompilation(csharp, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll, targetFramework: TargetFramework.NetCoreApp);
+            comp.VerifyEmitDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/38378")]
@@ -14480,13 +14861,15 @@ class PointerImpl : IPointerTest
                 }
                 """;
 
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
-                // (3,7): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-                //     C<int*[]> field;
-                Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(3, 7),
-                // (3,15): warning CS0169: The field 'C<T>.field' is never used
-                //     C<int*[]> field;
-                Diagnostic(ErrorCode.WRN_UnreferencedField, "field").WithArguments("C<T>.field").WithLocation(3, 15));
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll,
+                [
+                    // (3,7): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+                    //     C<int*[]> field;
+                    Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(3, 7),
+                    // (3,15): warning CS0169: The field 'C<T>.field' is never used
+                    //     C<int*[]> field;
+                    Diagnostic(ErrorCode.WRN_UnreferencedField, "field").WithArguments("C<T>.field").WithLocation(3, 15)
+                ]);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/44088")]
@@ -14518,13 +14901,15 @@ class PointerImpl : IPointerTest
                 }
                 """;
 
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
-                // (5,11): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-                //         C<int*[]> c = null;
-                Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(5, 11),
-                // (5,19): warning CS0219: The variable 'c' is assigned but its value is never used
-                //         C<int*[]> c = null;
-                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "c").WithArguments("c").WithLocation(5, 19));
+            VerifyUnsafeContextDiagnostics(code, TestOptions.UnsafeReleaseDll,
+                [
+                    // (5,11): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+                    //         C<int*[]> c = null;
+                    Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(5, 11),
+                    // (5,19): warning CS0219: The variable 'c' is assigned but its value is never used
+                    //         C<int*[]> c = null;
+                    Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "c").WithArguments("c").WithLocation(5, 19)
+                ]);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/44088")]

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/UsedAssembliesTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/UsedAssembliesTests.cs
@@ -3732,7 +3732,7 @@ public class C2
 }
 ");
 
-            verifyDiagnostics(comp0Ref, comp1Ref,
+            var sourceUsingStatic =
 @"
 using static C1<S<C0>*[]>;
 public class C2
@@ -3742,7 +3742,8 @@ public class C2
         _ = E1.F1 + 1;
     }
 }
-",
+";
+            verifyDiagnostics(comp0Ref, comp1Ref, sourceUsingStatic,
                 // (2,17): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // using static C1<S<C0>*[]>;
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "S<C0>*").WithLocation(2, 17),
@@ -3756,6 +3757,12 @@ public class C2
                 //         _ = E1.F1 + 1;
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "E1.F1 + 1").WithLocation(7, 13));
 
+            foreach (var parseOptions in new[] { TestOptions.RegularPreview, TestOptions.RegularNext })
+            {
+                var references = new[] { comp0Ref, comp1Ref };
+                CreateCompilation(sourceUsingStatic, parseOptions: parseOptions, references: references, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics();
+            }
+
             verifyDiagnostics(comp0Ref, comp1Ref,
 @"
 using static unsafe C1<S<C0>*[]>;
@@ -3768,7 +3775,7 @@ public class C2
 }
 ");
 
-            verifyDiagnostics(comp0Ref, comp1Ref,
+            var sourceUsingStaticE1 =
 @"
 using static C1<S<C0>*[]>.E1;
 public class C2
@@ -3778,7 +3785,8 @@ public class C2
         _ = F1 + 1;
     }
 }
-",
+";
+            verifyDiagnostics(comp0Ref, comp1Ref, sourceUsingStaticE1,
                 // (2,17): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // using static C1<S<C0>*[]>.E1;
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "S<C0>*").WithLocation(2, 17),
@@ -3791,6 +3799,12 @@ public class C2
                 // (7,13): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //         _ = F1 + 1;
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "F1 + 1").WithLocation(7, 13));
+
+            foreach (var parseOptions in new[] { TestOptions.RegularPreview, TestOptions.RegularNext })
+            {
+                var references = new[] { comp0Ref, comp1Ref };
+                CreateCompilation(sourceUsingStaticE1, parseOptions: parseOptions, references: references, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics();
+            }
 
             verifyDiagnostics(comp0Ref, comp1Ref,
 @"
@@ -3831,14 +3845,14 @@ public class C2
             void verifyDiagnostics(MetadataReference reference0, MetadataReference reference1, string source, params DiagnosticDescription[] diagnostics)
             {
                 var references = new[] { reference0, reference1 };
-                Compilation comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview, references: references, options: TestOptions.UnsafeDebugDll);
+                Compilation comp = CreateCompilation(source, parseOptions: TestOptions.Regular14, references: references, options: TestOptions.UnsafeDebugDll);
                 comp.VerifyDiagnostics(diagnostics);
             }
 
             void verify(MetadataReference reference0, MetadataReference reference1, string source)
             {
                 var references = new[] { reference0, reference1 };
-                AssertUsedAssemblyReferences(source, references, references, parseOptions: TestOptions.RegularPreview, options: TestOptions.UnsafeDebugDll);
+                AssertUsedAssemblyReferences(source, references, references, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll);
             }
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/PartialPropertiesTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/PartialPropertiesTests.cs
@@ -2099,11 +2099,17 @@ public partial class C
                     public partial int P2 { get => 1; set { } }
                 }
                 """;
-            var comp = CreateCompilation(source, options: TestOptions.UnsafeReleaseDll);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeReleaseDll);
             comp.VerifyEmitDiagnostics(
                 // (9,20): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     public partial int* P1 { get => null; set { } }
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(9, 20));
+
+            comp = CreateCompilation(source, options: TestOptions.UnsafeReleaseDll);
+            comp.VerifyEmitDiagnostics();
+
+            comp = CreateCompilation(source, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeReleaseDll);
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/EnumTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/EnumTests.cs
@@ -930,7 +930,7 @@ enum E2 : int* { }
 enum E3 : dynamic { }
 class C<T> { enum E4 : T { } }
 ";
-            var compilation = CreateEmptyCompilation(text, new[] { MscorlibRef });
+            var compilation = CreateEmptyCompilation(text, new[] { MscorlibRef }, parseOptions: TestOptions.Regular14);
             compilation.VerifyDiagnostics(
                 // (2,11): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // enum E2 : int* { }
@@ -984,6 +984,47 @@ class C<T> { enum E4 : T { } }
                 var symbol = model.GetDeclaredSymbol(decl);
                 var type = symbol.EnumUnderlyingType;
                 Assert.Equal(SpecialType.System_Int32, type.SpecialType);
+            }
+
+            foreach (var parseOptions in new[] { TestOptions.RegularPreview, TestOptions.RegularNext })
+            {
+                compilation = CreateEmptyCompilation(text, new[] { MscorlibRef }, parseOptions: parseOptions);
+                compilation.VerifyDiagnostics(
+                    // (2,11): error CS1008: Type byte, sbyte, short, ushort, int, uint, long, or ulong expected
+                    // enum E2 : int* { }
+                    Diagnostic(ErrorCode.ERR_IntegralTypeExpected, "int*").WithLocation(2, 11),
+                    // (3,11): error CS1980: Cannot define a class or member that utilizes 'dynamic' because the compiler required type 'System.Runtime.CompilerServices.DynamicAttribute' cannot be found. Are you missing a reference?
+                    // enum E3 : dynamic { }
+                    Diagnostic(ErrorCode.ERR_DynamicAttributeMissing, "dynamic").WithArguments("System.Runtime.CompilerServices.DynamicAttribute").WithLocation(3, 11),
+                    // (3,11): error CS1008: Type byte, sbyte, short, ushort, int, uint, long, or ulong expected
+                    // enum E3 : dynamic { }
+                    Diagnostic(ErrorCode.ERR_IntegralTypeExpected, "dynamic").WithLocation(3, 11),
+                    // (1,11): error CS1008: Type byte, sbyte, short, ushort, int, uint, long, or ulong expected
+                    // enum E1 : int[] { }
+                    Diagnostic(ErrorCode.ERR_IntegralTypeExpected, "int[]").WithLocation(1, 11),
+                    // (4,24): error CS1008: Type byte, sbyte, short, ushort, int, uint, long, or ulong expected
+                    // class C<T> { enum E4 : T { } }
+                    Diagnostic(ErrorCode.ERR_IntegralTypeExpected, "T").WithLocation(4, 24));
+
+                tree = compilation.SyntaxTrees[0];
+                model = compilation.GetSemanticModel(tree);
+                diagnostics = model.GetDeclarationDiagnostics();
+                diagnostics.Verify(
+                    // (2,11): error CS1008: Type byte, sbyte, short, ushort, int, uint, long, or ulong expected
+                    // enum E2 : int* { }
+                    Diagnostic(ErrorCode.ERR_IntegralTypeExpected, "int*").WithLocation(2, 11),
+                    // (1,11): error CS1008: Type byte, sbyte, short, ushort, int, uint, long, or ulong expected
+                    // enum E1 : int[] { }
+                    Diagnostic(ErrorCode.ERR_IntegralTypeExpected, "int[]").WithLocation(1, 11),
+                    // (3,11): error CS1980: Cannot define a class or member that utilizes 'dynamic' because the compiler required type 'System.Runtime.CompilerServices.DynamicAttribute' cannot be found. Are you missing a reference?
+                    // enum E3 : dynamic { }
+                    Diagnostic(ErrorCode.ERR_DynamicAttributeMissing, "dynamic").WithArguments("System.Runtime.CompilerServices.DynamicAttribute").WithLocation(3, 11),
+                    // (3,11): error CS1008: Type byte, sbyte, short, ushort, int, uint, long, or ulong expected
+                    // enum E3 : dynamic { }
+                    Diagnostic(ErrorCode.ERR_IntegralTypeExpected, "dynamic").WithLocation(3, 11),
+                    // (4,24): error CS1008: Type byte, sbyte, short, ushort, int, uint, long, or ulong expected
+                    // class C<T> { enum E4 : T { } }
+                    Diagnostic(ErrorCode.ERR_IntegralTypeExpected, "T").WithLocation(4, 24));
             }
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/UsingAliasTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/UsingAliasTests.cs
@@ -775,13 +775,16 @@ class C
                 //     void M(X x)
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "X").WithLocation(7, 12));
 
-            CreateCompilation(text, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(
+            CreateCompilation(text, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(
                 // (3,43): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // using X = System.Collections.Generic.List<int*[]>;
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(3, 43),
                 // (7,12): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     void M(X x)
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "X").WithLocation(7, 12));
+
+            CreateCompilation(text, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics();
+            CreateCompilation(text, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics();
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67281")]
@@ -841,7 +844,7 @@ class C
                 //         var y = x[0][0];
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "x[0][0]").WithLocation(9, 17));
 
-            CreateCompilation(text, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(
+            CreateCompilation(text, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(
                 // (3,43): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // using X = System.Collections.Generic.List<int*[]>;
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(3, 43),
@@ -857,6 +860,9 @@ class C
                 // (9,17): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //         var y = x[0][0];
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "x[0][0]").WithLocation(9, 17));
+
+            CreateCompilation(text, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics();
+            CreateCompilation(text, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics();
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67281")]
@@ -888,7 +894,10 @@ class C
             };
 
             CreateCompilation(text, parseOptions: TestOptions.Regular12).VerifyDiagnostics(expected);
-            CreateCompilation(text).VerifyDiagnostics(expected);
+            CreateCompilation(text, parseOptions: TestOptions.Regular14).VerifyDiagnostics(expected);
+
+            CreateCompilation(text).VerifyDiagnostics();
+            CreateCompilation(text, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67281")]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -2843,7 +2843,7 @@ public class MyClass
 }
 ";
             // NOTE: only first in scope is reported.
-            CreateCompilation(text, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+            CreateCompilation(text, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
                 // (11,9): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //         S* s2 = &s;    // CS0214
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "S*"),
@@ -2853,6 +2853,16 @@ public class MyClass
                 // (12,9): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //         s2->a = 3;      // CS0214
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "s2"));
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (12,11): error CS9360: This operation may only be used in an unsafe context
+                //         s2->a = 3;      // CS0214
+                Diagnostic(ErrorCode.ERR_UnsafeOperation, "->").WithLocation(12, 11),
+            };
+
+            CreateCompilation(text, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilation(text, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Fact]
@@ -2873,13 +2883,26 @@ class Program
     }
 }";
             // NOTE: only first in scope is reported.
-            CreateCompilation(text, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+            CreateCompilation(text, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
                 // (11,9): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //         s.x[1] = s.x[2];
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "s.x"),
                 // (11,18): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //         s.x[1] = s.x[2];
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "s.x"));
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (11,12): error CS9360: This operation may only be used in an unsafe context
+                //         s.x[1] = s.x[2];
+                Diagnostic(ErrorCode.ERR_UnsafeOperation, "[").WithLocation(11, 12),
+                // (11,21): error CS9360: This operation may only be used in an unsafe context
+                //         s.x[1] = s.x[2];
+                Diagnostic(ErrorCode.ERR_UnsafeOperation, "[").WithLocation(11, 21),
+            };
+
+            CreateCompilation(text, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilation(text, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Fact]
@@ -2890,10 +2913,13 @@ class Program
     public fixed int buf[10];
 }
 ";
-            CreateCompilation(text, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+            CreateCompilation(text, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
                 // (3,22): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //     public fixed int buf[10];
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "buf[10]"));
+
+            CreateCompilation(text, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
+            CreateCompilation(text, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
         }
 
         [Fact]
@@ -2912,10 +2938,13 @@ namespace System
     }
 }
 ";
-            CreateCompilationWithMscorlibAndSpan(text, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
                 // (8,21): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //             var x = stackalloc int[10];    // ERROR
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "stackalloc int[10]").WithLocation(8, 21));
+
+            CreateCompilationWithMscorlibAndSpan(text, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/AnonymousFunctionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/AnonymousFunctionParsingTests.cs
@@ -1864,7 +1864,7 @@ public class C
             var test = @"delegate*<void> ptr = &() => { };";
             var testWithStatement = @$"class C {{ void M() {{ {test} }} }}";
 
-            CreateCompilation(testWithStatement).VerifyDiagnostics(
+            CreateCompilation(testWithStatement, parseOptions: TestOptions.Regular14).VerifyDiagnostics(
                 // (1,22): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // class C { void M() { delegate*<void> ptr = &() => { }; } }
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "delegate*").WithLocation(1, 22),
@@ -1877,6 +1877,20 @@ public class C
                 // (1,51): error CS1002: ; expected
                 // class C { void M() { delegate*<void> ptr = &() => { }; } }
                 Diagnostic(ErrorCode.ERR_SemicolonExpected, "{").WithLocation(1, 51));
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (1,46): error CS1525: Invalid expression term ')'
+                // class C { void M() { delegate*<void> ptr = &() => { }; } }
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(1, 46),
+                // (1,48): error CS1003: Syntax error, ',' expected
+                // class C { void M() { delegate*<void> ptr = &() => { }; } }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "=>").WithArguments(",").WithLocation(1, 48),
+                // (1,51): error CS1002: ; expected
+                // class C { void M() { delegate*<void> ptr = &() => { }; } }
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "{").WithLocation(1, 51),
+            };
+            CreateCompilation(testWithStatement).VerifyDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilation(testWithStatement, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedPreviewDiagnostics);
             CreateCompilation(testWithStatement, parseOptions: TestOptions.Regular8).VerifyDiagnostics(
                 // (1,22): error CS8400: Feature 'function pointers' is not available in C# 8.0. Please use language version 9.0 or greater.
                 // class C { void M() { delegate*<void> ptr = &() => { }; } }
@@ -1970,7 +1984,7 @@ public class C
             var test = @"delegate*<void> ptr = &static () => { };";
             var testInMethod = @$"class C {{ void M() {{ {test} }} }}";
 
-            CreateCompilation(testInMethod).VerifyDiagnostics(
+            CreateCompilation(testInMethod, parseOptions: TestOptions.Regular14).VerifyDiagnostics(
                 // (1,22): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // class C { void M() { delegate*<void> ptr = &static () => { }; } }
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "delegate*").WithLocation(1, 22),
@@ -1995,6 +2009,32 @@ public class C
                 // (1,58): error CS1002: ; expected
                 // class C { void M() { delegate*<void> ptr = &static () => { }; } }
                 Diagnostic(ErrorCode.ERR_SemicolonExpected, "{").WithLocation(1, 58));
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (1,45): error CS1525: Invalid expression term 'static'
+                // class C { void M() { delegate*<void> ptr = &static () => { }; } }
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "static").WithArguments("static").WithLocation(1, 45),
+                // (1,45): error CS1002: ; expected
+                // class C { void M() { delegate*<void> ptr = &static () => { }; } }
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "static").WithLocation(1, 45),
+                // (1,45): error CS0106: The modifier 'static' is not valid for this item
+                // class C { void M() { delegate*<void> ptr = &static () => { }; } }
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "static").WithArguments("static").WithLocation(1, 45),
+                // (1,53): error CS8124: Tuple must contain at least two elements.
+                // class C { void M() { delegate*<void> ptr = &static () => { }; } }
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(1, 53),
+                // (1,55): error CS1001: Identifier expected
+                // class C { void M() { delegate*<void> ptr = &static () => { }; } }
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "=>").WithLocation(1, 55),
+                // (1,55): error CS1003: Syntax error, ',' expected
+                // class C { void M() { delegate*<void> ptr = &static () => { }; } }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "=>").WithArguments(",").WithLocation(1, 55),
+                // (1,58): error CS1002: ; expected
+                // class C { void M() { delegate*<void> ptr = &static () => { }; } }
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "{").WithLocation(1, 58),
+            };
+            CreateCompilation(testInMethod).VerifyDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilation(testInMethod, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedPreviewDiagnostics);
             CreateCompilation(testInMethod, parseOptions: TestOptions.Regular8).VerifyDiagnostics(
                 // (1,22): error CS8400: Feature 'function pointers' is not available in C# 8.0. Please use language version 9.0 or greater.
                 // class C { void M() { delegate*<void> ptr = &static () => { }; } }
@@ -2093,13 +2133,21 @@ public class C
         {
             var test = @"delegate*<void> ptr = &delegate() { };";
 
-            CreateCompilation(test).VerifyDiagnostics(
+            CreateCompilation(test, parseOptions: TestOptions.Regular14).VerifyDiagnostics(
                 // (1,1): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // delegate*<void> ptr = &delegate() { };
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "delegate*").WithLocation(1, 1),
                 // (1,24): error CS0211: Cannot take the address of the given expression
                 // delegate*<void> ptr = &delegate() { };
                 Diagnostic(ErrorCode.ERR_InvalidAddrOp, "delegate() { }").WithLocation(1, 24));
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (1,24): error CS0211: Cannot take the address of the given expression
+                // delegate*<void> ptr = &delegate() { };
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "delegate() { }").WithLocation(1, 24),
+            };
+            CreateCompilation(test).VerifyDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilation(test, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedPreviewDiagnostics);
             CreateCompilation(test, parseOptions: TestOptions.Regular8).VerifyDiagnostics(
                 // (1,1): error CS8400: Feature 'top-level statements' is not available in C# 8.0. Please use language version 9.0 or greater.
                 // delegate*<void> ptr = &delegate() { };
@@ -2182,13 +2230,21 @@ public class C
             var test = @"delegate*<void> ptr = &delegate() { };";
             var testWithStatement = @$"class C {{ void M() {{ {test} }} }}";
 
-            CreateCompilation(testWithStatement).VerifyDiagnostics(
+            CreateCompilation(testWithStatement, parseOptions: TestOptions.Regular14).VerifyDiagnostics(
                 // (1,22): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 // class C { void M() { delegate*<void> ptr = &delegate() { }; } }
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "delegate*").WithLocation(1, 22),
                 // (1,45): error CS0211: Cannot take the address of the given expression
                 // class C { void M() { delegate*<void> ptr = &delegate() { }; } }
                 Diagnostic(ErrorCode.ERR_InvalidAddrOp, "delegate() { }").WithLocation(1, 45));
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (1,45): error CS0211: Cannot take the address of the given expression
+                // class C { void M() { delegate*<void> ptr = &delegate() { }; } }
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "delegate() { }").WithLocation(1, 45),
+            };
+            CreateCompilation(testWithStatement).VerifyDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilation(testWithStatement, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedPreviewDiagnostics);
             CreateCompilation(testWithStatement, parseOptions: TestOptions.Regular8).VerifyDiagnostics(
                 // (1,22): error CS8400: Feature 'function pointers' is not available in C# 8.0. Please use language version 9.0 or greater.
                 // class C { void M() { delegate*<void> ptr = &delegate() { }; } }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ExtensionsParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ExtensionsParsingTests.cs
@@ -2617,7 +2617,7 @@ static class C
     }
 }
 """;
-        var comp = CreateCompilation(src);
+        var comp = CreateCompilation(src, parseOptions: TestOptions.Regular14);
         comp.VerifyEmitDiagnostics(
             // (5,19): error CS1642: Fixed size buffer fields may only be members of structs
             //         fixed int field[10];
@@ -2628,6 +2628,19 @@ static class C
             // (5,19): error CS9282: This member is not allowed in an extension block
             //         fixed int field[10];
             Diagnostic(ErrorCode.ERR_ExtensionDisallowsMember, "field").WithLocation(5, 19));
+
+        var expectedPreviewDiagnostics = new[]
+        {
+            // (5,19): error CS1642: Fixed size buffer fields may only be members of structs
+            //         fixed int field[10];
+            Diagnostic(ErrorCode.ERR_FixedNotInStruct, "field").WithLocation(5, 19),
+            // (5,19): error CS9282: This member is not allowed in an extension block
+            //         fixed int field[10];
+            Diagnostic(ErrorCode.ERR_ExtensionDisallowsMember, "field").WithLocation(5, 19),
+        };
+
+        CreateCompilation(src).VerifyEmitDiagnostics(expectedPreviewDiagnostics);
+        CreateCompilation(src, parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics(expectedPreviewDiagnostics);
 
         UsingTree(src, TestOptions.RegularPreview);
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/FileModifierParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/FileModifierParsingTests.cs
@@ -723,12 +723,14 @@ public sealed class FileModifierParsingTests : ParsingTests
     [Fact]
     public void FileModifier_18()
     {
-        UsingNode("""
+        var src = """
             class C
             {
                 file delegate*<int, void> M();
             }
-            """,
+            """;
+        UsingNode(src,
+            options: TestOptions.Regular14,
             expectedBindingDiagnostics: new[]
             {
                 // (3,10): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
@@ -741,6 +743,18 @@ public sealed class FileModifierParsingTests : ParsingTests
                 //     file delegate*<int, void> M();
                 Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "M").WithArguments("C.M()").WithLocation(3, 31)
             });
+
+        var expectedPreviewDiagnostics = new[]
+        {
+            // (3,31): error CS0106: The modifier 'file' is not valid for this item
+            //     file delegate*<int, void> M();
+            Diagnostic(ErrorCode.ERR_BadMemberFlag, "M").WithArguments("file").WithLocation(3, 31),
+            // (3,31): error CS0501: 'C.M()' must declare a body because it is not marked abstract, extern, or partial
+            //     file delegate*<int, void> M();
+            Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "M").WithArguments("C.M()").WithLocation(3, 31),
+        };
+        CreateCompilation(src).VerifyDiagnostics(expectedPreviewDiagnostics);
+        CreateCompilation(src, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedPreviewDiagnostics);
 
         N(SyntaxKind.CompilationUnit);
         {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -1100,7 +1100,7 @@ interface IB<T>
         where U : T*
         where V : T[];
 }";
-            CreateCompilation(source).VerifyDiagnostics(
+            CreateCompilation(source, parseOptions: TestOptions.Regular14).VerifyDiagnostics(
                 // (2,15): error CS0706: Invalid constraint type. A type used as a constraint must be an interface, a non-sealed class or a type parameter.
                 //     where U : T*
                 Diagnostic(ErrorCode.ERR_BadConstraintType, "T*").WithLocation(2, 15),
@@ -1122,6 +1122,24 @@ interface IB<T>
                 // (9,19): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
                 //         where U : T*
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "T*").WithLocation(9, 19));
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (2,15): error CS0706: Invalid constraint type. A type used as a constraint must be an interface, a non-sealed class or a type parameter.
+                //     where U : T*
+                Diagnostic(ErrorCode.ERR_BadConstraintType, "T*").WithLocation(2, 15),
+                // (3,15): error CS0706: Invalid constraint type. A type used as a constraint must be an interface, a non-sealed class or a type parameter.
+                //     where V : T[]
+                Diagnostic(ErrorCode.ERR_BadConstraintType, "T[]").WithLocation(3, 15),
+                // (9,19): error CS0706: Invalid constraint type. A type used as a constraint must be an interface, a non-sealed class or a type parameter.
+                //         where U : T*
+                Diagnostic(ErrorCode.ERR_BadConstraintType, "T*").WithLocation(9, 19),
+                // (10,19): error CS0706: Invalid constraint type. A type used as a constraint must be an interface, a non-sealed class or a type parameter.
+                //         where V : T[];
+                Diagnostic(ErrorCode.ERR_BadConstraintType, "T[]").WithLocation(10, 19),
+            };
+            CreateCompilation(source).VerifyDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Fact]
@@ -4042,7 +4060,7 @@ class Program
 }
 ";
             // note: ErrorCode.ManagedAddr not given for Test1* because the base type after binding is considered to be System.Object
-            CreateCompilation(test).GetDeclarationDiagnostics().Verify(
+            CreateCompilation(test, parseOptions: TestOptions.Regular14).GetDeclarationDiagnostics().Verify(
                 // (6,15): error CS1521: Invalid base type
                 // class Test3 : Test1*    // CS1521
                 Diagnostic(ErrorCode.ERR_BadBaseType, "Test1*").WithLocation(6, 15),
@@ -4058,6 +4076,24 @@ class Program
                 // (3,15): error CS0527: Type 'Test1[]' in interface list is not an interface
                 // class Test2 : Test1[]   // CS1521
                 Diagnostic(ErrorCode.ERR_NonInterfaceInInterfaceList, "Test1[]").WithArguments("Test1[]").WithLocation(3, 15));
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (6,15): error CS1521: Invalid base type
+                // class Test3 : Test1*    // CS1521
+                Diagnostic(ErrorCode.ERR_BadBaseType, "Test1*").WithLocation(6, 15),
+                // (6,15): error CS0527: Type 'Test1*' in interface list is not an interface
+                // class Test3 : Test1*    // CS1521
+                Diagnostic(ErrorCode.ERR_NonInterfaceInInterfaceList, "Test1*").WithArguments("Test1*").WithLocation(6, 15),
+                // (3,15): error CS1521: Invalid base type
+                // class Test2 : Test1[]   // CS1521
+                Diagnostic(ErrorCode.ERR_BadBaseType, "Test1[]").WithLocation(3, 15),
+                // (3,15): error CS0527: Type 'Test1[]' in interface list is not an interface
+                // class Test2 : Test1[]   // CS1521
+                Diagnostic(ErrorCode.ERR_NonInterfaceInInterfaceList, "Test1[]").WithArguments("Test1[]").WithLocation(3, 15),
+            };
+            CreateCompilation(test).GetDeclarationDiagnostics().Verify(expectedPreviewDiagnostics);
+            CreateCompilation(test, parseOptions: TestOptions.RegularNext).GetDeclarationDiagnostics().Verify(expectedPreviewDiagnostics);
         }
 
         [WorkItem(906299, "DevDiv/Personal")]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingErrorRecoveryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingErrorRecoveryTests.cs
@@ -4080,7 +4080,7 @@ class C
             Assert.Equal(1, diags.Length);
             Assert.Equal((int)ErrorCode.ERR_CloseParenExpected, diags[0].Code);
 
-            CreateCompilation(text).VerifyDiagnostics(
+            CreateCompilation(text, parseOptions: TestOptions.Regular14).VerifyDiagnostics(
                 // (1,31): error CS1026: ) expected
                 // class c { void m() { fixed(t v; } }
                 Diagnostic(ErrorCode.ERR_CloseParenExpected, ";").WithLocation(1, 31),
@@ -4102,6 +4102,30 @@ class C
                 // (1,31): warning CS0642: Possible mistaken empty statement
                 // class c { void m() { fixed(t v; } }
                 Diagnostic(ErrorCode.WRN_PossibleMistakenNullStatement, ";").WithLocation(1, 31));
+
+            var expectedPreviewDiagnostics = new[]
+            {
+                // (1,31): error CS1026: ) expected
+                // class c { void m() { fixed(t v; } }
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, ";").WithLocation(1, 31),
+                // (1,7): warning CS8981: The type name 'c' only contains lower-cased ascii characters. Such names may become reserved for the language.
+                // class c { void m() { fixed(t v; } }
+                Diagnostic(ErrorCode.WRN_LowerCaseTypeName, "c").WithArguments("c").WithLocation(1, 7),
+                // (1,28): error CS0246: The type or namespace name 't' could not be found (are you missing a using directive or an assembly reference?)
+                // class c { void m() { fixed(t v; } }
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "t").WithArguments("t").WithLocation(1, 28),
+                // (1,30): error CS0209: The type of a local declared in a fixed statement must be a pointer type
+                // class c { void m() { fixed(t v; } }
+                Diagnostic(ErrorCode.ERR_BadFixedInitType, "v").WithLocation(1, 30),
+                // (1,30): error CS0210: You must provide an initializer in a fixed or using statement declaration
+                // class c { void m() { fixed(t v; } }
+                Diagnostic(ErrorCode.ERR_FixedMustInit, "v").WithLocation(1, 30),
+                // (1,31): warning CS0642: Possible mistaken empty statement
+                // class c { void m() { fixed(t v; } }
+                Diagnostic(ErrorCode.WRN_PossibleMistakenNullStatement, ";").WithLocation(1, 31),
+            };
+            CreateCompilation(text).VerifyDiagnostics(expectedPreviewDiagnostics);
+            CreateCompilation(text, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedPreviewDiagnostics);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/UsingDirectiveParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/UsingDirectiveParsingTests.cs
@@ -602,7 +602,7 @@ public sealed class UsingDirectiveParsingTests : ParsingTests
 
 struct A { }";
         UsingTree(text);
-        CreateCompilation(text).VerifyDiagnostics(
+        CreateCompilation(text, parseOptions: TestOptions.Regular14).VerifyDiagnostics(
             // (1,1): hidden CS8019: Unnecessary using directive.
             // using x = A*;
             Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using x = A*;").WithLocation(1, 1),
@@ -612,6 +612,17 @@ struct A { }";
             // (1,11): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             // using x = A*;
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "A*").WithLocation(1, 11));
+        var expectedPreviewDiagnostics = new[]
+        {
+            // (1,1): hidden CS8019: Unnecessary using directive.
+            // using x = A*;
+            Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using x = A*;").WithLocation(1, 1),
+            // (1,7): warning CS8981: The type name 'x' only contains lower-cased ascii characters. Such names may become reserved for the language.
+            // using x = A*;
+            Diagnostic(ErrorCode.WRN_LowerCaseTypeName, "x").WithArguments("x").WithLocation(1, 7),
+        };
+        CreateCompilation(text).VerifyDiagnostics(expectedPreviewDiagnostics);
+        CreateCompilation(text, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedPreviewDiagnostics);
 
         N(SyntaxKind.CompilationUnit);
         {
@@ -706,7 +717,7 @@ struct A { }";
         var text = @"using x = delegate*<int, void>;";
 
         UsingTree(text);
-        CreateCompilation(text).VerifyDiagnostics(
+        CreateCompilation(text, parseOptions: TestOptions.Regular14).VerifyDiagnostics(
             // (1,1): hidden CS8019: Unnecessary using directive.
             // using x = delegate*<int, void>;
             Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using x = delegate*<int, void>;").WithLocation(1, 1),
@@ -716,6 +727,17 @@ struct A { }";
             // (1,11): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             // using x = delegate*<int, void>;
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "delegate*").WithLocation(1, 11));
+        var expectedPreviewDiagnostics = new[]
+        {
+            // (1,1): hidden CS8019: Unnecessary using directive.
+            // using x = delegate*<int, void>;
+            Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using x = delegate*<int, void>;").WithLocation(1, 1),
+            // (1,7): warning CS8981: The type name 'x' only contains lower-cased ascii characters. Such names may become reserved for the language.
+            // using x = delegate*<int, void>;
+            Diagnostic(ErrorCode.WRN_LowerCaseTypeName, "x").WithArguments("x").WithLocation(1, 7),
+        };
+        CreateCompilation(text).VerifyDiagnostics(expectedPreviewDiagnostics);
+        CreateCompilation(text, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedPreviewDiagnostics);
 
         N(SyntaxKind.CompilationUnit);
         {
@@ -1061,7 +1083,7 @@ struct A { }";
     {
         var text = @"using x = int*;";
         UsingTree(text);
-        CreateCompilation(text).VerifyDiagnostics(
+        CreateCompilation(text, parseOptions: TestOptions.Regular14).VerifyDiagnostics(
             // (1,1): hidden CS8019: Unnecessary using directive.
             // using x = int*;
             Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using x = int*;").WithLocation(1, 1),
@@ -1071,6 +1093,17 @@ struct A { }";
             // (1,11): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             // using x = int*;
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(1, 11));
+        var expectedPreviewDiagnostics = new[]
+        {
+            // (1,1): hidden CS8019: Unnecessary using directive.
+            // using x = int*;
+            Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using x = int*;").WithLocation(1, 1),
+            // (1,7): warning CS8981: The type name 'x' only contains lower-cased ascii characters. Such names may become reserved for the language.
+            // using x = int*;
+            Diagnostic(ErrorCode.WRN_LowerCaseTypeName, "x").WithArguments("x").WithLocation(1, 7),
+        };
+        CreateCompilation(text).VerifyDiagnostics(expectedPreviewDiagnostics);
+        CreateCompilation(text, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedPreviewDiagnostics);
 
         N(SyntaxKind.CompilationUnit);
         {
@@ -1153,13 +1186,21 @@ namespace N
     using Y = X;
 }";
         UsingTree(text);
-        CreateCompilation(text, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(
+        CreateCompilation(text, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(
             // (6,5): hidden CS8019: Unnecessary using directive.
             //     using Y = X;
             Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using Y = X;").WithLocation(6, 5),
             // (6,15): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             //     using Y = X;
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "X").WithLocation(6, 15));
+        var expectedPreviewDiagnostics = new[]
+        {
+            // (6,5): hidden CS8019: Unnecessary using directive.
+            //     using Y = X;
+            Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using Y = X;").WithLocation(6, 5),
+        };
+        CreateCompilation(text, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(expectedPreviewDiagnostics);
+        CreateCompilation(text, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(expectedPreviewDiagnostics);
 
         N(SyntaxKind.CompilationUnit);
         {
@@ -1301,13 +1342,21 @@ namespace N
     using unsafe Y = X;
 }";
         UsingTree(text);
-        CreateCompilation(text, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(
+        CreateCompilation(text, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(
             // (2,11): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             // using X = int*;
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(2, 11),
             // (6,5): hidden CS8019: Unnecessary using directive.
             //     using unsafe Y = X;
             Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using unsafe Y = X;").WithLocation(6, 5));
+        var expectedPreviewDiagnostics = new[]
+        {
+            // (6,5): hidden CS8019: Unnecessary using directive.
+            //     using unsafe Y = X;
+            Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using unsafe Y = X;").WithLocation(6, 5),
+        };
+        CreateCompilation(text, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(expectedPreviewDiagnostics);
+        CreateCompilation(text, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(expectedPreviewDiagnostics);
 
         N(SyntaxKind.CompilationUnit);
         {
@@ -1376,13 +1425,21 @@ namespace N
     using Y = X[];
 }";
         UsingTree(text);
-        CreateCompilation(text, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(
+        CreateCompilation(text, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(
             // (6,5): hidden CS8019: Unnecessary using directive.
             //     using Y = X[];
             Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using Y = X[];").WithLocation(6, 5),
             // (6,15): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             //     using Y = X[];
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "X").WithLocation(6, 15));
+        var expectedPreviewDiagnostics = new[]
+        {
+            // (6,5): hidden CS8019: Unnecessary using directive.
+            //     using Y = X[];
+            Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using Y = X[];").WithLocation(6, 5),
+        };
+        CreateCompilation(text, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(expectedPreviewDiagnostics);
+        CreateCompilation(text, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(expectedPreviewDiagnostics);
 
         N(SyntaxKind.CompilationUnit);
         {
@@ -2093,10 +2150,12 @@ class C
     void M(VP vp) { }
 }";
         UsingTree(text);
-        CreateCompilation(text, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(
+        CreateCompilation(text, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(
             // (5,12): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             //     void M(VP vp) { }
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "VP").WithLocation(5, 12));
+        CreateCompilation(text, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics();
+        CreateCompilation(text, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics();
 
         N(SyntaxKind.CompilationUnit);
         {
@@ -2245,10 +2304,12 @@ class C
     unsafe void M(VP vp) { }
 }";
         UsingTree(text);
-        CreateCompilation(text, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(
+        CreateCompilation(text, parseOptions: TestOptions.Regular14, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(
             // (1,12): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
             // using VP = void*;
             Diagnostic(ErrorCode.ERR_UnsafeNeeded, "void*").WithLocation(1, 12));
+        CreateCompilation(text, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics();
+        CreateCompilation(text, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics();
 
         N(SyntaxKind.CompilationUnit);
         {


### PR DESCRIPTION
Test plan: https://github.com/dotnet/roslyn/issues/81207
Related speclet changes:
- https://github.com/dotnet/csharplang/pull/10091
- https://github.com/dotnet/csharplang/pull/10105
- https://github.com/dotnet/csharplang/pull/10109

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83133)