### PR TITLE
Update the list of immunized frames in FaultReporter.cs

### DIFF
--- a/src/VisualStudio/Core/Def/Watson/FaultReporter.cs
+++ b/src/VisualStudio/Core/Def/Watson/FaultReporter.cs
@@ -94,10 +94,23 @@ internal static class FaultReporter
 
     private static readonly ImmutableArray<string> UnblameableMethodPrefixes =
     [
-        "Microsoft.CodeAnalysis.Shared.Extensions.ISolutionExtensions.GetRequired",
-        "Microsoft.CodeAnalysis.Host.HostLanguageServices.GetRequiredService",
-        "Roslyn.Utilities.Contract.",
+        // If GetRequiredDocument or similar throw, the real fault is the caller which is expecting the document but won't get it
+        typeof(Shared.Extensions.ISolutionExtensions).FullName + ".GetRequired",
+
+        // If GetRequiredService throws, the real fault is the caller which is expecting the service but won't get it
+        typeof(Host.HostLanguageServices).FullName + "." + nameof(Host.HostLanguageServices.GetRequiredService),
+
+        // Most of the members on RequestContext throw if the LSP request didn't carry a document or solution like the handler expected;
+        // this should be blamed on the caller since that way we can distinguish the different handlers
+        typeof(LanguageServer.Handler.RequestContext).FullName + ".",
+
+        // Ignore everything from our Contract.Throw* helpers
+        typeof(Contract).FullName + ".",
+
+        // Ignore common framework helpers
+        "System.Collections.Immutable.",
         "System.Linq.",
+        "System.Runtime.CompilerServices.",
     ];
 
     /// <summary>


### PR DESCRIPTION
This list has gotten out of date and could use a bit of updating. I'm moving to typeof as a way to generate the qualified names, since in at least one case we had moved a type but never updated this.