### PR TITLE
Fix OnAutoInsert_EnterKey3 failing on Linux

### DIFF
--- a/src/Features/CSharp/Portable/DocumentationComments/CSharpDocumentationCommentSnippetService.cs
+++ b/src/Features/CSharp/Portable/DocumentationComments/CSharpDocumentationCommentSnippetService.cs
@@ -253,7 +253,7 @@ internal sealed class CSharpDocumentationCommentSnippetService() : AbstractDocum
         }
 
         return syntaxTree.GetRoot(cancellationToken).FindTokenOnLeftOfPosition(
-            position - 1, includeDirectives: true, includeDocumentationComments: true, includeSkipped: true);
+            position, includeDirectives: true, includeDocumentationComments: true, includeSkipped: true);
     }
 
     protected override bool IsDocCommentNewLine(SyntaxToken token)

--- a/src/Features/VisualBasic/Portable/DocumentationComments/VisualBasicDocumentationCommentSnippetService.vb
+++ b/src/Features/VisualBasic/Portable/DocumentationComments/VisualBasicDocumentationCommentSnippetService.vb
@@ -256,7 +256,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.DocumentationComments
             End If
 
             Return syntaxTree.GetRoot(cancellationToken).FindTokenOnLeftOfPosition(
-                position - 1, includeDirectives:=True, includeDocumentationComments:=True)
+                position, includeDirectives:=True, includeDocumentationComments:=True)
         End Function
 
         Protected Overrides Function IsDocCommentNewLine(token As SyntaxToken) As Boolean

--- a/src/LanguageServer/ProtocolUnitTests/OnAutoInsert/OnAutoInsertTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/OnAutoInsert/OnAutoInsertTests.cs
@@ -203,8 +203,7 @@ public sealed partial class OnAutoInsertTests(ITestOutputHelper testOutputHelper
             }
             """, mutatingLspWorkspace);
 
-    [ConditionalTheory(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83117")]
-    [CombinatorialData]
+    [Theory, CombinatorialData]
     public Task OnAutoInsert_EnterKey3(bool mutatingLspWorkspace)
         => VerifyCSharpMarkupAndExpected("\n", """
             class A
@@ -224,6 +223,32 @@ public sealed partial class OnAutoInsertTests(ITestOutputHelper testOutputHelper
                 /// <param name="foo"></param>
                 /// <param name="bar"></param>
                 /// <returns></returns>
+                string M(int foo, bool bar)
+                {
+                }
+            }
+            """, mutatingLspWorkspace);
+
+    [Theory, CombinatorialData]
+    public Task OnAutoInsert_EnterKey3_WithIndentation(bool mutatingLspWorkspace)
+        => VerifyCSharpMarkupAndExpected("\n", """
+            class A
+            {
+                ///
+                {|type:|}
+                string M(int foo, bool bar)
+                {
+                }
+            }
+            """, """
+            class A
+            {
+                /// <summary>
+                /// $0
+                /// </summary>
+                /// <param name="foo"></param>
+                /// <param name="bar"></param>
+                /// <returns></returns>    
                 string M(int foo, bool bar)
                 {
                 }


### PR DESCRIPTION
The GetTokenToLeft method in both C# and VB doc comment snippet services passed position - 1 to FindTokenOnLeftOfPosition. With LF line endings (Linux/Mac), the newline token after /// is a single character, so position - 1 equals the token's SpanStart. FindTokenOnLeftOfPosition treats position <= SpanStart as 'before the token' and navigates to the previous token, causing the handler to return null.

With CRLF (Windows), position - 1 lands inside the 2-char \r\n token span (past SpanStart), so the token is correctly found.

Fix: Remove the - 1 offset, passing position directly to FindTokenOnLeftOfPosition. This correctly navigates past the zero-width EndOfDocumentationCommentToken at position to find the newline token in both LF and CRLF cases.

Also remove the WindowsOnly attribute from OnAutoInsert_EnterKey3.

Fixes https://github.com/dotnet/roslyn/issues/83117
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83183)