### PR TITLE
Shutdown build server before publishing logs in Correctness_Build_Artifacts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -496,6 +496,11 @@ stages:
         displayName: Validate Generated Syntax Files
         condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['compilerChange'], 'true'))
 
+      - script: dotnet build-server shutdown
+        displayName: Shutdown Build Server
+        continueOnError: true
+        condition: always()
+
       - template: eng/pipelines/publish-logs.yml
         parameters:
           jobName: Correctness_Build_Artifacts


### PR DESCRIPTION

The Correctness_Build_Artifacts job runs several post-build steps that invoke 'dotnet run' (Generate Syntax Files, Verify Synchronized Sources) which can start a new VBCSCompiler server process. This process holds Build.Server.log open (via the ROSLYNCOMMANDLINELOGFILE env var set in variables-build.yml) for its entire lifetime.

When the Publish Logs step then attempts to upload artifacts/log/Release/, the PublishPipelineArtifact task fails with:

  The process cannot access the file 'Build.Server.log' because it is
  being used by another process.

This causes the job to report succeededWithIssues and the overall build to become partiallySucceeded. The failure is intermittent because it depends on whether VBCSCompiler's idle timeout expires before artifact upload begins.

The initial eng/build.ps1 call passes -prepareMachine which shuts down the build server on exit, but the subsequent dotnet run steps restart it without any corresponding shutdown.

Fix this by adding an explicit 'dotnet build-server shutdown' step immediately before the publish-logs template. This ensures VBCSCompiler releases its handle on Build.Server.log before artifact upload.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83186)