### PR TITLE
Update the C# formatting result to fix up Elastic new lines

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/MisplacedUsingDirectives/MisplacedUsingDirectivesCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/MisplacedUsingDirectives/MisplacedUsingDirectivesCodeFixProvider.cs
@@ -376,7 +376,7 @@ internal sealed class MisplacedUsingDirectivesCodeFixProvider() : CodeFixProvide
         if (firstMemberTrivia is [(kind: SyntaxKind.EndOfLineTrivia), ..])
             return node;
 
-        var newFirstMember = firstMember.WithLeadingTrivia(firstMemberTrivia.Insert(0, SyntaxFactory.CarriageReturnLineFeed));
+        var newFirstMember = firstMember.WithLeadingTrivia(firstMemberTrivia.Insert(0, SyntaxFactory.ElasticCarriageReturnLineFeed));
         return node.ReplaceNode(firstMember, newFirstMember);
     }
 

--- a/src/Analyzers/CSharp/Tests/AddParameter/AddParameterTests.cs
+++ b/src/Analyzers/CSharp/Tests/AddParameter/AddParameterTests.cs
@@ -241,7 +241,7 @@ public sealed class AddParameterTests(ITestOutputHelper logger)
             }
             """);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     [WorkItem("https://github.com/dotnet/roslyn/issues/20708")]
     public Task TestMultiLineParameters1()
         => TestInRegularAndScriptAsync(
@@ -312,7 +312,7 @@ public sealed class AddParameterTests(ITestOutputHelper logger)
             }
             """);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     [WorkItem("https://github.com/dotnet/roslyn/issues/20708")]
     public Task TestMultiLineParameters3()
         => TestInRegularAndScriptAsync(
@@ -348,7 +348,7 @@ public sealed class AddParameterTests(ITestOutputHelper logger)
             }
             """);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     [WorkItem("https://github.com/dotnet/roslyn/issues/20708")]
     public Task TestMultiLineParameters4()
         => TestInRegularAndScriptAsync(
@@ -423,7 +423,7 @@ public sealed class AddParameterTests(ITestOutputHelper logger)
             }
             """);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     [WorkItem("https://github.com/dotnet/roslyn/issues/20708")]
     public Task TestMultiLineParameters6()
         => TestInRegularAndScriptAsync(
@@ -1640,7 +1640,7 @@ public sealed class AddParameterTests(ITestOutputHelper logger)
             </Workspace>
             """);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     [WorkItem("https://github.com/dotnet/roslyn/issues/21446")]
     public async Task TestInvocation_Cascading_RootNotInSource()
     {

--- a/src/Analyzers/CSharp/Tests/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/Analyzers/CSharp/Tests/GenerateConstructor/GenerateConstructorTests.cs
@@ -4650,7 +4650,7 @@ unsafe class C
             }
             """);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     [WorkItem("https://github.com/dotnet/roslyn/issues/50765")]
     public Task TestDelegateConstructorWithMissingType()
         => TestAsync("""

--- a/src/Analyzers/CSharp/Tests/GenerateMethod/GenerateMethodTests.cs
+++ b/src/Analyzers/CSharp/Tests/GenerateMethod/GenerateMethodTests.cs
@@ -9504,7 +9504,7 @@ public sealed partial class GenerateMethodTests(ITestOutputHelper logger) : Abst
                             </Workspace>
             """);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task TestIfGeneratingInPartialClassWithFileFromSourceGenerator()
         => TestInRegularAndScriptAsync(
             """
@@ -10650,7 +10650,7 @@ public sealed partial class GenerateMethodTests(ITestOutputHelper logger) : Abst
             """);
     }
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public async Task GenerateInCollection3()
     {
         await TestInRegularAndScriptAsync(
@@ -10724,7 +10724,7 @@ public sealed partial class GenerateMethodTests(ITestOutputHelper logger) : Abst
             """);
     }
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public async Task GenerateInCollection5()
     {
         await TestInRegularAndScriptAsync(

--- a/src/Analyzers/CSharp/Tests/ImplementAbstractClass/ImplementAbstractClassTests.cs
+++ b/src/Analyzers/CSharp/Tests/ImplementAbstractClass/ImplementAbstractClassTests.cs
@@ -2417,7 +2417,7 @@ public sealed partial class ImplementAbstractClassTests(ITestOutputHelper logger
             }
             """);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     [WorkItem("https://github.com/dotnet/roslyn/issues/75992")]
     public Task InsertMissingBraces()
         => TestAllOptionsOffAsync(

--- a/src/Analyzers/CSharp/Tests/MisplacedUsingDirectives/MisplacedUsingDirectivesTests.cs
+++ b/src/Analyzers/CSharp/Tests/MisplacedUsingDirectives/MisplacedUsingDirectivesTests.cs
@@ -231,7 +231,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
     /// <summary>
     /// Verifies that using statements in a namespace produces the expected diagnostics.
     /// </summary>
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task WhenOutsidePreferred_UsingsInNamespace_UsingsMoved()
         => TestInRegularAndScriptAsync("""
             namespace TestNamespace
@@ -248,7 +248,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
             }
             """, OutsideNamespaceOption, placeSystemNamespaceFirst: true);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task WhenOutsidePreferred_UsingsInNamespace_UsingsMoved_FileScopedNamespace()
         => TestInRegularAndScriptAsync("""
             namespace TestNamespace;
@@ -259,6 +259,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
 
             {|Warning:using System;|}
             {|Warning:using System.Threading;|}
+            
             namespace TestNamespace;
 
             """, OutsideNamespaceOption, placeSystemNamespaceFirst: true);
@@ -266,7 +267,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
     /// <summary>
     /// Verifies that simplified using statements in a namespace are expanded during the code fix operation.
     /// </summary>
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task WhenOutsidePreferred_SimplifiedUsingInNamespace_UsingsMovedAndExpanded()
         => TestInRegularAndScriptAsync("""
             namespace System
@@ -309,7 +310,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
     /// <summary>
     /// Verifies that simplified using statements in a namespace are expanded during the code fix operation.
     /// </summary>
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task WhenOutsidePreferred_SimplifiedUsingAliasInNamespace_UsingsMovedAndExpanded()
         => TestInRegularAndScriptAsync("""
             namespace System.MyExtension
@@ -360,7 +361,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
     /// <summary>
     /// Verifies that the file header of a file is properly preserved when moving using statements out of a namespace.
     /// </summary>
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task WhenOutsidePreferred_UsingsInNamespaceAndCompilationUnitHasFileHeader_UsingsMovedAndHeaderPreserved()
         => TestInRegularAndScriptAsync("""
             // Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
@@ -381,7 +382,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
             }
             """, OutsideNamespaceOption, placeSystemNamespaceFirst: true);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task WhenOutsidePreferred_UsingsInNamespaceWithCommentsAndCompilationUnitHasFileHeader_UsingsMovedWithCommentsAndHeaderPreserved()
         => TestInRegularAndScriptAsync("""
             // Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
@@ -410,7 +411,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
             }
             """, OutsideNamespaceOption, placeSystemNamespaceFirst: true);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task WhenOutsidePreferred_UsingsInNamespace_UsingsMovedAndSystemPlacedFirstIgnored()
         => TestInRegularAndScriptAsync("""
             namespace Foo
@@ -450,7 +451,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
             }
             """, OutsideNamespaceOption, placeSystemNamespaceFirst: true);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task WhenOutsidePreferred_UsingsInNamespace_UsingsMovedAndAlphaSortIgnored()
         => TestInRegularAndScriptAsync("""
             namespace Foo
@@ -785,7 +786,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
     /// <summary>
     /// Verifies that the code fix will move the using directives and not place System directives first.
     /// </summary>
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task WhenInsidePreferred_UsingsInCompilationUnit_UsingsMovedAndSystemPlacedFirstIgnored()
         => TestInRegularAndScriptAsync("""
             [|using Microsoft.CodeAnalysis;
@@ -828,7 +829,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
     /// <summary>
     /// Verifies that the code fix will move the using directives and not sort them alphabetically.
     /// </summary>
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task WhenInsidePreferred_UsingsInCompilationUnit_UsingsAndWithAlphaSortIgnored()
         => TestInRegularAndScriptAsync("""
             [|using Microsoft.CodeAnalysis;

--- a/src/Features/CSharpTest/GenerateFromMembers/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersTests.cs
+++ b/src/Features/CSharpTest/GenerateFromMembers/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersTests.cs
@@ -132,7 +132,7 @@ public sealed class AddConstructorParametersFromMembersTests
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(string.Format(FeaturesResources.Add_parameters_to_0, "Program(int i)"), codeAction.Title)
         }.RunAsync();
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     [WorkItem("https://github.com/dotnet/roslyn/issues/58040")]
     public Task TestProperlyWrapParameters2()
         => new VerifyCS.Test
@@ -180,7 +180,7 @@ public sealed class AddConstructorParametersFromMembersTests
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(string.Format(FeaturesResources.Add_parameters_to_0, "Program(int i, string s)"), codeAction.Title)
         }.RunAsync();
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     [WorkItem("https://github.com/dotnet/roslyn/issues/58040")]
     public Task TestProperlyWrapParameters3()
         => new VerifyCS.Test
@@ -226,7 +226,7 @@ public sealed class AddConstructorParametersFromMembersTests
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(string.Format(FeaturesResources.Add_parameters_to_0, "Program(int i, string s)"), codeAction.Title)
         }.RunAsync();
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     [WorkItem("https://github.com/dotnet/roslyn/issues/58040")]
     public Task TestProperlyWrapParameters4()
         => new VerifyCS.Test
@@ -2437,7 +2437,13 @@ public sealed class AddConstructorParametersFromMembersTests
             CodeActionIndex = 1
         }.RunAsync();
 
+<<<<<<< Updated upstream
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+||||||| Stash base
+    [ConditionalFact(typeof(WindowsOnly), Reason = "Mixed line endings cause failures on Unix")]
+=======
+    [Fact]
+>>>>>>> Stashed changes
     [WorkItem("https://github.com/dotnet/roslyn/issues/60816")]
     public Task TestAddMultipleParametersWithWrapping()
         => new VerifyCS.Test

--- a/src/Features/CSharpTest/GenerateFromMembers/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersTests.cs
+++ b/src/Features/CSharpTest/GenerateFromMembers/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersTests.cs
@@ -2437,13 +2437,7 @@ public sealed class AddConstructorParametersFromMembersTests
             CodeActionIndex = 1
         }.RunAsync();
 
-<<<<<<< Updated upstream
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
-||||||| Stash base
-    [ConditionalFact(typeof(WindowsOnly), Reason = "Mixed line endings cause failures on Unix")]
-=======
     [Fact]
->>>>>>> Stashed changes
     [WorkItem("https://github.com/dotnet/roslyn/issues/60816")]
     public Task TestAddMultipleParametersWithWrapping()
         => new VerifyCS.Test

--- a/src/Workspaces/CoreTestUtilities/Extensions/XElementExtensions.cs
+++ b/src/Workspaces/CoreTestUtilities/Extensions/XElementExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Xml.Linq;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.Extensions;
@@ -9,5 +10,5 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Extensions;
 public static class XElementExtensions
 {
     public static string NormalizedValue(this XElement element)
-        => element.Value.Replace("\n", "\r\n");
+        => element.Value.Replace("\n", Environment.NewLine);
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/CSharpSyntaxFormatting.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/CSharpSyntaxFormatting.cs
@@ -43,7 +43,7 @@ internal class CSharpSyntaxFormatting : AbstractSyntaxFormatting
         => new CSharpSyntaxFormattingOptions(options);
 
     protected override IFormattingResult CreateAggregatedFormattingResult(SyntaxNode node, IList<AbstractFormattingResult> results, TextSpanMutableIntervalTree? formattingSpans = null)
-        => new AggregatedFormattingResult(node, results, formattingSpans);
+        => new AggregatedFormattingResult(node, results, formattingSpans, DefaultOptions);
 
     protected override AbstractFormattingResult Format(SyntaxNode node, SyntaxFormattingOptions options, ImmutableArray<AbstractFormattingRule> formattingRules, SyntaxToken startToken, SyntaxToken endToken, CancellationToken cancellationToken)
         => new CSharpFormatEngine(node, options, formattingRules, startToken, endToken).Format(cancellationToken);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/AggregatedFormattingResult.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/AggregatedFormattingResult.cs
@@ -12,14 +12,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting;
 
 internal sealed class AggregatedFormattingResult : AbstractAggregatedFormattingResult
 {
-    public AggregatedFormattingResult(SyntaxNode node, IList<AbstractFormattingResult> results, TextSpanMutableIntervalTree? formattingSpans)
+    private readonly SyntaxFormattingOptions _options;
+
+    public AggregatedFormattingResult(SyntaxNode node, IList<AbstractFormattingResult> results, TextSpanMutableIntervalTree? formattingSpans, SyntaxFormattingOptions options)
         : base(node, results, formattingSpans)
     {
+        _options = options;
     }
 
     protected override SyntaxNode Rewriter(Dictionary<ValueTuple<SyntaxToken, SyntaxToken>, TriviaData> map, CancellationToken cancellationToken)
     {
-        var rewriter = new TriviaRewriter(this.Node, GetFormattingSpans(), map, cancellationToken);
+        var rewriter = new TriviaRewriter(this.Node, GetFormattingSpans(), map, this._options, cancellationToken);
         return rewriter.Transform();
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/CSharpFormatEngine.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/CSharpFormatEngine.cs
@@ -32,5 +32,5 @@ internal sealed class CSharpFormatEngine : AbstractFormatEngine
         => new TriviaDataFactory(this.TreeData, this.Options.LineFormatting);
 
     protected override AbstractFormattingResult CreateFormattingResult(TokenStream tokenStream)
-        => new FormattingResult(this.TreeData, tokenStream, this.SpanToFormat);
+        => new FormattingResult(this.TreeData, tokenStream, this.SpanToFormat, this.Options);
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/CSharpStructuredTriviaFormatEngine.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/CSharpStructuredTriviaFormatEngine.cs
@@ -54,5 +54,5 @@ internal sealed class CSharpStructuredTriviaFormatEngine : AbstractFormatEngine
     }
 
     protected override AbstractFormattingResult CreateFormattingResult(TokenStream tokenStream)
-        => new FormattingResult(this.TreeData, tokenStream, this.SpanToFormat);
+        => new FormattingResult(this.TreeData, tokenStream, this.SpanToFormat, this.Options);
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/FormattingResult.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/FormattingResult.cs
@@ -16,14 +16,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting;
 /// </summary>
 internal sealed class FormattingResult : AbstractFormattingResult
 {
-    internal FormattingResult(TreeData treeInfo, TokenStream tokenStream, TextSpan spanToFormat)
+    private readonly SyntaxFormattingOptions _options;
+
+    internal FormattingResult(TreeData treeInfo, TokenStream tokenStream, TextSpan spanToFormat, SyntaxFormattingOptions options)
         : base(treeInfo, tokenStream, spanToFormat)
     {
+        this._options = options;
     }
 
     protected override SyntaxNode Rewriter(Dictionary<ValueTuple<SyntaxToken, SyntaxToken>, TriviaData> changeMap, CancellationToken cancellationToken)
     {
-        var rewriter = new TriviaRewriter(this.TreeInfo.Root, new TextSpanMutableIntervalTree(this.FormattedSpan), changeMap, cancellationToken);
+        var rewriter = new TriviaRewriter(this.TreeInfo.Root, new TextSpanMutableIntervalTree(this.FormattedSpan), changeMap, this._options, cancellationToken);
         return rewriter.Transform();
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaRewriter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaRewriter.cs
@@ -218,8 +218,12 @@ internal sealed class TriviaRewriter : CSharpSyntaxRewriter
         if (triviaList.Count == 0)
             return (false, triviaList);
 
+        var hasElasticNewLine = triviaList.Any(t => t.IsElastic() && t.IsEndOfLine());
+        if (!hasElasticNewLine)
+            return (false, triviaList);
+
         var hasChanges = false;
-        var builder = new ArrayBuilder<SyntaxTrivia>(triviaList.Count);
+        using var _ = ArrayBuilder<SyntaxTrivia>.GetInstance(triviaList.Count, out var builder);
         foreach (var trivia in triviaList)
         {
             if (trivia.IsEndOfLine() && trivia.IsElastic())

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaRewriter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/TriviaRewriter.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.CSharp.Formatting;
 
@@ -19,6 +20,7 @@ internal sealed class TriviaRewriter : CSharpSyntaxRewriter
 {
     private readonly SyntaxNode _node;
     private readonly TextSpanMutableIntervalTree _spans;
+    private readonly SyntaxFormattingOptions _options;
     private readonly CancellationToken _cancellationToken;
 
     private readonly Dictionary<SyntaxToken, SyntaxTriviaList> _trailingTriviaMap = [];
@@ -28,6 +30,7 @@ internal sealed class TriviaRewriter : CSharpSyntaxRewriter
         SyntaxNode node,
         TextSpanMutableIntervalTree spanToFormat,
         Dictionary<ValueTuple<SyntaxToken, SyntaxToken>, TriviaData> map,
+        SyntaxFormattingOptions options,
         CancellationToken cancellationToken)
     {
         Contract.ThrowIfNull(node);
@@ -35,6 +38,7 @@ internal sealed class TriviaRewriter : CSharpSyntaxRewriter
 
         _node = node;
         _spans = spanToFormat;
+        _options = options;
         _cancellationToken = cancellationToken;
 
         PreprocessTriviaListMap(map, cancellationToken);
@@ -181,7 +185,8 @@ internal sealed class TriviaRewriter : CSharpSyntaxRewriter
         }
         else
         {
-            trailingTrivia = token.TrailingTrivia;
+            (var hasTrailingChanges, trailingTrivia) = NormalizeElasticNewLines(token.TrailingTrivia, _options.LineFormatting);
+            hasChanges |= hasTrailingChanges;
         }
 
         if (_leadingTriviaMap.TryGetValue(token, out var leadingTrivia))
@@ -192,7 +197,8 @@ internal sealed class TriviaRewriter : CSharpSyntaxRewriter
         }
         else
         {
-            leadingTrivia = token.LeadingTrivia;
+            (var hasLeadingChanges, leadingTrivia) = NormalizeElasticNewLines(token.LeadingTrivia, _options.LineFormatting);
+            hasChanges |= hasLeadingChanges;
         }
 
         if (hasChanges)
@@ -206,4 +212,27 @@ internal sealed class TriviaRewriter : CSharpSyntaxRewriter
 
     private static SyntaxToken CreateNewToken(SyntaxTriviaList leadingTrivia, SyntaxToken token, SyntaxTriviaList trailingTrivia)
         => token.With(leadingTrivia, trailingTrivia);
+
+    private static (bool hasChanges, SyntaxTriviaList triviaList) NormalizeElasticNewLines(SyntaxTriviaList triviaList, LineFormattingOptions options)
+    {
+        if (triviaList.Count == 0)
+            return (false, triviaList);
+
+        var hasChanges = false;
+        var builder = new ArrayBuilder<SyntaxTrivia>(triviaList.Count);
+        foreach (var trivia in triviaList)
+        {
+            if (trivia.IsEndOfLine() && trivia.IsElastic())
+            {
+                builder.Add(SyntaxFactory.EndOfLine(options.NewLine));
+                hasChanges = true;
+            }
+            else
+            {
+                builder.Add(trivia);
+            }
+        }
+
+        return (hasChanges, builder.ToSyntaxTriviaList());
+    }
 }


### PR DESCRIPTION
When formatting a document, elastic new lines added by code fixers were not being replaced with the line ending specified in LineFormattingOptions. This caused many unit tests to be Windows only as typically `ElasticCarriageReturnLineFeed` is used by the code generators. This PR updates the trivia rewriter used by formatting results to make the substitution.

Another small fix is that TestWorkspaces hydrated from a workspace XML string were normalizing line endings to CRLF instead of `Environment.NewLine` which is what our expected strings would use since they are typically Raw strings.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83224)