### PR TITLE
Skip TestFindReferencesAsync_UsingAlias on non-Windows platforms

### DIFF
--- a/src/LanguageServer/ProtocolUnitTests/References/FindAllReferencesHandlerTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/References/FindAllReferencesHandlerTests.cs
@@ -324,7 +324,7 @@ public sealed class FindAllReferencesHandlerTests(ITestOutputHelper testOutputHe
         AssertHighlightCount(results, expectedDefinitionCount: 0, expectedWrittenReferenceCount: 0, expectedReferenceCount: 3);
     }
 
-    [Theory, CombinatorialData]
+    [ConditionalTheory(typeof(WindowsOnly)), CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/83187")]
     public async Task TestFindReferencesAsync_UsingAlias(bool mutatingLspWorkspace)
     {
         var markup =


### PR DESCRIPTION
The test fails deterministically on macOS (Test_macOS_Debug_OSX.15.Amd64.Open) because the metadata navigation URI for System.String does not end with 'String.cs' on Unix platforms. The Assert.True at line 346 checking results[0].Location.DocumentUri.ToString().EndsWith("String.cs") always returns false on macOS while passing on Windows.

Use ConditionalTheory(typeof(WindowsOnly)) instead of Theory(Skip=...) so the test continues to run and provide coverage on Windows.

Tracked by https://github.com/dotnet/roslyn/issues/83187
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83188)