### PR TITLE
Support MatchPriority comparison in LSP completion

### DIFF
--- a/src/LanguageServer/Protocol.TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/LanguageServer/Protocol.TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -256,7 +256,8 @@ public abstract partial class AbstractLanguageServerProtocolTests
         string? filterText = null,
         long resultId = 0,
         bool vsResolveTextEditOnCommit = false,
-        LSP.CompletionItemLabelDetails? labelDetails = null)
+        LSP.CompletionItemLabelDetails? labelDetails = null,
+        int matchPriority = 0)
     {
         var position = await document.GetPositionFromLinePositionAsync(
             ProtocolConversions.PositionToLinePosition(request.Position), CancellationToken.None).ConfigureAwait(false);
@@ -275,7 +276,8 @@ public abstract partial class AbstractLanguageServerProtocolTests
             Data = JsonSerializer.SerializeToElement(new CompletionResolveData(resultId, ProtocolConversions.DocumentToTextDocumentIdentifier(document)), JsonSerializerOptions),
             Preselect = preselect,
             VsResolveTextEditOnCommit = vsResolveTextEditOnCommit,
-            LabelDetails = labelDetails
+            LabelDetails = labelDetails,
+            MatchPriority = matchPriority
         };
 
         if (tags != null)

--- a/src/LanguageServer/Protocol/Handler/Completion/CompletionResultFactory.cs
+++ b/src/LanguageServer/Protocol/Handler/Completion/CompletionResultFactory.cs
@@ -158,12 +158,6 @@ internal static class CompletionResultFactory
             {
                 lspItem.CommitCharacters = GetCommitCharacters(item, commitCharactersRuleCache);
 
-                // Flow the numeric match priority to VS so it can be used as a tiebreaker
-                // during best-match selection. The Preselect flag above only captures the
-                // extreme case (MatchPriority.Preselect); this preserves finer distinctions
-                // allowing MatchPriority comparison.
-                ((LSP.VSInternalCompletionItem)lspItem).MatchPriority = item.Rules.MatchPriority;
-
                 return lspItem;
             }
 
@@ -393,6 +387,7 @@ internal static class CompletionResultFactory
         {
             Label = item.GetEntireDisplayText(),
             Icon = new ImageElement(item.Tags.GetFirstGlyph().ToLSPImageId()),
+            MatchPriority = item.Rules.MatchPriority,
         };
 
         // Complex text edits (e.g. override and partial method completions) are always populated in the

--- a/src/LanguageServer/Protocol/Handler/Completion/CompletionResultFactory.cs
+++ b/src/LanguageServer/Protocol/Handler/Completion/CompletionResultFactory.cs
@@ -157,6 +157,13 @@ internal static class CompletionResultFactory
             if (lspVSClientCapability)
             {
                 lspItem.CommitCharacters = GetCommitCharacters(item, commitCharactersRuleCache);
+
+                // Flow the numeric match priority to VS so it can be used as a tiebreaker
+                // during best-match selection. The Preselect flag above only captures the
+                // extreme case (MatchPriority.Preselect); this preserves finer distinctions
+                // allowing MatchPriority comparison.
+                ((LSP.VSInternalCompletionItem)lspItem).MatchPriority = item.Rules.MatchPriority;
+
                 return lspItem;
             }
 

--- a/src/LanguageServer/Protocol/Protocol/Internal/Efficiency/OptimizedVSCompletionListJsonConverter.cs
+++ b/src/LanguageServer/Protocol/Protocol/Internal/Efficiency/OptimizedVSCompletionListJsonConverter.cs
@@ -145,6 +145,11 @@ internal sealed class OptimizedVSCompletionListJsonConverter : JsonConverter<Opt
             {
                 writer.WriteBoolean(VSInternalCompletionItem.VsResolveTextEditOnCommitName, vsCompletionItem.VsResolveTextEditOnCommit);
             }
+
+            if (vsCompletionItem.MatchPriority != 0)
+            {
+                writer.WriteNumber(VSInternalCompletionItem.MatchPrioritySerializedName, vsCompletionItem.MatchPriority);
+            }
         }
 
         var label = completionItem.Label;

--- a/src/LanguageServer/Protocol/Protocol/Internal/VSInternalCompletionItem.cs
+++ b/src/LanguageServer/Protocol/Protocol/Internal/VSInternalCompletionItem.cs
@@ -16,6 +16,7 @@ internal sealed class VSInternalCompletionItem : CompletionItem
     internal const string DescriptionSerializedName = "_vs_description";
     internal const string VsCommitCharactersSerializedName = "_vs_commitCharacters";
     internal const string VsResolveTextEditOnCommitName = "_vs_resolveTextEditOnCommit";
+    internal const string MatchPrioritySerializedName = "_vs_matchPriority";
 
     /// <summary>
     /// Gets or sets the icon to show for the completion item. In VS, this is more extensive than the completion kind.
@@ -50,4 +51,13 @@ internal sealed class VSInternalCompletionItem : CompletionItem
     [JsonPropertyName(VsResolveTextEditOnCommitName)]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public bool VsResolveTextEditOnCommit { get; set; }
+
+    /// <summary>
+    /// Gets or sets the match priority for this completion item. Used by the client as a tiebreaker
+    /// during best-match selection when multiple items have equal pattern match quality.
+    /// Higher values are preferred. A value of 0 indicates default priority.
+    /// </summary>
+    [JsonPropertyName(MatchPrioritySerializedName)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public int MatchPriority { get; set; }
 }

--- a/src/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -1598,6 +1598,76 @@ public sealed class CompletionTests : AbstractLanguageServerProtocolTests
         Assert.Null(results.ItemDefaults.InsertTextMode);
     }
 
+    [Theory, CombinatorialData]
+    public async Task TestGetCompletions_MatchPriority_SetForVSClient(bool mutatingLspWorkspace)
+    {
+        var markup =
+            """
+            class C
+            {
+                void M()
+                {
+                    var x = nu{|caret:|}
+                }
+            }
+            """;
+
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, s_vsCompletionCapabilities);
+        var completionParams = CreateCompletionParams(
+            testLspServer.GetLocations("caret").Single(),
+            invokeKind: LSP.VSInternalCompletionInvokeKind.Typing,
+            triggerCharacter: "u",
+            triggerKind: LSP.CompletionTriggerKind.TriggerForIncompleteCompletions);
+
+        var results = await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
+        AssertEx.NotNull(results);
+
+        var nullItem = results.Items.SingleOrDefault(i => i.Label == "null");
+        var nuintItem = results.Items.SingleOrDefault(i => i.Label == "nuint");
+        Assert.NotNull(nullItem);
+        Assert.NotNull(nuintItem);
+
+        var vsNullItem = (LSP.VSInternalCompletionItem)nullItem;
+        var vsNuintItem = (LSP.VSInternalCompletionItem)nuintItem;
+
+        // null has default MatchPriority (0), nuint has MatchPriority.Default - 1 (-1)
+        Assert.True(vsNullItem.MatchPriority > vsNuintItem.MatchPriority,
+            $"Expected null's MatchPriority ({vsNullItem.MatchPriority}) to be greater than nuint's ({vsNuintItem.MatchPriority})");
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestGetCompletions_MatchPriority_DefaultIsZero(bool mutatingLspWorkspace)
+    {
+        // Verify that items with default MatchPriority have value 0.
+        var markup =
+            """
+            class C
+            {
+                void M()
+                {
+                    int{|caret:|}
+                }
+            }
+            """;
+
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, s_vsCompletionCapabilities);
+        var completionParams = CreateCompletionParams(
+            testLspServer.GetLocations("caret").Single(),
+            invokeKind: LSP.VSInternalCompletionInvokeKind.Typing,
+            triggerCharacter: "t",
+            triggerKind: LSP.CompletionTriggerKind.TriggerForIncompleteCompletions);
+
+        var results = await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
+        AssertEx.NotNull(results);
+
+        // Find a standard keyword like "int" — it should have default (0) MatchPriority
+        var intItem = results.Items.SingleOrDefault(i => i.Label == "int");
+        Assert.NotNull(intItem);
+
+        var vsIntItem = (LSP.VSInternalCompletionItem)intItem;
+        Assert.Equal(0, vsIntItem.MatchPriority);
+    }
+
     internal static Task<LSP.CompletionList> RunGetCompletionsAsync(TestLspServer testLspServer, LSP.CompletionParams completionParams)
     {
         return testLspServer.ExecuteRequestAsync<LSP.CompletionParams, LSP.CompletionList>(LSP.Methods.TextDocumentCompletionName,

--- a/src/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -370,7 +370,8 @@ public sealed class CompletionTests : AbstractLanguageServerProtocolTests
         var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
 
         var expected = await CreateCompletionItemAsync("A", LSP.CompletionItemKind.Class, ["Class", "Internal"],
-            completionParams, document, preselect: true, commitCharacters: ImmutableArray.Create(' ', '(', '[', '{', ';', '.'), sortText: "0000").ConfigureAwait(false);
+            completionParams, document, preselect: true, commitCharacters: ImmutableArray.Create(' ', '(', '[', '{', ';', '.'), sortText: "0000",
+            matchPriority: MatchPriority.Preselect).ConfigureAwait(false);
 
         var results = await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
         AssertJsonEquals(expected, results.Items.First());


### PR DESCRIPTION
When using C# LSP-based completion, typing "nu" incorrectly selects nuint instead of null. In Roslyn's native (non-LSP) completion, null is correctly selected.

| ***Old Behavior*** | ***New Behavior*** |
|----------|----------|
| <img width="496" height="463" alt="image" src="https://github.com/user-attachments/assets/7dd77e99-6320-4d2e-9887-337a38e2092c" />    | <img width="500" height="490" alt="image" src="https://github.com/user-attachments/assets/6833e0ef-8625-4e0d-9198-9cdbfc141ca3" />     |

***Approach***

This PR adds a _vs_matchPriority VS-internal extension property to VSInternalCompletionItem so the full numeric MatchPriority value is available to the VS client for tiebreaking during best-match selection.

There are two companion PRs for to support this change:

1: [VSLanguageServerClient PR](https://devdiv.visualstudio.com/DevDiv/_git/VSLanguageServerClient/pullrequest/728799)
2: [VSEditor PR](https://devdiv.visualstudio.com/DevDiv/_git/VSEditor/pullrequest/728800)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83164)