### PR TITLE
Allow cohost rename in Razor source-generated docs

### DIFF
--- a/src/LanguageServer/Protocol/Handler/Rename/RenameHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Rename/RenameHandler.cs
@@ -28,10 +28,12 @@ internal sealed class RenameHandler() : ILspServiceDocumentRequestHandler<LSP.Re
     public TextDocumentIdentifier GetTextDocumentIdentifier(RenameParams request) => request.TextDocument;
 
     public Task<WorkspaceEdit?> HandleRequestAsync(RenameParams request, RequestContext context, CancellationToken cancellationToken)
-        => GetRenameEditAsync(context.GetRequiredDocument(), ProtocolConversions.PositionToLinePosition(request.Position), request.NewName, cancellationToken);
-
-    internal static async Task<WorkspaceEdit?> GetRenameEditAsync(Document document, LinePosition linePosition, string newName, CancellationToken cancellationToken)
-        => await GetRenameEditAsync(document, linePosition, newName, allowRenamesInRazorSourceGeneratedDocuments: false, cancellationToken).ConfigureAwait(false);
+        => GetRenameEditAsync(
+            context.GetRequiredDocument(),
+            ProtocolConversions.PositionToLinePosition(request.Position),
+            request.NewName,
+            allowRenamesInRazorSourceGeneratedDocuments: false,
+            cancellationToken);
 
     internal static async Task<WorkspaceEdit?> GetRenameEditAsync(Document document, LinePosition linePosition, string newName, bool allowRenamesInRazorSourceGeneratedDocuments, CancellationToken cancellationToken)
     {

--- a/src/LanguageServer/Protocol/Handler/Rename/RenameHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Rename/RenameHandler.cs
@@ -31,6 +31,9 @@ internal sealed class RenameHandler() : ILspServiceDocumentRequestHandler<LSP.Re
         => GetRenameEditAsync(context.GetRequiredDocument(), ProtocolConversions.PositionToLinePosition(request.Position), request.NewName, cancellationToken);
 
     internal static async Task<WorkspaceEdit?> GetRenameEditAsync(Document document, LinePosition linePosition, string newName, CancellationToken cancellationToken)
+        => await GetRenameEditAsync(document, linePosition, newName, allowRenamesInRazorSourceGeneratedDocuments: false, cancellationToken).ConfigureAwait(false);
+
+    internal static async Task<WorkspaceEdit?> GetRenameEditAsync(Document document, LinePosition linePosition, string newName, bool allowRenamesInRazorSourceGeneratedDocuments, CancellationToken cancellationToken)
     {
         var oldSolution = document.Project.Solution;
         var position = await document.GetPositionFromLinePositionAsync(linePosition, cancellationToken).ConfigureAwait(false);
@@ -50,6 +53,7 @@ internal sealed class RenameHandler() : ILspServiceDocumentRequestHandler<LSP.Re
             oldSolution,
             symbolicRenameInfo.Symbol,
             options,
+            allowRenamesInRazorSourceGeneratedDocuments,
             cancellationToken).ConfigureAwait(false);
 
         var renameReplacementInfo = await renameLocationSet.ResolveConflictsAsync(

--- a/src/LanguageServer/ProtocolUnitTests/Rename/RenameTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Rename/RenameTests.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
@@ -338,6 +339,65 @@ public sealed class RenameTests(ITestOutputHelper testOutputHelper) : AbstractLa
         var results = await RunRenameAsync(testLspServer, CreateRenameParams(renameLocation, renameValue));
         AssertJsonEquals(expectedEdits, ((TextDocumentEdit[])results.DocumentChanges).SelectMany(e => e.Edits));
 
+        Assert.False(service.DidMapEdits);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestRename_WithRazorSourceGeneratedFile_NoMappingService_AllowRazorSourceGeneratedDocuments(bool mutatingLspWorkspace)
+    {
+        var generatedMarkup = """
+            class B
+            {
+                void M()
+                {
+                    new A().{|renamed:M|}();
+
+                    var a = new A();
+                    a.{|renamed:M|}();
+                }
+            }
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync("""
+            public class A
+            {
+                public void {|caret:|}{|renamed:M|}()
+                {
+                }
+
+                void M2()
+                {
+                    {|renamed:M|}()
+                }
+            }
+            """, mutatingLspWorkspace);
+
+        TestFileMarkupParser.GetSpans(generatedMarkup, out var generatedCode, out ImmutableDictionary<string, ImmutableArray<TextSpan>> spans);
+        var generatedSourceText = SourceText.From(generatedCode);
+
+        var razorGenerator = new Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator((c) => c.AddSource("generated_file.cs", generatedCode));
+        var workspace = testLspServer.TestWorkspace;
+        var project = workspace.CurrentSolution.Projects.First().AddAnalyzerReference(new TestGeneratorReference(razorGenerator));
+        workspace.TryApplyChanges(project.Solution);
+
+        var document = workspace.CurrentSolution.Projects.First().Documents.First();
+
+        var service = Assert.IsType<TestSourceGeneratedDocumentSpanMappingService>(workspace.Services.GetService<ISourceGeneratedDocumentSpanMappingService>());
+        service.Enabled = false;
+
+        var renameLocation = testLspServer.GetLocations("caret").First();
+        var renameValue = "RENAME";
+        var expectedEdits = testLspServer.GetLocations("renamed").Select(location => new LSP.TextEdit() { NewText = renameValue, Range = location.Range });
+        var expectedGeneratedEdits = spans["renamed"].Select(span => new LSP.TextEdit() { NewText = renameValue, Range = ProtocolConversions.TextSpanToRange(span, generatedSourceText) });
+
+        var results = await RenameHandler.GetRenameEditAsync(
+            document,
+            ProtocolConversions.PositionToLinePosition(renameLocation.Range.Start),
+            renameValue,
+            allowRenamesInRazorSourceGeneratedDocuments: true,
+            CancellationToken.None);
+
+        Assert.NotNull(results);
+        AssertJsonEquals(expectedEdits.Concat(expectedGeneratedEdits), ((TextDocumentEdit[])results.DocumentChanges).SelectMany(e => e.Edits));
         Assert.False(service.DidMapEdits);
     }
 

--- a/src/Tools/ExternalAccess/Razor/Features/Cohost/Handlers/Rename.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/Cohost/Handlers/Rename.cs
@@ -16,5 +16,5 @@ internal static class Rename
         => PrepareRenameHandler.GetRenameRangeAsync(document, linePosition, cancellationToken);
 
     public static Task<WorkspaceEdit?> GetRenameEditAsync(Document document, LinePosition linePosition, string newName, CancellationToken cancellationToken)
-        => RenameHandler.GetRenameEditAsync(document, linePosition, newName, cancellationToken);
+        => RenameHandler.GetRenameEditAsync(document, linePosition, newName, allowRenamesInRazorSourceGeneratedDocuments: true, cancellationToken);
 }

--- a/src/Workspaces/Core/Portable/Rename/IRemoteRenamerService.cs
+++ b/src/Workspaces/Core/Portable/Rename/IRemoteRenamerService.cs
@@ -34,6 +34,7 @@ internal interface IRemoteRenamerService
         Checksum solutionChecksum,
         SerializableSymbolAndProjectId symbolAndProjectId,
         SymbolRenameOptions options,
+        bool allowRenamesInRazorSourceGeneratedDocuments,
         CancellationToken cancellationToken);
 
     ValueTask<SerializableConflictResolution?> ResolveConflictsAsync(

--- a/src/Workspaces/Core/Portable/Rename/LightweightRenameLocations.cs
+++ b/src/Workspaces/Core/Portable/Rename/LightweightRenameLocations.cs
@@ -71,6 +71,14 @@ internal sealed partial class LightweightRenameLocations
     /// </summary>
     public static async Task<LightweightRenameLocations> FindRenameLocationsAsync(
         ISymbol symbol, Solution solution, SymbolRenameOptions options, CancellationToken cancellationToken)
+        => await FindRenameLocationsAsync(symbol, solution, options, allowRenamesInRazorSourceGeneratedDocuments: false, cancellationToken).ConfigureAwait(false);
+
+    public static async Task<LightweightRenameLocations> FindRenameLocationsAsync(
+        ISymbol symbol,
+        Solution solution,
+        SymbolRenameOptions options,
+        bool allowRenamesInRazorSourceGeneratedDocuments,
+        CancellationToken cancellationToken)
     {
         Contract.ThrowIfNull(solution);
         Contract.ThrowIfNull(symbol);
@@ -86,7 +94,7 @@ internal sealed partial class LightweightRenameLocations
                 {
                     var result = await client.TryInvokeAsync<IRemoteRenamerService, SerializableRenameLocations?>(
                         solution,
-                        (service, solutionInfo, cancellationToken) => service.FindRenameLocationsAsync(solutionInfo, serializedSymbol, options, cancellationToken),
+                        (service, solutionInfo, cancellationToken) => service.FindRenameLocationsAsync(solutionInfo, serializedSymbol, options, allowRenamesInRazorSourceGeneratedDocuments, cancellationToken),
                         cancellationToken).ConfigureAwait(false);
 
                     if (result.HasValue && result.Value != null)
@@ -106,7 +114,7 @@ internal sealed partial class LightweightRenameLocations
 
         // Couldn't effectively search in OOP. Perform the search in-proc.
         var renameLocations = await SymbolicRenameLocations.FindLocationsInCurrentProcessAsync(
-            symbol, solution, options, cancellationToken).ConfigureAwait(false);
+            symbol, solution, options, allowRenamesInRazorSourceGeneratedDocuments, cancellationToken).ConfigureAwait(false);
 
         return new LightweightRenameLocations(
             solution, options, renameLocations.Locations,

--- a/src/Workspaces/Core/Portable/Rename/Renamer.cs
+++ b/src/Workspaces/Core/Portable/Rename/Renamer.cs
@@ -135,9 +135,17 @@ public static partial class Renamer
             options);
     }
 
-    /// <inheritdoc cref="LightweightRenameLocations.FindRenameLocationsAsync"/>
+    /// <inheritdoc cref="LightweightRenameLocations.FindRenameLocationsAsync(ISymbol, Solution, SymbolRenameOptions, CancellationToken)"/>
     internal static Task<LightweightRenameLocations> FindRenameLocationsAsync(Solution solution, ISymbol symbol, SymbolRenameOptions options, CancellationToken cancellationToken)
-        => LightweightRenameLocations.FindRenameLocationsAsync(symbol, solution, options, cancellationToken);
+        => FindRenameLocationsAsync(solution, symbol, options, allowRenamesInRazorSourceGeneratedDocuments: false, cancellationToken);
+
+    internal static Task<LightweightRenameLocations> FindRenameLocationsAsync(
+        Solution solution,
+        ISymbol symbol,
+        SymbolRenameOptions options,
+        bool allowRenamesInRazorSourceGeneratedDocuments,
+        CancellationToken cancellationToken)
+        => LightweightRenameLocations.FindRenameLocationsAsync(symbol, solution, options, allowRenamesInRazorSourceGeneratedDocuments, cancellationToken);
 
     internal static async Task<ConflictResolution> RenameSymbolAsync(
         Solution solution,

--- a/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.ReferenceProcessing.cs
+++ b/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.ReferenceProcessing.cs
@@ -238,8 +238,8 @@ internal sealed partial class SymbolicRenameLocations
                 // have cascaded to this symbol from our original source symbol, and the generator will update this file
                 // based on the renamed symbol. Razor source generated documents are an exception - cohost rename can opt
                 // into including them even when the span mapping service is unavailable.
-                if (document is SourceGeneratedDocument &&
-                    !ShouldIncludeSourceGeneratedDocument(document, allowRenamesInRazorSourceGeneratedDocuments))
+                if (document is SourceGeneratedDocument sourceGeneratedDocument &&
+                    !ShouldIncludeSourceGeneratedDocument(sourceGeneratedDocument, allowRenamesInRazorSourceGeneratedDocuments))
                 {
                     return;
                 }
@@ -254,8 +254,8 @@ internal sealed partial class SymbolicRenameLocations
             // We won't try to update references in source generated files; we'll assume the generator will rerun
             // and produce an updated document with the new name. Razor source generated documents are an exception -
             // cohost rename can opt into including them even when the span mapping service is unavailable.
-            if (location.Document is SourceGeneratedDocument &&
-                !ShouldIncludeSourceGeneratedDocument(location.Document, allowRenamesInRazorSourceGeneratedDocuments))
+            if (location.Document is SourceGeneratedDocument sourceGeneratedDocument &&
+                !ShouldIncludeSourceGeneratedDocument(sourceGeneratedDocument, allowRenamesInRazorSourceGeneratedDocuments))
             {
                 return [];
             }
@@ -444,17 +444,19 @@ internal sealed partial class SymbolicRenameLocations
         }
 
         private static bool ShouldIncludeSourceGeneratedDocument(
-            Document document,
+            SourceGeneratedDocument document,
             bool allowRenamesInRazorSourceGeneratedDocuments)
         {
+            // Razor will call us with this flag set at times where the mapping service isn't available, because
+            // it will do the mapping once it has the results from us. If the rename didn't originate from Razor,
+            // then we only want to include the document if the mapping service is available.
             if (allowRenamesInRazorSourceGeneratedDocuments && document.IsRazorSourceGeneratedDocument())
             {
                 return true;
             }
 
-            return document is SourceGeneratedDocument sourceGeneratedDocument
-                && document.Project.Solution.Services.GetService<ISourceGeneratedDocumentSpanMappingService>() is { } mappingService
-                && mappingService.CanMapSpans(sourceGeneratedDocument);
+            return document.Project.Solution.Services.GetService<ISourceGeneratedDocumentSpanMappingService>() is { } mappingService
+                && mappingService.CanMapSpans(document);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.ReferenceProcessing.cs
+++ b/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.ReferenceProcessing.cs
@@ -238,8 +238,13 @@ internal sealed partial class SymbolicRenameLocations
                 // have cascaded to this symbol from our original source symbol, and the generator will update this file
                 // based on the renamed symbol. Razor source generated documents are an exception - cohost rename can opt
                 // into including them even when the span mapping service is unavailable.
-                if (ShouldIncludeSourceGeneratedDocument(solution, document, allowRenamesInRazorSourceGeneratedDocuments))
-                    results.Add(new RenameLocation(location, document.Id, isRenamableAccessor: isRenamableAccessor));
+                if (document is SourceGeneratedDocument &&
+                    !ShouldIncludeSourceGeneratedDocument(document, allowRenamesInRazorSourceGeneratedDocuments))
+                {
+                    return;
+                }
+
+                results.Add(new RenameLocation(location, document.Id, isRenamableAccessor: isRenamableAccessor));
             }
         }
 
@@ -249,8 +254,11 @@ internal sealed partial class SymbolicRenameLocations
             // We won't try to update references in source generated files; we'll assume the generator will rerun
             // and produce an updated document with the new name. Razor source generated documents are an exception -
             // cohost rename can opt into including them even when the span mapping service is unavailable.
-            if (!ShouldIncludeSourceGeneratedDocument(solution, location.Document, allowRenamesInRazorSourceGeneratedDocuments))
+            if (location.Document is SourceGeneratedDocument &&
+                !ShouldIncludeSourceGeneratedDocument(location.Document, allowRenamesInRazorSourceGeneratedDocuments))
+            {
                 return [];
+            }
 
             var shouldIncludeSymbol = await ShouldIncludeSymbolAsync(referencedSymbol, originalSymbol, solution, true, cancellationToken).ConfigureAwait(false);
             if (!shouldIncludeSymbol)
@@ -435,25 +443,11 @@ internal sealed partial class SymbolicRenameLocations
             }
         }
 
-        private static bool CanMapSourceGeneratedDocument(Solution solution, Document document)
-        {
-            return document is SourceGeneratedDocument sourceGeneratedDocument
-                && solution.Services.GetService<ISourceGeneratedDocumentSpanMappingService>() is { } mappingService
-                && mappingService.CanMapSpans(sourceGeneratedDocument);
-        }
-
         private static bool ShouldIncludeSourceGeneratedDocument(
-            Solution solution,
             Document document,
             bool allowRenamesInRazorSourceGeneratedDocuments)
         {
-            if (document is not SourceGeneratedDocument)
-            {
-                return true;
-            }
-
-            return (allowRenamesInRazorSourceGeneratedDocuments && document.IsRazorSourceGeneratedDocument())
-                || CanMapSourceGeneratedDocument(solution, document);
+            return allowRenamesInRazorSourceGeneratedDocuments && document.IsRazorSourceGeneratedDocument();
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.ReferenceProcessing.cs
+++ b/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.ReferenceProcessing.cs
@@ -159,7 +159,7 @@ internal sealed partial class SymbolicRenameLocations
         /// Given a ISymbol, returns the renameable locations for a given symbol.
         /// </summary>
         public static async Task<ImmutableArray<RenameLocation>> GetRenamableDefinitionLocationsAsync(
-            ISymbol referencedSymbol, ISymbol originalSymbol, Solution solution, CancellationToken cancellationToken)
+            ISymbol referencedSymbol, ISymbol originalSymbol, Solution solution, bool allowRenamesInRazorSourceGeneratedDocuments, CancellationToken cancellationToken)
         {
             var shouldIncludeSymbol = await ShouldIncludeSymbolAsync(referencedSymbol, originalSymbol, solution, false, cancellationToken).ConfigureAwait(false);
             if (!shouldIncludeSymbol)
@@ -236,20 +236,20 @@ internal sealed partial class SymbolicRenameLocations
 
                 // If the location is in a source generated file, we won't rename it. Our assumption in this case is we
                 // have cascaded to this symbol from our original source symbol, and the generator will update this file
-                // based on the renamed symbol. Razor source generated documents are an exception - we include them only
-                // when a span mapping service is available to map edits back to the original .razor files.
-                if (document is not SourceGeneratedDocument || CanMapSourceGeneratedDocument(solution, document))
+                // based on the renamed symbol. Razor source generated documents are an exception - cohost rename can opt
+                // into including them even when the span mapping service is unavailable.
+                if (ShouldIncludeSourceGeneratedDocument(solution, document, allowRenamesInRazorSourceGeneratedDocuments))
                     results.Add(new RenameLocation(location, document.Id, isRenamableAccessor: isRenamableAccessor));
             }
         }
 
         internal static async Task<IEnumerable<RenameLocation>> GetRenamableReferenceLocationsAsync(
-            ISymbol referencedSymbol, ISymbol originalSymbol, ReferenceLocation location, Solution solution, CancellationToken cancellationToken)
+            ISymbol referencedSymbol, ISymbol originalSymbol, ReferenceLocation location, Solution solution, bool allowRenamesInRazorSourceGeneratedDocuments, CancellationToken cancellationToken)
         {
             // We won't try to update references in source generated files; we'll assume the generator will rerun
             // and produce an updated document with the new name. Razor source generated documents are an exception -
-            // we include them only when a span mapping service is available to map edits back to the original files.
-            if (location.Document is SourceGeneratedDocument && !CanMapSourceGeneratedDocument(solution, location.Document))
+            // cohost rename can opt into including them even when the span mapping service is unavailable.
+            if (!ShouldIncludeSourceGeneratedDocument(solution, location.Document, allowRenamesInRazorSourceGeneratedDocuments))
                 return [];
 
             var shouldIncludeSymbol = await ShouldIncludeSymbolAsync(referencedSymbol, originalSymbol, solution, true, cancellationToken).ConfigureAwait(false);
@@ -440,6 +440,20 @@ internal sealed partial class SymbolicRenameLocations
             return document is SourceGeneratedDocument sourceGeneratedDocument
                 && solution.Services.GetService<ISourceGeneratedDocumentSpanMappingService>() is { } mappingService
                 && mappingService.CanMapSpans(sourceGeneratedDocument);
+        }
+
+        private static bool ShouldIncludeSourceGeneratedDocument(
+            Solution solution,
+            Document document,
+            bool allowRenamesInRazorSourceGeneratedDocuments)
+        {
+            if (document is not SourceGeneratedDocument)
+            {
+                return true;
+            }
+
+            return (allowRenamesInRazorSourceGeneratedDocuments && document.IsRazorSourceGeneratedDocument())
+                || CanMapSourceGeneratedDocument(solution, document);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.ReferenceProcessing.cs
+++ b/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.ReferenceProcessing.cs
@@ -447,7 +447,14 @@ internal sealed partial class SymbolicRenameLocations
             Document document,
             bool allowRenamesInRazorSourceGeneratedDocuments)
         {
-            return allowRenamesInRazorSourceGeneratedDocuments && document.IsRazorSourceGeneratedDocument();
+            if (allowRenamesInRazorSourceGeneratedDocuments && document.IsRazorSourceGeneratedDocument())
+            {
+                return true;
+            }
+
+            return document is SourceGeneratedDocument sourceGeneratedDocument
+                && document.Project.Solution.Services.GetService<ISourceGeneratedDocumentSpanMappingService>() is { } mappingService
+                && mappingService.CanMapSpans(sourceGeneratedDocument);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.cs
+++ b/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.cs
@@ -56,6 +56,14 @@ internal sealed partial class SymbolicRenameLocations
     /// </summary>
     public static async Task<SymbolicRenameLocations> FindLocationsInCurrentProcessAsync(
         ISymbol symbol, Solution solution, SymbolRenameOptions options, CancellationToken cancellationToken)
+        => await FindLocationsInCurrentProcessAsync(symbol, solution, options, allowRenamesInRazorSourceGeneratedDocuments: false, cancellationToken).ConfigureAwait(false);
+
+    public static async Task<SymbolicRenameLocations> FindLocationsInCurrentProcessAsync(
+        ISymbol symbol,
+        Solution solution,
+        SymbolRenameOptions options,
+        bool allowRenamesInRazorSourceGeneratedDocuments,
+        CancellationToken cancellationToken)
     {
         Contract.ThrowIfNull(symbol);
         using (Logger.LogBlock(FunctionId.Rename_AllRenameLocations, cancellationToken))
@@ -63,7 +71,7 @@ internal sealed partial class SymbolicRenameLocations
             symbol = await RenameUtilities.FindDefinitionSymbolAsync(symbol, solution, cancellationToken).ConfigureAwait(false);
 
             // First, find the direct references just to the symbol being renamed.
-            var originalSymbolResult = await AddLocationsReferenceSymbolsAsync(symbol, solution, cancellationToken).ConfigureAwait(false);
+            var originalSymbolResult = await AddLocationsReferenceSymbolsAsync(symbol, solution, allowRenamesInRazorSourceGeneratedDocuments, cancellationToken).ConfigureAwait(false);
 
             // Next, find references to overloads, if the user has asked to rename those as well.
             var overloadsResult = options.RenameOverloads ? await GetOverloadsAsync(symbol, solution, cancellationToken).ConfigureAwait(false) :
@@ -116,7 +124,7 @@ internal sealed partial class SymbolicRenameLocations
         using var _ = ArrayBuilder<SearchResult>.GetInstance(out var overloadsResult);
 
         foreach (var overloadedSymbol in RenameUtilities.GetOverloadedSymbols(symbol))
-            overloadsResult.Add(await AddLocationsReferenceSymbolsAsync(overloadedSymbol, solution, cancellationToken).ConfigureAwait(false));
+            overloadsResult.Add(await AddLocationsReferenceSymbolsAsync(overloadedSymbol, solution, allowRenamesInRazorSourceGeneratedDocuments: false, cancellationToken).ConfigureAwait(false));
 
         return overloadsResult.ToImmutableAndClear();
     }
@@ -124,6 +132,7 @@ internal sealed partial class SymbolicRenameLocations
     private static async Task<SearchResult> AddLocationsReferenceSymbolsAsync(
         ISymbol symbol,
         Solution solution,
+        bool allowRenamesInRazorSourceGeneratedDocuments,
         CancellationToken cancellationToken)
     {
         var locations = ImmutableHashSet.CreateBuilder<RenameLocation>();
@@ -133,12 +142,12 @@ internal sealed partial class SymbolicRenameLocations
         foreach (var referencedSymbol in referenceSymbols)
         {
             locations.AddAll(
-                await ReferenceProcessing.GetRenamableDefinitionLocationsAsync(referencedSymbol.Definition, symbol, solution, cancellationToken).ConfigureAwait(false));
+                await ReferenceProcessing.GetRenamableDefinitionLocationsAsync(referencedSymbol.Definition, symbol, solution, allowRenamesInRazorSourceGeneratedDocuments, cancellationToken).ConfigureAwait(false));
 
             locations.AddAll(
                 await referencedSymbol.Locations.SelectManyInParallelAsync(
                     (l, c) => ReferenceProcessing.GetRenamableReferenceLocationsAsync(
-                        referencedSymbol.Definition, symbol, l, solution, c),
+                        referencedSymbol.Definition, symbol, l, solution, allowRenamesInRazorSourceGeneratedDocuments, c),
                     cancellationToken).ConfigureAwait(false));
         }
 

--- a/src/Workspaces/Remote/ServiceHub/Services/Renamer/RemoteRenamerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/Renamer/RemoteRenamerService.cs
@@ -45,6 +45,7 @@ internal sealed partial class RemoteRenamerService(in BrokeredServiceBase.Servic
         Checksum solutionChecksum,
         SerializableSymbolAndProjectId symbolAndProjectId,
         SymbolRenameOptions options,
+        bool allowRenamesInRazorSourceGeneratedDocuments,
         CancellationToken cancellationToken)
     {
         return RunServiceAsync(solutionChecksum, async solution =>
@@ -56,7 +57,7 @@ internal sealed partial class RemoteRenamerService(in BrokeredServiceBase.Servic
                 return null;
 
             var renameLocations = await SymbolicRenameLocations.FindLocationsInCurrentProcessAsync(
-                symbol, solution, options, cancellationToken).ConfigureAwait(false);
+                symbol, solution, options, allowRenamesInRazorSourceGeneratedDocuments, cancellationToken).ConfigureAwait(false);
 
             return new SerializableRenameLocations(
                 options,


### PR DESCRIPTION
This is an alternate to https://github.com/dotnet/roslyn/pull/83080 which broke Razor rename, so should fix https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2943480 (and our future unit test runs, and our integration tests 🙂)


## Summary
- add an internal cohost-only rename flag from `RenameHandler` through Roslyn rename location discovery
- allow cohost rename to include Razor source-generated documents even when `CanMapSpans` is false
- preserve the default LSP rename behavior when the mapping service is unavailable
- add Roslyn rename tests covering both the default and cohost-opt-in paths

## Testing
- `dotnet test src\LanguageServer\ProtocolUnitTests\Microsoft.CodeAnalysis.LanguageServer.Protocol.UnitTests.csproj --filter "FullyQualifiedName~Microsoft.CodeAnalysis.LanguageServer.UnitTests.Rename.RenameTests" --nologo --tl:off -v minimal`

## Notes
- this branch was created from the current `upstream/main` tip in this checkout, which does not contain the merged `src/Razor` tree, so `CohostRenameEndpointTest` is not available on this branch
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83217)