### PR TITLE
Update XML comments to use code tags for separators

### DIFF
--- a/src/Compilers/Core/Portable/SourceGeneration/IncrementalContexts.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/IncrementalContexts.cs
@@ -210,7 +210,7 @@ namespace Microsoft.CodeAnalysis
         /// <param name="hintName">An identifier that can be used to reference this source text, must be unique within this generator</param>
         /// <param name="sourceText">The <see cref="SourceText"/> to add to the compilation</param>
         /// <remarks>
-        /// Directory separators "/" and "\" are allowed in <paramref name="hintName"/>, they are normalized to "/" regardless of host platform.
+        /// Directory separators <code>/</code> and <code>\</code> are allowed in <paramref name="hintName"/>, they are normalized to <code>/</code> regardless of host platform.
         /// </remarks>
         public void AddSource(string hintName, SourceText sourceText) => AdditionalSources.Add(hintName, sourceText);
 
@@ -259,7 +259,7 @@ namespace Microsoft.CodeAnalysis
         /// <param name="hintName">An identifier that can be used to reference this source text, must be unique within this generator</param>
         /// <param name="sourceText">The <see cref="SourceText"/> to add to the compilation</param>
         /// <remarks>
-        /// Directory separators "/" and "\" are allowed in <paramref name="hintName"/>, they are normalized to "/" regardless of host platform.
+        /// Directory separators <code>/</code> and <code>\</code> are allowed in <paramref name="hintName"/>, they are normalized to <code>/</code> regardless of host platform.
         /// </remarks>
         public void AddSource(string hintName, SourceText sourceText) => Sources.Add(hintName, sourceText.WithChecksumAlgorithmIfAny(ChecksumAlgorithm));
 


### PR DESCRIPTION
Wrapped directory separators in `<code>` blocks to avoid them getting filtered out in HTML.

fixes https://github.com/dotnet/docs/issues/35431
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83179)