### PR TITLE
Fix restore of misc project for virtual files and older SDKs

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/CanonicalMiscellaneousFilesProjectProvider.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/CanonicalMiscellaneousFilesProjectProvider.cs
@@ -64,6 +64,8 @@ internal sealed class CanonicalMiscellaneousFilesProjectProvider : IDisposable
 
         Directory.CreateDirectory(_tempDirectory);
         var virtualProjectPath = Path.Combine(_tempDirectory, "Canonical.csproj");
+
+        // Write the csproj to disk so we can run restore on it later (required for SDKs prior to .NET 10)
         File.WriteAllText(virtualProjectPath, virtualProjectXml);
 
         await using var buildHostProcessManager = new BuildHostProcessManager(

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/CanonicalMiscellaneousFilesProjectProvider.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/CanonicalMiscellaneousFilesProjectProvider.cs
@@ -37,7 +37,6 @@ internal sealed class CanonicalMiscellaneousFilesProjectProvider : IDisposable
 
         var forkedInfos = canonicalInfos.SelectAsArray(info => info with
         {
-            FilePath = info.FilePath,
             Documents = info.Documents.Add(miscDocFileInfo),
             FileGlobs = [],
         });

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/CanonicalMiscellaneousFilesProjectProvider.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/CanonicalMiscellaneousFilesProjectProvider.cs
@@ -37,7 +37,7 @@ internal sealed class CanonicalMiscellaneousFilesProjectProvider : IDisposable
 
         var forkedInfos = canonicalInfos.SelectAsArray(info => info with
         {
-            FilePath = miscDocumentPath,
+            FilePath = info.FilePath,
             Documents = info.Documents.Add(miscDocFileInfo),
             FileGlobs = [],
         });
@@ -65,6 +65,7 @@ internal sealed class CanonicalMiscellaneousFilesProjectProvider : IDisposable
 
         Directory.CreateDirectory(_tempDirectory);
         var virtualProjectPath = Path.Combine(_tempDirectory, "Canonical.csproj");
+        File.WriteAllText(virtualProjectPath, virtualProjectXml);
 
         await using var buildHostProcessManager = new BuildHostProcessManager(
             _workspaceFactory.HostWorkspace.Services.SolutionServices.GetSupportedLanguages<ICommandLineParserService>(),

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/FileBasedProgramsProjectSystem.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/FileBasedProgramsProjectSystem.cs
@@ -295,6 +295,7 @@ internal sealed class FileBasedProgramsProjectSystem : LanguageServerProjectLoad
             {
                 ProjectFileInfos = projectInfos,
                 DiagnosticLogItems = [],
+                // This points to the Canonical.csproj, which always exists on disk and can be restored regardless of SDK.
                 ProjectRestorePath = projectInfos.FirstOrDefault()?.FilePath,
                 ProjectFactory = _workspaceFactory.MiscellaneousFilesWorkspaceProjectFactory,
                 IsFileBasedProgram = false,

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/FileBasedProgramsProjectSystem.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/FileBasedProgramsProjectSystem.cs
@@ -290,10 +290,12 @@ internal sealed class FileBasedProgramsProjectSystem : LanguageServerProjectLoad
 
         if (documentKind is LooseDocumentKind.MiscellaneousFileWithStandardReferences or LooseDocumentKind.MiscellaneousFileWithStandardReferencesAndSemanticErrors)
         {
+            var projectInfos = await _canonicalProjectProvider.GetProjectInfoAsync(documentPath, cancellationToken).ConfigureAwait(false);
             return new RemoteProjectLoadResult
             {
-                ProjectFileInfos = await _canonicalProjectProvider.GetProjectInfoAsync(documentPath, cancellationToken).ConfigureAwait(false),
+                ProjectFileInfos = projectInfos,
                 DiagnosticLogItems = [],
+                ProjectRestorePath = projectInfos.FirstOrDefault()?.FilePath,
                 ProjectFactory = _workspaceFactory.MiscellaneousFilesWorkspaceProjectFactory,
                 IsFileBasedProgram = false,
                 IsMiscellaneousFile = true,
@@ -331,6 +333,7 @@ internal sealed class FileBasedProgramsProjectSystem : LanguageServerProjectLoad
         {
             ProjectFileInfos = await loadedFile.GetProjectFileInfosAsync(cancellationToken),
             DiagnosticLogItems = await loadedFile.GetDiagnosticLogItemsAsync(cancellationToken),
+            ProjectRestorePath = documentPath,
             ProjectFactory = _workspaceFactory.HostProjectFactory,
             IsFileBasedProgram = true,
             IsMiscellaneousFile = false,

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
@@ -175,11 +175,11 @@ internal abstract class LanguageServerProjectLoader
                 produceItems: static async (projectToLoad, produceItem, args, cancellationToken) =>
                 {
                     var (@this, toastErrorReporter, buildHostProcessManager) = args;
-                    var projectNeedsRestore = await @this.ReloadProjectAsync(
+                    var projectRestorePath = await @this.ReloadProjectAsync(
                         projectToLoad, toastErrorReporter, buildHostProcessManager, cancellationToken);
 
-                    if (projectNeedsRestore)
-                        produceItem(projectToLoad.Path);
+                    if (projectRestorePath is not null)
+                        produceItem(projectRestorePath);
                 },
                 args: (@this: this, toastErrorReporter, buildHostProcessManager),
                 cancellationToken).ConfigureAwait(false);
@@ -200,6 +200,7 @@ internal abstract class LanguageServerProjectLoader
     {
         public required ImmutableArray<ProjectFileInfo> ProjectFileInfos { get; init; }
         public required ImmutableArray<DiagnosticLogItem> DiagnosticLogItems { get; init; }
+        public required string? ProjectRestorePath { get; init; }
         public required ProjectSystemProjectFactory ProjectFactory { get; init; }
         public required bool IsFileBasedProgram { get; init; }
         public required bool IsMiscellaneousFile { get; init; }
@@ -214,7 +215,7 @@ internal abstract class LanguageServerProjectLoader
         BuildHostProcessManager buildHostProcessManager, string projectPath, CancellationToken cancellationToken);
 
     /// <returns>True if the project needs a NuGet restore, false otherwise.</returns>
-    private async Task<bool> ReloadProjectAsync(ProjectToLoad projectToLoad, ToastErrorReporter toastErrorReporter, BuildHostProcessManager buildHostProcessManager, CancellationToken cancellationToken)
+    private async Task<string?> ReloadProjectAsync(ProjectToLoad projectToLoad, ToastErrorReporter toastErrorReporter, BuildHostProcessManager buildHostProcessManager, CancellationToken cancellationToken)
     {
         BuildHostProcessKind? preferredBuildHostKindThatWeDidNotGet = null;
         var projectPath = projectToLoad.Path;
@@ -224,7 +225,7 @@ internal abstract class LanguageServerProjectLoader
         {
             if (!_loadedProjects.ContainsKey(projectPath))
             {
-                return false;
+                return null;
             }
         }
 
@@ -238,7 +239,7 @@ internal abstract class LanguageServerProjectLoader
                 // - Reloading file-based app projects, where edits were performed to e.g. delete all `#:` directives,
                 //   making the file no longer a file-based app entry point.
                 _logger.LogDebug("Reload of '{projectPath}' was canceled.", projectPath);
-                return false;
+                return null;
             }
 
             var projectFactory = remoteProjectLoadResult.ProjectFactory;
@@ -252,7 +253,7 @@ internal abstract class LanguageServerProjectLoader
             {
                 await LogDiagnosticsAsync(diagnosticLogItems);
                 // We have total failures in evaluation, no point in continuing.
-                return false;
+                return null;
             }
 
             var loadedProjectInfos = remoteProjectLoadResult.ProjectFileInfos;
@@ -262,18 +263,18 @@ internal abstract class LanguageServerProjectLoader
             var projectLanguage = loadedProjectInfos.FirstOrDefault()?.Language;
             if (projectLanguage != null && projectFactory.Workspace.Services.GetLanguageService<ICommandLineParserService>(projectLanguage) == null)
             {
-                return false;
+                return null;
             }
 
             Dictionary<ProjectFileInfo, ProjectLoadTelemetryReporter.TelemetryInfo> telemetryInfos = [];
-            var needsRestore = false;
+            string? projectRestorePath = null;
 
             using (await _gate.DisposableWaitAsync(cancellationToken))
             {
                 if (!_loadedProjects.TryGetValue(projectPath, out var currentLoadState))
                 {
                     // Project was unloaded. Do not proceed with reloading it.
-                    return false;
+                    return null;
                 }
 
                 var previousProjectTargets = currentLoadState is ProjectLoadState.LoadedTargets loaded ? loaded.LoadedProjectTargets : [];
@@ -284,7 +285,11 @@ internal abstract class LanguageServerProjectLoader
                     newProjectTargetsBuilder.Add(target);
 
                     var (outputKind, metadataReferences, targetNeedsRestore) = await target.UpdateWithNewProjectInfoAsync(loadedProjectInfo, isMiscellaneousFile, remoteProjectLoadResult.HasAllInformation, _logger);
-                    needsRestore |= targetNeedsRestore;
+                    if (targetNeedsRestore)
+                    {
+                        projectRestorePath = remoteProjectLoadResult.ProjectRestorePath;
+                    }
+
                     if (!targetAlreadyExists)
                     {
                         telemetryInfos[loadedProjectInfo] = new ProjectLoadTelemetryReporter.TelemetryInfo
@@ -338,7 +343,7 @@ internal abstract class LanguageServerProjectLoader
                 _logger.LogInformation(string.Format(LanguageServerResources.Successfully_completed_load_of_0, projectPath));
             }
 
-            return needsRestore;
+            return projectRestorePath;
         }
         catch (Exception e)
         {
@@ -347,7 +352,7 @@ internal abstract class LanguageServerProjectLoader
             var diagnosticLogItem = new DiagnosticLogItem(DiagnosticLogItemKind.Error, message, projectPath);
             await LogDiagnosticsAsync([diagnosticLogItem]);
 
-            return false;
+            return null;
         }
 
         async Task<(LoadedProject, bool alreadyExists)> GetOrCreateProjectTargetAsync(ImmutableArray<LoadedProject> previousProjectTargets, ProjectSystemProjectFactory projectFactory, ProjectFileInfo loadedProjectInfo)

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
@@ -214,7 +214,7 @@ internal abstract class LanguageServerProjectLoader
     protected abstract Task<RemoteProjectLoadResult?> TryLoadProjectInMSBuildHostAsync(
         BuildHostProcessManager buildHostProcessManager, string projectPath, CancellationToken cancellationToken);
 
-    /// <returns>True if the project needs a NuGet restore, false otherwise.</returns>
+    /// <returns>The project file path that needs a NuGet restore, if any.</returns>
     private async Task<string?> ReloadProjectAsync(ProjectToLoad projectToLoad, ToastErrorReporter toastErrorReporter, BuildHostProcessManager buildHostProcessManager, CancellationToken cancellationToken)
     {
         BuildHostProcessKind? preferredBuildHostKindThatWeDidNotGet = null;

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
@@ -94,6 +94,7 @@ internal sealed class LanguageServerProjectSystem : LanguageServerProjectLoader
         {
             ProjectFileInfos = await loadedFile.GetProjectFileInfosAsync(cancellationToken),
             DiagnosticLogItems = await loadedFile.GetDiagnosticLogItemsAsync(cancellationToken),
+            ProjectRestorePath = projectPath,
             ProjectFactory = _hostProjectFactory,
             IsFileBasedProgram = false,
             IsMiscellaneousFile = false,

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectTelemetry/ProjectLoadTelemetryReporter.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectTelemetry/ProjectLoadTelemetryReporter.cs
@@ -61,7 +61,7 @@ internal sealed class ProjectLoadTelemetryReporter(ILoggerFactory loggerFactory,
                 return;
             }
 
-            var projectId = await GetProjectIdAsync(projectToLoad);
+            var projectId = await GetProjectIdAsync(projectToLoad, projectFileInfo);
             var targetFrameworks = GetTargetFrameworks(projectFileInfos.Keys);
 
             var projectCapabilities = projectFileInfo.ProjectCapabilities;
@@ -135,7 +135,7 @@ internal sealed class ProjectLoadTelemetryReporter(ILoggerFactory loggerFactory,
     /// This reads the solution file project id or hashes the contents+path
     /// Matches O# implementation - https://github.com/OmniSharp/omnisharp-roslyn/blob/master/src/OmniSharp.MSBuild/ProjectLoadListener.cs#L88
     /// </summary>
-    private static async Task<string> GetProjectIdAsync(ProjectToLoad projectToLoad)
+    private static async Task<string> GetProjectIdAsync(ProjectToLoad projectToLoad, ProjectFileInfo projectFileInfo)
     {
         if (projectToLoad.ProjectGuid is not null)
         {
@@ -145,6 +145,19 @@ internal sealed class ProjectLoadTelemetryReporter(ILoggerFactory loggerFactory,
 
             // No need to actually hash the project guid.
             return projectGuid;
+        }
+
+        var projectPath = projectToLoad.Path;
+        // The projectToLoad.Path might be a virtual document (misc file), attempt to fall back to the actual file path from the loaded project info.
+        if (!File.Exists(projectPath) && projectFileInfo.FilePath is not null)
+        {
+            projectPath = projectFileInfo.FilePath;
+        }
+
+        if (!File.Exists(projectPath))
+        {
+            // We have no file path at all and so cannot compute a contents hash, just return a sentinel value.
+            return "NONE";
         }
 
         var content = await File.ReadAllTextAsync(projectToLoad.Path);

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectTelemetry/ProjectLoadTelemetryReporter.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectTelemetry/ProjectLoadTelemetryReporter.cs
@@ -157,10 +157,10 @@ internal sealed class ProjectLoadTelemetryReporter(ILoggerFactory loggerFactory,
         if (!File.Exists(projectPath))
         {
             // We have no file path at all and so cannot compute a contents hash, just return a sentinel value.
-            return "NONE";
+            return "MISSING";
         }
 
-        var content = await File.ReadAllTextAsync(projectToLoad.Path);
+        var content = await File.ReadAllTextAsync(projectPath);
         // This should exactly match O# to ensure we get the same hashes.
         return VsReferenceHashingAlgorithm.HashInput($"Filename: {Path.GetFileName(projectToLoad.Path)}\n{content}");
     }


### PR DESCRIPTION
Issue - https://github.com/microsoft/vscode-dotnettools/issues/2802

##### Issue one
We were attempting to restore the misc document file path, which does not work on older SDKs (prior to .NET 10).

Fix: add a parameter to allow the canonical loader to specify the project path to restore (the loaded csproj) and write that csproj to disk.

##### Issue two
The telemetry reporter threw when trying to hash the project file contents for virtual files (the project to load path for virtual misc docs is the virtual uri)

Fix: Fall back to loaded project file path, otherwise default to a sentinel value
