### PR TITLE
Constrain proposal adjuster edits to avoid CompletionState.ApplicableToSpan

### DIFF
--- a/src/EditorFeatures/Core/Copilot/RoslynProposalAdjusterProvider.cs
+++ b/src/EditorFeatures/Core/Copilot/RoslynProposalAdjusterProvider.cs
@@ -196,8 +196,7 @@ internal sealed class RoslynProposalAdjusterProvider : ProposalAdjusterProviderB
         var adjustmentsProposed = false;
         var format = false;
 
-        // Extract the ApplicableToSpan from the CompletionState, if present. The proposal system
-        // requires that no edit intersect this span (except a zero-length edit at its end), so we
+        // Required that no edit intersect this span (except a zero-length edit at its end), so we
         // pass it to the adjuster to constrain its output.
         var completionState = proposal.CompletionState;
 
@@ -252,6 +251,11 @@ internal sealed class RoslynProposalAdjusterProvider : ProposalAdjusterProviderB
         // No adjustments were made.  Don't touch anything.
         if (!adjustmentsProposed)
             return default;
+
+        // Ensure edits are ordered by position.
+        // This constraint may be enforced later and other
+        // downstream logic depends on edits being sorted
+        finalEdits.Sort(static (a, b) => a.Span.Span.Start - b.Span.Span.Start);
 
         // We have some changes we want to to make to the proposal.  See if the proposal system allows us merging
         // those changes in.  Note: we should generally always be producing edits that are safe to merge in.  However,

--- a/src/EditorFeatures/Core/Copilot/RoslynProposalAdjusterProvider.cs
+++ b/src/EditorFeatures/Core/Copilot/RoslynProposalAdjusterProvider.cs
@@ -212,12 +212,10 @@ internal sealed class RoslynProposalAdjusterProvider : ProposalAdjusterProviderB
 
             var lineFormattingOptions = snapshot.TextBuffer.GetLineFormattingOptions(_editorOptionsService, explicitFormat: false);
 
-            TextSpan? applicableToSpan = null;
-            if (completionState is not null)
-            {
-                var atsSpan = completionState.ApplicableToSpan.Span;
-                applicableToSpan = new TextSpan(atsSpan.Start, atsSpan.Length);
-            }
+            // The ApplicableToSpan should be on the same snapshot as the edits
+            var applicableToSpan = completionState is not null && completionState.ApplicableToSpan.Snapshot == snapshot
+                ? new TextSpan(completionState.ApplicableToSpan.Start, completionState.ApplicableToSpan.Length)
+                : (TextSpan?)null;
 
             var proposalAdjusterService = document.GetLanguageService<ICopilotProposalAdjusterService>();
             var (proposedEdits, formatGroup, adjustmentResults) = proposalAdjusterService is null

--- a/src/EditorFeatures/Core/Copilot/RoslynProposalAdjusterProvider.cs
+++ b/src/EditorFeatures/Core/Copilot/RoslynProposalAdjusterProvider.cs
@@ -195,6 +195,12 @@ internal sealed class RoslynProposalAdjusterProvider : ProposalAdjusterProviderB
 
         var adjustmentsProposed = false;
         var format = false;
+
+        // Extract the ApplicableToSpan from the CompletionState, if present. The proposal system
+        // requires that no edit intersect this span (except a zero-length edit at its end), so we
+        // pass it to the adjuster to constrain its output.
+        var completionState = proposal.CompletionState;
+
         foreach (var editGroup in proposal.Edits.GroupBy(e => e.Span.Snapshot))
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -207,13 +213,20 @@ internal sealed class RoslynProposalAdjusterProvider : ProposalAdjusterProviderB
 
             var lineFormattingOptions = snapshot.TextBuffer.GetLineFormattingOptions(_editorOptionsService, explicitFormat: false);
 
+            TextSpan? applicableToSpan = null;
+            if (completionState is not null)
+            {
+                var atsSpan = completionState.ApplicableToSpan.Span;
+                applicableToSpan = new TextSpan(atsSpan.Start, atsSpan.Length);
+            }
+
             var proposalAdjusterService = document.GetLanguageService<ICopilotProposalAdjusterService>();
             var (proposedEdits, formatGroup, adjustmentResults) = proposalAdjusterService is null
                 ? default
                 : await proposalAdjusterService.TryAdjustProposalAsync(
                     this._allowableAdjustments, document,
                     CopilotEditorUtilities.TryGetNormalizedTextChanges(editGroup),
-                    lineFormattingOptions, cancellationToken).ConfigureAwait(false);
+                    lineFormattingOptions, applicableToSpan, cancellationToken).ConfigureAwait(false);
 
             if (proposedEdits.IsDefault || adjustmentResults.IsDefault)
             {

--- a/src/EditorFeatures/Test2/Copilot/RoslynProposalAdjusterTests.vb
+++ b/src/EditorFeatures/Test2/Copilot/RoslynProposalAdjusterTests.vb
@@ -928,7 +928,7 @@ class C
 
         <WpfFact>
         Public Sub TestConstrainChanges_ZeroLengthEditAtAtsEnd_Allowed()
-            ' A zero-length edit at the end of the protected span is allowed per ValidateEdits.
+            ' A zero-length edit at the end of the protected span is allowed.
             Dim originalText = SourceText.From("Console.wl" & vbCrLf & "return;")
             Dim protectedSpan = New TextSpan(8, 2) ' "wl"
             Dim changes = ImmutableArray.Create(
@@ -939,16 +939,16 @@ class C
             Assert.Equal(changes(0), constrained(0))
         End Sub
 
+        ' Simulates formatter re-indenting a line, producing a change that spans across
+        ' the ApplicableToSpan. The change should be split into before-ATS and after-ATS parts.
+        '
+        ' Original: "Console.wl\r\nreturn;" where ATS = [8,10) for "wl"
+        ' Diff change: replaces [0, 12) with "    Console.wl(""Hello"");\r\n"
+        ' This spans across ATS [8,10). Should split into:
+        '   [0,8) -> "    Console."   (indentation + prefix)
+        '   [10,12) -> "(""Hello"");\r\n" (edit + rest)
         <WpfFact>
         Public Sub TestConstrainChanges_ChangeFullyContainsAts_SplitsCorrectly()
-            ' Simulates formatter re-indenting a line, producing a change that spans across
-            ' the ATS. The change should be split into before-ATS and after-ATS parts.
-            '
-            ' Original: "Console.wl\r\nreturn;" where ATS = [8,10) for "wl"
-            ' Diff change: replaces [0, 12) with "    Console.wl(""Hello"");\r\n"
-            ' This spans across ATS [8,10). Should split into:
-            '   [0,8) -> "    Console."   (indentation + prefix)
-            '   [10,12) -> "(""Hello"");\r\n" (edit + rest)
             Dim originalText = SourceText.From("Console.wl" & vbCrLf & "return;")
             Dim protectedSpan = New TextSpan(8, 2) ' "wl"
             Dim changes = ImmutableArray.Create(
@@ -967,7 +967,6 @@ class C
             Assert.Equal(12, constrained(1).Span.End)
             Assert.Equal("(""Hello"");" & vbCrLf, constrained(1).NewText)
 
-            ' Verify: applying the split changes + keeping ATS text gives the same result.
             Dim applied = originalText.WithChanges(constrained)
             Assert.Equal("    Console.wl(""Hello"");" & vbCrLf & "return;", applied.ToString())
         End Sub

--- a/src/EditorFeatures/Test2/Copilot/RoslynProposalAdjusterTests.vb
+++ b/src/EditorFeatures/Test2/Copilot/RoslynProposalAdjusterTests.vb
@@ -1036,6 +1036,53 @@ class C
             Assert.Equal(changes(0), constrained(0))
         End Sub
 
+        <WpfFact>
+        Public Sub TestConstrainChanges_AtsTextAppearsMultipleTimes_DisambiguatesViaContext()
+            ' The ATS text "wl" appears in multiple places in the replacement text.
+            Dim originalText = SourceText.From("foo.wl(wl)")
+            Dim protectedSpan = New TextSpan(4, 2) ' "wl" after the dot
+            Dim changes = ImmutableArray.Create(
+                New TextChange(New TextSpan(0, 10), "    foo.wl(wl)"))
+
+            Dim constrained = AbstractCopilotProposalAdjusterService.TestAccessor.ConstrainChangesToAvoidSpan(originalText, changes, protectedSpan)
+            Assert.Equal(2, constrained.Length)
+
+            ' Before ATS: [0,4) -> "    foo."
+            Assert.Equal(0, constrained(0).Span.Start)
+            Assert.Equal(4, constrained(0).Span.End)
+            Assert.Equal("    foo.", constrained(0).NewText)
+
+            ' After ATS: [6,10) -> "(wl)"
+            Assert.Equal(6, constrained(1).Span.Start)
+            Assert.Equal(10, constrained(1).Span.End)
+            Assert.Equal("(wl)", constrained(1).NewText)
+
+            ' Verify round-trip: applying split changes + keeping ATS gives same result.
+            Dim applied = originalText.WithChanges(constrained)
+            Assert.Equal("    foo.wl(wl)", applied.ToString())
+        End Sub
+
+        <WpfFact>
+        Public Sub TestConstrainChanges_SamePrecedingChar_FindsClosestToExpectedPosition()
+            ' Original: ".wl = x.wl" where ATS = [8,10) for the second "wl"
+            ' Diff: replaces [0, 10) with "    .wl = x.wl"
+            ' newText has "wl" at indices 5 and 13. Original offset = 8.
+            ' Distances: |8-5|=3 vs |8-13|=5. Closest is index 5 (wrong one).
+            ' But the split still produces correct text because both the before-span
+            ' and after-span are applied to the original document positions, not the newText.
+            Dim originalText = SourceText.From(".wl = x.wl")
+            Dim protectedSpan = New TextSpan(8, 2) ' second "wl"
+            Dim changes = ImmutableArray.Create(
+                New TextChange(New TextSpan(0, 10), "    .wl = x.wl"))
+
+            Dim constrained = AbstractCopilotProposalAdjusterService.TestAccessor.ConstrainChangesToAvoidSpan(originalText, changes, protectedSpan)
+            Assert.Equal(2, constrained.Length)
+
+            ' Verify the round-trip produces the correct result regardless of which "wl" was matched.
+            Dim applied = originalText.WithChanges(constrained)
+            Assert.Equal("    .wl = x.wl", applied.ToString())
+        End Sub
+
 #End Region
 
 #Region "Visual Basic"

--- a/src/EditorFeatures/Test2/Copilot/RoslynProposalAdjusterTests.vb
+++ b/src/EditorFeatures/Test2/Copilot/RoslynProposalAdjusterTests.vb
@@ -52,7 +52,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Copilot
 
                 Dim service = originalDocument.GetRequiredLanguageService(Of ICopilotProposalAdjusterService)
                 Dim tuple = Await service.TryAdjustProposalAsync(
-                    allowableAdjustments:=fixers, originalDocument, CopilotUtilities.TryNormalizeCopilotTextChanges(changes), lineFormattingOptions:=Nothing, CancellationToken.None)
+                    allowableAdjustments:=fixers, originalDocument, CopilotUtilities.TryNormalizeCopilotTextChanges(changes), lineFormattingOptions:=Nothing, applicableToSpan:=Nothing, CancellationToken.None)
 
                 Dim adjustedChanges = tuple.TextChanges
                 Dim format = tuple.Format
@@ -607,7 +607,7 @@ class C
 
                 Dim service = originalDocument.GetRequiredLanguageService(Of ICopilotProposalAdjusterService)
                 Dim result = Await service.TryAdjustProposalAsync(
-                    allowableAdjustments:=fixers, originalDocument, changes, lineFormattingOptions:=Nothing, CancellationToken.None)
+                    allowableAdjustments:=fixers, originalDocument, changes, lineFormattingOptions:=Nothing, applicableToSpan:=Nothing, CancellationToken.None)
 
                 ' The adjuster should have made changes (at minimum, adding "using System;").
                 Assert.False(result.TextChanges.IsDefaultOrEmpty)
@@ -673,7 +673,7 @@ class C
 
                 Dim service = originalDocument.GetRequiredLanguageService(Of ICopilotProposalAdjusterService)
                 Dim result = Await service.TryAdjustProposalAsync(
-                    allowableAdjustments:=fixers, originalDocument, changes, lineFormattingOptions:=Nothing, CancellationToken.None)
+                    allowableAdjustments:=fixers, originalDocument, changes, lineFormattingOptions:=Nothing, applicableToSpan:=Nothing, CancellationToken.None)
 
                 Assert.False(result.TextChanges.IsDefaultOrEmpty)
 
@@ -760,7 +760,7 @@ class C
 
                 Dim service = originalDocument.GetRequiredLanguageService(Of ICopilotProposalAdjusterService)
                 Dim result = Await service.TryAdjustProposalAsync(
-                    allowableAdjustments:=fixers, originalDocument, changes, lineFormattingOptions:=lfOptions, CancellationToken.None)
+                    allowableAdjustments:=fixers, originalDocument, changes, lineFormattingOptions:=lfOptions, applicableToSpan:=Nothing, CancellationToken.None)
 
                 Assert.False(result.TextChanges.IsDefaultOrEmpty)
 
@@ -907,6 +907,134 @@ class C
 
             Dim result = originalText.WithChanges(fixed)
             Assert.Equal("XY" & vbLf & "CD", result.ToString())
+        End Sub
+
+#End Region
+
+#Region "ConstrainChangesToAvoidSpan"
+
+        <WpfFact>
+        Public Sub TestConstrainChanges_NoOverlap_ReturnsUnchanged()
+            ' Change doesn't overlap the protected span - should return unchanged.
+            Dim originalText = SourceText.From("Console.wl" & vbCrLf & "return;")
+            Dim protectedSpan = New TextSpan(8, 2) ' "wl"
+            Dim changes = ImmutableArray.Create(
+                New TextChange(New TextSpan(10, 2), "(""Hello"");" & vbCrLf))
+
+            Dim constrained = AbstractCopilotProposalAdjusterService.TestAccessor.ConstrainChangesToAvoidSpan(originalText, changes, protectedSpan)
+            Assert.Equal(1, constrained.Length)
+            Assert.Equal(changes(0), constrained(0))
+        End Sub
+
+        <WpfFact>
+        Public Sub TestConstrainChanges_ZeroLengthEditAtAtsEnd_Allowed()
+            ' A zero-length edit at the end of the protected span is allowed per ValidateEdits.
+            Dim originalText = SourceText.From("Console.wl" & vbCrLf & "return;")
+            Dim protectedSpan = New TextSpan(8, 2) ' "wl"
+            Dim changes = ImmutableArray.Create(
+                New TextChange(New TextSpan(10, 0), "(""Hello"");"))
+
+            Dim constrained = AbstractCopilotProposalAdjusterService.TestAccessor.ConstrainChangesToAvoidSpan(originalText, changes, protectedSpan)
+            Assert.Equal(1, constrained.Length)
+            Assert.Equal(changes(0), constrained(0))
+        End Sub
+
+        <WpfFact>
+        Public Sub TestConstrainChanges_ChangeFullyContainsAts_SplitsCorrectly()
+            ' Simulates formatter re-indenting a line, producing a change that spans across
+            ' the ATS. The change should be split into before-ATS and after-ATS parts.
+            '
+            ' Original: "Console.wl\r\nreturn;" where ATS = [8,10) for "wl"
+            ' Diff change: replaces [0, 12) with "    Console.wl(""Hello"");\r\n"
+            ' This spans across ATS [8,10). Should split into:
+            '   [0,8) -> "    Console."   (indentation + prefix)
+            '   [10,12) -> "(""Hello"");\r\n" (edit + rest)
+            Dim originalText = SourceText.From("Console.wl" & vbCrLf & "return;")
+            Dim protectedSpan = New TextSpan(8, 2) ' "wl"
+            Dim changes = ImmutableArray.Create(
+                New TextChange(New TextSpan(0, 12), "    Console.wl(""Hello"");" & vbCrLf))
+
+            Dim constrained = AbstractCopilotProposalAdjusterService.TestAccessor.ConstrainChangesToAvoidSpan(originalText, changes, protectedSpan)
+            Assert.Equal(2, constrained.Length)
+
+            ' Before ATS: [0,8) -> "    Console."
+            Assert.Equal(0, constrained(0).Span.Start)
+            Assert.Equal(8, constrained(0).Span.End)
+            Assert.Equal("    Console.", constrained(0).NewText)
+
+            ' After ATS: [10,12) -> "(""Hello"");\r\n"
+            Assert.Equal(10, constrained(1).Span.Start)
+            Assert.Equal(12, constrained(1).Span.End)
+            Assert.Equal("(""Hello"");" & vbCrLf, constrained(1).NewText)
+
+            ' Verify: applying the split changes + keeping ATS text gives the same result.
+            Dim applied = originalText.WithChanges(constrained)
+            Assert.Equal("    Console.wl(""Hello"");" & vbCrLf & "return;", applied.ToString())
+        End Sub
+
+        <WpfFact>
+        Public Sub TestConstrainChanges_AtsTextNotFound_ReturnsDefault()
+            ' If the adjuster somehow changed the ATS text, we can't split. Return default.
+            Dim originalText = SourceText.From("Console.wl" & vbCrLf & "return;")
+            Dim protectedSpan = New TextSpan(8, 2) ' "wl"
+            Dim changes = ImmutableArray.Create(
+                New TextChange(New TextSpan(0, 12), "    Console.WriteLine(""Hello"");" & vbCrLf))
+
+            Dim constrained = AbstractCopilotProposalAdjusterService.TestAccessor.ConstrainChangesToAvoidSpan(originalText, changes, protectedSpan)
+            Assert.True(constrained.IsDefault)
+        End Sub
+
+        <WpfFact>
+        Public Sub TestConstrainChanges_PartialOverlap_ReturnsDefault()
+            ' A change that partially overlaps the ATS cannot be split safely.
+            Dim originalText = SourceText.From("Console.wl" & vbCrLf & "return;")
+            Dim protectedSpan = New TextSpan(8, 2) ' "wl"
+            ' Change spans [7,9) which partially overlaps ATS [8,10).
+            Dim changes = ImmutableArray.Create(
+                New TextChange(New TextSpan(7, 2), ".W"))
+
+            Dim constrained = AbstractCopilotProposalAdjusterService.TestAccessor.ConstrainChangesToAvoidSpan(originalText, changes, protectedSpan)
+            Assert.True(constrained.IsDefault)
+        End Sub
+
+        <WpfFact>
+        Public Sub TestConstrainChanges_MultipleChanges_OnlyIntersectingSplit()
+            ' Multiple changes: one before ATS (kept), one spanning ATS (split), one after (kept).
+            Dim originalText = SourceText.From("using X;" & vbCrLf & "Console.wl" & vbCrLf & "return;")
+            Dim protectedSpan = New TextSpan(18, 2) ' "wl" at offset 18 in "using X;\r\nConsole.wl\r\nreturn;"
+            Dim changes = ImmutableArray.Create(
+                New TextChange(New TextSpan(0, 0), "using System;" & vbCrLf),
+                New TextChange(New TextSpan(10, 22), "    Console.wl(""Hello"");" & vbCrLf & "    return;"))
+
+            Dim constrained = AbstractCopilotProposalAdjusterService.TestAccessor.ConstrainChangesToAvoidSpan(originalText, changes, protectedSpan)
+            Assert.Equal(3, constrained.Length)
+
+            ' First change: import addition, untouched
+            Assert.Equal(New TextSpan(0, 0), constrained(0).Span)
+            Assert.Equal("using System;" & vbCrLf, constrained(0).NewText)
+
+            ' Second change (split before ATS): [10, 18) -> "    Console."
+            Assert.Equal(10, constrained(1).Span.Start)
+            Assert.Equal(18, constrained(1).Span.End)
+            Assert.Equal("    Console.", constrained(1).NewText)
+
+            ' Third change (split after ATS): [20, 32) -> "(""Hello"");\r\n    return;"
+            Assert.Equal(20, constrained(2).Span.Start)
+            Assert.Equal(32, constrained(2).Span.End)
+            Assert.Equal("(""Hello"");" & vbCrLf & "    return;", constrained(2).NewText)
+        End Sub
+
+        <WpfFact>
+        Public Sub TestConstrainChanges_EmptyProtectedSpan_ReturnsUnchanged()
+            ' An empty protected span should be a no-op.
+            Dim originalText = SourceText.From("Console.wl" & vbCrLf & "return;")
+            Dim protectedSpan = New TextSpan(8, 0) ' empty
+            Dim changes = ImmutableArray.Create(
+                New TextChange(New TextSpan(0, 12), "    Console.wl(""Hello"");" & vbCrLf))
+
+            Dim constrained = AbstractCopilotProposalAdjusterService.TestAccessor.ConstrainChangesToAvoidSpan(originalText, changes, protectedSpan)
+            Assert.Equal(1, constrained.Length)
+            Assert.Equal(changes(0), constrained(0))
         End Sub
 
 #End Region

--- a/src/EditorFeatures/Test2/Copilot/RoslynProposalAdjusterTests.vb
+++ b/src/EditorFeatures/Test2/Copilot/RoslynProposalAdjusterTests.vb
@@ -984,16 +984,45 @@ class C
         End Sub
 
         <WpfFact>
-        Public Sub TestConstrainChanges_PartialOverlap_ReturnsDefault()
-            ' A change that partially overlaps the ATS cannot be split safely.
+        Public Sub TestConstrainChanges_PartialOverlapStart_TrimsBeforeAts()
+            ' Change spans [5,9) which overlaps the start of ATS [8,10).
+            ' Original overlap text at [8,9) is "w". Replacement "LE.w" ends with "w" (preserved).
+            ' Trimmed: span=[5,8), newText="LE." (drop trailing overlap "w").
             Dim originalText = SourceText.From("Console.wl" & vbCrLf & "return;")
             Dim protectedSpan = New TextSpan(8, 2) ' "wl"
-            ' Change spans [7,9) which partially overlaps ATS [8,10).
             Dim changes = ImmutableArray.Create(
-                New TextChange(New TextSpan(7, 2), ".W"))
+                New TextChange(New TextSpan(5, 4), "LE.w"))
 
             Dim constrained = AbstractCopilotProposalAdjusterService.TestAccessor.ConstrainChangesToAvoidSpan(originalText, changes, protectedSpan)
-            Assert.True(constrained.IsDefault)
+            Assert.Equal(1, constrained.Length)
+
+            Assert.Equal(5, constrained(0).Span.Start)
+            Assert.Equal(8, constrained(0).Span.End)
+            Assert.Equal("LE.", constrained(0).NewText)
+
+            Dim applied = originalText.WithChanges(constrained)
+            Assert.Equal("ConsoLE.wl" & vbCrLf & "return;", applied.ToString())
+        End Sub
+
+        <WpfFact>
+        Public Sub TestConstrainChanges_PartialOverlapEnd_TrimsAfterAts()
+            ' Change spans [9,14) which overlaps the end of ATS [8,10).
+            ' Original overlap text at [9,10) is "l". Replacement "l" & vbCrLf & "RE" starts with "l" (preserved).
+            ' Trimmed: span=[10,14), newText=vbCrLf & "RE" (drop leading overlap "l").
+            Dim originalText = SourceText.From("Console.wl" & vbCrLf & "return;")
+            Dim protectedSpan = New TextSpan(8, 2) ' "wl"
+            Dim changes = ImmutableArray.Create(
+                New TextChange(New TextSpan(9, 5), "l" & vbCrLf & "RE"))
+
+            Dim constrained = AbstractCopilotProposalAdjusterService.TestAccessor.ConstrainChangesToAvoidSpan(originalText, changes, protectedSpan)
+            Assert.Equal(1, constrained.Length)
+
+            Assert.Equal(10, constrained(0).Span.Start)
+            Assert.Equal(14, constrained(0).Span.End)
+            Assert.Equal(vbCrLf & "RE", constrained(0).NewText)
+
+            Dim applied = originalText.WithChanges(constrained)
+            Assert.Equal("Console.wl" & vbCrLf & "REturn;", applied.ToString())
         End Sub
 
         <WpfFact>

--- a/src/Features/Core/Portable/Copilot/IProposalAdjusterService.cs
+++ b/src/Features/Core/Portable/Copilot/IProposalAdjusterService.cs
@@ -286,7 +286,6 @@ internal abstract class AbstractCopilotProposalAdjusterService : ICopilotProposa
         if (editSpan.Length == 0 && editSpan.Start == protectedSpan.End)
             return false;
 
-        // Two spans intersect if they share at least one position.
         return editSpan.Start < protectedSpan.End && editSpan.End > protectedSpan.Start;
     }
 
@@ -306,7 +305,7 @@ internal abstract class AbstractCopilotProposalAdjusterService : ICopilotProposa
         var overlapsStart = change.Span.Start <= protectedSpan.Start;
         var overlapsEnd = change.Span.End >= protectedSpan.End;
 
-        // Full containment
+        // Full containment case
         if (overlapsStart && overlapsEnd)
         {
             var protectedText = originalText.ToString(protectedSpan);
@@ -329,7 +328,6 @@ internal abstract class AbstractCopilotProposalAdjusterService : ICopilotProposa
         }
         else if (overlapsStart)
         {
-            // Partial overlap on the start side — verify the overlap text is at the end of the replacement.
             var overlapText = originalText.ToString(TextSpan.FromBounds(protectedSpan.Start, change.Span.End));
             if (!newText.EndsWith(overlapText, StringComparison.Ordinal))
                 return false;
@@ -340,7 +338,6 @@ internal abstract class AbstractCopilotProposalAdjusterService : ICopilotProposa
         }
         else
         {
-            // Partial overlap on the end side — verify the overlap text is at the start of the replacement.
             var overlapText = originalText.ToString(TextSpan.FromBounds(change.Span.Start, protectedSpan.End));
             if (!newText.StartsWith(overlapText, StringComparison.Ordinal))
                 return false;
@@ -364,10 +361,7 @@ internal abstract class AbstractCopilotProposalAdjusterService : ICopilotProposa
     {
         var midpoint = newText.Length / 2;
 
-        // Search forward from the midpoint.
         var forwardIndex = newText.IndexOf(protectedText, midpoint, StringComparison.Ordinal);
-
-        // Search backward from the midpoint.
         var backwardIndex = newText.LastIndexOf(protectedText, midpoint, StringComparison.Ordinal);
 
         return (forwardIndex, backwardIndex) switch

--- a/src/Features/Core/Portable/Copilot/IProposalAdjusterService.cs
+++ b/src/Features/Core/Portable/Copilot/IProposalAdjusterService.cs
@@ -319,16 +319,9 @@ internal abstract class AbstractCopilotProposalAdjusterService : ICopilotProposa
 
         // Find the protected text in newText. Adjusters (formatting, missing tokens, imports)
         // don't modify identifiers, so the ATS text should be preserved in the replacement.
-        var protectedIndex = FindProtectedTextInNewText(originalText, change.Span, newText, protectedSpan, protectedText);
+        var protectedIndex = FindProtectedTextInNewText(change.Span, newText, protectedSpan, protectedText);
         if (protectedIndex < 0)
             return false;
-
-        // Verify the match is actually the protected text.
-        if (protectedIndex + protectedText.Length > newText.Length ||
-            string.Compare(newText, protectedIndex, protectedText, 0, protectedText.Length, StringComparison.Ordinal) != 0)
-        {
-            return false;
-        }
 
         // Emit the portion before the protected span.
         var beforeSpan = TextSpan.FromBounds(change.Span.Start, protectedSpan.Start);
@@ -349,30 +342,49 @@ internal abstract class AbstractCopilotProposalAdjusterService : ICopilotProposa
 
     /// <summary>
     /// Finds the position of the ApplicableToSpan text within a change's replacement text.
-    /// Uses surrounding context characters from the original text to disambiguate when the ATS
-    /// text is short and could appear in multiple places.
+    /// Computes the expected position arithmetically from the ATS offset within the original
+    /// change span, then searches outward from that position. This handles cases where the
+    /// ATS text appears multiple times in the replacement.
     /// </summary>
     private static int FindProtectedTextInNewText(
-        SourceText originalText,
         TextSpan changeSpan,
         string newText,
         TextSpan protectedSpan,
         string protectedText)
     {
-        // Use the character immediately before the ATS in the original text for disambiguation.
-        // This character ('.' in "Console.wl") is a non-whitespace token boundary that
-        // formatting adjusters preserve.
-        if (protectedSpan.Start > changeSpan.Start)
+        // The ATS sits at a known offset within the original change span. Since adjusters
+        // primarily modify whitespace (indentation, line endings) rather than identifiers,
+        // the ATS text should appear near this same relative offset in the replacement text.
+        var originalOffset = protectedSpan.Start - changeSpan.Start;
+
+        // Search outward from the expected position, checking progressively further away.
+        // This ensures we find the closest match to the expected position rather than
+        // always picking the first occurrence (which could be wrong when the ATS text
+        // appears multiple times).
+        var maxDistance = Math.Max(originalOffset, newText.Length - originalOffset);
+        for (var distance = 0; distance <= maxDistance; distance++)
         {
-            var charBefore = originalText[protectedSpan.Start - 1];
-            var searchText = charBefore + protectedText;
-            var idx = newText.IndexOf(searchText, StringComparison.Ordinal);
-            if (idx >= 0)
-                return idx + 1;
+            // Check at expectedOffset + distance
+            var idx = originalOffset + distance;
+            if (idx >= 0 && idx + protectedText.Length <= newText.Length &&
+                string.Compare(newText, idx, protectedText, 0, protectedText.Length, StringComparison.Ordinal) == 0)
+            {
+                return idx;
+            }
+
+            // Check at expectedOffset - distance (skip 0 to avoid double-checking)
+            if (distance > 0)
+            {
+                idx = originalOffset - distance;
+                if (idx >= 0 && idx + protectedText.Length <= newText.Length &&
+                    string.Compare(newText, idx, protectedText, 0, protectedText.Length, StringComparison.Ordinal) == 0)
+                {
+                    return idx;
+                }
+            }
         }
 
-        // Fallback: plain search for the protected text.
-        return newText.IndexOf(protectedText, StringComparison.Ordinal);
+        return -1;
     }
 
     private static async Task<Document> TryGetAddImportTextChangesAsync(

--- a/src/Features/Core/Portable/Copilot/IProposalAdjusterService.cs
+++ b/src/Features/Core/Portable/Copilot/IProposalAdjusterService.cs
@@ -43,11 +43,16 @@ internal readonly record struct AdjustmentResult(
 
 internal interface ICopilotProposalAdjusterService : ILanguageService
 {
+    /// <param name="applicableToSpan">
+    /// When non-null, indicates the span of the <c>CompletionState.ApplicableToSpan</c> on the original document. Edits
+    /// that intersect this span will be split so they do not overlap it, since the proposal system's
+    /// <c>ValidateEdits</c> requires that no edit intersect this span (except a zero-length edit at its end).
+    /// </param>
     /// <returns><c>default</c> if the proposal was not adjusted</returns>
     ValueTask<ProposalAdjustmentResult> TryAdjustProposalAsync(
         ImmutableHashSet<string> allowableAdjustments, Document document,
         ImmutableArray<TextChange> normalizedChanges, LineFormattingOptions? lineFormattingOptions,
-        CancellationToken cancellationToken);
+        TextSpan? applicableToSpan, CancellationToken cancellationToken);
 }
 
 internal interface IRemoteCopilotProposalAdjusterService
@@ -56,7 +61,8 @@ internal interface IRemoteCopilotProposalAdjusterService
     ValueTask<ProposalAdjustmentResult> TryAdjustProposalAsync(
         ImmutableHashSet<string> allowableAdjustments, Checksum solutionChecksum,
         DocumentId documentId, ImmutableArray<TextChange> normalizedChanges,
-        LineFormattingOptions? lineFormattingOptions, CancellationToken cancellationToken);
+        LineFormattingOptions? lineFormattingOptions, TextSpan? applicableToSpan,
+        CancellationToken cancellationToken);
 }
 
 internal abstract class AbstractCopilotProposalAdjusterService : ICopilotProposalAdjusterService
@@ -81,7 +87,7 @@ internal abstract class AbstractCopilotProposalAdjusterService : ICopilotProposa
     public async ValueTask<ProposalAdjustmentResult> TryAdjustProposalAsync(
         ImmutableHashSet<string> allowableAdjustments, Document document,
         ImmutableArray<TextChange> normalizedChanges, LineFormattingOptions? lineFormattingOptions,
-        CancellationToken cancellationToken)
+        TextSpan? applicableToSpan, CancellationToken cancellationToken)
     {
         if (normalizedChanges.IsDefaultOrEmpty)
             return default;
@@ -93,7 +99,7 @@ internal abstract class AbstractCopilotProposalAdjusterService : ICopilotProposa
                 document.Project,
                 (service, checksum, cancellationToken) => service.TryAdjustProposalAsync(
                     allowableAdjustments, checksum, document.Id, normalizedChanges,
-                    lineFormattingOptions, cancellationToken),
+                    lineFormattingOptions, applicableToSpan, cancellationToken),
                 cancellationToken).ConfigureAwait(false);
 
             return result.HasValue ? result.Value : default;
@@ -101,13 +107,13 @@ internal abstract class AbstractCopilotProposalAdjusterService : ICopilotProposa
 
         return await TryAdjustProposalInCurrentProcessAsync(
             allowableAdjustments, document, normalizedChanges, lineFormattingOptions,
-            cancellationToken).ConfigureAwait(false);
+            applicableToSpan, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<ProposalAdjustmentResult> TryAdjustProposalInCurrentProcessAsync(
         ImmutableHashSet<string> allowableAdjustments, Document originalDocument,
         ImmutableArray<TextChange> normalizedChanges, LineFormattingOptions? lineFormattingOptions,
-        CancellationToken cancellationToken)
+        TextSpan? applicableToSpan, CancellationToken cancellationToken)
     {
         Debug.Assert(allowableAdjustments is not null);
 
@@ -154,6 +160,16 @@ internal abstract class AbstractCopilotProposalAdjusterService : ICopilotProposa
         // Get the final set of changes between the original document and the new document.
         var allChanges = await forkedDocument.GetTextChangesAsync(originalDocument, cancellationToken).ConfigureAwait(false);
         var totalChanges = FixLineEndingBoundaries(oldText, allChanges.AsImmutableOrEmpty());
+
+        // When a CompletionState is present, the proposal system requires that no edit intersects the
+        // ApplicableToSpan (except a zero-length edit at its end). The diff algorithm can merge nearby
+        // changes into a single TextChange that spans across the ATS boundary. Split any such changes.
+        if (applicableToSpan is { } ats)
+        {
+            totalChanges = ConstrainChangesToAvoidSpan(oldText, totalChanges, ats);
+            if (totalChanges.IsDefault)
+                return new(normalizedChanges, Format: false, AdjustmentResults: default);
+        }
 
         return new(totalChanges, Format: true, adjustmentResults.ToImmutableAndClear());
     }
@@ -225,6 +241,143 @@ internal abstract class AbstractCopilotProposalAdjusterService : ICopilotProposa
         }
 
         return anyFixed ? result.ToImmutableAndClear() : changes;
+    }
+
+    /// <summary>
+    /// When a <c>CompletionState</c> is present with an <c>ApplicableToSpan</c> (ATS), the proposal system
+    /// requires that no edit intersect the ATS (except a zero-length edit at its end). If the diff algorithm
+    /// merged adjacent changes into a single <see cref="TextChange"/> that spans across the ATS boundary,
+    /// split it into before-ATS and after-ATS parts so the proposal system accepts the edits.
+    /// </summary>
+    /// <returns>
+    /// The constrained changes, or <c>default</c> if splitting was not possible (caller should fall back to
+    /// the original unadjusted changes).
+    /// </returns>
+    internal static ImmutableArray<TextChange> ConstrainChangesToAvoidSpan(
+        SourceText originalText, ImmutableArray<TextChange> changes, TextSpan protectedSpan)
+    {
+        if (changes.IsDefaultOrEmpty || protectedSpan.IsEmpty)
+            return changes;
+
+        using var _ = ArrayBuilder<TextChange>.GetInstance(out var result);
+        var anyConstrained = false;
+
+        foreach (var change in changes)
+        {
+            if (!IntersectsProtectedSpan(change.Span, protectedSpan))
+            {
+                result.Add(change);
+                continue;
+            }
+
+            anyConstrained = true;
+
+            // The only case we can handle safely is when the change fully contains the
+            // protected span, because we can find the protected text in newText and split.
+            if (change.Span.Start > protectedSpan.Start || change.Span.End < protectedSpan.End)
+            {
+                // Partial overlap or change is contained within the protected span.
+                // We can't safely split this. Bail out.
+                return default;
+            }
+
+            if (!TrySplitChangeAroundProtectedSpan(originalText, change, protectedSpan, result))
+                return default;
+        }
+
+        return anyConstrained ? result.ToImmutableAndClear() : changes;
+    }
+
+    /// <summary>
+    /// Determines whether <paramref name="editSpan"/> intersects <paramref name="protectedSpan"/>.
+    /// A zero-length edit at the end of the protected span is allowed (per <c>Proposal.ValidateEdits</c>)
+    /// and is NOT considered an intersection.
+    /// </summary>
+    private static bool IntersectsProtectedSpan(TextSpan editSpan, TextSpan protectedSpan)
+    {
+        // A zero-length edit at the end of the protected span is allowed.
+        if (editSpan.Length == 0 && editSpan.Start == protectedSpan.End)
+            return false;
+
+        // Two spans intersect if they share at least one position.
+        return editSpan.Start < protectedSpan.End && editSpan.End > protectedSpan.Start;
+    }
+
+    /// <summary>
+    /// Splits a <see cref="TextChange"/> that fully contains the protected span into parts that avoid it.
+    /// Finds the protected text within <paramref name="change"/>.<see cref="TextChange.NewText"/> and splits
+    /// around it, discarding the portion that corresponds to the protected span.
+    /// </summary>
+    private static bool TrySplitChangeAroundProtectedSpan(
+        SourceText originalText,
+        TextChange change,
+        TextSpan protectedSpan,
+        ArrayBuilder<TextChange> result)
+    {
+        Debug.Assert(change.Span.Start <= protectedSpan.Start && change.Span.End >= protectedSpan.End);
+
+        var newText = change.NewText ?? "";
+        var protectedText = originalText.ToString(protectedSpan);
+
+        if (protectedText.Length == 0)
+            return false;
+
+        // Find the protected text in newText. Adjusters (formatting, missing tokens, imports)
+        // don't modify identifiers, so the ATS text should be preserved in the replacement.
+        var protectedIndex = FindProtectedTextInNewText(originalText, change.Span, newText, protectedSpan, protectedText);
+        if (protectedIndex < 0)
+            return false;
+
+        // Verify the match is actually the protected text.
+        if (protectedIndex + protectedText.Length > newText.Length ||
+            string.Compare(newText, protectedIndex, protectedText, 0, protectedText.Length, StringComparison.Ordinal) != 0)
+        {
+            return false;
+        }
+
+        // Emit the portion before the protected span.
+        var beforeSpan = TextSpan.FromBounds(change.Span.Start, protectedSpan.Start);
+        var beforeText = newText[..protectedIndex];
+
+        if (beforeSpan.Length > 0 || beforeText.Length > 0)
+            result.Add(new TextChange(beforeSpan, beforeText));
+
+        // Emit the portion after the protected span.
+        var afterSpan = TextSpan.FromBounds(protectedSpan.End, change.Span.End);
+        var afterText = newText[(protectedIndex + protectedText.Length)..];
+
+        if (afterSpan.Length > 0 || afterText.Length > 0)
+            result.Add(new TextChange(afterSpan, afterText));
+
+        return true;
+    }
+
+    /// <summary>
+    /// Finds the position of the protected (ATS) text within a change's replacement text.
+    /// Uses surrounding context characters from the original text to disambiguate when the ATS
+    /// text is short and could appear in multiple places.
+    /// </summary>
+    private static int FindProtectedTextInNewText(
+        SourceText originalText,
+        TextSpan changeSpan,
+        string newText,
+        TextSpan protectedSpan,
+        string protectedText)
+    {
+        // Use the character immediately before the ATS in the original text for disambiguation.
+        // This character (e.g., '.' in "Console.wl") is a non-whitespace token boundary that
+        // formatting adjusters preserve.
+        if (protectedSpan.Start > changeSpan.Start)
+        {
+            var charBefore = originalText[protectedSpan.Start - 1];
+            var searchText = charBefore + protectedText;
+            var idx = newText.IndexOf(searchText, StringComparison.Ordinal);
+            if (idx >= 0)
+                return idx + 1;
+        }
+
+        // Fallback: plain search for the protected text.
+        return newText.IndexOf(protectedText, StringComparison.Ordinal);
     }
 
     private static async Task<Document> TryGetAddImportTextChangesAsync(
@@ -302,5 +455,9 @@ internal abstract class AbstractCopilotProposalAdjusterService : ICopilotProposa
         internal static ImmutableArray<TextChange> FixLineEndingBoundaries(
             SourceText originalText, ImmutableArray<TextChange> changes)
             => AbstractCopilotProposalAdjusterService.FixLineEndingBoundaries(originalText, changes);
+
+        internal static ImmutableArray<TextChange> ConstrainChangesToAvoidSpan(
+            SourceText originalText, ImmutableArray<TextChange> changes, TextSpan protectedSpan)
+            => AbstractCopilotProposalAdjusterService.ConstrainChangesToAvoidSpan(originalText, changes, protectedSpan);
     }
 }

--- a/src/Features/Core/Portable/Copilot/IProposalAdjusterService.cs
+++ b/src/Features/Core/Portable/Copilot/IProposalAdjusterService.cs
@@ -274,7 +274,7 @@ internal abstract class AbstractCopilotProposalAdjusterService : ICopilotProposa
             if (change.Span.Start > protectedSpan.Start || change.Span.End < protectedSpan.End)
             {
                 // Partial overlap or change is contained within the protected span.
-                // We can't safely split this. Bail out.
+                // We can't safely split this.
                 return default;
             }
 
@@ -287,12 +287,10 @@ internal abstract class AbstractCopilotProposalAdjusterService : ICopilotProposa
 
     /// <summary>
     /// Determines whether <paramref name="editSpan"/> intersects <paramref name="protectedSpan"/>.
-    /// A zero-length edit at the end of the protected span is allowed (per <c>Proposal.ValidateEdits</c>)
-    /// and is NOT considered an intersection.
+    /// A zero-length edit at the end of the protected span is allowed and is NOT considered an intersection.
     /// </summary>
     private static bool IntersectsProtectedSpan(TextSpan editSpan, TextSpan protectedSpan)
     {
-        // A zero-length edit at the end of the protected span is allowed.
         if (editSpan.Length == 0 && editSpan.Start == protectedSpan.End)
             return false;
 
@@ -350,7 +348,7 @@ internal abstract class AbstractCopilotProposalAdjusterService : ICopilotProposa
     }
 
     /// <summary>
-    /// Finds the position of the protected (ATS) text within a change's replacement text.
+    /// Finds the position of the ApplicableToSpan text within a change's replacement text.
     /// Uses surrounding context characters from the original text to disambiguate when the ATS
     /// text is short and could appear in multiple places.
     /// </summary>
@@ -362,7 +360,7 @@ internal abstract class AbstractCopilotProposalAdjusterService : ICopilotProposa
         string protectedText)
     {
         // Use the character immediately before the ATS in the original text for disambiguation.
-        // This character (e.g., '.' in "Console.wl") is a non-whitespace token boundary that
+        // This character ('.' in "Console.wl") is a non-whitespace token boundary that
         // formatting adjusters preserve.
         if (protectedSpan.Start > changeSpan.Start)
         {

--- a/src/Features/Core/Portable/Copilot/IProposalAdjusterService.cs
+++ b/src/Features/Core/Portable/Copilot/IProposalAdjusterService.cs
@@ -270,15 +270,6 @@ internal abstract class AbstractCopilotProposalAdjusterService : ICopilotProposa
 
             anyConstrained = true;
 
-            // The only case we can handle safely is when the change fully contains the
-            // protected span, because we can find the protected text in newText and split.
-            if (change.Span.Start > protectedSpan.Start || change.Span.End < protectedSpan.End)
-            {
-                // Partial overlap or change is contained within the protected span.
-                // We can't safely split this.
-                return default;
-            }
-
             if (!TrySplitChangeAroundProtectedSpan(originalText, change, protectedSpan, result))
                 return default;
         }
@@ -300,9 +291,10 @@ internal abstract class AbstractCopilotProposalAdjusterService : ICopilotProposa
     }
 
     /// <summary>
-    /// Splits a <see cref="TextChange"/> that fully contains the protected span into parts that avoid it.
-    /// Finds the protected text within <paramref name="change"/>.<see cref="TextChange.NewText"/> and splits
-    /// around it, discarding the portion that corresponds to the protected span.
+    /// Splits or trims a <see cref="TextChange"/> that intersects the protected span.
+    /// For the portion before the protected span, the protected text is located via
+    /// <see cref="FindProtectedTextInNewText"/>. For partial overlaps, the overlap text
+    /// is verified via StartsWith or EndsWith checks.
     /// </summary>
     private static bool TrySplitChangeAroundProtectedSpan(
         SourceText originalText,
@@ -310,82 +302,82 @@ internal abstract class AbstractCopilotProposalAdjusterService : ICopilotProposa
         TextSpan protectedSpan,
         ArrayBuilder<TextChange> result)
     {
-        Debug.Assert(change.Span.Start <= protectedSpan.Start && change.Span.End >= protectedSpan.End);
-
         var newText = change.NewText ?? "";
-        var protectedText = originalText.ToString(protectedSpan);
+        var overlapsStart = change.Span.Start <= protectedSpan.Start;
+        var overlapsEnd = change.Span.End >= protectedSpan.End;
 
-        if (protectedText.Length == 0)
-            return false;
+        // Full containment
+        if (overlapsStart && overlapsEnd)
+        {
+            var protectedText = originalText.ToString(protectedSpan);
+            if (protectedText.Length == 0)
+                return false;
 
-        // Find the protected text in newText. Adjusters (formatting, missing tokens, imports)
-        // don't modify identifiers, so the ATS text should be preserved in the replacement.
-        var protectedIndex = FindProtectedTextInNewText(change.Span, newText, protectedSpan, protectedText);
-        if (protectedIndex < 0)
-            return false;
+            var protectedIndex = FindProtectedTextInNewText(newText, protectedText);
+            if (protectedIndex < 0)
+                return false;
 
-        // Emit the portion before the protected span.
-        var beforeSpan = TextSpan.FromBounds(change.Span.Start, protectedSpan.Start);
-        var beforeText = newText[..protectedIndex];
+            var beforeSpan = TextSpan.FromBounds(change.Span.Start, protectedSpan.Start);
+            var beforeText = newText[..protectedIndex];
+            if (beforeSpan.Length > 0 || beforeText.Length > 0)
+                result.Add(new TextChange(beforeSpan, beforeText));
 
-        if (beforeSpan.Length > 0 || beforeText.Length > 0)
-            result.Add(new TextChange(beforeSpan, beforeText));
+            var afterSpan = TextSpan.FromBounds(protectedSpan.End, change.Span.End);
+            var afterText = newText[(protectedIndex + protectedText.Length)..];
+            if (afterSpan.Length > 0 || afterText.Length > 0)
+                result.Add(new TextChange(afterSpan, afterText));
+        }
+        else if (overlapsStart)
+        {
+            // Partial overlap on the start side — verify the overlap text is at the end of the replacement.
+            var overlapText = originalText.ToString(TextSpan.FromBounds(protectedSpan.Start, change.Span.End));
+            if (!newText.EndsWith(overlapText, StringComparison.Ordinal))
+                return false;
 
-        // Emit the portion after the protected span.
-        var afterSpan = TextSpan.FromBounds(protectedSpan.End, change.Span.End);
-        var afterText = newText[(protectedIndex + protectedText.Length)..];
+            result.Add(new TextChange(
+                TextSpan.FromBounds(change.Span.Start, protectedSpan.Start),
+                newText[..^overlapText.Length]));
+        }
+        else
+        {
+            // Partial overlap on the end side — verify the overlap text is at the start of the replacement.
+            var overlapText = originalText.ToString(TextSpan.FromBounds(change.Span.Start, protectedSpan.End));
+            if (!newText.StartsWith(overlapText, StringComparison.Ordinal))
+                return false;
 
-        if (afterSpan.Length > 0 || afterText.Length > 0)
-            result.Add(new TextChange(afterSpan, afterText));
+            result.Add(new TextChange(
+                TextSpan.FromBounds(protectedSpan.End, change.Span.End),
+                newText[overlapText.Length..]));
+        }
 
         return true;
     }
 
     /// <summary>
     /// Finds the position of the ApplicableToSpan text within a change's replacement text.
-    /// Computes the expected position arithmetically from the ATS offset within the original
-    /// change span, then searches outward from that position. This handles cases where the
-    /// ATS text appears multiple times in the replacement.
+    /// Searches forward and backward from the midpoint of the replacement text and returns
+    /// whichever match is closer to that midpoint.
     /// </summary>
     private static int FindProtectedTextInNewText(
-        TextSpan changeSpan,
         string newText,
-        TextSpan protectedSpan,
         string protectedText)
     {
-        // The ATS sits at a known offset within the original change span. Since adjusters
-        // primarily modify whitespace (indentation, line endings) rather than identifiers,
-        // the ATS text should appear near this same relative offset in the replacement text.
-        var originalOffset = protectedSpan.Start - changeSpan.Start;
+        var midpoint = newText.Length / 2;
 
-        // Search outward from the expected position, checking progressively further away.
-        // This ensures we find the closest match to the expected position rather than
-        // always picking the first occurrence (which could be wrong when the ATS text
-        // appears multiple times).
-        var maxDistance = Math.Max(originalOffset, newText.Length - originalOffset);
-        for (var distance = 0; distance <= maxDistance; distance++)
+        // Search forward from the midpoint.
+        var forwardIndex = newText.IndexOf(protectedText, midpoint, StringComparison.Ordinal);
+
+        // Search backward from the midpoint.
+        var backwardIndex = newText.LastIndexOf(protectedText, midpoint, StringComparison.Ordinal);
+
+        return (forwardIndex, backwardIndex) switch
         {
-            // Check at expectedOffset + distance
-            var idx = originalOffset + distance;
-            if (idx >= 0 && idx + protectedText.Length <= newText.Length &&
-                string.Compare(newText, idx, protectedText, 0, protectedText.Length, StringComparison.Ordinal) == 0)
-            {
-                return idx;
-            }
-
-            // Check at expectedOffset - distance (skip 0 to avoid double-checking)
-            if (distance > 0)
-            {
-                idx = originalOffset - distance;
-                if (idx >= 0 && idx + protectedText.Length <= newText.Length &&
-                    string.Compare(newText, idx, protectedText, 0, protectedText.Length, StringComparison.Ordinal) == 0)
-                {
-                    return idx;
-                }
-            }
-        }
-
-        return -1;
+            ( >= 0, < 0) => forwardIndex,
+            ( < 0, >= 0) => backwardIndex,
+            ( < 0, < 0) => -1,
+            // Both found — pick whichever is closer to the midpoint.
+            _ => (midpoint - backwardIndex <= forwardIndex - midpoint) ? backwardIndex : forwardIndex,
+        };
     }
 
     private static async Task<Document> TryGetAddImportTextChangesAsync(

--- a/src/Features/Core/Portable/Copilot/IProposalAdjusterService.cs
+++ b/src/Features/Core/Portable/Copilot/IProposalAdjusterService.cs
@@ -44,9 +44,9 @@ internal readonly record struct AdjustmentResult(
 internal interface ICopilotProposalAdjusterService : ILanguageService
 {
     /// <param name="applicableToSpan">
-    /// When non-null, indicates the span of the <c>CompletionState.ApplicableToSpan</c> on the original document. Edits
-    /// that intersect this span will be split so they do not overlap it, since the proposal system's
-    /// <c>ValidateEdits</c> requires that no edit intersect this span (except a zero-length edit at its end).
+    /// Indicates the span of the <c>CompletionState.ApplicableToSpan</c> on the original document.
+    /// Edits that intersect this span will be split so they do not overlap it, since the proposal system
+    /// requires that no edit intersect this span (except a zero-length edit at its end).
     /// </param>
     /// <returns><c>default</c> if the proposal was not adjusted</returns>
     ValueTask<ProposalAdjustmentResult> TryAdjustProposalAsync(
@@ -161,9 +161,7 @@ internal abstract class AbstractCopilotProposalAdjusterService : ICopilotProposa
         var allChanges = await forkedDocument.GetTextChangesAsync(originalDocument, cancellationToken).ConfigureAwait(false);
         var totalChanges = FixLineEndingBoundaries(oldText, allChanges.AsImmutableOrEmpty());
 
-        // When a CompletionState is present, the proposal system requires that no edit intersects the
-        // ApplicableToSpan (except a zero-length edit at its end). The diff algorithm can merge nearby
-        // changes into a single TextChange that spans across the ATS boundary. Split any such changes.
+        // Merge nearby changes into a single TextChange that spans across the ATS boundary. Split any such changes.
         if (applicableToSpan is { } ats)
         {
             totalChanges = ConstrainChangesToAvoidSpan(oldText, totalChanges, ats);
@@ -244,9 +242,8 @@ internal abstract class AbstractCopilotProposalAdjusterService : ICopilotProposa
     }
 
     /// <summary>
-    /// When a <c>CompletionState</c> is present with an <c>ApplicableToSpan</c> (ATS), the proposal system
-    /// requires that no edit intersect the ATS (except a zero-length edit at its end). If the diff algorithm
-    /// merged adjacent changes into a single <see cref="TextChange"/> that spans across the ATS boundary,
+    /// The proposal system requires that no edit intersect the ApplicableToSpan (except a zero-length edit at its end).
+    /// If the diff algorithm merged adjacent changes into a single <see cref="TextChange"/> that spans across the ATS boundary,
     /// split it into before-ATS and after-ATS parts so the proposal system accepts the edits.
     /// </summary>
     /// <returns>

--- a/src/Features/Core/Portable/Copilot/IProposalAdjusterService.cs
+++ b/src/Features/Core/Portable/Copilot/IProposalAdjusterService.cs
@@ -362,7 +362,11 @@ internal abstract class AbstractCopilotProposalAdjusterService : ICopilotProposa
         var midpoint = newText.Length / 2;
 
         var forwardIndex = newText.IndexOf(protectedText, midpoint, StringComparison.Ordinal);
-        var backwardIndex = newText.LastIndexOf(protectedText, midpoint, StringComparison.Ordinal);
+
+        var backwardStart = Math.Min(midpoint + protectedText.Length - 1, newText.Length - 1);
+        var backwardIndex = backwardStart >= 0
+            ? newText.LastIndexOf(protectedText, backwardStart, StringComparison.Ordinal)
+            : -1;
 
         return (forwardIndex, backwardIndex) switch
         {

--- a/src/Features/Core/Portable/Copilot/IProposalAdjusterService.cs
+++ b/src/Features/Core/Portable/Copilot/IProposalAdjusterService.cs
@@ -161,7 +161,8 @@ internal abstract class AbstractCopilotProposalAdjusterService : ICopilotProposa
         var allChanges = await forkedDocument.GetTextChangesAsync(originalDocument, cancellationToken).ConfigureAwait(false);
         var totalChanges = FixLineEndingBoundaries(oldText, allChanges.AsImmutableOrEmpty());
 
-        // Merge nearby changes into a single TextChange that spans across the ATS boundary. Split any such changes.
+        // The diff algorithm may have merged nearby changes into a single TextChange that spans
+        // across the ATS boundary. Split any such changes to avoid the protected span.
         if (applicableToSpan is { } ats)
         {
             totalChanges = ConstrainChangesToAvoidSpan(oldText, totalChanges, ats);

--- a/src/Workspaces/Remote/ServiceHub/Services/Copilot/RemoteCopilotProposalAdjusterService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/Copilot/RemoteCopilotProposalAdjusterService.cs
@@ -25,7 +25,8 @@ internal sealed partial class RemoteCopilotProposalAdjusterService(
     public ValueTask<ProposalAdjustmentResult> TryAdjustProposalAsync(
         ImmutableHashSet<string> allowableAdjustments,
         Checksum solutionChecksum, DocumentId documentId, ImmutableArray<TextChange> textChanges,
-        LineFormattingOptions? lineFormattingOptions, CancellationToken cancellationToken)
+        LineFormattingOptions? lineFormattingOptions, TextSpan? applicableToSpan,
+        CancellationToken cancellationToken)
     {
         return RunServiceAsync(solutionChecksum, async solution =>
         {
@@ -33,7 +34,7 @@ internal sealed partial class RemoteCopilotProposalAdjusterService(
                 documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
 
             var service = document.GetRequiredLanguageService<ICopilotProposalAdjusterService>();
-            return await service.TryAdjustProposalAsync(allowableAdjustments, document, textChanges, lineFormattingOptions, cancellationToken).ConfigureAwait(false);
+            return await service.TryAdjustProposalAsync(allowableAdjustments, document, textChanges, lineFormattingOptions, applicableToSpan, cancellationToken).ConfigureAwait(false);
         }, cancellationToken);
     }
 }


### PR DESCRIPTION
### Problem
When `CompletionState` is present, the proposal system rejects any edit that intersects `ApplicableToSpan` (except a zero-length edit at its end). Our adjusters (formatting, imports, missing tokens) diff the adjusted document against the original, and the diff algorithm can merge nearby changes into a single TextChange that spans across the `ApplicableToSpan` boundary, which discards all adjustments.

### Proposed Fix
 - Threads `applicableToSpan` from `proposal.CompletionState` through the adjuster service
 - Adds `ConstrainChangesToAvoidSpan` to split any TextChange that intersects the `ApplicableToSpan` into before/after parts, leaving the region untouched for the completion system
 - Falls back to unadjusted edits if splitting isn't possible (partial overlap)
 - Sorts `finalEdits` by position before calling `TryCreateProposal`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83160)