### PR TITLE
Allow creation of DocumentUri for uris System.Uri cannot parse

### DIFF
--- a/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -218,13 +218,24 @@ internal static partial class ProtocolConversions
     /// Converts an absolute local file path or an absolute URL string to <see cref="DocumentUri"/>.
     /// For use with callers (generally LSP) that require <see cref="DocumentUri"/>
     /// </summary>
-    /// <exception cref="UriFormatException">
-    /// The <paramref name="absolutePath"/> can't be represented as <see cref="Uri"/>.
-    /// For example, UNC paths with invalid characters in server name.
-    /// </exception>
+    /// <remarks>
+    /// Unlike <see cref="CreateAbsoluteUri"/>, this method gracefully handles paths that
+    /// <see cref="Uri"/> cannot parse (e.g., UNC paths with <c>$</c> in the server name).
+    /// In such cases, it falls back to manually constructing the URI string, which
+    /// <see cref="DocumentUri"/> stores without requiring <see cref="Uri"/> parsing.
+    /// </remarks>
     public static DocumentUri CreateAbsoluteDocumentUri(string absolutePath)
     {
-        return new(CreateAbsoluteUri(absolutePath));
+        try
+        {
+            return new(CreateAbsoluteUri(absolutePath));
+        }
+        catch (UriFormatException)
+        {
+            // System.Uri can't handle certain valid paths (e.g. UNC paths with $ in server name).
+            // Fall back to constructing the URI string manually.
+            return new(GetAbsoluteUriString(absolutePath));
+        }
     }
 
     internal static DocumentUri CreateRelativePatternBaseUri(string path)
@@ -240,7 +251,7 @@ internal static partial class ProtocolConversions
 
         Debug.Assert(!path.Split(System.IO.Path.DirectorySeparatorChar).Any(p => p == "." || p == ".."));
 
-        return new(CreateAbsoluteUri(path));
+        return CreateAbsoluteDocumentUri(path);
     }
 
     // Implements workaround for https://github.com/dotnet/runtime/issues/89538:

--- a/src/LanguageServer/ProtocolUnitTests/ProtocolConversionsTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/ProtocolConversionsTests.cs
@@ -136,6 +136,31 @@ public sealed class ProtocolConversionsTests : AbstractLanguageServerProtocolTes
         Assert.Equal(expectedUri, uri.GetRequiredParsedUri().AbsoluteUri);
     }
 
+    [ConditionalTheory(typeof(WindowsOnly))]
+    [InlineData(@"\\home$\share\path", @"file://home$/share/path")]
+    [InlineData(@"\\home$\share\path\", @"file://home$/share/path")]
+    public void CreateRelativePatternBaseUri_UncPathWithDollarSign_Windows(string filePath, string expectedUri)
+    {
+        // UNC paths with $ in the server name (e.g. admin shares) are valid Windows paths
+        // but System.Uri cannot parse them. We should still get a DocumentUri back with the
+        // correct URI string, even though System.Uri can't parse it.
+        var uri = ProtocolConversions.CreateRelativePatternBaseUri(filePath);
+        Assert.Equal(expectedUri, uri.UriString);
+        Assert.Null(uri.ParsedUri);
+    }
+
+    [ConditionalTheory(typeof(WindowsOnly))]
+    [InlineData(@"\\home$\share\path", @"file://home$/share/path")]
+    public void CreateAbsoluteDocumentUri_UncPathWithDollarSign_Windows(string filePath, string expectedUri)
+    {
+        // UNC paths with $ in the server name (e.g. admin shares) are valid Windows paths
+        // but System.Uri cannot parse them. We should still get a DocumentUri back with the
+        // correct URI string, even though System.Uri can't parse it.
+        var uri = ProtocolConversions.CreateAbsoluteDocumentUri(filePath);
+        Assert.Equal(expectedUri, uri.UriString);
+        Assert.Null(uri.ParsedUri);
+    }
+
     [ConditionalTheory(typeof(UnixLikeOnly))]
     [InlineData("/u", "file:///u")]
     [InlineData("/unix/", "file:///unix")]


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode-dotnettools/issues/2959

Caused by https://github.com/dotnet/runtime/issues/64707 (again)

We're trying to create file watchers on a URI that contains a `$` in the host name.  System.Uri does not allow this, but these are valid URIs
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83210)