### PR TITLE
Enable TestHost.OutOfProcess on Linux

### DIFF
--- a/src/Features/Test/EditAndContinue/RemoteEditAndContinueServiceTests.cs
+++ b/src/Features/Test/EditAndContinue/RemoteEditAndContinueServiceTests.cs
@@ -40,10 +40,6 @@ public sealed class RemoteEditAndContinueServiceTests
     [Theory, CombinatorialData]
     public async Task Proxy(TestHost testHost)
     {
-        // https://github.com/dotnet/roslyn/issues/83054
-        if (!ExecutionConditionUtil.IsWindows && testHost == TestHost.OutOfProcess)
-            testHost = TestHost.InProcess;
-
         var localComposition = FeaturesTestCompositions.Features.WithTestHostParts(testHost)
             .AddParts(typeof(NoCompilationLanguageService));
 

--- a/src/Workspaces/Core/Portable/Serialization/SerializableSourceText.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializableSourceText.cs
@@ -14,9 +14,6 @@ using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 using static Microsoft.CodeAnalysis.Host.TemporaryStorageService;
 
-#if DEBUG
-#endif
-
 namespace Microsoft.CodeAnalysis.Serialization;
 
 #pragma warning disable CA1416 // Validate platform compatibility
@@ -165,7 +162,7 @@ internal sealed class SerializableSourceText
 
     public static SerializableSourceText Deserialize(
         ObjectReader reader,
-        TemporaryStorageService storageService,
+        ITemporaryStorageServiceInternal storageService,
         ITextFactoryService textService,
         CancellationToken cancellationToken)
     {
@@ -176,11 +173,13 @@ internal sealed class SerializableSourceText
 
         if (kind == SerializationKinds.MemoryMapFile)
         {
+            // Can only get here with the TemporaryStorageService is the implementation of ITemporaryStorageServiceInternal
+            var temporaryStorageService = (TemporaryStorageService)storageService;
             var identifier = TemporaryStorageIdentifier.ReadFrom(reader);
             var checksumAlgorithm = (SourceHashAlgorithm)reader.ReadInt32();
             var encoding = reader.ReadEncoding();
             var contentHash = ImmutableCollectionsMarshal.AsImmutableArray(reader.ReadByteArray());
-            var storageHandle = storageService.GetTextHandle(identifier, checksumAlgorithm, encoding, contentHash);
+            var storageHandle = temporaryStorageService.GetTextHandle(identifier, checksumAlgorithm, encoding, contentHash);
 
             return new SerializableSourceText(storageHandle);
         }

--- a/src/Workspaces/Core/Portable/Serialization/SerializedPortableExecutableReference.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializedPortableExecutableReference.cs
@@ -19,7 +19,7 @@ internal partial class SerializerService
     private sealed class SerializedPortableExecutableReference : PortableExecutableReference, ISupportTemporaryStorage
     {
         private readonly Metadata _metadata;
-        private readonly ImmutableArray<TemporaryStorageStreamHandle> _storageHandles;
+        private readonly ImmutableArray<ITemporaryStorageStreamHandle> _storageHandles;
         private readonly DocumentationProvider _provider;
 
         public IReadOnlyList<ITemporaryStorageStreamHandle> StorageHandles => _storageHandles;
@@ -28,7 +28,7 @@ internal partial class SerializerService
             MetadataReferenceProperties properties,
             string? fullPath,
             Metadata metadata,
-            ImmutableArray<TemporaryStorageStreamHandle> storageHandles,
+            ImmutableArray<ITemporaryStorageStreamHandle> storageHandles,
             DocumentationProvider initialDocumentation)
             : base(properties, fullPath, initialDocumentation)
         {

--- a/src/Workspaces/Core/Portable/Serialization/SerializerService.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService.cs
@@ -40,7 +40,7 @@ internal partial class SerializerService(SolutionServices workspaceServices) : I
     // compute project state checksums). So lazily instantiate the storage service to avoid attempting to get the
     // TemporaryStorageService when not available.
 
-    private readonly Lazy<TemporaryStorageService> _storageService = new(() => (TemporaryStorageService)workspaceServices.GetRequiredService<ITemporaryStorageServiceInternal>());
+    private readonly Lazy<ITemporaryStorageServiceInternal> _storageService = new(() => workspaceServices.GetRequiredService<ITemporaryStorageServiceInternal>());
     private readonly ITextFactoryService _textService = workspaceServices.GetRequiredService<ITextFactoryService>();
     private readonly IDocumentationProviderService? _documentationService = workspaceServices.GetService<IDocumentationProviderService>();
     private readonly IAnalyzerAssemblyLoaderProvider _analyzerLoaderProvider = workspaceServices.GetRequiredService<IAnalyzerAssemblyLoaderProvider>();

--- a/src/Workspaces/Core/Portable/Serialization/SerializerService_Reference.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService_Reference.cs
@@ -5,9 +5,12 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection.Metadata;
+using System.Runtime.InteropServices;
+using System.Threading;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -381,7 +384,7 @@ internal partial class SerializerService
         return true;
     }
 
-    private (Metadata metadata, ImmutableArray<TemporaryStorageStreamHandle> storageHandles)? TryReadMetadataFrom(
+    private (Metadata metadata, ImmutableArray<ITemporaryStorageStreamHandle> storageHandles)? TryReadMetadataFrom(
         ObjectReader reader, SerializationKinds kind)
     {
         var imageKind = reader.ReadInt32();
@@ -397,7 +400,7 @@ internal partial class SerializerService
             var count = reader.ReadInt32();
 
             var allMetadata = new FixedSizeArrayBuilder<ModuleMetadata>(count);
-            var allHandles = new FixedSizeArrayBuilder<TemporaryStorageStreamHandle>(count);
+            var allHandles = new FixedSizeArrayBuilder<ITemporaryStorageStreamHandle>(count);
 
             for (var i = 0; i < count; i++)
             {
@@ -421,7 +424,7 @@ internal partial class SerializerService
         }
     }
 
-    private (ModuleMetadata metadata, TemporaryStorageStreamHandle storageHandle) ReadModuleMetadataFrom(
+    private (ModuleMetadata metadata, ITemporaryStorageStreamHandle storageHandle) ReadModuleMetadataFrom(
         ObjectReader reader, SerializationKinds kind)
     {
         Contract.ThrowIfFalse(kind is SerializationKinds.Bits or SerializationKinds.MemoryMapFile);
@@ -430,7 +433,7 @@ internal partial class SerializerService
             ? ReadModuleMetadataFromBits()
             : ReadModuleMetadataFromMemoryMappedFile();
 
-        (ModuleMetadata metadata, TemporaryStorageStreamHandle storageHandle) ReadModuleMetadataFromMemoryMappedFile()
+        (ModuleMetadata metadata, ITemporaryStorageStreamHandle storageHandle) ReadModuleMetadataFromMemoryMappedFile()
         {
             // Host passed us a segment of its own memory mapped file.  We can just refer to that segment directly as it
             // will not be released by the host.
@@ -439,7 +442,7 @@ internal partial class SerializerService
             return ReadModuleMetadataFromStorage(storageHandle);
         }
 
-        (ModuleMetadata metadata, TemporaryStorageStreamHandle storageHandle) ReadModuleMetadataFromBits()
+        (ModuleMetadata metadata, ITemporaryStorageStreamHandle storageHandle) ReadModuleMetadataFromBits()
         {
             // Host is sending us all the data as bytes.  Take that and write that out to a memory mapped file on the
             // server side so that we can refer to this data uniformly.
@@ -447,32 +450,78 @@ internal partial class SerializerService
             CopyByteArrayToStream(reader, stream);
 
             var length = stream.Length;
-            var storageHandle = _storageService.Value.WriteToTemporaryStorage(stream);
+            var storageHandle = _storageService.Value.WriteToTemporaryStorage(stream, CancellationToken.None);
             Contract.ThrowIfTrue(length != storageHandle.Identifier.Size);
             return ReadModuleMetadataFromStorage(storageHandle);
         }
 
-        (ModuleMetadata metadata, TemporaryStorageStreamHandle storageHandle) ReadModuleMetadataFromStorage(
-            TemporaryStorageStreamHandle storageHandle)
+        (ModuleMetadata metadata, ITemporaryStorageStreamHandle storageHandle) ReadModuleMetadataFromStorage(
+            ITemporaryStorageStreamHandle storageHandle)
         {
             // Now read in the module data using that identifier.  This will either be reading from the host's memory if
             // they passed us the information about that memory segment.  Or it will be reading from our own memory if they
             // sent us the full contents.
             //
-            // The ITemporaryStorageStreamHandle should have given us an UnmanagedMemoryStream
-            // since this only runs on Windows for VS.
-            var unmanagedStream = (UnmanagedMemoryStream)storageHandle.ReadFromTemporaryStorage();
-            Contract.ThrowIfFalse(storageHandle.Identifier.Size == unmanagedStream.Length);
-
-            // For an unmanaged memory stream, ModuleMetadata can take ownership directly.  Stream will be kept alive as
-            // long as the ModuleMetadata is alive due to passing its .Dispose method in as the onDispose callback of
-            // the metadata.
-            unsafe
+            var stream = storageHandle.ReadFromTemporaryStorage();
+            if (stream is UnmanagedMemoryStream unmanagedStream)
             {
-                var metadata = ModuleMetadata.CreateFromMetadata(
-                    (IntPtr)unmanagedStream.PositionPointer, (int)unmanagedStream.Length, unmanagedStream.Dispose);
-                return (metadata, storageHandle);
+                Contract.ThrowIfFalse(storageHandle.Identifier.Size == unmanagedStream.Length);
+
+                // For an unmanaged memory stream, ModuleMetadata can take ownership directly.  Stream will be kept alive as
+                // long as the ModuleMetadata is alive due to passing its .Dispose method in as the onDispose callback of
+                // the metadata.
+                unsafe
+                {
+                    var metadata = ModuleMetadata.CreateFromMetadata(
+                        (IntPtr)unmanagedStream.PositionPointer, (int)unmanagedStream.Length, unmanagedStream.Dispose);
+                    return (metadata, storageHandle);
+                }
             }
+
+            if (stream is MemoryStream memoryStream)
+            {
+                Contract.ThrowIfFalse(storageHandle.Identifier.Size == memoryStream.Length);
+
+                // The serialized bytes are raw CLI metadata (from MetadataReader.MetadataPointer), not a PE file.
+                // We must use CreateFromMetadata (pointer-based) rather than CreateFromImage (PE-based).  Allocate
+                // unmanaged memory and copy the data there to avoid pinning managed arrays (which causes GC
+                // fragmentation).
+                var length = (int)memoryStream.Length;
+                var unmanagedMemory = Marshal.AllocHGlobal(length);
+
+                unsafe
+                {
+                    var unmanagedSpan = new Span<byte>((void*)unmanagedMemory, length);
+                    CopyMemoryStreamToSpan(memoryStream, unmanagedSpan);
+                    memoryStream.Dispose();
+
+                    var metadata = ModuleMetadata.CreateFromMetadata(
+                        unmanagedMemory,
+                        length,
+                        () => Marshal.FreeHGlobal(unmanagedMemory));
+                    return (metadata, storageHandle);
+                }
+            }
+
+            throw ExceptionUtilities.UnexpectedValue(stream.GetType());
+        }
+
+        unsafe void CopyMemoryStreamToSpan(MemoryStream stream, Span<byte> span)
+        {
+            Debug.Assert(stream.Length == span.Length);
+
+#if NET
+            stream.ReadExactly(span);
+#else
+            if (stream.TryGetBuffer(out var segment))
+            {
+                segment.AsSpan(0, (int)stream.Length).CopyTo(span);
+            }
+            else
+            {
+                stream.ToArray().AsSpan().CopyTo(span);
+            }
+#endif
         }
     }
 

--- a/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageService.cs
+++ b/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageService.cs
@@ -174,6 +174,7 @@ internal sealed partial class TemporaryStorageService : ITemporaryStorageService
 
     internal static TemporaryStorageStreamHandle GetStreamHandle(TemporaryStorageIdentifier storageIdentifier)
     {
+        Contract.ThrowIfFalse(PlatformInformation.IsWindows, $"{nameof(GetStreamHandle)} should only be called for VS on Windows (where named memory mapped files as supported)");
         Contract.ThrowIfNull(storageIdentifier.Name, $"{nameof(GetStreamHandle)} should only be called for VS on Windows (where named memory mapped files as supported)");
         var memoryMappedFile = MemoryMappedFile.OpenExisting(storageIdentifier.Name);
         return new(memoryMappedFile, storageIdentifier);


### PR DESCRIPTION
The `SerializerService` had a strong dependency on memory mapped files due to the direct use of `TemporaryStorageService`. This blocked it from being fully usable on Linux which doesn't have an equivalent implementation. To fix this I moved the uses of `TemporaryStorageService` to only places where we are definitively using memory mapped files (hence known to be on Windows). In other places I moved to the `ITemporaryStorageServiceInternal` / `ITemporaryStorageStreamHandle` so it would work on both abstractions.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83170)