### PR TITLE
Ensure we don't touch the remote host during new document formatting

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
@@ -230,11 +230,10 @@ internal abstract class AbstractEditorFactory(IComponentModel componentModel) : 
         if (((__EFNFLAGS)grfEFN & __EFNFLAGS.EFN_ClonedFromTemplate) != 0)
         {
             var uiThreadOperationExecutor = _componentModel.GetService<IUIThreadOperationExecutor>();
-            // TODO(cyrusn): Can this be cancellable?
             uiThreadOperationExecutor.Execute(
-                "Intellisense",
-                defaultDescription: "",
-                allowCancellation: false,
+                ServicesVSResources.Visual_Studio,
+                defaultDescription: ServicesVSResources.Formatting_new_document,
+                allowCancellation: true,
                 showProgress: false,
                 action: c => FormatDocumentCreatedFromTemplate(pHier, pszMkDocument, c.UserCancellationToken));
         }

--- a/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
@@ -282,7 +282,7 @@ internal abstract class AbstractEditorFactory(IComponentModel componentModel) : 
                 out pguidCmdUI);
     }
 
-    private async Task FormatDocumentCreatedFromTemplateAsync(IVsHierarchy hierarchy, string filePath, CancellationToken cancellationToken)
+    internal async Task FormatDocumentCreatedFromTemplateAsync(IVsHierarchy hierarchy, string filePath, CancellationToken cancellationToken)
     {
         // A file has been created on disk which the user added from the "Add Item" dialog. We need
         // to include this in a workspace to figure out the right options it should be formatted with.
@@ -338,7 +338,10 @@ internal abstract class AbstractEditorFactory(IComponentModel componentModel) : 
                 loader: fileLoader,
                 filePath: filePath));
 
-        var addedDocument = forkedSolution.GetRequiredDocument(documentId);
+        // Call WithFrozenPartialSemantics so we don't do expensive work here. Since this could be runnnig during the creation of a new solution or project, our OOP process
+        // might not be running yet. Expecting full semantics would mean we might need to synchronize everything OOP to run generators or other semantics, and that causes
+        // UI delays.
+        var addedDocument = forkedSolution.GetRequiredDocument(documentId).WithFrozenPartialSemantics(cancellationToken);
 
         var cleanupOptions = await addedDocument.GetCodeCleanupOptionsAsync(cancellationToken).ConfigureAwait(true);
 

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -158,15 +158,20 @@ internal abstract partial class VisualStudioWorkspaceImpl : VisualStudioWorkspac
 
         _updateUIContextJoinableTasks = new JoinableTaskCollection(_threadingContext.JoinableTaskContext);
 
-        // Set up our telemetry session and log an event for the version
-        var logDelta = _globalOptions.GetOption(DiagnosticOptionsStorage.LogTelemetryForBackgroundAnalyzerExecution);
-        var telemetryService = (VisualStudioWorkspaceTelemetryService)Services.GetRequiredService<IWorkspaceTelemetryService>();
-        telemetryService.InitializeTelemetrySession(TelemetryService.DefaultSession, logDelta);
+        InitializeTelemetrySession();
 
         Logger.Log(FunctionId.Run_Environment, KeyValueLogMessage.Create(
             static m => m["Version"] = FileVersionInfo.GetVersionInfo(typeof(VisualStudioWorkspace).Assembly.Location).FileVersion));
 
         SubscribeToSourceGeneratorImpactingEvents();
+    }
+
+    protected virtual void InitializeTelemetrySession()
+    {
+        // Set up our telemetry session and log an event for the version
+        var logDelta = _globalOptions.GetOption(DiagnosticOptionsStorage.LogTelemetryForBackgroundAnalyzerExecution);
+        var telemetryService = (VisualStudioWorkspaceTelemetryService)Services.GetRequiredService<IWorkspaceTelemetryService>();
+        telemetryService.InitializeTelemetrySession(TelemetryService.DefaultSession, logDelta);
     }
 
     private void SolutionClosingContext_UIContextChanged(object sender, UIContextChangedEventArgs e)

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1922,4 +1922,7 @@ Additional information: {1}</value>
   <data name="Show_Inheritance" xml:space="preserve">
     <value>Show Inheritance</value>
   </data>
+  <data name="Formatting_new_document" xml:space="preserve">
+    <value>Formatting new document...</value>
+  </data>
 </root>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -487,6 +487,11 @@
         <target state="translated">Formátovat dokument</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formatting_new_document">
+        <source>Formatting new document...</source>
+        <target state="new">Formatting new document...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_dot_editorconfig_file_from_settings">
         <source>Generate .editorconfig file from settings</source>
         <target state="translated">Generovat soubor .editorconfig z nastavení</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -487,6 +487,11 @@
         <target state="translated">Dokument formatieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formatting_new_document">
+        <source>Formatting new document...</source>
+        <target state="new">Formatting new document...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_dot_editorconfig_file_from_settings">
         <source>Generate .editorconfig file from settings</source>
         <target state="translated">EDITORCONFIG-Datei aus Einstellungen generieren</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -487,6 +487,11 @@
         <target state="translated">Dar formato al documento</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formatting_new_document">
+        <source>Formatting new document...</source>
+        <target state="new">Formatting new document...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_dot_editorconfig_file_from_settings">
         <source>Generate .editorconfig file from settings</source>
         <target state="translated">Generar archivo .editorconfig a partir de la configuración</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -487,6 +487,11 @@
         <target state="translated">Mettre en forme le document</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formatting_new_document">
+        <source>Formatting new document...</source>
+        <target state="new">Formatting new document...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_dot_editorconfig_file_from_settings">
         <source>Generate .editorconfig file from settings</source>
         <target state="translated">Générer le fichier .editorconfig à partir des paramètres</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -487,6 +487,11 @@
         <target state="translated">Formatta documento</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formatting_new_document">
+        <source>Formatting new document...</source>
+        <target state="new">Formatting new document...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_dot_editorconfig_file_from_settings">
         <source>Generate .editorconfig file from settings</source>
         <target state="translated">Genera file con estensione editorconfig dalle impostazioni</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -487,6 +487,11 @@
         <target state="translated">ドキュメントのフォーマット</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formatting_new_document">
+        <source>Formatting new document...</source>
+        <target state="new">Formatting new document...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_dot_editorconfig_file_from_settings">
         <source>Generate .editorconfig file from settings</source>
         <target state="translated">設定から .editorconfig ファイルを生成</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -487,6 +487,11 @@
         <target state="translated">문서 서식</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formatting_new_document">
+        <source>Formatting new document...</source>
+        <target state="new">Formatting new document...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_dot_editorconfig_file_from_settings">
         <source>Generate .editorconfig file from settings</source>
         <target state="translated">설정에서 .editorconfig 파일 생성</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -487,6 +487,11 @@
         <target state="translated">Formatuj dokument</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formatting_new_document">
+        <source>Formatting new document...</source>
+        <target state="new">Formatting new document...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_dot_editorconfig_file_from_settings">
         <source>Generate .editorconfig file from settings</source>
         <target state="translated">Wygeneruj plik .editorconfig na podstawie ustawień</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -487,6 +487,11 @@
         <target state="translated">Formatar o documento</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formatting_new_document">
+        <source>Formatting new document...</source>
+        <target state="new">Formatting new document...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_dot_editorconfig_file_from_settings">
         <source>Generate .editorconfig file from settings</source>
         <target state="translated">Gerar o arquivo .editorconfig das configurações</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -487,6 +487,11 @@
         <target state="translated">Форматировать документ</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formatting_new_document">
+        <source>Formatting new document...</source>
+        <target state="new">Formatting new document...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_dot_editorconfig_file_from_settings">
         <source>Generate .editorconfig file from settings</source>
         <target state="translated">Создать файл EDITORCONFIG на основе параметров</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -487,6 +487,11 @@
         <target state="translated">Belgeyi biçimlendir</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formatting_new_document">
+        <source>Formatting new document...</source>
+        <target state="new">Formatting new document...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_dot_editorconfig_file_from_settings">
         <source>Generate .editorconfig file from settings</source>
         <target state="translated">Ayarlardan .editorconfig dosyası oluştur</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -487,6 +487,11 @@
         <target state="translated">设置文档的格式</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formatting_new_document">
+        <source>Formatting new document...</source>
+        <target state="new">Formatting new document...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_dot_editorconfig_file_from_settings">
         <source>Generate .editorconfig file from settings</source>
         <target state="translated">基于设置生成 .editorconfig 文件</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -487,6 +487,11 @@
         <target state="translated">格式化文件</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formatting_new_document">
+        <source>Formatting new document...</source>
+        <target state="new">Formatting new document...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_dot_editorconfig_file_from_settings">
         <source>Generate .editorconfig file from settings</source>
         <target state="translated">從設定產生 .editorconfig 檔案</target>

--- a/src/VisualStudio/Core/Test.Next/EditorFactoryTests.cs
+++ b/src/VisualStudio/Core/Test.Next/EditorFactoryTests.cs
@@ -1,0 +1,86 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Composition;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Remote;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService;
+using Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel;
+using Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.Mocks;
+using Microsoft.VisualStudio.Shell.Interop;
+using Moq;
+using Roslyn.Test.Utilities;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Microsoft.VisualStudio.LanguageServices.UnitTests;
+
+[UseExportProvider]
+public sealed class EditorFactoryTests
+{
+    // Remove VisualStudioWorkspaceTelemetryService from the composition, since it tries to initialize the "telemetry" in the other process right away
+    private static readonly TestComposition s_composition =
+        CodeModelTestHelpers.Composition
+            .AddParts(typeof(ThrowingRemoteHostClientProvider));
+
+    [WpfFact]
+    public async Task FormatDocumentCreatedFromTemplateAsync_DoesNotRequestRemoteHostClient()
+    {
+        // This test asserts that we don't have a request for the RemoteHost when trying to format a newly created document.
+        // Since that can happen during the creation of a new solution, we can end up in cases where we are blocking the UI thread on the launch
+        // of the remote host where we're then blocking on the spinning up of an entire process.
+
+        using var tempRoot = new TempRoot();
+        var filePath = tempRoot.CreateFile("Test", "cs").Path;
+        var contents = """
+            class C
+            {
+                void M()
+                {
+                }
+            }
+            """.ReplaceLineEndings();
+
+        File.WriteAllText(filePath, contents);
+
+        var exportProvider = s_composition.ExportProviderFactory.CreateExportProvider();
+        using var workspace = exportProvider.GetExportedValue<MockVisualStudioWorkspace>();
+        var remoteHostClientProvider = (ThrowingRemoteHostClientProvider)workspace.Services.GetRequiredService<IRemoteHostClientProvider>();
+        var editorFactory = new CSharpEditorFactory(new MockComponentModel(exportProvider));
+
+        await editorFactory.FormatDocumentCreatedFromTemplateAsync(Mock.Of<IVsHierarchy>(), filePath, CancellationToken.None);
+
+        // Assert there were no requests that might have gotten caught by some other layer of the stack.
+        Assert.Empty(remoteHostClientProvider.StackTracesOfAttemptsToGetTheRemoteHost);
+    }
+
+    [ExportWorkspaceService(typeof(IRemoteHostClientProvider), WorkspaceKind.Host), Shared, PartNotDiscoverable]
+    [method: ImportingConstructor]
+    [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    private sealed class ThrowingRemoteHostClientProvider() : IRemoteHostClientProvider
+    {
+        private readonly ConcurrentBag<StackTrace> _stackTracesOfAttemptsToGetTheRemoteHost = new ConcurrentBag<StackTrace>();
+
+        public IEnumerable<StackTrace> StackTracesOfAttemptsToGetTheRemoteHost => _stackTracesOfAttemptsToGetTheRemoteHost;
+
+        public Task<RemoteHostClient?> TryGetRemoteHostClientAsync(CancellationToken cancellationToken)
+        {
+            // Keep track of all the places this gets called. This is done just to ensure we don't catch the failure somewhere and try to fall to an "in-process" path and run anwyays.
+            _stackTracesOfAttemptsToGetTheRemoteHost.Add(new StackTrace());
+            throw new XunitException("Unexpected attempt to request a remote host client while formatting a newly created document.");
+        }
+
+        public Task WaitForClientCreationAsync(CancellationToken cancellationToken)
+            => Task.CompletedTask;
+    }
+}

--- a/src/VisualStudio/TestUtilities2/CodeModel/Mocks/MockVisualStudioWorkspace.vb
+++ b/src/VisualStudio/TestUtilities2/CodeModel/Mocks/MockVisualStudioWorkspace.vb
@@ -38,6 +38,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.Mocks
             Me.Services.GetService(Of IWorkspaceEventListenerService)()
         End Sub
 
+        Protected Overrides Sub InitializeTelemetrySession()
+            ' Don't do anything in unit tests, since the telemetry wouldn't go anywhere anyways
+        End Sub
+
         Public Overrides Function CanApplyChange(feature As ApplyChangesKind) As Boolean
             Return _workspace.CanApplyChange(feature)
         End Function

--- a/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
+++ b/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
@@ -23,7 +23,6 @@ Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.CPS
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Legacy
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
 Imports Microsoft.VisualStudio.LanguageServices.TaskList
-Imports Microsoft.VisualStudio.LanguageServices.Telemetry
 Imports Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
 Imports Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 Imports Microsoft.VisualStudio.Shell.Interop
@@ -68,7 +67,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
                 GetType(MockWorkspaceEventListenerProvider),
                 GetType(HierarchyItemToProjectIdMap),
                 GetType(DiagnosticAnalyzerService),
-                GetType(VisualStudioWorkspaceTelemetryService),
                 GetType(OpenTextBufferProvider),
                 GetType(StubVsEditorAdaptersFactoryService),
                 GetType(ExternalErrorDiagnosticUpdateSource),
@@ -106,6 +104,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
             Public Sub New(exportProvider As Composition.ExportProvider)
                 MyBase.New(exportProvider,
                            exportProvider.GetExportedValue(Of MockServiceProvider))
+            End Sub
+
+            Protected Overrides Sub InitializeTelemetrySession()
+                ' Don't do anything in unit tests, since the telemetry wouldn't go anywhere anyways
             End Sub
 
             Public Overrides Sub DisplayReferencedSymbols(solution As Solution, referencedSymbols As IEnumerable(Of ReferencedSymbol))


### PR DESCRIPTION
When we create a new document, we run the formatter on the document to ensure that the new document matches any settings in the user's .editorconfig files. Ideally this is syntax-only manipulation and should be fast. It's critical that we don't accidentally touch any remote host services; this is blocking on the UI thread, and we don't want to be blocking on loading up our services in another process which can sometimes be slow.

Currently we were touching that service -- for example when we apply our formatter for adding or removing accessibilty modifiers, we fetch semantics for the document as a way to see what the default accessibilities are for symbols. Asking for semantics had the side effect of running source generators in our ServiceHub process, since the project may be freshly created and no request for semantics has happened yet so it's the "first time run". We could try rewriting that formatter and all the other  formatters to avoid the use of semantics entirely, but that adds a lot of extra complexity to deal with this case. Instead we can just freeze partial semantics for the file we're formatting, which also ensures we aren't spending a lot of time parsing other files in the new project as well.

I've written a test to ensure we don't regress this again; to make this test work I had to also change our VisualStudioWorkspace implementation in unit tests to not try initializing the telemetry service. That's not doing anything useful in unit tests anyways, so it was simple to override that behavior with a no-op.

While I was here, there was a TODO asking why we couldn't make this cancellable. Since we already have a threaded wait dialog up, I just made the change.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1540532