### PR TITLE
Fix WIF dnceng token: use explicit az CLI token instead of DefaultAzureCredential

### DIFF
--- a/eng/pipelines/insert.yml
+++ b/eng/pipelines/insert.yml
@@ -167,7 +167,10 @@ steps:
 
   # Now that everything is set, actually perform the insertion.
   # Uses AzureCLI@2 so that roslyn-tools can acquire a dnceng AzDO token
-  # via DefaultAzureCredential (AzureCliCredential) instead of a PAT.
+  # via az account get-access-token (the WIF SP is logged in by AzureCLI@2).
+  # NOTE: Do NOT use DefaultAzureCredential here — on 1ES hosted agents,
+  # ManagedIdentityCredential fires before AzureCliCredential and picks up
+  # the agent's MI instead of the WIF SP, causing VS30063 for dnceng.
   - task: AzureCLI@2
     displayName: 'Create VS Insertion PR'
     inputs:
@@ -175,6 +178,14 @@ steps:
       scriptType: ps
       scriptLocation: inlineScript
       inlineScript: |
+        # Acquire AzDO token explicitly from the WIF SP login context.
+        # DefaultAzureCredential is unreliable on hosted agents (picks up agent MI).
+        $dncEngAzdoToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($dncEngAzdoToken)) {
+          Write-Error 'Failed to acquire dnceng AzDO access token via WIF service connection.'
+          exit 1
+        }
+
         $arguments = @(
           "create-insertion"
           "--insertion-name", "Roslyn"
@@ -190,7 +201,7 @@ steps:
           "--retain-inserted-build", "${{ parameters.retainInsertedBuild }}"
           "--reviewer-guid", "6c25b447-1d90-4840-8fde-d8b22cb8733e"
           "--devdiv-azdo-token", $Env:DevDivToken
-          "--dnceng-azdo-token", "unset"
+          "--dnceng-azdo-token", $dncEngAzdoToken
           "--ci"
         )
 


### PR DESCRIPTION
## Problem

Build [2948422](https://dev.azure.com/dnceng/internal/_build/results?buildId=2948422) (and all builds since PR #83058 merged) fail in the **Insert to VS** stage:

```
Verifying given authentication for https://dev.azure.com/dnceng/
Could not authenticate with https://dev.azure.com/dnceng/
VS30063: You are not authorized to access https://dev.azure.com.
```

## Root Cause

`insert.yml` passes `--dnceng-azdo-token "unset"` to `roslyn-tools`, which causes it to fall back to `DefaultAzureCredential`. On 1ES hosted agents, `DefaultAzureCredential` tries `ManagedIdentityCredential` **before** `AzureCliCredential` in its credential chain. The agent's managed identity gets picked up instead of the WIF SP that `AzureCLI@2` logged in via `az login --federated-token`. That agent MI is not enrolled in the dnceng org, so VS30063.

## Fix

Explicitly acquire the AzDO token via `az account get-access-token --resource 499b84ac-...` inside the `AzureCLI@2` script block (where the correct WIF SP is logged in), then pass the token to `roslyn-tools` via `--dnceng-azdo-token`.

This matches the working pattern already used in `insertion-pr-tagger.yml` in the same repo.

## Important

**PR validation will likely show green even before merge** because the 1ES pipeline reads YAML from `main`, not the PR branch. The real test is the first **post-merge** CI build — monitor its Insert to VS stage to confirm dnceng auth succeeds.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83168)