### PR TITLE
Skip AnalyzerAssemblyLoaderTests.AssemblyLoading_DependencyInDifferentDirectory on RuntimeAsync

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerAssemblyLoaderTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerAssemblyLoaderTests.cs
@@ -561,7 +561,7 @@ Delta: Gamma: Beta: Test B
             });
         }
 
-        [ConditionalTheory(typeof(WindowsOnly), Reason = "https://github.com/dotnet/runtime/issues/81108")]
+        [ConditionalTheory(typeof(WindowsOnly), typeof(CompilerAsync), Reason = "https://github.com/dotnet/runtime/issues/81108 https://github.com/dotnet/roslyn/issues/79352")]
         [CombinatorialData]
         public void AssemblyLoading_DependencyInDifferentDirectory(AnalyzerTestKind kind)
         {

--- a/src/Compilers/Test/Utilities/CSharp/RuntimeAsyncTestHelpers.cs
+++ b/src/Compilers/Test/Utilities/CSharp/RuntimeAsyncTestHelpers.cs
@@ -27,4 +27,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
         /// </returns>
         public static string? ExpectedOutput(string? output) => ExecutionConditionUtil.IsCoreClr && IsRuntimeAsyncEnabled ? output : null;
     }
+
+    public class CompilerAsync : ExecutionCondition
+    {
+        public override bool ShouldSkip => RuntimeAsyncTestHelpers.IsRuntimeAsyncEnabled;
+        public override string SkipReason => "Test not supported when runtime async is enabled";
+    }
 }

--- a/src/Compilers/Test/Utilities/CSharp/RuntimeAsyncTestHelpers.cs
+++ b/src/Compilers/Test/Utilities/CSharp/RuntimeAsyncTestHelpers.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
         public static string? ExpectedOutput(string? output) => ExecutionConditionUtil.IsCoreClr && IsRuntimeAsyncEnabled ? output : null;
     }
 
-    public class CompilerAsync : ExecutionCondition
+    public sealed class CompilerAsync : ExecutionCondition
     {
         public override bool ShouldSkip => RuntimeAsyncTestHelpers.IsRuntimeAsyncEnabled;
         public override string SkipReason => "Test not supported when runtime async is enabled";


### PR DESCRIPTION
Add CompilerAsync ExecutionCondition that skips tests when DOTNET_RuntimeAsync is enabled. Apply it to AssemblyLoading_DependencyInDifferentDirectory.

Tracking issue https://github.com/dotnet/roslyn/issues/79352
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83193)