### PR TITLE
Add syntax and parsing support for labeled break/continue

### DIFF
--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Internal.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Internal.Generated.cs
@@ -11479,12 +11479,13 @@ internal sealed partial class BreakStatementSyntax : StatementSyntax
 {
     internal readonly GreenNode? attributeLists;
     internal readonly SyntaxToken breakKeyword;
+    internal readonly IdentifierNameSyntax? name;
     internal readonly SyntaxToken semicolonToken;
 
-    internal BreakStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken breakKeyword, SyntaxToken semicolonToken, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
+    internal BreakStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken breakKeyword, IdentifierNameSyntax? name, SyntaxToken semicolonToken, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
       : base(kind, diagnostics, annotations)
     {
-        this.SlotCount = 3;
+        this.SlotCount = 4;
         if (attributeLists != null)
         {
             this.AdjustFlagsAndWidth(attributeLists);
@@ -11492,15 +11493,20 @@ internal sealed partial class BreakStatementSyntax : StatementSyntax
         }
         this.AdjustFlagsAndWidth(breakKeyword);
         this.breakKeyword = breakKeyword;
+        if (name != null)
+        {
+            this.AdjustFlagsAndWidth(name);
+            this.name = name;
+        }
         this.AdjustFlagsAndWidth(semicolonToken);
         this.semicolonToken = semicolonToken;
     }
 
-    internal BreakStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken breakKeyword, SyntaxToken semicolonToken, SyntaxFactoryContext context)
+    internal BreakStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken breakKeyword, IdentifierNameSyntax? name, SyntaxToken semicolonToken, SyntaxFactoryContext context)
       : base(kind)
     {
         this.SetFactoryContext(context);
-        this.SlotCount = 3;
+        this.SlotCount = 4;
         if (attributeLists != null)
         {
             this.AdjustFlagsAndWidth(attributeLists);
@@ -11508,14 +11514,19 @@ internal sealed partial class BreakStatementSyntax : StatementSyntax
         }
         this.AdjustFlagsAndWidth(breakKeyword);
         this.breakKeyword = breakKeyword;
+        if (name != null)
+        {
+            this.AdjustFlagsAndWidth(name);
+            this.name = name;
+        }
         this.AdjustFlagsAndWidth(semicolonToken);
         this.semicolonToken = semicolonToken;
     }
 
-    internal BreakStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken breakKeyword, SyntaxToken semicolonToken)
+    internal BreakStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken breakKeyword, IdentifierNameSyntax? name, SyntaxToken semicolonToken)
       : base(kind)
     {
-        this.SlotCount = 3;
+        this.SlotCount = 4;
         if (attributeLists != null)
         {
             this.AdjustFlagsAndWidth(attributeLists);
@@ -11523,12 +11534,18 @@ internal sealed partial class BreakStatementSyntax : StatementSyntax
         }
         this.AdjustFlagsAndWidth(breakKeyword);
         this.breakKeyword = breakKeyword;
+        if (name != null)
+        {
+            this.AdjustFlagsAndWidth(name);
+            this.name = name;
+        }
         this.AdjustFlagsAndWidth(semicolonToken);
         this.semicolonToken = semicolonToken;
     }
 
     public override CoreSyntax.SyntaxList<AttributeListSyntax> AttributeLists => new CoreSyntax.SyntaxList<AttributeListSyntax>(this.attributeLists);
     public SyntaxToken BreakKeyword => this.breakKeyword;
+    public IdentifierNameSyntax? Name => this.name;
     public SyntaxToken SemicolonToken => this.semicolonToken;
 
     internal override GreenNode? GetSlot(int index)
@@ -11536,7 +11553,8 @@ internal sealed partial class BreakStatementSyntax : StatementSyntax
         {
             0 => this.attributeLists,
             1 => this.breakKeyword,
-            2 => this.semicolonToken,
+            2 => this.name,
+            3 => this.semicolonToken,
             _ => null,
         };
 
@@ -11545,11 +11563,11 @@ internal sealed partial class BreakStatementSyntax : StatementSyntax
     public override void Accept(CSharpSyntaxVisitor visitor) => visitor.VisitBreakStatement(this);
     public override TResult Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) => visitor.VisitBreakStatement(this);
 
-    public BreakStatementSyntax Update(CoreSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken breakKeyword, SyntaxToken semicolonToken)
+    public BreakStatementSyntax Update(CoreSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken breakKeyword, IdentifierNameSyntax name, SyntaxToken semicolonToken)
     {
-        if (attributeLists != this.AttributeLists || breakKeyword != this.BreakKeyword || semicolonToken != this.SemicolonToken)
+        if (attributeLists != this.AttributeLists || breakKeyword != this.BreakKeyword || name != this.Name || semicolonToken != this.SemicolonToken)
         {
-            var newNode = SyntaxFactory.BreakStatement(attributeLists, breakKeyword, semicolonToken);
+            var newNode = SyntaxFactory.BreakStatement(attributeLists, breakKeyword, name, semicolonToken);
             var diags = GetDiagnostics();
             if (diags?.Length > 0)
                 newNode = newNode.WithDiagnosticsGreen(diags);
@@ -11563,22 +11581,23 @@ internal sealed partial class BreakStatementSyntax : StatementSyntax
     }
 
     internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
-        => new BreakStatementSyntax(this.Kind, this.attributeLists, this.breakKeyword, this.semicolonToken, diagnostics, GetAnnotations());
+        => new BreakStatementSyntax(this.Kind, this.attributeLists, this.breakKeyword, this.name, this.semicolonToken, diagnostics, GetAnnotations());
 
     internal override GreenNode SetAnnotations(SyntaxAnnotation[]? annotations)
-        => new BreakStatementSyntax(this.Kind, this.attributeLists, this.breakKeyword, this.semicolonToken, GetDiagnostics(), annotations);
+        => new BreakStatementSyntax(this.Kind, this.attributeLists, this.breakKeyword, this.name, this.semicolonToken, GetDiagnostics(), annotations);
 }
 
 internal sealed partial class ContinueStatementSyntax : StatementSyntax
 {
     internal readonly GreenNode? attributeLists;
     internal readonly SyntaxToken continueKeyword;
+    internal readonly IdentifierNameSyntax? name;
     internal readonly SyntaxToken semicolonToken;
 
-    internal ContinueStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken continueKeyword, SyntaxToken semicolonToken, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
+    internal ContinueStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken continueKeyword, IdentifierNameSyntax? name, SyntaxToken semicolonToken, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
       : base(kind, diagnostics, annotations)
     {
-        this.SlotCount = 3;
+        this.SlotCount = 4;
         if (attributeLists != null)
         {
             this.AdjustFlagsAndWidth(attributeLists);
@@ -11586,15 +11605,20 @@ internal sealed partial class ContinueStatementSyntax : StatementSyntax
         }
         this.AdjustFlagsAndWidth(continueKeyword);
         this.continueKeyword = continueKeyword;
+        if (name != null)
+        {
+            this.AdjustFlagsAndWidth(name);
+            this.name = name;
+        }
         this.AdjustFlagsAndWidth(semicolonToken);
         this.semicolonToken = semicolonToken;
     }
 
-    internal ContinueStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken continueKeyword, SyntaxToken semicolonToken, SyntaxFactoryContext context)
+    internal ContinueStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken continueKeyword, IdentifierNameSyntax? name, SyntaxToken semicolonToken, SyntaxFactoryContext context)
       : base(kind)
     {
         this.SetFactoryContext(context);
-        this.SlotCount = 3;
+        this.SlotCount = 4;
         if (attributeLists != null)
         {
             this.AdjustFlagsAndWidth(attributeLists);
@@ -11602,14 +11626,19 @@ internal sealed partial class ContinueStatementSyntax : StatementSyntax
         }
         this.AdjustFlagsAndWidth(continueKeyword);
         this.continueKeyword = continueKeyword;
+        if (name != null)
+        {
+            this.AdjustFlagsAndWidth(name);
+            this.name = name;
+        }
         this.AdjustFlagsAndWidth(semicolonToken);
         this.semicolonToken = semicolonToken;
     }
 
-    internal ContinueStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken continueKeyword, SyntaxToken semicolonToken)
+    internal ContinueStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken continueKeyword, IdentifierNameSyntax? name, SyntaxToken semicolonToken)
       : base(kind)
     {
-        this.SlotCount = 3;
+        this.SlotCount = 4;
         if (attributeLists != null)
         {
             this.AdjustFlagsAndWidth(attributeLists);
@@ -11617,12 +11646,18 @@ internal sealed partial class ContinueStatementSyntax : StatementSyntax
         }
         this.AdjustFlagsAndWidth(continueKeyword);
         this.continueKeyword = continueKeyword;
+        if (name != null)
+        {
+            this.AdjustFlagsAndWidth(name);
+            this.name = name;
+        }
         this.AdjustFlagsAndWidth(semicolonToken);
         this.semicolonToken = semicolonToken;
     }
 
     public override CoreSyntax.SyntaxList<AttributeListSyntax> AttributeLists => new CoreSyntax.SyntaxList<AttributeListSyntax>(this.attributeLists);
     public SyntaxToken ContinueKeyword => this.continueKeyword;
+    public IdentifierNameSyntax? Name => this.name;
     public SyntaxToken SemicolonToken => this.semicolonToken;
 
     internal override GreenNode? GetSlot(int index)
@@ -11630,7 +11665,8 @@ internal sealed partial class ContinueStatementSyntax : StatementSyntax
         {
             0 => this.attributeLists,
             1 => this.continueKeyword,
-            2 => this.semicolonToken,
+            2 => this.name,
+            3 => this.semicolonToken,
             _ => null,
         };
 
@@ -11639,11 +11675,11 @@ internal sealed partial class ContinueStatementSyntax : StatementSyntax
     public override void Accept(CSharpSyntaxVisitor visitor) => visitor.VisitContinueStatement(this);
     public override TResult Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) => visitor.VisitContinueStatement(this);
 
-    public ContinueStatementSyntax Update(CoreSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken continueKeyword, SyntaxToken semicolonToken)
+    public ContinueStatementSyntax Update(CoreSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken continueKeyword, IdentifierNameSyntax name, SyntaxToken semicolonToken)
     {
-        if (attributeLists != this.AttributeLists || continueKeyword != this.ContinueKeyword || semicolonToken != this.SemicolonToken)
+        if (attributeLists != this.AttributeLists || continueKeyword != this.ContinueKeyword || name != this.Name || semicolonToken != this.SemicolonToken)
         {
-            var newNode = SyntaxFactory.ContinueStatement(attributeLists, continueKeyword, semicolonToken);
+            var newNode = SyntaxFactory.ContinueStatement(attributeLists, continueKeyword, name, semicolonToken);
             var diags = GetDiagnostics();
             if (diags?.Length > 0)
                 newNode = newNode.WithDiagnosticsGreen(diags);
@@ -11657,10 +11693,10 @@ internal sealed partial class ContinueStatementSyntax : StatementSyntax
     }
 
     internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
-        => new ContinueStatementSyntax(this.Kind, this.attributeLists, this.continueKeyword, this.semicolonToken, diagnostics, GetAnnotations());
+        => new ContinueStatementSyntax(this.Kind, this.attributeLists, this.continueKeyword, this.name, this.semicolonToken, diagnostics, GetAnnotations());
 
     internal override GreenNode SetAnnotations(SyntaxAnnotation[]? annotations)
-        => new ContinueStatementSyntax(this.Kind, this.attributeLists, this.continueKeyword, this.semicolonToken, GetDiagnostics(), annotations);
+        => new ContinueStatementSyntax(this.Kind, this.attributeLists, this.continueKeyword, this.name, this.semicolonToken, GetDiagnostics(), annotations);
 }
 
 internal sealed partial class ReturnStatementSyntax : StatementSyntax
@@ -27891,10 +27927,10 @@ internal partial class CSharpSyntaxRewriter : CSharpSyntaxVisitor<CSharpSyntaxNo
         => node.Update(VisitList(node.AttributeLists), (SyntaxToken)Visit(node.GotoKeyword), (SyntaxToken)Visit(node.CaseOrDefaultKeyword), (ExpressionSyntax)Visit(node.Expression), (SyntaxToken)Visit(node.SemicolonToken));
 
     public override CSharpSyntaxNode VisitBreakStatement(BreakStatementSyntax node)
-        => node.Update(VisitList(node.AttributeLists), (SyntaxToken)Visit(node.BreakKeyword), (SyntaxToken)Visit(node.SemicolonToken));
+        => node.Update(VisitList(node.AttributeLists), (SyntaxToken)Visit(node.BreakKeyword), (IdentifierNameSyntax)Visit(node.Name), (SyntaxToken)Visit(node.SemicolonToken));
 
     public override CSharpSyntaxNode VisitContinueStatement(ContinueStatementSyntax node)
-        => node.Update(VisitList(node.AttributeLists), (SyntaxToken)Visit(node.ContinueKeyword), (SyntaxToken)Visit(node.SemicolonToken));
+        => node.Update(VisitList(node.AttributeLists), (SyntaxToken)Visit(node.ContinueKeyword), (IdentifierNameSyntax)Visit(node.Name), (SyntaxToken)Visit(node.SemicolonToken));
 
     public override CSharpSyntaxNode VisitReturnStatement(ReturnStatementSyntax node)
         => node.Update(VisitList(node.AttributeLists), (SyntaxToken)Visit(node.ReturnKeyword), (ExpressionSyntax)Visit(node.Expression), (SyntaxToken)Visit(node.SemicolonToken));
@@ -30933,7 +30969,7 @@ internal partial class ContextAwareSyntax
         return new GotoStatementSyntax(kind, attributeLists.Node, gotoKeyword, caseOrDefaultKeyword, expression, semicolonToken, this.context);
     }
 
-    public BreakStatementSyntax BreakStatement(CoreSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken breakKeyword, SyntaxToken semicolonToken)
+    public BreakStatementSyntax BreakStatement(CoreSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken breakKeyword, IdentifierNameSyntax? name, SyntaxToken semicolonToken)
     {
 #if DEBUG
         if (breakKeyword == null) throw new ArgumentNullException(nameof(breakKeyword));
@@ -30942,20 +30978,10 @@ internal partial class ContextAwareSyntax
         if (semicolonToken.Kind != SyntaxKind.SemicolonToken) throw new ArgumentException(nameof(semicolonToken));
 #endif
 
-        int hash;
-        var cached = CSharpSyntaxNodeCache.TryGetNode((int)SyntaxKind.BreakStatement, attributeLists.Node, breakKeyword, semicolonToken, this.context, out hash);
-        if (cached != null) return (BreakStatementSyntax)cached;
-
-        var result = new BreakStatementSyntax(SyntaxKind.BreakStatement, attributeLists.Node, breakKeyword, semicolonToken, this.context);
-        if (hash >= 0)
-        {
-            SyntaxNodeCache.AddNode(result, hash);
-        }
-
-        return result;
+        return new BreakStatementSyntax(SyntaxKind.BreakStatement, attributeLists.Node, breakKeyword, name, semicolonToken, this.context);
     }
 
-    public ContinueStatementSyntax ContinueStatement(CoreSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken continueKeyword, SyntaxToken semicolonToken)
+    public ContinueStatementSyntax ContinueStatement(CoreSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken continueKeyword, IdentifierNameSyntax? name, SyntaxToken semicolonToken)
     {
 #if DEBUG
         if (continueKeyword == null) throw new ArgumentNullException(nameof(continueKeyword));
@@ -30964,17 +30990,7 @@ internal partial class ContextAwareSyntax
         if (semicolonToken.Kind != SyntaxKind.SemicolonToken) throw new ArgumentException(nameof(semicolonToken));
 #endif
 
-        int hash;
-        var cached = CSharpSyntaxNodeCache.TryGetNode((int)SyntaxKind.ContinueStatement, attributeLists.Node, continueKeyword, semicolonToken, this.context, out hash);
-        if (cached != null) return (ContinueStatementSyntax)cached;
-
-        var result = new ContinueStatementSyntax(SyntaxKind.ContinueStatement, attributeLists.Node, continueKeyword, semicolonToken, this.context);
-        if (hash >= 0)
-        {
-            SyntaxNodeCache.AddNode(result, hash);
-        }
-
-        return result;
+        return new ContinueStatementSyntax(SyntaxKind.ContinueStatement, attributeLists.Node, continueKeyword, name, semicolonToken, this.context);
     }
 
     public ReturnStatementSyntax ReturnStatement(CoreSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken returnKeyword, ExpressionSyntax? expression, SyntaxToken semicolonToken)
@@ -36332,7 +36348,7 @@ internal static partial class SyntaxFactory
         return new GotoStatementSyntax(kind, attributeLists.Node, gotoKeyword, caseOrDefaultKeyword, expression, semicolonToken);
     }
 
-    public static BreakStatementSyntax BreakStatement(CoreSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken breakKeyword, SyntaxToken semicolonToken)
+    public static BreakStatementSyntax BreakStatement(CoreSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken breakKeyword, IdentifierNameSyntax? name, SyntaxToken semicolonToken)
     {
 #if DEBUG
         if (breakKeyword == null) throw new ArgumentNullException(nameof(breakKeyword));
@@ -36341,20 +36357,10 @@ internal static partial class SyntaxFactory
         if (semicolonToken.Kind != SyntaxKind.SemicolonToken) throw new ArgumentException(nameof(semicolonToken));
 #endif
 
-        int hash;
-        var cached = SyntaxNodeCache.TryGetNode((int)SyntaxKind.BreakStatement, attributeLists.Node, breakKeyword, semicolonToken, out hash);
-        if (cached != null) return (BreakStatementSyntax)cached;
-
-        var result = new BreakStatementSyntax(SyntaxKind.BreakStatement, attributeLists.Node, breakKeyword, semicolonToken);
-        if (hash >= 0)
-        {
-            SyntaxNodeCache.AddNode(result, hash);
-        }
-
-        return result;
+        return new BreakStatementSyntax(SyntaxKind.BreakStatement, attributeLists.Node, breakKeyword, name, semicolonToken);
     }
 
-    public static ContinueStatementSyntax ContinueStatement(CoreSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken continueKeyword, SyntaxToken semicolonToken)
+    public static ContinueStatementSyntax ContinueStatement(CoreSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken continueKeyword, IdentifierNameSyntax? name, SyntaxToken semicolonToken)
     {
 #if DEBUG
         if (continueKeyword == null) throw new ArgumentNullException(nameof(continueKeyword));
@@ -36363,17 +36369,7 @@ internal static partial class SyntaxFactory
         if (semicolonToken.Kind != SyntaxKind.SemicolonToken) throw new ArgumentException(nameof(semicolonToken));
 #endif
 
-        int hash;
-        var cached = SyntaxNodeCache.TryGetNode((int)SyntaxKind.ContinueStatement, attributeLists.Node, continueKeyword, semicolonToken, out hash);
-        if (cached != null) return (ContinueStatementSyntax)cached;
-
-        var result = new ContinueStatementSyntax(SyntaxKind.ContinueStatement, attributeLists.Node, continueKeyword, semicolonToken);
-        if (hash >= 0)
-        {
-            SyntaxNodeCache.AddNode(result, hash);
-        }
-
-        return result;
+        return new ContinueStatementSyntax(SyntaxKind.ContinueStatement, attributeLists.Node, continueKeyword, name, semicolonToken);
     }
 
     public static ReturnStatementSyntax ReturnStatement(CoreSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken returnKeyword, ExpressionSyntax? expression, SyntaxToken semicolonToken)

--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Main.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Main.Generated.cs
@@ -1879,10 +1879,10 @@ public partial class CSharpSyntaxRewriter : CSharpSyntaxVisitor<SyntaxNode?>
         => node.Update(VisitList(node.AttributeLists), VisitToken(node.GotoKeyword), VisitToken(node.CaseOrDefaultKeyword), (ExpressionSyntax?)Visit(node.Expression), VisitToken(node.SemicolonToken));
 
     public override SyntaxNode? VisitBreakStatement(BreakStatementSyntax node)
-        => node.Update(VisitList(node.AttributeLists), VisitToken(node.BreakKeyword), VisitToken(node.SemicolonToken));
+        => node.Update(VisitList(node.AttributeLists), VisitToken(node.BreakKeyword), (IdentifierNameSyntax?)Visit(node.Name), VisitToken(node.SemicolonToken));
 
     public override SyntaxNode? VisitContinueStatement(ContinueStatementSyntax node)
-        => node.Update(VisitList(node.AttributeLists), VisitToken(node.ContinueKeyword), VisitToken(node.SemicolonToken));
+        => node.Update(VisitList(node.AttributeLists), VisitToken(node.ContinueKeyword), (IdentifierNameSyntax?)Visit(node.Name), VisitToken(node.SemicolonToken));
 
     public override SyntaxNode? VisitReturnStatement(ReturnStatementSyntax node)
         => node.Update(VisitList(node.AttributeLists), VisitToken(node.ReturnKeyword), (ExpressionSyntax?)Visit(node.Expression), VisitToken(node.SemicolonToken));
@@ -4207,36 +4207,40 @@ public static partial class SyntaxFactory
 #pragma warning restore RS0027
 
     /// <summary>Creates a new BreakStatementSyntax instance.</summary>
-    public static BreakStatementSyntax BreakStatement(SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken breakKeyword, SyntaxToken semicolonToken)
+    public static BreakStatementSyntax BreakStatement(SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken breakKeyword, IdentifierNameSyntax? name, SyntaxToken semicolonToken)
     {
         if (breakKeyword.Kind() != SyntaxKind.BreakKeyword) throw new ArgumentException(nameof(breakKeyword));
         if (semicolonToken.Kind() != SyntaxKind.SemicolonToken) throw new ArgumentException(nameof(semicolonToken));
-        return (BreakStatementSyntax)Syntax.InternalSyntax.SyntaxFactory.BreakStatement(attributeLists.Node.ToGreenList<Syntax.InternalSyntax.AttributeListSyntax>(), (Syntax.InternalSyntax.SyntaxToken)breakKeyword.Node!, (Syntax.InternalSyntax.SyntaxToken)semicolonToken.Node!).CreateRed();
+        return (BreakStatementSyntax)Syntax.InternalSyntax.SyntaxFactory.BreakStatement(attributeLists.Node.ToGreenList<Syntax.InternalSyntax.AttributeListSyntax>(), (Syntax.InternalSyntax.SyntaxToken)breakKeyword.Node!, name == null ? null : (Syntax.InternalSyntax.IdentifierNameSyntax)name.Green, (Syntax.InternalSyntax.SyntaxToken)semicolonToken.Node!).CreateRed();
     }
 
     /// <summary>Creates a new BreakStatementSyntax instance.</summary>
-    public static BreakStatementSyntax BreakStatement(SyntaxList<AttributeListSyntax> attributeLists)
-        => SyntaxFactory.BreakStatement(attributeLists, SyntaxFactory.Token(SyntaxKind.BreakKeyword), SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+    public static BreakStatementSyntax BreakStatement(SyntaxList<AttributeListSyntax> attributeLists, IdentifierNameSyntax? name)
+        => SyntaxFactory.BreakStatement(attributeLists, SyntaxFactory.Token(SyntaxKind.BreakKeyword), name, SyntaxFactory.Token(SyntaxKind.SemicolonToken));
 
+#pragma warning disable RS0027
     /// <summary>Creates a new BreakStatementSyntax instance.</summary>
-    public static BreakStatementSyntax BreakStatement()
-        => SyntaxFactory.BreakStatement(default, SyntaxFactory.Token(SyntaxKind.BreakKeyword), SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+    public static BreakStatementSyntax BreakStatement(IdentifierNameSyntax? name = default)
+        => SyntaxFactory.BreakStatement(default, SyntaxFactory.Token(SyntaxKind.BreakKeyword), name, SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+#pragma warning restore RS0027
 
     /// <summary>Creates a new ContinueStatementSyntax instance.</summary>
-    public static ContinueStatementSyntax ContinueStatement(SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken continueKeyword, SyntaxToken semicolonToken)
+    public static ContinueStatementSyntax ContinueStatement(SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken continueKeyword, IdentifierNameSyntax? name, SyntaxToken semicolonToken)
     {
         if (continueKeyword.Kind() != SyntaxKind.ContinueKeyword) throw new ArgumentException(nameof(continueKeyword));
         if (semicolonToken.Kind() != SyntaxKind.SemicolonToken) throw new ArgumentException(nameof(semicolonToken));
-        return (ContinueStatementSyntax)Syntax.InternalSyntax.SyntaxFactory.ContinueStatement(attributeLists.Node.ToGreenList<Syntax.InternalSyntax.AttributeListSyntax>(), (Syntax.InternalSyntax.SyntaxToken)continueKeyword.Node!, (Syntax.InternalSyntax.SyntaxToken)semicolonToken.Node!).CreateRed();
+        return (ContinueStatementSyntax)Syntax.InternalSyntax.SyntaxFactory.ContinueStatement(attributeLists.Node.ToGreenList<Syntax.InternalSyntax.AttributeListSyntax>(), (Syntax.InternalSyntax.SyntaxToken)continueKeyword.Node!, name == null ? null : (Syntax.InternalSyntax.IdentifierNameSyntax)name.Green, (Syntax.InternalSyntax.SyntaxToken)semicolonToken.Node!).CreateRed();
     }
 
     /// <summary>Creates a new ContinueStatementSyntax instance.</summary>
-    public static ContinueStatementSyntax ContinueStatement(SyntaxList<AttributeListSyntax> attributeLists)
-        => SyntaxFactory.ContinueStatement(attributeLists, SyntaxFactory.Token(SyntaxKind.ContinueKeyword), SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+    public static ContinueStatementSyntax ContinueStatement(SyntaxList<AttributeListSyntax> attributeLists, IdentifierNameSyntax? name)
+        => SyntaxFactory.ContinueStatement(attributeLists, SyntaxFactory.Token(SyntaxKind.ContinueKeyword), name, SyntaxFactory.Token(SyntaxKind.SemicolonToken));
 
+#pragma warning disable RS0027
     /// <summary>Creates a new ContinueStatementSyntax instance.</summary>
-    public static ContinueStatementSyntax ContinueStatement()
-        => SyntaxFactory.ContinueStatement(default, SyntaxFactory.Token(SyntaxKind.ContinueKeyword), SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+    public static ContinueStatementSyntax ContinueStatement(IdentifierNameSyntax? name = default)
+        => SyntaxFactory.ContinueStatement(default, SyntaxFactory.Token(SyntaxKind.ContinueKeyword), name, SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+#pragma warning restore RS0027
 
     /// <summary>Creates a new ReturnStatementSyntax instance.</summary>
     public static ReturnStatementSyntax ReturnStatement(SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken returnKeyword, ExpressionSyntax? expression, SyntaxToken semicolonToken)

--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Syntax.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Syntax.Generated.cs
@@ -7163,6 +7163,7 @@ public sealed partial class GotoStatementSyntax : StatementSyntax
 public sealed partial class BreakStatementSyntax : StatementSyntax
 {
     private SyntaxNode? attributeLists;
+    private IdentifierNameSyntax? name;
 
     internal BreakStatementSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
       : base(green, parent, position)
@@ -7173,20 +7174,34 @@ public sealed partial class BreakStatementSyntax : StatementSyntax
 
     public SyntaxToken BreakKeyword => new SyntaxToken(this, ((InternalSyntax.BreakStatementSyntax)this.Green).breakKeyword, GetChildPosition(1), GetChildIndex(1));
 
-    public SyntaxToken SemicolonToken => new SyntaxToken(this, ((InternalSyntax.BreakStatementSyntax)this.Green).semicolonToken, GetChildPosition(2), GetChildIndex(2));
+    public IdentifierNameSyntax? Name => GetRed(ref this.name, 2);
 
-    internal override SyntaxNode? GetNodeSlot(int index) => index == 0 ? GetRedAtZero(ref this.attributeLists)! : null;
+    public SyntaxToken SemicolonToken => new SyntaxToken(this, ((InternalSyntax.BreakStatementSyntax)this.Green).semicolonToken, GetChildPosition(3), GetChildIndex(3));
 
-    internal override SyntaxNode? GetCachedSlot(int index) => index == 0 ? this.attributeLists : null;
+    internal override SyntaxNode? GetNodeSlot(int index)
+        => index switch
+        {
+            0 => GetRedAtZero(ref this.attributeLists)!,
+            2 => GetRed(ref this.name, 2),
+            _ => null,
+        };
+
+    internal override SyntaxNode? GetCachedSlot(int index)
+        => index switch
+        {
+            0 => this.attributeLists,
+            2 => this.name,
+            _ => null,
+        };
 
     public override void Accept(CSharpSyntaxVisitor visitor) => visitor.VisitBreakStatement(this);
     public override TResult? Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) where TResult : default => visitor.VisitBreakStatement(this);
 
-    public BreakStatementSyntax Update(SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken breakKeyword, SyntaxToken semicolonToken)
+    public BreakStatementSyntax Update(SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken breakKeyword, IdentifierNameSyntax? name, SyntaxToken semicolonToken)
     {
-        if (attributeLists != this.AttributeLists || breakKeyword != this.BreakKeyword || semicolonToken != this.SemicolonToken)
+        if (attributeLists != this.AttributeLists || breakKeyword != this.BreakKeyword || name != this.Name || semicolonToken != this.SemicolonToken)
         {
-            var newNode = SyntaxFactory.BreakStatement(attributeLists, breakKeyword, semicolonToken);
+            var newNode = SyntaxFactory.BreakStatement(attributeLists, breakKeyword, name, semicolonToken);
             var annotations = GetAnnotations();
             return annotations?.Length > 0 ? newNode.WithAnnotations(annotations) : newNode;
         }
@@ -7195,9 +7210,10 @@ public sealed partial class BreakStatementSyntax : StatementSyntax
     }
 
     internal override StatementSyntax WithAttributeListsCore(SyntaxList<AttributeListSyntax> attributeLists) => WithAttributeLists(attributeLists);
-    public new BreakStatementSyntax WithAttributeLists(SyntaxList<AttributeListSyntax> attributeLists) => Update(attributeLists, this.BreakKeyword, this.SemicolonToken);
-    public BreakStatementSyntax WithBreakKeyword(SyntaxToken breakKeyword) => Update(this.AttributeLists, breakKeyword, this.SemicolonToken);
-    public BreakStatementSyntax WithSemicolonToken(SyntaxToken semicolonToken) => Update(this.AttributeLists, this.BreakKeyword, semicolonToken);
+    public new BreakStatementSyntax WithAttributeLists(SyntaxList<AttributeListSyntax> attributeLists) => Update(attributeLists, this.BreakKeyword, this.Name, this.SemicolonToken);
+    public BreakStatementSyntax WithBreakKeyword(SyntaxToken breakKeyword) => Update(this.AttributeLists, breakKeyword, this.Name, this.SemicolonToken);
+    public BreakStatementSyntax WithName(IdentifierNameSyntax? name) => Update(this.AttributeLists, this.BreakKeyword, name, this.SemicolonToken);
+    public BreakStatementSyntax WithSemicolonToken(SyntaxToken semicolonToken) => Update(this.AttributeLists, this.BreakKeyword, this.Name, semicolonToken);
 
     internal override StatementSyntax AddAttributeListsCore(params AttributeListSyntax[] items) => AddAttributeLists(items);
     public new BreakStatementSyntax AddAttributeLists(params AttributeListSyntax[] items) => WithAttributeLists(this.AttributeLists.AddRange(items));
@@ -7212,6 +7228,7 @@ public sealed partial class BreakStatementSyntax : StatementSyntax
 public sealed partial class ContinueStatementSyntax : StatementSyntax
 {
     private SyntaxNode? attributeLists;
+    private IdentifierNameSyntax? name;
 
     internal ContinueStatementSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
       : base(green, parent, position)
@@ -7222,20 +7239,34 @@ public sealed partial class ContinueStatementSyntax : StatementSyntax
 
     public SyntaxToken ContinueKeyword => new SyntaxToken(this, ((InternalSyntax.ContinueStatementSyntax)this.Green).continueKeyword, GetChildPosition(1), GetChildIndex(1));
 
-    public SyntaxToken SemicolonToken => new SyntaxToken(this, ((InternalSyntax.ContinueStatementSyntax)this.Green).semicolonToken, GetChildPosition(2), GetChildIndex(2));
+    public IdentifierNameSyntax? Name => GetRed(ref this.name, 2);
 
-    internal override SyntaxNode? GetNodeSlot(int index) => index == 0 ? GetRedAtZero(ref this.attributeLists)! : null;
+    public SyntaxToken SemicolonToken => new SyntaxToken(this, ((InternalSyntax.ContinueStatementSyntax)this.Green).semicolonToken, GetChildPosition(3), GetChildIndex(3));
 
-    internal override SyntaxNode? GetCachedSlot(int index) => index == 0 ? this.attributeLists : null;
+    internal override SyntaxNode? GetNodeSlot(int index)
+        => index switch
+        {
+            0 => GetRedAtZero(ref this.attributeLists)!,
+            2 => GetRed(ref this.name, 2),
+            _ => null,
+        };
+
+    internal override SyntaxNode? GetCachedSlot(int index)
+        => index switch
+        {
+            0 => this.attributeLists,
+            2 => this.name,
+            _ => null,
+        };
 
     public override void Accept(CSharpSyntaxVisitor visitor) => visitor.VisitContinueStatement(this);
     public override TResult? Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) where TResult : default => visitor.VisitContinueStatement(this);
 
-    public ContinueStatementSyntax Update(SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken continueKeyword, SyntaxToken semicolonToken)
+    public ContinueStatementSyntax Update(SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken continueKeyword, IdentifierNameSyntax? name, SyntaxToken semicolonToken)
     {
-        if (attributeLists != this.AttributeLists || continueKeyword != this.ContinueKeyword || semicolonToken != this.SemicolonToken)
+        if (attributeLists != this.AttributeLists || continueKeyword != this.ContinueKeyword || name != this.Name || semicolonToken != this.SemicolonToken)
         {
-            var newNode = SyntaxFactory.ContinueStatement(attributeLists, continueKeyword, semicolonToken);
+            var newNode = SyntaxFactory.ContinueStatement(attributeLists, continueKeyword, name, semicolonToken);
             var annotations = GetAnnotations();
             return annotations?.Length > 0 ? newNode.WithAnnotations(annotations) : newNode;
         }
@@ -7244,9 +7275,10 @@ public sealed partial class ContinueStatementSyntax : StatementSyntax
     }
 
     internal override StatementSyntax WithAttributeListsCore(SyntaxList<AttributeListSyntax> attributeLists) => WithAttributeLists(attributeLists);
-    public new ContinueStatementSyntax WithAttributeLists(SyntaxList<AttributeListSyntax> attributeLists) => Update(attributeLists, this.ContinueKeyword, this.SemicolonToken);
-    public ContinueStatementSyntax WithContinueKeyword(SyntaxToken continueKeyword) => Update(this.AttributeLists, continueKeyword, this.SemicolonToken);
-    public ContinueStatementSyntax WithSemicolonToken(SyntaxToken semicolonToken) => Update(this.AttributeLists, this.ContinueKeyword, semicolonToken);
+    public new ContinueStatementSyntax WithAttributeLists(SyntaxList<AttributeListSyntax> attributeLists) => Update(attributeLists, this.ContinueKeyword, this.Name, this.SemicolonToken);
+    public ContinueStatementSyntax WithContinueKeyword(SyntaxToken continueKeyword) => Update(this.AttributeLists, continueKeyword, this.Name, this.SemicolonToken);
+    public ContinueStatementSyntax WithName(IdentifierNameSyntax? name) => Update(this.AttributeLists, this.ContinueKeyword, name, this.SemicolonToken);
+    public ContinueStatementSyntax WithSemicolonToken(SyntaxToken semicolonToken) => Update(this.AttributeLists, this.ContinueKeyword, this.Name, semicolonToken);
 
     internal override StatementSyntax AddAttributeListsCore(params AttributeListSyntax[] items) => AddAttributeLists(items);
     public new ContinueStatementSyntax AddAttributeLists(params AttributeListSyntax[] items) => WithAttributeLists(this.AttributeLists.AddRange(items));

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -9329,6 +9329,7 @@ done:
             return _syntaxFactory.BreakStatement(
                 attributes,
                 this.EatToken(SyntaxKind.BreakKeyword),
+                this.IsTrueIdentifier() ? this.ParseIdentifierName() : null,
                 this.EatToken(SyntaxKind.SemicolonToken));
         }
 
@@ -9337,6 +9338,7 @@ done:
             return _syntaxFactory.ContinueStatement(
                 attributes,
                 this.EatToken(SyntaxKind.ContinueKeyword),
+                this.IsTrueIdentifier() ? this.ParseIdentifierName() : null,
                 this.EatToken(SyntaxKind.SemicolonToken));
         }
 

--- a/src/Compilers/CSharp/Portable/Syntax/BreakStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/BreakStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class BreakStatementSyntax
     {
         public BreakStatementSyntax Update(SyntaxToken breakKeyword, SyntaxToken semicolonToken)
-            => Update(AttributeLists, breakKeyword, semicolonToken);
+            => Update(AttributeLists, breakKeyword, Name, semicolonToken);
     }
 }
 
@@ -18,6 +18,6 @@ namespace Microsoft.CodeAnalysis.CSharp
     public partial class SyntaxFactory
     {
         public static BreakStatementSyntax BreakStatement(SyntaxToken breakKeyword, SyntaxToken semicolonToken)
-            => BreakStatement(attributeLists: default, breakKeyword, semicolonToken);
+            => BreakStatement(attributeLists: default, breakKeyword, name: null, semicolonToken);
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/ContinueStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/ContinueStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class ContinueStatementSyntax
     {
         public ContinueStatementSyntax Update(SyntaxToken continueKeyword, SyntaxToken semicolonToken)
-            => Update(AttributeLists, continueKeyword, semicolonToken);
+            => Update(AttributeLists, continueKeyword, Name, semicolonToken);
     }
 }
 
@@ -18,6 +18,6 @@ namespace Microsoft.CodeAnalysis.CSharp
     public partial class SyntaxFactory
     {
         public static ContinueStatementSyntax ContinueStatement(SyntaxToken continueKeyword, SyntaxToken semicolonToken)
-            => ContinueStatement(attributeLists: default, continueKeyword, semicolonToken);
+            => ContinueStatement(attributeLists: default, continueKeyword, name: null, semicolonToken);
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -2468,6 +2468,7 @@
     <Field Name="BreakKeyword" Type="SyntaxToken">
       <Kind Name="BreakKeyword"/>
     </Field>
+    <Field Name="Name" Type="IdentifierNameSyntax" Optional="true"/>
     <Field Name="SemicolonToken" Type="SyntaxToken">
       <Kind Name="SemicolonToken"/>
     </Field>
@@ -2478,6 +2479,7 @@
     <Field Name="ContinueKeyword" Type="SyntaxToken">
       <Kind Name="ContinueKeyword"/>
     </Field>
+    <Field Name="Name" Type="IdentifierNameSyntax" Optional="true"/>
     <Field Name="SemicolonToken" Type="SyntaxToken">
       <Kind Name="SemicolonToken"/>
     </Field>

--- a/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
@@ -377,10 +377,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             => InternalSyntaxFactory.GotoStatement(SyntaxKind.GotoStatement, new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.AttributeListSyntax>(), InternalSyntaxFactory.Token(SyntaxKind.GotoKeyword), null, null, InternalSyntaxFactory.Token(SyntaxKind.SemicolonToken));
 
         private static Syntax.InternalSyntax.BreakStatementSyntax GenerateBreakStatement()
-            => InternalSyntaxFactory.BreakStatement(new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.AttributeListSyntax>(), InternalSyntaxFactory.Token(SyntaxKind.BreakKeyword), InternalSyntaxFactory.Token(SyntaxKind.SemicolonToken));
+            => InternalSyntaxFactory.BreakStatement(new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.AttributeListSyntax>(), InternalSyntaxFactory.Token(SyntaxKind.BreakKeyword), null, InternalSyntaxFactory.Token(SyntaxKind.SemicolonToken));
 
         private static Syntax.InternalSyntax.ContinueStatementSyntax GenerateContinueStatement()
-            => InternalSyntaxFactory.ContinueStatement(new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.AttributeListSyntax>(), InternalSyntaxFactory.Token(SyntaxKind.ContinueKeyword), InternalSyntaxFactory.Token(SyntaxKind.SemicolonToken));
+            => InternalSyntaxFactory.ContinueStatement(new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.AttributeListSyntax>(), InternalSyntaxFactory.Token(SyntaxKind.ContinueKeyword), null, InternalSyntaxFactory.Token(SyntaxKind.SemicolonToken));
 
         private static Syntax.InternalSyntax.ReturnStatementSyntax GenerateReturnStatement()
             => InternalSyntaxFactory.ReturnStatement(new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.AttributeListSyntax>(), InternalSyntaxFactory.Token(SyntaxKind.ReturnKeyword), null, InternalSyntaxFactory.Token(SyntaxKind.SemicolonToken));
@@ -2208,6 +2208,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(default, node.AttributeLists);
             Assert.Equal(SyntaxKind.BreakKeyword, node.BreakKeyword.Kind);
+            Assert.Null(node.Name);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SemicolonToken.Kind);
 
             AttachAndCheckDiagnostics(node);
@@ -2220,6 +2221,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(default, node.AttributeLists);
             Assert.Equal(SyntaxKind.ContinueKeyword, node.ContinueKeyword.Kind);
+            Assert.Null(node.Name);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SemicolonToken.Kind);
 
             AttachAndCheckDiagnostics(node);
@@ -10767,10 +10769,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             => SyntaxFactory.GotoStatement(SyntaxKind.GotoStatement, new SyntaxList<AttributeListSyntax>(), SyntaxFactory.Token(SyntaxKind.GotoKeyword), default(SyntaxToken), default(ExpressionSyntax), SyntaxFactory.Token(SyntaxKind.SemicolonToken));
 
         private static BreakStatementSyntax GenerateBreakStatement()
-            => SyntaxFactory.BreakStatement(new SyntaxList<AttributeListSyntax>(), SyntaxFactory.Token(SyntaxKind.BreakKeyword), SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+            => SyntaxFactory.BreakStatement(new SyntaxList<AttributeListSyntax>(), SyntaxFactory.Token(SyntaxKind.BreakKeyword), default(IdentifierNameSyntax), SyntaxFactory.Token(SyntaxKind.SemicolonToken));
 
         private static ContinueStatementSyntax GenerateContinueStatement()
-            => SyntaxFactory.ContinueStatement(new SyntaxList<AttributeListSyntax>(), SyntaxFactory.Token(SyntaxKind.ContinueKeyword), SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+            => SyntaxFactory.ContinueStatement(new SyntaxList<AttributeListSyntax>(), SyntaxFactory.Token(SyntaxKind.ContinueKeyword), default(IdentifierNameSyntax), SyntaxFactory.Token(SyntaxKind.SemicolonToken));
 
         private static ReturnStatementSyntax GenerateReturnStatement()
             => SyntaxFactory.ReturnStatement(new SyntaxList<AttributeListSyntax>(), SyntaxFactory.Token(SyntaxKind.ReturnKeyword), default(ExpressionSyntax), SyntaxFactory.Token(SyntaxKind.SemicolonToken));
@@ -12598,8 +12600,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(default, node.AttributeLists);
             Assert.Equal(SyntaxKind.BreakKeyword, node.BreakKeyword.Kind());
+            Assert.Null(node.Name);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SemicolonToken.Kind());
-            var newNode = node.WithAttributeLists(node.AttributeLists).WithBreakKeyword(node.BreakKeyword).WithSemicolonToken(node.SemicolonToken);
+            var newNode = node.WithAttributeLists(node.AttributeLists).WithBreakKeyword(node.BreakKeyword).WithName(node.Name).WithSemicolonToken(node.SemicolonToken);
             Assert.Equal(node, newNode);
         }
 
@@ -12610,8 +12613,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(default, node.AttributeLists);
             Assert.Equal(SyntaxKind.ContinueKeyword, node.ContinueKeyword.Kind());
+            Assert.Null(node.Name);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SemicolonToken.Kind());
-            var newNode = node.WithAttributeLists(node.AttributeLists).WithContinueKeyword(node.ContinueKeyword).WithSemicolonToken(node.SemicolonToken);
+            var newNode = node.WithAttributeLists(node.AttributeLists).WithContinueKeyword(node.ContinueKeyword).WithName(node.Name).WithSemicolonToken(node.SemicolonToken);
             Assert.Equal(node, newNode);
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LabeledBreakContinueParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LabeledBreakContinueParsingTests.cs
@@ -1,0 +1,1084 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests;
+
+public sealed class LabeledBreakContinueParsingTests : ParsingTests
+{
+    public LabeledBreakContinueParsingTests(ITestOutputHelper output) : base(output) { }
+
+    #region Valid labeled forms
+
+    [Fact]
+    public void LabeledBreak()
+    {
+        UsingStatement("break myLabel;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "myLabel");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void LabeledContinue()
+    {
+        UsingStatement("continue myLabel;");
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "myLabel");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void UnlabeledBreak()
+    {
+        UsingStatement("break;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void UnlabeledContinue()
+    {
+        UsingStatement("continue;");
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void LabeledBreak_EscapedKeyword()
+    {
+        UsingStatement("break @class;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "@class");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void LabeledContinue_EscapedKeyword()
+    {
+        UsingStatement("continue @while;");
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "@while");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    #endregion
+
+    #region Contextual keywords as labels
+
+    [Fact]
+    public void Break_AwaitAsLabel()
+    {
+        UsingStatement("break await;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "await");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Continue_AwaitAsLabel()
+    {
+        UsingStatement("continue await;");
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "await");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_AwaitAsLabel_InsideAsyncMethod()
+    {
+        UsingDeclaration("""
+            async void M()
+            {
+                while (true)
+                {
+                    break await;
+                }
+            }
+            """,
+            options: null,
+            // (5,15): error CS4003: 'await' cannot be used as an identifier within an async method or lambda expression
+            //             break await;
+            Diagnostic(ErrorCode.ERR_BadAwaitAsIdentifier, "await").WithLocation(5, 15));
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.AsyncKeyword);
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.VoidKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.Block);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.WhileStatement);
+                {
+                    N(SyntaxKind.WhileKeyword);
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.TrueLiteralExpression);
+                    {
+                        N(SyntaxKind.TrueKeyword);
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                    N(SyntaxKind.Block);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.BreakStatement);
+                        {
+                            N(SyntaxKind.BreakKeyword);
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "await");
+                            }
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_AsyncAsLabel()
+    {
+        UsingStatement("break async;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "async");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_VarAsLabel()
+    {
+        UsingStatement("break var;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "var");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_FieldAsLabel()
+    {
+        UsingStatement("break field;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "field");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_ValueAsLabel()
+    {
+        UsingStatement("break value;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "value");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [InlineData("yield")]
+    [InlineData("partial")]
+    [InlineData("from")]
+    [InlineData("group")]
+    [InlineData("join")]
+    [InlineData("into")]
+    [InlineData("let")]
+    [InlineData("by")]
+    [InlineData("where")]
+    [InlineData("select")]
+    [InlineData("get")]
+    [InlineData("set")]
+    [InlineData("add")]
+    [InlineData("remove")]
+    [InlineData("orderby")]
+    [InlineData("alias")]
+    [InlineData("on")]
+    [InlineData("equals")]
+    [InlineData("ascending")]
+    [InlineData("descending")]
+    [InlineData("assembly")]
+    [InlineData("module")]
+    [InlineData("type")]
+    [InlineData("global")]
+    [InlineData("method")]
+    [InlineData("param")]
+    [InlineData("property")]
+    [InlineData("typevar")]
+    [InlineData("nameof")]
+    [InlineData("when")]
+    [InlineData("or")]
+    [InlineData("and")]
+    [InlineData("not")]
+    [InlineData("with")]
+    [InlineData("init")]
+    [InlineData("record")]
+    [InlineData("managed")]
+    [InlineData("unmanaged")]
+    [InlineData("required")]
+    [InlineData("scoped")]
+    [InlineData("file")]
+    [InlineData("allows")]
+    [InlineData("extension")]
+    [InlineData("union")]
+    public void Break_ContextualKeywordAsLabel(string keyword)
+    {
+        UsingStatement($"break {keyword};");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, keyword);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [InlineData("yield")]
+    [InlineData("partial")]
+    [InlineData("from")]
+    [InlineData("group")]
+    [InlineData("join")]
+    [InlineData("into")]
+    [InlineData("let")]
+    [InlineData("by")]
+    [InlineData("where")]
+    [InlineData("select")]
+    [InlineData("get")]
+    [InlineData("set")]
+    [InlineData("add")]
+    [InlineData("remove")]
+    [InlineData("orderby")]
+    [InlineData("alias")]
+    [InlineData("on")]
+    [InlineData("equals")]
+    [InlineData("ascending")]
+    [InlineData("descending")]
+    [InlineData("assembly")]
+    [InlineData("module")]
+    [InlineData("type")]
+    [InlineData("global")]
+    [InlineData("method")]
+    [InlineData("param")]
+    [InlineData("property")]
+    [InlineData("typevar")]
+    [InlineData("nameof")]
+    [InlineData("when")]
+    [InlineData("or")]
+    [InlineData("and")]
+    [InlineData("not")]
+    [InlineData("with")]
+    [InlineData("init")]
+    [InlineData("record")]
+    [InlineData("managed")]
+    [InlineData("unmanaged")]
+    [InlineData("required")]
+    [InlineData("scoped")]
+    [InlineData("file")]
+    [InlineData("allows")]
+    [InlineData("extension")]
+    [InlineData("union")]
+    public void Continue_ContextualKeywordAsLabel(string keyword)
+    {
+        UsingStatement($"continue {keyword};");
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, keyword);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_YieldAsLabel_ConsumedAsLabel()
+    {
+        UsingStatement("break yield;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "yield");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_WhereAsLabel_NotGenericConstraintContext()
+    {
+        UsingStatement("break where;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "where");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_PartialAsLabel_NotPartialTypePosition()
+    {
+        UsingStatement("break partial;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "partial");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_FromAsLabel_NotInQuery()
+    {
+        UsingStatement("break from;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "from");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_DynamicAsLabel()
+    {
+        UsingStatement("break dynamic;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "dynamic");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void LabeledBreak_EscapedAwait()
+    {
+        UsingStatement("break @await;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "@await");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void LabeledBreak_EscapedVar()
+    {
+        UsingStatement("break @var;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "@var");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void LabeledContinue_EscapedYield()
+    {
+        UsingStatement("continue @yield;");
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "@yield");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    #endregion
+
+    #region Non-identifier tokens after break/continue
+
+    [Fact]
+    public void Break_NumericLiteral()
+    {
+        UsingStatement("break 0;",
+            // (1,1): error CS1073: Unexpected token '0'
+            // break 0;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break ").WithArguments("0").WithLocation(1, 1),
+            // (1,7): error CS1002: ; expected
+            // break 0;
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "0").WithLocation(1, 7));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Continue_NumericLiteral()
+    {
+        UsingStatement("continue 0;",
+            // (1,1): error CS1073: Unexpected token '0'
+            // continue 0;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "continue ").WithArguments("0").WithLocation(1, 1),
+            // (1,10): error CS1002: ; expected
+            // continue 0;
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "0").WithLocation(1, 10));
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_CaseKeyword()
+    {
+        UsingStatement("break case;",
+            // (1,1): error CS1073: Unexpected token 'case'
+            // break case;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break ").WithArguments("case").WithLocation(1, 1),
+            // (1,7): error CS1002: ; expected
+            // break case;
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "case").WithLocation(1, 7));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_ReturnKeyword()
+    {
+        UsingStatement("break return;",
+            // (1,1): error CS1073: Unexpected token 'return'
+            // break return;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break ").WithArguments("return").WithLocation(1, 1),
+            // (1,7): error CS1002: ; expected
+            // break return;
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "return").WithLocation(1, 7));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_IntKeyword()
+    {
+        UsingStatement("break int;",
+            // (1,1): error CS1073: Unexpected token 'int'
+            // break int;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break ").WithArguments("int").WithLocation(1, 1),
+            // (1,7): error CS1002: ; expected
+            // break int;
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "int").WithLocation(1, 7));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_BreakKeyword()
+    {
+        UsingStatement("break break a;",
+            // (1,1): error CS1073: Unexpected token 'break'
+            // break break a;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break ").WithArguments("break").WithLocation(1, 1),
+            // (1,7): error CS1002: ; expected
+            // break break a;
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "break").WithLocation(1, 7));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_ContinueKeyword()
+    {
+        UsingStatement("break continue a;",
+            // (1,1): error CS1073: Unexpected token 'continue'
+            // break continue a;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break ").WithArguments("continue").WithLocation(1, 1),
+            // (1,7): error CS1002: ; expected
+            // break continue a;
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "continue").WithLocation(1, 7));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Continue_ContinueKeyword()
+    {
+        UsingStatement("continue continue a;",
+            // (1,1): error CS1073: Unexpected token 'continue'
+            // continue continue a;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "continue ").WithArguments("continue").WithLocation(1, 1),
+            // (1,10): error CS1002: ; expected
+            // continue continue a;
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "continue").WithLocation(1, 10));
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Continue_BreakKeyword()
+    {
+        UsingStatement("continue break a;",
+            // (1,1): error CS1073: Unexpected token 'break'
+            // continue break a;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "continue ").WithArguments("break").WithLocation(1, 1),
+            // (1,10): error CS1002: ; expected
+            // continue break a;
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "break").WithLocation(1, 10));
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Continue_CaseKeyword()
+    {
+        UsingStatement("continue case;",
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "continue ").WithArguments("case").WithLocation(1, 1),
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "case").WithLocation(1, 10));
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Continue_ReturnKeyword()
+    {
+        UsingStatement("continue return;",
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "continue ").WithArguments("return").WithLocation(1, 1),
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "return").WithLocation(1, 10));
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Continue_IntKeyword()
+    {
+        UsingStatement("continue int;",
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "continue ").WithArguments("int").WithLocation(1, 1),
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "int").WithLocation(1, 10));
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_ThisKeyword()
+    {
+        UsingStatement("break this;",
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break ").WithArguments("this").WithLocation(1, 1),
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "this").WithLocation(1, 7));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_NullKeyword()
+    {
+        UsingStatement("break null;",
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break ").WithArguments("null").WithLocation(1, 1),
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "null").WithLocation(1, 7));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_TrueKeyword()
+    {
+        UsingStatement("break true;",
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break ").WithArguments("true").WithLocation(1, 1),
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "true").WithLocation(1, 7));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_FalseKeyword()
+    {
+        UsingStatement("break false;",
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break ").WithArguments("false").WithLocation(1, 1),
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "false").WithLocation(1, 7));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_ParenthesizedExpression()
+    {
+        UsingStatement("break (a);",
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break ").WithArguments("(").WithLocation(1, 1),
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "(").WithLocation(1, 7));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_StringLiteral()
+    {
+        UsingStatement("""break "label";""",
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break ").WithArguments(@"""label""").WithLocation(1, 1),
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, @"""label""").WithLocation(1, 7));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    #endregion
+
+    #region Expressions after break/continue (only simple identifier consumed)
+
+    [Fact]
+    public void Break_ExpressionNotConsumed()
+    {
+        UsingStatement("break a + b;",
+            // (1,1): error CS1073: Unexpected token '+'
+            // break a + b;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break a ").WithArguments("+").WithLocation(1, 1),
+            // (1,9): error CS1002: ; expected
+            // break a + b;
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "+").WithLocation(1, 9));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "a");
+            }
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Continue_ExpressionNotConsumed()
+    {
+        UsingStatement("continue a + b;",
+            // (1,1): error CS1073: Unexpected token '+'
+            // continue a + b;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "continue a ").WithArguments("+").WithLocation(1, 1),
+            // (1,12): error CS1002: ; expected
+            // continue a + b;
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "+").WithLocation(1, 12));
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "a");
+            }
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_DottedNameNotConsumed()
+    {
+        UsingStatement("break a.b;",
+            // (1,1): error CS1073: Unexpected token '.'
+            // break a.b;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break a").WithArguments(".").WithLocation(1, 1),
+            // (1,8): error CS1002: ; expected
+            // break a.b;
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, ".").WithLocation(1, 8));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "a");
+            }
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Continue_DottedNameNotConsumed()
+    {
+        UsingStatement("continue a.b;",
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "continue a").WithArguments(".").WithLocation(1, 1),
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, ".").WithLocation(1, 11));
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "a");
+            }
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Continue_DottedNameMultipleMembersNotConsumed()
+    {
+        UsingStatement("continue a.b.c;",
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "continue a").WithArguments(".").WithLocation(1, 1),
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, ".").WithLocation(1, 11));
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "a");
+            }
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_ExtraIdentifierAfterLabel()
+    {
+        UsingStatement("break a b;",
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break a ").WithArguments("b").WithLocation(1, 1),
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "b").WithLocation(1, 9));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "a");
+            }
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Continue_ExtraIdentifierAfterLabel()
+    {
+        UsingStatement("continue a b;",
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "continue a ").WithArguments("b").WithLocation(1, 1),
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "b").WithLocation(1, 12));
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "a");
+            }
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_LabelFollowedByOpenBrace()
+    {
+        UsingStatement("break a {",
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break a ").WithArguments("{").WithLocation(1, 1),
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "{").WithLocation(1, 9));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "a");
+            }
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    #endregion
+
+    #region Missing semicolon
+
+    [Fact]
+    public void LabeledBreak_MissingSemicolon()
+    {
+        UsingStatement("break myLabel",
+            // (1,14): error CS1002: ; expected
+            // break myLabel
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(1, 14));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "myLabel");
+            }
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void LabeledContinue_MissingSemicolon()
+    {
+        UsingStatement("continue myLabel",
+            // (1,17): error CS1002: ; expected
+            // continue myLabel
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(1, 17));
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "myLabel");
+            }
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    #endregion
+
+    #region yield break not affected
+
+    [Fact]
+    public void YieldBreak_NotAffected()
+    {
+        UsingStatement("yield break;");
+        N(SyntaxKind.YieldBreakStatement);
+        {
+            N(SyntaxKind.YieldKeyword);
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void YieldBreak_WithIdentifier()
+    {
+        // `yield break a;` still parses as YieldBreakStatement. The `a` is unconsumed.
+        UsingStatement("yield break a;",
+            // (1,1): error CS1073: Unexpected token 'a'
+            // yield break a;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "yield break ").WithArguments("a").WithLocation(1, 1),
+            // (1,13): error CS1002: ; expected
+            // yield break a;
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "a").WithLocation(1, 13));
+        N(SyntaxKind.YieldBreakStatement);
+        {
+            N(SyntaxKind.YieldKeyword);
+            N(SyntaxKind.BreakKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    #endregion
+
+    #region Language version agnostic
+
+    [Theory, CombinatorialData]
+    public void LabeledBreak_AllLanguageVersions(LanguageVersion version)
+    {
+        UsingStatement("break myLabel;", TestOptions.Regular.WithLanguageVersion(version));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "myLabel");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Theory, CombinatorialData]
+    public void LabeledContinue_AllLanguageVersions(LanguageVersion version)
+    {
+        UsingStatement("continue myLabel;", TestOptions.Regular.WithLanguageVersion(version));
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "myLabel");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Add the `break identifier;` and `continue identifier;` syntax shape to `BreakStatementSyntax` and `ContinueStatementSyntax` (new `Name` property of type `IdentifierNameSyntax?`).
- Update the parser to recognize the optional label identifier after `break`/`continue`.
- Gate behind `LanguageVersion.Preview`.
- Add comprehensive parsing tests covering valid syntax, error recovery, and contextual keyword handling.

## Test plan
- [x] `LabeledBreakContinueParsingTests` — valid syntax, error cases, contextual keywords
- [x] Build succeeds

> Part 1 of a stack implementing labeled break/continue for C#.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83196)