### PR TITLE
 Use 'dotnet pwsh' in skills

### DIFF
--- a/.github/skills/ci-analysis/SKILL.md
+++ b/.github/skills/ci-analysis/SKILL.md
@@ -33,20 +33,26 @@ However, the analysis patterns in this skill (interpreting failures, correlating
 
 ## Quick Start
 
+```sh
+# Ensure powershell tool is restored
+dotnet tool restore
+```
+
 ```powershell
 # Analyze PR failures (most common) - defaults to dotnet/runtime
-./scripts/Get-CIStatus.ps1 -PRNumber 123445 -ShowLogs
+# NOTE: file paths are relative to the containing folder of the SKILL.md file
+dotnet pwsh ./scripts/Get-CIStatus.ps1 -PRNumber 123445 -ShowLogs
 
 # Analyze by build ID
-./scripts/Get-CIStatus.ps1 -BuildId 1276327 -ShowLogs
+dotnet pwsh ./scripts/Get-CIStatus.ps1 -BuildId 1276327 -ShowLogs
 
 # Query specific Helix work item
-./scripts/Get-CIStatus.ps1 -HelixJob "4b24b2c2-..." -WorkItem "System.Net.Http.Tests"
+dotnet pwsh ./scripts/Get-CIStatus.ps1 -HelixJob "4b24b2c2-..." -WorkItem "System.Net.Http.Tests"
 
 # Other dotnet repositories
-./scripts/Get-CIStatus.ps1 -PRNumber 12345 -Repository "dotnet/aspnetcore"
-./scripts/Get-CIStatus.ps1 -PRNumber 67890 -Repository "dotnet/sdk"
-./scripts/Get-CIStatus.ps1 -PRNumber 11111 -Repository "dotnet/roslyn"
+dotnet pwsh ./scripts/Get-CIStatus.ps1 -PRNumber 12345 -Repository "dotnet/aspnetcore"
+dotnet pwsh ./scripts/Get-CIStatus.ps1 -PRNumber 67890 -Repository "dotnet/sdk"
+dotnet pwsh ./scripts/Get-CIStatus.ps1 -PRNumber 11111 -Repository "dotnet/roslyn"
 ```
 
 ## Key Parameters

--- a/.github/skills/integration-test-analysis/SKILL.md
+++ b/.github/skills/integration-test-analysis/SKILL.md
@@ -22,15 +22,20 @@ Use this skill when:
 
 ## Quick Start
 
+```sh
+# Ensure powershell tool is restored
+dotnet tool restore
+```
+
 ```powershell
 # Analyze integration test failures by build ID
-pwsh -File .github/skills/integration-test-analysis/scripts/Get-IntegrationTestStatus.ps1 -BuildId 1354185
+dotnet pwsh -File .github/skills/integration-test-analysis/scripts/Get-IntegrationTestStatus.ps1 -BuildId 1354185
 
 # Analyze with verbose artifact download (downloads and parses exception XMLs)
-pwsh -File .github/skills/integration-test-analysis/scripts/Get-IntegrationTestStatus.ps1 -BuildId 1354185 -DownloadArtifacts
+dotnet pwsh -File .github/skills/integration-test-analysis/scripts/Get-IntegrationTestStatus.ps1 -BuildId 1354185 -DownloadArtifacts
 
 # Limit artifact download size (default 200MB)
-pwsh -File .github/skills/integration-test-analysis/scripts/Get-IntegrationTestStatus.ps1 -BuildId 1354185 -DownloadArtifacts -MaxArtifactSizeMB 500
+dotnet pwsh -File .github/skills/integration-test-analysis/scripts/Get-IntegrationTestStatus.ps1 -BuildId 1354185 -DownloadArtifacts -MaxArtifactSizeMB 500
 ```
 
 ## Key Parameters

--- a/docs/contributing/Powershell Guidelines.md
+++ b/docs/contributing/Powershell Guidelines.md
@@ -104,8 +104,10 @@ The Roslyn infrastructure should use `powershell` for execution not `pwsh`. The 
 still uses `Powershell` and calls into our scripts. Moving to `pwsh` in our scripts creates errors
 in source and unified build. Until that moves to `pwsh` our scripts need to stay on `Powershell`.
 
-The exception is that our VS Code helper scripts should use `pwsh`. That is not a part of our 
-infrastructure and needs to run cross platform hence `pwsh` is appropriate.
+`pwsh` is permitted in cases which are not part of our infrastructure. i.e., scripts that are not under the `eng/` folder, and not expected to be run by the build process.
+This is necessary in scenarios where the script needs to run cross-platform, such as:
+- VS Code helper scripts
+- AI skills
 
 ### Supporting .cmd file
 

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -5,13 +5,15 @@
       "version": "7.0.360304",
       "commands": [
         "dotnet-format"
-      ]
+      ],
+      "rollForward": false
     },
     "powershell": {
-      "version": "7.0.0",
+      "version": "7.6.0",
       "commands": [
         "pwsh"
-      ]
+      ],
+      "rollForward": false
     }
   }
 }


### PR DESCRIPTION
Running `restore.cmd/.sh` already results in a powershell showing up on the local machine. It just needs to be used with `dotnet pwsh` in order to work.

Bumped the pwsh version also as that resolved an issue with `Encoding.GetBytes()` in one of the scripts blowing up about existence of a span overload.

@jaredpar @333fred @akhera99 for review
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83139)