### PR TITLE
Extension indexers: fix receiver handling for implicit indexers being read

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1149,7 +1149,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
 
                 case BoundKind.ImplicitIndexerReceiverPlaceholder:
-                    break;
+                    {
+                        var placeholder = (BoundImplicitIndexerReceiverPlaceholder)expr;
+                        return CheckValueKind(node, placeholder.Receiver, valueKind, checkingReceiver, diagnostics);
+                    }
 
                 case BoundKind.DeconstructValuePlaceholder:
                     break;

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -3735,6 +3735,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // Equivalent to a non-ref local with the underlying receiver as an initializer provided at declaration 
                     return _localScopeDepth;
 
+                case BoundKind.ImplicitIndexerReceiverPlaceholder:
+                    Debug.Assert(false);
+                    return GetRefEscape(((BoundImplicitIndexerReceiverPlaceholder)expr).Receiver);
+
                 case BoundKind.ThisReference:
                     var thisParam = ((MethodSymbol)_symbol).ThisParameter;
                     Debug.Assert(thisParam.Type.Equals(((BoundThisReference)expr).Type, TypeCompareKind.ConsiderEverything));
@@ -4029,6 +4033,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return true;
                     }
                     break;
+
+                case BoundKind.ImplicitIndexerReceiverPlaceholder:
+                    Debug.Assert(false);
+                    return CheckRefEscape(node, ((BoundImplicitIndexerReceiverPlaceholder)expr).Receiver, escapeTo, checkingReceiver, diagnostics);
 
                 case BoundKind.ThisReference:
                     var thisParam = ((MethodSymbol)_symbol).ThisParameter;
@@ -4389,6 +4397,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // Equivalent to a non-ref local with the underlying receiver as an initializer provided at declaration 
                     var placeholder = (BoundCapturedReceiverPlaceholder)expr;
                     return GetValEscape(placeholder.Receiver);
+
+                case BoundKind.ImplicitIndexerReceiverPlaceholder:
+                    Debug.Assert(false);
+                    return GetValEscape(((BoundImplicitIndexerReceiverPlaceholder)expr).Receiver);
 
                 case BoundKind.StackAllocArrayCreation:
                 case BoundKind.ConvertedStackAllocExpression:
@@ -5106,6 +5118,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     // for ref-like fields defer to the receiver.
                     return CheckValEscape(node, fieldAccess.ReceiverOpt, escapeTo, true, diagnostics);
+
+                case BoundKind.ImplicitIndexerReceiverPlaceholder:
+                    Debug.Assert(false);
+                    return CheckValEscape(node, ((BoundImplicitIndexerReceiverPlaceholder)expr).Receiver, escapeTo, checkingReceiver, diagnostics);
 
                 case BoundKind.Call:
                     {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -9283,7 +9283,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 Debug.Assert(receiver.Type is not null);
 
-                var receiverPlaceholder = new BoundImplicitIndexerReceiverPlaceholder(receiver.Syntax, receiver.IsEquivalentToThisReference, receiver.Type).MakeCompilerGenerated();
+                var receiverPlaceholder = new BoundImplicitIndexerReceiverPlaceholder(receiver.Syntax, receiver.IsEquivalentToThisReference, receiver, receiver.Type).MakeCompilerGenerated();
 
                 var implicitIndexerDiagnostics = BindingDiagnosticBag.GetInstance(diagnostics);
                 BoundExpression? indexerOrSliceAccess = null;
@@ -10655,7 +10655,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(convertedArguments.Length == 1);
 
                 var int32 = GetSpecialType(SpecialType.System_Int32, diagnostics, node);
-                var receiverPlaceholder = new BoundImplicitIndexerReceiverPlaceholder(expr.Syntax, isEquivalentToThisReference: expr.IsEquivalentToThisReference, expr.Type) { WasCompilerGenerated = true };
+                var receiverPlaceholder = new BoundImplicitIndexerReceiverPlaceholder(expr.Syntax, isEquivalentToThisReference: expr.IsEquivalentToThisReference, expr, expr.Type) { WasCompilerGenerated = true };
                 var argumentPlaceholders = ImmutableArray.Create(new BoundImplicitIndexerValuePlaceholder(convertedArguments[0].Syntax, int32) { WasCompilerGenerated = true });
 
                 return new BoundImplicitIndexerAccess(
@@ -11224,7 +11224,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
-            var receiverPlaceholder = new BoundImplicitIndexerReceiverPlaceholder(receiver.Syntax, isEquivalentToThisReference: receiver.IsEquivalentToThisReference, receiver.Type) { WasCompilerGenerated = true };
+            var receiverPlaceholder = new BoundImplicitIndexerReceiverPlaceholder(receiver.Syntax, isEquivalentToThisReference: receiver.IsEquivalentToThisReference, receiver, receiver.Type) { WasCompilerGenerated = true };
             ImmutableArray<BoundImplicitIndexerValuePlaceholder> intIndexerOrSliceArgumentPlaceholders = default;
             if (TryBindNonExtensionImplicitIndexerParts(syntax, receiverPlaceholder, argKind,
                 out BoundExpression? lengthOrCountAccess, out BoundExpression? indexerOrSliceAccess, ref intIndexerOrSliceArgumentPlaceholders, ref useSiteInfo, diagnostics))

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -103,7 +103,7 @@
   that will be replaced with a copy captured in a temp during IL gen. 
   -->
   <Node Name="BoundCapturedReceiverPlaceholder" Base="BoundValuePlaceholderBase">
-    <Field Name="Receiver" Type="BoundExpression"/>
+    <Field Name="Receiver" Type="BoundExpression" SkipInVisit="true"/>
   </Node>
 
   <!--
@@ -154,7 +154,7 @@
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
     <Field Name="IsEquivalentToThisReference" Type="bool" PropertyOverrides="true"/>
     <!-- The original receiver expression this placeholder stands in for. Used to delegate value checks. -->
-    <Field Name="Receiver" Type="BoundExpression"/>
+    <Field Name="Receiver" Type="BoundExpression" SkipInVisit="true"/>
   </Node>
 
   <!-- This node represents the receiver for a list pattern. -->

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -153,6 +153,8 @@
   <Node Name="BoundImplicitIndexerReceiverPlaceholder" Base="BoundValuePlaceholderBase" DoesNotSurvive="LocalRewriting">
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
     <Field Name="IsEquivalentToThisReference" Type="bool" PropertyOverrides="true"/>
+    <!-- The original receiver expression this placeholder stands in for. Used to delegate value checks. -->
+    <Field Name="Receiver" Type="BoundExpression"/>
   </Node>
 
   <!-- This node represents the receiver for a list pattern. -->

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -724,35 +724,29 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundImplicitIndexerReceiverPlaceholder : BoundValuePlaceholderBase
     {
-        public BoundImplicitIndexerReceiverPlaceholder(SyntaxNode syntax, bool isEquivalentToThisReference, TypeSymbol type, bool hasErrors)
-            : base(BoundKind.ImplicitIndexerReceiverPlaceholder, syntax, type, hasErrors)
+        public BoundImplicitIndexerReceiverPlaceholder(SyntaxNode syntax, bool isEquivalentToThisReference, BoundExpression receiver, TypeSymbol type, bool hasErrors = false)
+            : base(BoundKind.ImplicitIndexerReceiverPlaceholder, syntax, type, hasErrors || receiver.HasErrors())
         {
 
+            RoslynDebug.Assert(receiver is object, "Field 'receiver' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
             RoslynDebug.Assert(type is object, "Field 'type' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
 
             this.IsEquivalentToThisReference = isEquivalentToThisReference;
-        }
-
-        public BoundImplicitIndexerReceiverPlaceholder(SyntaxNode syntax, bool isEquivalentToThisReference, TypeSymbol type)
-            : base(BoundKind.ImplicitIndexerReceiverPlaceholder, syntax, type)
-        {
-
-            RoslynDebug.Assert(type is object, "Field 'type' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
-
-            this.IsEquivalentToThisReference = isEquivalentToThisReference;
+            this.Receiver = receiver;
         }
 
         public new TypeSymbol Type => base.Type!;
         public override bool IsEquivalentToThisReference { get; }
+        public BoundExpression Receiver { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitImplicitIndexerReceiverPlaceholder(this);
 
-        public BoundImplicitIndexerReceiverPlaceholder Update(bool isEquivalentToThisReference, TypeSymbol type)
+        public BoundImplicitIndexerReceiverPlaceholder Update(bool isEquivalentToThisReference, BoundExpression receiver, TypeSymbol type)
         {
-            if (isEquivalentToThisReference != this.IsEquivalentToThisReference || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
+            if (isEquivalentToThisReference != this.IsEquivalentToThisReference || receiver != this.Receiver || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
             {
-                var result = new BoundImplicitIndexerReceiverPlaceholder(this.Syntax, isEquivalentToThisReference, type, this.HasErrors);
+                var result = new BoundImplicitIndexerReceiverPlaceholder(this.Syntax, isEquivalentToThisReference, receiver, type, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -10090,7 +10084,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitDisposableValuePlaceholder(BoundDisposableValuePlaceholder node) => null;
         public override BoundNode? VisitObjectOrCollectionValuePlaceholder(BoundObjectOrCollectionValuePlaceholder node) => null;
         public override BoundNode? VisitImplicitIndexerValuePlaceholder(BoundImplicitIndexerValuePlaceholder node) => null;
-        public override BoundNode? VisitImplicitIndexerReceiverPlaceholder(BoundImplicitIndexerReceiverPlaceholder node) => null;
+        public override BoundNode? VisitImplicitIndexerReceiverPlaceholder(BoundImplicitIndexerReceiverPlaceholder node)
+        {
+            this.Visit(node.Receiver);
+            return null;
+        }
         public override BoundNode? VisitListPatternReceiverPlaceholder(BoundListPatternReceiverPlaceholder node) => null;
         public override BoundNode? VisitListPatternIndexPlaceholder(BoundListPatternIndexPlaceholder node) => null;
         public override BoundNode? VisitSlicePatternReceiverPlaceholder(BoundSlicePatternReceiverPlaceholder node) => null;
@@ -11177,8 +11175,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitImplicitIndexerReceiverPlaceholder(BoundImplicitIndexerReceiverPlaceholder node)
         {
+            BoundExpression receiver = (BoundExpression)this.Visit(node.Receiver);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.IsEquivalentToThisReference, type);
+            return node.Update(node.IsEquivalentToThisReference, receiver, type);
         }
         public override BoundNode? VisitListPatternReceiverPlaceholder(BoundListPatternReceiverPlaceholder node)
         {
@@ -12850,13 +12849,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitImplicitIndexerReceiverPlaceholder(BoundImplicitIndexerReceiverPlaceholder node)
         {
-            if (!_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol? Type) infoAndType))
-            {
-                return node;
-            }
+            BoundExpression receiver = (BoundExpression)this.Visit(node.Receiver);
+            BoundImplicitIndexerReceiverPlaceholder updatedNode;
 
-            BoundImplicitIndexerReceiverPlaceholder updatedNode = node.Update(node.IsEquivalentToThisReference, infoAndType.Type!);
-            updatedNode.TopLevelNullability = infoAndType.Info;
+            if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol? Type) infoAndType))
+            {
+                updatedNode = node.Update(node.IsEquivalentToThisReference, receiver, infoAndType.Type!);
+                updatedNode.TopLevelNullability = infoAndType.Info;
+            }
+            else
+            {
+                updatedNode = node.Update(node.IsEquivalentToThisReference, receiver, node.Type);
+            }
             return updatedNode;
         }
 
@@ -15568,6 +15572,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override TreeDumperNode VisitImplicitIndexerReceiverPlaceholder(BoundImplicitIndexerReceiverPlaceholder node, object? arg) => new TreeDumperNode("implicitIndexerReceiverPlaceholder", null, new TreeDumperNode[]
         {
             new TreeDumperNode("isEquivalentToThisReference", node.IsEquivalentToThisReference, null),
+            new TreeDumperNode("receiver", null, new TreeDumperNode[] { Visit(node.Receiver, null) }),
             new TreeDumperNode("type", node.Type, null),
             new TreeDumperNode("isSuppressed", node.IsSuppressed, null),
             new TreeDumperNode("hasErrors", node.HasErrors, null)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
@@ -276,10 +276,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private bool IsExtensionPropertyWithByValPossiblyStructReceiverWhichHasHomeAndCanChangeValueBetweenReads(BoundExpression rewrittenReceiver, PropertySymbol property)
+        private bool IsExtensionPropertyWithByValPossiblyStructReceiverWhichHasHomeAndCanChangeValueBetweenReads(BoundExpression rewrittenReceiver, Symbol? symbol)
         {
-            return CanChangeValueBetweenReads(rewrittenReceiver, localsMayBeAssignedOrCaptured: true, structThisCanChangeValueBetweenReads: true) &&
-                   IsExtensionBlockMemberWithByValPossiblyStructReceiver(property) &&
+            return symbol is not null &&
+                   CanChangeValueBetweenReads(rewrittenReceiver, localsMayBeAssignedOrCaptured: true, structThisCanChangeValueBetweenReads: true) &&
+                   IsExtensionBlockMemberWithByValPossiblyStructReceiver(symbol) &&
                    CodeGen.CodeGenerator.HasHome(rewrittenReceiver,
                                        CodeGen.CodeGenerator.AddressKind.ReadOnlyStrict,
                                        _factory.CurrentFunction,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
 
                 case BoundKind.IndexerAccess:
-                    loweredLeft = VisitIndexerAccess((BoundIndexerAccess)left, isLeftOfAssignment: true);
+                    loweredLeft = VisitIndexerAccess((BoundIndexerAccess)left, isLeftOfAssignment: true, receiverIsKnownToBeCaptured: false);
                     break;
 
                 case BoundKind.ImplicitIndexerAccess:

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -1026,7 +1026,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 (forceProtection ||
                     !CodeGenerator.IsSafeToDereferenceReceiverRefAfterEvaluatingArguments(argumentsToCheckForRefSafety)))
             {
-                Debug.Assert(receiverTemp.LocalSymbol.Type is { IsReferenceType: false, IsValueType: false });
                 ReferToTempIfReferenceTypeReceiver(receiverTemp, ref assignmentToTemp, out extraRefInitialization, tempsBuilder);
             }
         }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -647,12 +647,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Visits all arguments of a method, doing any necessary rewriting for interpolated string handler conversions that
         /// might be present in the arguments and creating temps for any discard parameters.
         /// 
-        /// When <paramref name="forceReceiverCapturing"/> is true the receiver must be captured regardless of
-        /// interpolated string handler conversions needs, and <paramref name="storesOpt"/> must be not null.
-        /// Callers should set this when the lowering will run additional code between argument evaluation and
-        /// the call. In addition to forcing the capture itself, this flag also forces
-        /// the ref-type-receiver-swap protection (see <see cref="ProtectAgainstRefTypeReceiverSwapIfNeeded"/>)
-        /// to apply unconditionally, since the args-only safety check cannot see the additional code.
+        /// When <paramref name="forceReceiverCapturing"/> is true (which means the receiver must be captured regardless of
+        /// interpolated string handler conversions needs), <paramref name="storesOpt"/> must be not null.
         /// 
         /// If receiver is captured by this method:
         /// - If <paramref name="storesOpt"/> is not null, the side effect of capturing is added to <paramref name="storesOpt"/>
@@ -803,16 +799,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 BoundAssignmentOperator? extraRefInitialization = null;
 
-                if (receiverTemp.LocalSymbol.IsRef)
+                if (receiverTemp.LocalSymbol.IsRef &&
+                    IsPossibleReferenceTypeReceiverOfConstrainedOrExtensionCall(methodOrIndexer, receiverTemp) &&
+                    !CodeGenerator.ReceiverIsKnownToReferToTempIfReferenceType(receiverTemp) &&
+                    (forceReceiverCapturing ||
+                     !CodeGenerator.IsSafeToDereferenceReceiverRefAfterEvaluatingArguments(rewrittenArguments)))
                 {
-                    ProtectAgainstRefTypeReceiverSwapIfNeeded(
-                        receiverTemp,
-                        ref assignmentToTemp,
-                        isPossibleReferenceTypeReceiver: IsPossibleReferenceTypeReceiverOfConstrainedOrExtensionCall(methodOrIndexer, receiverTemp),
-                        forceProtection: forceReceiverCapturing,
-                        argumentsToCheckForRefSafety: rewrittenArguments,
-                        tempsBuilder: tempsOpt,
-                        out extraRefInitialization);
+                    ReferToTempIfReferenceTypeReceiver(receiverTemp, ref assignmentToTemp, out extraRefInitialization, tempsOpt);
                 }
 
                 if (storesOpt is object)
@@ -992,42 +985,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return RefKind.None;
-        }
-
-        /// <summary>
-        /// If the captured receiver is a ref to a heap location whose underlying type might be a
-        /// reference type (unconstrained T, or extension on class), the heap reference can be
-        /// replaced while arguments (or the right-hand value of a compound assignment) are evaluated,
-        /// causing the call to target a different instance than source order implies.
-        /// This helper applies <see cref="ReferToTempIfReferenceTypeReceiver"/> when needed
-        /// to copy the reference into a temp before those evaluations run.
-        /// </summary>
-        /// <param name="forceProtection">
-        /// When true, always apply protection regardless of whether the receiver ref is statically
-        /// known to be safe to dereference after the arguments are evaluated.
-        /// </param>
-        /// <param name="extraRefInitialization">
-        /// Non-null if protection was applied; null otherwise.
-        /// </param>
-        private void ProtectAgainstRefTypeReceiverSwapIfNeeded(
-            BoundLocal receiverTemp,
-            ref BoundAssignmentOperator assignmentToTemp,
-            bool isPossibleReferenceTypeReceiver,
-            bool forceProtection,
-            ImmutableArray<BoundExpression> argumentsToCheckForRefSafety,
-            ArrayBuilder<LocalSymbol> tempsBuilder,
-            out BoundAssignmentOperator? extraRefInitialization)
-        {
-            Debug.Assert(receiverTemp.LocalSymbol.IsRef);
-            extraRefInitialization = null;
-
-            if (isPossibleReferenceTypeReceiver &&
-                !CodeGenerator.ReceiverIsKnownToReferToTempIfReferenceType(receiverTemp) &&
-                (forceProtection ||
-                    !CodeGenerator.IsSafeToDereferenceReceiverRefAfterEvaluatingArguments(argumentsToCheckForRefSafety)))
-            {
-                ReferToTempIfReferenceTypeReceiver(receiverTemp, ref assignmentToTemp, out extraRefInitialization, tempsBuilder);
-            }
         }
 
         private void ReferToTempIfReferenceTypeReceiver(BoundLocal receiverTemp, ref BoundAssignmentOperator assignmentToTemp, out BoundAssignmentOperator? extraRefInitialization, ArrayBuilder<LocalSymbol> temps)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -800,7 +800,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 BoundAssignmentOperator? extraRefInitialization = null;
 
                 if (receiverTemp.LocalSymbol.IsRef &&
-                    IsPossibleReferenceTypeReceiverOfConstrainedCall(methodOrIndexer, receiverTemp) &&
+                    IsPossibleReferenceTypeReceiverOfConstrainedOrExtensionCall(methodOrIndexer, receiverTemp) &&
                     !CodeGenerator.ReceiverIsKnownToReferToTempIfReferenceType(receiverTemp) &&
                     (forceReceiverCapturing ||
                      !CodeGenerator.IsSafeToDereferenceReceiverRefAfterEvaluatingArguments(rewrittenArguments)))

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -647,8 +647,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Visits all arguments of a method, doing any necessary rewriting for interpolated string handler conversions that
         /// might be present in the arguments and creating temps for any discard parameters.
         /// 
-        /// When <paramref name="forceReceiverCapturing"/> is true (which means the receiver must be captured regardless of
-        /// interpolated string handler conversions needs), <paramref name="storesOpt"/> must be not null.
+        /// When <paramref name="forceReceiverCapturing"/> is true the receiver must be captured regardless of
+        /// interpolated string handler conversions needs, and <paramref name="storesOpt"/> must be not null.
+        /// Callers should set this when the lowering will run additional code between argument evaluation and
+        /// the call. In addition to forcing the capture itself, this flag also forces
+        /// the ref-type-receiver-swap protection (see <see cref="ProtectAgainstRefTypeReceiverSwapIfNeeded"/>)
+        /// to apply unconditionally, since the args-only safety check cannot see the additional code.
         /// 
         /// If receiver is captured by this method:
         /// - If <paramref name="storesOpt"/> is not null, the side effect of capturing is added to <paramref name="storesOpt"/>
@@ -799,13 +803,16 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 BoundAssignmentOperator? extraRefInitialization = null;
 
-                if (receiverTemp.LocalSymbol.IsRef &&
-                    IsPossibleReferenceTypeReceiverOfConstrainedOrExtensionCall(methodOrIndexer, receiverTemp) &&
-                    !CodeGenerator.ReceiverIsKnownToReferToTempIfReferenceType(receiverTemp) &&
-                    (forceReceiverCapturing ||
-                     !CodeGenerator.IsSafeToDereferenceReceiverRefAfterEvaluatingArguments(rewrittenArguments)))
+                if (receiverTemp.LocalSymbol.IsRef)
                 {
-                    ReferToTempIfReferenceTypeReceiver(receiverTemp, ref assignmentToTemp, out extraRefInitialization, tempsOpt);
+                    ProtectAgainstRefTypeReceiverSwapIfNeeded(
+                        receiverTemp,
+                        ref assignmentToTemp,
+                        isPossibleReferenceTypeReceiver: IsPossibleReferenceTypeReceiverOfConstrainedOrExtensionCall(methodOrIndexer, receiverTemp),
+                        forceProtection: forceReceiverCapturing,
+                        argumentsToCheckForRefSafety: rewrittenArguments,
+                        tempsBuilder: tempsOpt,
+                        out extraRefInitialization);
                 }
 
                 if (storesOpt is object)
@@ -985,6 +992,43 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return RefKind.None;
+        }
+
+        /// <summary>
+        /// If the captured receiver is a ref to a heap location whose underlying type might be a
+        /// reference type (unconstrained T, or extension on class), the heap reference can be
+        /// replaced while arguments (or the right-hand value of a compound assignment) are evaluated,
+        /// causing the call to target a different instance than source order implies.
+        /// This helper applies <see cref="ReferToTempIfReferenceTypeReceiver"/> when needed
+        /// to copy the reference into a temp before those evaluations run.
+        /// </summary>
+        /// <param name="forceProtection">
+        /// When true, always apply protection regardless of whether the receiver ref is statically
+        /// known to be safe to dereference after the arguments are evaluated.
+        /// </param>
+        /// <param name="extraRefInitialization">
+        /// Non-null if protection was applied; null otherwise.
+        /// </param>
+        private void ProtectAgainstRefTypeReceiverSwapIfNeeded(
+            BoundLocal receiverTemp,
+            ref BoundAssignmentOperator assignmentToTemp,
+            bool isPossibleReferenceTypeReceiver,
+            bool forceProtection,
+            ImmutableArray<BoundExpression> argumentsToCheckForRefSafety,
+            ArrayBuilder<LocalSymbol> tempsBuilder,
+            out BoundAssignmentOperator? extraRefInitialization)
+        {
+            Debug.Assert(receiverTemp.LocalSymbol.IsRef);
+            extraRefInitialization = null;
+
+            if (isPossibleReferenceTypeReceiver &&
+                !CodeGenerator.ReceiverIsKnownToReferToTempIfReferenceType(receiverTemp) &&
+                (forceProtection ||
+                    !CodeGenerator.IsSafeToDereferenceReceiverRefAfterEvaluatingArguments(argumentsToCheckForRefSafety)))
+            {
+                Debug.Assert(receiverTemp.LocalSymbol.Type is { IsReferenceType: false, IsValueType: false });
+                ReferToTempIfReferenceTypeReceiver(receiverTemp, ref assignmentToTemp, out extraRefInitialization, tempsBuilder);
+            }
         }
 
         private void ReferToTempIfReferenceTypeReceiver(BoundLocal receiverTemp, ref BoundAssignmentOperator assignmentToTemp, out BoundAssignmentOperator? extraRefInitialization, ArrayBuilder<LocalSymbol> temps)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -800,9 +800,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 BoundAssignmentOperator? extraRefInitialization = null;
 
                 if (receiverTemp.LocalSymbol.IsRef &&
-                   (methodOrIndexer.IsExtensionBlockMember() ?
-                     !receiverTemp.Type.IsValueType :
-                     CodeGenerator.IsPossibleReferenceTypeReceiverOfConstrainedCall(receiverTemp)) &&
+                    IsPossibleReferenceTypeReceiverOfConstrainedCall(methodOrIndexer, receiverTemp) &&
                     !CodeGenerator.ReceiverIsKnownToReferToTempIfReferenceType(receiverTemp) &&
                     (forceReceiverCapturing ||
                      !CodeGenerator.IsSafeToDereferenceReceiverRefAfterEvaluatingArguments(rewrittenArguments)))

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
@@ -554,7 +554,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private BoundExpression TransformIndexPatternIndexerAccess(BoundImplicitIndexerAccess implicitIndexerAccess, ArrayBuilder<BoundExpression> stores, ArrayBuilder<LocalSymbol> temps, bool isDynamicAssignment)
         {
             Debug.Assert(implicitIndexerAccess.IndexerOrSliceAccess.GetRefKind() == RefKind.None);
-            var access = GetUnderlyingIndexerOrSliceAccess(
+            var access = VisitIndexPatternIndexerAccess(
                 implicitIndexerAccess,
                 isLeftOfAssignment: true,
                 isRegularAssignment: false,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
@@ -329,9 +329,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             temps.Add(receiverTemp.LocalSymbol);
 
             if (receiverTemp.LocalSymbol.IsRef &&
-                (propertyOrEvent.IsExtensionBlockMember() ?
-                     !receiverTemp.Type.IsValueType :
-                     CodeGenerator.IsPossibleReferenceTypeReceiverOfConstrainedCall(receiverTemp)) &&
+                IsPossibleReferenceTypeReceiverOfConstrainedCall(propertyOrEvent, receiverTemp) &&
                 !CodeGenerator.ReceiverIsKnownToReferToTempIfReferenceType(receiverTemp))
             {
                 BoundAssignmentOperator? extraRefInitialization;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
@@ -329,7 +329,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             temps.Add(receiverTemp.LocalSymbol);
 
             if (receiverTemp.LocalSymbol.IsRef &&
-                IsPossibleReferenceTypeReceiverOfConstrainedCall(propertyOrEvent, receiverTemp) &&
+                IsPossibleReferenceTypeReceiverOfConstrainedOrExtensionCall(propertyOrEvent, receiverTemp) &&
                 !CodeGenerator.ReceiverIsKnownToReferToTempIfReferenceType(receiverTemp))
             {
                 BoundAssignmentOperator? extraRefInitialization;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
@@ -883,18 +883,20 @@ namespace Microsoft.CodeAnalysis.CSharp
                     IsPossibleReferenceTypeReceiverOfConstrainedOrExtensionCall(node.LengthOrCountAccess.ExpressionSymbol, receiverLocal)
                     || IsPossibleReferenceTypeReceiverOfConstrainedOrExtensionCall(node.IndexerOrSliceAccess.ExpressionSymbol, receiverLocal);
 
-                ProtectAgainstRefTypeReceiverSwapIfNeeded(
-                    receiverLocal,
-                    ref receiverStore,
-                    isPossibleReferenceTypeReceiver,
-                    forceProtection: forceProtectionAgainstRefTypeReceiverSwap,
-                    argumentsToCheckForRefSafety,
-                    tempsBuilder: localsBuilder,
-                    out BoundAssignmentOperator? extraRefInitialization);
-
-                if (extraRefInitialization is object)
+                if (isPossibleReferenceTypeReceiver &&
+                    !CodeGenerator.ReceiverIsKnownToReferToTempIfReferenceType(receiverLocal) &&
+                    (forceProtectionAgainstRefTypeReceiverSwap ||
+                        !CodeGenerator.IsSafeToDereferenceReceiverRefAfterEvaluatingArguments(argumentsToCheckForRefSafety)))
                 {
-                    sideEffectsBuilder.Add(extraRefInitialization);
+                    Debug.Assert(receiverLocal.LocalSymbol.Type is { IsReferenceType: false, IsValueType: false });
+
+                    BoundAssignmentOperator? extraRefInitialization;
+                    ReferToTempIfReferenceTypeReceiver(receiverLocal, ref receiverStore, out extraRefInitialization, localsBuilder);
+
+                    if (extraRefInitialization is object)
+                    {
+                        sideEffectsBuilder.Add(extraRefInitialization);
+                    }
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
@@ -293,6 +293,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (rangeExpr is not null && endMakeOffsetInput is null &&
                         TryGetStartOnlyOverload(getItemOrSliceHelper, node.Syntax) is MethodSymbol startOnlyOverload)
                     {
+                        Debug.Assert(!startOnlyOverload.IsExtensionBlockMember());
                         BoundExpression startExpr = makePatternIndexOffsetExpression(startMakeOffsetInput, length, startStrategy);
                         if (isInt32ConstantZero(startExpr))
                         {
@@ -573,16 +574,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                         Debug.Assert(node.LengthOrCountAccess.ExpressionSymbol is not null);
                         Debug.Assert(node.IndexerOrSliceAccess.ExpressionSymbol is not null);
 
-                        bool isPossibleReferenceTypeReceiver = node.LengthOrCountAccess.ExpressionSymbol.IsExtensionBlockMember()
-                            ? !receiverLocal.Type.IsValueType
-                            : CodeGenerator.IsPossibleReferenceTypeReceiverOfConstrainedCall(receiverLocal);
-
-                        if (!isPossibleReferenceTypeReceiver)
-                        {
-                            isPossibleReferenceTypeReceiver = node.IndexerOrSliceAccess.ExpressionSymbol.IsExtensionBlockMember()
-                                ? !receiverLocal.Type.IsValueType
-                                : CodeGenerator.IsPossibleReferenceTypeReceiverOfConstrainedCall(receiverLocal);
-                        }
+                        bool isPossibleReferenceTypeReceiver =
+                            IsPossibleReferenceTypeReceiverOfConstrainedCall(node.LengthOrCountAccess.ExpressionSymbol, receiverLocal)
+                            || IsPossibleReferenceTypeReceiverOfConstrainedCall(node.IndexerOrSliceAccess.ExpressionSymbol, receiverLocal);
 
                         if (isPossibleReferenceTypeReceiver &&
                             !CodeGenerator.ReceiverIsKnownToReferToTempIfReferenceType(receiverLocal) &&
@@ -846,6 +840,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 rewrittenIndexerAccess);
         }
 
+        private bool IsPossibleReferenceTypeReceiverOfConstrainedCall(Symbol symbol, BoundLocal receiverLocal)
+        {
+            return symbol.IsExtensionBlockMember()
+                ? !receiverLocal.Type.IsValueType
+                : CodeGenerator.IsPossibleReferenceTypeReceiverOfConstrainedCall(receiverLocal);
+        }
+
         private BoundExpression VisitRangePatternIndexerAccess(BoundImplicitIndexerAccess node, ArrayBuilder<LocalSymbol> localsBuilder, ArrayBuilder<BoundExpression> sideEffectsBuilder, bool cacheAllArgumentsOnly)
         {
             Debug.Assert(node.ArgumentPlaceholders.Length == 2);
@@ -893,16 +894,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(node.LengthOrCountAccess.ExpressionSymbol is not null);
                     Debug.Assert(node.IndexerOrSliceAccess.ExpressionSymbol is not null);
 
-                    bool isPossibleReferenceTypeReceiver = node.LengthOrCountAccess.ExpressionSymbol.IsExtensionBlockMember()
-                        ? !receiverLocal.Type.IsValueType
-                        : CodeGenerator.IsPossibleReferenceTypeReceiverOfConstrainedCall(receiverLocal);
-
-                    if (!isPossibleReferenceTypeReceiver)
-                    {
-                        isPossibleReferenceTypeReceiver = node.IndexerOrSliceAccess.ExpressionSymbol.IsExtensionBlockMember()
-                            ? !receiverLocal.Type.IsValueType
-                            : CodeGenerator.IsPossibleReferenceTypeReceiverOfConstrainedCall(receiverLocal);
-                    }
+                    bool isPossibleReferenceTypeReceiver =
+                        IsPossibleReferenceTypeReceiverOfConstrainedCall(node.LengthOrCountAccess.ExpressionSymbol, receiverLocal)
+                        || IsPossibleReferenceTypeReceiverOfConstrainedCall(node.IndexerOrSliceAccess.ExpressionSymbol, receiverLocal);
 
                     if (isPossibleReferenceTypeReceiver &&
                         !CodeGenerator.ReceiverIsKnownToReferToTempIfReferenceType(receiverLocal))
@@ -960,6 +954,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     endMakeOffsetInput is null &&
                     TryGetStartOnlyOverload(sliceCall.Method, node.Syntax) is MethodSymbol startOnlyOverload)
                 {
+                    Debug.Assert(!startOnlyOverload.IsExtensionBlockMember());
                     if (startStrategy is PatternIndexOffsetLoweringStrategy.SubtractFromLength or PatternIndexOffsetLoweringStrategy.UseGetOffsetAPI)
                     {
                         if (startStrategy == PatternIndexOffsetLoweringStrategy.SubtractFromLength)
@@ -974,6 +969,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     startExpr = MakePatternIndexOffsetExpression(startMakeOffsetInput, lengthAccess, startStrategy);
 
                     RemovePlaceholderReplacement(node.ReceiverPlaceholder);
+                    // Note: if the optimization is extended to new types or to support extension members,
+                    // we may need to add special handling for receiver capture and argument side-effects.
                     return F.Call(receiver, startOnlyOverload, startExpr);
                 }
 
@@ -1042,6 +1039,28 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert((rewriteFlags & captureStartOffset) == 0 || (rewriteFlags & captureEndOffset) != 0 || endStrategy == PatternIndexOffsetLoweringStrategy.Length);
                 Debug.Assert(endStrategy != PatternIndexOffsetLoweringStrategy.Length || (rewriteFlags & captureEndOffset) == 0);
                 Debug.Assert((rewriteFlags & captureLength) == 0 || (rewriteFlags & useLength) != 0);
+
+                bool needSpecialExtensionReceiverReadOrder =
+                    IsExtensionPropertyWithByValPossiblyStructReceiverWhichHasHomeAndCanChangeValueBetweenReads(receiver, node.LengthOrCountAccess.ExpressionSymbol)
+                    || IsExtensionPropertyWithByValPossiblyStructReceiverWhichHasHomeAndCanChangeValueBetweenReads(receiver, node.IndexerOrSliceAccess.ExpressionSymbol);
+
+                if (needSpecialExtensionReceiverReadOrder)
+                {
+                    if (startMakeOffsetInput is not null)
+                    {
+                        rewriteFlags |= captureStartOffset;
+                    }
+
+                    if (endMakeOffsetInput is not null)
+                    {
+                        rewriteFlags |= captureEndOffset;
+                    }
+
+                    if ((rewriteFlags & useLength) != 0)
+                    {
+                        rewriteFlags |= captureLength;
+                    }
+                }
 
                 if ((rewriteFlags & captureStartOffset) != 0)
                 {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
@@ -163,6 +163,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 bool needSpecialExtensionPropertyReceiverReadOrder = false;
                 ArrayBuilder<BoundExpression>? storesOpt = null;
 
+                bool receiverIsAlreadyStable = false;
                 if (IsExtensionPropertyWithByValPossiblyStructReceiverWhichHasHomeAndCanChangeValueBetweenReads(rewrittenReceiver, indexer))
                 {
                     // The receiver has location, but extension indexer takes receiver by value.
@@ -174,6 +175,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     needSpecialExtensionPropertyReceiverReadOrder = true;
                     storesOpt = ArrayBuilder<BoundExpression>.GetInstance();
+
+                    // If the receiver is already a stable ref temp produced by an enclosing capture
+                    // (ie. by GetUnderlyingIndexerOrSliceAccess for an implicit Index pattern), we still
+                    // need the special read-order treatment of the arguments but we don't need to
+                    // re-capture the receiver. This avoids producing a second BoundComplexConditionalReceiver.
+                    receiverIsAlreadyStable =
+                        CodeGenerator.ReceiverIsKnownToReferToTempIfReferenceType(rewrittenReceiver);
                 }
 
 #if DEBUG
@@ -181,7 +189,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 #endif
                 ImmutableArray<BoundExpression> rewrittenArguments = VisitArgumentsAndCaptureReceiverIfNeeded(
                     ref rewrittenReceiver,
-                    forceReceiverCapturing: needSpecialExtensionPropertyReceiverReadOrder,
+                    forceReceiverCapturing: needSpecialExtensionPropertyReceiverReadOrder && !receiverIsAlreadyStable,
                     arguments,
                     indexer,
                     argsToParamsOpt,
@@ -192,11 +200,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (needSpecialExtensionPropertyReceiverReadOrder)
                 {
 #if DEBUG
-                    Debug.Assert(rewrittenReceiverBeforePossibleCapture != (object?)rewrittenReceiver);
+                    Debug.Assert(receiverIsAlreadyStable || rewrittenReceiverBeforePossibleCapture != (object?)rewrittenReceiver);
 #endif
                     Debug.Assert(storesOpt is { });
-                    Debug.Assert(storesOpt.Count != 0);
-                    Debug.Assert(temps is not null);
+                    temps ??= ArrayBuilder<LocalSymbol>.GetInstance();
 
                     // Store everything that is non-trivial into a temporary; record the
                     // stores in storesToTemps and make the actual argument a reference to the temp.

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BitVector defaultArguments,
             BoundExpression oldNode,
             bool isLeftOfAssignment,
-            bool receiverIsKnownToBeCaptured = false)
+            bool receiverIsKnownToBeCaptured)
         {
             Debug.Assert(oldNode is BoundIndexerAccess or BoundObjectInitializerMember);
             Debug.Assert(arguments.Length != 0);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
@@ -71,10 +71,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(node.Indexer.IsIndexer || node.Indexer.IsIndexedProperty);
             Debug.Assert((object?)node.Indexer.GetOwnOrInheritedGetMethod() != null);
 
-            return VisitIndexerAccess(node, isLeftOfAssignment: false);
+            return VisitIndexerAccess(node, isLeftOfAssignment: false, receiverIsKnownToBeCaptured: false);
         }
 
-        private BoundExpression VisitIndexerAccess(BoundIndexerAccess node, bool isLeftOfAssignment, bool receiverIsKnownToBeCaptured = false)
+        private BoundExpression VisitIndexerAccess(BoundIndexerAccess node, bool isLeftOfAssignment, bool receiverIsKnownToBeCaptured)
         {
             PropertySymbol indexer = node.Indexer;
             Debug.Assert(indexer.IsIndexer || indexer.IsIndexedProperty);
@@ -515,7 +515,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var locals = ArrayBuilder<LocalSymbol>.GetInstance(2);
             var sideeffects = ArrayBuilder<BoundExpression>.GetInstance(2);
 
-            BoundExpression rewrittenIndexerAccess = GetUnderlyingIndexerOrSliceAccess(
+            BoundExpression rewrittenIndexerAccess = VisitIndexPatternIndexerAccess(
                 node, isLeftOfAssignment,
                 isRegularAssignment: isLeftOfAssignment,
                 cacheAllArgumentsOnly: false,
@@ -527,7 +527,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 rewrittenIndexerAccess);
         }
 
-        private BoundExpression GetUnderlyingIndexerOrSliceAccess(
+        private BoundExpression VisitIndexPatternIndexerAccess(
             BoundImplicitIndexerAccess node,
             bool isLeftOfAssignment,
             bool isRegularAssignment,
@@ -548,6 +548,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var receiver = VisitExpression(node.Receiver);
 
+            bool receiverIsKnownToBeCaptured = false;
             // Do not capture receiver if we're in an initializer
             if (!cacheAllArgumentsOnly)
             {
@@ -564,24 +565,46 @@ namespace Microsoft.CodeAnalysis.CSharp
                         receiver.Type.IsReferenceType ? RefKind.None : RefKind.Ref);
                     locals.Add(receiverLocal.LocalSymbol);
 
-                    if (receiverLocal.LocalSymbol.IsRef &&
-                        CodeGenerator.IsPossibleReferenceTypeReceiverOfConstrainedCall(receiverLocal) &&
-                        !CodeGenerator.ReceiverIsKnownToReferToTempIfReferenceType(receiverLocal) &&
-                        ((isLeftOfAssignment && !isRegularAssignment) ||
-                         !CodeGenerator.IsSafeToDereferenceReceiverRefAfterEvaluatingArguments(ImmutableArray.Create(makeOffsetInput))))
+                    // When we take a `ref` to a receiver with an unconstrained type `T`,
+                    // the instance it would hold when `T` is a reference type is vulnerable
+                    // to being replaced when evaluating arguments or assigned value. We need additional protection.
+                    if (receiverLocal.LocalSymbol.IsRef)
                     {
-                        BoundAssignmentOperator? extraRefInitialization;
-                        ReferToTempIfReferenceTypeReceiver(receiverLocal, ref receiverStore, out extraRefInitialization, locals);
+                        Debug.Assert(node.LengthOrCountAccess.ExpressionSymbol is not null);
+                        Debug.Assert(node.IndexerOrSliceAccess.ExpressionSymbol is not null);
 
-                        if (extraRefInitialization is object)
+                        bool isPossibleReferenceTypeReceiver = node.LengthOrCountAccess.ExpressionSymbol.IsExtensionBlockMember()
+                            ? !receiverLocal.Type.IsValueType
+                            : CodeGenerator.IsPossibleReferenceTypeReceiverOfConstrainedCall(receiverLocal);
+
+                        if (!isPossibleReferenceTypeReceiver)
                         {
-                            sideeffects.Add(extraRefInitialization);
+                            isPossibleReferenceTypeReceiver = node.IndexerOrSliceAccess.ExpressionSymbol.IsExtensionBlockMember()
+                                ? !receiverLocal.Type.IsValueType
+                                : CodeGenerator.IsPossibleReferenceTypeReceiverOfConstrainedCall(receiverLocal);
+                        }
+
+                        if (isPossibleReferenceTypeReceiver &&
+                            !CodeGenerator.ReceiverIsKnownToReferToTempIfReferenceType(receiverLocal) &&
+                            ((isLeftOfAssignment && !isRegularAssignment) ||
+                                 !CodeGenerator.IsSafeToDereferenceReceiverRefAfterEvaluatingArguments(ImmutableArray.Create(makeOffsetInput))))
+                        {
+                            Debug.Assert(receiverLocal.LocalSymbol.Type is { IsReferenceType: false, IsValueType: false });
+
+                            BoundAssignmentOperator? extraRefInitialization;
+                            ReferToTempIfReferenceTypeReceiver(receiverLocal, ref receiverStore, out extraRefInitialization, locals);
+
+                            if (extraRefInitialization is object)
+                            {
+                                sideeffects.Add(extraRefInitialization);
+                            }
                         }
                     }
 
                     sideeffects.Add(receiverStore);
 
                     receiver = receiverLocal;
+                    receiverIsKnownToBeCaptured = true;
                 }
             }
 
@@ -665,7 +688,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
 
                     AddPlaceholderReplacement(argumentPlaceholder, integerArgument);
-                    rewrittenIndexerAccess = VisitIndexerAccess(indexerAccess, isLeftOfAssignment, receiverIsKnownToBeCaptured: true);
+                    rewrittenIndexerAccess = VisitIndexerAccess(indexerAccess, isLeftOfAssignment, receiverIsKnownToBeCaptured: receiverIsKnownToBeCaptured);
                 }
             }
             else
@@ -862,35 +885,56 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 localsBuilder.Add(receiverLocal.LocalSymbol);
 
-                if (receiverLocal.LocalSymbol.IsRef &&
-                    CodeGenerator.IsPossibleReferenceTypeReceiverOfConstrainedCall(receiverLocal) &&
-                    !CodeGenerator.ReceiverIsKnownToReferToTempIfReferenceType(receiverLocal))
+                // When we take a `ref` to a receiver with an unconstrained type `T`,
+                // the instance it would hold when `T` is a reference type is vulnerable
+                // to being replaced when evaluating arguments. We need additional protection.
+                if (receiverLocal.LocalSymbol.IsRef)
                 {
-                    var argumentsBuilder = ArrayBuilder<BoundExpression>.GetInstance(2);
+                    Debug.Assert(node.LengthOrCountAccess.ExpressionSymbol is not null);
+                    Debug.Assert(node.IndexerOrSliceAccess.ExpressionSymbol is not null);
 
-                    if (startMakeOffsetInput is not null)
+                    bool isPossibleReferenceTypeReceiver = node.LengthOrCountAccess.ExpressionSymbol.IsExtensionBlockMember()
+                        ? !receiverLocal.Type.IsValueType
+                        : CodeGenerator.IsPossibleReferenceTypeReceiverOfConstrainedCall(receiverLocal);
+
+                    if (!isPossibleReferenceTypeReceiver)
                     {
-                        argumentsBuilder.Add(startMakeOffsetInput);
+                        isPossibleReferenceTypeReceiver = node.IndexerOrSliceAccess.ExpressionSymbol.IsExtensionBlockMember()
+                            ? !receiverLocal.Type.IsValueType
+                            : CodeGenerator.IsPossibleReferenceTypeReceiverOfConstrainedCall(receiverLocal);
                     }
 
-                    if (endMakeOffsetInput is not null)
+                    if (isPossibleReferenceTypeReceiver &&
+                        !CodeGenerator.ReceiverIsKnownToReferToTempIfReferenceType(receiverLocal))
                     {
-                        argumentsBuilder.Add(endMakeOffsetInput);
-                    }
+                        var argumentsBuilder = ArrayBuilder<BoundExpression>.GetInstance(2);
 
-                    if (rewrittenRangeArg is not null)
-                    {
-                        argumentsBuilder.Add(rewrittenRangeArg);
-                    }
-
-                    if (!CodeGenerator.IsSafeToDereferenceReceiverRefAfterEvaluatingArguments(argumentsBuilder.ToImmutableAndFree()))
-                    {
-                        BoundAssignmentOperator? extraRefInitialization;
-                        ReferToTempIfReferenceTypeReceiver(receiverLocal, ref receiverStore, out extraRefInitialization, localsBuilder);
-
-                        if (extraRefInitialization is object)
+                        if (startMakeOffsetInput is not null)
                         {
-                            sideEffectsBuilder.Add(extraRefInitialization);
+                            argumentsBuilder.Add(startMakeOffsetInput);
+                        }
+
+                        if (endMakeOffsetInput is not null)
+                        {
+                            argumentsBuilder.Add(endMakeOffsetInput);
+                        }
+
+                        if (rewrittenRangeArg is not null)
+                        {
+                            argumentsBuilder.Add(rewrittenRangeArg);
+                        }
+
+                        if (!CodeGenerator.IsSafeToDereferenceReceiverRefAfterEvaluatingArguments(argumentsBuilder.ToImmutableAndFree()))
+                        {
+                            Debug.Assert(receiverLocal.LocalSymbol.Type is { IsReferenceType: false, IsValueType: false });
+
+                            BoundAssignmentOperator? extraRefInitialization;
+                            ReferToTempIfReferenceTypeReceiver(receiverLocal, ref receiverStore, out extraRefInitialization, localsBuilder);
+
+                            if (extraRefInitialization is object)
+                            {
+                                sideEffectsBuilder.Add(extraRefInitialization);
+                            }
                         }
                     }
                 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return VisitIndexerAccess(node, isLeftOfAssignment: false);
         }
 
-        private BoundExpression VisitIndexerAccess(BoundIndexerAccess node, bool isLeftOfAssignment)
+        private BoundExpression VisitIndexerAccess(BoundIndexerAccess node, bool isLeftOfAssignment, bool receiverIsKnownToBeCaptured = false)
         {
             PropertySymbol indexer = node.Indexer;
             Debug.Assert(indexer.IsIndexer || indexer.IsIndexedProperty);
@@ -96,7 +96,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 node.ArgsToParamsOpt,
                 node.DefaultArguments,
                 node,
-                isLeftOfAssignment);
+                isLeftOfAssignment,
+                receiverIsKnownToBeCaptured);
         }
 
         private BoundExpression MakeIndexerAccess(
@@ -110,7 +111,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<int> argsToParamsOpt,
             BitVector defaultArguments,
             BoundExpression oldNode,
-            bool isLeftOfAssignment)
+            bool isLeftOfAssignment,
+            bool receiverIsKnownToBeCaptured = false)
         {
             Debug.Assert(oldNode is BoundIndexerAccess or BoundObjectInitializerMember);
             Debug.Assert(arguments.Length != 0);
@@ -163,7 +165,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 bool needSpecialExtensionPropertyReceiverReadOrder = false;
                 ArrayBuilder<BoundExpression>? storesOpt = null;
 
-                bool receiverIsAlreadyStable = false;
                 if (IsExtensionPropertyWithByValPossiblyStructReceiverWhichHasHomeAndCanChangeValueBetweenReads(rewrittenReceiver, indexer))
                 {
                     // The receiver has location, but extension indexer takes receiver by value.
@@ -175,13 +176,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     needSpecialExtensionPropertyReceiverReadOrder = true;
                     storesOpt = ArrayBuilder<BoundExpression>.GetInstance();
-
-                    // If the receiver is already a stable ref temp produced by an enclosing capture
-                    // (ie. by GetUnderlyingIndexerOrSliceAccess for an implicit Index pattern), we still
-                    // need the special read-order treatment of the arguments but we don't need to
-                    // re-capture the receiver. This avoids producing a second BoundComplexConditionalReceiver.
-                    receiverIsAlreadyStable =
-                        CodeGenerator.ReceiverIsKnownToReferToTempIfReferenceType(rewrittenReceiver);
                 }
 
 #if DEBUG
@@ -189,7 +183,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 #endif
                 ImmutableArray<BoundExpression> rewrittenArguments = VisitArgumentsAndCaptureReceiverIfNeeded(
                     ref rewrittenReceiver,
-                    forceReceiverCapturing: needSpecialExtensionPropertyReceiverReadOrder && !receiverIsAlreadyStable,
+                    forceReceiverCapturing: needSpecialExtensionPropertyReceiverReadOrder && !receiverIsKnownToBeCaptured,
                     arguments,
                     indexer,
                     argsToParamsOpt,
@@ -200,7 +194,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (needSpecialExtensionPropertyReceiverReadOrder)
                 {
 #if DEBUG
-                    Debug.Assert(receiverIsAlreadyStable || rewrittenReceiverBeforePossibleCapture != (object?)rewrittenReceiver);
+                    Debug.Assert(receiverIsKnownToBeCaptured || rewrittenReceiverBeforePossibleCapture != (object?)rewrittenReceiver);
 #endif
                     Debug.Assert(storesOpt is { });
                     temps ??= ArrayBuilder<LocalSymbol>.GetInstance();
@@ -671,7 +665,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
 
                     AddPlaceholderReplacement(argumentPlaceholder, integerArgument);
-                    rewrittenIndexerAccess = VisitIndexerAccess(indexerAccess, isLeftOfAssignment);
+                    rewrittenIndexerAccess = VisitIndexerAccess(indexerAccess, isLeftOfAssignment, receiverIsKnownToBeCaptured: true);
                 }
             }
             else

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
@@ -943,6 +943,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression startExpr;
             BoundExpression rangeSizeExpr;
             var sliceCall = (BoundCall)node.IndexerOrSliceAccess;
+
+            bool needSpecialExtensionReceiverReadOrder =
+                IsExtensionPropertyWithByValPossiblyStructReceiverWhichHasHomeAndCanChangeValueBetweenReads(receiver, node.LengthOrCountAccess.ExpressionSymbol)
+                || IsExtensionPropertyWithByValPossiblyStructReceiverWhichHasHomeAndCanChangeValueBetweenReads(receiver, node.IndexerOrSliceAccess.ExpressionSymbol);
+
             if (rangeExpr is not null)
             {
                 BoundExpression? lengthAccess = null;
@@ -969,8 +974,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     startExpr = MakePatternIndexOffsetExpression(startMakeOffsetInput, lengthAccess, startStrategy);
 
                     RemovePlaceholderReplacement(node.ReceiverPlaceholder);
-                    // Note: if the optimization is extended to new types or to support extension members,
-                    // we may need to add special handling for receiver capture and argument side-effects.
+                    // Note: if the optimization is extended to support extension members,
+                    // we need to add special handling for receiver capture and argument side-effects.
+                    Debug.Assert(!needSpecialExtensionReceiverReadOrder);
                     return F.Call(receiver, startOnlyOverload, startExpr);
                 }
 
@@ -1039,10 +1045,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert((rewriteFlags & captureStartOffset) == 0 || (rewriteFlags & captureEndOffset) != 0 || endStrategy == PatternIndexOffsetLoweringStrategy.Length);
                 Debug.Assert(endStrategy != PatternIndexOffsetLoweringStrategy.Length || (rewriteFlags & captureEndOffset) == 0);
                 Debug.Assert((rewriteFlags & captureLength) == 0 || (rewriteFlags & useLength) != 0);
-
-                bool needSpecialExtensionReceiverReadOrder =
-                    IsExtensionPropertyWithByValPossiblyStructReceiverWhichHasHomeAndCanChangeValueBetweenReads(receiver, node.LengthOrCountAccess.ExpressionSymbol)
-                    || IsExtensionPropertyWithByValPossiblyStructReceiverWhichHasHomeAndCanChangeValueBetweenReads(receiver, node.IndexerOrSliceAccess.ExpressionSymbol);
 
                 if (needSpecialExtensionReceiverReadOrder)
                 {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
@@ -553,14 +553,53 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Do not capture receiver if we're in an initializer
             if (!cacheAllArgumentsOnly)
             {
-                var capturedReceiver = CaptureReceiverForImplicitIndexerAccess(
-                    receiver, node,
-                    argumentsToCheckForRefSafety: [makeOffsetInput],
-                    forceProtectionAgainstRefTypeReceiverSwap: isLeftOfAssignment && !isRegularAssignment,
-                    locals, sideeffects);
+                // Do not capture receiver if it is a local or parameter and we are evaluating a pattern
+                // If length access is a local, then we are evaluating a pattern
+                if (node.LengthOrCountAccess.Kind is not BoundKind.Local || receiver.Kind is not (BoundKind.Local or BoundKind.Parameter))
+                {
+                    Debug.Assert(receiver.Type is { });
 
-                receiverIsKnownToBeCaptured = !ReferenceEquals(capturedReceiver, receiver);
-                receiver = capturedReceiver;
+                    var receiverLocal = F.StoreToTemp(
+                        receiver,
+                        out var receiverStore,
+                        // Store the receiver as a ref local if it's a value type to ensure side effects are propagated
+                        receiver.Type.IsReferenceType ? RefKind.None : RefKind.Ref);
+                    locals.Add(receiverLocal.LocalSymbol);
+
+                    // When we take a `ref` to a receiver with an unconstrained type `T`,
+                    // the instance it would hold when `T` is a reference type is vulnerable
+                    // to being replaced when evaluating arguments or assigned value. We need additional protection.
+                    if (receiverLocal.LocalSymbol.IsRef)
+                    {
+                        Debug.Assert(node.LengthOrCountAccess.ExpressionSymbol is not null);
+                        Debug.Assert(node.IndexerOrSliceAccess.ExpressionSymbol is not null);
+
+                        bool isPossibleReferenceTypeReceiver =
+                            IsPossibleReferenceTypeReceiverOfConstrainedOrExtensionCall(node.LengthOrCountAccess.ExpressionSymbol, receiverLocal)
+                            || IsPossibleReferenceTypeReceiverOfConstrainedOrExtensionCall(node.IndexerOrSliceAccess.ExpressionSymbol, receiverLocal);
+
+                        if (isPossibleReferenceTypeReceiver &&
+                            !CodeGenerator.ReceiverIsKnownToReferToTempIfReferenceType(receiverLocal) &&
+                            ((isLeftOfAssignment && !isRegularAssignment) ||
+                                 !CodeGenerator.IsSafeToDereferenceReceiverRefAfterEvaluatingArguments(ImmutableArray.Create(makeOffsetInput))))
+                        {
+                            Debug.Assert(receiverLocal.LocalSymbol.Type is { IsReferenceType: false, IsValueType: false });
+
+                            BoundAssignmentOperator? extraRefInitialization;
+                            ReferToTempIfReferenceTypeReceiver(receiverLocal, ref receiverStore, out extraRefInitialization, locals);
+
+                            if (extraRefInitialization is object)
+                            {
+                                sideeffects.Add(extraRefInitialization);
+                            }
+                        }
+                    }
+
+                    sideeffects.Add(receiverStore);
+
+                    receiver = receiverLocal;
+                    receiverIsKnownToBeCaptured = true;
+                }
             }
 
             AddPlaceholderReplacement(node.ReceiverPlaceholder, receiver);
@@ -808,102 +847,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 : CodeGenerator.IsPossibleReferenceTypeReceiverOfConstrainedCall(receiverLocal);
         }
 
-        /// <summary>
-        /// Common receiver capture for implicit indexer access lowerings (Index pattern + Range pattern).
-        /// Both have two call sites on the captured receiver (Length call + indexer/Slice call).
-        ///
-        /// Two correctness concerns are addressed by this capture:
-        ///
-        /// (1) Side-effect propagation: If the receiver is a value-type lvalue, we capture by ref
-        /// so that mutations performed by the Length getter or the indexer/Slice call on the receiver
-        /// (ie. assignment to a field of an instance Length getter, or to a `ref` extension parameter)
-        /// propagate back to the original location.
-        ///
-        /// (2) Reference-type-receiver swap during argument evaluation: When the captured receiver
-        /// is a ref to a heap location whose underlying type might be a reference type
-        /// (unconstrained T or extension on class), the heap reference can be replaced while
-        /// arguments are evaluated, causing the Length/indexer/Slice call to target a different
-        /// instance than source order implies. <see cref="ReferToTempIfReferenceTypeReceiver"/>
-        /// copies the reference into a temp before arguments run. Both Length and the indexer/Slice
-        /// symbols are checked because either call could see the swapped reference.
-        ///
-        /// A third concern - ensuring the receiver value is read AFTER side-effecting arguments
-        /// when the indexer/Slice takes its receiver by value (so the call observes the post-arg
-        /// state) - is NOT handled here. The Index pattern path delegates that to
-        /// <see cref="MakeIndexerAccess"/>, which forces capture and uses
-        /// <c>ExtractSideEffectsFromArguments</c>; the Range pattern path handles it by
-        /// caching <c>startExpr</c>/<c>rangeSizeExpr</c> into temps before the Slice call.
-        /// </summary>
-        /// <returns>
-        /// The captured receiver, or the original receiver if no capture was performed.
-        /// Callers can compare reference-equality against the input to detect whether capture happened.
-        /// </returns>
-        /// <param name="forceProtectionAgainstRefTypeReceiverSwap">
-        /// When true, always apply the reference-type-receiver-swap protection (Issue 2 above) when
-        /// the receiver is captured by ref and the type is possibly a reference type, regardless of
-        /// whether the receiver ref is statically known to be safe to dereference after the arguments
-        /// are evaluated. Set this for compound/null-coalescing assignments, where additional code
-        /// runs after arguments and could swap the receiver reference. For straight reads, leave this
-        /// false to allow the optimization that skips protection when the arguments are known not to
-        /// invalidate the receiver ref.
-        /// </param>
-        private BoundExpression CaptureReceiverForImplicitIndexerAccess(
-            BoundExpression receiver,
-            BoundImplicitIndexerAccess node,
-            ImmutableArray<BoundExpression> argumentsToCheckForRefSafety,
-            bool forceProtectionAgainstRefTypeReceiverSwap,
-            ArrayBuilder<LocalSymbol> localsBuilder,
-            ArrayBuilder<BoundExpression> sideEffectsBuilder)
-        {
-            // Do not capture receiver if it is a local or parameter and we are evaluating a pattern
-            // If length access is a local, then we are evaluating a pattern
-            if (node.LengthOrCountAccess.Kind is BoundKind.Local && receiver.Kind is BoundKind.Local or BoundKind.Parameter)
-            {
-                return receiver;
-            }
-
-            Debug.Assert(receiver.Type is { });
-
-            var receiverLocal = _factory.StoreToTemp(
-                receiver,
-                out var receiverStore,
-                // Store the receiver as a ref local if it's a value type to ensure side effects are propagated
-                receiver.Type.IsReferenceType ? RefKind.None : RefKind.Ref);
-            localsBuilder.Add(receiverLocal.LocalSymbol);
-
-            // When we take a `ref` to a receiver with an unconstrained type `T`,
-            // the instance it would hold when `T` is a reference type is vulnerable
-            // to being replaced when evaluating arguments. We need additional protection.
-            if (receiverLocal.LocalSymbol.IsRef)
-            {
-                Debug.Assert(node.LengthOrCountAccess.ExpressionSymbol is not null);
-                Debug.Assert(node.IndexerOrSliceAccess.ExpressionSymbol is not null);
-
-                bool isPossibleReferenceTypeReceiver =
-                    IsPossibleReferenceTypeReceiverOfConstrainedOrExtensionCall(node.LengthOrCountAccess.ExpressionSymbol, receiverLocal)
-                    || IsPossibleReferenceTypeReceiverOfConstrainedOrExtensionCall(node.IndexerOrSliceAccess.ExpressionSymbol, receiverLocal);
-
-                if (isPossibleReferenceTypeReceiver &&
-                    !CodeGenerator.ReceiverIsKnownToReferToTempIfReferenceType(receiverLocal) &&
-                    (forceProtectionAgainstRefTypeReceiverSwap ||
-                        !CodeGenerator.IsSafeToDereferenceReceiverRefAfterEvaluatingArguments(argumentsToCheckForRefSafety)))
-                {
-                    Debug.Assert(receiverLocal.LocalSymbol.Type is { IsReferenceType: false, IsValueType: false });
-
-                    BoundAssignmentOperator? extraRefInitialization;
-                    ReferToTempIfReferenceTypeReceiver(receiverLocal, ref receiverStore, out extraRefInitialization, localsBuilder);
-
-                    if (extraRefInitialization is object)
-                    {
-                        sideEffectsBuilder.Add(extraRefInitialization);
-                    }
-                }
-            }
-
-            sideEffectsBuilder.Add(receiverStore);
-            return receiverLocal;
-        }
-
         private BoundExpression VisitRangePatternIndexerAccess(BoundImplicitIndexerAccess node, ArrayBuilder<LocalSymbol> localsBuilder, ArrayBuilder<BoundExpression> sideEffectsBuilder, bool cacheAllArgumentsOnly)
         {
             Debug.Assert(node.ArgumentPlaceholders.Length == 2);
@@ -929,28 +872,71 @@ namespace Microsoft.CodeAnalysis.CSharp
             PatternIndexOffsetLoweringStrategy startStrategy, endStrategy;
             RewriteRangeParts(rangeArg, out rangeExpr, out startMakeOffsetInput, out startStrategy, out endMakeOffsetInput, out endStrategy, out rewrittenRangeArg);
 
-            var argumentsBuilder = ArrayBuilder<BoundExpression>.GetInstance(3);
-
-            if (startMakeOffsetInput is not null)
+            // Do not capture receiver if it is a local or parameter and we are evaluating a pattern
+            // If length access is a local, then we are evaluating a pattern
+            if (node.LengthOrCountAccess.Kind is not BoundKind.Local || receiver.Kind is not (BoundKind.Local or BoundKind.Parameter))
             {
-                argumentsBuilder.Add(startMakeOffsetInput);
-            }
+                Debug.Assert(receiver.Type is { });
 
-            if (endMakeOffsetInput is not null)
-            {
-                argumentsBuilder.Add(endMakeOffsetInput);
-            }
+                var receiverLocal = F.StoreToTemp(
+                    receiver,
+                    out var receiverStore,
+                    // Store the receiver as a ref local if it's a value type to ensure side effects are propagated
+                    receiver.Type.IsReferenceType ? RefKind.None : RefKind.Ref);
 
-            if (rewrittenRangeArg is not null)
-            {
-                argumentsBuilder.Add(rewrittenRangeArg);
-            }
+                localsBuilder.Add(receiverLocal.LocalSymbol);
 
-            receiver = CaptureReceiverForImplicitIndexerAccess(
-                receiver, node,
-                argumentsToCheckForRefSafety: argumentsBuilder.ToImmutableAndFree(),
-                forceProtectionAgainstRefTypeReceiverSwap: false,
-                localsBuilder, sideEffectsBuilder);
+                // When we take a `ref` to a receiver with an unconstrained type `T`,
+                // the instance it would hold when `T` is a reference type is vulnerable
+                // to being replaced when evaluating arguments. We need additional protection.
+                if (receiverLocal.LocalSymbol.IsRef)
+                {
+                    Debug.Assert(node.LengthOrCountAccess.ExpressionSymbol is not null);
+                    Debug.Assert(node.IndexerOrSliceAccess.ExpressionSymbol is not null);
+
+                    bool isPossibleReferenceTypeReceiver =
+                        IsPossibleReferenceTypeReceiverOfConstrainedOrExtensionCall(node.LengthOrCountAccess.ExpressionSymbol, receiverLocal)
+                        || IsPossibleReferenceTypeReceiverOfConstrainedOrExtensionCall(node.IndexerOrSliceAccess.ExpressionSymbol, receiverLocal);
+
+                    if (isPossibleReferenceTypeReceiver &&
+                        !CodeGenerator.ReceiverIsKnownToReferToTempIfReferenceType(receiverLocal))
+                    {
+                        var argumentsBuilder = ArrayBuilder<BoundExpression>.GetInstance(2);
+
+                        if (startMakeOffsetInput is not null)
+                        {
+                            argumentsBuilder.Add(startMakeOffsetInput);
+                        }
+
+                        if (endMakeOffsetInput is not null)
+                        {
+                            argumentsBuilder.Add(endMakeOffsetInput);
+                        }
+
+                        if (rewrittenRangeArg is not null)
+                        {
+                            argumentsBuilder.Add(rewrittenRangeArg);
+                        }
+
+                        if (!CodeGenerator.IsSafeToDereferenceReceiverRefAfterEvaluatingArguments(argumentsBuilder.ToImmutableAndFree()))
+                        {
+                            Debug.Assert(receiverLocal.LocalSymbol.Type is { IsReferenceType: false, IsValueType: false });
+
+                            BoundAssignmentOperator? extraRefInitialization;
+                            ReferToTempIfReferenceTypeReceiver(receiverLocal, ref receiverStore, out extraRefInitialization, localsBuilder);
+
+                            if (extraRefInitialization is object)
+                            {
+                                sideEffectsBuilder.Add(extraRefInitialization);
+                            }
+                        }
+                    }
+                }
+
+                sideEffectsBuilder.Add(receiverStore);
+
+                receiver = receiverLocal;
+            }
 
             AddPlaceholderReplacement(node.ReceiverPlaceholder, receiver);
 
@@ -958,11 +944,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression rangeSizeExpr;
             var sliceCall = (BoundCall)node.IndexerOrSliceAccess;
 
-            // Although the implicit Range pattern lowers to a Slice method call, we intentionally use
-            // indexer semantics rather than method semantics for the receiver: side-effecting arguments
-            // are evaluated into temps before the receiver value is read for the Slice call.
             bool needSpecialExtensionReceiverReadOrder =
-                IsExtensionPropertyWithByValPossiblyStructReceiverWhichHasHomeAndCanChangeValueBetweenReads(receiver, sliceCall.Method);
+                IsExtensionPropertyWithByValPossiblyStructReceiverWhichHasHomeAndCanChangeValueBetweenReads(receiver, node.IndexerOrSliceAccess.ExpressionSymbol);
 
             if (rangeExpr is not null)
             {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
@@ -883,20 +883,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                     IsPossibleReferenceTypeReceiverOfConstrainedOrExtensionCall(node.LengthOrCountAccess.ExpressionSymbol, receiverLocal)
                     || IsPossibleReferenceTypeReceiverOfConstrainedOrExtensionCall(node.IndexerOrSliceAccess.ExpressionSymbol, receiverLocal);
 
-                if (isPossibleReferenceTypeReceiver &&
-                    !CodeGenerator.ReceiverIsKnownToReferToTempIfReferenceType(receiverLocal) &&
-                    (forceProtectionAgainstRefTypeReceiverSwap ||
-                        !CodeGenerator.IsSafeToDereferenceReceiverRefAfterEvaluatingArguments(argumentsToCheckForRefSafety)))
+                ProtectAgainstRefTypeReceiverSwapIfNeeded(
+                    receiverLocal,
+                    ref receiverStore,
+                    isPossibleReferenceTypeReceiver,
+                    forceProtection: forceProtectionAgainstRefTypeReceiverSwap,
+                    argumentsToCheckForRefSafety,
+                    tempsBuilder: localsBuilder,
+                    out BoundAssignmentOperator? extraRefInitialization);
+
+                if (extraRefInitialization is object)
                 {
-                    Debug.Assert(receiverLocal.LocalSymbol.Type is { IsReferenceType: false, IsValueType: false });
-
-                    BoundAssignmentOperator? extraRefInitialization;
-                    ReferToTempIfReferenceTypeReceiver(receiverLocal, ref receiverStore, out extraRefInitialization, localsBuilder);
-
-                    if (extraRefInitialization is object)
-                    {
-                        sideEffectsBuilder.Add(extraRefInitialization);
-                    }
+                    sideEffectsBuilder.Add(extraRefInitialization);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
@@ -553,53 +553,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Do not capture receiver if we're in an initializer
             if (!cacheAllArgumentsOnly)
             {
-                // Do not capture receiver if it is a local or parameter and we are evaluating a pattern
-                // If length access is a local, then we are evaluating a pattern
-                if (node.LengthOrCountAccess.Kind is not BoundKind.Local || receiver.Kind is not (BoundKind.Local or BoundKind.Parameter))
-                {
-                    Debug.Assert(receiver.Type is { });
+                var capturedReceiver = CaptureReceiverForImplicitIndexerAccess(
+                    receiver, node,
+                    argumentsToCheckForRefSafety: [makeOffsetInput],
+                    forceProtectionAgainstRefTypeReceiverSwap: isLeftOfAssignment && !isRegularAssignment,
+                    locals, sideeffects);
 
-                    var receiverLocal = F.StoreToTemp(
-                        receiver,
-                        out var receiverStore,
-                        // Store the receiver as a ref local if it's a value type to ensure side effects are propagated
-                        receiver.Type.IsReferenceType ? RefKind.None : RefKind.Ref);
-                    locals.Add(receiverLocal.LocalSymbol);
-
-                    // When we take a `ref` to a receiver with an unconstrained type `T`,
-                    // the instance it would hold when `T` is a reference type is vulnerable
-                    // to being replaced when evaluating arguments or assigned value. We need additional protection.
-                    if (receiverLocal.LocalSymbol.IsRef)
-                    {
-                        Debug.Assert(node.LengthOrCountAccess.ExpressionSymbol is not null);
-                        Debug.Assert(node.IndexerOrSliceAccess.ExpressionSymbol is not null);
-
-                        bool isPossibleReferenceTypeReceiver =
-                            IsPossibleReferenceTypeReceiverOfConstrainedOrExtensionCall(node.LengthOrCountAccess.ExpressionSymbol, receiverLocal)
-                            || IsPossibleReferenceTypeReceiverOfConstrainedOrExtensionCall(node.IndexerOrSliceAccess.ExpressionSymbol, receiverLocal);
-
-                        if (isPossibleReferenceTypeReceiver &&
-                            !CodeGenerator.ReceiverIsKnownToReferToTempIfReferenceType(receiverLocal) &&
-                            ((isLeftOfAssignment && !isRegularAssignment) ||
-                                 !CodeGenerator.IsSafeToDereferenceReceiverRefAfterEvaluatingArguments(ImmutableArray.Create(makeOffsetInput))))
-                        {
-                            Debug.Assert(receiverLocal.LocalSymbol.Type is { IsReferenceType: false, IsValueType: false });
-
-                            BoundAssignmentOperator? extraRefInitialization;
-                            ReferToTempIfReferenceTypeReceiver(receiverLocal, ref receiverStore, out extraRefInitialization, locals);
-
-                            if (extraRefInitialization is object)
-                            {
-                                sideeffects.Add(extraRefInitialization);
-                            }
-                        }
-                    }
-
-                    sideeffects.Add(receiverStore);
-
-                    receiver = receiverLocal;
-                    receiverIsKnownToBeCaptured = true;
-                }
+                receiverIsKnownToBeCaptured = !ReferenceEquals(capturedReceiver, receiver);
+                receiver = capturedReceiver;
             }
 
             AddPlaceholderReplacement(node.ReceiverPlaceholder, receiver);
@@ -847,6 +808,102 @@ namespace Microsoft.CodeAnalysis.CSharp
                 : CodeGenerator.IsPossibleReferenceTypeReceiverOfConstrainedCall(receiverLocal);
         }
 
+        /// <summary>
+        /// Common receiver capture for implicit indexer access lowerings (Index pattern + Range pattern).
+        /// Both have two call sites on the captured receiver (Length call + indexer/Slice call).
+        ///
+        /// Two correctness concerns are addressed by this capture:
+        ///
+        /// (1) Side-effect propagation: If the receiver is a value-type lvalue, we capture by ref
+        /// so that mutations performed by the Length getter or the indexer/Slice call on the receiver
+        /// (ie. assignment to a field of an instance Length getter, or to a `ref` extension parameter)
+        /// propagate back to the original location.
+        ///
+        /// (2) Reference-type-receiver swap during argument evaluation: When the captured receiver
+        /// is a ref to a heap location whose underlying type might be a reference type
+        /// (unconstrained T or extension on class), the heap reference can be replaced while
+        /// arguments are evaluated, causing the Length/indexer/Slice call to target a different
+        /// instance than source order implies. <see cref="ReferToTempIfReferenceTypeReceiver"/>
+        /// copies the reference into a temp before arguments run. Both Length and the indexer/Slice
+        /// symbols are checked because either call could see the swapped reference.
+        ///
+        /// A third concern - ensuring the receiver value is read AFTER side-effecting arguments
+        /// when the indexer/Slice takes its receiver by value (so the call observes the post-arg
+        /// state) - is NOT handled here. The Index pattern path delegates that to
+        /// <see cref="MakeIndexerAccess"/>, which forces capture and uses
+        /// <c>ExtractSideEffectsFromArguments</c>; the Range pattern path handles it by
+        /// caching <c>startExpr</c>/<c>rangeSizeExpr</c> into temps before the Slice call.
+        /// </summary>
+        /// <returns>
+        /// The captured receiver, or the original receiver if no capture was performed.
+        /// Callers can compare reference-equality against the input to detect whether capture happened.
+        /// </returns>
+        /// <param name="forceProtectionAgainstRefTypeReceiverSwap">
+        /// When true, always apply the reference-type-receiver-swap protection (Issue 2 above) when
+        /// the receiver is captured by ref and the type is possibly a reference type, regardless of
+        /// whether the receiver ref is statically known to be safe to dereference after the arguments
+        /// are evaluated. Set this for compound/null-coalescing assignments, where additional code
+        /// runs after arguments and could swap the receiver reference. For straight reads, leave this
+        /// false to allow the optimization that skips protection when the arguments are known not to
+        /// invalidate the receiver ref.
+        /// </param>
+        private BoundExpression CaptureReceiverForImplicitIndexerAccess(
+            BoundExpression receiver,
+            BoundImplicitIndexerAccess node,
+            ImmutableArray<BoundExpression> argumentsToCheckForRefSafety,
+            bool forceProtectionAgainstRefTypeReceiverSwap,
+            ArrayBuilder<LocalSymbol> localsBuilder,
+            ArrayBuilder<BoundExpression> sideEffectsBuilder)
+        {
+            // Do not capture receiver if it is a local or parameter and we are evaluating a pattern
+            // If length access is a local, then we are evaluating a pattern
+            if (node.LengthOrCountAccess.Kind is BoundKind.Local && receiver.Kind is BoundKind.Local or BoundKind.Parameter)
+            {
+                return receiver;
+            }
+
+            Debug.Assert(receiver.Type is { });
+
+            var receiverLocal = _factory.StoreToTemp(
+                receiver,
+                out var receiverStore,
+                // Store the receiver as a ref local if it's a value type to ensure side effects are propagated
+                receiver.Type.IsReferenceType ? RefKind.None : RefKind.Ref);
+            localsBuilder.Add(receiverLocal.LocalSymbol);
+
+            // When we take a `ref` to a receiver with an unconstrained type `T`,
+            // the instance it would hold when `T` is a reference type is vulnerable
+            // to being replaced when evaluating arguments. We need additional protection.
+            if (receiverLocal.LocalSymbol.IsRef)
+            {
+                Debug.Assert(node.LengthOrCountAccess.ExpressionSymbol is not null);
+                Debug.Assert(node.IndexerOrSliceAccess.ExpressionSymbol is not null);
+
+                bool isPossibleReferenceTypeReceiver =
+                    IsPossibleReferenceTypeReceiverOfConstrainedOrExtensionCall(node.LengthOrCountAccess.ExpressionSymbol, receiverLocal)
+                    || IsPossibleReferenceTypeReceiverOfConstrainedOrExtensionCall(node.IndexerOrSliceAccess.ExpressionSymbol, receiverLocal);
+
+                if (isPossibleReferenceTypeReceiver &&
+                    !CodeGenerator.ReceiverIsKnownToReferToTempIfReferenceType(receiverLocal) &&
+                    (forceProtectionAgainstRefTypeReceiverSwap ||
+                        !CodeGenerator.IsSafeToDereferenceReceiverRefAfterEvaluatingArguments(argumentsToCheckForRefSafety)))
+                {
+                    Debug.Assert(receiverLocal.LocalSymbol.Type is { IsReferenceType: false, IsValueType: false });
+
+                    BoundAssignmentOperator? extraRefInitialization;
+                    ReferToTempIfReferenceTypeReceiver(receiverLocal, ref receiverStore, out extraRefInitialization, localsBuilder);
+
+                    if (extraRefInitialization is object)
+                    {
+                        sideEffectsBuilder.Add(extraRefInitialization);
+                    }
+                }
+            }
+
+            sideEffectsBuilder.Add(receiverStore);
+            return receiverLocal;
+        }
+
         private BoundExpression VisitRangePatternIndexerAccess(BoundImplicitIndexerAccess node, ArrayBuilder<LocalSymbol> localsBuilder, ArrayBuilder<BoundExpression> sideEffectsBuilder, bool cacheAllArgumentsOnly)
         {
             Debug.Assert(node.ArgumentPlaceholders.Length == 2);
@@ -872,71 +929,28 @@ namespace Microsoft.CodeAnalysis.CSharp
             PatternIndexOffsetLoweringStrategy startStrategy, endStrategy;
             RewriteRangeParts(rangeArg, out rangeExpr, out startMakeOffsetInput, out startStrategy, out endMakeOffsetInput, out endStrategy, out rewrittenRangeArg);
 
-            // Do not capture receiver if it is a local or parameter and we are evaluating a pattern
-            // If length access is a local, then we are evaluating a pattern
-            if (node.LengthOrCountAccess.Kind is not BoundKind.Local || receiver.Kind is not (BoundKind.Local or BoundKind.Parameter))
+            var argumentsBuilder = ArrayBuilder<BoundExpression>.GetInstance(3);
+
+            if (startMakeOffsetInput is not null)
             {
-                Debug.Assert(receiver.Type is { });
-
-                var receiverLocal = F.StoreToTemp(
-                    receiver,
-                    out var receiverStore,
-                    // Store the receiver as a ref local if it's a value type to ensure side effects are propagated
-                    receiver.Type.IsReferenceType ? RefKind.None : RefKind.Ref);
-
-                localsBuilder.Add(receiverLocal.LocalSymbol);
-
-                // When we take a `ref` to a receiver with an unconstrained type `T`,
-                // the instance it would hold when `T` is a reference type is vulnerable
-                // to being replaced when evaluating arguments. We need additional protection.
-                if (receiverLocal.LocalSymbol.IsRef)
-                {
-                    Debug.Assert(node.LengthOrCountAccess.ExpressionSymbol is not null);
-                    Debug.Assert(node.IndexerOrSliceAccess.ExpressionSymbol is not null);
-
-                    bool isPossibleReferenceTypeReceiver =
-                        IsPossibleReferenceTypeReceiverOfConstrainedOrExtensionCall(node.LengthOrCountAccess.ExpressionSymbol, receiverLocal)
-                        || IsPossibleReferenceTypeReceiverOfConstrainedOrExtensionCall(node.IndexerOrSliceAccess.ExpressionSymbol, receiverLocal);
-
-                    if (isPossibleReferenceTypeReceiver &&
-                        !CodeGenerator.ReceiverIsKnownToReferToTempIfReferenceType(receiverLocal))
-                    {
-                        var argumentsBuilder = ArrayBuilder<BoundExpression>.GetInstance(2);
-
-                        if (startMakeOffsetInput is not null)
-                        {
-                            argumentsBuilder.Add(startMakeOffsetInput);
-                        }
-
-                        if (endMakeOffsetInput is not null)
-                        {
-                            argumentsBuilder.Add(endMakeOffsetInput);
-                        }
-
-                        if (rewrittenRangeArg is not null)
-                        {
-                            argumentsBuilder.Add(rewrittenRangeArg);
-                        }
-
-                        if (!CodeGenerator.IsSafeToDereferenceReceiverRefAfterEvaluatingArguments(argumentsBuilder.ToImmutableAndFree()))
-                        {
-                            Debug.Assert(receiverLocal.LocalSymbol.Type is { IsReferenceType: false, IsValueType: false });
-
-                            BoundAssignmentOperator? extraRefInitialization;
-                            ReferToTempIfReferenceTypeReceiver(receiverLocal, ref receiverStore, out extraRefInitialization, localsBuilder);
-
-                            if (extraRefInitialization is object)
-                            {
-                                sideEffectsBuilder.Add(extraRefInitialization);
-                            }
-                        }
-                    }
-                }
-
-                sideEffectsBuilder.Add(receiverStore);
-
-                receiver = receiverLocal;
+                argumentsBuilder.Add(startMakeOffsetInput);
             }
+
+            if (endMakeOffsetInput is not null)
+            {
+                argumentsBuilder.Add(endMakeOffsetInput);
+            }
+
+            if (rewrittenRangeArg is not null)
+            {
+                argumentsBuilder.Add(rewrittenRangeArg);
+            }
+
+            receiver = CaptureReceiverForImplicitIndexerAccess(
+                receiver, node,
+                argumentsToCheckForRefSafety: argumentsBuilder.ToImmutableAndFree(),
+                forceProtectionAgainstRefTypeReceiverSwap: false,
+                localsBuilder, sideEffectsBuilder);
 
             AddPlaceholderReplacement(node.ReceiverPlaceholder, receiver);
 
@@ -944,8 +958,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression rangeSizeExpr;
             var sliceCall = (BoundCall)node.IndexerOrSliceAccess;
 
+            // Although the implicit Range pattern lowers to a Slice method call, we intentionally use
+            // indexer semantics rather than method semantics for the receiver: side-effecting arguments
+            // are evaluated into temps before the receiver value is read for the Slice call.
             bool needSpecialExtensionReceiverReadOrder =
-                IsExtensionPropertyWithByValPossiblyStructReceiverWhichHasHomeAndCanChangeValueBetweenReads(receiver, node.IndexerOrSliceAccess.ExpressionSymbol);
+                IsExtensionPropertyWithByValPossiblyStructReceiverWhichHasHomeAndCanChangeValueBetweenReads(receiver, sliceCall.Method);
 
             if (rangeExpr is not null)
             {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
@@ -596,10 +596,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
 
                     sideeffects.Add(receiverStore);
-
                     receiver = receiverLocal;
-                    receiverIsKnownToBeCaptured = true;
                 }
+
+                receiverIsKnownToBeCaptured = true;
             }
 
             AddPlaceholderReplacement(node.ReceiverPlaceholder, receiver);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
@@ -322,7 +322,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         else
                         {
                             Debug.Assert(rewrittenRangeArg is not null);
-                            DeconstructRange(rewrittenRangeArg, _factory.Literal(length), localsBuilder, sideEffectsBuilder, out startExpr, out rangeSizeExpr);
+                            (startExpr, rangeSizeExpr) = DeconstructRangeIntoLocals(rewrittenRangeArg, _factory.Literal(length), localsBuilder, sideEffectsBuilder);
                         }
 
                         BoundExpression possiblyRefCapturedReceiver = rewrittenReceiver;
@@ -575,8 +575,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         Debug.Assert(node.IndexerOrSliceAccess.ExpressionSymbol is not null);
 
                         bool isPossibleReferenceTypeReceiver =
-                            IsPossibleReferenceTypeReceiverOfConstrainedCall(node.LengthOrCountAccess.ExpressionSymbol, receiverLocal)
-                            || IsPossibleReferenceTypeReceiverOfConstrainedCall(node.IndexerOrSliceAccess.ExpressionSymbol, receiverLocal);
+                            IsPossibleReferenceTypeReceiverOfConstrainedOrExtensionCall(node.LengthOrCountAccess.ExpressionSymbol, receiverLocal)
+                            || IsPossibleReferenceTypeReceiverOfConstrainedOrExtensionCall(node.IndexerOrSliceAccess.ExpressionSymbol, receiverLocal);
 
                         if (isPossibleReferenceTypeReceiver &&
                             !CodeGenerator.ReceiverIsKnownToReferToTempIfReferenceType(receiverLocal) &&
@@ -840,7 +840,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 rewrittenIndexerAccess);
         }
 
-        private bool IsPossibleReferenceTypeReceiverOfConstrainedCall(Symbol symbol, BoundLocal receiverLocal)
+        private bool IsPossibleReferenceTypeReceiverOfConstrainedOrExtensionCall(Symbol symbol, BoundLocal receiverLocal)
         {
             return symbol.IsExtensionBlockMember()
                 ? !receiverLocal.Type.IsValueType
@@ -895,8 +895,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(node.IndexerOrSliceAccess.ExpressionSymbol is not null);
 
                     bool isPossibleReferenceTypeReceiver =
-                        IsPossibleReferenceTypeReceiverOfConstrainedCall(node.LengthOrCountAccess.ExpressionSymbol, receiverLocal)
-                        || IsPossibleReferenceTypeReceiverOfConstrainedCall(node.IndexerOrSliceAccess.ExpressionSymbol, receiverLocal);
+                        IsPossibleReferenceTypeReceiverOfConstrainedOrExtensionCall(node.LengthOrCountAccess.ExpressionSymbol, receiverLocal)
+                        || IsPossibleReferenceTypeReceiverOfConstrainedOrExtensionCall(node.IndexerOrSliceAccess.ExpressionSymbol, receiverLocal);
 
                     if (isPossibleReferenceTypeReceiver &&
                         !CodeGenerator.ReceiverIsKnownToReferToTempIfReferenceType(receiverLocal))
@@ -945,8 +945,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var sliceCall = (BoundCall)node.IndexerOrSliceAccess;
 
             bool needSpecialExtensionReceiverReadOrder =
-                IsExtensionPropertyWithByValPossiblyStructReceiverWhichHasHomeAndCanChangeValueBetweenReads(receiver, node.LengthOrCountAccess.ExpressionSymbol)
-                || IsExtensionPropertyWithByValPossiblyStructReceiverWhichHasHomeAndCanChangeValueBetweenReads(receiver, node.IndexerOrSliceAccess.ExpressionSymbol);
+                IsExtensionPropertyWithByValPossiblyStructReceiverWhichHasHomeAndCanChangeValueBetweenReads(receiver, node.IndexerOrSliceAccess.ExpressionSymbol);
 
             if (rangeExpr is not null)
             {
@@ -1046,24 +1045,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(endStrategy != PatternIndexOffsetLoweringStrategy.Length || (rewriteFlags & captureEndOffset) == 0);
                 Debug.Assert((rewriteFlags & captureLength) == 0 || (rewriteFlags & useLength) != 0);
 
-                if (needSpecialExtensionReceiverReadOrder)
-                {
-                    if (startMakeOffsetInput is not null)
-                    {
-                        rewriteFlags |= captureStartOffset;
-                    }
-
-                    if (endMakeOffsetInput is not null)
-                    {
-                        rewriteFlags |= captureEndOffset;
-                    }
-
-                    if ((rewriteFlags & useLength) != 0)
-                    {
-                        rewriteFlags |= captureLength;
-                    }
-                }
-
                 if ((rewriteFlags & captureStartOffset) != 0)
                 {
                     Debug.Assert(startMakeOffsetInput is not null);
@@ -1094,7 +1075,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 BoundExpression endExpr = MakePatternIndexOffsetExpression(endMakeOffsetInput, lengthAccess, endStrategy);
                 rangeSizeExpr = MakeRangeSize(ref startExpr, endExpr, localsBuilder, sideEffectsBuilder);
 
-                if (cacheAllArgumentsOnly)
+                if (cacheAllArgumentsOnly || needSpecialExtensionReceiverReadOrder)
                 {
                     var startLocal = F.StoreToTemp(startExpr, out var startStore);
                     localsBuilder.Add(startLocal.LocalSymbol);
@@ -1110,7 +1091,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             else
             {
                 Debug.Assert(rewrittenRangeArg is not null);
-                DeconstructRange(rewrittenRangeArg, VisitExpression(node.LengthOrCountAccess), localsBuilder, sideEffectsBuilder, out startExpr, out rangeSizeExpr);
+                (startExpr, rangeSizeExpr) = DeconstructRangeIntoLocals(rewrittenRangeArg, VisitExpression(node.LengthOrCountAccess), localsBuilder, sideEffectsBuilder);
             }
 
             Debug.Assert(node.ArgumentPlaceholders.Length == 2);
@@ -1231,7 +1212,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             return rangeSizeExpr;
         }
 
-        private void DeconstructRange(BoundExpression rewrittenRangeArg, BoundExpression lengthAccess, ArrayBuilder<LocalSymbol> localsBuilder, ArrayBuilder<BoundExpression> sideEffectsBuilder, out BoundExpression startExpr, out BoundExpression rangeSizeExpr)
+        private (BoundLocal startExpr, BoundLocal rangeSizeExpr)
+            DeconstructRangeIntoLocals(BoundExpression rewrittenRangeArg, BoundExpression lengthAccess, ArrayBuilder<LocalSymbol> localsBuilder, ArrayBuilder<BoundExpression> sideEffectsBuilder)
         {
             var F = _factory;
 
@@ -1256,7 +1238,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             localsBuilder.Add(startLocal.LocalSymbol);
             sideEffectsBuilder.Add(startStore);
-            startExpr = startLocal;
 
             var rangeSizeLocal = F.StoreToTemp(
                 F.IntSubtract(
@@ -1264,12 +1245,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                         F.Call(rangeLocal, F.WellKnownMethod(WellKnownMember.System_Range__get_End)),
                         F.WellKnownMethod(WellKnownMember.System_Index__GetOffset),
                         lengthAccess),
-                    startExpr),
+                    startLocal),
                 out var rangeSizeStore);
 
             localsBuilder.Add(rangeSizeLocal.LocalSymbol);
             sideEffectsBuilder.Add(rangeSizeStore);
-            rangeSizeExpr = rangeSizeLocal;
+
+            return (startLocal, rangeSizeLocal);
         }
 
         private void RewriteRangeParts(BoundExpression rangeArg, out BoundRangeExpression? rangeExpr, out BoundExpression? startMakeOffsetInput, out PatternIndexOffsetLoweringStrategy startStrategy, out BoundExpression? endMakeOffsetInput, out PatternIndexOffsetLoweringStrategy endStrategy, out BoundExpression? rewrittenRangeArg)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
@@ -516,7 +516,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     if (TypeSymbol.Equals(implicitIndexer.Argument.Type, _compilation.GetWellKnownType(WellKnownType.System_Index), TypeCompareKind.ConsiderEverything))
                     {
-                        rewrittenAccess = GetUnderlyingIndexerOrSliceAccess(
+                        rewrittenAccess = VisitIndexPatternIndexerAccess(
                             implicitIndexer,
                             isLeftOfAssignment: !isRhsNestedInitializer,
                             isRegularAssignment: true,
@@ -727,7 +727,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             rewrittenLeft.ArgsToParamsOpt,
                             rewrittenLeft.DefaultArguments,
                             rewrittenLeft,
-                            isLeftOfAssignment: !isRhsNestedInitializer);
+                            isLeftOfAssignment: !isRhsNestedInitializer,
+                            receiverIsKnownToBeCaptured: true); // PROTOTYPE add test when fixing receiver handling in SET scenarios
                     }
                     else
                     {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
@@ -728,7 +728,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             rewrittenLeft.DefaultArguments,
                             rewrittenLeft,
                             isLeftOfAssignment: !isRhsNestedInitializer,
-                            receiverIsKnownToBeCaptured: true); // PROTOTYPE add test when fixing receiver handling in SET scenarios
+                            receiverIsKnownToBeCaptured: false);
                     }
                     else
                     {

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 #nullable disable
@@ -10885,11 +10885,13 @@ namespace Outer
             Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using Outer;").WithLocation(1, 1));
         verifier.VerifyIL("Inner.C.Main", """
 {
-  // Code size       50 (0x32)
-  .maxstack  4
+  // Code size       56 (0x38)
+  .maxstack  3
   .locals init (S V_0, //x
                 S V_1,
-                int V_2)
+                int V_2,
+                int V_3,
+                int V_4)
   IL_0000:  nop
   IL_0001:  ldloca.s   V_1
   IL_0003:  initobj    "S"
@@ -10898,25 +10900,29 @@ namespace Outer
   IL_0010:  stloc.2
   IL_0011:  ldloc.2
   IL_0012:  ldc.i4.1
-  IL_0013:  blt.s      IL_002f
-  IL_0015:  ldloc.1
-  IL_0016:  ldc.i4.0
+  IL_0013:  blt.s      IL_0035
+  IL_0015:  ldc.i4.0
+  IL_0016:  stloc.3
   IL_0017:  ldloc.2
   IL_0018:  ldc.i4.1
   IL_0019:  sub
-  IL_001a:  call       "S Inner.E1.Slice(S, int, int)"
-  IL_001f:  stloc.0
-  IL_0020:  ldloca.s   V_1
-  IL_0022:  ldloc.2
-  IL_0023:  ldc.i4.1
-  IL_0024:  sub
-  IL_0025:  call       "int S.this[int].get"
-  IL_002a:  ldc.i4.1
-  IL_002b:  ceq
-  IL_002d:  br.s       IL_0030
-  IL_002f:  ldc.i4.0
-  IL_0030:  pop
-  IL_0031:  ret
+  IL_001a:  stloc.s    V_4
+  IL_001c:  ldloc.1
+  IL_001d:  ldloc.3
+  IL_001e:  ldloc.s    V_4
+  IL_0020:  call       "S Inner.E1.Slice(S, int, int)"
+  IL_0025:  stloc.0
+  IL_0026:  ldloca.s   V_1
+  IL_0028:  ldloc.2
+  IL_0029:  ldc.i4.1
+  IL_002a:  sub
+  IL_002b:  call       "int S.this[int].get"
+  IL_0030:  ldc.i4.1
+  IL_0031:  ceq
+  IL_0033:  br.s       IL_0036
+  IL_0035:  ldc.i4.0
+  IL_0036:  pop
+  IL_0037:  ret
 }
 """);
     }
@@ -10948,6 +10954,75 @@ public static class E
 
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
         CompileAndVerify(comp, expectedOutput: ExpectedOutput("(1, 2)"), verify: Verification.FailsPEVerify).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void SlicePattern_21()
+    {
+        // struct receiver passed by value, extension Length + extension this[Index] + extension this[Range]
+        var src = """
+_ = new S() is [.. var x, 1];
+
+public struct S { }
+
+public static class E
+{
+    extension(S s)
+    {
+        public int Length => 3;
+        public int this[System.Index i] { get { System.Console.Write($"{i}, "); return 0; } }
+        public int this[System.Range r] { get { System.Console.Write($"{r}, "); return 0; } }
+    }
+}
+""";
+
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70, options: TestOptions.DebugExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("0..^1, ^1, "), verify: Verification.FailsPEVerify).VerifyDiagnostics();
+
+        // Verify that the receiver (pattern temp local) is not unnecessarily captured.
+        verifier.VerifyIL("<top-level-statements-entry-point>", """
+{
+  // Code size       82 (0x52)
+  .maxstack  5
+  .locals init (int V_0, //x
+                S V_1,
+                System.Range V_2,
+                System.Index V_3)
+  IL_0000:  ldloca.s   V_1
+  IL_0002:  initobj    "S"
+  IL_0008:  ldloc.1
+  IL_0009:  call       "int E.get_Length(S)"
+  IL_000e:  ldc.i4.1
+  IL_000f:  blt.s      IL_004f
+  IL_0011:  ldloca.s   V_1
+  IL_0013:  ldloca.s   V_2
+  IL_0015:  ldc.i4.0
+  IL_0016:  ldc.i4.0
+  IL_0017:  newobj     "System.Index..ctor(int, bool)"
+  IL_001c:  ldc.i4.1
+  IL_001d:  ldc.i4.1
+  IL_001e:  newobj     "System.Index..ctor(int, bool)"
+  IL_0023:  call       "System.Range..ctor(System.Index, System.Index)"
+  IL_0028:  ldobj      "S"
+  IL_002d:  ldloc.2
+  IL_002e:  call       "int E.get_Item(S, System.Range)"
+  IL_0033:  stloc.0
+  IL_0034:  ldloca.s   V_1
+  IL_0036:  ldloca.s   V_3
+  IL_0038:  ldc.i4.1
+  IL_0039:  ldc.i4.1
+  IL_003a:  call       "System.Index..ctor(int, bool)"
+  IL_003f:  ldobj      "S"
+  IL_0044:  ldloc.3
+  IL_0045:  call       "int E.get_Item(S, System.Index)"
+  IL_004a:  ldc.i4.1
+  IL_004b:  ceq
+  IL_004d:  br.s       IL_0050
+  IL_004f:  ldc.i4.0
+  IL_0050:  pop
+  IL_0051:  ret
+}
+""");
     }
 
     [Theory, CombinatorialData]
@@ -28286,56 +28361,60 @@ class Program
 
         verifier.VerifyIL("Program.Test1", """
 {
-  // Code size       40 (0x28)
-  .maxstack  4
+  // Code size       42 (0x2a)
+  .maxstack  3
   .locals init (int V_0,
-                int V_1)
+                int V_1,
+                int V_2)
   IL_0000:  nop
   IL_0001:  ldsflda    "S1 Program.F"
   IL_0006:  call       "int Program.GetStart()"
   IL_000b:  stloc.0
-  IL_000c:  dup
-  IL_000d:  ldobj      "S1"
-  IL_0012:  call       "int E.get_Length(S1)"
-  IL_0017:  stloc.1
-  IL_0018:  ldobj      "S1"
-  IL_001d:  ldloc.0
-  IL_001e:  ldloc.1
-  IL_001f:  ldloc.0
-  IL_0020:  sub
-  IL_0021:  call       "int E.Slice(S1, int, int)"
-  IL_0026:  pop
-  IL_0027:  ret
+  IL_000c:  ldloc.0
+  IL_000d:  stloc.1
+  IL_000e:  dup
+  IL_000f:  ldobj      "S1"
+  IL_0014:  call       "int E.get_Length(S1)"
+  IL_0019:  ldloc.0
+  IL_001a:  sub
+  IL_001b:  stloc.2
+  IL_001c:  ldobj      "S1"
+  IL_0021:  ldloc.1
+  IL_0022:  ldloc.2
+  IL_0023:  call       "int E.Slice(S1, int, int)"
+  IL_0028:  pop
+  IL_0029:  ret
 }
 """);
 
         verifier.VerifyIL("S1.Test2", """
 {
-  // Code size       36 (0x24)
-  .maxstack  4
+  // Code size       38 (0x26)
+  .maxstack  3
   .locals init (int V_0,
-                int V_1)
+                int V_1,
+                int V_2)
   IL_0000:  nop
   IL_0001:  ldarg.0
   IL_0002:  call       "int Program.GetStart()"
   IL_0007:  stloc.0
-  IL_0008:  dup
-  IL_0009:  ldobj      "S1"
-  IL_000e:  call       "int E.get_Length(S1)"
-  IL_0013:  stloc.1
-  IL_0014:  ldobj      "S1"
-  IL_0019:  ldloc.0
-  IL_001a:  ldloc.1
-  IL_001b:  ldloc.0
-  IL_001c:  sub
-  IL_001d:  call       "int E.Slice(S1, int, int)"
-  IL_0022:  pop
-  IL_0023:  ret
+  IL_0008:  ldloc.0
+  IL_0009:  stloc.1
+  IL_000a:  dup
+  IL_000b:  ldobj      "S1"
+  IL_0010:  call       "int E.get_Length(S1)"
+  IL_0015:  ldloc.0
+  IL_0016:  sub
+  IL_0017:  stloc.2
+  IL_0018:  ldobj      "S1"
+  IL_001d:  ldloc.1
+  IL_001e:  ldloc.2
+  IL_001f:  call       "int E.Slice(S1, int, int)"
+  IL_0024:  pop
+  IL_0025:  ret
 }
 """);
-    }
-
-    [Fact]
+    }    [Fact]
     public void ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartOpenEndRangeExpr_01_02()
     {
         // sibling of ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartOpenEndRangeExpr_01
@@ -28392,49 +28471,55 @@ class Program
 
         verifier.VerifyIL("Program.Test1", """
 {
-  // Code size       35 (0x23)
-  .maxstack  4
+  // Code size       37 (0x25)
+  .maxstack  3
   .locals init (int V_0,
-                int V_1)
+                int V_1,
+                int V_2)
   IL_0000:  nop
   IL_0001:  ldsflda    "S1 Program.F"
   IL_0006:  call       "int Program.GetStart()"
   IL_000b:  stloc.0
-  IL_000c:  dup
-  IL_000d:  call       "int S1.Length.get"
-  IL_0012:  stloc.1
-  IL_0013:  ldobj      "S1"
-  IL_0018:  ldloc.0
-  IL_0019:  ldloc.1
-  IL_001a:  ldloc.0
-  IL_001b:  sub
-  IL_001c:  call       "int E.Slice(S1, int, int)"
-  IL_0021:  pop
-  IL_0022:  ret
+  IL_000c:  ldloc.0
+  IL_000d:  stloc.1
+  IL_000e:  dup
+  IL_000f:  call       "int S1.Length.get"
+  IL_0014:  ldloc.0
+  IL_0015:  sub
+  IL_0016:  stloc.2
+  IL_0017:  ldobj      "S1"
+  IL_001c:  ldloc.1
+  IL_001d:  ldloc.2
+  IL_001e:  call       "int E.Slice(S1, int, int)"
+  IL_0023:  pop
+  IL_0024:  ret
 }
 """);
 
         verifier.VerifyIL("S1.Test2", """
 {
-  // Code size       31 (0x1f)
-  .maxstack  4
+  // Code size       33 (0x21)
+  .maxstack  3
   .locals init (int V_0,
-                int V_1)
+                int V_1,
+                int V_2)
   IL_0000:  nop
   IL_0001:  ldarg.0
   IL_0002:  call       "int Program.GetStart()"
   IL_0007:  stloc.0
-  IL_0008:  dup
-  IL_0009:  call       "int S1.Length.get"
-  IL_000e:  stloc.1
-  IL_000f:  ldobj      "S1"
-  IL_0014:  ldloc.0
-  IL_0015:  ldloc.1
-  IL_0016:  ldloc.0
-  IL_0017:  sub
-  IL_0018:  call       "int E.Slice(S1, int, int)"
-  IL_001d:  pop
-  IL_001e:  ret
+  IL_0008:  ldloc.0
+  IL_0009:  stloc.1
+  IL_000a:  dup
+  IL_000b:  call       "int S1.Length.get"
+  IL_0010:  ldloc.0
+  IL_0011:  sub
+  IL_0012:  stloc.2
+  IL_0013:  ldobj      "S1"
+  IL_0018:  ldloc.1
+  IL_0019:  ldloc.2
+  IL_001a:  call       "int E.Slice(S1, int, int)"
+  IL_001f:  pop
+  IL_0020:  ret
 }
 """);
     }
@@ -28498,19 +28583,19 @@ class Program
 {
   // Code size       35 (0x23)
   .maxstack  4
-  .locals init (int V_0,
+  .locals init (S1& V_0,
                 int V_1)
   IL_0000:  nop
   IL_0001:  ldsflda    "S1 Program.F"
-  IL_0006:  call       "int Program.GetStart()"
-  IL_000b:  stloc.0
-  IL_000c:  dup
-  IL_000d:  ldobj      "S1"
-  IL_0012:  call       "int E.get_Length(S1)"
-  IL_0017:  stloc.1
-  IL_0018:  ldloc.0
-  IL_0019:  ldloc.1
-  IL_001a:  ldloc.0
+  IL_0006:  stloc.0
+  IL_0007:  call       "int Program.GetStart()"
+  IL_000c:  stloc.1
+  IL_000d:  ldloc.0
+  IL_000e:  ldloc.1
+  IL_000f:  ldloc.0
+  IL_0010:  ldobj      "S1"
+  IL_0015:  call       "int E.get_Length(S1)"
+  IL_001a:  ldloc.1
   IL_001b:  sub
   IL_001c:  call       "int S1.Slice(int, int)"
   IL_0021:  pop
@@ -28522,19 +28607,19 @@ class Program
 {
   // Code size       31 (0x1f)
   .maxstack  4
-  .locals init (int V_0,
+  .locals init (S1& V_0,
                 int V_1)
   IL_0000:  nop
   IL_0001:  ldarg.0
-  IL_0002:  call       "int Program.GetStart()"
-  IL_0007:  stloc.0
-  IL_0008:  dup
-  IL_0009:  ldobj      "S1"
-  IL_000e:  call       "int E.get_Length(S1)"
-  IL_0013:  stloc.1
-  IL_0014:  ldloc.0
-  IL_0015:  ldloc.1
-  IL_0016:  ldloc.0
+  IL_0002:  stloc.0
+  IL_0003:  call       "int Program.GetStart()"
+  IL_0008:  stloc.1
+  IL_0009:  ldloc.0
+  IL_000a:  ldloc.1
+  IL_000b:  ldloc.0
+  IL_000c:  ldobj      "S1"
+  IL_0011:  call       "int E.get_Length(S1)"
+  IL_0016:  ldloc.1
   IL_0017:  sub
   IL_0018:  call       "int S1.Slice(int, int)"
   IL_001d:  pop
@@ -28914,19 +28999,20 @@ class Program
 
         verifier.VerifyIL("Program.Test1<T>(ref T)", """
 {
-  // Code size       66 (0x42)
-  .maxstack  4
+  // Code size       70 (0x46)
+  .maxstack  3
   .locals init (T V_0,
                 T& V_1,
                 int V_2,
                 int V_3,
-                T V_4)
+                int V_4,
+                T V_5)
   IL_0000:  nop
   IL_0001:  ldarg.0
   IL_0002:  stloc.1
-  IL_0003:  ldloca.s   V_4
+  IL_0003:  ldloca.s   V_5
   IL_0005:  initobj    "T"
-  IL_000b:  ldloc.s    V_4
+  IL_000b:  ldloc.s    V_5
   IL_000d:  box        "T"
   IL_0012:  brtrue.s   IL_001f
   IL_0014:  ldloc.1
@@ -28937,43 +29023,48 @@ class Program
   IL_001f:  ldloc.1
   IL_0020:  call       "int Program.GetStart()"
   IL_0025:  stloc.2
-  IL_0026:  dup
-  IL_0027:  ldobj      "T"
-  IL_002c:  call       "int E.get_Length<T>(T)"
-  IL_0031:  stloc.3
-  IL_0032:  ldobj      "T"
-  IL_0037:  ldloc.2
-  IL_0038:  ldloc.3
-  IL_0039:  ldloc.2
-  IL_003a:  sub
-  IL_003b:  call       "int E.Slice<T>(T, int, int)"
-  IL_0040:  pop
-  IL_0041:  ret
+  IL_0026:  ldloc.2
+  IL_0027:  stloc.3
+  IL_0028:  dup
+  IL_0029:  ldobj      "T"
+  IL_002e:  call       "int E.get_Length<T>(T)"
+  IL_0033:  ldloc.2
+  IL_0034:  sub
+  IL_0035:  stloc.s    V_4
+  IL_0037:  ldobj      "T"
+  IL_003c:  ldloc.3
+  IL_003d:  ldloc.s    V_4
+  IL_003f:  call       "int E.Slice<T>(T, int, int)"
+  IL_0044:  pop
+  IL_0045:  ret
 }
 """);
 
         verifier.VerifyIL("Program.Test2<T>(ref T)", """
 {
-  // Code size       36 (0x24)
-  .maxstack  4
+  // Code size       38 (0x26)
+  .maxstack  3
   .locals init (int V_0,
-                int V_1)
+                int V_1,
+                int V_2)
   IL_0000:  nop
   IL_0001:  ldarg.0
   IL_0002:  call       "int Program.GetStart()"
   IL_0007:  stloc.0
-  IL_0008:  dup
-  IL_0009:  ldobj      "T"
-  IL_000e:  call       "int E.get_Length<T>(T)"
-  IL_0013:  stloc.1
-  IL_0014:  ldobj      "T"
-  IL_0019:  ldloc.0
-  IL_001a:  ldloc.1
-  IL_001b:  ldloc.0
-  IL_001c:  sub
-  IL_001d:  call       "int E.Slice<T>(T, int, int)"
-  IL_0022:  pop
-  IL_0023:  ret
+  IL_0008:  ldloc.0
+  IL_0009:  stloc.1
+  IL_000a:  dup
+  IL_000b:  ldobj      "T"
+  IL_0010:  call       "int E.get_Length<T>(T)"
+  IL_0015:  ldloc.0
+  IL_0016:  sub
+  IL_0017:  stloc.2
+  IL_0018:  ldobj      "T"
+  IL_001d:  ldloc.1
+  IL_001e:  ldloc.2
+  IL_001f:  call       "int E.Slice<T>(T, int, int)"
+  IL_0024:  pop
+  IL_0025:  ret
 }
 """);
     }
@@ -29156,19 +29247,20 @@ class Program
 
         verifier.VerifyIL("Program.Test1<T>(ref T)", """
 {
-  // Code size       66 (0x42)
-  .maxstack  4
+  // Code size       70 (0x46)
+  .maxstack  3
   .locals init (T V_0,
                 T& V_1,
                 int V_2,
                 int V_3,
-                T V_4)
+                int V_4,
+                T V_5)
   IL_0000:  nop
   IL_0001:  ldarg.0
   IL_0002:  stloc.1
-  IL_0003:  ldloca.s   V_4
+  IL_0003:  ldloca.s   V_5
   IL_0005:  initobj    "T"
-  IL_000b:  ldloc.s    V_4
+  IL_000b:  ldloc.s    V_5
   IL_000d:  box        "T"
   IL_0012:  brtrue.s   IL_001f
   IL_0014:  ldloc.1
@@ -29179,18 +29271,20 @@ class Program
   IL_001f:  ldloc.1
   IL_0020:  call       "int Program.GetStart()"
   IL_0025:  stloc.2
-  IL_0026:  dup
-  IL_0027:  ldobj      "T"
-  IL_002c:  call       "int E.get_Length<T>(T)"
-  IL_0031:  stloc.3
-  IL_0032:  ldobj      "T"
-  IL_0037:  ldloc.2
-  IL_0038:  ldloc.3
-  IL_0039:  ldloc.2
-  IL_003a:  sub
-  IL_003b:  call       "int E.Slice<T>(T, int, int)"
-  IL_0040:  pop
-  IL_0041:  ret
+  IL_0026:  ldloc.2
+  IL_0027:  stloc.3
+  IL_0028:  dup
+  IL_0029:  ldobj      "T"
+  IL_002e:  call       "int E.get_Length<T>(T)"
+  IL_0033:  ldloc.2
+  IL_0034:  sub
+  IL_0035:  stloc.s    V_4
+  IL_0037:  ldobj      "T"
+  IL_003c:  ldloc.3
+  IL_003d:  ldloc.s    V_4
+  IL_003f:  call       "int E.Slice<T>(T, int, int)"
+  IL_0044:  pop
+  IL_0045:  ret
 }
 """);
 
@@ -29276,51 +29370,63 @@ class Program
 
         verifier.VerifyIL("Program.Test1", """
 {
-  // Code size       45 (0x2d)
-  .maxstack  4
-  .locals init (System.Index V_0,
-                int V_1)
+  // Code size       49 (0x31)
+  .maxstack  3
+  .locals init (S1& V_0,
+                int V_1,
+                int V_2,
+                System.Index V_3)
   IL_0000:  nop
   IL_0001:  ldsflda    "S1 Program.F"
-  IL_0006:  call       "System.Index Program.GetIndex()"
-  IL_000b:  stloc.0
-  IL_000c:  dup
-  IL_000d:  ldobj      "S1"
-  IL_0012:  call       "int E.get_Length(S1)"
-  IL_0017:  stloc.1
-  IL_0018:  ldobj      "S1"
-  IL_001d:  ldc.i4.0
-  IL_001e:  ldloca.s   V_0
-  IL_0020:  ldloc.1
-  IL_0021:  call       "int System.Index.GetOffset(int)"
-  IL_0026:  call       "int E.Slice(S1, int, int)"
-  IL_002b:  pop
-  IL_002c:  ret
+  IL_0006:  stloc.0
+  IL_0007:  ldc.i4.0
+  IL_0008:  stloc.1
+  IL_0009:  call       "System.Index Program.GetIndex()"
+  IL_000e:  stloc.3
+  IL_000f:  ldloca.s   V_3
+  IL_0011:  ldloc.0
+  IL_0012:  ldobj      "S1"
+  IL_0017:  call       "int E.get_Length(S1)"
+  IL_001c:  call       "int System.Index.GetOffset(int)"
+  IL_0021:  stloc.2
+  IL_0022:  ldloc.0
+  IL_0023:  ldobj      "S1"
+  IL_0028:  ldloc.1
+  IL_0029:  ldloc.2
+  IL_002a:  call       "int E.Slice(S1, int, int)"
+  IL_002f:  pop
+  IL_0030:  ret
 }
 """);
 
         verifier.VerifyIL("S1.Test2", """
 {
-  // Code size       41 (0x29)
-  .maxstack  4
-  .locals init (System.Index V_0,
-                int V_1)
+  // Code size       45 (0x2d)
+  .maxstack  3
+  .locals init (S1& V_0,
+                int V_1,
+                int V_2,
+                System.Index V_3)
   IL_0000:  nop
   IL_0001:  ldarg.0
-  IL_0002:  call       "System.Index Program.GetIndex()"
-  IL_0007:  stloc.0
-  IL_0008:  dup
-  IL_0009:  ldobj      "S1"
-  IL_000e:  call       "int E.get_Length(S1)"
-  IL_0013:  stloc.1
-  IL_0014:  ldobj      "S1"
-  IL_0019:  ldc.i4.0
-  IL_001a:  ldloca.s   V_0
-  IL_001c:  ldloc.1
-  IL_001d:  call       "int System.Index.GetOffset(int)"
-  IL_0022:  call       "int E.Slice(S1, int, int)"
-  IL_0027:  pop
-  IL_0028:  ret
+  IL_0002:  stloc.0
+  IL_0003:  ldc.i4.0
+  IL_0004:  stloc.1
+  IL_0005:  call       "System.Index Program.GetIndex()"
+  IL_000a:  stloc.3
+  IL_000b:  ldloca.s   V_3
+  IL_000d:  ldloc.0
+  IL_000e:  ldobj      "S1"
+  IL_0013:  call       "int E.get_Length(S1)"
+  IL_0018:  call       "int System.Index.GetOffset(int)"
+  IL_001d:  stloc.2
+  IL_001e:  ldloc.0
+  IL_001f:  ldobj      "S1"
+  IL_0024:  ldloc.1
+  IL_0025:  ldloc.2
+  IL_0026:  call       "int E.Slice(S1, int, int)"
+  IL_002b:  pop
+  IL_002c:  ret
 }
 """);
     }
@@ -29383,61 +29489,73 @@ class Program
 
         verifier.VerifyIL("Program.Test1", """
 {
-  // Code size       53 (0x35)
-  .maxstack  4
-  .locals init (int V_0,
-                System.Index V_1,
-                int V_2)
+  // Code size       58 (0x3a)
+  .maxstack  3
+  .locals init (S1& V_0,
+                int V_1,
+                int V_2,
+                int V_3,
+                System.Index V_4)
   IL_0000:  nop
   IL_0001:  ldsflda    "S1 Program.F"
-  IL_0006:  call       "int Program.GetStart()"
-  IL_000b:  stloc.0
-  IL_000c:  call       "System.Index Program.GetIndex()"
-  IL_0011:  stloc.1
-  IL_0012:  dup
-  IL_0013:  ldobj      "S1"
-  IL_0018:  call       "int E.get_Length(S1)"
-  IL_001d:  stloc.2
-  IL_001e:  ldobj      "S1"
-  IL_0023:  ldloc.0
-  IL_0024:  ldloca.s   V_1
-  IL_0026:  ldloc.2
-  IL_0027:  call       "int System.Index.GetOffset(int)"
-  IL_002c:  ldloc.0
-  IL_002d:  sub
-  IL_002e:  call       "int E.Slice(S1, int, int)"
-  IL_0033:  pop
-  IL_0034:  ret
+  IL_0006:  stloc.0
+  IL_0007:  call       "int Program.GetStart()"
+  IL_000c:  stloc.1
+  IL_000d:  ldloc.1
+  IL_000e:  stloc.2
+  IL_000f:  call       "System.Index Program.GetIndex()"
+  IL_0014:  stloc.s    V_4
+  IL_0016:  ldloca.s   V_4
+  IL_0018:  ldloc.0
+  IL_0019:  ldobj      "S1"
+  IL_001e:  call       "int E.get_Length(S1)"
+  IL_0023:  call       "int System.Index.GetOffset(int)"
+  IL_0028:  ldloc.1
+  IL_0029:  sub
+  IL_002a:  stloc.3
+  IL_002b:  ldloc.0
+  IL_002c:  ldobj      "S1"
+  IL_0031:  ldloc.2
+  IL_0032:  ldloc.3
+  IL_0033:  call       "int E.Slice(S1, int, int)"
+  IL_0038:  pop
+  IL_0039:  ret
 }
 """);
 
         verifier.VerifyIL("S1.Test2", """
 {
-  // Code size       49 (0x31)
-  .maxstack  4
-  .locals init (int V_0,
-                System.Index V_1,
-                int V_2)
+  // Code size       54 (0x36)
+  .maxstack  3
+  .locals init (S1& V_0,
+                int V_1,
+                int V_2,
+                int V_3,
+                System.Index V_4)
   IL_0000:  nop
   IL_0001:  ldarg.0
-  IL_0002:  call       "int Program.GetStart()"
-  IL_0007:  stloc.0
-  IL_0008:  call       "System.Index Program.GetIndex()"
-  IL_000d:  stloc.1
-  IL_000e:  dup
-  IL_000f:  ldobj      "S1"
-  IL_0014:  call       "int E.get_Length(S1)"
-  IL_0019:  stloc.2
-  IL_001a:  ldobj      "S1"
-  IL_001f:  ldloc.0
-  IL_0020:  ldloca.s   V_1
-  IL_0022:  ldloc.2
-  IL_0023:  call       "int System.Index.GetOffset(int)"
-  IL_0028:  ldloc.0
-  IL_0029:  sub
-  IL_002a:  call       "int E.Slice(S1, int, int)"
-  IL_002f:  pop
-  IL_0030:  ret
+  IL_0002:  stloc.0
+  IL_0003:  call       "int Program.GetStart()"
+  IL_0008:  stloc.1
+  IL_0009:  ldloc.1
+  IL_000a:  stloc.2
+  IL_000b:  call       "System.Index Program.GetIndex()"
+  IL_0010:  stloc.s    V_4
+  IL_0012:  ldloca.s   V_4
+  IL_0014:  ldloc.0
+  IL_0015:  ldobj      "S1"
+  IL_001a:  call       "int E.get_Length(S1)"
+  IL_001f:  call       "int System.Index.GetOffset(int)"
+  IL_0024:  ldloc.1
+  IL_0025:  sub
+  IL_0026:  stloc.3
+  IL_0027:  ldloc.0
+  IL_0028:  ldobj      "S1"
+  IL_002d:  ldloc.2
+  IL_002e:  ldloc.3
+  IL_002f:  call       "int E.Slice(S1, int, int)"
+  IL_0034:  pop
+  IL_0035:  ret
 }
 """);
     }
@@ -29573,11 +29691,12 @@ class Program
 
         verifier.VerifyIL("Program.Test1", """
 {
-  // Code size       44 (0x2c)
+  // Code size       46 (0x2e)
   .maxstack  4
   .locals init (int V_0,
                 int V_1,
-                int V_2)
+                int V_2,
+                int V_3)
   IL_0000:  nop
   IL_0001:  ldsflda    "S1 Program.F"
   IL_0006:  call       "int Program.GetEnd()"
@@ -29585,29 +29704,32 @@ class Program
   IL_000c:  dup
   IL_000d:  ldobj      "S1"
   IL_0012:  call       "int E.get_Length(S1)"
-  IL_0017:  stloc.1
-  IL_0018:  ldloc.1
-  IL_0019:  ldloc.0
-  IL_001a:  sub
-  IL_001b:  stloc.2
-  IL_001c:  ldobj      "S1"
-  IL_0021:  ldloc.2
-  IL_0022:  ldloc.1
-  IL_0023:  ldloc.2
-  IL_0024:  sub
-  IL_0025:  call       "int E.Slice(S1, int, int)"
-  IL_002a:  pop
-  IL_002b:  ret
+  IL_0017:  dup
+  IL_0018:  ldloc.0
+  IL_0019:  sub
+  IL_001a:  stloc.1
+  IL_001b:  ldloc.1
+  IL_001c:  stloc.2
+  IL_001d:  ldloc.1
+  IL_001e:  sub
+  IL_001f:  stloc.3
+  IL_0020:  ldobj      "S1"
+  IL_0025:  ldloc.2
+  IL_0026:  ldloc.3
+  IL_0027:  call       "int E.Slice(S1, int, int)"
+  IL_002c:  pop
+  IL_002d:  ret
 }
 """);
 
         verifier.VerifyIL("S1.Test2", """
 {
-  // Code size       40 (0x28)
+  // Code size       42 (0x2a)
   .maxstack  4
   .locals init (int V_0,
                 int V_1,
-                int V_2)
+                int V_2,
+                int V_3)
   IL_0000:  nop
   IL_0001:  ldarg.0
   IL_0002:  call       "int Program.GetEnd()"
@@ -29615,19 +29737,21 @@ class Program
   IL_0008:  dup
   IL_0009:  ldobj      "S1"
   IL_000e:  call       "int E.get_Length(S1)"
-  IL_0013:  stloc.1
-  IL_0014:  ldloc.1
-  IL_0015:  ldloc.0
-  IL_0016:  sub
-  IL_0017:  stloc.2
-  IL_0018:  ldobj      "S1"
-  IL_001d:  ldloc.2
-  IL_001e:  ldloc.1
-  IL_001f:  ldloc.2
-  IL_0020:  sub
-  IL_0021:  call       "int E.Slice(S1, int, int)"
-  IL_0026:  pop
-  IL_0027:  ret
+  IL_0013:  dup
+  IL_0014:  ldloc.0
+  IL_0015:  sub
+  IL_0016:  stloc.1
+  IL_0017:  ldloc.1
+  IL_0018:  stloc.2
+  IL_0019:  ldloc.1
+  IL_001a:  sub
+  IL_001b:  stloc.3
+  IL_001c:  ldobj      "S1"
+  IL_0021:  ldloc.2
+  IL_0022:  ldloc.3
+  IL_0023:  call       "int E.Slice(S1, int, int)"
+  IL_0028:  pop
+  IL_0029:  ret
 }
 """);
     }
@@ -29690,47 +29814,53 @@ class Program
 
         verifier.VerifyIL("Program.Test1", """
 {
-  // Code size       34 (0x22)
-  .maxstack  4
+  // Code size       36 (0x24)
+  .maxstack  3
   .locals init (int V_0,
-                int V_1)
+                int V_1,
+                int V_2)
   IL_0000:  nop
   IL_0001:  ldsflda    "S1 Program.F"
   IL_0006:  call       "int Program.GetStart()"
   IL_000b:  stloc.0
-  IL_000c:  call       "int Program.GetEnd()"
-  IL_0011:  stloc.1
-  IL_0012:  ldobj      "S1"
-  IL_0017:  ldloc.0
-  IL_0018:  ldloc.1
-  IL_0019:  ldloc.0
-  IL_001a:  sub
-  IL_001b:  call       "int E.Slice(S1, int, int)"
-  IL_0020:  pop
-  IL_0021:  ret
+  IL_000c:  ldloc.0
+  IL_000d:  stloc.1
+  IL_000e:  call       "int Program.GetEnd()"
+  IL_0013:  ldloc.0
+  IL_0014:  sub
+  IL_0015:  stloc.2
+  IL_0016:  ldobj      "S1"
+  IL_001b:  ldloc.1
+  IL_001c:  ldloc.2
+  IL_001d:  call       "int E.Slice(S1, int, int)"
+  IL_0022:  pop
+  IL_0023:  ret
 }
 """);
 
         verifier.VerifyIL("S1.Test2", """
 {
-  // Code size       30 (0x1e)
-  .maxstack  4
+  // Code size       32 (0x20)
+  .maxstack  3
   .locals init (int V_0,
-                int V_1)
+                int V_1,
+                int V_2)
   IL_0000:  nop
   IL_0001:  ldarg.0
   IL_0002:  call       "int Program.GetStart()"
   IL_0007:  stloc.0
-  IL_0008:  call       "int Program.GetEnd()"
-  IL_000d:  stloc.1
-  IL_000e:  ldobj      "S1"
-  IL_0013:  ldloc.0
-  IL_0014:  ldloc.1
-  IL_0015:  ldloc.0
-  IL_0016:  sub
-  IL_0017:  call       "int E.Slice(S1, int, int)"
-  IL_001c:  pop
-  IL_001d:  ret
+  IL_0008:  ldloc.0
+  IL_0009:  stloc.1
+  IL_000a:  call       "int Program.GetEnd()"
+  IL_000f:  ldloc.0
+  IL_0010:  sub
+  IL_0011:  stloc.2
+  IL_0012:  ldobj      "S1"
+  IL_0017:  ldloc.1
+  IL_0018:  ldloc.2
+  IL_0019:  call       "int E.Slice(S1, int, int)"
+  IL_001e:  pop
+  IL_001f:  ret
 }
 """);
     }
@@ -29783,29 +29913,32 @@ class Program
 
         verifier.VerifyIL("Program.Test", """
 {
-  // Code size       43 (0x2b)
-  .maxstack  4
+  // Code size       45 (0x2d)
+  .maxstack  3
   .locals init (int V_0,
                 int V_1,
-                S1 V_2)
+                int V_2,
+                S1 V_3)
   IL_0000:  nop
   IL_0001:  call       "S1 Program.GetS1()"
-  IL_0006:  stloc.2
-  IL_0007:  ldloca.s   V_2
+  IL_0006:  stloc.3
+  IL_0007:  ldloca.s   V_3
   IL_0009:  call       "int Program.GetStart()"
   IL_000e:  stloc.0
-  IL_000f:  dup
-  IL_0010:  ldobj      "S1"
-  IL_0015:  call       "int E.get_Length(S1)"
-  IL_001a:  stloc.1
-  IL_001b:  ldobj      "S1"
-  IL_0020:  ldloc.0
-  IL_0021:  ldloc.1
-  IL_0022:  ldloc.0
-  IL_0023:  sub
-  IL_0024:  call       "int E.Slice(S1, int, int)"
-  IL_0029:  pop
-  IL_002a:  ret
+  IL_000f:  ldloc.0
+  IL_0010:  stloc.1
+  IL_0011:  dup
+  IL_0012:  ldobj      "S1"
+  IL_0017:  call       "int E.get_Length(S1)"
+  IL_001c:  ldloc.0
+  IL_001d:  sub
+  IL_001e:  stloc.2
+  IL_001f:  ldobj      "S1"
+  IL_0024:  ldloc.1
+  IL_0025:  ldloc.2
+  IL_0026:  call       "int E.Slice(S1, int, int)"
+  IL_002b:  pop
+  IL_002c:  ret
 }
 """);
     }
@@ -30061,22 +30194,23 @@ class Program
 
         verifier.VerifyIL("Program.Test1<T>()", """
 {
-  // Code size       74 (0x4a)
-  .maxstack  4
+  // Code size       78 (0x4e)
+  .maxstack  3
   .locals init (T V_0,
                 T& V_1,
                 int V_2,
                 int V_3,
-                T V_4,
-                T V_5)
+                int V_4,
+                T V_5,
+                T V_6)
   IL_0000:  nop
   IL_0001:  call       "T Program.GetT<T>()"
-  IL_0006:  stloc.s    V_4
-  IL_0008:  ldloca.s   V_4
+  IL_0006:  stloc.s    V_5
+  IL_0008:  ldloca.s   V_5
   IL_000a:  stloc.1
-  IL_000b:  ldloca.s   V_5
+  IL_000b:  ldloca.s   V_6
   IL_000d:  initobj    "T"
-  IL_0013:  ldloc.s    V_5
+  IL_0013:  ldloc.s    V_6
   IL_0015:  box        "T"
   IL_001a:  brtrue.s   IL_0027
   IL_001c:  ldloc.1
@@ -30087,46 +30221,51 @@ class Program
   IL_0027:  ldloc.1
   IL_0028:  call       "int Program.GetStart()"
   IL_002d:  stloc.2
-  IL_002e:  dup
-  IL_002f:  ldobj      "T"
-  IL_0034:  call       "int E.get_Length<T>(T)"
-  IL_0039:  stloc.3
-  IL_003a:  ldobj      "T"
-  IL_003f:  ldloc.2
-  IL_0040:  ldloc.3
-  IL_0041:  ldloc.2
-  IL_0042:  sub
-  IL_0043:  call       "int E.Slice<T>(T, int, int)"
-  IL_0048:  pop
-  IL_0049:  ret
+  IL_002e:  ldloc.2
+  IL_002f:  stloc.3
+  IL_0030:  dup
+  IL_0031:  ldobj      "T"
+  IL_0036:  call       "int E.get_Length<T>(T)"
+  IL_003b:  ldloc.2
+  IL_003c:  sub
+  IL_003d:  stloc.s    V_4
+  IL_003f:  ldobj      "T"
+  IL_0044:  ldloc.3
+  IL_0045:  ldloc.s    V_4
+  IL_0047:  call       "int E.Slice<T>(T, int, int)"
+  IL_004c:  pop
+  IL_004d:  ret
 }
 """);
 
         verifier.VerifyIL("Program.Test2<T>()", """
 {
-  // Code size       43 (0x2b)
-  .maxstack  4
+  // Code size       45 (0x2d)
+  .maxstack  3
   .locals init (int V_0,
                 int V_1,
-                T V_2)
+                int V_2,
+                T V_3)
   IL_0000:  nop
   IL_0001:  call       "T Program.GetT<T>()"
-  IL_0006:  stloc.2
-  IL_0007:  ldloca.s   V_2
+  IL_0006:  stloc.3
+  IL_0007:  ldloca.s   V_3
   IL_0009:  call       "int Program.GetStart()"
   IL_000e:  stloc.0
-  IL_000f:  dup
-  IL_0010:  ldobj      "T"
-  IL_0015:  call       "int E.get_Length<T>(T)"
-  IL_001a:  stloc.1
-  IL_001b:  ldobj      "T"
-  IL_0020:  ldloc.0
-  IL_0021:  ldloc.1
-  IL_0022:  ldloc.0
-  IL_0023:  sub
-  IL_0024:  call       "int E.Slice<T>(T, int, int)"
-  IL_0029:  pop
-  IL_002a:  ret
+  IL_000f:  ldloc.0
+  IL_0010:  stloc.1
+  IL_0011:  dup
+  IL_0012:  ldobj      "T"
+  IL_0017:  call       "int E.get_Length<T>(T)"
+  IL_001c:  ldloc.0
+  IL_001d:  sub
+  IL_001e:  stloc.2
+  IL_001f:  ldobj      "T"
+  IL_0024:  ldloc.1
+  IL_0025:  ldloc.2
+  IL_0026:  call       "int E.Slice<T>(T, int, int)"
+  IL_002b:  pop
+  IL_002c:  ret
 }
 """);
     }
@@ -30265,22 +30404,23 @@ class Program
 
         verifier.VerifyIL("Program.Test1<T>()", """
 {
-  // Code size       74 (0x4a)
-  .maxstack  4
+  // Code size       78 (0x4e)
+  .maxstack  3
   .locals init (T V_0,
                 T& V_1,
                 int V_2,
                 int V_3,
-                T V_4,
-                T V_5)
+                int V_4,
+                T V_5,
+                T V_6)
   IL_0000:  nop
   IL_0001:  call       "T Program.GetT<T>()"
-  IL_0006:  stloc.s    V_4
-  IL_0008:  ldloca.s   V_4
+  IL_0006:  stloc.s    V_5
+  IL_0008:  ldloca.s   V_5
   IL_000a:  stloc.1
-  IL_000b:  ldloca.s   V_5
+  IL_000b:  ldloca.s   V_6
   IL_000d:  initobj    "T"
-  IL_0013:  ldloc.s    V_5
+  IL_0013:  ldloc.s    V_6
   IL_0015:  box        "T"
   IL_001a:  brtrue.s   IL_0027
   IL_001c:  ldloc.1
@@ -30291,18 +30431,20 @@ class Program
   IL_0027:  ldloc.1
   IL_0028:  call       "int Program.GetStart()"
   IL_002d:  stloc.2
-  IL_002e:  dup
-  IL_002f:  ldobj      "T"
-  IL_0034:  call       "int E.get_Length<T>(T)"
-  IL_0039:  stloc.3
-  IL_003a:  ldobj      "T"
-  IL_003f:  ldloc.2
-  IL_0040:  ldloc.3
-  IL_0041:  ldloc.2
-  IL_0042:  sub
-  IL_0043:  call       "int E.Slice<T>(T, int, int)"
-  IL_0048:  pop
-  IL_0049:  ret
+  IL_002e:  ldloc.2
+  IL_002f:  stloc.3
+  IL_0030:  dup
+  IL_0031:  ldobj      "T"
+  IL_0036:  call       "int E.get_Length<T>(T)"
+  IL_003b:  ldloc.2
+  IL_003c:  sub
+  IL_003d:  stloc.s    V_4
+  IL_003f:  ldobj      "T"
+  IL_0044:  ldloc.3
+  IL_0045:  ldloc.s    V_4
+  IL_0047:  call       "int E.Slice<T>(T, int, int)"
+  IL_004c:  pop
+  IL_004d:  ret
 }
 """);
 

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
@@ -22517,7 +22517,6 @@ class Program
     [InlineData("in")]
     public void ImplicitIndexIndexerAccess_Get_LValueReceiver_02(string refKind)
     {
-        // TODO2 System.InvalidOperationException : Unexpected value 'ComplexConditionalReceiver' of type 'Microsoft.CodeAnalysis.CSharp.BoundKind'
         // sibling of IndexerAccess_Get_LValueReceiver_02
         // struct lvalue receiver passed by ref, extension implicit this[Index]
         var src = $$$"""
@@ -22662,7 +22661,7 @@ class Program
 
         if (refKind != "ref")
         {
-            verifier = CompileAndVerify(comp2);
+            verifier = CompileAndVerify(comp2, verify: Verification.Skipped);
             verifier.VerifyIL("Program.Test", $$"""
 {
   // Code size       24 (0x18)
@@ -22681,6 +22680,100 @@ class Program
 }
 """);
         }
+    }
+
+    [Theory]
+    [InlineData("ref")]
+    [InlineData("ref readonly")]
+    [InlineData("in")]
+    public void ImplicitIndexIndexerAccess_Get_LValueReceiver_02_02(string refKind)
+    {
+        // struct lvalue receiver passed by ref, instance Length + extension implicit this[Index]
+        var src = $$$"""
+static class E
+{
+    extension({{{refKind}}} S1 x)
+    {
+        public int this[int i] { get { System.Console.Write($"get:{x.F1} "); return 0; } }
+    }
+}
+
+struct S1
+{
+    public int F1;
+    public int Length { get { System.Console.Write($"length:{F1} "); Program.F.F1++; return 3; } }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        _ = F[Program.GetIndex()];
+    }
+
+    public static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program.F.F1} "); Program.F.F1++; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:4 get:5 final:5"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Theory]
+    [InlineData("ref")]
+    [InlineData("ref readonly")]
+    [InlineData("in")]
+    public void ImplicitIndexIndexerAccess_Get_LValueReceiver_02_03(string refKind)
+    {
+        // struct lvalue receiver passed by ref, extension Length + instance this[Index]
+        var src = $$$"""
+static class E
+{
+    extension({{{refKind}}} S1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 3; } }
+    }
+}
+
+struct S1
+{
+    public int F1;
+    public int this[int i] { get { System.Console.Write($"get:{F1} "); return 0; } }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        _ = F[Program.GetIndex()];
+    }
+
+    public static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program.F.F1} "); Program.F.F1++; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:4 get:5 final:5"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
     }
 
     [Fact]
@@ -22827,16 +22920,14 @@ class Program
 
         verifier.VerifyIL("Program.Test1<T>(ref T)", """
 {
-  // Code size      107 (0x6b)
-  .maxstack  3
+  // Code size       74 (0x4a)
+  .maxstack  2
   .locals init (T& V_0,
                 T V_1,
                 T& V_2,
                 T V_3,
-                T& V_4,
-                int V_5,
-                T V_6,
-                System.Index V_7)
+                int V_4,
+                System.Index V_5)
   IL_0000:  nop
   IL_0001:  ldarg.0
   IL_0002:  stloc.2
@@ -22852,32 +22943,20 @@ class Program
   IL_001c:  br.s       IL_001f
   IL_001e:  ldloc.2
   IL_001f:  stloc.0
-  IL_0020:  ldloc.0
-  IL_0021:  stloc.s    V_4
-  IL_0023:  ldloca.s   V_6
-  IL_0025:  initobj    "T"
-  IL_002b:  ldloc.s    V_6
-  IL_002d:  box        "T"
-  IL_0032:  brtrue.s   IL_0040
-  IL_0034:  ldloc.s    V_4
-  IL_0036:  ldobj      "T"
-  IL_003b:  stloc.3
-  IL_003c:  ldloca.s   V_3
-  IL_003e:  br.s       IL_0042
-  IL_0040:  ldloc.s    V_4
-  IL_0042:  call       "System.Index Program.GetIndex()"
-  IL_0047:  stloc.s    V_7
-  IL_0049:  ldloca.s   V_7
-  IL_004b:  ldloc.0
-  IL_004c:  ldobj      "T"
-  IL_0051:  call       "int E.get_Length<T>(T)"
-  IL_0056:  call       "int System.Index.GetOffset(int)"
-  IL_005b:  stloc.s    V_5
-  IL_005d:  ldobj      "T"
-  IL_0062:  ldloc.s    V_5
-  IL_0064:  call       "int E.get_Item<T>(T, int)"
-  IL_0069:  pop
-  IL_006a:  ret
+  IL_0020:  call       "System.Index Program.GetIndex()"
+  IL_0025:  stloc.s    V_5
+  IL_0027:  ldloca.s   V_5
+  IL_0029:  ldloc.0
+  IL_002a:  ldobj      "T"
+  IL_002f:  call       "int E.get_Length<T>(T)"
+  IL_0034:  call       "int System.Index.GetOffset(int)"
+  IL_0039:  stloc.s    V_4
+  IL_003b:  ldloc.0
+  IL_003c:  ldobj      "T"
+  IL_0041:  ldloc.s    V_4
+  IL_0043:  call       "int E.get_Item<T>(T, int)"
+  IL_0048:  pop
+  IL_0049:  ret
 }
 """);
 
@@ -22907,6 +22986,132 @@ class Program
   IL_0029:  ret
 }
 """);
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_Get_LValueReceiver_04_02()
+    {
+        // generic struct lvalue receiver passed by value, instance Length (via interface) + extension implicit this[Index]
+        var src = """
+interface IHasLength
+{
+    int Length { get; }
+}
+
+static class E
+{
+    extension<T>(T x) where T : IHasLength
+    {
+        public int this[int i] { get { System.Console.Write($"get:{((S1)(object)x).F1} "); return 0; } }
+    }
+}
+
+struct S1 : IHasLength
+{
+    public int F1;
+    public int Length { get { System.Console.Write($"length:{F1} "); Program<S1>.F.F1++; return 3; } }
+}
+
+class Program<T>
+{
+    public static T F;
+}
+
+class Program
+{
+    static void Main()
+    {
+        Program<S1>.F = new S1 { F1 = 3 };
+        Test1(ref Program<S1>.F);
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+
+        System.Console.Write(", ");
+
+        Program<S1>.F = new S1 { F1 = 3 };
+        Test2(ref Program<S1>.F);
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+    }
+
+    static void Test1<T>(ref T f) where T : IHasLength
+    {
+        _ = f[GetIndex()];
+    }
+
+    static void Test2<T>(ref T f) where T : struct, IHasLength
+    {
+        _ = f[GetIndex()];
+    }
+
+    static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program<S1>.F.F1} "); Program<S1>.F.F1++; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:4 get:5 final:5, GetIndex:3 length:4 get:5 final:5"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_Get_LValueReceiver_04_03()
+    {
+        // generic struct lvalue receiver passed by value, extension Length + instance this[Index] (via interface)
+        var src = """
+interface IHasIndexer
+{
+    int this[int i] { get; }
+}
+
+static class E
+{
+    extension<T>(T x) where T : IHasIndexer
+    {
+        public int Length { get { System.Console.Write($"length:{((S1)(object)x).F1} "); Program<S1>.F.F1++; return 3; } }
+    }
+}
+
+struct S1 : IHasIndexer
+{
+    public int F1;
+    public int this[int i] { get { System.Console.Write($"get:{F1} "); return 0; } }
+}
+
+class Program<T>
+{
+    public static T F;
+}
+
+class Program
+{
+    static void Main()
+    {
+        Program<S1>.F = new S1 { F1 = 3 };
+        Test1(ref Program<S1>.F);
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+
+        System.Console.Write(", ");
+
+        Program<S1>.F = new S1 { F1 = 3 };
+        Test2(ref Program<S1>.F);
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+    }
+
+    static void Test1<T>(ref T f) where T : IHasIndexer
+    {
+        _ = f[GetIndex()];
+    }
+
+    static void Test2<T>(ref T f) where T : struct, IHasIndexer
+    {
+        _ = f[GetIndex()];
+    }
+
+    static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program<S1>.F.F1} "); Program<S1>.F.F1++; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:4 get:5 final:5, GetIndex:3 length:4 get:5 final:5"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
     }
 
     [Fact]
@@ -23126,16 +23331,14 @@ class Program
 
         verifier.VerifyIL("Program.Test1<T>(ref T)", """
 {
-  // Code size      107 (0x6b)
-  .maxstack  3
+  // Code size       74 (0x4a)
+  .maxstack  2
   .locals init (T& V_0,
                 T V_1,
                 T& V_2,
                 T V_3,
-                T& V_4,
-                int V_5,
-                T V_6,
-                System.Index V_7)
+                int V_4,
+                System.Index V_5)
   IL_0000:  nop
   IL_0001:  ldarg.0
   IL_0002:  stloc.2
@@ -23151,32 +23354,20 @@ class Program
   IL_001c:  br.s       IL_001f
   IL_001e:  ldloc.2
   IL_001f:  stloc.0
-  IL_0020:  ldloc.0
-  IL_0021:  stloc.s    V_4
-  IL_0023:  ldloca.s   V_6
-  IL_0025:  initobj    "T"
-  IL_002b:  ldloc.s    V_6
-  IL_002d:  box        "T"
-  IL_0032:  brtrue.s   IL_0040
-  IL_0034:  ldloc.s    V_4
-  IL_0036:  ldobj      "T"
-  IL_003b:  stloc.3
-  IL_003c:  ldloca.s   V_3
-  IL_003e:  br.s       IL_0042
-  IL_0040:  ldloc.s    V_4
-  IL_0042:  call       "System.Index Program.GetIndex()"
-  IL_0047:  stloc.s    V_7
-  IL_0049:  ldloca.s   V_7
-  IL_004b:  ldloc.0
-  IL_004c:  ldobj      "T"
-  IL_0051:  call       "int E.get_Length<T>(T)"
-  IL_0056:  call       "int System.Index.GetOffset(int)"
-  IL_005b:  stloc.s    V_5
-  IL_005d:  ldobj      "T"
-  IL_0062:  ldloc.s    V_5
-  IL_0064:  call       "int E.get_Item<T>(T, int)"
-  IL_0069:  pop
-  IL_006a:  ret
+  IL_0020:  call       "System.Index Program.GetIndex()"
+  IL_0025:  stloc.s    V_5
+  IL_0027:  ldloca.s   V_5
+  IL_0029:  ldloc.0
+  IL_002a:  ldobj      "T"
+  IL_002f:  call       "int E.get_Length<T>(T)"
+  IL_0034:  call       "int System.Index.GetOffset(int)"
+  IL_0039:  stloc.s    V_4
+  IL_003b:  ldloc.0
+  IL_003c:  ldobj      "T"
+  IL_0041:  ldloc.s    V_4
+  IL_0043:  call       "int E.get_Item<T>(T, int)"
+  IL_0048:  pop
+  IL_0049:  ret
 }
 """);
 
@@ -23202,6 +23393,132 @@ class Program
   IL_0022:  ret
 }
 """);
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_Get_LValueReceiver_06_02()
+    {
+        // generic class lvalue receiver passed by value, instance Length (via interface) + extension implicit this[Index]
+        var src = """
+interface IHasLength
+{
+    int Length { get; }
+}
+
+static class E
+{
+    extension<T>(T x) where T : IHasLength
+    {
+        public int this[int i] { get { System.Console.Write($"get:{((C1)(object)x).F1} "); return 0; } }
+    }
+}
+
+class C1 : IHasLength
+{
+    public int F1;
+    public int Length { get { System.Console.Write($"length:{F1} "); Program<C1>.F = new C1 { F1 = Program<C1>.F.F1 + 1 }; return 3; } }
+}
+
+class Program<T>
+{
+    public static T F;
+}
+
+class Program
+{
+    static void Main()
+    {
+        Program<C1>.F = new C1 { F1 = 3 };
+        Test1(ref Program<C1>.F);
+        System.Console.Write($"final:{Program<C1>.F.F1}");
+
+        System.Console.Write(", ");
+
+        Program<C1>.F = new C1 { F1 = 3 };
+        Test2(ref Program<C1>.F);
+        System.Console.Write($"final:{Program<C1>.F.F1}");
+    }
+
+    static void Test1<T>(ref T f) where T : IHasLength
+    {
+        _ = f[GetIndex()];
+    }
+
+    static void Test2<T>(ref T f) where T : class, IHasLength
+    {
+        _ = f[GetIndex()];
+    }
+
+    static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program<C1>.F.F1} "); Program<C1>.F = new C1 { F1 = Program<C1>.F.F1 + 1 }; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:3 get:3 final:5, GetIndex:3 length:3 get:3 final:5"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_Get_LValueReceiver_06_03()
+    {
+        // generic class lvalue receiver passed by value, extension Length + instance this[Index] (via interface)
+        var src = """
+interface IHasIndexer
+{
+    int this[int i] { get; }
+}
+
+static class E
+{
+    extension<T>(T x) where T : IHasIndexer
+    {
+        public int Length { get { System.Console.Write($"length:{((C1)(object)x).F1} "); Program<C1>.F = new C1 { F1 = Program<C1>.F.F1 + 1 }; return 3; } }
+    }
+}
+
+class C1 : IHasIndexer
+{
+    public int F1;
+    public int this[int i] { get { System.Console.Write($"get:{F1} "); return 0; } }
+}
+
+class Program<T>
+{
+    public static T F;
+}
+
+class Program
+{
+    static void Main()
+    {
+        Program<C1>.F = new C1 { F1 = 3 };
+        Test1(ref Program<C1>.F);
+        System.Console.Write($"final:{Program<C1>.F.F1}");
+
+        System.Console.Write(", ");
+
+        Program<C1>.F = new C1 { F1 = 3 };
+        Test2(ref Program<C1>.F);
+        System.Console.Write($"final:{Program<C1>.F.F1}");
+    }
+
+    static void Test1<T>(ref T f) where T : IHasIndexer
+    {
+        _ = f[GetIndex()];
+    }
+
+    static void Test2<T>(ref T f) where T : class, IHasIndexer
+    {
+        _ = f[GetIndex()];
+    }
+
+    static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program<C1>.F.F1} "); Program<C1>.F = new C1 { F1 = Program<C1>.F.F1 + 1 }; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:3 get:3 final:5, GetIndex:3 length:3 get:3 final:5"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
     }
 
     [Fact]
@@ -23453,7 +23770,6 @@ class Program
     [Fact]
     public void ImplicitIndexIndexerAccess_Get_RValueReceiver_04()
     {
-        // TODO2 System.InvalidOperationException : Unexpected value 'ComplexConditionalReceiver' of type 'Microsoft.CodeAnalysis.CSharp.BoundKind'
         // sibling of IndexerAccess_Get_RValueReceiver_04
         // generic struct rvalue receiver passed by value, extension implicit this[Index]
         var src = """
@@ -23511,6 +23827,160 @@ class Program
     static System.Index GetIndex() { System.Console.Write($"GetIndex:{State} "); State++; return ^1; }
 
     static async Task Test3<T>()
+    {
+        _ = GetT<T>()[await GetIndexAsync()];
+    }
+
+    static async Task<System.Index> GetIndexAsync() { System.Console.Write($"GetIndexAsync:{State} "); State++; await Task.Yield(); return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:3 get:3 final:5, GetIndex:3 length:3 get:3 final:5, GetIndexAsync:3 length:3 get:3 final:5"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_Get_RValueReceiver_04_02()
+    {
+        // generic struct rvalue receiver passed by value, instance Length (via interface) + extension implicit this[Index]
+        var src = """
+using System.Threading.Tasks;
+
+interface IHasLength
+{
+    int Length { get; }
+}
+
+static class E
+{
+    extension<T>(T x) where T : IHasLength
+    {
+        public int this[int i] { get { System.Console.Write($"get:{((S1)(object)x).F1} "); return 0; } }
+    }
+}
+
+struct S1 : IHasLength
+{
+    public int F1;
+    public int Length { get { System.Console.Write($"length:{F1} "); Program.State++; return 3; } }
+}
+
+class Program
+{
+    public static int State;
+
+    static async Task Main()
+    {
+        State = 3;
+        Test1<S1>();
+        System.Console.Write($"final:{State}");
+
+        System.Console.Write(", ");
+
+        State = 3;
+        Test2<S1>();
+        System.Console.Write($"final:{State}");
+
+        System.Console.Write(", ");
+
+        State = 3;
+        await Test3<S1>();
+        System.Console.Write($"final:{State}");
+    }
+
+    static T GetT<T>() where T : IHasLength => (T)(object)new S1 { F1 = State };
+
+    static void Test1<T>() where T : IHasLength
+    {
+        _ = GetT<T>()[GetIndex()];
+    }
+
+    static void Test2<T>() where T : struct, IHasLength
+    {
+        _ = GetT<T>()[GetIndex()];
+    }
+
+    static System.Index GetIndex() { System.Console.Write($"GetIndex:{State} "); State++; return ^1; }
+
+    static async Task Test3<T>() where T : IHasLength
+    {
+        _ = GetT<T>()[await GetIndexAsync()];
+    }
+
+    static async Task<System.Index> GetIndexAsync() { System.Console.Write($"GetIndexAsync:{State} "); State++; await Task.Yield(); return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:3 get:3 final:5, GetIndex:3 length:3 get:3 final:5, GetIndexAsync:3 length:3 get:3 final:5"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_Get_RValueReceiver_04_03()
+    {
+        // generic struct rvalue receiver passed by value, extension Length + instance this[Index] (via interface)
+        var src = """
+using System.Threading.Tasks;
+
+interface IHasIndexer
+{
+    int this[int i] { get; }
+}
+
+static class E
+{
+    extension<T>(T x) where T : IHasIndexer
+    {
+        public int Length { get { System.Console.Write($"length:{((S1)(object)x).F1} "); Program.State++; return 3; } }
+    }
+}
+
+struct S1 : IHasIndexer
+{
+    public int F1;
+    public int this[int i] { get { System.Console.Write($"get:{F1} "); return 0; } }
+}
+
+class Program
+{
+    public static int State;
+
+    static async Task Main()
+    {
+        State = 3;
+        Test1<S1>();
+        System.Console.Write($"final:{State}");
+
+        System.Console.Write(", ");
+
+        State = 3;
+        Test2<S1>();
+        System.Console.Write($"final:{State}");
+
+        System.Console.Write(", ");
+
+        State = 3;
+        await Test3<S1>();
+        System.Console.Write($"final:{State}");
+    }
+
+    static T GetT<T>() where T : IHasIndexer => (T)(object)new S1 { F1 = State };
+
+    static void Test1<T>() where T : IHasIndexer
+    {
+        _ = GetT<T>()[GetIndex()];
+    }
+
+    static void Test2<T>() where T : struct, IHasIndexer
+    {
+        _ = GetT<T>()[GetIndex()];
+    }
+
+    static System.Index GetIndex() { System.Console.Write($"GetIndex:{State} "); State++; return ^1; }
+
+    static async Task Test3<T>() where T : IHasIndexer
     {
         _ = GetT<T>()[await GetIndexAsync()];
     }
@@ -23592,7 +24062,6 @@ class Program
     [Fact]
     public void ImplicitIndexIndexerAccess_Get_RValueReceiver_06()
     {
-        // TODO2 System.InvalidOperationException : Unexpected value 'ComplexConditionalReceiver' of type 'Microsoft.CodeAnalysis.CSharp.BoundKind'
         // sibling of IndexerAccess_Get_RValueReceiver_06
         // generic class rvalue receiver passed by value, extension implicit this[Index]
         var src = """
@@ -23650,6 +24119,160 @@ class Program
     static System.Index GetIndex() { System.Console.Write($"GetIndex:{State} "); State++; return ^1; }
 
     static async Task Test3<T>()
+    {
+        _ = GetT<T>()[await GetIndexAsync()];
+    }
+
+    static async Task<System.Index> GetIndexAsync() { System.Console.Write($"GetIndexAsync:{State} "); State++; await Task.Yield(); return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:3 get:3 final:5, GetIndex:3 length:3 get:3 final:5, GetIndexAsync:3 length:3 get:3 final:5"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_Get_RValueReceiver_06_02()
+    {
+        // generic class rvalue receiver passed by value, instance Length (via interface) + extension implicit this[Index]
+        var src = """
+using System.Threading.Tasks;
+
+interface IHasLength
+{
+    int Length { get; }
+}
+
+static class E
+{
+    extension<T>(T x) where T : IHasLength
+    {
+        public int this[int i] { get { System.Console.Write($"get:{((C1)(object)x).F1} "); return 0; } }
+    }
+}
+
+class C1 : IHasLength
+{
+    public int F1;
+    public int Length { get { System.Console.Write($"length:{F1} "); Program.State++; return 3; } }
+}
+
+class Program
+{
+    public static int State;
+
+    static async Task Main()
+    {
+        State = 3;
+        Test1<C1>();
+        System.Console.Write($"final:{State}");
+
+        System.Console.Write(", ");
+
+        State = 3;
+        Test2<C1>();
+        System.Console.Write($"final:{State}");
+
+        System.Console.Write(", ");
+
+        State = 3;
+        await Test3<C1>();
+        System.Console.Write($"final:{State}");
+    }
+
+    static T GetT<T>() where T : IHasLength => (T)(object)new C1 { F1 = State };
+
+    static void Test1<T>() where T : IHasLength
+    {
+        _ = GetT<T>()[GetIndex()];
+    }
+
+    static void Test2<T>() where T : class, IHasLength
+    {
+        _ = GetT<T>()[GetIndex()];
+    }
+
+    static System.Index GetIndex() { System.Console.Write($"GetIndex:{State} "); State++; return ^1; }
+
+    static async Task Test3<T>() where T : IHasLength
+    {
+        _ = GetT<T>()[await GetIndexAsync()];
+    }
+
+    static async Task<System.Index> GetIndexAsync() { System.Console.Write($"GetIndexAsync:{State} "); State++; await Task.Yield(); return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:3 get:3 final:5, GetIndex:3 length:3 get:3 final:5, GetIndexAsync:3 length:3 get:3 final:5"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_Get_RValueReceiver_06_03()
+    {
+        // generic class rvalue receiver passed by value, extension Length + instance this[Index] (via interface)
+        var src = """
+using System.Threading.Tasks;
+
+interface IHasIndexer
+{
+    int this[int i] { get; }
+}
+
+static class E
+{
+    extension<T>(T x) where T : IHasIndexer
+    {
+        public int Length { get { System.Console.Write($"length:{((C1)(object)x).F1} "); Program.State++; return 3; } }
+    }
+}
+
+class C1 : IHasIndexer
+{
+    public int F1;
+    public int this[int i] { get { System.Console.Write($"get:{F1} "); return 0; } }
+}
+
+class Program
+{
+    public static int State;
+
+    static async Task Main()
+    {
+        State = 3;
+        Test1<C1>();
+        System.Console.Write($"final:{State}");
+
+        System.Console.Write(", ");
+
+        State = 3;
+        Test2<C1>();
+        System.Console.Write($"final:{State}");
+
+        System.Console.Write(", ");
+
+        State = 3;
+        await Test3<C1>();
+        System.Console.Write($"final:{State}");
+    }
+
+    static T GetT<T>() where T : IHasIndexer => (T)(object)new C1 { F1 = State };
+
+    static void Test1<T>() where T : IHasIndexer
+    {
+        _ = GetT<T>()[GetIndex()];
+    }
+
+    static void Test2<T>() where T : class, IHasIndexer
+    {
+        _ = GetT<T>()[GetIndex()];
+    }
+
+    static System.Index GetIndex() { System.Console.Write($"GetIndex:{State} "); State++; return ^1; }
+
+    static async Task Test3<T>() where T : IHasIndexer
     {
         _ = GetT<T>()[await GetIndexAsync()];
     }
@@ -23915,6 +24538,233 @@ class Program
 
         var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
         CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:4 Slice:5 final:6, GetRange:3 length:4 Slice:5 final:6"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Theory]
+    [InlineData("ref")]
+    [InlineData("ref readonly")]
+    [InlineData("in")]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_02(string refKind)
+    {
+        // sibling of IndexerAccess_Get_LValueReceiver_02 / ImplicitIndexIndexerAccess_Get_LValueReceiver_02
+        // struct lvalue receiver passed by ref, extension Length + extension Slice
+        var src = $$$"""
+static class E
+{
+    extension({{{refKind}}} S1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 5; } }
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); return 0; }
+    }
+}
+
+struct S1
+{
+    public int F1;
+
+    public void Test2()
+    {
+        _ = this[Program.GetRange()];
+    }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        F = new S1 { F1 = 3 };
+        F.Test2();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        _ = F[Program.GetRange()];
+    }
+
+    public static System.Range GetRange() { System.Console.Write($"GetRange:{Program.F.F1} "); Program.F.F1++; return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:4 Slice:5 final:5, GetRange:3 length:4 Slice:5 final:5"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", $$"""
+{
+  // Code size       66 (0x42)
+  .maxstack  3
+  .locals init (System.Range V_0,
+                int V_1,
+                int V_2,
+                int V_3,
+                System.Index V_4)
+  IL_0000:  nop
+  IL_0001:  ldsflda    "S1 Program.F"
+  IL_0006:  call       "System.Range Program.GetRange()"
+  IL_000b:  stloc.0
+  IL_000c:  dup
+  IL_000d:  call       "int E.get_Length({{refKind}} S1)"
+  IL_0012:  stloc.1
+  IL_0013:  ldloca.s   V_0
+  IL_0015:  call       "System.Index System.Range.Start.get"
+  IL_001a:  stloc.s    V_4
+  IL_001c:  ldloca.s   V_4
+  IL_001e:  ldloc.1
+  IL_001f:  call       "int System.Index.GetOffset(int)"
+  IL_0024:  stloc.2
+  IL_0025:  ldloca.s   V_0
+  IL_0027:  call       "System.Index System.Range.End.get"
+  IL_002c:  stloc.s    V_4
+  IL_002e:  ldloca.s   V_4
+  IL_0030:  ldloc.1
+  IL_0031:  call       "int System.Index.GetOffset(int)"
+  IL_0036:  ldloc.2
+  IL_0037:  sub
+  IL_0038:  stloc.3
+  IL_0039:  ldloc.2
+  IL_003a:  ldloc.3
+  IL_003b:  call       "int E.Slice({{refKind}} S1, int, int)"
+  IL_0040:  pop
+  IL_0041:  ret
+}
+""");
+
+        verifier.VerifyIL("S1.Test2", $$"""
+{
+  // Code size       62 (0x3e)
+  .maxstack  3
+  .locals init (System.Range V_0,
+                int V_1,
+                int V_2,
+                int V_3,
+                System.Index V_4)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  call       "System.Range Program.GetRange()"
+  IL_0007:  stloc.0
+  IL_0008:  dup
+  IL_0009:  call       "int E.get_Length({{refKind}} S1)"
+  IL_000e:  stloc.1
+  IL_000f:  ldloca.s   V_0
+  IL_0011:  call       "System.Index System.Range.Start.get"
+  IL_0016:  stloc.s    V_4
+  IL_0018:  ldloca.s   V_4
+  IL_001a:  ldloc.1
+  IL_001b:  call       "int System.Index.GetOffset(int)"
+  IL_0020:  stloc.2
+  IL_0021:  ldloca.s   V_0
+  IL_0023:  call       "System.Index System.Range.End.get"
+  IL_0028:  stloc.s    V_4
+  IL_002a:  ldloca.s   V_4
+  IL_002c:  ldloc.1
+  IL_002d:  call       "int System.Index.GetOffset(int)"
+  IL_0032:  ldloc.2
+  IL_0033:  sub
+  IL_0034:  stloc.3
+  IL_0035:  ldloc.2
+  IL_0036:  ldloc.3
+  IL_0037:  call       "int E.Slice({{refKind}} S1, int, int)"
+  IL_003c:  pop
+  IL_003d:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_02_02()
+    {
+        // struct lvalue receiver passed by ref, instance Length + extension Slice
+        var src = """
+static class E
+{
+    extension(ref S1 x)
+    {
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); return 0; }
+    }
+}
+
+struct S1
+{
+    public int F1;
+    public int Length { get { System.Console.Write($"length:{F1} "); Program.F.F1++; return 5; } }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        _ = F[Program.GetRange()];
+    }
+
+    public static System.Range GetRange() { System.Console.Write($"GetRange:{Program.F.F1} "); Program.F.F1++; return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:4 Slice:5 final:5"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_02_03()
+    {
+        // struct lvalue receiver passed by ref, extension Length + instance Slice
+        var src = """
+static class E
+{
+    extension(ref S1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 5; } }
+    }
+}
+
+struct S1
+{
+    public int F1;
+    public int Slice(int start, int length) { System.Console.Write($"Slice:{F1} "); return 0; }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        _ = F[Program.GetRange()];
+    }
+
+    public static System.Range GetRange() { System.Console.Write($"GetRange:{Program.F.F1} "); Program.F.F1++; return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:4 Slice:5 final:5"), verify: Verification.Skipped)
             .VerifyDiagnostics();
     }
 
@@ -24265,6 +25115,142 @@ class Program
     }
 
     [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_04_02()
+    {
+        // generic struct lvalue receiver passed by value, instance Length (via interface) + extension Slice
+        var src = """
+interface IHasLength
+{
+    int Length { get; }
+}
+
+static class E
+{
+    extension<T>(T x) where T : IHasLength
+    {
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{((S1)(object)x).F1} "); Program<S1>.F.F1++; return 0; }
+    }
+}
+
+struct S1 : IHasLength
+{
+    public int F1;
+    public int Length { get { System.Console.Write($"length:{F1} "); Program<S1>.F.F1++; return 5; } }
+}
+
+class Program<T>
+{
+    public static T F;
+}
+
+class Program
+{
+    static void Main()
+    {
+        Program<S1>.F = new S1 { F1 = 3 };
+        Test1(ref Program<S1>.F);
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+
+        System.Console.Write(", ");
+
+        Program<S1>.F = new S1 { F1 = 3 };
+        Test2(ref Program<S1>.F);
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+    }
+
+    static void Test1<T>(ref T f) where T : IHasLength
+    {
+        _ = f[GetRange()];
+    }
+
+    static void Test2<T>(ref T f) where T : struct, IHasLength
+    {
+        _ = f[GetRange()];
+    }
+
+    static System.Range GetRange()
+    {
+        System.Console.Write($"GetRange:{Program<S1>.F.F1} ");
+        Program<S1>.F.F1++;
+        return 1..^1;
+    }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:4 Slice:5 final:6, GetRange:3 length:4 Slice:5 final:6"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_04_03()
+    {
+        // generic struct lvalue receiver passed by value, extension Length + instance Slice (via interface)
+        var src = """
+interface IHasSlice
+{
+    int Slice(int start, int length);
+}
+
+static class E
+{
+    extension<T>(T x) where T : IHasSlice
+    {
+        public int Length { get { System.Console.Write($"length:{((S1)(object)x).F1} "); Program<S1>.F.F1++; return 5; } }
+    }
+}
+
+struct S1 : IHasSlice
+{
+    public int F1;
+    public int Slice(int start, int length) { System.Console.Write($"Slice:{F1} "); Program<S1>.F.F1++; return 0; }
+}
+
+class Program<T>
+{
+    public static T F;
+}
+
+class Program
+{
+    static void Main()
+    {
+        Program<S1>.F = new S1 { F1 = 3 };
+        Test1(ref Program<S1>.F);
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+
+        System.Console.Write(", ");
+
+        Program<S1>.F = new S1 { F1 = 3 };
+        Test2(ref Program<S1>.F);
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+    }
+
+    static void Test1<T>(ref T f) where T : IHasSlice
+    {
+        _ = f[GetRange()];
+    }
+
+    static void Test2<T>(ref T f) where T : struct, IHasSlice
+    {
+        _ = f[GetRange()];
+    }
+
+    static System.Range GetRange()
+    {
+        System.Console.Write($"GetRange:{Program<S1>.F.F1} ");
+        Program<S1>.F.F1++;
+        return 1..^1;
+    }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:4 Slice:5 final:6, GetRange:3 length:4 Slice:5 final:6"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Fact]
     public void ImplicitRangeIndexerAccess_Get_LValueReceiver_05()
     {
         // sibling of IndexerAccess_Get_LValueReceiver_05
@@ -24393,6 +25379,140 @@ class Program
             // (14,13): error CS1510: A ref or out value must be an assignable variable
             //         _ = default(T)[1..^1];
             Diagnostic(ErrorCode.ERR_RefLvalueExpected, "default(T)").WithLocation(14, 13));
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_05_02()
+    {
+        // struct lvalue receiver passed by ref, constrained to struct, instance Length (via interface) + extension Slice (by ref)
+        var src = """
+using System.Threading.Tasks;
+
+interface IHasLength
+{
+    int Length { get; }
+}
+
+static class E
+{
+    extension<T>(ref T x) where T : struct, IHasLength
+    {
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{((S1)(object)x).F1} "); Program<S1>.F.F1++; return 0; }
+    }
+}
+
+struct S1 : IHasLength
+{
+    public int F1;
+    public int Length { get { System.Console.Write($"length:{F1} "); Program<S1>.F.F1++; return 5; } }
+}
+
+class Program<T>
+{
+    public static T F;
+}
+
+class Program
+{
+    static async Task Main()
+    {
+        Program<S1>.F = new S1 { F1 = 3 };
+        Test2(ref Program<S1>.F);
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+
+        System.Console.Write(", ");
+
+        Program<S1>.F = new S1 { F1 = 3 };
+        await Test3<S1>();
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+    }
+
+    static void Test2<T>(ref T f) where T : struct, IHasLength
+    {
+        _ = f[GetRange()];
+    }
+
+    static System.Range GetRange() { System.Console.Write($"GetRange:{Program<S1>.F.F1} "); Program<S1>.F.F1++; return 1..^1; }
+
+    static async Task Test3<T>() where T : struct, IHasLength
+    {
+        _ = Program<T>.F[await GetRangeAsync()];
+    }
+
+    static async Task<System.Range> GetRangeAsync() { System.Console.Write($"GetRangeAsync:{Program<S1>.F.F1} "); Program<S1>.F.F1++; await Task.Yield(); return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:4 Slice:5 final:6, GetRangeAsync:3 length:4 Slice:5 final:6"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_05_03()
+    {
+        // struct lvalue receiver passed by ref, constrained to struct, extension Length (by ref) + instance Slice (via interface)
+        var src = """
+using System.Threading.Tasks;
+
+interface IHasSlice
+{
+    int Slice(int start, int length);
+}
+
+static class E
+{
+    extension<T>(ref T x) where T : struct, IHasSlice
+    {
+        public int Length { get { System.Console.Write($"length:{((S1)(object)x).F1} "); Program<S1>.F.F1++; return 5; } }
+    }
+}
+
+struct S1 : IHasSlice
+{
+    public int F1;
+    public int Slice(int start, int length) { System.Console.Write($"Slice:{F1} "); Program<S1>.F.F1++; return 0; }
+}
+
+class Program<T>
+{
+    public static T F;
+}
+
+class Program
+{
+    static async Task Main()
+    {
+        Program<S1>.F = new S1 { F1 = 3 };
+        Test2(ref Program<S1>.F);
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+
+        System.Console.Write(", ");
+
+        Program<S1>.F = new S1 { F1 = 3 };
+        await Test3<S1>();
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+    }
+
+    static void Test2<T>(ref T f) where T : struct, IHasSlice
+    {
+        _ = f[GetRange()];
+    }
+
+    static System.Range GetRange() { System.Console.Write($"GetRange:{Program<S1>.F.F1} "); Program<S1>.F.F1++; return 1..^1; }
+
+    static async Task Test3<T>() where T : struct, IHasSlice
+    {
+        _ = Program<T>.F[await GetRangeAsync()];
+    }
+
+    static async Task<System.Range> GetRangeAsync() { System.Console.Write($"GetRangeAsync:{Program<S1>.F.F1} "); Program<S1>.F.F1++; await Task.Yield(); return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:4 Slice:5 final:6, GetRangeAsync:3 length:4 Slice:5 final:6"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
     }
 
     [Fact]
@@ -24550,6 +25670,132 @@ class Program
   IL_0042:  ret
 }
 """);
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_06_02()
+    {
+        // generic class lvalue receiver, instance Length (via interface) + extension Slice
+        var src = """
+interface IHasLength
+{
+    int Length { get; }
+}
+
+static class E
+{
+    extension<T>(T x) where T : IHasLength
+    {
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{((C1)(object)x).F1} "); Program<C1>.F = new C1 { F1 = Program<C1>.F.F1 + 1 }; return 0; }
+    }
+}
+
+class C1 : IHasLength
+{
+    public int F1;
+    public int Length { get { System.Console.Write($"length:{F1} "); Program<C1>.F = new C1 { F1 = Program<C1>.F.F1 + 1 }; return 5; } }
+}
+
+class Program<T>
+{
+    public static T F;
+}
+
+class Program
+{
+    static void Main()
+    {
+        Program<C1>.F = new C1 { F1 = 3 };
+        Test1(ref Program<C1>.F);
+        System.Console.Write($"final:{Program<C1>.F.F1}");
+
+        System.Console.Write(", ");
+
+        Program<C1>.F = new C1 { F1 = 3 };
+        Test2(ref Program<C1>.F);
+        System.Console.Write($"final:{Program<C1>.F.F1}");
+    }
+
+    static void Test1<T>(ref T f) where T : IHasLength
+    {
+        _ = f[GetRange()];
+    }
+
+    static void Test2<T>(ref T f) where T : class, IHasLength
+    {
+        _ = f[GetRange()];
+    }
+
+    static System.Range GetRange() { System.Console.Write($"GetRange:{Program<C1>.F.F1} "); Program<C1>.F = new C1 { F1 = Program<C1>.F.F1 + 1 }; return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:3 Slice:3 final:6, GetRange:3 length:3 Slice:3 final:6"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_06_03()
+    {
+        // generic class lvalue receiver, extension Length + instance Slice (via interface)
+        var src = """
+interface IHasSlice
+{
+    int Slice(int start, int length);
+}
+
+static class E
+{
+    extension<T>(T x) where T : IHasSlice
+    {
+        public int Length { get { System.Console.Write($"length:{((C1)(object)x).F1} "); Program<C1>.F = new C1 { F1 = Program<C1>.F.F1 + 1 }; return 5; } }
+    }
+}
+
+class C1 : IHasSlice
+{
+    public int F1;
+    public int Slice(int start, int length) { System.Console.Write($"Slice:{F1} "); Program<C1>.F = new C1 { F1 = Program<C1>.F.F1 + 1 }; return 0; }
+}
+
+class Program<T>
+{
+    public static T F;
+}
+
+class Program
+{
+    static void Main()
+    {
+        Program<C1>.F = new C1 { F1 = 3 };
+        Test1(ref Program<C1>.F);
+        System.Console.Write($"final:{Program<C1>.F.F1}");
+
+        System.Console.Write(", ");
+
+        Program<C1>.F = new C1 { F1 = 3 };
+        Test2(ref Program<C1>.F);
+        System.Console.Write($"final:{Program<C1>.F.F1}");
+    }
+
+    static void Test1<T>(ref T f) where T : IHasSlice
+    {
+        _ = f[GetRange()];
+    }
+
+    static void Test2<T>(ref T f) where T : class, IHasSlice
+    {
+        _ = f[GetRange()];
+    }
+
+    static System.Range GetRange() { System.Console.Write($"GetRange:{Program<C1>.F.F1} "); Program<C1>.F = new C1 { F1 = Program<C1>.F.F1 + 1 }; return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:3 Slice:3 final:6, GetRange:3 length:3 Slice:3 final:6"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
     }
 
     [Fact]
@@ -25353,6 +26599,160 @@ class Program
     }
 
     [Fact]
+    public void ImplicitRangeIndexerAccess_Get_RValueReceiver_04_02()
+    {
+        // generic struct rvalue, instance Length (via interface) + extension Slice
+        var src = """
+using System.Threading.Tasks;
+
+interface IHasLength
+{
+    int Length { get; }
+}
+
+static class E
+{
+    extension<T>(T x) where T : IHasLength
+    {
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{((S1)(object)x).F1} "); Program.State++; return 0; }
+    }
+}
+
+struct S1 : IHasLength
+{
+    public int F1;
+    public int Length { get { System.Console.Write($"length:{F1} "); Program.State++; return 5; } }
+}
+
+class Program
+{
+    public static int State;
+
+    static async Task Main()
+    {
+        State = 3;
+        Test1<S1>();
+        System.Console.Write($"final:{State}");
+
+        System.Console.Write(", ");
+
+        State = 3;
+        Test2<S1>();
+        System.Console.Write($"final:{State}");
+
+        System.Console.Write(", ");
+
+        State = 3;
+        await Test3<S1>();
+        System.Console.Write($"final:{State}");
+    }
+
+    static T GetT<T>() => (T)(object)new S1 { F1 = State };
+
+    static void Test1<T>() where T : IHasLength
+    {
+        _ = GetT<T>()[GetRange()];
+    }
+
+    static void Test2<T>() where T : struct, IHasLength
+    {
+        _ = GetT<T>()[GetRange()];
+    }
+
+    static System.Range GetRange() { System.Console.Write($"GetRange:{State} "); State++; return 1..^1; }
+
+    static async Task Test3<T>() where T : IHasLength
+    {
+        _ = GetT<T>()[await GetRangeAsync()];
+    }
+
+    static async Task<System.Range> GetRangeAsync() { System.Console.Write($"GetRangeAsync:{State} "); State++; await Task.Yield(); return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:3 Slice:3 final:6, GetRange:3 length:3 Slice:3 final:6, GetRangeAsync:3 length:3 Slice:3 final:6"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_RValueReceiver_04_03()
+    {
+        // generic struct rvalue, extension Length + instance Slice (via interface)
+        var src = """
+using System.Threading.Tasks;
+
+interface IHasSlice
+{
+    int Slice(int start, int length);
+}
+
+static class E
+{
+    extension<T>(T x) where T : IHasSlice
+    {
+        public int Length { get { System.Console.Write($"length:{((S1)(object)x).F1} "); Program.State++; return 5; } }
+    }
+}
+
+struct S1 : IHasSlice
+{
+    public int F1;
+    public int Slice(int start, int length) { System.Console.Write($"Slice:{F1} "); Program.State++; return 0; }
+}
+
+class Program
+{
+    public static int State;
+
+    static async Task Main()
+    {
+        State = 3;
+        Test1<S1>();
+        System.Console.Write($"final:{State}");
+
+        System.Console.Write(", ");
+
+        State = 3;
+        Test2<S1>();
+        System.Console.Write($"final:{State}");
+
+        System.Console.Write(", ");
+
+        State = 3;
+        await Test3<S1>();
+        System.Console.Write($"final:{State}");
+    }
+
+    static T GetT<T>() => (T)(object)new S1 { F1 = State };
+
+    static void Test1<T>() where T : IHasSlice
+    {
+        _ = GetT<T>()[GetRange()];
+    }
+
+    static void Test2<T>() where T : struct, IHasSlice
+    {
+        _ = GetT<T>()[GetRange()];
+    }
+
+    static System.Range GetRange() { System.Console.Write($"GetRange:{State} "); State++; return 1..^1; }
+
+    static async Task Test3<T>() where T : IHasSlice
+    {
+        _ = GetT<T>()[await GetRangeAsync()];
+    }
+
+    static async Task<System.Range> GetRangeAsync() { System.Console.Write($"GetRangeAsync:{State} "); State++; await Task.Yield(); return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:3 Slice:3 final:6, GetRange:3 length:3 Slice:3 final:6, GetRangeAsync:3 length:3 Slice:3 final:6"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Fact]
     public void ImplicitRangeIndexerAccess_Get_RValueReceiver_05()
     {
         // sibling of IndexerAccess_Get_RValueReceiver_05
@@ -25406,6 +26806,114 @@ class Program
             // (29,13): error CS1510: A ref or out value must be an assignable variable
             //         _ = GetT<T>()[await GetRangeAsync()];
             Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetT<T>()").WithLocation(29, 13));
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_RValueReceiver_05_02()
+    {
+        // struct rvalue receiver, instance Length (via interface) + extension Slice (by ref)
+        var src = """
+using System.Threading.Tasks;
+
+interface IHasLength
+{
+    int Length { get; }
+}
+
+static class E
+{
+    extension<T>(ref T x) where T : struct, IHasLength
+    {
+        public int Slice(int start, int length) => 0;
+    }
+}
+
+struct S1 : IHasLength
+{
+    public int F1;
+    public int Length => 5;
+}
+
+class Program
+{
+    static void Test2<T>() where T : struct, IHasLength
+    {
+        _ = GetT<T>()[GetRange()];
+    }
+
+    static T GetT<T>() => (T)(object)new S1 { F1 = 3 };
+    static System.Range GetRange() => 1..^1;
+
+    static async Task Test3<T>() where T : struct, IHasLength
+    {
+        _ = GetT<T>()[await GetRangeAsync()];
+    }
+
+    static async Task<System.Range> GetRangeAsync() { await Task.Yield(); return 1..^1; }
+}
+""";
+
+        CreateCompilation(src, targetFramework: TargetFramework.Net100).VerifyDiagnostics(
+            // (26,13): error CS1510: A ref or out value must be an assignable variable
+            //         _ = GetT<T>()[GetRange()];
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetT<T>()").WithLocation(26, 13),
+            // (34,13): error CS1510: A ref or out value must be an assignable variable
+            //         _ = GetT<T>()[await GetRangeAsync()];
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetT<T>()").WithLocation(34, 13));
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_RValueReceiver_05_03()
+    {
+        // struct rvalue receiver, extension Length (by ref) + instance Slice (via interface)
+        var src = """
+using System.Threading.Tasks;
+
+interface IHasSlice
+{
+    int Slice(int start, int length);
+}
+
+static class E
+{
+    extension<T>(ref T x) where T : struct, IHasSlice
+    {
+        public int Length => 5;
+    }
+}
+
+struct S1 : IHasSlice
+{
+    public int F1;
+    public int Slice(int start, int length) => 0;
+}
+
+class Program
+{
+    static void Test2<T>() where T : struct, IHasSlice
+    {
+        _ = GetT<T>()[GetRange()];
+    }
+
+    static T GetT<T>() => (T)(object)new S1 { F1 = 3 };
+    static System.Range GetRange() => 1..^1;
+
+    static async Task Test3<T>() where T : struct, IHasSlice
+    {
+        _ = GetT<T>()[await GetRangeAsync()];
+    }
+
+    static async Task<System.Range> GetRangeAsync() { await Task.Yield(); return 1..^1; }
+}
+""";
+
+        CreateCompilation(src, targetFramework: TargetFramework.Net100).VerifyDiagnostics(
+            // (26,13): error CS1510: A ref or out value must be an assignable variable
+            //         _ = GetT<T>()[GetRange()];
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetT<T>()").WithLocation(26, 13),
+            // (34,13): error CS1510: A ref or out value must be an assignable variable
+            //         _ = GetT<T>()[await GetRangeAsync()];
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetT<T>()").WithLocation(34, 13));
     }
 
     [Fact]
@@ -25579,5 +27087,159 @@ class Program
   IL_0041:  ret
 }
 """);
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_RValueReceiver_06_02()
+    {
+        // generic class rvalue, instance Length (via interface) + extension Slice
+        var src = """
+using System.Threading.Tasks;
+
+interface IHasLength
+{
+    int Length { get; }
+}
+
+static class E
+{
+    extension<T>(T x) where T : IHasLength
+    {
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{((C1)(object)x).F1} "); Program.State++; return 0; }
+    }
+}
+
+class C1 : IHasLength
+{
+    public int F1;
+    public int Length { get { System.Console.Write($"length:{F1} "); Program.State++; return 5; } }
+}
+
+class Program
+{
+    public static int State;
+
+    static async Task Main()
+    {
+        State = 3;
+        Test1<C1>();
+        System.Console.Write($"final:{State}");
+
+        System.Console.Write(", ");
+
+        State = 3;
+        Test2<C1>();
+        System.Console.Write($"final:{State}");
+
+        System.Console.Write(", ");
+
+        State = 3;
+        await Test3<C1>();
+        System.Console.Write($"final:{State}");
+    }
+
+    static T GetT<T>() => (T)(object)new C1 { F1 = State };
+
+    static void Test1<T>() where T : IHasLength
+    {
+        _ = GetT<T>()[GetRange()];
+    }
+
+    static void Test2<T>() where T : class, IHasLength
+    {
+        _ = GetT<T>()[GetRange()];
+    }
+
+    static System.Range GetRange() { System.Console.Write($"GetRange:{State} "); State++; return 1..^1; }
+
+    static async Task Test3<T>() where T : IHasLength
+    {
+        _ = GetT<T>()[await GetRangeAsync()];
+    }
+
+    static async Task<System.Range> GetRangeAsync() { System.Console.Write($"GetRangeAsync:{State} "); State++; await Task.Yield(); return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:3 Slice:3 final:6, GetRange:3 length:3 Slice:3 final:6, GetRangeAsync:3 length:3 Slice:3 final:6"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_RValueReceiver_06_03()
+    {
+        // generic class rvalue, extension Length + instance Slice (via interface)
+        var src = """
+using System.Threading.Tasks;
+
+interface IHasSlice
+{
+    int Slice(int start, int length);
+}
+
+static class E
+{
+    extension<T>(T x) where T : IHasSlice
+    {
+        public int Length { get { System.Console.Write($"length:{((C1)(object)x).F1} "); Program.State++; return 5; } }
+    }
+}
+
+class C1 : IHasSlice
+{
+    public int F1;
+    public int Slice(int start, int length) { System.Console.Write($"Slice:{F1} "); Program.State++; return 0; }
+}
+
+class Program
+{
+    public static int State;
+
+    static async Task Main()
+    {
+        State = 3;
+        Test1<C1>();
+        System.Console.Write($"final:{State}");
+
+        System.Console.Write(", ");
+
+        State = 3;
+        Test2<C1>();
+        System.Console.Write($"final:{State}");
+
+        System.Console.Write(", ");
+
+        State = 3;
+        await Test3<C1>();
+        System.Console.Write($"final:{State}");
+    }
+
+    static T GetT<T>() => (T)(object)new C1 { F1 = State };
+
+    static void Test1<T>() where T : IHasSlice
+    {
+        _ = GetT<T>()[GetRange()];
+    }
+
+    static void Test2<T>() where T : class, IHasSlice
+    {
+        _ = GetT<T>()[GetRange()];
+    }
+
+    static System.Range GetRange() { System.Console.Write($"GetRange:{State} "); State++; return 1..^1; }
+
+    static async Task Test3<T>() where T : IHasSlice
+    {
+        _ = GetT<T>()[await GetRangeAsync()];
+    }
+
+    static async Task<System.Range> GetRangeAsync() { System.Console.Write($"GetRangeAsync:{State} "); State++; await Task.Yield(); return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:3 Slice:3 final:6, GetRange:3 length:3 Slice:3 final:6, GetRangeAsync:3 length:3 Slice:3 final:6"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
     }
 }

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
@@ -10792,7 +10792,7 @@ namespace Outer
         var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("0,2, 2"), verify: Verification.FailsPEVerify).VerifyDiagnostics();
         verifier.VerifyIL("Inner.C.Main", """
 {
-  // Code size       56 (0x38)
+  // Code size       62 (0x3e)
   .maxstack  4
   .locals init (object V_0, //x
                 S V_1,
@@ -10806,7 +10806,7 @@ namespace Outer
   IL_0010:  stloc.2
   IL_0011:  ldloc.2
   IL_0012:  ldc.i4.1
-  IL_0013:  blt.s      IL_0035
+  IL_0013:  blt.s      IL_003b
   IL_0015:  ldloc.1
   IL_0016:  box        "S"
   IL_001b:  ldc.i4.0
@@ -10815,19 +10815,20 @@ namespace Outer
   IL_001e:  sub
   IL_001f:  call       "object Outer.E2.Slice(object, int, int)"
   IL_0024:  stloc.0
-  IL_0025:  ldloc.2
-  IL_0026:  ldc.i4.1
-  IL_0027:  sub
-  IL_0028:  stloc.3
-  IL_0029:  ldloc.1
-  IL_002a:  ldloc.3
-  IL_002b:  call       "int Inner.E1.get_Item(S, int)"
-  IL_0030:  ldc.i4.1
-  IL_0031:  ceq
-  IL_0033:  br.s       IL_0036
-  IL_0035:  ldc.i4.0
-  IL_0036:  pop
-  IL_0037:  ret
+  IL_0025:  ldloca.s   V_1
+  IL_0027:  ldloc.2
+  IL_0028:  ldc.i4.1
+  IL_0029:  sub
+  IL_002a:  stloc.3
+  IL_002b:  ldobj      "S"
+  IL_0030:  ldloc.3
+  IL_0031:  call       "int Inner.E1.get_Item(S, int)"
+  IL_0036:  ldc.i4.1
+  IL_0037:  ceq
+  IL_0039:  br.s       IL_003c
+  IL_003b:  ldc.i4.0
+  IL_003c:  pop
+  IL_003d:  ret
 }
 """);
     }
@@ -22509,6 +22510,216 @@ class Program
 """);
     }
 
+    [Fact]
+    public void ImplicitIndexIndexerAccess_Get_LValueReceiver_01_02()
+    {
+        // sibling of IndexerAccess_Get_LValueReceiver_01
+        // struct lvalue receiver passed by value, extension this[int] + instance Length
+        var src = """
+static class E
+{
+    extension(S1 x)
+    {
+        public int this[int i] { get { System.Console.Write($"get:{x.F1} "); return 0; } }
+    }
+}
+
+public struct S1
+{
+    public int F1;
+    public int Length { get { System.Console.Write($"length:{F1} "); Program.F.F1++; return 3; } }
+
+    public void Test2()
+    {
+        _ = this[Program.GetIndex()];
+    }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        F = new S1 { F1 = 3 };
+        F.Test2();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        _ = F[GetIndex()];
+    }
+
+    public static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program.F.F1} "); Program.F.F1++; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:4 get:5 final:5, GetIndex:3 length:4 get:5 final:5"), verify: Verification.Skipped)
+                  .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", """
+{
+  // Code size       41 (0x29)
+  .maxstack  2
+  .locals init (S1& V_0,
+                int V_1,
+                System.Index V_2)
+  IL_0000:  nop
+  IL_0001:  ldsflda    "S1 Program.F"
+  IL_0006:  stloc.0
+  IL_0007:  call       "System.Index Program.GetIndex()"
+  IL_000c:  stloc.2
+  IL_000d:  ldloca.s   V_2
+  IL_000f:  ldloc.0
+  IL_0010:  call       "int S1.Length.get"
+  IL_0015:  call       "int System.Index.GetOffset(int)"
+  IL_001a:  stloc.1
+  IL_001b:  ldloc.0
+  IL_001c:  ldobj      "S1"
+  IL_0021:  ldloc.1
+  IL_0022:  call       "int E.get_Item(S1, int)"
+  IL_0027:  pop
+  IL_0028:  ret
+}
+""");
+
+        verifier.VerifyIL("S1.Test2", """
+{
+  // Code size       37 (0x25)
+  .maxstack  2
+  .locals init (S1& V_0,
+                int V_1,
+                System.Index V_2)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  stloc.0
+  IL_0003:  call       "System.Index Program.GetIndex()"
+  IL_0008:  stloc.2
+  IL_0009:  ldloca.s   V_2
+  IL_000b:  ldloc.0
+  IL_000c:  call       "int S1.Length.get"
+  IL_0011:  call       "int System.Index.GetOffset(int)"
+  IL_0016:  stloc.1
+  IL_0017:  ldloc.0
+  IL_0018:  ldobj      "S1"
+  IL_001d:  ldloc.1
+  IL_001e:  call       "int E.get_Item(S1, int)"
+  IL_0023:  pop
+  IL_0024:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_Get_LValueReceiver_01_03()
+    {
+        // sibling of IndexerAccess_Get_LValueReceiver_01
+        // struct lvalue receiver passed by value, instance this[int] + extension Length
+        var src = """
+static class E
+{
+    extension(S1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 3; } }
+    }
+}
+
+public struct S1
+{
+    public int F1;
+    public int this[int i] { get { System.Console.Write($"get:{F1} "); return 0; } }
+
+    public void Test2()
+    {
+        _ = this[Program.GetIndex()];
+    }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        F = new S1 { F1 = 3 };
+        F.Test2();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        _ = F[GetIndex()];
+    }
+
+    public static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program.F.F1} "); Program.F.F1++; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:4 get:5 final:5, GetIndex:3 length:4 get:5 final:5"), verify: Verification.Skipped)
+                  .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", """
+{
+  // Code size       39 (0x27)
+  .maxstack  3
+  .locals init (S1& V_0,
+                System.Index V_1)
+  IL_0000:  nop
+  IL_0001:  ldsflda    "S1 Program.F"
+  IL_0006:  stloc.0
+  IL_0007:  ldloc.0
+  IL_0008:  call       "System.Index Program.GetIndex()"
+  IL_000d:  stloc.1
+  IL_000e:  ldloca.s   V_1
+  IL_0010:  ldloc.0
+  IL_0011:  ldobj      "S1"
+  IL_0016:  call       "int E.get_Length(S1)"
+  IL_001b:  call       "int System.Index.GetOffset(int)"
+  IL_0020:  call       "int S1.this[int].get"
+  IL_0025:  pop
+  IL_0026:  ret
+}
+""");
+
+        verifier.VerifyIL("S1.Test2", """
+{
+  // Code size       35 (0x23)
+  .maxstack  3
+  .locals init (S1& V_0,
+                System.Index V_1)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  stloc.0
+  IL_0003:  ldloc.0
+  IL_0004:  call       "System.Index Program.GetIndex()"
+  IL_0009:  stloc.1
+  IL_000a:  ldloca.s   V_1
+  IL_000c:  ldloc.0
+  IL_000d:  ldobj      "S1"
+  IL_0012:  call       "int E.get_Length(S1)"
+  IL_0017:  call       "int System.Index.GetOffset(int)"
+  IL_001c:  call       "int S1.this[int].get"
+  IL_0021:  pop
+  IL_0022:  ret
+}
+""");
+    }
+
     [Theory]
     [InlineData("ref")]
     [InlineData("ref readonly")]
@@ -22686,7 +22897,7 @@ class Program
     [InlineData("in")]
     public void ImplicitIndexIndexerAccess_Get_LValueReceiver_02_02(string refKind)
     {
-        // struct lvalue receiver passed by ref, instance Length + extension implicit this[Index]
+        // struct lvalue receiver passed by ref, instance Length + extension this[int]
         var src = $$$"""
 static class E
 {
@@ -22733,7 +22944,7 @@ class Program
     [InlineData("in")]
     public void ImplicitIndexIndexerAccess_Get_LValueReceiver_02_03(string refKind)
     {
-        // struct lvalue receiver passed by ref, extension Length + instance this[Index]
+        // struct lvalue receiver passed by ref, extension Length + instance this[int]
         var src = $$$"""
 static class E
 {
@@ -22839,6 +23050,94 @@ class Program
   IL_0021:  ret
 }
 """);
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_Get_LValueReceiver_03_02()
+    {
+        // class lvalue receiver passed by value, instance Length + extension this[int]
+        var src = """
+static class E
+{
+    extension(C1 x)
+    {
+        public int this[int i] { get { System.Console.Write($"get:{x.F1} "); return 0; } }
+    }
+}
+
+class C1
+{
+    public int F1;
+    public int Length { get { System.Console.Write($"length:{F1} "); Program.F = new C1 { F1 = Program.F.F1 + 1 }; return 3; } }
+}
+
+class Program
+{
+    public static C1 F;
+
+    static void Main()
+    {
+        F = new C1 { F1 = 3 };
+        Test();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test()
+    {
+        _ = F[GetIndex()];
+    }
+
+    static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program.F.F1} "); Program.F = new C1 { F1 = Program.F.F1 + 1 }; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:3 get:3 final:5"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_Get_LValueReceiver_03_03()
+    {
+        // class lvalue receiver passed by value, extension Length + instance this[int]
+        var src = """
+static class E
+{
+    extension(C1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F = new C1 { F1 = Program.F.F1 + 1 }; return 3; } }
+    }
+}
+
+class C1
+{
+    public int F1;
+    public int this[int i] { get { System.Console.Write($"get:{F1} "); return 0; } }
+}
+
+class Program
+{
+    public static C1 F;
+
+    static void Main()
+    {
+        F = new C1 { F1 = 3 };
+        Test();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test()
+    {
+        _ = F[GetIndex()];
+    }
+
+    static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program.F.F1} "); Program.F = new C1 { F1 = Program.F.F1 + 1 }; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:3 get:3 final:5"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
     }
 
     [Fact]
@@ -22989,7 +23288,7 @@ class Program
     [Fact]
     public void ImplicitIndexIndexerAccess_Get_LValueReceiver_04_02()
     {
-        // generic struct lvalue receiver passed by value, instance Length (via interface) + extension implicit this[Index]
+        // generic struct lvalue receiver passed by value, instance Length (via interface) + extension this[int]
         var src = """
 interface IHasLength
 {
@@ -23050,9 +23349,113 @@ class Program
     }
 
     [Fact]
+    public void ImplicitIndexIndexerAccess_Get_LValueReceiver_04_02_02()
+    {
+        // generic struct lvalue receiver passed by value, instance Length (via interface) + extension this[int], struct constraint
+        var src = """
+interface IHasLength
+{
+    int Length { get; }
+}
+
+static class E
+{
+    extension<T>(T x) where T : struct, IHasLength
+    {
+        public int this[int i] { get { System.Console.Write($"get:{((S1)(object)x).F1} "); return 0; } }
+    }
+}
+
+struct S1 : IHasLength
+{
+    public int F1;
+    public int Length { get { System.Console.Write($"length:{F1} "); Program<S1>.F.F1++; return 3; } }
+}
+
+class Program<T>
+{
+    public static T F;
+}
+
+class Program
+{
+    static void Main()
+    {
+        Program<S1>.F = new S1 { F1 = 3 };
+        Test1(ref Program<S1>.F);
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+    }
+
+    static void Test1<T>(ref T f) where T : struct, IHasLength
+    {
+        _ = f[GetIndex()];
+    }
+
+    static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program<S1>.F.F1} "); Program<S1>.F.F1++; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:4 get:5 final:5"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_Get_LValueReceiver_04_02_03()
+    {
+        // generic struct lvalue receiver passed by value, instance Length (via interface) + extension this[int], class constraint
+        var src = """
+interface IHasLength
+{
+    int Length { get; }
+}
+
+static class E
+{
+    extension<T>(T x) where T : class, IHasLength
+    {
+        public int this[int i] { get { System.Console.Write($"get:{((C1)(object)x).F1} "); return 0; } }
+    }
+}
+
+class C1 : IHasLength
+{
+    public int F1;
+    public int Length { get { System.Console.Write($"length:{F1} "); Program<C1>.F.F1++; return 3; } }
+}
+
+class Program<T>
+{
+    public static T F;
+}
+
+class Program
+{
+    static void Main()
+    {
+        Program<C1>.F = new C1 { F1 = 3 };
+        Test1(ref Program<C1>.F);
+        System.Console.Write($"final:{Program<C1>.F.F1}");
+    }
+
+    static void Test1<T>(ref T f) where T : class, IHasLength
+    {
+        _ = f[GetIndex()];
+    }
+
+    static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program<C1>.F.F1} "); Program<C1>.F.F1++; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:4 get:5 final:5"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Fact]
     public void ImplicitIndexIndexerAccess_Get_LValueReceiver_04_03()
     {
-        // generic struct lvalue receiver passed by value, extension Length + instance this[Index] (via interface)
+        // generic struct lvalue receiver passed by value, extension Length + instance this[int] (via interface)
         var src = """
 interface IHasIndexer
 {
@@ -23250,6 +23653,140 @@ namespace NS2
             //         extension<T>(ref readonly T x) where T : struct
             Diagnostic(ErrorCode.ERR_InExtensionParameterMustBeValueType, "T").WithLocation(32, 35)
             );
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_Get_LValueReceiver_05_02()
+    {
+        // struct lvalue receiver passed by ref, constrained to struct, instance Length (via interface) + extension this[int]
+        var src = """
+using System.Threading.Tasks;
+
+interface IHasLength
+{
+    int Length { get; }
+}
+
+static class E
+{
+    extension<T>(ref T x) where T : struct, IHasLength
+    {
+        public int this[int i] { get { System.Console.Write($"get:{((S1)(object)x).F1} "); return 0; } }
+    }
+}
+
+struct S1 : IHasLength
+{
+    public int F1;
+    public int Length { get { System.Console.Write($"length:{F1} "); Program<S1>.F.F1++; return 3; } }
+}
+
+class Program<T>
+{
+    public static T F;
+}
+
+class Program
+{
+    static async Task Main()
+    {
+        Program<S1>.F = new S1 { F1 = 3 };
+        Test2(ref Program<S1>.F);
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+
+        System.Console.Write(", ");
+
+        Program<S1>.F = new S1 { F1 = 3 };
+        await Test3<S1>();
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+    }
+
+    static void Test2<T>(ref T f) where T : struct, IHasLength
+    {
+        _ = f[GetIndex()];
+    }
+
+    static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program<S1>.F.F1} "); Program<S1>.F.F1++; return ^1; }
+
+    static async Task Test3<T>() where T : struct, IHasLength
+    {
+        _ = Program<T>.F[await GetIndexAsync()];
+    }
+
+    static async Task<System.Index> GetIndexAsync() { System.Console.Write($"GetIndexAsync:{Program<S1>.F.F1} "); Program<S1>.F.F1++; await Task.Yield(); return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:4 get:5 final:5, GetIndexAsync:3 length:4 get:5 final:5"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_Get_LValueReceiver_05_03()
+    {
+        // struct lvalue receiver passed by ref, constrained to struct, extension Length + instance this[int] (via interface)
+        var src = """
+using System.Threading.Tasks;
+
+interface IHasIndexer
+{
+    int this[int i] { get; }
+}
+
+static class E
+{
+    extension<T>(ref T x) where T : struct, IHasIndexer
+    {
+        public int Length { get { System.Console.Write($"length:{((S1)(object)x).F1} "); Program<S1>.F.F1++; return 3; } }
+    }
+}
+
+struct S1 : IHasIndexer
+{
+    public int F1;
+    public int this[int i] { get { System.Console.Write($"get:{F1} "); return 0; } }
+}
+
+class Program<T>
+{
+    public static T F;
+}
+
+class Program
+{
+    static async Task Main()
+    {
+        Program<S1>.F = new S1 { F1 = 3 };
+        Test2(ref Program<S1>.F);
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+
+        System.Console.Write(", ");
+
+        Program<S1>.F = new S1 { F1 = 3 };
+        await Test3<S1>();
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+    }
+
+    static void Test2<T>(ref T f) where T : struct, IHasIndexer
+    {
+        _ = f[GetIndex()];
+    }
+
+    static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program<S1>.F.F1} "); Program<S1>.F.F1++; return ^1; }
+
+    static async Task Test3<T>() where T : struct, IHasIndexer
+    {
+        _ = Program<T>.F[await GetIndexAsync()];
+    }
+
+    static async Task<System.Index> GetIndexAsync() { System.Console.Write($"GetIndexAsync:{Program<S1>.F.F1} "); Program<S1>.F.F1++; await Task.Yield(); return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:4 get:5 final:5, GetIndexAsync:3 length:4 get:5 final:5"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
     }
 
     [Fact]
@@ -23990,6 +24527,155 @@ class Program
         var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
         CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:3 get:3 final:5, GetIndex:3 length:3 get:3 final:5, GetIndexAsync:3 length:3 get:3 final:5"), verify: Verification.Skipped)
             .VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_Get_LValueReceiver_04_04()
+    {
+        // generic struct lvalue receiver passed by value, extension implicit this[Index], object creation
+        var src = """
+using System.Threading.Tasks;
+
+static class E
+{
+    extension<T>(T x)
+    {
+        public Item this[int i] { get { System.Console.Write("get"); return new Item(); } }
+        public int Length { get { System.Console.Write("length "); return 3; } }
+    }
+}
+
+class Item
+{
+    public int Property { get; set; }
+}
+
+struct S1 { }
+
+class Program
+{
+    static async Task Main()
+    {
+        _ = Test1<S1>();
+        System.Console.Write(", ");
+
+        _ = Test2<S1>();
+        System.Console.Write(", ");
+
+        _ = await Test3<S1>();
+    }
+
+    static T Test1<T>() where T : new()
+    {
+        return new T() { [GetIndex()] = { Property = 42 } };
+    }
+
+    static T Test2<T>() where T : struct
+    {
+        return new T() { [GetIndex()] = { Property = 42 } };
+    }
+
+    static System.Index GetIndex() { System.Console.Write("GetIndex "); return ^1; }
+
+    static async Task<T> Test3<T>() where T : new()
+    {
+        return new T() { [await GetIndexAsync()] = { Property = 42 } };
+    }
+
+    static async Task<System.Index> GetIndexAsync() { System.Console.Write("GetIndexAsync "); await Task.Yield(); return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex length get, GetIndex length get, GetIndexAsync length get"), verify: Verification.Skipped)
+             .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1<T>()", """
+{
+  // Code size       93 (0x5d)
+  .maxstack  2
+  .locals init (T V_0,
+                int V_1,
+                System.Index V_2,
+                T V_3,
+                T& V_4,
+                int V_5,
+                T V_6,
+                T V_7)
+  IL_0000:  nop
+  IL_0001:  call       "T System.Activator.CreateInstance<T>()"
+  IL_0006:  stloc.0
+  IL_0007:  call       "System.Index Program.GetIndex()"
+  IL_000c:  stloc.2
+  IL_000d:  ldloca.s   V_2
+  IL_000f:  ldloc.0
+  IL_0010:  call       "int E.get_Length<T>(T)"
+  IL_0015:  call       "int System.Index.GetOffset(int)"
+  IL_001a:  stloc.1
+  IL_001b:  ldloca.s   V_0
+  IL_001d:  stloc.s    V_4
+  IL_001f:  ldloca.s   V_6
+  IL_0021:  initobj    "T"
+  IL_0027:  ldloc.s    V_6
+  IL_0029:  box        "T"
+  IL_002e:  brtrue.s   IL_003c
+  IL_0030:  ldloc.s    V_4
+  IL_0032:  ldobj      "T"
+  IL_0037:  stloc.3
+  IL_0038:  ldloca.s   V_3
+  IL_003a:  br.s       IL_003e
+  IL_003c:  ldloc.s    V_4
+  IL_003e:  ldloc.1
+  IL_003f:  stloc.s    V_5
+  IL_0041:  ldobj      "T"
+  IL_0046:  ldloc.s    V_5
+  IL_0048:  call       "Item E.get_Item<T>(T, int)"
+  IL_004d:  ldc.i4.s   42
+  IL_004f:  callvirt   "void Item.Property.set"
+  IL_0054:  nop
+  IL_0055:  ldloc.0
+  IL_0056:  stloc.s    V_7
+  IL_0058:  br.s       IL_005a
+  IL_005a:  ldloc.s    V_7
+  IL_005c:  ret
+}
+""");
+
+        verifier.VerifyIL("Program.Test2<T>()", """
+{
+  // Code size       58 (0x3a)
+  .maxstack  2
+  .locals init (T V_0,
+                System.Index V_1,
+                T& V_2,
+                int V_3,
+                T V_4)
+  IL_0000:  nop
+  IL_0001:  call       "T System.Activator.CreateInstance<T>()"
+  IL_0006:  stloc.0
+  IL_0007:  call       "System.Index Program.GetIndex()"
+  IL_000c:  stloc.1
+  IL_000d:  ldloca.s   V_1
+  IL_000f:  ldloc.0
+  IL_0010:  call       "int E.get_Length<T>(T)"
+  IL_0015:  call       "int System.Index.GetOffset(int)"
+  IL_001a:  ldloca.s   V_0
+  IL_001c:  stloc.2
+  IL_001d:  stloc.3
+  IL_001e:  ldloc.2
+  IL_001f:  ldobj      "T"
+  IL_0024:  ldloc.3
+  IL_0025:  call       "Item E.get_Item<T>(T, int)"
+  IL_002a:  ldc.i4.s   42
+  IL_002c:  callvirt   "void Item.Property.set"
+  IL_0031:  nop
+  IL_0032:  ldloc.0
+  IL_0033:  stloc.s    V_4
+  IL_0035:  br.s       IL_0037
+  IL_0037:  ldloc.s    V_4
+  IL_0039:  ret
+}
+""");
     }
 
     [Fact]
@@ -25246,6 +25932,187 @@ class Program
         var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
         CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:4 Slice:5 final:6, GetRange:3 length:4 Slice:5 final:6"), verify: Verification.Skipped)
             .VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_04_04()
+    {
+        // generic struct lvalue receiver passed by value, extension implicit this[Range], object creation
+        var src = """
+using System.Threading.Tasks;
+
+static class E
+{
+    extension<T>(T x)
+    {
+        public Item Slice(int i, int j) { System.Console.Write("slice"); return new Item(); }
+        public int Length { get { System.Console.Write("length "); return 3; } }
+    }
+}
+
+class Item
+{
+    public int Property { get; set; }
+}
+
+struct S1 { }
+
+class Program
+{
+    static async Task Main()
+    {
+        S1 s1 = Test1<S1>();
+        System.Console.Write(", ");
+
+        S1 s2 = Test2<S1>();
+        System.Console.Write(", ");
+
+        S1 s3 = await Test3<S1>();
+    }
+
+    static T Test1<T>() where T : new()
+    {
+        return new T() { [GetRange()] = { Property = 42 } };
+    }
+
+    static T Test2<T>() where T : struct
+    {
+        return new T() { [GetRange()] = { Property = 42 } };
+    }
+
+    static System.Range GetRange() { System.Console.Write("GetRange "); return ..^1; }
+
+    static async Task<T> Test3<T>() where T : new()
+    {
+        return new T() { [await GetRangeAsync()] = { Property = 42 } };
+    }
+
+    static async Task<System.Range> GetRangeAsync() { System.Console.Write("GetRangeAsync "); await Task.Yield(); return ..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange length slice, GetRange length slice, GetRangeAsync length slice"), verify: Verification.Skipped)
+             .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1<T>()", """
+{
+  // Code size      131 (0x83)
+  .maxstack  3
+  .locals init (T V_0,
+                T V_1,
+                T& V_2,
+                System.Range V_3,
+                int V_4,
+                int V_5,
+                int V_6,
+                T V_7,
+                System.Index V_8,
+                T V_9)
+  IL_0000:  nop
+  IL_0001:  call       "T System.Activator.CreateInstance<T>()"
+  IL_0006:  stloc.0
+  IL_0007:  ldloca.s   V_0
+  IL_0009:  stloc.2
+  IL_000a:  ldloca.s   V_7
+  IL_000c:  initobj    "T"
+  IL_0012:  ldloc.s    V_7
+  IL_0014:  box        "T"
+  IL_0019:  brtrue.s   IL_0026
+  IL_001b:  ldloc.2
+  IL_001c:  ldobj      "T"
+  IL_0021:  stloc.1
+  IL_0022:  ldloca.s   V_1
+  IL_0024:  br.s       IL_0027
+  IL_0026:  ldloc.2
+  IL_0027:  call       "System.Range Program.GetRange()"
+  IL_002c:  stloc.3
+  IL_002d:  dup
+  IL_002e:  ldobj      "T"
+  IL_0033:  call       "int E.get_Length<T>(T)"
+  IL_0038:  stloc.s    V_4
+  IL_003a:  ldloca.s   V_3
+  IL_003c:  call       "System.Index System.Range.Start.get"
+  IL_0041:  stloc.s    V_8
+  IL_0043:  ldloca.s   V_8
+  IL_0045:  ldloc.s    V_4
+  IL_0047:  call       "int System.Index.GetOffset(int)"
+  IL_004c:  stloc.s    V_5
+  IL_004e:  ldloca.s   V_3
+  IL_0050:  call       "System.Index System.Range.End.get"
+  IL_0055:  stloc.s    V_8
+  IL_0057:  ldloca.s   V_8
+  IL_0059:  ldloc.s    V_4
+  IL_005b:  call       "int System.Index.GetOffset(int)"
+  IL_0060:  ldloc.s    V_5
+  IL_0062:  sub
+  IL_0063:  stloc.s    V_6
+  IL_0065:  ldobj      "T"
+  IL_006a:  ldloc.s    V_5
+  IL_006c:  ldloc.s    V_6
+  IL_006e:  call       "Item E.Slice<T>(T, int, int)"
+  IL_0073:  ldc.i4.s   42
+  IL_0075:  callvirt   "void Item.Property.set"
+  IL_007a:  nop
+  IL_007b:  ldloc.0
+  IL_007c:  stloc.s    V_9
+  IL_007e:  br.s       IL_0080
+  IL_0080:  ldloc.s    V_9
+  IL_0082:  ret
+}
+""");
+
+        verifier.VerifyIL("Program.Test2<T>()", """
+{
+  // Code size       95 (0x5f)
+  .maxstack  3
+  .locals init (T V_0,
+                System.Range V_1,
+                int V_2,
+                int V_3,
+                int V_4,
+                System.Index V_5,
+                T V_6)
+  IL_0000:  nop
+  IL_0001:  call       "T System.Activator.CreateInstance<T>()"
+  IL_0006:  stloc.0
+  IL_0007:  ldloca.s   V_0
+  IL_0009:  call       "System.Range Program.GetRange()"
+  IL_000e:  stloc.1
+  IL_000f:  dup
+  IL_0010:  ldobj      "T"
+  IL_0015:  call       "int E.get_Length<T>(T)"
+  IL_001a:  stloc.2
+  IL_001b:  ldloca.s   V_1
+  IL_001d:  call       "System.Index System.Range.Start.get"
+  IL_0022:  stloc.s    V_5
+  IL_0024:  ldloca.s   V_5
+  IL_0026:  ldloc.2
+  IL_0027:  call       "int System.Index.GetOffset(int)"
+  IL_002c:  stloc.3
+  IL_002d:  ldloca.s   V_1
+  IL_002f:  call       "System.Index System.Range.End.get"
+  IL_0034:  stloc.s    V_5
+  IL_0036:  ldloca.s   V_5
+  IL_0038:  ldloc.2
+  IL_0039:  call       "int System.Index.GetOffset(int)"
+  IL_003e:  ldloc.3
+  IL_003f:  sub
+  IL_0040:  stloc.s    V_4
+  IL_0042:  ldobj      "T"
+  IL_0047:  ldloc.3
+  IL_0048:  ldloc.s    V_4
+  IL_004a:  call       "Item E.Slice<T>(T, int, int)"
+  IL_004f:  ldc.i4.s   42
+  IL_0051:  callvirt   "void Item.Property.set"
+  IL_0056:  nop
+  IL_0057:  ldloc.0
+  IL_0058:  stloc.s    V_6
+  IL_005a:  br.s       IL_005c
+  IL_005c:  ldloc.s    V_6
+  IL_005e:  ret
+}
+""");
     }
 
     [Fact]
@@ -27239,5 +28106,126 @@ class Program
         var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
         CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:3 Slice:3 final:6, GetRange:3 length:3 Slice:3 final:6, GetRangeAsync:3 length:3 Slice:3 final:6"), verify: Verification.Skipped)
             .VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_RefAnalysis_01()
+    {
+        var src = """
+public ref struct MyStruct
+{
+    public ref int i;
+}
+
+public static class E
+{
+    extension(MyStruct s1)
+    {
+        public int Length => 1;
+        public MyStruct this[int i] => s1;
+    }
+}
+
+class Program
+{
+    static MyStruct M()
+    {
+        int i = 0;
+        return new MyStruct() { i = ref i }[^1];
+    }
+}
+""";
+
+        CreateCompilation(src, targetFramework: TargetFramework.Net100).VerifyEmitDiagnostics(
+            // (20,31): error CS8352: Cannot use variable 'i = ref i' in this context because it may expose referenced variables outside of their declaration scope
+            //         return new MyStruct() { i = ref i }[^1];
+            Diagnostic(ErrorCode.ERR_EscapeVariable, "{ i = ref i }").WithArguments("i = ref i").WithLocation(20, 31),
+            // (20,16): error CS8347: Cannot use a result of 'E.extension(MyStruct).this[int]' in this context because it may expose variables referenced by parameter 's1' outside of their declaration scope
+            //         return new MyStruct() { i = ref i }[^1];
+            Diagnostic(ErrorCode.ERR_EscapeCall, "new MyStruct() { i = ref i }[^1]").WithArguments("E.extension(MyStruct).this[int]", "s1").WithLocation(20, 16));
+
+        // instance this[int] + instance Length
+        src = """
+public ref struct MyStruct
+{
+    public ref int i;
+    public int Length => 1;
+    public MyStruct this[int i] => throw null;
+}
+
+class Program
+{
+    static MyStruct M()
+    {
+        int i = 0;
+        return new MyStruct() { i = ref i }[^1];
+    }
+}
+""";
+
+        CreateCompilation(src, targetFramework: TargetFramework.Net100).VerifyEmitDiagnostics(
+            // (13,31): error CS8352: Cannot use variable 'i = ref i' in this context because it may expose referenced variables outside of their declaration scope
+            //         return new MyStruct() { i = ref i }[^1];
+            Diagnostic(ErrorCode.ERR_EscapeVariable, "{ i = ref i }").WithArguments("i = ref i").WithLocation(13, 31));
+
+        // instance this[Index]
+        src = """
+public ref struct MyStruct
+{
+    public ref int i;
+    public MyStruct this[System.Index i] => throw null;
+}
+
+class Program
+{
+    static MyStruct M()
+    {
+        int i = 0;
+        return new MyStruct() { i = ref i }[^1];
+    }
+}
+""";
+
+        CreateCompilation(src, targetFramework: TargetFramework.Net100).VerifyEmitDiagnostics(
+            // (12,31): error CS8352: Cannot use variable 'i = ref i' in this context because it may expose referenced variables outside of their declaration scope
+            //         return new MyStruct() { i = ref i }[^1];
+            Diagnostic(ErrorCode.ERR_EscapeVariable, "{ i = ref i }").WithArguments("i = ref i").WithLocation(12, 31));
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_RefAnalysis_01()
+    {
+        var src = """
+public ref struct MyStruct
+{
+    public ref int i;
+}
+
+public static class E
+{
+    extension(MyStruct s1)
+    {
+        public int Length => 1;
+        public MyStruct Slice(int start, int length) => s1;
+    }
+}
+
+class Program
+{
+    static MyStruct M()
+    {
+        int i = 0;
+        return new MyStruct() { i = ref i }[0..];
+    }
+}
+""";
+
+        CreateCompilation(src, targetFramework: TargetFramework.Net100).VerifyEmitDiagnostics(
+            // (20,31): error CS8352: Cannot use variable 'i = ref i' in this context because it may expose referenced variables outside of their declaration scope
+            //         return new MyStruct() { i = ref i }[0..];
+            Diagnostic(ErrorCode.ERR_EscapeVariable, "{ i = ref i }").WithArguments("i = ref i").WithLocation(20, 31),
+            // (20,16): error CS8347: Cannot use a result of 'E.extension(MyStruct).Slice(int, int)' in this context because it may expose variables referenced by parameter 's1' outside of their declaration scope
+            //         return new MyStruct() { i = ref i }[0..];
+            Diagnostic(ErrorCode.ERR_EscapeCall, "new MyStruct() { i = ref i }[0..]").WithArguments("E.extension(MyStruct).Slice(int, int)", "s1").WithLocation(20, 16));
     }
 }

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
@@ -10792,7 +10792,7 @@ namespace Outer
         var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("0,2, 2"), verify: Verification.FailsPEVerify).VerifyDiagnostics();
         verifier.VerifyIL("Inner.C.Main", """
 {
-  // Code size       62 (0x3e)
+  // Code size       56 (0x38)
   .maxstack  4
   .locals init (object V_0, //x
                 S V_1,
@@ -10806,7 +10806,7 @@ namespace Outer
   IL_0010:  stloc.2
   IL_0011:  ldloc.2
   IL_0012:  ldc.i4.1
-  IL_0013:  blt.s      IL_003b
+  IL_0013:  blt.s      IL_0035
   IL_0015:  ldloc.1
   IL_0016:  box        "S"
   IL_001b:  ldc.i4.0
@@ -10815,20 +10815,155 @@ namespace Outer
   IL_001e:  sub
   IL_001f:  call       "object Outer.E2.Slice(object, int, int)"
   IL_0024:  stloc.0
-  IL_0025:  ldloca.s   V_1
-  IL_0027:  ldloc.2
-  IL_0028:  ldc.i4.1
-  IL_0029:  sub
-  IL_002a:  stloc.3
-  IL_002b:  ldobj      "S"
-  IL_0030:  ldloc.3
-  IL_0031:  call       "int Inner.E1.get_Item(S, int)"
-  IL_0036:  ldc.i4.1
-  IL_0037:  ceq
-  IL_0039:  br.s       IL_003c
-  IL_003b:  ldc.i4.0
-  IL_003c:  pop
-  IL_003d:  ret
+  IL_0025:  ldloc.2
+  IL_0026:  ldc.i4.1
+  IL_0027:  sub
+  IL_0028:  stloc.3
+  IL_0029:  ldloc.1
+  IL_002a:  ldloc.3
+  IL_002b:  call       "int Inner.E1.get_Item(S, int)"
+  IL_0030:  ldc.i4.1
+  IL_0031:  ceq
+  IL_0033:  br.s       IL_0036
+  IL_0035:  ldc.i4.0
+  IL_0036:  pop
+  IL_0037:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void SlicePattern_18_2()
+    {
+        // instance Length + extension this[int] + extension Slice(int, int)
+        var src = """
+_ = new S() is [.. var x, 1];
+
+public struct S
+{
+    public int Length => 3;
+}
+
+public static class E
+{
+    extension(S s)
+    {
+        public int this[int i] { get { System.Console.Write($"this[{i}], "); return 0; } }
+        public S Slice(int i, int j) { System.Console.Write($"Slice({i},{j}), "); return s; }
+    }
+}
+""";
+
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("Slice(0,2), this[2], "), verify: Verification.FailsPEVerify).VerifyDiagnostics();
+        verifier.VerifyIL("<top-level-statements-entry-point>", """
+{
+  // Code size       54 (0x36)
+  .maxstack  3
+  .locals init (S V_0,
+                int V_1,
+                int V_2,
+                int V_3)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  initobj    "S"
+  IL_0008:  ldloca.s   V_0
+  IL_000a:  call       "int S.Length.get"
+  IL_000f:  stloc.1
+  IL_0010:  ldloc.1
+  IL_0011:  ldc.i4.1
+  IL_0012:  blt.s      IL_0033
+  IL_0014:  ldc.i4.0
+  IL_0015:  stloc.2
+  IL_0016:  ldloc.1
+  IL_0017:  ldc.i4.1
+  IL_0018:  sub
+  IL_0019:  stloc.3
+  IL_001a:  ldloc.0
+  IL_001b:  ldloc.2
+  IL_001c:  ldloc.3
+  IL_001d:  call       "S E.Slice(S, int, int)"
+  IL_0022:  pop
+  IL_0023:  ldloc.1
+  IL_0024:  ldc.i4.1
+  IL_0025:  sub
+  IL_0026:  stloc.3
+  IL_0027:  ldloc.0
+  IL_0028:  ldloc.3
+  IL_0029:  call       "int E.get_Item(S, int)"
+  IL_002e:  ldc.i4.1
+  IL_002f:  ceq
+  IL_0031:  br.s       IL_0034
+  IL_0033:  ldc.i4.0
+  IL_0034:  pop
+  IL_0035:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void SlicePattern_18_3()
+    {
+        // instance Length + extension this[Index] + extension this[Range]
+        var src = """
+_ = new S() is [.. var x, 1];
+
+public struct S
+{
+    public int Length => 3;
+}
+
+public static class E
+{
+    extension(S s)
+    {
+        public int this[System.Index i] { get { System.Console.Write($"this[{i}], "); return 0; } }
+        public S this[System.Range r] { get { System.Console.Write($"this[{r}], "); return s; } }
+    }
+}
+""";
+
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("this[0..^1], this[^1], "), verify: Verification.FailsPEVerify).VerifyDiagnostics();
+        verifier.VerifyIL("<top-level-statements-entry-point>", """
+{
+  // Code size       83 (0x53)
+  .maxstack  5
+  .locals init (S V_0,
+                System.Range V_1,
+                System.Index V_2)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  initobj    "S"
+  IL_0008:  ldloca.s   V_0
+  IL_000a:  call       "int S.Length.get"
+  IL_000f:  ldc.i4.1
+  IL_0010:  blt.s      IL_0050
+  IL_0012:  ldloca.s   V_0
+  IL_0014:  ldloca.s   V_1
+  IL_0016:  ldc.i4.0
+  IL_0017:  ldc.i4.0
+  IL_0018:  newobj     "System.Index..ctor(int, bool)"
+  IL_001d:  ldc.i4.1
+  IL_001e:  ldc.i4.1
+  IL_001f:  newobj     "System.Index..ctor(int, bool)"
+  IL_0024:  call       "System.Range..ctor(System.Index, System.Index)"
+  IL_0029:  ldobj      "S"
+  IL_002e:  ldloc.1
+  IL_002f:  call       "S E.get_Item(S, System.Range)"
+  IL_0034:  pop
+  IL_0035:  ldloca.s   V_0
+  IL_0037:  ldloca.s   V_2
+  IL_0039:  ldc.i4.1
+  IL_003a:  ldc.i4.1
+  IL_003b:  call       "System.Index..ctor(int, bool)"
+  IL_0040:  ldobj      "S"
+  IL_0045:  ldloc.2
+  IL_0046:  call       "int E.get_Item(S, System.Index)"
+  IL_004b:  ldc.i4.1
+  IL_004c:  ceq
+  IL_004e:  br.s       IL_0051
+  IL_0050:  ldc.i4.0
+  IL_0051:  pop
+  IL_0052:  ret
 }
 """);
     }

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 #nullable disable
@@ -26177,7 +26177,7 @@ class Program
         var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:4 Slice:5 final:6, GetRangeAsync:3 length:4 Slice:5 final:6"), verify: Verification.Skipped)
                     .VerifyDiagnostics();
 
-        verifier.VerifyIL("Program.Test2<T>(ref T)", """ 
+        verifier.VerifyIL("Program.Test2<T>(ref T)", """
 {
   // Code size       62 (0x3e)
   .maxstack  3
@@ -28228,4 +28228,2106 @@ class Program
             //         return new MyStruct() { i = ref i }[0..];
             Diagnostic(ErrorCode.ERR_EscapeCall, "new MyStruct() { i = ref i }[0..]").WithArguments("E.extension(MyStruct).Slice(int, int)", "s1").WithLocation(20, 16));
     }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartOpenEndRangeExpr_01()
+    {
+        // sibling of IndexerAccess_Get_LValueReceiver_01
+        // struct lvalue receiver passed by value, extension Length + extension Slice(int, int) + extension Slice(int), slice from end
+        var src = """
+static class E
+{
+    extension(S1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 5; } }
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); Program.F.F1++; return 0; }
+    }
 }
+
+public struct S1
+{
+    public int F1;
+
+    public void Test2()
+    {
+        _ = this[Program.GetStart()..];
+    }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        F = new S1 { F1 = 3 };
+        F.Test2();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        _ = F[GetStart()..];
+    }
+
+    public static int GetStart() { System.Console.Write($"GetStart:{Program.F.F1} "); Program.F.F1++; return 1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetStart:3 length:4 Slice:5 final:6, GetStart:3 length:4 Slice:5 final:6"), verify: Verification.Skipped)
+             .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", """
+{
+  // Code size       40 (0x28)
+  .maxstack  4
+  .locals init (int V_0,
+                int V_1)
+  IL_0000:  nop
+  IL_0001:  ldsflda    "S1 Program.F"
+  IL_0006:  call       "int Program.GetStart()"
+  IL_000b:  stloc.0
+  IL_000c:  dup
+  IL_000d:  ldobj      "S1"
+  IL_0012:  call       "int E.get_Length(S1)"
+  IL_0017:  stloc.1
+  IL_0018:  ldobj      "S1"
+  IL_001d:  ldloc.0
+  IL_001e:  ldloc.1
+  IL_001f:  ldloc.0
+  IL_0020:  sub
+  IL_0021:  call       "int E.Slice(S1, int, int)"
+  IL_0026:  pop
+  IL_0027:  ret
+}
+""");
+
+        verifier.VerifyIL("S1.Test2", """
+{
+  // Code size       36 (0x24)
+  .maxstack  4
+  .locals init (int V_0,
+                int V_1)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  call       "int Program.GetStart()"
+  IL_0007:  stloc.0
+  IL_0008:  dup
+  IL_0009:  ldobj      "S1"
+  IL_000e:  call       "int E.get_Length(S1)"
+  IL_0013:  stloc.1
+  IL_0014:  ldobj      "S1"
+  IL_0019:  ldloc.0
+  IL_001a:  ldloc.1
+  IL_001b:  ldloc.0
+  IL_001c:  sub
+  IL_001d:  call       "int E.Slice(S1, int, int)"
+  IL_0022:  pop
+  IL_0023:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartOpenEndRangeExpr_01_02()
+    {
+        // sibling of ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartOpenEndRangeExpr_01
+        // struct lvalue receiver passed by value, instance Length + extension Slice, start..
+        var src = """
+static class E
+{
+    extension(S1 x)
+    {
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); Program.F.F1++; return 0; }
+    }
+}
+
+public struct S1
+{
+    public int F1;
+    public int Length { get { System.Console.Write($"length:{F1} "); Program.F.F1++; return 5; } }
+
+    public void Test2()
+    {
+        _ = this[Program.GetStart()..];
+    }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        F = new S1 { F1 = 3 };
+        F.Test2();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        _ = F[GetStart()..];
+    }
+
+    public static int GetStart() { System.Console.Write($"GetStart:{Program.F.F1} "); Program.F.F1++; return 1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetStart:3 length:4 Slice:5 final:6, GetStart:3 length:4 Slice:5 final:6"), verify: Verification.Skipped)
+             .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", """
+{
+  // Code size       35 (0x23)
+  .maxstack  4
+  .locals init (int V_0,
+                int V_1)
+  IL_0000:  nop
+  IL_0001:  ldsflda    "S1 Program.F"
+  IL_0006:  call       "int Program.GetStart()"
+  IL_000b:  stloc.0
+  IL_000c:  dup
+  IL_000d:  call       "int S1.Length.get"
+  IL_0012:  stloc.1
+  IL_0013:  ldobj      "S1"
+  IL_0018:  ldloc.0
+  IL_0019:  ldloc.1
+  IL_001a:  ldloc.0
+  IL_001b:  sub
+  IL_001c:  call       "int E.Slice(S1, int, int)"
+  IL_0021:  pop
+  IL_0022:  ret
+}
+""");
+
+        verifier.VerifyIL("S1.Test2", """
+{
+  // Code size       31 (0x1f)
+  .maxstack  4
+  .locals init (int V_0,
+                int V_1)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  call       "int Program.GetStart()"
+  IL_0007:  stloc.0
+  IL_0008:  dup
+  IL_0009:  call       "int S1.Length.get"
+  IL_000e:  stloc.1
+  IL_000f:  ldobj      "S1"
+  IL_0014:  ldloc.0
+  IL_0015:  ldloc.1
+  IL_0016:  ldloc.0
+  IL_0017:  sub
+  IL_0018:  call       "int E.Slice(S1, int, int)"
+  IL_001d:  pop
+  IL_001e:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartOpenEndRangeExpr_01_03()
+    {
+        // sibling of ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartOpenEndRangeExpr_01
+        // struct lvalue receiver passed by value, extension Length + instance Slice, start..
+        var src = """
+static class E
+{
+    extension(S1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 5; } }
+    }
+}
+
+public struct S1
+{
+    public int F1;
+    public int Slice(int start, int length) { System.Console.Write($"Slice:{F1} "); Program.F.F1++; return 0; }
+
+    public void Test2()
+    {
+        _ = this[Program.GetStart()..];
+    }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        F = new S1 { F1 = 3 };
+        F.Test2();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        _ = F[GetStart()..];
+    }
+
+    public static int GetStart() { System.Console.Write($"GetStart:{Program.F.F1} "); Program.F.F1++; return 1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetStart:3 length:4 Slice:5 final:6, GetStart:3 length:4 Slice:5 final:6"), verify: Verification.Skipped)
+             .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", """
+{
+  // Code size       35 (0x23)
+  .maxstack  4
+  .locals init (int V_0,
+                int V_1)
+  IL_0000:  nop
+  IL_0001:  ldsflda    "S1 Program.F"
+  IL_0006:  call       "int Program.GetStart()"
+  IL_000b:  stloc.0
+  IL_000c:  dup
+  IL_000d:  ldobj      "S1"
+  IL_0012:  call       "int E.get_Length(S1)"
+  IL_0017:  stloc.1
+  IL_0018:  ldloc.0
+  IL_0019:  ldloc.1
+  IL_001a:  ldloc.0
+  IL_001b:  sub
+  IL_001c:  call       "int S1.Slice(int, int)"
+  IL_0021:  pop
+  IL_0022:  ret
+}
+""");
+
+        verifier.VerifyIL("S1.Test2", """
+{
+  // Code size       31 (0x1f)
+  .maxstack  4
+  .locals init (int V_0,
+                int V_1)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  call       "int Program.GetStart()"
+  IL_0007:  stloc.0
+  IL_0008:  dup
+  IL_0009:  ldobj      "S1"
+  IL_000e:  call       "int E.get_Length(S1)"
+  IL_0013:  stloc.1
+  IL_0014:  ldloc.0
+  IL_0015:  ldloc.1
+  IL_0016:  ldloc.0
+  IL_0017:  sub
+  IL_0018:  call       "int S1.Slice(int, int)"
+  IL_001d:  pop
+  IL_001e:  ret
+}
+""");
+    }
+
+    [Theory]
+    [InlineData("ref")]
+    [InlineData("ref readonly")]
+    [InlineData("in")]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartOpenEndRangeExpr_02(string refKind)
+    {
+        // sibling of ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartOpenEndRangeExpr_01
+        // struct lvalue receiver passed by ref/ref readonly/in to extension Length + extension Slice, start..
+        var src = $$$"""
+static class E
+{
+    extension({{{refKind}}} S1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 5; } }
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); return 0; }
+    }
+}
+
+struct S1
+{
+    public int F1;
+
+    public void Test2()
+    {
+        _ = this[Program.GetStart()..];
+    }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        F = new S1 { F1 = 3 };
+        F.Test2();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        _ = F[Program.GetStart()..];
+    }
+
+    public static int GetStart() { System.Console.Write($"GetStart:{Program.F.F1} "); Program.F.F1++; return 1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetStart:3 length:4 Slice:5 final:5, GetStart:3 length:4 Slice:5 final:5"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", $$"""
+{
+  // Code size       30 (0x1e)
+  .maxstack  4
+  .locals init (S1& V_0,
+                int V_1)
+  IL_0000:  nop
+  IL_0001:  ldsflda    "S1 Program.F"
+  IL_0006:  stloc.0
+  IL_0007:  call       "int Program.GetStart()"
+  IL_000c:  stloc.1
+  IL_000d:  ldloc.0
+  IL_000e:  ldloc.1
+  IL_000f:  ldloc.0
+  IL_0010:  call       "int E.get_Length({{refKind}} S1)"
+  IL_0015:  ldloc.1
+  IL_0016:  sub
+  IL_0017:  call       "int E.Slice({{refKind}} S1, int, int)"
+  IL_001c:  pop
+  IL_001d:  ret
+}
+""");
+
+        verifier.VerifyIL("S1.Test2", $$"""
+{
+  // Code size       26 (0x1a)
+  .maxstack  4
+  .locals init (S1& V_0,
+                int V_1)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  stloc.0
+  IL_0003:  call       "int Program.GetStart()"
+  IL_0008:  stloc.1
+  IL_0009:  ldloc.0
+  IL_000a:  ldloc.1
+  IL_000b:  ldloc.0
+  IL_000c:  call       "int E.get_Length({{refKind}} S1)"
+  IL_0011:  ldloc.1
+  IL_0012:  sub
+  IL_0013:  call       "int E.Slice({{refKind}} S1, int, int)"
+  IL_0018:  pop
+  IL_0019:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartOpenEndRangeExpr_03()
+    {
+        // sibling of ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartOpenEndRangeExpr_01
+        // class lvalue receiver passed by value (reference type), extension Length + extension Slice, start..
+        var src = """
+static class E
+{
+    extension(C1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F = new C1 { F1 = Program.F.F1 + 1 }; return 5; } }
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); Program.F = new C1 { F1 = Program.F.F1 + 1 }; return 0; }
+    }
+}
+
+class C1
+{
+    public int F1;
+}
+
+class Program
+{
+    public static C1 F;
+
+    static void Main()
+    {
+        F = new C1 { F1 = 3 };
+        Test();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test()
+    {
+        _ = F[GetStart()..];
+    }
+
+    public static int GetStart() { System.Console.Write($"GetStart:{Program.F.F1} "); Program.F.F1++; return 1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetStart:3 length:4 Slice:4 final:6"), verify: Verification.Skipped)
+             .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test", """
+{
+  // Code size       30 (0x1e)
+  .maxstack  4
+  .locals init (C1 V_0,
+                int V_1)
+  IL_0000:  nop
+  IL_0001:  ldsfld     "C1 Program.F"
+  IL_0006:  stloc.0
+  IL_0007:  call       "int Program.GetStart()"
+  IL_000c:  stloc.1
+  IL_000d:  ldloc.0
+  IL_000e:  ldloc.1
+  IL_000f:  ldloc.0
+  IL_0010:  call       "int E.get_Length(C1)"
+  IL_0015:  ldloc.1
+  IL_0016:  sub
+  IL_0017:  call       "int E.Slice(C1, int, int)"
+  IL_001c:  pop
+  IL_001d:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartOpenEndRangeExpr_03_02()
+    {
+        // sibling of ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartOpenEndRangeExpr_03
+        // class lvalue receiver passed by value (reference type), instance Length + extension Slice, start..
+        var src = """
+static class E
+{
+    extension(C1 x)
+    {
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); Program.F = new C1 { F1 = Program.F.F1 + 1 }; return 0; }
+    }
+}
+
+class C1
+{
+    public int F1;
+    public int Length { get { System.Console.Write($"length:{F1} "); Program.F = new C1 { F1 = Program.F.F1 + 1 }; return 5; } }
+}
+
+class Program
+{
+    public static C1 F;
+
+    static void Main()
+    {
+        F = new C1 { F1 = 3 };
+        Test();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test()
+    {
+        _ = F[GetStart()..];
+    }
+
+    public static int GetStart() { System.Console.Write($"GetStart:{Program.F.F1} "); Program.F.F1++; return 1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetStart:3 length:4 Slice:4 final:6"), verify: Verification.Skipped)
+             .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test", """
+{
+  // Code size       30 (0x1e)
+  .maxstack  4
+  .locals init (C1 V_0,
+                int V_1)
+  IL_0000:  nop
+  IL_0001:  ldsfld     "C1 Program.F"
+  IL_0006:  stloc.0
+  IL_0007:  call       "int Program.GetStart()"
+  IL_000c:  stloc.1
+  IL_000d:  ldloc.0
+  IL_000e:  ldloc.1
+  IL_000f:  ldloc.0
+  IL_0010:  callvirt   "int C1.Length.get"
+  IL_0015:  ldloc.1
+  IL_0016:  sub
+  IL_0017:  call       "int E.Slice(C1, int, int)"
+  IL_001c:  pop
+  IL_001d:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartOpenEndRangeExpr_03_03()
+    {
+        // sibling of ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartOpenEndRangeExpr_03
+        // class lvalue receiver passed by value (reference type), extension Length + instance Slice, start..
+        var src = """
+static class E
+{
+    extension(C1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F = new C1 { F1 = Program.F.F1 + 1 }; return 5; } }
+    }
+}
+
+class C1
+{
+    public int F1;
+    public int Slice(int start, int length) { System.Console.Write($"Slice:{F1} "); Program.F = new C1 { F1 = Program.F.F1 + 1 }; return 0; }
+}
+
+class Program
+{
+    public static C1 F;
+
+    static void Main()
+    {
+        F = new C1 { F1 = 3 };
+        Test();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test()
+    {
+        _ = F[GetStart()..];
+    }
+
+    public static int GetStart() { System.Console.Write($"GetStart:{Program.F.F1} "); Program.F.F1++; return 1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetStart:3 length:4 Slice:4 final:6"), verify: Verification.Skipped)
+             .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test", """
+{
+  // Code size       30 (0x1e)
+  .maxstack  4
+  .locals init (C1 V_0,
+                int V_1)
+  IL_0000:  nop
+  IL_0001:  ldsfld     "C1 Program.F"
+  IL_0006:  stloc.0
+  IL_0007:  call       "int Program.GetStart()"
+  IL_000c:  stloc.1
+  IL_000d:  ldloc.0
+  IL_000e:  ldloc.1
+  IL_000f:  ldloc.0
+  IL_0010:  call       "int E.get_Length(C1)"
+  IL_0015:  ldloc.1
+  IL_0016:  sub
+  IL_0017:  callvirt   "int C1.Slice(int, int)"
+  IL_001c:  pop
+  IL_001d:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartOpenEndRangeExpr_04()
+    {
+        // sibling of ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartOpenEndRangeExpr_01
+        // generic struct lvalue receiver passed by value to extension Length + extension Slice(int, int)
+        // Test1: unconstrained T (could be struct or class)
+        // Test2: T constrained to struct, start..
+        var src = """
+static class E
+{
+    extension<T>(T x)
+    {
+        public int Length { get { System.Console.Write($"length:{((S1)(object)x).F1} "); Program<S1>.F.F1++; return 5; } }
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{((S1)(object)x).F1} "); Program<S1>.F.F1++; return 0; }
+    }
+}
+
+struct S1
+{
+    public int F1;
+}
+
+class Program<T>
+{
+    public static T F;
+}
+
+class Program
+{
+    static void Main()
+    {
+        Program<S1>.F = new S1 { F1 = 3 };
+        Test1(ref Program<S1>.F);
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+
+        System.Console.Write(", ");
+
+        Program<S1>.F = new S1 { F1 = 3 };
+        Test2(ref Program<S1>.F);
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+    }
+
+    static void Test1<T>(ref T f)
+    {
+        _ = f[GetStart()..];
+    }
+
+    static void Test2<T>(ref T f) where T : struct
+    {
+        _ = f[GetStart()..];
+    }
+
+    public static int GetStart() { System.Console.Write($"GetStart:{Program<S1>.F.F1} "); Program<S1>.F.F1++; return 1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetStart:3 length:4 Slice:5 final:6, GetStart:3 length:4 Slice:5 final:6"), verify: Verification.Skipped)
+              .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1<T>(ref T)", """
+{
+  // Code size       66 (0x42)
+  .maxstack  4
+  .locals init (T V_0,
+                T& V_1,
+                int V_2,
+                int V_3,
+                T V_4)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  stloc.1
+  IL_0003:  ldloca.s   V_4
+  IL_0005:  initobj    "T"
+  IL_000b:  ldloc.s    V_4
+  IL_000d:  box        "T"
+  IL_0012:  brtrue.s   IL_001f
+  IL_0014:  ldloc.1
+  IL_0015:  ldobj      "T"
+  IL_001a:  stloc.0
+  IL_001b:  ldloca.s   V_0
+  IL_001d:  br.s       IL_0020
+  IL_001f:  ldloc.1
+  IL_0020:  call       "int Program.GetStart()"
+  IL_0025:  stloc.2
+  IL_0026:  dup
+  IL_0027:  ldobj      "T"
+  IL_002c:  call       "int E.get_Length<T>(T)"
+  IL_0031:  stloc.3
+  IL_0032:  ldobj      "T"
+  IL_0037:  ldloc.2
+  IL_0038:  ldloc.3
+  IL_0039:  ldloc.2
+  IL_003a:  sub
+  IL_003b:  call       "int E.Slice<T>(T, int, int)"
+  IL_0040:  pop
+  IL_0041:  ret
+}
+""");
+
+        verifier.VerifyIL("Program.Test2<T>(ref T)", """
+{
+  // Code size       36 (0x24)
+  .maxstack  4
+  .locals init (int V_0,
+                int V_1)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  call       "int Program.GetStart()"
+  IL_0007:  stloc.0
+  IL_0008:  dup
+  IL_0009:  ldobj      "T"
+  IL_000e:  call       "int E.get_Length<T>(T)"
+  IL_0013:  stloc.1
+  IL_0014:  ldobj      "T"
+  IL_0019:  ldloc.0
+  IL_001a:  ldloc.1
+  IL_001b:  ldloc.0
+  IL_001c:  sub
+  IL_001d:  call       "int E.Slice<T>(T, int, int)"
+  IL_0022:  pop
+  IL_0023:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartOpenEndRangeExpr_05()
+    {
+        // sibling of ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartOpenEndRangeExpr_01
+        // generic struct lvalue receiver passed by ref to extension Length + extension Slice(int, int)
+        // Test2: synchronous start expression
+        // Test3: asynchronous start expression (await), start..
+        var src = """
+using System.Threading.Tasks;
+
+static class E
+{
+    extension<T>(ref T x) where T : struct
+    {
+        public int Length { get { System.Console.Write($"length:{((S1)(object)x).F1} "); Program<S1>.F.F1++; return 5; } }
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{((S1)(object)x).F1} "); Program<S1>.F.F1++; return 0; }
+    }
+}
+
+struct S1
+{
+    public int F1;
+}
+
+class Program<T>
+{
+    public static T F;
+}
+
+class Program
+{
+    static async Task Main()
+    {
+        Program<S1>.F = new S1 { F1 = 3 };
+        Test2(ref Program<S1>.F);
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+
+        System.Console.Write(", ");
+
+        Program<S1>.F = new S1 { F1 = 3 };
+        await Test3<S1>();
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+    }
+
+    static void Test2<T>(ref T f) where T : struct
+    {
+        _ = f[GetStart()..];
+    }
+
+    public static int GetStart() { System.Console.Write($"GetStart:{Program<S1>.F.F1} "); Program<S1>.F.F1++; return 1; }
+
+    static async Task Test3<T>() where T : struct
+    {
+        _ = Program<T>.F[(await GetStartAsync())..];
+    }
+
+    static async Task<int> GetStartAsync() { System.Console.Write($"GetStartAsync:{Program<S1>.F.F1} "); Program<S1>.F.F1++; await Task.Yield(); return 1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetStart:3 length:4 Slice:5 final:6, GetStartAsync:3 length:4 Slice:5 final:6"), verify: Verification.Skipped)
+                    .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test2<T>(ref T)", """
+{
+  // Code size       26 (0x1a)
+  .maxstack  4
+  .locals init (T& V_0,
+                int V_1)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  stloc.0
+  IL_0003:  call       "int Program.GetStart()"
+  IL_0008:  stloc.1
+  IL_0009:  ldloc.0
+  IL_000a:  ldloc.1
+  IL_000b:  ldloc.0
+  IL_000c:  call       "int E.get_Length<T>(ref T)"
+  IL_0011:  ldloc.1
+  IL_0012:  sub
+  IL_0013:  call       "int E.Slice<T>(ref T, int, int)"
+  IL_0018:  pop
+  IL_0019:  ret
+}
+""");
+
+        // receiver is not a variable
+        var src2 = """
+static class E
+{
+    extension<T>(ref T x) where T : struct
+    {
+        public int Length => 5;
+        public int Slice(int start, int length) => 0;
+    }
+}
+
+class Program
+{
+    static void Test<T>() where T : struct
+    {
+        _ = default(T)[1..^1];
+    }
+}
+""";
+
+        CreateCompilation(src2, targetFramework: TargetFramework.Net100).VerifyEmitDiagnostics(
+            // (14,13): error CS1510: A ref or out value must be an assignable variable
+            //         _ = default(T)[1..^1];
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "default(T)").WithLocation(14, 13),
+            // (14,13): error CS1510: A ref or out value must be an assignable variable
+            //         _ = default(T)[1..^1];
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "default(T)").WithLocation(14, 13));
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartOpenEndRangeExpr_06()
+    {
+        // sibling of ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartOpenEndRangeExpr_01
+        // generic class lvalue receiver passed by value to extension Length + extension Slice(int, int)
+        // Test1: unconstrained T (could be struct or class)
+        // Test2: T constrained to class, start..
+        var src = """
+static class E
+{
+    extension<T>(T x)
+    {
+        public int Length { get { System.Console.Write($"length:{((C1)(object)x).F1} "); Program<C1>.F = new C1 { F1 = Program<C1>.F.F1 + 1 }; return 5; } }
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{((C1)(object)x).F1} "); Program<C1>.F = new C1 { F1 = Program<C1>.F.F1 + 1 }; return 0; }
+    }
+}
+
+class C1
+{
+    public int F1;
+}
+
+class Program<T>
+{
+    public static T F;
+}
+
+class Program
+{
+    static void Main()
+    {
+        Program<C1>.F = new C1 { F1 = 3 };
+        Test1(ref Program<C1>.F);
+        System.Console.Write($"final:{Program<C1>.F.F1}");
+
+        System.Console.Write(", ");
+
+        Program<C1>.F = new C1 { F1 = 3 };
+        Test2(ref Program<C1>.F);
+        System.Console.Write($"final:{Program<C1>.F.F1}");
+    }
+
+    static void Test1<T>(ref T f)
+    {
+        _ = f[GetStart()..];
+    }
+
+    static void Test2<T>(ref T f) where T : class
+    {
+        _ = f[GetStart()..];
+    }
+
+    public static int GetStart() { System.Console.Write($"GetStart:{Program<C1>.F.F1} "); Program<C1>.F.F1++; return 1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetStart:3 length:4 Slice:4 final:6, GetStart:3 length:4 Slice:4 final:6"), verify: Verification.Skipped)
+             .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1<T>(ref T)", """
+{
+  // Code size       66 (0x42)
+  .maxstack  4
+  .locals init (T V_0,
+                T& V_1,
+                int V_2,
+                int V_3,
+                T V_4)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  stloc.1
+  IL_0003:  ldloca.s   V_4
+  IL_0005:  initobj    "T"
+  IL_000b:  ldloc.s    V_4
+  IL_000d:  box        "T"
+  IL_0012:  brtrue.s   IL_001f
+  IL_0014:  ldloc.1
+  IL_0015:  ldobj      "T"
+  IL_001a:  stloc.0
+  IL_001b:  ldloca.s   V_0
+  IL_001d:  br.s       IL_0020
+  IL_001f:  ldloc.1
+  IL_0020:  call       "int Program.GetStart()"
+  IL_0025:  stloc.2
+  IL_0026:  dup
+  IL_0027:  ldobj      "T"
+  IL_002c:  call       "int E.get_Length<T>(T)"
+  IL_0031:  stloc.3
+  IL_0032:  ldobj      "T"
+  IL_0037:  ldloc.2
+  IL_0038:  ldloc.3
+  IL_0039:  ldloc.2
+  IL_003a:  sub
+  IL_003b:  call       "int E.Slice<T>(T, int, int)"
+  IL_0040:  pop
+  IL_0041:  ret
+}
+""");
+
+        verifier.VerifyIL("Program.Test2<T>(ref T)", """
+{
+  // Code size       31 (0x1f)
+  .maxstack  4
+  .locals init (T V_0,
+                int V_1)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  ldobj      "T"
+  IL_0007:  stloc.0
+  IL_0008:  call       "int Program.GetStart()"
+  IL_000d:  stloc.1
+  IL_000e:  ldloc.0
+  IL_000f:  ldloc.1
+  IL_0010:  ldloc.0
+  IL_0011:  call       "int E.get_Length<T>(T)"
+  IL_0016:  ldloc.1
+  IL_0017:  sub
+  IL_0018:  call       "int E.Slice<T>(T, int, int)"
+  IL_001d:  pop
+  IL_001e:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_OpenStartIndexEndRangeExpr_01()
+    {
+        // sibling of ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartOpenEndRangeExpr_01
+        // struct lvalue receiver passed by value, extension Length + extension Slice, ..endIndex
+        var src = """
+static class E
+{
+    extension(S1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 5; } }
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); Program.F.F1++; return 0; }
+    }
+}
+
+public struct S1
+{
+    public int F1;
+
+    public void Test2()
+    {
+        _ = this[..Program.GetIndex()];
+    }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        F = new S1 { F1 = 3 };
+        F.Test2();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        _ = F[..GetIndex()];
+    }
+
+    public static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program.F.F1} "); Program.F.F1++; return new System.Index(1); }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:4 Slice:5 final:6, GetIndex:3 length:4 Slice:5 final:6"), verify: Verification.Skipped)
+             .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", """
+{
+  // Code size       45 (0x2d)
+  .maxstack  4
+  .locals init (System.Index V_0,
+                int V_1)
+  IL_0000:  nop
+  IL_0001:  ldsflda    "S1 Program.F"
+  IL_0006:  call       "System.Index Program.GetIndex()"
+  IL_000b:  stloc.0
+  IL_000c:  dup
+  IL_000d:  ldobj      "S1"
+  IL_0012:  call       "int E.get_Length(S1)"
+  IL_0017:  stloc.1
+  IL_0018:  ldobj      "S1"
+  IL_001d:  ldc.i4.0
+  IL_001e:  ldloca.s   V_0
+  IL_0020:  ldloc.1
+  IL_0021:  call       "int System.Index.GetOffset(int)"
+  IL_0026:  call       "int E.Slice(S1, int, int)"
+  IL_002b:  pop
+  IL_002c:  ret
+}
+""");
+
+        verifier.VerifyIL("S1.Test2", """
+{
+  // Code size       41 (0x29)
+  .maxstack  4
+  .locals init (System.Index V_0,
+                int V_1)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  call       "System.Index Program.GetIndex()"
+  IL_0007:  stloc.0
+  IL_0008:  dup
+  IL_0009:  ldobj      "S1"
+  IL_000e:  call       "int E.get_Length(S1)"
+  IL_0013:  stloc.1
+  IL_0014:  ldobj      "S1"
+  IL_0019:  ldc.i4.0
+  IL_001a:  ldloca.s   V_0
+  IL_001c:  ldloc.1
+  IL_001d:  call       "int System.Index.GetOffset(int)"
+  IL_0022:  call       "int E.Slice(S1, int, int)"
+  IL_0027:  pop
+  IL_0028:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartIndexEndRangeExpr_01()
+    {
+        // sibling of ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartOpenEndRangeExpr_01
+        // struct lvalue receiver passed by value, extension Length + extension Slice, start..endIndex
+        var src = """
+static class E
+{
+    extension(S1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 5; } }
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); Program.F.F1++; return 0; }
+    }
+}
+
+public struct S1
+{
+    public int F1;
+
+    public void Test2()
+    {
+        _ = this[Program.GetStart()..Program.GetIndex()];
+    }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        F = new S1 { F1 = 3 };
+        F.Test2();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        _ = F[GetStart()..GetIndex()];
+    }
+
+    public static int GetStart() { System.Console.Write($"GetStart:{Program.F.F1} "); Program.F.F1++; return 1; }
+    public static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program.F.F1} "); Program.F.F1++; return new System.Index(2); }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetStart:3 GetIndex:4 length:5 Slice:6 final:7, GetStart:3 GetIndex:4 length:5 Slice:6 final:7"), verify: Verification.Skipped)
+             .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", """
+{
+  // Code size       53 (0x35)
+  .maxstack  4
+  .locals init (int V_0,
+                System.Index V_1,
+                int V_2)
+  IL_0000:  nop
+  IL_0001:  ldsflda    "S1 Program.F"
+  IL_0006:  call       "int Program.GetStart()"
+  IL_000b:  stloc.0
+  IL_000c:  call       "System.Index Program.GetIndex()"
+  IL_0011:  stloc.1
+  IL_0012:  dup
+  IL_0013:  ldobj      "S1"
+  IL_0018:  call       "int E.get_Length(S1)"
+  IL_001d:  stloc.2
+  IL_001e:  ldobj      "S1"
+  IL_0023:  ldloc.0
+  IL_0024:  ldloca.s   V_1
+  IL_0026:  ldloc.2
+  IL_0027:  call       "int System.Index.GetOffset(int)"
+  IL_002c:  ldloc.0
+  IL_002d:  sub
+  IL_002e:  call       "int E.Slice(S1, int, int)"
+  IL_0033:  pop
+  IL_0034:  ret
+}
+""");
+
+        verifier.VerifyIL("S1.Test2", """
+{
+  // Code size       49 (0x31)
+  .maxstack  4
+  .locals init (int V_0,
+                System.Index V_1,
+                int V_2)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  call       "int Program.GetStart()"
+  IL_0007:  stloc.0
+  IL_0008:  call       "System.Index Program.GetIndex()"
+  IL_000d:  stloc.1
+  IL_000e:  dup
+  IL_000f:  ldobj      "S1"
+  IL_0014:  call       "int E.get_Length(S1)"
+  IL_0019:  stloc.2
+  IL_001a:  ldobj      "S1"
+  IL_001f:  ldloc.0
+  IL_0020:  ldloca.s   V_1
+  IL_0022:  ldloc.2
+  IL_0023:  call       "int System.Index.GetOffset(int)"
+  IL_0028:  ldloc.0
+  IL_0029:  sub
+  IL_002a:  call       "int E.Slice(S1, int, int)"
+  IL_002f:  pop
+  IL_0030:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartIndexEndRangeExpr_03()
+    {
+        // sibling of ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartOpenEndRangeExpr_03
+        // class lvalue receiver passed by value (reference type), extension Length + extension Slice, start..endIndex
+        var src = """
+static class E
+{
+    extension(C1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F = new C1 { F1 = Program.F.F1 + 1 }; return 5; } }
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); Program.F = new C1 { F1 = Program.F.F1 + 1 }; return 0; }
+    }
+}
+
+class C1
+{
+    public int F1;
+}
+
+class Program
+{
+    public static C1 F;
+
+    static void Main()
+    {
+        F = new C1 { F1 = 3 };
+        Test();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test()
+    {
+        _ = F[GetStart()..GetIndex()];
+    }
+
+    public static int GetStart() { System.Console.Write($"GetStart:{Program.F.F1} "); Program.F.F1++; return 1; }
+    public static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program.F.F1} "); Program.F.F1++; return new System.Index(2); }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetStart:3 GetIndex:4 length:5 Slice:5 final:7"), verify: Verification.Skipped)
+             .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test", """
+{
+  // Code size       43 (0x2b)
+  .maxstack  4
+  .locals init (C1 V_0,
+                int V_1,
+                System.Index V_2)
+  IL_0000:  nop
+  IL_0001:  ldsfld     "C1 Program.F"
+  IL_0006:  stloc.0
+  IL_0007:  call       "int Program.GetStart()"
+  IL_000c:  stloc.1
+  IL_000d:  ldloc.0
+  IL_000e:  ldloc.1
+  IL_000f:  call       "System.Index Program.GetIndex()"
+  IL_0014:  stloc.2
+  IL_0015:  ldloca.s   V_2
+  IL_0017:  ldloc.0
+  IL_0018:  call       "int E.get_Length(C1)"
+  IL_001d:  call       "int System.Index.GetOffset(int)"
+  IL_0022:  ldloc.1
+  IL_0023:  sub
+  IL_0024:  call       "int E.Slice(C1, int, int)"
+  IL_0029:  pop
+  IL_002a:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_HatStartOpenEndRangeExpr_01()
+    {
+        // sibling of ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartOpenEndRangeExpr_01
+        // struct lvalue receiver passed by value, extension Length + extension Slice, ^end..
+        var src = """
+static class E
+{
+    extension(S1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 5; } }
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); Program.F.F1++; return 0; }
+    }
+}
+
+public struct S1
+{
+    public int F1;
+
+    public void Test2()
+    {
+        _ = this[^Program.GetEnd()..];
+    }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        F = new S1 { F1 = 3 };
+        F.Test2();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        _ = F[^GetEnd()..];
+    }
+
+    public static int GetEnd() { System.Console.Write($"GetEnd:{Program.F.F1} "); Program.F.F1++; return 1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetEnd:3 length:4 Slice:5 final:6, GetEnd:3 length:4 Slice:5 final:6"), verify: Verification.Skipped)
+             .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", """
+{
+  // Code size       44 (0x2c)
+  .maxstack  4
+  .locals init (int V_0,
+                int V_1,
+                int V_2)
+  IL_0000:  nop
+  IL_0001:  ldsflda    "S1 Program.F"
+  IL_0006:  call       "int Program.GetEnd()"
+  IL_000b:  stloc.0
+  IL_000c:  dup
+  IL_000d:  ldobj      "S1"
+  IL_0012:  call       "int E.get_Length(S1)"
+  IL_0017:  stloc.1
+  IL_0018:  ldloc.1
+  IL_0019:  ldloc.0
+  IL_001a:  sub
+  IL_001b:  stloc.2
+  IL_001c:  ldobj      "S1"
+  IL_0021:  ldloc.2
+  IL_0022:  ldloc.1
+  IL_0023:  ldloc.2
+  IL_0024:  sub
+  IL_0025:  call       "int E.Slice(S1, int, int)"
+  IL_002a:  pop
+  IL_002b:  ret
+}
+""");
+
+        verifier.VerifyIL("S1.Test2", """
+{
+  // Code size       40 (0x28)
+  .maxstack  4
+  .locals init (int V_0,
+                int V_1,
+                int V_2)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  call       "int Program.GetEnd()"
+  IL_0007:  stloc.0
+  IL_0008:  dup
+  IL_0009:  ldobj      "S1"
+  IL_000e:  call       "int E.get_Length(S1)"
+  IL_0013:  stloc.1
+  IL_0014:  ldloc.1
+  IL_0015:  ldloc.0
+  IL_0016:  sub
+  IL_0017:  stloc.2
+  IL_0018:  ldobj      "S1"
+  IL_001d:  ldloc.2
+  IL_001e:  ldloc.1
+  IL_001f:  ldloc.2
+  IL_0020:  sub
+  IL_0021:  call       "int E.Slice(S1, int, int)"
+  IL_0026:  pop
+  IL_0027:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartIntEndRangeExpr_01()
+    {
+        // sibling of ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartOpenEndRangeExpr_01
+        // struct lvalue receiver passed by value, extension Length + extension Slice, start..end
+        var src = """
+static class E
+{
+    extension(S1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 5; } }
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); Program.F.F1++; return 0; }
+    }
+}
+
+public struct S1
+{
+    public int F1;
+
+    public void Test2()
+    {
+        _ = this[Program.GetStart()..Program.GetEnd()];
+    }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        F = new S1 { F1 = 3 };
+        F.Test2();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        _ = F[GetStart()..GetEnd()];
+    }
+
+    public static int GetStart() { System.Console.Write($"GetStart:{Program.F.F1} "); Program.F.F1++; return 1; }
+    public static int GetEnd() { System.Console.Write($"GetEnd:{Program.F.F1} "); Program.F.F1++; return 2; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetStart:3 GetEnd:4 Slice:5 final:6, GetStart:3 GetEnd:4 Slice:5 final:6"), verify: Verification.Skipped)
+             .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", """
+{
+  // Code size       34 (0x22)
+  .maxstack  4
+  .locals init (int V_0,
+                int V_1)
+  IL_0000:  nop
+  IL_0001:  ldsflda    "S1 Program.F"
+  IL_0006:  call       "int Program.GetStart()"
+  IL_000b:  stloc.0
+  IL_000c:  call       "int Program.GetEnd()"
+  IL_0011:  stloc.1
+  IL_0012:  ldobj      "S1"
+  IL_0017:  ldloc.0
+  IL_0018:  ldloc.1
+  IL_0019:  ldloc.0
+  IL_001a:  sub
+  IL_001b:  call       "int E.Slice(S1, int, int)"
+  IL_0020:  pop
+  IL_0021:  ret
+}
+""");
+
+        verifier.VerifyIL("S1.Test2", """
+{
+  // Code size       30 (0x1e)
+  .maxstack  4
+  .locals init (int V_0,
+                int V_1)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  call       "int Program.GetStart()"
+  IL_0007:  stloc.0
+  IL_0008:  call       "int Program.GetEnd()"
+  IL_000d:  stloc.1
+  IL_000e:  ldobj      "S1"
+  IL_0013:  ldloc.0
+  IL_0014:  ldloc.1
+  IL_0015:  ldloc.0
+  IL_0016:  sub
+  IL_0017:  call       "int E.Slice(S1, int, int)"
+  IL_001c:  pop
+  IL_001d:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_RValueReceiver_IntStartOpenEndRangeExpr_01()
+    {
+        // sibling of ImplicitRangeIndexerAccess_Get_RValueReceiver_01
+        // struct rvalue receiver passed by value to extension Length + extension Slice, start..
+        var src = """
+static class E
+{
+    extension(S1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.State++; return 5; } }
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); Program.State++; return 0; }
+    }
+}
+
+public struct S1
+{
+    public int F1;
+}
+
+class Program
+{
+    public static int State;
+
+    static void Main()
+    {
+        State = 3;
+        Test();
+        System.Console.Write($"final:{State}");
+    }
+
+    static void Test()
+    {
+        _ = GetS1()[GetStart()..];
+    }
+
+    static S1 GetS1() => new S1 { F1 = State };
+
+    public static int GetStart() { System.Console.Write($"GetStart:{State} "); State++; return 1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetStart:3 length:3 Slice:3 final:6"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test", """
+{
+  // Code size       43 (0x2b)
+  .maxstack  4
+  .locals init (int V_0,
+                int V_1,
+                S1 V_2)
+  IL_0000:  nop
+  IL_0001:  call       "S1 Program.GetS1()"
+  IL_0006:  stloc.2
+  IL_0007:  ldloca.s   V_2
+  IL_0009:  call       "int Program.GetStart()"
+  IL_000e:  stloc.0
+  IL_000f:  dup
+  IL_0010:  ldobj      "S1"
+  IL_0015:  call       "int E.get_Length(S1)"
+  IL_001a:  stloc.1
+  IL_001b:  ldobj      "S1"
+  IL_0020:  ldloc.0
+  IL_0021:  ldloc.1
+  IL_0022:  ldloc.0
+  IL_0023:  sub
+  IL_0024:  call       "int E.Slice(S1, int, int)"
+  IL_0029:  pop
+  IL_002a:  ret
+}
+""");
+    }
+
+    [Theory]
+    [InlineData("ref")]
+    [InlineData("ref readonly")]
+    [InlineData("in")]
+    public void ImplicitRangeIndexerAccess_Get_RValueReceiver_IntStartOpenEndRangeExpr_02(string refKind)
+    {
+        // sibling of ImplicitRangeIndexerAccess_Get_RValueReceiver_02
+        // struct rvalue receiver passed by ref/in/ref readonly to extension Length + extension Slice, start..
+        var src = $$$"""
+static class E
+{
+    extension({{{refKind}}} S1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.State++; return 5; } }
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); Program.State++; return 0; }
+    }
+}
+
+struct S1
+{
+    public int F1;
+}
+
+class Program
+{
+    public static int State;
+
+    static void Main()
+    {
+        State = 3;
+        Test();
+        System.Console.Write($"final:{State}");
+    }
+
+    static void Test()
+    {
+        _ = GetS1()[GetStart()..];
+    }
+
+    static S1 GetS1() => new S1 { F1 = State };
+
+    public static int GetStart() { System.Console.Write($"GetStart:{State} "); State++; return 1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        switch (refKind)
+        {
+            case "ref":
+                comp.VerifyEmitDiagnostics(
+                    // (28,13): error CS1510: A ref or out value must be an assignable variable
+                    //         _ = GetS1()[GetStart()..];
+                    Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetS1()").WithLocation(28, 13),
+                    // (28,13): error CS1510: A ref or out value must be an assignable variable
+                    //         _ = GetS1()[GetStart()..];
+                    Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetS1()").WithLocation(28, 13));
+                return;
+            case "ref readonly":
+                comp.VerifyEmitDiagnostics(
+                    // (28,13): warning CS9193: Argument 0 should be a variable because it is passed to a 'ref readonly' parameter
+                    //         _ = GetS1()[GetStart()..];
+                    Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "GetS1()").WithArguments("0").WithLocation(28, 13),
+                    // (28,13): warning CS9193: Argument 0 should be a variable because it is passed to a 'ref readonly' parameter
+                    //         _ = GetS1()[GetStart()..];
+                    Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "GetS1()").WithArguments("0").WithLocation(28, 13),
+                    // (28,13): warning CS9193: Argument 0 should be a variable because it is passed to a 'ref readonly' parameter
+                    //         _ = GetS1()[GetStart()..];
+                    Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "GetS1()").WithArguments("0").WithLocation(28, 13));
+                break;
+            case "in":
+                comp.VerifyEmitDiagnostics();
+                break;
+            default:
+                throw ExceptionUtilities.UnexpectedValue(refKind);
+        }
+
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetStart:3 length:3 Slice:3 final:6"), verify: Verification.Skipped);
+        verifier.VerifyIL("Program.Test", $$"""
+{
+  // Code size       33 (0x21)
+  .maxstack  4
+  .locals init (S1& V_0,
+                int V_1,
+                S1 V_2)
+  IL_0000:  nop
+  IL_0001:  call       "S1 Program.GetS1()"
+  IL_0006:  stloc.2
+  IL_0007:  ldloca.s   V_2
+  IL_0009:  stloc.0
+  IL_000a:  call       "int Program.GetStart()"
+  IL_000f:  stloc.1
+  IL_0010:  ldloc.0
+  IL_0011:  ldloc.1
+  IL_0012:  ldloc.0
+  IL_0013:  call       "int E.get_Length({{refKind}} S1)"
+  IL_0018:  ldloc.1
+  IL_0019:  sub
+  IL_001a:  call       "int E.Slice({{refKind}} S1, int, int)"
+  IL_001f:  pop
+  IL_0020:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_RValueReceiver_IntStartOpenEndRangeExpr_03()
+    {
+        // sibling of ImplicitRangeIndexerAccess_Get_RValueReceiver_03
+        // class rvalue receiver passed by value (reference type), extension Length + extension Slice, start..
+        var src = """
+static class E
+{
+    extension(C1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.State++; return 5; } }
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); Program.State++; return 0; }
+    }
+}
+
+class C1
+{
+    public int F1;
+}
+
+class Program
+{
+    public static int State;
+
+    static void Main()
+    {
+        State = 3;
+        Test();
+        System.Console.Write($"final:{State}");
+    }
+
+    static void Test()
+    {
+        _ = GetC1()[GetStart()..];
+    }
+
+    static C1 GetC1() => new C1 { F1 = State };
+
+    static int GetStart() { System.Console.Write($"GetStart:{State} "); State++; return 1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetStart:3 length:3 Slice:3 final:6"), verify: Verification.Skipped)
+                .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test", """
+{
+  // Code size       30 (0x1e)
+  .maxstack  4
+  .locals init (C1 V_0,
+                int V_1)
+  IL_0000:  nop
+  IL_0001:  call       "C1 Program.GetC1()"
+  IL_0006:  stloc.0
+  IL_0007:  call       "int Program.GetStart()"
+  IL_000c:  stloc.1
+  IL_000d:  ldloc.0
+  IL_000e:  ldloc.1
+  IL_000f:  ldloc.0
+  IL_0010:  call       "int E.get_Length(C1)"
+  IL_0015:  ldloc.1
+  IL_0016:  sub
+  IL_0017:  call       "int E.Slice(C1, int, int)"
+  IL_001c:  pop
+  IL_001d:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_RValueReceiver_IntStartOpenEndRangeExpr_04()
+    {
+        // sibling of ImplicitRangeIndexerAccess_Get_RValueReceiver_04
+        // generic struct rvalue receiver passed by value to extension Length + extension Slice(int, int)
+        // Test1: unconstrained T (could be struct or class)
+        // Test2: T constrained to struct
+        // Test3: asynchronous start expression (await), start..
+        var src = """
+using System.Threading.Tasks;
+
+static class E
+{
+    extension<T>(T x)
+    {
+        public int Length { get { System.Console.Write($"length:{((S1)(object)x).F1} "); Program.State++; return 5; } }
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{((S1)(object)x).F1} "); Program.State++; return 0; }
+    }
+}
+
+struct S1
+{
+    public int F1;
+}
+
+class Program
+{
+    public static int State;
+
+    static async Task Main()
+    {
+        State = 3;
+        Test1<S1>();
+        System.Console.Write($"final:{State}");
+
+        System.Console.Write(", ");
+
+        State = 3;
+        Test2<S1>();
+        System.Console.Write($"final:{State}");
+
+        System.Console.Write(", ");
+
+        State = 3;
+        await Test3<S1>();
+        System.Console.Write($"final:{State}");
+    }
+
+    static T GetT<T>() => (T)(object)new S1 { F1 = State };
+
+    static void Test1<T>()
+    {
+        _ = GetT<T>()[GetStart()..];
+    }
+
+    static void Test2<T>() where T : struct
+    {
+        _ = GetT<T>()[GetStart()..];
+    }
+
+    static int GetStart() { System.Console.Write($"GetStart:{State} "); State++; return 1; }
+
+    static async Task Test3<T>()
+    {
+        _ = GetT<T>()[(await GetStartAsync())..];
+    }
+
+    static async Task<int> GetStartAsync() { System.Console.Write($"GetStartAsync:{State} "); State++; await Task.Yield(); return 1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetStart:3 length:3 Slice:3 final:6, GetStart:3 length:3 Slice:3 final:6, GetStartAsync:3 length:3 Slice:3 final:6"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1<T>()", """
+{
+  // Code size       74 (0x4a)
+  .maxstack  4
+  .locals init (T V_0,
+                T& V_1,
+                int V_2,
+                int V_3,
+                T V_4,
+                T V_5)
+  IL_0000:  nop
+  IL_0001:  call       "T Program.GetT<T>()"
+  IL_0006:  stloc.s    V_4
+  IL_0008:  ldloca.s   V_4
+  IL_000a:  stloc.1
+  IL_000b:  ldloca.s   V_5
+  IL_000d:  initobj    "T"
+  IL_0013:  ldloc.s    V_5
+  IL_0015:  box        "T"
+  IL_001a:  brtrue.s   IL_0027
+  IL_001c:  ldloc.1
+  IL_001d:  ldobj      "T"
+  IL_0022:  stloc.0
+  IL_0023:  ldloca.s   V_0
+  IL_0025:  br.s       IL_0028
+  IL_0027:  ldloc.1
+  IL_0028:  call       "int Program.GetStart()"
+  IL_002d:  stloc.2
+  IL_002e:  dup
+  IL_002f:  ldobj      "T"
+  IL_0034:  call       "int E.get_Length<T>(T)"
+  IL_0039:  stloc.3
+  IL_003a:  ldobj      "T"
+  IL_003f:  ldloc.2
+  IL_0040:  ldloc.3
+  IL_0041:  ldloc.2
+  IL_0042:  sub
+  IL_0043:  call       "int E.Slice<T>(T, int, int)"
+  IL_0048:  pop
+  IL_0049:  ret
+}
+""");
+
+        verifier.VerifyIL("Program.Test2<T>()", """
+{
+  // Code size       43 (0x2b)
+  .maxstack  4
+  .locals init (int V_0,
+                int V_1,
+                T V_2)
+  IL_0000:  nop
+  IL_0001:  call       "T Program.GetT<T>()"
+  IL_0006:  stloc.2
+  IL_0007:  ldloca.s   V_2
+  IL_0009:  call       "int Program.GetStart()"
+  IL_000e:  stloc.0
+  IL_000f:  dup
+  IL_0010:  ldobj      "T"
+  IL_0015:  call       "int E.get_Length<T>(T)"
+  IL_001a:  stloc.1
+  IL_001b:  ldobj      "T"
+  IL_0020:  ldloc.0
+  IL_0021:  ldloc.1
+  IL_0022:  ldloc.0
+  IL_0023:  sub
+  IL_0024:  call       "int E.Slice<T>(T, int, int)"
+  IL_0029:  pop
+  IL_002a:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_RValueReceiver_IntStartOpenEndRangeExpr_05()
+    {
+        // sibling of ImplicitRangeIndexerAccess_Get_RValueReceiver_05
+        // generic struct rvalue receiver passed by ref to extension Length + extension Slice(int, int)
+        // ref-extension on rvalue receiver is an error, start..
+        var src = """
+using System.Threading.Tasks;
+
+static class E
+{
+    extension<T>(ref T x) where T : struct
+    {
+        public int Length => 5;
+        public int Slice(int start, int length) => 0;
+    }
+}
+
+struct S1
+{
+    public int F1;
+}
+
+class Program
+{
+    static void Test2<T>() where T : struct
+    {
+        _ = GetT<T>()[GetStart()..];
+    }
+
+    static T GetT<T>() => (T)(object)new S1 { F1 = 3 };
+    static int GetStart() => 1;
+
+    static async Task Test3<T>() where T : struct
+    {
+        _ = GetT<T>()[(await GetStartAsync())..];
+    }
+
+    static async Task<int> GetStartAsync() { await Task.Yield(); return 1; }
+}
+""";
+
+        CreateCompilation(src, targetFramework: TargetFramework.Net100).VerifyDiagnostics(
+            // (21,13): error CS1510: A ref or out value must be an assignable variable
+            //         _ = GetT<T>()[GetStart()..];
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetT<T>()").WithLocation(21, 13),
+            // (21,13): error CS1510: A ref or out value must be an assignable variable
+            //         _ = GetT<T>()[GetStart()..];
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetT<T>()").WithLocation(21, 13),
+            // (29,13): error CS1510: A ref or out value must be an assignable variable
+            //         _ = GetT<T>()[(await GetStartAsync())..];
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetT<T>()").WithLocation(29, 13),
+            // (29,13): error CS1510: A ref or out value must be an assignable variable
+            //         _ = GetT<T>()[(await GetStartAsync())..];
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetT<T>()").WithLocation(29, 13));
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_RValueReceiver_IntStartOpenEndRangeExpr_06()
+    {
+        // sibling of ImplicitRangeIndexerAccess_Get_RValueReceiver_06
+        // generic class rvalue receiver passed by value to extension Length + extension Slice(int, int)
+        // Test1: unconstrained T (could be struct or class)
+        // Test2: T constrained to class
+        // Test3: asynchronous start expression (await), start..
+        var src = """
+using System.Threading.Tasks;
+
+static class E
+{
+    extension<T>(T x)
+    {
+        public int Length { get { System.Console.Write($"length:{((C1)(object)x).F1} "); Program.State++; return 5; } }
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{((C1)(object)x).F1} "); Program.State++; return 0; }
+    }
+}
+
+class C1
+{
+    public int F1;
+}
+
+class Program
+{
+    public static int State;
+
+    static async Task Main()
+    {
+        State = 3;
+        Test1<C1>();
+        System.Console.Write($"final:{State}");
+
+        System.Console.Write(", ");
+
+        State = 3;
+        Test2<C1>();
+        System.Console.Write($"final:{State}");
+
+        System.Console.Write(", ");
+
+        State = 3;
+        await Test3<C1>();
+        System.Console.Write($"final:{State}");
+    }
+
+    static T GetT<T>() => (T)(object)new C1 { F1 = State };
+
+    static void Test1<T>()
+    {
+        _ = GetT<T>()[GetStart()..];
+    }
+
+    static void Test2<T>() where T : class
+    {
+        _ = GetT<T>()[GetStart()..];
+    }
+
+    static int GetStart() { System.Console.Write($"GetStart:{State} "); State++; return 1; }
+
+    static async Task Test3<T>()
+    {
+        _ = GetT<T>()[(await GetStartAsync())..];
+    }
+
+    static async Task<int> GetStartAsync() { System.Console.Write($"GetStartAsync:{State} "); State++; await Task.Yield(); return 1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetStart:3 length:3 Slice:3 final:6, GetStart:3 length:3 Slice:3 final:6, GetStartAsync:3 length:3 Slice:3 final:6"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1<T>()", """
+{
+  // Code size       74 (0x4a)
+  .maxstack  4
+  .locals init (T V_0,
+                T& V_1,
+                int V_2,
+                int V_3,
+                T V_4,
+                T V_5)
+  IL_0000:  nop
+  IL_0001:  call       "T Program.GetT<T>()"
+  IL_0006:  stloc.s    V_4
+  IL_0008:  ldloca.s   V_4
+  IL_000a:  stloc.1
+  IL_000b:  ldloca.s   V_5
+  IL_000d:  initobj    "T"
+  IL_0013:  ldloc.s    V_5
+  IL_0015:  box        "T"
+  IL_001a:  brtrue.s   IL_0027
+  IL_001c:  ldloc.1
+  IL_001d:  ldobj      "T"
+  IL_0022:  stloc.0
+  IL_0023:  ldloca.s   V_0
+  IL_0025:  br.s       IL_0028
+  IL_0027:  ldloc.1
+  IL_0028:  call       "int Program.GetStart()"
+  IL_002d:  stloc.2
+  IL_002e:  dup
+  IL_002f:  ldobj      "T"
+  IL_0034:  call       "int E.get_Length<T>(T)"
+  IL_0039:  stloc.3
+  IL_003a:  ldobj      "T"
+  IL_003f:  ldloc.2
+  IL_0040:  ldloc.3
+  IL_0041:  ldloc.2
+  IL_0042:  sub
+  IL_0043:  call       "int E.Slice<T>(T, int, int)"
+  IL_0048:  pop
+  IL_0049:  ret
+}
+""");
+
+        verifier.VerifyIL("Program.Test2<T>()", """
+{
+  // Code size       30 (0x1e)
+  .maxstack  4
+  .locals init (T V_0,
+                int V_1)
+  IL_0000:  nop
+  IL_0001:  call       "T Program.GetT<T>()"
+  IL_0006:  stloc.0
+  IL_0007:  call       "int Program.GetStart()"
+  IL_000c:  stloc.1
+  IL_000d:  ldloc.0
+  IL_000e:  ldloc.1
+  IL_000f:  ldloc.0
+  IL_0010:  call       "int E.get_Length<T>(T)"
+  IL_0015:  ldloc.1
+  IL_0016:  sub
+  IL_0017:  call       "int E.Slice<T>(T, int, int)"
+  IL_001c:  pop
+  IL_001d:  ret
+}
+""");
+    }
+}
+

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System.Linq;
-using ILVerify;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
@@ -30517,7 +30517,7 @@ class Driver
 }
 """;
         var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
-        CompileAndVerify(comp, expectedOutput: "M(C1,0) final=C99").VerifyDiagnostics();
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("M(C1,0) final=C99"), verify: Verification.FailsPEVerify).VerifyDiagnostics();
     }
 
     [Fact]
@@ -30564,7 +30564,7 @@ class Driver
 }
 """;
         var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
-        CompileAndVerify(comp, expectedOutput: "set_Item(C1,0,0) final=C99").VerifyDiagnostics();
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("set_Item(C1,0,0) final=C99"), verify: Verification.FailsPEVerify).VerifyDiagnostics();
     }
 
     [Fact]
@@ -30611,7 +30611,7 @@ class Driver
 }
 """;
         var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
-        CompileAndVerify(comp, expectedOutput: "set_Item(C1,4,0) final=C99").VerifyDiagnostics();
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("set_Item(C1,4,0) final=C99"), verify: Verification.FailsPEVerify).VerifyDiagnostics();
     }
 
     [Fact]
@@ -30658,7 +30658,7 @@ class Driver
 }
 """;
         var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
-        CompileAndVerify(comp, expectedOutput: "Length(C1) Slice(C1,0,5) final=C99").VerifyDiagnostics();
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("Length(C1) Slice(C1,0,5) final=C99"), verify: Verification.FailsPEVerify).VerifyDiagnostics();
     }
 }
 

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
@@ -10792,7 +10792,7 @@ namespace Outer
         var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("0,2, 2"), verify: Verification.FailsPEVerify).VerifyDiagnostics();
         verifier.VerifyIL("Inner.C.Main", """
 {
-  // Code size       62 (0x3e)
+  // Code size       56 (0x38)
   .maxstack  4
   .locals init (object V_0, //x
                 S V_1,
@@ -10806,7 +10806,7 @@ namespace Outer
   IL_0010:  stloc.2
   IL_0011:  ldloc.2
   IL_0012:  ldc.i4.1
-  IL_0013:  blt.s      IL_003b
+  IL_0013:  blt.s      IL_0035
   IL_0015:  ldloc.1
   IL_0016:  box        "S"
   IL_001b:  ldc.i4.0
@@ -10815,20 +10815,19 @@ namespace Outer
   IL_001e:  sub
   IL_001f:  call       "object Outer.E2.Slice(object, int, int)"
   IL_0024:  stloc.0
-  IL_0025:  ldloca.s   V_1
-  IL_0027:  ldloc.2
-  IL_0028:  ldc.i4.1
-  IL_0029:  sub
-  IL_002a:  stloc.3
-  IL_002b:  ldobj      "S"
-  IL_0030:  ldloc.3
-  IL_0031:  call       "int Inner.E1.get_Item(S, int)"
-  IL_0036:  ldc.i4.1
-  IL_0037:  ceq
-  IL_0039:  br.s       IL_003c
-  IL_003b:  ldc.i4.0
-  IL_003c:  pop
-  IL_003d:  ret
+  IL_0025:  ldloc.2
+  IL_0026:  ldc.i4.1
+  IL_0027:  sub
+  IL_0028:  stloc.3
+  IL_0029:  ldloc.1
+  IL_002a:  ldloc.3
+  IL_002b:  call       "int Inner.E1.get_Item(S, int)"
+  IL_0030:  ldc.i4.1
+  IL_0031:  ceq
+  IL_0033:  br.s       IL_0036
+  IL_0035:  ldc.i4.0
+  IL_0036:  pop
+  IL_0037:  ret
 }
 """);
     }
@@ -22458,22 +22457,22 @@ class Program
         verifier.VerifyIL("Program.Test1", """
 {
   // Code size       46 (0x2e)
-  .maxstack  3
+  .maxstack  2
   .locals init (S1& V_0,
                 int V_1,
                 System.Index V_2)
   IL_0000:  nop
   IL_0001:  ldsflda    "S1 Program.F"
   IL_0006:  stloc.0
-  IL_0007:  ldloc.0
-  IL_0008:  call       "System.Index Program.GetIndex()"
-  IL_000d:  stloc.2
-  IL_000e:  ldloca.s   V_2
-  IL_0010:  ldloc.0
-  IL_0011:  ldobj      "S1"
-  IL_0016:  call       "int E.get_Length(S1)"
-  IL_001b:  call       "int System.Index.GetOffset(int)"
-  IL_0020:  stloc.1
+  IL_0007:  call       "System.Index Program.GetIndex()"
+  IL_000c:  stloc.2
+  IL_000d:  ldloca.s   V_2
+  IL_000f:  ldloc.0
+  IL_0010:  ldobj      "S1"
+  IL_0015:  call       "int E.get_Length(S1)"
+  IL_001a:  call       "int System.Index.GetOffset(int)"
+  IL_001f:  stloc.1
+  IL_0020:  ldloc.0
   IL_0021:  ldobj      "S1"
   IL_0026:  ldloc.1
   IL_0027:  call       "int E.get_Item(S1, int)"
@@ -22485,22 +22484,22 @@ class Program
         verifier.VerifyIL("S1.Test2", """
 {
   // Code size       42 (0x2a)
-  .maxstack  3
+  .maxstack  2
   .locals init (S1& V_0,
                 int V_1,
                 System.Index V_2)
   IL_0000:  nop
   IL_0001:  ldarg.0
   IL_0002:  stloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  call       "System.Index Program.GetIndex()"
-  IL_0009:  stloc.2
-  IL_000a:  ldloca.s   V_2
-  IL_000c:  ldloc.0
-  IL_000d:  ldobj      "S1"
-  IL_0012:  call       "int E.get_Length(S1)"
-  IL_0017:  call       "int System.Index.GetOffset(int)"
-  IL_001c:  stloc.1
+  IL_0003:  call       "System.Index Program.GetIndex()"
+  IL_0008:  stloc.2
+  IL_0009:  ldloca.s   V_2
+  IL_000b:  ldloc.0
+  IL_000c:  ldobj      "S1"
+  IL_0011:  call       "int E.get_Length(S1)"
+  IL_0016:  call       "int System.Index.GetOffset(int)"
+  IL_001b:  stloc.1
+  IL_001c:  ldloc.0
   IL_001d:  ldobj      "S1"
   IL_0022:  ldloc.1
   IL_0023:  call       "int E.get_Item(S1, int)"
@@ -22962,22 +22961,22 @@ class Program
         verifier.VerifyIL("Program.Test2<T>(ref T)", """
 {
   // Code size       42 (0x2a)
-  .maxstack  3
+  .maxstack  2
   .locals init (T& V_0,
                 int V_1,
                 System.Index V_2)
   IL_0000:  nop
   IL_0001:  ldarg.0
   IL_0002:  stloc.0
-  IL_0003:  ldloc.0
-  IL_0004:  call       "System.Index Program.GetIndex()"
-  IL_0009:  stloc.2
-  IL_000a:  ldloca.s   V_2
-  IL_000c:  ldloc.0
-  IL_000d:  ldobj      "T"
-  IL_0012:  call       "int E.get_Length<T>(T)"
-  IL_0017:  call       "int System.Index.GetOffset(int)"
-  IL_001c:  stloc.1
+  IL_0003:  call       "System.Index Program.GetIndex()"
+  IL_0008:  stloc.2
+  IL_0009:  ldloca.s   V_2
+  IL_000b:  ldloc.0
+  IL_000c:  ldobj      "T"
+  IL_0011:  call       "int E.get_Length<T>(T)"
+  IL_0016:  call       "int System.Index.GetOffset(int)"
+  IL_001b:  stloc.1
+  IL_001c:  ldloc.0
   IL_001d:  ldobj      "T"
   IL_0022:  ldloc.1
   IL_0023:  call       "int E.get_Item<T>(T, int)"
@@ -23569,7 +23568,7 @@ class Program
         verifier.VerifyIL("Program.Test", """
 {
   // Code size       49 (0x31)
-  .maxstack  3
+  .maxstack  2
   .locals init (S1& V_0,
                 S1 V_1,
                 int V_2,
@@ -23579,15 +23578,15 @@ class Program
   IL_0006:  stloc.1
   IL_0007:  ldloca.s   V_1
   IL_0009:  stloc.0
-  IL_000a:  ldloc.0
-  IL_000b:  call       "System.Index Program.GetIndex()"
-  IL_0010:  stloc.3
-  IL_0011:  ldloca.s   V_3
-  IL_0013:  ldloc.0
-  IL_0014:  ldobj      "S1"
-  IL_0019:  call       "int E.get_Length(S1)"
-  IL_001e:  call       "int System.Index.GetOffset(int)"
-  IL_0023:  stloc.2
+  IL_000a:  call       "System.Index Program.GetIndex()"
+  IL_000f:  stloc.3
+  IL_0010:  ldloca.s   V_3
+  IL_0012:  ldloc.0
+  IL_0013:  ldobj      "S1"
+  IL_0018:  call       "int E.get_Length(S1)"
+  IL_001d:  call       "int System.Index.GetOffset(int)"
+  IL_0022:  stloc.2
+  IL_0023:  ldloc.0
   IL_0024:  ldobj      "S1"
   IL_0029:  ldloc.2
   IL_002a:  call       "int E.get_Item(S1, int)"

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
@@ -28414,7 +28414,9 @@ class Program
   IL_0025:  ret
 }
 """);
-    }    [Fact]
+    }
+
+    [Fact]
     public void ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartOpenEndRangeExpr_01_02()
     {
         // sibling of ImplicitRangeIndexerAccess_Get_LValueReceiver_IntStartOpenEndRangeExpr_01
@@ -30470,6 +30472,193 @@ class Program
   IL_001d:  ret
 }
 """);
+    }
+
+    [Fact]
+    public void RefTypeReceiverSwap_01()
+    {
+        // Method invocation on unconstrained-T receiver. The argument expression mutates the
+        // receiver via a ref parameter. Since the swap happens during argument evaluation,
+        // IsSafeToDereferenceReceiverRefAfterEvaluatingArguments correctly identifies the
+        // unsafe arg and protection (ReferToTempIfReferenceTypeReceiver) is applied.
+        // Expected: M called on the original instance (C1, not C99).
+        var src = """
+interface I
+{
+    void M(int arg);
+}
+
+class C : I
+{
+    public int Counter;
+    public void M(int arg) { System.Console.Write($"M(C{Counter},{arg}) "); }
+}
+
+class Driver
+{
+    public static void Test<T>(ref T t) where T : I, new()
+    {
+        t.M(Swap(ref t));
+    }
+
+    public static int Swap<T>(ref T t) where T : I, new()
+    {
+        var newC = new C { Counter = 99 };
+        t = (T)(object)newC;
+        return 0;
+    }
+
+    static void Main()
+    {
+        C original = new C { Counter = 1 };
+        Test<C>(ref original);
+        System.Console.Write($"final=C{original.Counter}");
+    }
+}
+""";
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: "M(C1,0) final=C99").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void RefTypeReceiverSwap_02()
+    {
+        // Real (explicit) indexer regular assignment on unconstrained-T receiver.
+        // The RHS Swap(ref t) becomes the last argument to the setter call (set_Item(idx, value)),
+        // so the args safety check at codegen time sees it as unsafe and protection
+        // (ReferToTempIfReferenceTypeReceiver, materialized as a runtime ref-type check that
+        // copies the receiver value into a temp) is applied.
+        // Expected: setter is called on the original instance (C1, not C99).
+        var src = """
+interface I
+{
+    int this[int i] { get; set; }
+}
+
+class C : I
+{
+    public int Counter;
+    public int this[int i] { get => 0; set { System.Console.Write($"set_Item(C{Counter},{i},{value}) "); } }
+}
+
+class Driver
+{
+    public static void Test<T>(ref T t) where T : I, new()
+    {
+        t[0] = Swap(ref t);
+    }
+
+    public static int Swap<T>(ref T t) where T : I, new()
+    {
+        var newC = new C { Counter = 99 };
+        t = (T)(object)newC;
+        return 0;
+    }
+
+    static void Main()
+    {
+        C original = new C { Counter = 1 };
+        Test<C>(ref original);
+        System.Console.Write($"final=C{original.Counter}");
+    }
+}
+""";
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: "set_Item(C1,0,0) final=C99").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void RefTypeReceiverSwap_03()
+    {
+        // Implicit Index indexer regular assignment on unconstrained-T receiver.
+        // Same protection as RefTypeReceiverSwap_02: the RHS becomes the last setter arg,
+        // codegen's args safety check sees Swap as unsafe, protection is applied.
+        // Expected: setter is called on the original instance (C1, not C99).
+        var src = """
+interface I
+{
+    int Length { get; }
+    int this[int i] { get; set; }
+}
+
+class C : I
+{
+    public int Counter;
+    public int Length => 5;
+    public int this[int i] { get => 0; set { System.Console.Write($"set_Item(C{Counter},{i},{value}) "); } }
+}
+
+class Driver
+{
+    public static void Test<T>(ref T t) where T : I, new()
+    {
+        t[^1] = Swap(ref t);
+    }
+
+    public static int Swap<T>(ref T t) where T : I, new()
+    {
+        var newC = new C { Counter = 99 };
+        t = (T)(object)newC;
+        return 0;
+    }
+
+    static void Main()
+    {
+        C original = new C { Counter = 1 };
+        Test<C>(ref original);
+        System.Console.Write($"final=C{original.Counter}");
+    }
+}
+""";
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: "set_Item(C1,4,0) final=C99").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void RefTypeReceiverSwap_04()
+    {
+        // Implicit Range indexer (read) on unconstrained-T receiver. Range patterns have no
+        // setter, so the swap can only happen during argument evaluation. Args check sees the
+        // Swap call as unsafe and protection is applied.
+        // Expected: Length and Slice called on the original instance (C1, not C99).
+        var src = """
+interface I
+{
+    int Length { get; }
+    int Slice(int start, int length);
+}
+
+class C : I
+{
+    public int Counter;
+    public int Length { get { System.Console.Write($"Length(C{Counter}) "); return 5; } }
+    public int Slice(int s, int l) { System.Console.Write($"Slice(C{Counter},{s},{l}) "); return 0; }
+}
+
+class Driver
+{
+    public static void Test<T>(ref T t) where T : I, new()
+    {
+        _ = t[Swap(ref t)..];
+    }
+
+    public static int Swap<T>(ref T t) where T : I, new()
+    {
+        var newC = new C { Counter = 99 };
+        t = (T)(object)newC;
+        return 0;
+    }
+
+    static void Main()
+    {
+        C original = new C { Counter = 1 };
+        Test<C>(ref original);
+        System.Console.Write($"final=C{original.Counter}");
+    }
+}
+""";
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: "Length(C1) Slice(C1,0,5) final=C99").VerifyDiagnostics();
     }
 }
 

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System.Linq;
+using ILVerify;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -22398,5 +22399,3186 @@ public static class E
             // (5,15): error CS0029: Cannot implicitly convert type 'C' to 'int'
             //         _ = i[c];
             Diagnostic(ErrorCode.ERR_NoImplicitConv, "c").WithArguments("C", "int").WithLocation(5, 15));
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_Get_LValueReceiver_01()
+    {
+        // sibling of IndexerAccess_Get_LValueReceiver_01
+        // struct lvalue receiver passed by value, extension implicit this[Index]
+        var src = """
+static class E
+{
+    extension(S1 x)
+    {
+        public int this[int i] { get { System.Console.Write($"get:{x.F1} "); return 0; } }
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 3; } }
+    }
+}
+
+public struct S1
+{
+    public int F1;
+
+    public void Test2()
+    {
+        _ = this[Program.GetIndex()];
+    }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        F = new S1 { F1 = 3 };
+        F.Test2();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        _ = F[GetIndex()];
+    }
+
+    public static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program.F.F1} "); Program.F.F1++; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:4 get:5 final:5, GetIndex:3 length:4 get:5 final:5"), verify: Verification.Skipped)
+                  .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", """
+{
+  // Code size       46 (0x2e)
+  .maxstack  3
+  .locals init (S1& V_0,
+                int V_1,
+                System.Index V_2)
+  IL_0000:  nop
+  IL_0001:  ldsflda    "S1 Program.F"
+  IL_0006:  stloc.0
+  IL_0007:  ldloc.0
+  IL_0008:  call       "System.Index Program.GetIndex()"
+  IL_000d:  stloc.2
+  IL_000e:  ldloca.s   V_2
+  IL_0010:  ldloc.0
+  IL_0011:  ldobj      "S1"
+  IL_0016:  call       "int E.get_Length(S1)"
+  IL_001b:  call       "int System.Index.GetOffset(int)"
+  IL_0020:  stloc.1
+  IL_0021:  ldobj      "S1"
+  IL_0026:  ldloc.1
+  IL_0027:  call       "int E.get_Item(S1, int)"
+  IL_002c:  pop
+  IL_002d:  ret
+}
+""");
+
+        verifier.VerifyIL("S1.Test2", """
+{
+  // Code size       42 (0x2a)
+  .maxstack  3
+  .locals init (S1& V_0,
+                int V_1,
+                System.Index V_2)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  stloc.0
+  IL_0003:  ldloc.0
+  IL_0004:  call       "System.Index Program.GetIndex()"
+  IL_0009:  stloc.2
+  IL_000a:  ldloca.s   V_2
+  IL_000c:  ldloc.0
+  IL_000d:  ldobj      "S1"
+  IL_0012:  call       "int E.get_Length(S1)"
+  IL_0017:  call       "int System.Index.GetOffset(int)"
+  IL_001c:  stloc.1
+  IL_001d:  ldobj      "S1"
+  IL_0022:  ldloc.1
+  IL_0023:  call       "int E.get_Item(S1, int)"
+  IL_0028:  pop
+  IL_0029:  ret
+}
+""");
+    }
+
+    [Theory]
+    [InlineData("ref")]
+    [InlineData("ref readonly")]
+    [InlineData("in")]
+    public void ImplicitIndexIndexerAccess_Get_LValueReceiver_02(string refKind)
+    {
+        // TODO2 System.InvalidOperationException : Unexpected value 'ComplexConditionalReceiver' of type 'Microsoft.CodeAnalysis.CSharp.BoundKind'
+        // sibling of IndexerAccess_Get_LValueReceiver_02
+        // struct lvalue receiver passed by ref, extension implicit this[Index]
+        var src = $$$"""
+static class E
+{
+    extension({{{refKind}}} S1 x)
+    {
+        public int this[int i] { get { System.Console.Write($"get:{x.F1} "); return 0; } }
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 3; } }
+    }
+}
+
+struct S1
+{
+    public int F1;
+
+    public void Test2()
+    {
+        _ = this[Program.GetIndex()];
+    }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        F = new S1 { F1 = 3 };
+        F.Test2();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        _ = F[Program.GetIndex()];
+    }
+
+    public static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program.F.F1} "); Program.F.F1++; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:4 get:5 final:5, GetIndex:3 length:4 get:5 final:5"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", $$"""
+{
+  // Code size       34 (0x22)
+  .maxstack  3
+  .locals init (S1& V_0,
+                System.Index V_1)
+  IL_0000:  nop
+  IL_0001:  ldsflda    "S1 Program.F"
+  IL_0006:  stloc.0
+  IL_0007:  ldloc.0
+  IL_0008:  call       "System.Index Program.GetIndex()"
+  IL_000d:  stloc.1
+  IL_000e:  ldloca.s   V_1
+  IL_0010:  ldloc.0
+  IL_0011:  call       "int E.get_Length({{refKind}} S1)"
+  IL_0016:  call       "int System.Index.GetOffset(int)"
+  IL_001b:  call       "int E.get_Item({{refKind}} S1, int)"
+  IL_0020:  pop
+  IL_0021:  ret
+}
+""");
+
+        verifier.VerifyIL("S1.Test2", $$"""
+{
+  // Code size       30 (0x1e)
+  .maxstack  3
+  .locals init (S1& V_0,
+                System.Index V_1)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  stloc.0
+  IL_0003:  ldloc.0
+  IL_0004:  call       "System.Index Program.GetIndex()"
+  IL_0009:  stloc.1
+  IL_000a:  ldloca.s   V_1
+  IL_000c:  ldloc.0
+  IL_000d:  call       "int E.get_Length({{refKind}} S1)"
+  IL_0012:  call       "int System.Index.GetOffset(int)"
+  IL_0017:  call       "int E.get_Item({{refKind}} S1, int)"
+  IL_001c:  pop
+  IL_001d:  ret
+}
+""");
+
+        var src2 = $$$"""
+static class E
+{
+    extension({{{refKind}}} S1 x)
+    {
+        public int this[int i] { get => 0; set {} }
+        public int Length => 3;
+    }
+}
+
+struct S1;
+
+class Program
+{
+    static void Test()
+    {
+        _ = default(S1)[^1];
+    }
+}
+""";
+        var comp2 = CreateCompilation(src2, targetFramework: TargetFramework.Net100);
+        if (refKind == "ref")
+        {
+            comp2.VerifyDiagnostics(
+                // (16,13): error CS1510: A ref or out value must be an assignable variable
+                //         _ = default(S1)[^1];
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "default(S1)").WithLocation(16, 13),
+                // (16,13): error CS1510: A ref or out value must be an assignable variable
+                //         _ = default(S1)[^1];
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "default(S1)").WithLocation(16, 13));
+        }
+        else if (refKind == "ref readonly")
+        {
+            comp2.VerifyDiagnostics(
+                // (16,13): warning CS9193: Argument 0 should be a variable because it is passed to a 'ref readonly' parameter
+                //         _ = default(S1)[^1];
+                Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "default(S1)").WithArguments("0").WithLocation(16, 13),
+                // (16,13): warning CS9193: Argument 0 should be a variable because it is passed to a 'ref readonly' parameter
+                //         _ = default(S1)[^1];
+                Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "default(S1)").WithArguments("0").WithLocation(16, 13));
+        }
+        else
+        {
+            comp2.VerifyDiagnostics();
+        }
+
+        if (refKind != "ref")
+        {
+            verifier = CompileAndVerify(comp2);
+            verifier.VerifyIL("Program.Test", $$"""
+{
+  // Code size       24 (0x18)
+  .maxstack  3
+  .locals init (S1 V_0)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  dup
+  IL_0003:  initobj    "S1"
+  IL_0009:  dup
+  IL_000a:  call       "int E.get_Length({{refKind}} S1)"
+  IL_000f:  ldc.i4.1
+  IL_0010:  sub
+  IL_0011:  call       "int E.get_Item({{refKind}} S1, int)"
+  IL_0016:  pop
+  IL_0017:  ret
+}
+""");
+        }
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_Get_LValueReceiver_03()
+    {
+        // sibling of IndexerAccess_Get_LValueReceiver_03
+        // class lvalue receiver passed by value, extension implicit this[Index]
+        var src = """
+static class E
+{
+    extension(C1 x)
+    {
+        public int this[int i] { get { System.Console.Write($"get:{x.F1} "); return 0; } }
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F = new C1 { F1 = Program.F.F1 + 1 }; return 3; } }
+    }
+}
+
+class C1
+{
+    public int F1;
+}
+
+class Program
+{
+    public static C1 F;
+
+    static void Main()
+    {
+        F = new C1 { F1 = 3 };
+        Test();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test()
+    {
+        _ = F[GetIndex()];
+    }
+
+    static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program.F.F1} "); Program.F = new C1 { F1 = Program.F.F1 + 1 }; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:3 get:3 final:5"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test", """
+{
+  // Code size       34 (0x22)
+  .maxstack  3
+  .locals init (C1 V_0,
+                System.Index V_1)
+  IL_0000:  nop
+  IL_0001:  ldsfld     "C1 Program.F"
+  IL_0006:  stloc.0
+  IL_0007:  ldloc.0
+  IL_0008:  call       "System.Index Program.GetIndex()"
+  IL_000d:  stloc.1
+  IL_000e:  ldloca.s   V_1
+  IL_0010:  ldloc.0
+  IL_0011:  call       "int E.get_Length(C1)"
+  IL_0016:  call       "int System.Index.GetOffset(int)"
+  IL_001b:  call       "int E.get_Item(C1, int)"
+  IL_0020:  pop
+  IL_0021:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_Get_LValueReceiver_04()
+    {
+        // sibling of IndexerAccess_Get_LValueReceiver_04
+        // generic struct lvalue receiver passed by value, extension implicit this[Index]
+        var src = """
+using System.Threading.Tasks;
+
+static class E
+{
+    extension<T>(T x)
+    {
+        public int this[int i] { get { System.Console.Write($"get:{((S1)(object)x).F1} "); return 0; } }
+        public int Length { get { System.Console.Write($"length:{((S1)(object)x).F1} "); Program<S1>.F.F1++; return 3; } }
+    }
+}
+
+struct S1
+{
+    public int F1;
+}
+
+class Program<T>
+{
+    public static T F;
+}
+
+class Program
+{
+    static async Task Main()
+    {
+        Program<S1>.F = new S1 { F1 = 3 };
+        Test1(ref Program<S1>.F);
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+
+        System.Console.Write(", ");
+
+        Program<S1>.F = new S1 { F1 = 3 };
+        Test2(ref Program<S1>.F);
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+
+        // https://github.com/dotnet/roslyn/issues/79416 - uncomment the following code once fixed
+        //System.Console.Write(", ");
+
+        //Program<S1>.F = new S1 { F1 = 3 };
+        //await Test3<S1>();
+        //System.Console.Write($"final:{Program<S1>.F.F1}");
+    }
+
+    static void Test1<T>(ref T f)
+    {
+        _ = f[GetIndex()];
+    }
+
+    static void Test2<T>(ref T f) where T : struct
+    {
+        _ = f[GetIndex()];
+    }
+
+    static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program<S1>.F.F1} "); Program<S1>.F.F1++; return ^1; }
+
+    // https://github.com/dotnet/roslyn/issues/79416 - uncomment the following code once fixed
+    //static async Task Test3<T>()
+    //{
+    //    _ = Program<T>.F[await GetIndexAsync()];
+    //}
+
+    //static async Task<System.Index> GetIndexAsync() { System.Console.Write($"GetIndexAsync:{Program<S1>.F.F1} "); Program<S1>.F.F1++; await Task.Yield(); return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:4 get:5 final:5, GetIndex:3 length:4 get:5 final:5"), verify: Verification.Skipped)
+             .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1<T>(ref T)", """
+{
+  // Code size      107 (0x6b)
+  .maxstack  3
+  .locals init (T& V_0,
+                T V_1,
+                T& V_2,
+                T V_3,
+                T& V_4,
+                int V_5,
+                T V_6,
+                System.Index V_7)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  stloc.2
+  IL_0003:  ldloca.s   V_3
+  IL_0005:  initobj    "T"
+  IL_000b:  ldloc.3
+  IL_000c:  box        "T"
+  IL_0011:  brtrue.s   IL_001e
+  IL_0013:  ldloc.2
+  IL_0014:  ldobj      "T"
+  IL_0019:  stloc.1
+  IL_001a:  ldloca.s   V_1
+  IL_001c:  br.s       IL_001f
+  IL_001e:  ldloc.2
+  IL_001f:  stloc.0
+  IL_0020:  ldloc.0
+  IL_0021:  stloc.s    V_4
+  IL_0023:  ldloca.s   V_6
+  IL_0025:  initobj    "T"
+  IL_002b:  ldloc.s    V_6
+  IL_002d:  box        "T"
+  IL_0032:  brtrue.s   IL_0040
+  IL_0034:  ldloc.s    V_4
+  IL_0036:  ldobj      "T"
+  IL_003b:  stloc.3
+  IL_003c:  ldloca.s   V_3
+  IL_003e:  br.s       IL_0042
+  IL_0040:  ldloc.s    V_4
+  IL_0042:  call       "System.Index Program.GetIndex()"
+  IL_0047:  stloc.s    V_7
+  IL_0049:  ldloca.s   V_7
+  IL_004b:  ldloc.0
+  IL_004c:  ldobj      "T"
+  IL_0051:  call       "int E.get_Length<T>(T)"
+  IL_0056:  call       "int System.Index.GetOffset(int)"
+  IL_005b:  stloc.s    V_5
+  IL_005d:  ldobj      "T"
+  IL_0062:  ldloc.s    V_5
+  IL_0064:  call       "int E.get_Item<T>(T, int)"
+  IL_0069:  pop
+  IL_006a:  ret
+}
+""");
+
+        verifier.VerifyIL("Program.Test2<T>(ref T)", """
+{
+  // Code size       42 (0x2a)
+  .maxstack  3
+  .locals init (T& V_0,
+                int V_1,
+                System.Index V_2)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  stloc.0
+  IL_0003:  ldloc.0
+  IL_0004:  call       "System.Index Program.GetIndex()"
+  IL_0009:  stloc.2
+  IL_000a:  ldloca.s   V_2
+  IL_000c:  ldloc.0
+  IL_000d:  ldobj      "T"
+  IL_0012:  call       "int E.get_Length<T>(T)"
+  IL_0017:  call       "int System.Index.GetOffset(int)"
+  IL_001c:  stloc.1
+  IL_001d:  ldobj      "T"
+  IL_0022:  ldloc.1
+  IL_0023:  call       "int E.get_Item<T>(T, int)"
+  IL_0028:  pop
+  IL_0029:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_Get_LValueReceiver_05()
+    {
+        // sibling of IndexerAccess_Get_LValueReceiver_05
+        // struct lvalue receiver passed by ref, constrained to struct, extension implicit this[Index]
+        var src = """
+using System.Threading.Tasks;
+
+static class E
+{
+    extension<T>(ref T x) where T : struct
+    {
+        public int this[int i] { get { System.Console.Write($"get:{((S1)(object)x).F1} "); return 0; } }
+        public int Length { get { System.Console.Write($"length:{((S1)(object)x).F1} "); Program<S1>.F.F1++; return 3; } }
+    }
+}
+
+struct S1
+{
+    public int F1;
+}
+
+class Program<T>
+{
+    public static T F;
+}
+
+class Program
+{
+    static async Task Main()
+    {
+        Program<S1>.F = new S1 { F1 = 3 };
+        Test2(ref Program<S1>.F);
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+
+        System.Console.Write(", ");
+
+        Program<S1>.F = new S1 { F1 = 3 };
+        await Test3<S1>();
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+    }
+
+    static void Test2<T>(ref T f) where T : struct
+    {
+        _ = f[GetIndex()];
+    }
+
+    static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program<S1>.F.F1} "); Program<S1>.F.F1++; return ^1; }
+
+    static async Task Test3<T>() where T : struct
+    {
+        _ = Program<T>.F[await GetIndexAsync()];
+    }
+
+    static async Task<System.Index> GetIndexAsync() { System.Console.Write($"GetIndexAsync:{Program<S1>.F.F1} "); Program<S1>.F.F1++; await Task.Yield(); return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:4 get:5 final:5, GetIndexAsync:3 length:4 get:5 final:5"), verify: Verification.Skipped)
+             .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test2<T>(ref T)", """
+{
+  // Code size       30 (0x1e)
+  .maxstack  3
+  .locals init (T& V_0,
+                System.Index V_1)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  stloc.0
+  IL_0003:  ldloc.0
+  IL_0004:  call       "System.Index Program.GetIndex()"
+  IL_0009:  stloc.1
+  IL_000a:  ldloca.s   V_1
+  IL_000c:  ldloc.0
+  IL_000d:  call       "int E.get_Length<T>(ref T)"
+  IL_0012:  call       "int System.Index.GetOffset(int)"
+  IL_0017:  call       "int E.get_Item<T>(ref T, int)"
+  IL_001c:  pop
+  IL_001d:  ret
+}
+""");
+
+        var src2 = """
+static class E
+{
+    extension<T>(ref T x) where T : struct
+    {
+        public int this[int i] { get => 0; set {} }
+        public int Length => 3;
+    }
+}
+
+class Program
+{
+    static void Test<T>() where T : struct
+    {
+        _ = default(T)[^1];
+    }
+}
+
+namespace NS1
+{
+    static class E
+    {
+        extension<T>(in T x) where T : struct
+        {
+        }
+    }
+}
+
+namespace NS2
+{
+    static class E
+    {
+        extension<T>(ref readonly T x) where T : struct
+        {
+        }
+    }
+}
+""";
+
+        var comp2 = CreateCompilation(src2, targetFramework: TargetFramework.Net100);
+        comp2.VerifyDiagnostics(
+            // (14,13): error CS1510: A ref or out value must be an assignable variable
+            //         _ = default(T)[^1];
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "default(T)").WithLocation(14, 13),
+            // (14,13): error CS1510: A ref or out value must be an assignable variable
+            //         _ = default(T)[^1];
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "default(T)").WithLocation(14, 13),
+            // (22,25): error CS9301: The 'in' or 'ref readonly' receiver parameter of extension must be a concrete (non-generic) value type.
+            //         extension<T>(in T x) where T : struct
+            Diagnostic(ErrorCode.ERR_InExtensionParameterMustBeValueType, "T").WithLocation(22, 25),
+            // (32,35): error CS9301: The 'in' or 'ref readonly' receiver parameter of extension must be a concrete (non-generic) value type.
+            //         extension<T>(ref readonly T x) where T : struct
+            Diagnostic(ErrorCode.ERR_InExtensionParameterMustBeValueType, "T").WithLocation(32, 35)
+            );
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_Get_LValueReceiver_06()
+    {
+        // sibling of IndexerAccess_Get_LValueReceiver_06
+        // generic class lvalue receiver passed by value, extension implicit this[Index]
+        var src = """
+using System.Threading.Tasks;
+
+static class E
+{
+    extension<T>(T x)
+    {
+        public int this[int i] { get { System.Console.Write($"get:{((C1)(object)x).F1} "); return 0; } }
+        public int Length { get { System.Console.Write($"length:{((C1)(object)x).F1} "); Program<C1>.F = new C1 { F1 = Program<C1>.F.F1 + 1 }; return 3; } }
+    }
+}
+
+class C1
+{
+    public int F1;
+}
+
+class Program<T>
+{
+    public static T F;
+}
+
+class Program
+{
+    static async Task Main()
+    {
+        Program<C1>.F = new C1 { F1 = 3 };
+        Test1(ref Program<C1>.F);
+        System.Console.Write($"final:{Program<C1>.F.F1}");
+
+        System.Console.Write(", ");
+
+        Program<C1>.F = new C1 { F1 = 3 };
+        Test2(ref Program<C1>.F);
+        System.Console.Write($"final:{Program<C1>.F.F1}");
+
+        // https://github.com/dotnet/roslyn/issues/79416 - uncomment the following code once fixed
+        //System.Console.Write(", ");
+
+        //Program<C1>.F = new C1 { F1 = 3 };
+        //await Test3<C1>();
+        //System.Console.Write($"final:{Program<C1>.F.F1}");
+    }
+
+    static void Test1<T>(ref T f)
+    {
+        _ = f[GetIndex()];
+    }
+
+    static void Test2<T>(ref T f) where T : class
+    {
+        _ = f[GetIndex()];
+    }
+
+    static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program<C1>.F.F1} "); Program<C1>.F = new C1 { F1 = Program<C1>.F.F1 + 1 }; return ^1; }
+
+    // https://github.com/dotnet/roslyn/issues/79416 - uncomment the following code once fixed
+    //static async Task Test3<T>()
+    //{
+    //    _ = Program<T>.F[await GetIndexAsync()];
+    //}
+
+    //static async Task<System.Index> GetIndexAsync() { System.Console.Write($"GetIndexAsync:{Program<C1>.F.F1} "); Program<C1>.F = new C1 { F1 = Program<C1>.F.F1 + 1 }; await Task.Yield(); return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:3 get:3 final:5, GetIndex:3 length:3 get:3 final:5"), verify: Verification.Skipped)
+               .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1<T>(ref T)", """
+{
+  // Code size      107 (0x6b)
+  .maxstack  3
+  .locals init (T& V_0,
+                T V_1,
+                T& V_2,
+                T V_3,
+                T& V_4,
+                int V_5,
+                T V_6,
+                System.Index V_7)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  stloc.2
+  IL_0003:  ldloca.s   V_3
+  IL_0005:  initobj    "T"
+  IL_000b:  ldloc.3
+  IL_000c:  box        "T"
+  IL_0011:  brtrue.s   IL_001e
+  IL_0013:  ldloc.2
+  IL_0014:  ldobj      "T"
+  IL_0019:  stloc.1
+  IL_001a:  ldloca.s   V_1
+  IL_001c:  br.s       IL_001f
+  IL_001e:  ldloc.2
+  IL_001f:  stloc.0
+  IL_0020:  ldloc.0
+  IL_0021:  stloc.s    V_4
+  IL_0023:  ldloca.s   V_6
+  IL_0025:  initobj    "T"
+  IL_002b:  ldloc.s    V_6
+  IL_002d:  box        "T"
+  IL_0032:  brtrue.s   IL_0040
+  IL_0034:  ldloc.s    V_4
+  IL_0036:  ldobj      "T"
+  IL_003b:  stloc.3
+  IL_003c:  ldloca.s   V_3
+  IL_003e:  br.s       IL_0042
+  IL_0040:  ldloc.s    V_4
+  IL_0042:  call       "System.Index Program.GetIndex()"
+  IL_0047:  stloc.s    V_7
+  IL_0049:  ldloca.s   V_7
+  IL_004b:  ldloc.0
+  IL_004c:  ldobj      "T"
+  IL_0051:  call       "int E.get_Length<T>(T)"
+  IL_0056:  call       "int System.Index.GetOffset(int)"
+  IL_005b:  stloc.s    V_5
+  IL_005d:  ldobj      "T"
+  IL_0062:  ldloc.s    V_5
+  IL_0064:  call       "int E.get_Item<T>(T, int)"
+  IL_0069:  pop
+  IL_006a:  ret
+}
+""");
+
+        verifier.VerifyIL("Program.Test2<T>(ref T)", """
+{
+  // Code size       35 (0x23)
+  .maxstack  3
+  .locals init (T V_0,
+                System.Index V_1)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  ldobj      "T"
+  IL_0007:  stloc.0
+  IL_0008:  ldloc.0
+  IL_0009:  call       "System.Index Program.GetIndex()"
+  IL_000e:  stloc.1
+  IL_000f:  ldloca.s   V_1
+  IL_0011:  ldloc.0
+  IL_0012:  call       "int E.get_Length<T>(T)"
+  IL_0017:  call       "int System.Index.GetOffset(int)"
+  IL_001c:  call       "int E.get_Item<T>(T, int)"
+  IL_0021:  pop
+  IL_0022:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_Get_RValueReceiver_01()
+    {
+        // sibling of IndexerAccess_Get_RValueReceiver_01
+        // struct rvalue receiver passed by value, extension implicit this[Index]
+        var src = """
+static class E
+{
+    extension(S1 x)
+    {
+        public int this[int i] { get { System.Console.Write($"get:{x.F1} "); return 0; } }
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.State++; return 3; } }
+    }
+}
+
+public struct S1
+{
+    public int F1;
+}
+
+class Program
+{
+    public static int State;
+
+    static void Main()
+    {
+        State = 3;
+        Test();
+        System.Console.Write($"final:{State}");
+    }
+
+    static void Test()
+    {
+        _ = GetS1()[GetIndex()];
+    }
+
+    static S1 GetS1() => new S1 { F1 = State };
+
+    public static System.Index GetIndex() { System.Console.Write($"GetIndex:{State} "); State++; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:3 get:3 final:5"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test", """
+{
+  // Code size       49 (0x31)
+  .maxstack  3
+  .locals init (S1& V_0,
+                S1 V_1,
+                int V_2,
+                System.Index V_3)
+  IL_0000:  nop
+  IL_0001:  call       "S1 Program.GetS1()"
+  IL_0006:  stloc.1
+  IL_0007:  ldloca.s   V_1
+  IL_0009:  stloc.0
+  IL_000a:  ldloc.0
+  IL_000b:  call       "System.Index Program.GetIndex()"
+  IL_0010:  stloc.3
+  IL_0011:  ldloca.s   V_3
+  IL_0013:  ldloc.0
+  IL_0014:  ldobj      "S1"
+  IL_0019:  call       "int E.get_Length(S1)"
+  IL_001e:  call       "int System.Index.GetOffset(int)"
+  IL_0023:  stloc.2
+  IL_0024:  ldobj      "S1"
+  IL_0029:  ldloc.2
+  IL_002a:  call       "int E.get_Item(S1, int)"
+  IL_002f:  pop
+  IL_0030:  ret
+}
+""");
+    }
+
+    [Theory]
+    [InlineData("ref")]
+    [InlineData("ref readonly")]
+    [InlineData("in")]
+    public void ImplicitIndexIndexerAccess_Get_RValueReceiver_02(string refKind)
+    {
+        // sibling of IndexerAccess_Get_RValueReceiver_02
+        // struct rvalue receiver passed by ref, extension implicit this[Index]
+        var src = $$$"""
+static class E
+{
+    extension({{{refKind}}} S1 x)
+    {
+        public int this[int i] { get { System.Console.Write($"get:{x.F1} "); return 0; } }
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.State++; return 3; } }
+    }
+}
+
+struct S1
+{
+    public int F1;
+}
+
+class Program
+{
+    public static int State;
+
+    static void Main()
+    {
+        State = 3;
+        Test();
+        System.Console.Write($"final:{State}");
+    }
+
+    static void Test()
+    {
+        _ = GetS1()[GetIndex()];
+    }
+
+    static S1 GetS1() => new S1 { F1 = State };
+
+    public static System.Index GetIndex() { System.Console.Write($"GetIndex:{State} "); State++; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe.WithAllowUnsafe(true), targetFramework: TargetFramework.Net100);
+        if (refKind == "ref")
+        {
+            comp.VerifyEmitDiagnostics(
+                // (28,13): error CS1510: A ref or out value must be an assignable variable
+                //         _ = GetS1()[GetIndex()];
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetS1()").WithLocation(28, 13),
+                // (28,13): error CS1510: A ref or out value must be an assignable variable
+                //         _ = GetS1()[GetIndex()];
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetS1()").WithLocation(28, 13));
+            return;
+        }
+        else if (refKind == "ref readonly")
+        {
+            comp.VerifyEmitDiagnostics(
+                // (28,13): warning CS9193: Argument 0 should be a variable because it is passed to a 'ref readonly' parameter
+                //         _ = GetS1()[GetIndex()];
+                Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "GetS1()").WithArguments("0").WithLocation(28, 13),
+                // (28,13): warning CS9193: Argument 0 should be a variable because it is passed to a 'ref readonly' parameter
+                //         _ = GetS1()[GetIndex()];
+                Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "GetS1()").WithArguments("0").WithLocation(28, 13));
+        }
+        else
+        {
+            comp.VerifyEmitDiagnostics();
+        }
+
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:3 get:3 final:5"), verify: Verification.Skipped);
+
+        verifier.VerifyIL("Program.Test", $$"""
+{
+  // Code size       37 (0x25)
+  .maxstack  3
+  .locals init (S1& V_0,
+                S1 V_1,
+                System.Index V_2)
+  IL_0000:  nop
+  IL_0001:  call       "S1 Program.GetS1()"
+  IL_0006:  stloc.1
+  IL_0007:  ldloca.s   V_1
+  IL_0009:  stloc.0
+  IL_000a:  ldloc.0
+  IL_000b:  call       "System.Index Program.GetIndex()"
+  IL_0010:  stloc.2
+  IL_0011:  ldloca.s   V_2
+  IL_0013:  ldloc.0
+  IL_0014:  call       "int E.get_Length({{refKind}} S1)"
+  IL_0019:  call       "int System.Index.GetOffset(int)"
+  IL_001e:  call       "int E.get_Item({{refKind}} S1, int)"
+  IL_0023:  pop
+  IL_0024:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_Get_RValueReceiver_03()
+    {
+        // sibling of IndexerAccess_Get_RValueReceiver_03
+        // class rvalue receiver passed by value, extension implicit this[Index]
+        var src = """
+static class E
+{
+    extension(C1 x)
+    {
+        public int this[int i] { get { System.Console.Write($"get:{x.F1} "); return 0; } }
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.State++; return 3; } }
+    }
+}
+
+class C1
+{
+    public int F1;
+}
+
+class Program
+{
+    public static int State;
+
+    static void Main()
+    {
+        State = 3;
+        Test();
+        System.Console.Write($"final:{State}");
+    }
+
+    static void Test()
+    {
+        _ = GetC1()[GetIndex()];
+    }
+
+    static C1 GetC1() => new C1 { F1 = State };
+
+    static System.Index GetIndex() { System.Console.Write($"GetIndex:{State} "); State++; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:3 get:3 final:5"), verify: Verification.Skipped)
+                  .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test", """
+{
+  // Code size       34 (0x22)
+  .maxstack  3
+  .locals init (C1 V_0,
+                System.Index V_1)
+  IL_0000:  nop
+  IL_0001:  call       "C1 Program.GetC1()"
+  IL_0006:  stloc.0
+  IL_0007:  ldloc.0
+  IL_0008:  call       "System.Index Program.GetIndex()"
+  IL_000d:  stloc.1
+  IL_000e:  ldloca.s   V_1
+  IL_0010:  ldloc.0
+  IL_0011:  call       "int E.get_Length(C1)"
+  IL_0016:  call       "int System.Index.GetOffset(int)"
+  IL_001b:  call       "int E.get_Item(C1, int)"
+  IL_0020:  pop
+  IL_0021:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_Get_RValueReceiver_04()
+    {
+        // TODO2 System.InvalidOperationException : Unexpected value 'ComplexConditionalReceiver' of type 'Microsoft.CodeAnalysis.CSharp.BoundKind'
+        // sibling of IndexerAccess_Get_RValueReceiver_04
+        // generic struct rvalue receiver passed by value, extension implicit this[Index]
+        var src = """
+using System.Threading.Tasks;
+
+static class E
+{
+    extension<T>(T x)
+    {
+        public int this[int i] { get { System.Console.Write($"get:{((S1)(object)x).F1} "); return 0; } }
+        public int Length { get { System.Console.Write($"length:{((S1)(object)x).F1} "); Program.State++; return 3; } }
+    }
+}
+
+struct S1
+{
+    public int F1;
+}
+
+class Program
+{
+    public static int State;
+
+    static async Task Main()
+    {
+        State = 3;
+        Test1<S1>();
+        System.Console.Write($"final:{State}");
+
+        System.Console.Write(", ");
+
+        State = 3;
+        Test2<S1>();
+        System.Console.Write($"final:{State}");
+
+        System.Console.Write(", ");
+
+        State = 3;
+        await Test3<S1>();
+        System.Console.Write($"final:{State}");
+    }
+
+    static T GetT<T>() => (T)(object)new S1 { F1 = State };
+
+    static void Test1<T>()
+    {
+        _ = GetT<T>()[GetIndex()];
+    }
+
+    static void Test2<T>() where T : struct
+    {
+        _ = GetT<T>()[GetIndex()];
+    }
+
+    static System.Index GetIndex() { System.Console.Write($"GetIndex:{State} "); State++; return ^1; }
+
+    static async Task Test3<T>()
+    {
+        _ = GetT<T>()[await GetIndexAsync()];
+    }
+
+    static async Task<System.Index> GetIndexAsync() { System.Console.Write($"GetIndexAsync:{State} "); State++; await Task.Yield(); return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:3 get:3 final:5, GetIndex:3 length:3 get:3 final:5, GetIndexAsync:3 length:3 get:3 final:5"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_Get_RValueReceiver_05()
+    {
+        // sibling of IndexerAccess_Get_RValueReceiver_05
+        // struct rvalue receiver passed by ref, constrained to struct, extension implicit this[Index]
+        var src = """
+using System.Threading.Tasks;
+
+static class E
+{
+    extension<T>(ref T x) where T : struct
+    {
+        public int this[int i] { get { System.Console.Write($"get:{((S1)(object)x).F1} "); return 0; } }
+        public int Length => 3;
+    }
+}
+
+struct S1
+{
+    public int F1;
+}
+
+class Program
+{
+    static async Task Main()
+    {
+        Test2<S1>();
+        System.Console.Write(", ");
+        await Test3<S1>();
+    }
+
+    static void Test2<T>() where T : struct
+    {
+        _ = GetT<T>()[GetIndex()];
+    }
+
+    static T GetT<T>() => (T)(object)new S1 { F1 = 3 };
+
+    static System.Index GetIndex() => ^1;
+
+    static async Task Test3<T>() where T : struct
+    {
+        _ = GetT<T>()[await GetIndexAsync()];
+    }
+
+    static async Task<System.Index> GetIndexAsync() { await Task.Yield(); return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        comp.VerifyEmitDiagnostics(
+            // (28,13): error CS1510: A ref or out value must be an assignable variable
+            //         _ = GetT<T>()[GetIndex()];
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetT<T>()").WithLocation(28, 13),
+            // (28,13): error CS1510: A ref or out value must be an assignable variable
+            //         _ = GetT<T>()[GetIndex()];
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetT<T>()").WithLocation(28, 13),
+            // (37,13): error CS1510: A ref or out value must be an assignable variable
+            //         _ = GetT<T>()[await GetIndexAsync()];
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetT<T>()").WithLocation(37, 13),
+            // (37,13): error CS1510: A ref or out value must be an assignable variable
+            //         _ = GetT<T>()[await GetIndexAsync()];
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetT<T>()").WithLocation(37, 13));
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_Get_RValueReceiver_06()
+    {
+        // TODO2 System.InvalidOperationException : Unexpected value 'ComplexConditionalReceiver' of type 'Microsoft.CodeAnalysis.CSharp.BoundKind'
+        // sibling of IndexerAccess_Get_RValueReceiver_06
+        // generic class rvalue receiver passed by value, extension implicit this[Index]
+        var src = """
+using System.Threading.Tasks;
+
+static class E
+{
+    extension<T>(T x)
+    {
+        public int this[int i] { get { System.Console.Write($"get:{((C1)(object)x).F1} "); return 0; } }
+        public int Length { get { System.Console.Write($"length:{((C1)(object)x).F1} "); Program.State++; return 3; } }
+    }
+}
+
+class C1
+{
+    public int F1;
+}
+
+class Program
+{
+    public static int State;
+
+    static async Task Main()
+    {
+        State = 3;
+        Test1<C1>();
+        System.Console.Write($"final:{State}");
+
+        System.Console.Write(", ");
+
+        State = 3;
+        Test2<C1>();
+        System.Console.Write($"final:{State}");
+
+        System.Console.Write(", ");
+
+        State = 3;
+        await Test3<C1>();
+        System.Console.Write($"final:{State}");
+    }
+
+    static T GetT<T>() => (T)(object)new C1 { F1 = State };
+
+    static void Test1<T>()
+    {
+        _ = GetT<T>()[GetIndex()];
+    }
+
+    static void Test2<T>() where T : class
+    {
+        _ = GetT<T>()[GetIndex()];
+    }
+
+    static System.Index GetIndex() { System.Console.Write($"GetIndex:{State} "); State++; return ^1; }
+
+    static async Task Test3<T>()
+    {
+        _ = GetT<T>()[await GetIndexAsync()];
+    }
+
+    static async Task<System.Index> GetIndexAsync() { System.Console.Write($"GetIndexAsync:{State} "); State++; await Task.Yield(); return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:3 get:3 final:5, GetIndex:3 length:3 get:3 final:5, GetIndexAsync:3 length:3 get:3 final:5"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_01()
+    {
+        // sibling of IndexerAccess_Get_LValueReceiver_01
+        // struct lvalue receiver passed by value, extension Length + extension Slice
+        var src = """
+static class E
+{
+    extension(S1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 5; } }
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); Program.F.F1++; return 0; }
+    }
+}
+
+public struct S1
+{
+    public int F1;
+
+    public void Test2()
+    {
+        _ = this[Program.GetRange()];
+    }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        F = new S1 { F1 = 3 };
+        F.Test2();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        _ = F[GetRange()];
+    }
+
+    public static System.Range GetRange() { System.Console.Write($"GetRange:{Program.F.F1} "); Program.F.F1++; return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:4 Slice:5 final:6, GetRange:3 length:4 Slice:5 final:6"), verify: Verification.Skipped)
+             .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", """
+{
+  // Code size       76 (0x4c)
+  .maxstack  3
+  .locals init (System.Range V_0,
+                int V_1,
+                int V_2,
+                int V_3,
+                System.Index V_4)
+  IL_0000:  nop
+  IL_0001:  ldsflda    "S1 Program.F"
+  IL_0006:  call       "System.Range Program.GetRange()"
+  IL_000b:  stloc.0
+  IL_000c:  dup
+  IL_000d:  ldobj      "S1"
+  IL_0012:  call       "int E.get_Length(S1)"
+  IL_0017:  stloc.1
+  IL_0018:  ldloca.s   V_0
+  IL_001a:  call       "System.Index System.Range.Start.get"
+  IL_001f:  stloc.s    V_4
+  IL_0021:  ldloca.s   V_4
+  IL_0023:  ldloc.1
+  IL_0024:  call       "int System.Index.GetOffset(int)"
+  IL_0029:  stloc.2
+  IL_002a:  ldloca.s   V_0
+  IL_002c:  call       "System.Index System.Range.End.get"
+  IL_0031:  stloc.s    V_4
+  IL_0033:  ldloca.s   V_4
+  IL_0035:  ldloc.1
+  IL_0036:  call       "int System.Index.GetOffset(int)"
+  IL_003b:  ldloc.2
+  IL_003c:  sub
+  IL_003d:  stloc.3
+  IL_003e:  ldobj      "S1"
+  IL_0043:  ldloc.2
+  IL_0044:  ldloc.3
+  IL_0045:  call       "int E.Slice(S1, int, int)"
+  IL_004a:  pop
+  IL_004b:  ret
+}
+""");
+
+        verifier.VerifyIL("S1.Test2", """
+{
+  // Code size       72 (0x48)
+  .maxstack  3
+  .locals init (System.Range V_0,
+                int V_1,
+                int V_2,
+                int V_3,
+                System.Index V_4)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  call       "System.Range Program.GetRange()"
+  IL_0007:  stloc.0
+  IL_0008:  dup
+  IL_0009:  ldobj      "S1"
+  IL_000e:  call       "int E.get_Length(S1)"
+  IL_0013:  stloc.1
+  IL_0014:  ldloca.s   V_0
+  IL_0016:  call       "System.Index System.Range.Start.get"
+  IL_001b:  stloc.s    V_4
+  IL_001d:  ldloca.s   V_4
+  IL_001f:  ldloc.1
+  IL_0020:  call       "int System.Index.GetOffset(int)"
+  IL_0025:  stloc.2
+  IL_0026:  ldloca.s   V_0
+  IL_0028:  call       "System.Index System.Range.End.get"
+  IL_002d:  stloc.s    V_4
+  IL_002f:  ldloca.s   V_4
+  IL_0031:  ldloc.1
+  IL_0032:  call       "int System.Index.GetOffset(int)"
+  IL_0037:  ldloc.2
+  IL_0038:  sub
+  IL_0039:  stloc.3
+  IL_003a:  ldobj      "S1"
+  IL_003f:  ldloc.2
+  IL_0040:  ldloc.3
+  IL_0041:  call       "int E.Slice(S1, int, int)"
+  IL_0046:  pop
+  IL_0047:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_01_02()
+    {
+        // struct lvalue receiver passed by value, instance Length + extension Slice
+        var src = """
+static class E
+{
+    extension(S1 x)
+    {
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); Program.F.F1++; return 0; }
+    }
+}
+
+public struct S1
+{
+    public int F1;
+    public int Length { get { System.Console.Write($"length:{F1} "); Program.F.F1++; return 5; } }
+
+    public void Test()
+    {
+        _ = this[Program.GetRange()];
+    }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        F = new S1 { F1 = 3 };
+        F.Test();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        _ = F[GetRange()];
+    }
+
+    public static System.Range GetRange() { System.Console.Write($"GetRange:{Program.F.F1} "); Program.F.F1++; return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:4 Slice:5 final:6, GetRange:3 length:4 Slice:5 final:6"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_01_03()
+    {
+        // struct lvalue receiver passed by value, extension Length + instance Slice
+        var src = """
+static class E
+{
+    extension(S1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 5; } }
+    }
+}
+
+public struct S1
+{
+    public int F1;
+    public int Slice(int start, int length) { System.Console.Write($"Slice:{F1} "); Program.F.F1++; return 0; }
+
+    public void Test()
+    {
+        _ = this[Program.GetRange()];
+    }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        F = new S1 { F1 = 3 };
+        F.Test();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        _ = F[GetRange()];
+    }
+
+    public static System.Range GetRange()
+    {
+        System.Console.Write($"GetRange:{Program.F.F1} ");
+        Program.F.F1++;
+        return 1..^1;
+    }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:4 Slice:5 final:6, GetRange:3 length:4 Slice:5 final:6"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_03()
+    {
+        // sibling of IndexerAccess_Get_LValueReceiver_03
+        // class lvalue receiver passed by value, extension Length + extension Slice
+        var src = """
+static class E
+{
+    extension(C1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F = new C1 { F1 = Program.F.F1 + 1 }; return 5; } }
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); Program.F = new C1 { F1 = Program.F.F1 + 1 }; return 0; }
+    }
+}
+
+class C1
+{
+    public int F1;
+}
+
+class Program
+{
+    public static C1 F;
+
+    static void Main()
+    {
+        F = new C1 { F1 = 3 };
+        Test();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test()
+    {
+        _ = F[GetRange()];
+    }
+
+    static System.Range GetRange() { System.Console.Write($"GetRange:{Program.F.F1} "); Program.F = new C1 { F1 = Program.F.F1 + 1 }; return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:3 Slice:3 final:6"), verify: Verification.Skipped)
+             .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test", """
+{
+  // Code size       66 (0x42)
+  .maxstack  3
+  .locals init (System.Range V_0,
+                int V_1,
+                int V_2,
+                int V_3,
+                System.Index V_4)
+  IL_0000:  nop
+  IL_0001:  ldsfld     "C1 Program.F"
+  IL_0006:  call       "System.Range Program.GetRange()"
+  IL_000b:  stloc.0
+  IL_000c:  dup
+  IL_000d:  call       "int E.get_Length(C1)"
+  IL_0012:  stloc.1
+  IL_0013:  ldloca.s   V_0
+  IL_0015:  call       "System.Index System.Range.Start.get"
+  IL_001a:  stloc.s    V_4
+  IL_001c:  ldloca.s   V_4
+  IL_001e:  ldloc.1
+  IL_001f:  call       "int System.Index.GetOffset(int)"
+  IL_0024:  stloc.2
+  IL_0025:  ldloca.s   V_0
+  IL_0027:  call       "System.Index System.Range.End.get"
+  IL_002c:  stloc.s    V_4
+  IL_002e:  ldloca.s   V_4
+  IL_0030:  ldloc.1
+  IL_0031:  call       "int System.Index.GetOffset(int)"
+  IL_0036:  ldloc.2
+  IL_0037:  sub
+  IL_0038:  stloc.3
+  IL_0039:  ldloc.2
+  IL_003a:  ldloc.3
+  IL_003b:  call       "int E.Slice(C1, int, int)"
+  IL_0040:  pop
+  IL_0041:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_03_02()
+    {
+        // class lvalue receiver passed by value, instance Length + extension Slice
+        var src = """
+static class E
+{
+    extension(C1 x)
+    {
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); Program.F = new C1 { F1 = Program.F.F1 + 1 }; return 0; }
+    }
+}
+
+class C1
+{
+    public int F1;
+    public int Length { get { System.Console.Write($"length:{F1} "); Program.F = new C1 { F1 = Program.F.F1 + 1 }; return 5; } }
+}
+
+class Program
+{
+    public static C1 F;
+
+    static void Main()
+    {
+        F = new C1 { F1 = 3 };
+        Test();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test()
+    {
+        _ = F[GetRange()];
+    }
+
+    static System.Range GetRange()
+    {
+        System.Console.Write($"GetRange:{Program.F.F1} ");
+        Program.F = new C1 { F1 = Program.F.F1 + 1 };
+        return 1..^1;
+    }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:3 Slice:3 final:6"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_03_03()
+    {
+        // class lvalue receiver passed by value, extension Length + instance Slice
+        var src = """
+static class E
+{
+    extension(C1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F = new C1 { F1 = Program.F.F1 + 1 }; return 5; } }
+    }
+}
+
+class C1
+{
+    public int F1;
+    public int Slice(int start, int length) { System.Console.Write($"Slice:{F1} "); Program.F = new C1 { F1 = Program.F.F1 + 1 }; return 0; }
+}
+
+class Program
+{
+    public static C1 F;
+
+    static void Main()
+    {
+        F = new C1 { F1 = 3 };
+        Test();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test()
+    {
+        _ = F[GetRange()];
+    }
+
+    static System.Range GetRange()
+    {
+        System.Console.Write($"GetRange:{Program.F.F1} ");
+        Program.F = new C1 { F1 = Program.F.F1 + 1 };
+        return 1..^1;
+    }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:3 Slice:3 final:6"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_04()
+    {
+        // sibling of IndexerAccess_Get_LValueReceiver_04
+        // generic struct lvalue receiver passed by value, extension Length + extension Slice
+        var src = """
+static class E
+{
+    extension<T>(T x)
+    {
+        public int Length { get { System.Console.Write($"length:{((S1)(object)x).F1} "); Program<S1>.F.F1++; return 5; } }
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{((S1)(object)x).F1} "); Program<S1>.F.F1++; return 0; }
+    }
+}
+
+struct S1
+{
+    public int F1;
+}
+
+class Program<T>
+{
+    public static T F;
+}
+
+class Program
+{
+    static void Main()
+    {
+        Program<S1>.F = new S1 { F1 = 3 };
+        Test1(ref Program<S1>.F);
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+
+        System.Console.Write(", ");
+
+        Program<S1>.F = new S1 { F1 = 3 };
+        Test2(ref Program<S1>.F);
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+    }
+
+    static void Test1<T>(ref T f)
+    {
+        _ = f[GetRange()];
+    }
+
+    static void Test2<T>(ref T f) where T : struct
+    {
+        _ = f[GetRange()];
+    }
+
+    static System.Range GetRange()
+    {
+        System.Console.Write($"GetRange:{Program<S1>.F.F1} ");
+        Program<S1>.F.F1++;
+        return 1..^1;
+    }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:4 Slice:5 final:6, GetRange:3 length:4 Slice:5 final:6"), verify: Verification.Skipped)
+              .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1<T>(ref T)", """
+{
+  // Code size      107 (0x6b)
+  .maxstack  3
+  .locals init (T V_0,
+                T& V_1,
+                System.Range V_2,
+                int V_3,
+                int V_4,
+                int V_5,
+                T V_6,
+                System.Index V_7)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  stloc.1
+  IL_0003:  ldloca.s   V_6
+  IL_0005:  initobj    "T"
+  IL_000b:  ldloc.s    V_6
+  IL_000d:  box        "T"
+  IL_0012:  brtrue.s   IL_001f
+  IL_0014:  ldloc.1
+  IL_0015:  ldobj      "T"
+  IL_001a:  stloc.0
+  IL_001b:  ldloca.s   V_0
+  IL_001d:  br.s       IL_0020
+  IL_001f:  ldloc.1
+  IL_0020:  call       "System.Range Program.GetRange()"
+  IL_0025:  stloc.2
+  IL_0026:  dup
+  IL_0027:  ldobj      "T"
+  IL_002c:  call       "int E.get_Length<T>(T)"
+  IL_0031:  stloc.3
+  IL_0032:  ldloca.s   V_2
+  IL_0034:  call       "System.Index System.Range.Start.get"
+  IL_0039:  stloc.s    V_7
+  IL_003b:  ldloca.s   V_7
+  IL_003d:  ldloc.3
+  IL_003e:  call       "int System.Index.GetOffset(int)"
+  IL_0043:  stloc.s    V_4
+  IL_0045:  ldloca.s   V_2
+  IL_0047:  call       "System.Index System.Range.End.get"
+  IL_004c:  stloc.s    V_7
+  IL_004e:  ldloca.s   V_7
+  IL_0050:  ldloc.3
+  IL_0051:  call       "int System.Index.GetOffset(int)"
+  IL_0056:  ldloc.s    V_4
+  IL_0058:  sub
+  IL_0059:  stloc.s    V_5
+  IL_005b:  ldobj      "T"
+  IL_0060:  ldloc.s    V_4
+  IL_0062:  ldloc.s    V_5
+  IL_0064:  call       "int E.Slice<T>(T, int, int)"
+  IL_0069:  pop
+  IL_006a:  ret
+}
+""");
+
+        verifier.VerifyIL("Program.Test2<T>(ref T)", """
+{
+  // Code size       72 (0x48)
+  .maxstack  3
+  .locals init (System.Range V_0,
+                int V_1,
+                int V_2,
+                int V_3,
+                System.Index V_4)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  call       "System.Range Program.GetRange()"
+  IL_0007:  stloc.0
+  IL_0008:  dup
+  IL_0009:  ldobj      "T"
+  IL_000e:  call       "int E.get_Length<T>(T)"
+  IL_0013:  stloc.1
+  IL_0014:  ldloca.s   V_0
+  IL_0016:  call       "System.Index System.Range.Start.get"
+  IL_001b:  stloc.s    V_4
+  IL_001d:  ldloca.s   V_4
+  IL_001f:  ldloc.1
+  IL_0020:  call       "int System.Index.GetOffset(int)"
+  IL_0025:  stloc.2
+  IL_0026:  ldloca.s   V_0
+  IL_0028:  call       "System.Index System.Range.End.get"
+  IL_002d:  stloc.s    V_4
+  IL_002f:  ldloca.s   V_4
+  IL_0031:  ldloc.1
+  IL_0032:  call       "int System.Index.GetOffset(int)"
+  IL_0037:  ldloc.2
+  IL_0038:  sub
+  IL_0039:  stloc.3
+  IL_003a:  ldobj      "T"
+  IL_003f:  ldloc.2
+  IL_0040:  ldloc.3
+  IL_0041:  call       "int E.Slice<T>(T, int, int)"
+  IL_0046:  pop
+  IL_0047:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_05()
+    {
+        // sibling of IndexerAccess_Get_LValueReceiver_05
+        // struct lvalue receiver passed by ref, constrained to struct, extension Length + extension Slice
+        var src = """
+using System.Threading.Tasks;
+
+static class E
+{
+    extension<T>(ref T x) where T : struct
+    {
+        public int Length { get { System.Console.Write($"length:{((S1)(object)x).F1} "); Program<S1>.F.F1++; return 5; } }
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{((S1)(object)x).F1} "); Program<S1>.F.F1++; return 0; }
+    }
+}
+
+struct S1
+{
+    public int F1;
+}
+
+class Program<T>
+{
+    public static T F;
+}
+
+class Program
+{
+    static async Task Main()
+    {
+        Program<S1>.F = new S1 { F1 = 3 };
+        Test2(ref Program<S1>.F);
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+
+        System.Console.Write(", ");
+
+        Program<S1>.F = new S1 { F1 = 3 };
+        await Test3<S1>();
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+    }
+
+    static void Test2<T>(ref T f) where T : struct
+    {
+        _ = f[GetRange()];
+    }
+
+    static System.Range GetRange() { System.Console.Write($"GetRange:{Program<S1>.F.F1} "); Program<S1>.F.F1++; return 1..^1; }
+
+    static async Task Test3<T>() where T : struct
+    {
+        _ = Program<T>.F[await GetRangeAsync()];
+    }
+
+    static async Task<System.Range> GetRangeAsync() { System.Console.Write($"GetRangeAsync:{Program<S1>.F.F1} "); Program<S1>.F.F1++; await Task.Yield(); return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:4 Slice:5 final:6, GetRangeAsync:3 length:4 Slice:5 final:6"), verify: Verification.Skipped)
+                    .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test2<T>(ref T)", """ 
+{
+  // Code size       62 (0x3e)
+  .maxstack  3
+  .locals init (System.Range V_0,
+                int V_1,
+                int V_2,
+                int V_3,
+                System.Index V_4)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  call       "System.Range Program.GetRange()"
+  IL_0007:  stloc.0
+  IL_0008:  dup
+  IL_0009:  call       "int E.get_Length<T>(ref T)"
+  IL_000e:  stloc.1
+  IL_000f:  ldloca.s   V_0
+  IL_0011:  call       "System.Index System.Range.Start.get"
+  IL_0016:  stloc.s    V_4
+  IL_0018:  ldloca.s   V_4
+  IL_001a:  ldloc.1
+  IL_001b:  call       "int System.Index.GetOffset(int)"
+  IL_0020:  stloc.2
+  IL_0021:  ldloca.s   V_0
+  IL_0023:  call       "System.Index System.Range.End.get"
+  IL_0028:  stloc.s    V_4
+  IL_002a:  ldloca.s   V_4
+  IL_002c:  ldloc.1
+  IL_002d:  call       "int System.Index.GetOffset(int)"
+  IL_0032:  ldloc.2
+  IL_0033:  sub
+  IL_0034:  stloc.3
+  IL_0035:  ldloc.2
+  IL_0036:  ldloc.3
+  IL_0037:  call       "int E.Slice<T>(ref T, int, int)"
+  IL_003c:  pop
+  IL_003d:  ret
+}
+""");
+
+        // receiver is not a variable
+        var src2 = """
+static class E
+{
+    extension<T>(ref T x) where T : struct
+    {
+        public int Length => 5;
+        public int Slice(int start, int length) => 0;
+    }
+}
+
+class Program
+{
+    static void Test<T>() where T : struct
+    {
+        _ = default(T)[1..^1];
+    }
+}
+""";
+
+        CreateCompilation(src2, targetFramework: TargetFramework.Net100).VerifyEmitDiagnostics(
+            // (14,13): error CS1510: A ref or out value must be an assignable variable
+            //         _ = default(T)[1..^1];
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "default(T)").WithLocation(14, 13),
+            // (14,13): error CS1510: A ref or out value must be an assignable variable
+            //         _ = default(T)[1..^1];
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "default(T)").WithLocation(14, 13));
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_LValueReceiver_06()
+    {
+        // sibling of IndexerAccess_Get_LValueReceiver_06
+        // generic class lvalue receiver passed by value, extension Length + extension Slice
+        var src = """
+static class E
+{
+    extension<T>(T x)
+    {
+        public int Length { get { System.Console.Write($"length:{((C1)(object)x).F1} "); Program<C1>.F = new C1 { F1 = Program<C1>.F.F1 + 1 }; return 5; } }
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{((C1)(object)x).F1} "); Program<C1>.F = new C1 { F1 = Program<C1>.F.F1 + 1 }; return 0; }
+    }
+}
+
+class C1
+{
+    public int F1;
+}
+
+class Program<T>
+{
+    public static T F;
+}
+
+class Program
+{
+    static void Main()
+    {
+        Program<C1>.F = new C1 { F1 = 3 };
+        Test1(ref Program<C1>.F);
+        System.Console.Write($"final:{Program<C1>.F.F1}");
+
+        System.Console.Write(", ");
+
+        Program<C1>.F = new C1 { F1 = 3 };
+        Test2(ref Program<C1>.F);
+        System.Console.Write($"final:{Program<C1>.F.F1}");
+    }
+
+    static void Test1<T>(ref T f)
+    {
+        _ = f[GetRange()];
+    }
+
+    static void Test2<T>(ref T f) where T : class
+    {
+        _ = f[GetRange()];
+    }
+
+    static System.Range GetRange() { System.Console.Write($"GetRange:{Program<C1>.F.F1} "); Program<C1>.F = new C1 { F1 = Program<C1>.F.F1 + 1 }; return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:3 Slice:3 final:6, GetRange:3 length:3 Slice:3 final:6"), verify: Verification.Skipped)
+             .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1<T>(ref T)", """
+{
+  // Code size      107 (0x6b)
+  .maxstack  3
+  .locals init (T V_0,
+                T& V_1,
+                System.Range V_2,
+                int V_3,
+                int V_4,
+                int V_5,
+                T V_6,
+                System.Index V_7)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  stloc.1
+  IL_0003:  ldloca.s   V_6
+  IL_0005:  initobj    "T"
+  IL_000b:  ldloc.s    V_6
+  IL_000d:  box        "T"
+  IL_0012:  brtrue.s   IL_001f
+  IL_0014:  ldloc.1
+  IL_0015:  ldobj      "T"
+  IL_001a:  stloc.0
+  IL_001b:  ldloca.s   V_0
+  IL_001d:  br.s       IL_0020
+  IL_001f:  ldloc.1
+  IL_0020:  call       "System.Range Program.GetRange()"
+  IL_0025:  stloc.2
+  IL_0026:  dup
+  IL_0027:  ldobj      "T"
+  IL_002c:  call       "int E.get_Length<T>(T)"
+  IL_0031:  stloc.3
+  IL_0032:  ldloca.s   V_2
+  IL_0034:  call       "System.Index System.Range.Start.get"
+  IL_0039:  stloc.s    V_7
+  IL_003b:  ldloca.s   V_7
+  IL_003d:  ldloc.3
+  IL_003e:  call       "int System.Index.GetOffset(int)"
+  IL_0043:  stloc.s    V_4
+  IL_0045:  ldloca.s   V_2
+  IL_0047:  call       "System.Index System.Range.End.get"
+  IL_004c:  stloc.s    V_7
+  IL_004e:  ldloca.s   V_7
+  IL_0050:  ldloc.3
+  IL_0051:  call       "int System.Index.GetOffset(int)"
+  IL_0056:  ldloc.s    V_4
+  IL_0058:  sub
+  IL_0059:  stloc.s    V_5
+  IL_005b:  ldobj      "T"
+  IL_0060:  ldloc.s    V_4
+  IL_0062:  ldloc.s    V_5
+  IL_0064:  call       "int E.Slice<T>(T, int, int)"
+  IL_0069:  pop
+  IL_006a:  ret
+}
+""");
+
+        verifier.VerifyIL("Program.Test2<T>(ref T)", """
+{
+  // Code size       67 (0x43)
+  .maxstack  3
+  .locals init (System.Range V_0,
+                int V_1,
+                int V_2,
+                int V_3,
+                System.Index V_4)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  ldobj      "T"
+  IL_0007:  call       "System.Range Program.GetRange()"
+  IL_000c:  stloc.0
+  IL_000d:  dup
+  IL_000e:  call       "int E.get_Length<T>(T)"
+  IL_0013:  stloc.1
+  IL_0014:  ldloca.s   V_0
+  IL_0016:  call       "System.Index System.Range.Start.get"
+  IL_001b:  stloc.s    V_4
+  IL_001d:  ldloca.s   V_4
+  IL_001f:  ldloc.1
+  IL_0020:  call       "int System.Index.GetOffset(int)"
+  IL_0025:  stloc.2
+  IL_0026:  ldloca.s   V_0
+  IL_0028:  call       "System.Index System.Range.End.get"
+  IL_002d:  stloc.s    V_4
+  IL_002f:  ldloca.s   V_4
+  IL_0031:  ldloc.1
+  IL_0032:  call       "int System.Index.GetOffset(int)"
+  IL_0037:  ldloc.2
+  IL_0038:  sub
+  IL_0039:  stloc.3
+  IL_003a:  ldloc.2
+  IL_003b:  ldloc.3
+  IL_003c:  call       "int E.Slice<T>(T, int, int)"
+  IL_0041:  pop
+  IL_0042:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_RValueReceiver_01()
+    {
+        // sibling of IndexerAccess_Get_RValueReceiver_01
+        // struct rvalue receiver passed by value, extension Length + extension Slice
+        var src = """
+static class E
+{
+    extension(S1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.State++; return 5; } }
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); Program.State++; return 0; }
+    }
+}
+
+public struct S1
+{
+    public int F1;
+}
+
+class Program
+{
+    public static int State;
+
+    static void Main()
+    {
+        State = 3;
+        Test();
+        System.Console.Write($"final:{State}");
+    }
+
+    static void Test()
+    {
+        _ = GetS1()[GetRange()];
+    }
+
+    static S1 GetS1() => new S1 { F1 = State };
+
+    public static System.Range GetRange() { System.Console.Write($"GetRange:{State} "); State++; return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:3 Slice:3 final:6"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test", """
+{
+  // Code size       80 (0x50)
+  .maxstack  3
+  .locals init (System.Range V_0,
+                int V_1,
+                int V_2,
+                int V_3,
+                S1 V_4,
+                System.Index V_5)
+  IL_0000:  nop
+  IL_0001:  call       "S1 Program.GetS1()"
+  IL_0006:  stloc.s    V_4
+  IL_0008:  ldloca.s   V_4
+  IL_000a:  call       "System.Range Program.GetRange()"
+  IL_000f:  stloc.0
+  IL_0010:  dup
+  IL_0011:  ldobj      "S1"
+  IL_0016:  call       "int E.get_Length(S1)"
+  IL_001b:  stloc.1
+  IL_001c:  ldloca.s   V_0
+  IL_001e:  call       "System.Index System.Range.Start.get"
+  IL_0023:  stloc.s    V_5
+  IL_0025:  ldloca.s   V_5
+  IL_0027:  ldloc.1
+  IL_0028:  call       "int System.Index.GetOffset(int)"
+  IL_002d:  stloc.2
+  IL_002e:  ldloca.s   V_0
+  IL_0030:  call       "System.Index System.Range.End.get"
+  IL_0035:  stloc.s    V_5
+  IL_0037:  ldloca.s   V_5
+  IL_0039:  ldloc.1
+  IL_003a:  call       "int System.Index.GetOffset(int)"
+  IL_003f:  ldloc.2
+  IL_0040:  sub
+  IL_0041:  stloc.3
+  IL_0042:  ldobj      "S1"
+  IL_0047:  ldloc.2
+  IL_0048:  ldloc.3
+  IL_0049:  call       "int E.Slice(S1, int, int)"
+  IL_004e:  pop
+  IL_004f:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_RValueReceiver_01_02()
+    {
+        // struct rvalue receiver passed by value, instance Length + extension Slice
+        var src = """
+static class E
+{
+    extension(S1 x)
+    {
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); Program.State++; return 0; }
+    }
+}
+
+public struct S1
+{
+    public int F1;
+    public int Length { get { System.Console.Write($"length:{F1} "); Program.State++; return 5; } }
+}
+
+class Program
+{
+    public static int State;
+
+    static void Main()
+    {
+        State = 3;
+        Test();
+        System.Console.Write($"final:{State}");
+    }
+
+    static void Test()
+    {
+        _ = GetS1()[GetRange()];
+    }
+
+    static S1 GetS1() => new S1 { F1 = State };
+
+    public static System.Range GetRange() { System.Console.Write($"GetRange:{State} "); State++; return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:3 Slice:3 final:6"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_RValueReceiver_01_03()
+    {
+        // struct rvalue receiver passed by value, extension Length + instance Slice
+        var src = """
+static class E
+{
+    extension(S1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.State++; return 5; } }
+    }
+}
+
+public struct S1
+{
+    public int F1;
+    public int Slice(int start, int length) { System.Console.Write($"Slice:{F1} "); Program.State++; return 0; }
+}
+
+class Program
+{
+    public static int State;
+
+    static void Main()
+    {
+        State = 3;
+        Test();
+        System.Console.Write($"final:{State}");
+    }
+
+    static void Test()
+    {
+        _ = GetS1()[GetRange()];
+    }
+
+    static S1 GetS1() => new S1 { F1 = State };
+
+    public static System.Range GetRange() { System.Console.Write($"GetRange:{State} "); State++; return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:3 Slice:3 final:6"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Theory]
+    [InlineData("ref")]
+    [InlineData("ref readonly")]
+    [InlineData("in")]
+    public void ImplicitRangeIndexerAccess_Get_RValueReceiver_02(string refKind)
+    {
+        // TODO2 review
+        // sibling of IndexerAccess_Get_RValueReceiver_02
+        // struct rvalue receiver passed by ref, extension Length + extension Slice
+        var src = $$$"""
+static class E
+{
+    extension({{{refKind}}} S1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.State++; return 5; } }
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); Program.State++; return 0; }
+    }
+}
+
+struct S1
+{
+    public int F1;
+}
+
+class Program
+{
+    public static int State;
+
+    static void Main()
+    {
+        State = 3;
+        Test();
+        System.Console.Write($"final:{State}");
+    }
+
+    static void Test()
+    {
+        _ = GetS1()[GetRange()];
+    }
+
+    static S1 GetS1() => new S1 { F1 = State };
+
+    public static System.Range GetRange() { System.Console.Write($"GetRange:{State} "); State++; return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        switch (refKind)
+        {
+            case "ref":
+                comp.VerifyEmitDiagnostics(
+                    // (28,13): error CS1510: A ref or out value must be an assignable variable
+                    //         _ = GetS1()[GetRange()];
+                    Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetS1()").WithLocation(28, 13),
+                    // (28,13): error CS1510: A ref or out value must be an assignable variable
+                    //         _ = GetS1()[GetRange()];
+                    Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetS1()").WithLocation(28, 13));
+                return;
+            case "ref readonly":
+                comp.VerifyEmitDiagnostics(
+                    // (28,13): warning CS9193: Argument 0 should be a variable because it is passed to a 'ref readonly' parameter
+                    //         _ = GetS1()[GetRange()];
+                    Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "GetS1()").WithArguments("0").WithLocation(28, 13),
+                    // (28,13): warning CS9193: Argument 0 should be a variable because it is passed to a 'ref readonly' parameter
+                    //         _ = GetS1()[GetRange()];
+                    Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "GetS1()").WithArguments("0").WithLocation(28, 13),
+                    // (28,13): warning CS9193: Argument 0 should be a variable because it is passed to a 'ref readonly' parameter
+                    //         _ = GetS1()[GetRange()];
+                    Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "GetS1()").WithArguments("0").WithLocation(28, 13));
+                break;
+            case "in":
+                comp.VerifyEmitDiagnostics();
+                break;
+            default:
+                throw ExceptionUtilities.UnexpectedValue(refKind);
+        }
+
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:3 Slice:3 final:6"), verify: Verification.Skipped);
+        verifier.VerifyIL("Program.Test", $$"""
+{
+  // Code size       70 (0x46)
+  .maxstack  3
+  .locals init (System.Range V_0,
+                int V_1,
+                int V_2,
+                int V_3,
+                S1 V_4,
+                System.Index V_5)
+  IL_0000:  nop
+  IL_0001:  call       "S1 Program.GetS1()"
+  IL_0006:  stloc.s    V_4
+  IL_0008:  ldloca.s   V_4
+  IL_000a:  call       "System.Range Program.GetRange()"
+  IL_000f:  stloc.0
+  IL_0010:  dup
+  IL_0011:  call       "int E.get_Length({{refKind}} S1)"
+  IL_0016:  stloc.1
+  IL_0017:  ldloca.s   V_0
+  IL_0019:  call       "System.Index System.Range.Start.get"
+  IL_001e:  stloc.s    V_5
+  IL_0020:  ldloca.s   V_5
+  IL_0022:  ldloc.1
+  IL_0023:  call       "int System.Index.GetOffset(int)"
+  IL_0028:  stloc.2
+  IL_0029:  ldloca.s   V_0
+  IL_002b:  call       "System.Index System.Range.End.get"
+  IL_0030:  stloc.s    V_5
+  IL_0032:  ldloca.s   V_5
+  IL_0034:  ldloc.1
+  IL_0035:  call       "int System.Index.GetOffset(int)"
+  IL_003a:  ldloc.2
+  IL_003b:  sub
+  IL_003c:  stloc.3
+  IL_003d:  ldloc.2
+  IL_003e:  ldloc.3
+  IL_003f:  call       "int E.Slice({{refKind}} S1, int, int)"
+  IL_0044:  pop
+  IL_0045:  ret
+}
+""");
+    }
+
+    [Theory]
+    [InlineData("ref")]
+    [InlineData("ref readonly")]
+    [InlineData("in")]
+    public void ImplicitRangeIndexerAccess_Get_RValueReceiver_02_02(string refKind)
+    {
+        // struct rvalue receiver passed by ref, instance Length + extension Slice
+        var src = $$$"""
+static class E
+{
+    extension({{{refKind}}} S1 x)
+    {
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); Program.State++; return 0; }
+    }
+}
+
+struct S1
+{
+    public int F1;
+    public int Length { get { System.Console.Write($"length:{F1} "); Program.State++; return 5; } }
+}
+
+class Program
+{
+    public static int State;
+
+    static void Main()
+    {
+        State = 3;
+        Test();
+        System.Console.Write($"final:{State}");
+    }
+
+    static void Test()
+    {
+        _ = GetS1()[GetRange()];
+    }
+
+    static S1 GetS1() => new S1 { F1 = State };
+
+    public static System.Range GetRange() { System.Console.Write($"GetRange:{State} "); State++; return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        switch (refKind)
+        {
+            case "ref":
+                comp.VerifyEmitDiagnostics(
+                    // (28,13): error CS1510: A ref or out value must be an assignable variable
+                    //         _ = GetS1()[GetRange()];
+                    Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetS1()").WithLocation(28, 13));
+                return;
+            case "ref readonly":
+                comp.VerifyEmitDiagnostics(
+                    // (28,13): warning CS9193: Argument 0 should be a variable because it is passed to a 'ref readonly' parameter
+                    //         _ = GetS1()[GetRange()];
+                    Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "GetS1()").WithArguments("0").WithLocation(28, 13));
+                break;
+            case "in":
+                comp.VerifyEmitDiagnostics();
+                break;
+            default:
+                throw ExceptionUtilities.UnexpectedValue(refKind);
+        }
+
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:3 Slice:3 final:6"), verify: Verification.Skipped);
+    }
+
+    [Theory]
+    [InlineData("ref")]
+    [InlineData("ref readonly")]
+    [InlineData("in")]
+    public void ImplicitRangeIndexerAccess_Get_RValueReceiver_02_03(string refKind)
+    {
+        // struct rvalue receiver passed by ref, extension Length + instance Slice
+        var src = $$$"""
+static class E
+{
+    extension({{{refKind}}} S1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.State++; return 5; } }
+    }
+}
+
+struct S1
+{
+    public int F1;
+    public int Slice(int start, int length) { System.Console.Write($"Slice:{F1} "); Program.State++; return 0; }
+}
+
+class Program
+{
+    public static int State;
+
+    static void Main()
+    {
+        State = 3;
+        Test();
+        System.Console.Write($"final:{State}");
+    }
+
+    static void Test()
+    {
+        _ = GetS1()[GetRange()];
+    }
+
+    static S1 GetS1() => new S1 { F1 = State };
+
+    public static System.Range GetRange() { System.Console.Write($"GetRange:{State} "); State++; return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        switch (refKind)
+        {
+            case "ref":
+                comp.VerifyEmitDiagnostics(
+                    // (28,13): error CS1510: A ref or out value must be an assignable variable
+                    //         _ = GetS1()[GetRange()];
+                    Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetS1()").WithLocation(28, 13));
+                return;
+            case "ref readonly":
+                comp.VerifyEmitDiagnostics(
+                    // (28,13): warning CS9193: Argument 0 should be a variable because it is passed to a 'ref readonly' parameter
+                    //         _ = GetS1()[GetRange()];
+                    Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "GetS1()").WithArguments("0").WithLocation(28, 13));
+                break;
+            case "in":
+                comp.VerifyEmitDiagnostics();
+                break;
+            default:
+                throw ExceptionUtilities.UnexpectedValue(refKind);
+        }
+
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:3 Slice:3 final:6"), verify: Verification.Skipped);
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_RValueReceiver_03()
+    {
+        // sibling of IndexerAccess_Get_RValueReceiver_03
+        // class rvalue receiver passed by value, extension Length + extension Slice
+        var src = """
+static class E
+{
+    extension(C1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.State++; return 5; } }
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); Program.State++; return 0; }
+    }
+}
+
+class C1
+{
+    public int F1;
+}
+
+class Program
+{
+    public static int State;
+
+    static void Main()
+    {
+        State = 3;
+        Test();
+        System.Console.Write($"final:{State}");
+    }
+
+    static void Test()
+    {
+        _ = GetC1()[GetRange()];
+    }
+
+    static C1 GetC1() => new C1 { F1 = State };
+
+    static System.Range GetRange() { System.Console.Write($"GetRange:{State} "); State++; return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:3 Slice:3 final:6"), verify: Verification.Skipped)
+                .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test", """
+{
+  // Code size       66 (0x42)
+  .maxstack  3
+  .locals init (System.Range V_0,
+                int V_1,
+                int V_2,
+                int V_3,
+                System.Index V_4)
+  IL_0000:  nop
+  IL_0001:  call       "C1 Program.GetC1()"
+  IL_0006:  call       "System.Range Program.GetRange()"
+  IL_000b:  stloc.0
+  IL_000c:  dup
+  IL_000d:  call       "int E.get_Length(C1)"
+  IL_0012:  stloc.1
+  IL_0013:  ldloca.s   V_0
+  IL_0015:  call       "System.Index System.Range.Start.get"
+  IL_001a:  stloc.s    V_4
+  IL_001c:  ldloca.s   V_4
+  IL_001e:  ldloc.1
+  IL_001f:  call       "int System.Index.GetOffset(int)"
+  IL_0024:  stloc.2
+  IL_0025:  ldloca.s   V_0
+  IL_0027:  call       "System.Index System.Range.End.get"
+  IL_002c:  stloc.s    V_4
+  IL_002e:  ldloca.s   V_4
+  IL_0030:  ldloc.1
+  IL_0031:  call       "int System.Index.GetOffset(int)"
+  IL_0036:  ldloc.2
+  IL_0037:  sub
+  IL_0038:  stloc.3
+  IL_0039:  ldloc.2
+  IL_003a:  ldloc.3
+  IL_003b:  call       "int E.Slice(C1, int, int)"
+  IL_0040:  pop
+  IL_0041:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_RValueReceiver_03_02()
+    {
+        // class rvalue receiver passed by value, instance Length + extension Slice
+        var src = """
+static class E
+{
+    extension(C1 x)
+    {
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); Program.State++; return 0; }
+    }
+}
+
+class C1
+{
+    public int F1;
+    public int Length { get { System.Console.Write($"length:{F1} "); Program.State++; return 5; } }
+}
+
+class Program
+{
+    public static int State;
+
+    static void Main()
+    {
+        State = 3;
+        Test();
+        System.Console.Write($"final:{State}");
+    }
+
+    static void Test()
+    {
+        _ = GetC1()[GetRange()];
+    }
+
+    static C1 GetC1() => new C1 { F1 = State };
+
+    static System.Range GetRange() { System.Console.Write($"GetRange:{State} "); State++; return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:3 Slice:3 final:6"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_RValueReceiver_03_03()
+    {
+        // class rvalue receiver passed by value, extension Length + instance Slice
+        var src = """
+static class E
+{
+    extension(C1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.State++; return 5; } }
+    }
+}
+
+class C1
+{
+    public int F1;
+    public int Slice(int start, int length) { System.Console.Write($"Slice:{this.F1} "); Program.State++; return 0; }
+}
+
+class Program
+{
+    public static int State;
+
+    static void Main()
+    {
+        State = 3;
+        Test();
+        System.Console.Write($"final:{State}");
+    }
+
+    static void Test()
+    {
+        _ = GetC1()[GetRange()];
+    }
+
+    static C1 GetC1() => new C1 { F1 = State };
+
+    static System.Range GetRange() { System.Console.Write($"GetRange:{State} "); State++; return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:3 Slice:3 final:6"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_RValueReceiver_04()
+    {
+        // sibling of IndexerAccess_Get_RValueReceiver_04
+        // generic struct rvalue receiver passed by value, extension Length + extension Slice
+        var src = """
+using System.Threading.Tasks;
+
+static class E
+{
+    extension<T>(T x)
+    {
+        public int Length { get { System.Console.Write($"length:{((S1)(object)x).F1} "); Program.State++; return 5; } }
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{((S1)(object)x).F1} "); Program.State++; return 0; }
+    }
+}
+
+struct S1
+{
+    public int F1;
+}
+
+class Program
+{
+    public static int State;
+
+    static async Task Main()
+    {
+        State = 3;
+        Test1<S1>();
+        System.Console.Write($"final:{State}");
+
+        System.Console.Write(", ");
+
+        State = 3;
+        Test2<S1>();
+        System.Console.Write($"final:{State}");
+
+        System.Console.Write(", ");
+
+        State = 3;
+        await Test3<S1>();
+        System.Console.Write($"final:{State}");
+    }
+
+    static T GetT<T>() => (T)(object)new S1 { F1 = State };
+
+    static void Test1<T>()
+    {
+        _ = GetT<T>()[GetRange()];
+    }
+
+    static void Test2<T>() where T : struct
+    {
+        _ = GetT<T>()[GetRange()];
+    }
+
+    static System.Range GetRange() { System.Console.Write($"GetRange:{State} "); State++; return 1..^1; }
+
+    static async Task Test3<T>()
+    {
+        _ = GetT<T>()[await GetRangeAsync()];
+    }
+
+    static async Task<System.Range> GetRangeAsync() { System.Console.Write($"GetRangeAsync:{State} "); State++; await Task.Yield(); return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:3 Slice:3 final:6, GetRange:3 length:3 Slice:3 final:6, GetRangeAsync:3 length:3 Slice:3 final:6"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1<T>()", """
+{
+  // Code size      115 (0x73)
+  .maxstack  3
+  .locals init (T V_0,
+                T& V_1,
+                System.Range V_2,
+                int V_3,
+                int V_4,
+                int V_5,
+                T V_6,
+                T V_7,
+                System.Index V_8)
+  IL_0000:  nop
+  IL_0001:  call       "T Program.GetT<T>()"
+  IL_0006:  stloc.s    V_6
+  IL_0008:  ldloca.s   V_6
+  IL_000a:  stloc.1
+  IL_000b:  ldloca.s   V_7
+  IL_000d:  initobj    "T"
+  IL_0013:  ldloc.s    V_7
+  IL_0015:  box        "T"
+  IL_001a:  brtrue.s   IL_0027
+  IL_001c:  ldloc.1
+  IL_001d:  ldobj      "T"
+  IL_0022:  stloc.0
+  IL_0023:  ldloca.s   V_0
+  IL_0025:  br.s       IL_0028
+  IL_0027:  ldloc.1
+  IL_0028:  call       "System.Range Program.GetRange()"
+  IL_002d:  stloc.2
+  IL_002e:  dup
+  IL_002f:  ldobj      "T"
+  IL_0034:  call       "int E.get_Length<T>(T)"
+  IL_0039:  stloc.3
+  IL_003a:  ldloca.s   V_2
+  IL_003c:  call       "System.Index System.Range.Start.get"
+  IL_0041:  stloc.s    V_8
+  IL_0043:  ldloca.s   V_8
+  IL_0045:  ldloc.3
+  IL_0046:  call       "int System.Index.GetOffset(int)"
+  IL_004b:  stloc.s    V_4
+  IL_004d:  ldloca.s   V_2
+  IL_004f:  call       "System.Index System.Range.End.get"
+  IL_0054:  stloc.s    V_8
+  IL_0056:  ldloca.s   V_8
+  IL_0058:  ldloc.3
+  IL_0059:  call       "int System.Index.GetOffset(int)"
+  IL_005e:  ldloc.s    V_4
+  IL_0060:  sub
+  IL_0061:  stloc.s    V_5
+  IL_0063:  ldobj      "T"
+  IL_0068:  ldloc.s    V_4
+  IL_006a:  ldloc.s    V_5
+  IL_006c:  call       "int E.Slice<T>(T, int, int)"
+  IL_0071:  pop
+  IL_0072:  ret
+}
+""");
+
+        verifier.VerifyIL("Program.Test2<T>()", """
+{
+  // Code size       80 (0x50)
+  .maxstack  3
+  .locals init (System.Range V_0,
+                int V_1,
+                int V_2,
+                int V_3,
+                T V_4,
+                System.Index V_5)
+  IL_0000:  nop
+  IL_0001:  call       "T Program.GetT<T>()"
+  IL_0006:  stloc.s    V_4
+  IL_0008:  ldloca.s   V_4
+  IL_000a:  call       "System.Range Program.GetRange()"
+  IL_000f:  stloc.0
+  IL_0010:  dup
+  IL_0011:  ldobj      "T"
+  IL_0016:  call       "int E.get_Length<T>(T)"
+  IL_001b:  stloc.1
+  IL_001c:  ldloca.s   V_0
+  IL_001e:  call       "System.Index System.Range.Start.get"
+  IL_0023:  stloc.s    V_5
+  IL_0025:  ldloca.s   V_5
+  IL_0027:  ldloc.1
+  IL_0028:  call       "int System.Index.GetOffset(int)"
+  IL_002d:  stloc.2
+  IL_002e:  ldloca.s   V_0
+  IL_0030:  call       "System.Index System.Range.End.get"
+  IL_0035:  stloc.s    V_5
+  IL_0037:  ldloca.s   V_5
+  IL_0039:  ldloc.1
+  IL_003a:  call       "int System.Index.GetOffset(int)"
+  IL_003f:  ldloc.2
+  IL_0040:  sub
+  IL_0041:  stloc.3
+  IL_0042:  ldobj      "T"
+  IL_0047:  ldloc.2
+  IL_0048:  ldloc.3
+  IL_0049:  call       "int E.Slice<T>(T, int, int)"
+  IL_004e:  pop
+  IL_004f:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_RValueReceiver_05()
+    {
+        // sibling of IndexerAccess_Get_RValueReceiver_05
+        // struct rvalue receiver passed by ref, constrained to struct, extension Length + extension Slice
+        var src = """
+using System.Threading.Tasks;
+
+static class E
+{
+    extension<T>(ref T x) where T : struct
+    {
+        public int Length => 5;
+        public int Slice(int start, int length) => 0;
+    }
+}
+
+struct S1
+{
+    public int F1;
+}
+
+class Program
+{
+    static void Test2<T>() where T : struct
+    {
+        _ = GetT<T>()[GetRange()];
+    }
+
+    static T GetT<T>() => (T)(object)new S1 { F1 = 3 };
+    static System.Range GetRange() => 1..^1;
+
+    static async Task Test3<T>() where T : struct
+    {
+        _ = GetT<T>()[await GetRangeAsync()];
+    }
+
+    static async Task<System.Range> GetRangeAsync() { await Task.Yield(); return 1..^1; }
+}
+""";
+
+        CreateCompilation(src, targetFramework: TargetFramework.Net100).VerifyDiagnostics(
+            // (21,13): error CS1510: A ref or out value must be an assignable variable
+            //         _ = GetT<T>()[GetRange()];
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetT<T>()").WithLocation(21, 13),
+            // (21,13): error CS1510: A ref or out value must be an assignable variable
+            //         _ = GetT<T>()[GetRange()];
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetT<T>()").WithLocation(21, 13),
+            // (29,13): error CS1510: A ref or out value must be an assignable variable
+            //         _ = GetT<T>()[await GetRangeAsync()];
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetT<T>()").WithLocation(29, 13),
+            // (29,13): error CS1510: A ref or out value must be an assignable variable
+            //         _ = GetT<T>()[await GetRangeAsync()];
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetT<T>()").WithLocation(29, 13));
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_Get_RValueReceiver_06()
+    {
+        // sibling of IndexerAccess_Get_RValueReceiver_06
+        // generic class rvalue receiver passed by value, extension Length + extension Slice
+        var src = """
+using System.Threading.Tasks;
+
+static class E
+{
+    extension<T>(T x)
+    {
+        public int Length { get { System.Console.Write($"length:{((C1)(object)x).F1} "); Program.State++; return 5; } }
+        public int Slice(int start, int length) { System.Console.Write($"Slice:{((C1)(object)x).F1} "); Program.State++; return 0; }
+    }
+}
+
+class C1
+{
+    public int F1;
+}
+
+class Program
+{
+    public static int State;
+
+    static async Task Main()
+    {
+        State = 3;
+        Test1<C1>();
+        System.Console.Write($"final:{State}");
+
+        System.Console.Write(", ");
+
+        State = 3;
+        Test2<C1>();
+        System.Console.Write($"final:{State}");
+
+        System.Console.Write(", ");
+
+        State = 3;
+        await Test3<C1>();
+        System.Console.Write($"final:{State}");
+    }
+
+    static T GetT<T>() => (T)(object)new C1 { F1 = State };
+
+    static void Test1<T>()
+    {
+        _ = GetT<T>()[GetRange()];
+    }
+
+    static void Test2<T>() where T : class
+    {
+        _ = GetT<T>()[GetRange()];
+    }
+
+    static System.Range GetRange() { System.Console.Write($"GetRange:{State} "); State++; return 1..^1; }
+
+    static async Task Test3<T>()
+    {
+        _ = GetT<T>()[await GetRangeAsync()];
+    }
+
+    static async Task<System.Range> GetRangeAsync() { System.Console.Write($"GetRangeAsync:{State} "); State++; await Task.Yield(); return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:3 Slice:3 final:6, GetRange:3 length:3 Slice:3 final:6, GetRangeAsync:3 length:3 Slice:3 final:6"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1<T>()", """
+{
+  // Code size      115 (0x73)
+  .maxstack  3
+  .locals init (T V_0,
+                T& V_1,
+                System.Range V_2,
+                int V_3,
+                int V_4,
+                int V_5,
+                T V_6,
+                T V_7,
+                System.Index V_8)
+  IL_0000:  nop
+  IL_0001:  call       "T Program.GetT<T>()"
+  IL_0006:  stloc.s    V_6
+  IL_0008:  ldloca.s   V_6
+  IL_000a:  stloc.1
+  IL_000b:  ldloca.s   V_7
+  IL_000d:  initobj    "T"
+  IL_0013:  ldloc.s    V_7
+  IL_0015:  box        "T"
+  IL_001a:  brtrue.s   IL_0027
+  IL_001c:  ldloc.1
+  IL_001d:  ldobj      "T"
+  IL_0022:  stloc.0
+  IL_0023:  ldloca.s   V_0
+  IL_0025:  br.s       IL_0028
+  IL_0027:  ldloc.1
+  IL_0028:  call       "System.Range Program.GetRange()"
+  IL_002d:  stloc.2
+  IL_002e:  dup
+  IL_002f:  ldobj      "T"
+  IL_0034:  call       "int E.get_Length<T>(T)"
+  IL_0039:  stloc.3
+  IL_003a:  ldloca.s   V_2
+  IL_003c:  call       "System.Index System.Range.Start.get"
+  IL_0041:  stloc.s    V_8
+  IL_0043:  ldloca.s   V_8
+  IL_0045:  ldloc.3
+  IL_0046:  call       "int System.Index.GetOffset(int)"
+  IL_004b:  stloc.s    V_4
+  IL_004d:  ldloca.s   V_2
+  IL_004f:  call       "System.Index System.Range.End.get"
+  IL_0054:  stloc.s    V_8
+  IL_0056:  ldloca.s   V_8
+  IL_0058:  ldloc.3
+  IL_0059:  call       "int System.Index.GetOffset(int)"
+  IL_005e:  ldloc.s    V_4
+  IL_0060:  sub
+  IL_0061:  stloc.s    V_5
+  IL_0063:  ldobj      "T"
+  IL_0068:  ldloc.s    V_4
+  IL_006a:  ldloc.s    V_5
+  IL_006c:  call       "int E.Slice<T>(T, int, int)"
+  IL_0071:  pop
+  IL_0072:  ret
+}
+""");
+
+        verifier.VerifyIL("Program.Test2<T>()", """
+{
+  // Code size       66 (0x42)
+  .maxstack  3
+  .locals init (System.Range V_0,
+                int V_1,
+                int V_2,
+                int V_3,
+                System.Index V_4)
+  IL_0000:  nop
+  IL_0001:  call       "T Program.GetT<T>()"
+  IL_0006:  call       "System.Range Program.GetRange()"
+  IL_000b:  stloc.0
+  IL_000c:  dup
+  IL_000d:  call       "int E.get_Length<T>(T)"
+  IL_0012:  stloc.1
+  IL_0013:  ldloca.s   V_0
+  IL_0015:  call       "System.Index System.Range.Start.get"
+  IL_001a:  stloc.s    V_4
+  IL_001c:  ldloca.s   V_4
+  IL_001e:  ldloc.1
+  IL_001f:  call       "int System.Index.GetOffset(int)"
+  IL_0024:  stloc.2
+  IL_0025:  ldloca.s   V_0
+  IL_0027:  call       "System.Index System.Range.End.get"
+  IL_002c:  stloc.s    V_4
+  IL_002e:  ldloca.s   V_4
+  IL_0030:  ldloc.1
+  IL_0031:  call       "int System.Index.GetOffset(int)"
+  IL_0036:  ldloc.2
+  IL_0037:  sub
+  IL_0038:  stloc.3
+  IL_0039:  ldloc.2
+  IL_003a:  ldloc.3
+  IL_003b:  call       "int E.Slice<T>(T, int, int)"
+  IL_0040:  pop
+  IL_0041:  ret
+}
+""");
     }
 }

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
@@ -24742,7 +24742,6 @@ class Program
     [InlineData("in")]
     public void ImplicitRangeIndexerAccess_Get_RValueReceiver_02(string refKind)
     {
-        // TODO2 review
         // sibling of IndexerAccess_Get_RValueReceiver_02
         // struct rvalue receiver passed by ref, extension Length + extension Slice
         var src = $$$"""

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/IndexAndRangeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/IndexAndRangeTests.cs
@@ -4939,14 +4939,137 @@ class Program
 
             verifier.VerifyIL("Program.Test", """
 {
-  // Code size       18 (0x12)
+  // Code size       15 (0xf)
   .maxstack  2
   IL_0000:  nop
-  IL_0001:  ldsfld     "string Program.F"
-  IL_0006:  call       "int Program.GetStart()"
-  IL_000b:  callvirt   "string string.Substring(int)"
-  IL_0010:  pop
-  IL_0011:  ret
+  IL_0001:  ldarg.0
+  IL_0002:  ldind.ref
+  IL_0003:  call       "int Program.GetStart()"
+  IL_0008:  callvirt   "string string.Substring(int)"
+  IL_000d:  pop
+  IL_000e:  ret
+}
+""");
+        }
+
+        [Theory]
+        [InlineData("Span<char>")]
+        [InlineData("ReadOnlySpan<char>")]
+        public void SliceStart_13(string typeName)
+        {
+            // Span<T>/ReadOnlySpan<T> with [GetStart()..]: UseAsIs strategy + start-only Slice optimization (struct receiver)
+            var src = $$"""
+using System;
+
+class Program
+{
+    static void Main()
+    {
+        {{typeName}} s = "0123".ToCharArray();
+        System.Console.Write(Test(ref s).ToString());
+    }
+
+    static {{typeName}} Test(ref {{typeName}} s) => s[GetStart()..];
+
+    static int GetStart() { System.Console.Write("GetStart "); return 1; }
+}
+""";
+            var comp = CreateCompilation(src, options: TestOptions.ReleaseExe, targetFramework: TargetFramework.Net100);
+            var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetStart 123"), verify: Verification.Skipped);
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("Program.Test", $$"""
+{
+  // Code size       12 (0xc)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  call       "int Program.GetStart()"
+  IL_0006:  call       "System.{{typeName}} System.{{typeName}}.Slice(int)"
+  IL_000b:  ret
+}
+""");
+        }
+
+        [Theory]
+        [InlineData("Memory<int>")]
+        [InlineData("ReadOnlyMemory<int>")]
+        public void SliceStart_14(string typeName)
+        {
+            // Memory<T>/ReadOnlyMemory<T> with [GetStart()..]: UseAsIs strategy + start-only Slice optimization (struct receiver)
+            var src = $$"""
+class Program
+{
+    public static System.{{typeName}} F;
+
+    static void Main()
+    {
+        F = new int[] { 1, 2, 3, 4 };
+        Test();
+        System.Console.Write($"final:{F.Span[0]}");
+    }
+
+    static void Test()
+    {
+        _ = F[GetStart()..];
+    }
+
+    static int GetStart() { System.Console.Write($"GetStart:{F.Span[0]} "); F = new int[] { 9, 9 }; return 1; }
+}
+""";
+            var comp = CreateCompilation(src, options: TestOptions.ReleaseExe, targetFramework: TargetFramework.Net100);
+            var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetStart:1 final:9"), verify: Verification.Skipped);
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("Program.Test", $$"""
+{
+  // Code size       17 (0x11)
+  .maxstack  2
+  IL_0000:  ldsflda    "System.{{typeName}} Program.F"
+  IL_0005:  call       "int Program.GetStart()"
+  IL_000a:  call       "System.{{typeName}} System.{{typeName}}.Slice(int)"
+  IL_000f:  pop
+  IL_0010:  ret
+}
+""");
+        }
+
+        [Theory]
+        [InlineData("Span<char>")]
+        [InlineData("ReadOnlySpan<char>")]
+        public void SliceStart_15(string typeName)
+        {
+            // Span<T>/ReadOnlySpan<T> with [^GetStart()..]: SubtractFromLength strategy + start-only Slice optimization (struct receiver)
+            var src = $$"""
+using System;
+
+class Program
+{
+    static void Main()
+    {
+        {{typeName}} s = "0123".ToCharArray();
+        System.Console.Write(Test(ref s).ToString());
+    }
+
+    static {{typeName}} Test(ref {{typeName}} s) => s[^GetStart()..];
+
+    static int GetStart() { System.Console.Write("GetStart "); return 1; }
+}
+""";
+            var comp = CreateCompilation(src, options: TestOptions.ReleaseExe, targetFramework: TargetFramework.Net100);
+            var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetStart 3"), verify: Verification.Skipped);
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("Program.Test", $$"""
+{
+  // Code size       21 (0x15)
+  .maxstack  3
+  .locals init (int V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  call       "int Program.GetStart()"
+  IL_0006:  stloc.0
+  IL_0007:  dup
+  IL_0008:  call       "int System.{{typeName}}.Length.get"
+  IL_000d:  ldloc.0
+  IL_000e:  sub
+  IL_000f:  call       "System.{{typeName}} System.{{typeName}}.Slice(int)"
+  IL_0014:  ret
 }
 """);
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/IndexAndRangeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/IndexAndRangeTests.cs
@@ -4866,5 +4866,89 @@ static class C
 }
 """);
         }
+
+        [Fact]
+        public void SliceStart_11()
+        {
+            var src = """
+class Program
+{
+    public static string F;
+
+    static void Main()
+    {
+        F = "1";
+        Test();
+        System.Console.Write($"final:{F}");
+    }
+
+    static void Test()
+    {
+        _ = F[GetStart()..];
+    }
+
+    public static int GetStart() { System.Console.Write($"GetStart:{Program.F} "); Program.F = "2"; return 1; }
+}
+""";
+
+            var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+            var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetStart:1 final:2"), verify: Verification.Skipped)
+                 .VerifyDiagnostics();
+
+            verifier.VerifyIL("Program.Test", """
+{
+  // Code size       18 (0x12)
+  .maxstack  2
+  IL_0000:  nop
+  IL_0001:  ldsfld     "string Program.F"
+  IL_0006:  call       "int Program.GetStart()"
+  IL_000b:  callvirt   "string string.Substring(int)"
+  IL_0010:  pop
+  IL_0011:  ret
+}
+""");
+        }
+
+        [Fact]
+        public void SliceStart_12()
+        {
+            var src = """
+class Program
+{
+    public static string F;
+
+    static void Main()
+    {
+        F = "1";
+        Test(ref F);
+        System.Console.Write($"final:{F}");
+    }
+
+    static void Test(ref string f)
+    {
+        _ = f[GetStart()..];
+    }
+
+    public static int GetStart() { System.Console.Write($"GetStart:{Program.F} "); Program.F = "2"; return 1; }
+}
+""";
+
+            var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+            var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetStart:1 final:2"), verify: Verification.Skipped)
+                 .VerifyDiagnostics();
+
+            verifier.VerifyIL("Program.Test", """
+{
+  // Code size       18 (0x12)
+  .maxstack  2
+  IL_0000:  nop
+  IL_0001:  ldsfld     "string Program.F"
+  IL_0006:  call       "int Program.GetStart()"
+  IL_000b:  callvirt   "string string.Substring(int)"
+  IL_0010:  pop
+  IL_0011:  ret
+}
+""");
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 #nullable disable

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests2.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 #nullable disable
@@ -39473,5 +39473,1141 @@ namespace Outer
             // (4,1): error CS0012: The type 'Missing' is defined in an assembly that is not referenced. You must add a reference to assembly 'missing, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
             // o.M();
             Diagnostic(ErrorCode.ERR_NoTypeDef, "o.M").WithArguments("Missing", "missing, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(4, 1));
+    }
+
+    [Fact]
+    public void Invocation_LValueReceiver_01()
+    {
+        // struct lvalue receiver passed by value
+        var src = """
+static class E
+{
+    extension(S1 x)
+    {
+        public void M(int i) { System.Console.Write($"M:{x.F1} "); }
+    }
+
+    public static void M3(this S1 x, int i) { System.Console.Write($"M3:{x.F1} "); }
+}
+
+public struct S1
+{
+    public int F1;
+
+    public void M2(int i) { System.Console.Write($"M2:{F1} "); }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        F = new S1 { F1 = 3 };
+        Test2();
+        System.Console.Write($"final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        F = new S1 { F1 = 3 };
+        Test3();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        F.M(GetArg());
+    }
+
+    static void Test2()
+    {
+        F.M2(GetArg());
+    }
+
+    static void Test3()
+    {
+        F.M3(GetArg());
+    }
+
+    public static int GetArg() { System.Console.Write($"GetArg:{Program.F.F1} "); Program.F.F1++; return 42; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        var verifier = CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetArg:3 M:3 final:4, GetArg:3 M2:4 final:4, GetArg:3 M3:3 final:4"), verify: Verification.Skipped)
+            .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1", """
+{
+  // Code size       18 (0x12)
+  .maxstack  2
+  IL_0000:  nop
+  IL_0001:  ldsfld     "S1 Program.F"
+  IL_0006:  call       "int Program.GetArg()"
+  IL_000b:  call       "void E.M(S1, int)"
+  IL_0010:  nop
+  IL_0011:  ret
+}
+""");
+
+        verifier.VerifyIL("Program.Test2", """
+{
+  // Code size       18 (0x12)
+  .maxstack  2
+  IL_0000:  nop
+  IL_0001:  ldsflda    "S1 Program.F"
+  IL_0006:  call       "int Program.GetArg()"
+  IL_000b:  call       "void S1.M2(int)"
+  IL_0010:  nop
+  IL_0011:  ret
+}
+""");
+
+        verifier.VerifyIL("Program.Test3", """
+{
+  // Code size       18 (0x12)
+  .maxstack  2
+  IL_0000:  nop
+  IL_0001:  ldsfld     "S1 Program.F"
+  IL_0006:  call       "int Program.GetArg()"
+  IL_000b:  call       "void E.M3(S1, int)"
+  IL_0010:  nop
+  IL_0011:  ret
+}
+""");
+    }
+
+    [Theory]
+    [InlineData("ref")]
+    [InlineData("ref readonly")]
+    [InlineData("in")]
+    public void Invocation_LValueReceiver_02(string refKind)
+    {
+        // sibling of IndexerAccess_Get_LValueReceiver_02
+        // struct lvalue receiver passed by ref/in/ref readonly to extension method
+        var src = $$$"""
+static class E
+{
+    extension({{{refKind}}} S1 x)
+    {
+        public void M(int i) { System.Console.Write($"M:{x.F1}"); }
+    }
+
+    public static void M3(this {{{refKind}}} S1 x, int i) { System.Console.Write($"M3:{x.F1}"); }
+}
+
+struct S1
+{
+    public int F1;
+
+    public void M2(int i) { System.Console.Write($"M2:{F1}"); }
+
+    public void Test()
+    {
+        this.M(Program.GetArg());
+        System.Console.Write(", ");
+        this.M2(Program.GetArg());
+        System.Console.Write(", ");
+        this.M3(Program.GetArg());
+    }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test();
+        System.Console.Write($" final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        F = new S1 { F1 = 3 };
+        F.Test();
+        System.Console.Write($" final:{F.F1}");
+    }
+
+    static void Test()
+    {
+        F.M(GetArg());
+        System.Console.Write(", ");
+        F.M2(GetArg());
+        System.Console.Write(", ");
+        F.M3(GetArg());
+    }
+
+    public static int GetArg() { System.Console.Write($"GetArg:{Program.F.F1} "); Program.F.F1++; return 42; }
+}
+""";
+
+        var comp = CreateCompilation([src], options: TestOptions.DebugExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: "GetArg:3 M:4, GetArg:4 M2:5, GetArg:5 M3:6 final:6, GetArg:3 M:4, GetArg:4 M2:5, GetArg:5 M3:6 final:6")
+            .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test", $$"""
+{
+  // Code size       72 (0x48)
+  .maxstack  2
+  IL_0000:  nop
+  IL_0001:  ldsflda    "S1 Program.F"
+  IL_0006:  call       "int Program.GetArg()"
+  IL_000b:  call       "void E.M({{refKind}} S1, int)"
+  IL_0010:  nop
+  IL_0011:  ldstr      ", "
+  IL_0016:  call       "void System.Console.Write(string)"
+  IL_001b:  nop
+  IL_001c:  ldsflda    "S1 Program.F"
+  IL_0021:  call       "int Program.GetArg()"
+  IL_0026:  call       "void S1.M2(int)"
+  IL_002b:  nop
+  IL_002c:  ldstr      ", "
+  IL_0031:  call       "void System.Console.Write(string)"
+  IL_0036:  nop
+  IL_0037:  ldsflda    "S1 Program.F"
+  IL_003c:  call       "int Program.GetArg()"
+  IL_0041:  call       "void E.M3({{refKind}} S1, int)"
+  IL_0046:  nop
+  IL_0047:  ret
+}
+""");
+
+        verifier.VerifyIL("S1.Test", $$"""
+{
+  // Code size       60 (0x3c)
+  .maxstack  2
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  call       "int Program.GetArg()"
+  IL_0007:  call       "void E.M({{refKind}} S1, int)"
+  IL_000c:  nop
+  IL_000d:  ldstr      ", "
+  IL_0012:  call       "void System.Console.Write(string)"
+  IL_0017:  nop
+  IL_0018:  ldarg.0
+  IL_0019:  call       "int Program.GetArg()"
+  IL_001e:  call       "void S1.M2(int)"
+  IL_0023:  nop
+  IL_0024:  ldstr      ", "
+  IL_0029:  call       "void System.Console.Write(string)"
+  IL_002e:  nop
+  IL_002f:  ldarg.0
+  IL_0030:  call       "int Program.GetArg()"
+  IL_0035:  call       "void E.M3({{refKind}} S1, int)"
+  IL_003a:  nop
+  IL_003b:  ret
+}
+""");
+
+        var src2 = $$$"""
+static class E
+{
+    extension({{{refKind}}} S1 x)
+    {
+        public void M(int i) { }
+    }
+}
+
+struct S1;
+
+class Program
+{
+    static void Test()
+    {
+        default(S1).M(0);
+    }
+}
+""";
+
+        var comp2 = CreateCompilation([src2]);
+        if (refKind == "ref")
+        {
+            comp2.VerifyDiagnostics(
+                // (15,9): error CS1510: A ref or out value must be an assignable variable
+                //         default(S1).M(0);
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "default(S1)").WithLocation(15, 9));
+        }
+        else if (refKind == "ref readonly")
+        {
+            comp2.VerifyDiagnostics(
+                // (15,9): warning CS9193: Argument 0 should be a variable because it is passed to a 'ref readonly' parameter
+                //         default(S1).M(0);
+                Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "default(S1)").WithArguments("0").WithLocation(15, 9));
+        }
+        else
+        {
+            comp2.VerifyDiagnostics();
+        }
+    }
+
+    [Fact]
+    public void Invocation_LValueReceiver_03()
+    {
+        // sibling of IndexerAccess_Get_LValueReceiver_03
+        // class lvalue receiver
+        var src = """
+static class E
+{
+    extension(C1 x)
+    {
+        public void M(int i) { System.Console.Write($"M:{x.F1}"); }
+    }
+
+    public static void M3(this C1 x, int i) { System.Console.Write($"M3:{x.F1}"); }
+}
+
+class C1
+{
+    public int F1;
+}
+
+class Program
+{
+    public static C1 F;
+
+    static void Main()
+    {
+        F = new C1 { F1 = 3 };
+        Test();
+        System.Console.Write($" final:{F.F1}");
+    }
+
+    static void Test()
+    {
+        F.M(GetArg());
+        System.Console.Write(", ");
+        F.M3(GetArg());
+    }
+
+    static int GetArg()
+    {
+        System.Console.Write($"GetArg:{Program.F.F1} ");
+        Program.F = new C1 { F1 = Program.F.F1 + 1 };
+        return 42;
+    }
+}
+""";
+
+        var comp = CreateCompilation([src], options: TestOptions.DebugExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: "GetArg:3 M:3, GetArg:4 M3:4 final:5")
+            .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test", """
+{
+  // Code size       45 (0x2d)
+  .maxstack  2
+  IL_0000:  nop
+  IL_0001:  ldsfld     "C1 Program.F"
+  IL_0006:  call       "int Program.GetArg()"
+  IL_000b:  call       "void E.M(C1, int)"
+  IL_0010:  nop
+  IL_0011:  ldstr      ", "
+  IL_0016:  call       "void System.Console.Write(string)"
+  IL_001b:  nop
+  IL_001c:  ldsfld     "C1 Program.F"
+  IL_0021:  call       "int Program.GetArg()"
+  IL_0026:  call       "void E.M3(C1, int)"
+  IL_002b:  nop
+  IL_002c:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void Invocation_LValueReceiver_04()
+    {
+        // sibling of IndexerAccess_Get_LValueReceiver_04
+        // unconstrained generic extension receiver
+        var src = """
+using System.Threading.Tasks;
+
+static class E
+{
+    extension<T>(T x)
+    {
+        public void M(int i) { System.Console.Write($"M:{((S1)(object)x).F1}"); }
+    }
+
+    public static void M3<T>(this T x, int i) { System.Console.Write($"M3:{((S1)(object)x).F1}"); }
+}
+
+struct S1
+{
+    public int F1;
+}
+
+class Program<T>
+{
+    public static T F;
+}
+
+class Program
+{
+    static async Task Main()
+    {
+        Program<S1>.F = new S1 { F1 = 3 };
+        Test1(ref Program<S1>.F);
+        System.Console.Write($" final:{Program<S1>.F.F1}");
+
+        System.Console.Write(", ");
+
+        Program<S1>.F = new S1 { F1 = 3 };
+        Test2(ref Program<S1>.F);
+        System.Console.Write($" final:{Program<S1>.F.F1}");
+    }
+
+    static void Test1<T>(ref T f)
+    {
+        f.M(GetArg());
+        System.Console.Write(", ");
+        f.M3(GetArg());
+    }
+
+    static void Test2<T>(ref T f) where T : struct
+    {
+        f.M(GetArg());
+        System.Console.Write(", ");
+        f.M3(GetArg());
+    }
+
+    static int GetArg()
+    {
+        System.Console.Write($"GetArg:{Program<S1>.F.F1} ");
+        Program<S1>.F.F1++;
+        return 42;
+    }
+}
+""";
+
+        var comp = CreateCompilation([src], options: TestOptions.DebugExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: "GetArg:3 M:3, GetArg:4 M3:4 final:5, GetArg:3 M:3, GetArg:4 M3:4 final:5")
+            .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1<T>(ref T)", """
+{
+  // Code size       47 (0x2f)
+  .maxstack  2
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  ldobj      "T"
+  IL_0007:  call       "int Program.GetArg()"
+  IL_000c:  call       "void E.M<T>(T, int)"
+  IL_0011:  nop
+  IL_0012:  ldstr      ", "
+  IL_0017:  call       "void System.Console.Write(string)"
+  IL_001c:  nop
+  IL_001d:  ldarg.0
+  IL_001e:  ldobj      "T"
+  IL_0023:  call       "int Program.GetArg()"
+  IL_0028:  call       "void E.M3<T>(T, int)"
+  IL_002d:  nop
+  IL_002e:  ret
+}
+""");
+
+        verifier.VerifyIL("Program.Test2<T>(ref T)", """
+{
+  // Code size       47 (0x2f)
+  .maxstack  2
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  ldobj      "T"
+  IL_0007:  call       "int Program.GetArg()"
+  IL_000c:  call       "void E.M<T>(T, int)"
+  IL_0011:  nop
+  IL_0012:  ldstr      ", "
+  IL_0017:  call       "void System.Console.Write(string)"
+  IL_001c:  nop
+  IL_001d:  ldarg.0
+  IL_001e:  ldobj      "T"
+  IL_0023:  call       "int Program.GetArg()"
+  IL_0028:  call       "void E.M3<T>(T, int)"
+  IL_002d:  nop
+  IL_002e:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void Invocation_LValueReceiver_05()
+    {
+        // sibling of IndexerAccess_Get_LValueReceiver_05
+        // 'ref T' (struct) extension receiver
+        var src = """
+using System.Threading.Tasks;
+
+static class E
+{
+    extension<T>(ref T x) where T : struct
+    {
+        public void M(int i) { System.Console.Write($"M:{((S1)(object)x).F1}"); }
+    }
+
+    public static void M3<T>(this ref T x, int i) where T : struct { System.Console.Write($"M3:{((S1)(object)x).F1}"); }
+}
+
+struct S1
+{
+    public int F1;
+}
+
+class Program<T>
+{
+    public static T F;
+}
+
+class Program
+{
+    static async Task Main()
+    {
+        Program<S1>.F = new S1 { F1 = 3 };
+        Test2(ref Program<S1>.F);
+        System.Console.Write($" final:{Program<S1>.F.F1}");
+
+        System.Console.Write(", ");
+
+        Program<S1>.F = new S1 { F1 = 3 };
+        await Test3<S1>();
+        System.Console.Write($" final:{Program<S1>.F.F1}");
+    }
+
+    static void Test2<T>(ref T f) where T : struct
+    {
+        f.M(GetArg());
+        System.Console.Write(", ");
+        f.M3(GetArg());
+    }
+
+    static int GetArg()
+    {
+        System.Console.Write($"GetArg:{Program<S1>.F.F1} ");
+        Program<S1>.F.F1++;
+        return 42;
+    }
+
+    static async Task Test3<T>() where T : struct
+    {
+        Program<T>.F.M(await GetArgAsync());
+        System.Console.Write(", ");
+        Program<T>.F.M3(await GetArgAsync());
+    }
+
+    static async Task<int> GetArgAsync()
+    {
+        System.Console.Write($"GetArg:{Program<S1>.F.F1} ");
+        Program<S1>.F.F1++;
+        await Task.Yield();
+        return 42;
+    }
+}
+""";
+
+        var comp = CreateCompilation([src], options: TestOptions.DebugExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: "GetArg:3 M:4, GetArg:4 M3:5 final:5, GetArg:3 M:4, GetArg:4 M3:5 final:5")
+            .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test2<T>(ref T)", """
+{
+  // Code size       37 (0x25)
+  .maxstack  2
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  call       "int Program.GetArg()"
+  IL_0007:  call       "void E.M<T>(ref T, int)"
+  IL_000c:  nop
+  IL_000d:  ldstr      ", "
+  IL_0012:  call       "void System.Console.Write(string)"
+  IL_0017:  nop
+  IL_0018:  ldarg.0
+  IL_0019:  call       "int Program.GetArg()"
+  IL_001e:  call       "void E.M3<T>(ref T, int)"
+  IL_0023:  nop
+  IL_0024:  ret
+}
+""");
+
+        var src2 = """
+static class E
+{
+    extension<T>(ref T x) where T : struct
+    {
+        public void M(int i) { }
+    }
+}
+
+class Program
+{
+    static void Test<T>() where T : struct
+    {
+        default(T).M(0);
+    }
+}
+""";
+
+        var comp2 = CreateCompilation([src2]);
+        comp2.VerifyDiagnostics(
+            // (13,9): error CS1510: A ref or out value must be an assignable variable
+            //         default(T).M(0);
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "default(T)").WithLocation(13, 9));
+    }
+
+    [Fact]
+    public void Invocation_LValueReceiver_06()
+    {
+        // sibling of IndexerAccess_Get_LValueReceiver_06
+        // unconstrained generic extension receiver with class type at runtime.
+        var src = """
+using System.Threading.Tasks;
+
+static class E
+{
+    extension<T>(T x)
+    {
+        public void M(int i) { System.Console.Write($"M:{((C1)(object)x).F1}"); }
+    }
+
+    public static void M3<T>(this T x, int i) { System.Console.Write($"M3:{((C1)(object)x).F1}"); }
+}
+
+class C1
+{
+    public int F1;
+}
+
+class Program<T>
+{
+    public static T F;
+}
+
+class Program
+{
+    static async Task Main()
+    {
+        Program<C1>.F = new C1 { F1 = 3 };
+        Test1(ref Program<C1>.F);
+        System.Console.Write($" final:{Program<C1>.F.F1}");
+
+        System.Console.Write(", ");
+
+        Program<C1>.F = new C1 { F1 = 3 };
+        Test2(ref Program<C1>.F);
+        System.Console.Write($" final:{Program<C1>.F.F1}");
+    }
+
+    static void Test1<T>(ref T f)
+    {
+        f.M(GetArg());
+        System.Console.Write(", ");
+        f.M3(GetArg());
+    }
+
+    static void Test2<T>(ref T f) where T : class
+    {
+        f.M(GetArg());
+        System.Console.Write(", ");
+        f.M3(GetArg());
+    }
+
+    static int GetArg()
+    {
+        System.Console.Write($"GetArg:{Program<C1>.F.F1} ");
+        Program<C1>.F = new C1 { F1 = Program<C1>.F.F1 + 1 };
+        return 42;
+    }
+}
+""";
+
+        var comp = CreateCompilation([src], options: TestOptions.DebugExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: "GetArg:3 M:3, GetArg:4 M3:4 final:5, GetArg:3 M:3, GetArg:4 M3:4 final:5")
+            .VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1<T>(ref T)", """
+{
+  // Code size       47 (0x2f)
+  .maxstack  2
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  ldobj      "T"
+  IL_0007:  call       "int Program.GetArg()"
+  IL_000c:  call       "void E.M<T>(T, int)"
+  IL_0011:  nop
+  IL_0012:  ldstr      ", "
+  IL_0017:  call       "void System.Console.Write(string)"
+  IL_001c:  nop
+  IL_001d:  ldarg.0
+  IL_001e:  ldobj      "T"
+  IL_0023:  call       "int Program.GetArg()"
+  IL_0028:  call       "void E.M3<T>(T, int)"
+  IL_002d:  nop
+  IL_002e:  ret
+}
+""");
+
+        verifier.VerifyIL("Program.Test2<T>(ref T)", """
+{
+  // Code size       47 (0x2f)
+  .maxstack  2
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  ldobj      "T"
+  IL_0007:  call       "int Program.GetArg()"
+  IL_000c:  call       "void E.M<T>(T, int)"
+  IL_0011:  nop
+  IL_0012:  ldstr      ", "
+  IL_0017:  call       "void System.Console.Write(string)"
+  IL_001c:  nop
+  IL_001d:  ldarg.0
+  IL_001e:  ldobj      "T"
+  IL_0023:  call       "int Program.GetArg()"
+  IL_0028:  call       "void E.M3<T>(T, int)"
+  IL_002d:  nop
+  IL_002e:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void Invocation_RValueReceiver_01()
+    {
+        // sibling of IndexerAccess_Get_RValueReceiver_01
+        // struct rvalue receiver
+        var src = """
+static class E
+{
+    extension(S1 x)
+    {
+        public void M(int i) { System.Console.Write($"M:{x.F1} "); }
+    }
+}
+
+public struct S1
+{
+    public int F1;
+}
+
+class Program
+{
+    static void Main()
+    {
+        Test();
+    }
+
+    static void Test()
+    {
+        GetS1().M(GetArg());
+    }
+
+    static S1 GetS1() => new S1 { F1 = 3 };
+
+    public static int GetArg() => 42;
+}
+""";
+
+        var comp = CreateCompilation([src], options: TestOptions.DebugExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: "M:3").VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test", """
+{
+  // Code size       18 (0x12)
+  .maxstack  2
+  IL_0000:  nop
+  IL_0001:  call       "S1 Program.GetS1()"
+  IL_0006:  call       "int Program.GetArg()"
+  IL_000b:  call       "void E.M(S1, int)"
+  IL_0010:  nop
+  IL_0011:  ret
+}
+""");
+    }
+
+    [Theory]
+    [InlineData("ref")]
+    [InlineData("ref readonly")]
+    [InlineData("in")]
+    public void Invocation_RValueReceiver_02(string refKind)
+    {
+        // sibling of IndexerAccess_Get_RValueReceiver_02
+        // struct rvalue receiver with ref/in/ref readonly extension parameter
+        var src = $$$"""
+static class E
+{
+    extension({{{refKind}}} S1 x)
+    {
+        public void M(int i) { System.Console.Write($"M:{x.F1} "); }
+    }
+}
+
+struct S1
+{
+    public int F1;
+}
+
+class Program
+{
+    static void Main()
+    {
+        Test();
+    }
+
+    static void Test()
+    {
+        GetS1().M(GetArg());
+    }
+
+    static S1 GetS1() => new S1 { F1 = 3 };
+
+    public static int GetArg() => 42;
+}
+""";
+
+        var comp = CreateCompilation([src], options: TestOptions.DebugExe.WithAllowUnsafe(true));
+        if (refKind == "ref")
+        {
+            comp.VerifyEmitDiagnostics(
+                // (23,9): error CS1510: A ref or out value must be an assignable variable
+                //         GetS1().M(GetArg());
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetS1()").WithLocation(23, 9));
+            return;
+        }
+        else if (refKind == "ref readonly")
+        {
+            comp.VerifyEmitDiagnostics(
+                // (23,9): warning CS9193: Argument 0 should be a variable because it is passed to a 'ref readonly' parameter
+                //         GetS1().M(GetArg());
+                Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "GetS1()").WithArguments("0").WithLocation(23, 9));
+        }
+        else
+        {
+            comp.VerifyEmitDiagnostics();
+        }
+
+        var verifier = CompileAndVerify(comp, expectedOutput: "M:3");
+
+        verifier.VerifyIL("Program.Test", $$"""
+{
+  // Code size       21 (0x15)
+  .maxstack  2
+  .locals init (S1 V_0)
+  IL_0000:  nop
+  IL_0001:  call       "S1 Program.GetS1()"
+  IL_0006:  stloc.0
+  IL_0007:  ldloca.s   V_0
+  IL_0009:  call       "int Program.GetArg()"
+  IL_000e:  call       "void E.M({{refKind}} S1, int)"
+  IL_0013:  nop
+  IL_0014:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void Invocation_RValueReceiver_03()
+    {
+        // sibling of IndexerAccess_Get_RValueReceiver_03
+        // class rvalue receiver
+        var src = """
+static class E
+{
+    extension(C1 x)
+    {
+        public void M(int i) { System.Console.Write($"M:{x.F1} "); }
+    }
+}
+
+class C1
+{
+    public int F1;
+}
+
+class Program
+{
+    static void Main()
+    {
+        Test();
+    }
+
+    static void Test()
+    {
+        GetC1().M(GetArg());
+    }
+
+    static C1 GetC1() => new C1 { F1 = 3 };
+
+    static int GetArg() => 42;
+}
+""";
+
+        var comp = CreateCompilation([src], options: TestOptions.DebugExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: "M:3").VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test", """
+{
+  // Code size       18 (0x12)
+  .maxstack  2
+  IL_0000:  nop
+  IL_0001:  call       "C1 Program.GetC1()"
+  IL_0006:  call       "int Program.GetArg()"
+  IL_000b:  call       "void E.M(C1, int)"
+  IL_0010:  nop
+  IL_0011:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void Invocation_RValueReceiver_04()
+    {
+        // sibling of IndexerAccess_Get_RValueReceiver_04
+        // unconstrained generic extension receiver
+        var src = """
+using System.Threading.Tasks;
+
+static class E
+{
+    extension<T>(T x)
+    {
+        public void M(int i) { System.Console.Write($"M:{((S1)(object)x).F1} "); }
+    }
+}
+
+struct S1
+{
+    public int F1;
+}
+
+class Program
+{
+    static async Task Main()
+    {
+        Test1<S1>();
+
+        System.Console.Write(", ");
+
+        Test2<S1>();
+
+        System.Console.Write(", ");
+
+        await Test3<S1>();
+    }
+
+    static T GetT<T>() => (T)(object)new S1 { F1 = 3 };
+
+    static void Test1<T>()
+    {
+        GetT<T>().M(GetArg());
+    }
+
+    static void Test2<T>() where T : struct
+    {
+        GetT<T>().M(GetArg());
+    }
+
+    static int GetArg() => 42;
+
+    static async Task Test3<T>()
+    {
+        GetT<T>().M(await GetArgAsync());
+    }
+
+    static async Task<int> GetArgAsync()
+    {
+        await Task.Yield();
+        return 42;
+    }
+}
+""";
+
+        var comp = CreateCompilation([src], options: TestOptions.DebugExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: "M:3 , M:3 , M:3").VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1<T>()", """
+{
+  // Code size       18 (0x12)
+  .maxstack  2
+  IL_0000:  nop
+  IL_0001:  call       "T Program.GetT<T>()"
+  IL_0006:  call       "int Program.GetArg()"
+  IL_000b:  call       "void E.M<T>(T, int)"
+  IL_0010:  nop
+  IL_0011:  ret
+}
+""");
+
+        verifier.VerifyIL("Program.Test2<T>()", """
+{
+  // Code size       18 (0x12)
+  .maxstack  2
+  IL_0000:  nop
+  IL_0001:  call       "T Program.GetT<T>()"
+  IL_0006:  call       "int Program.GetArg()"
+  IL_000b:  call       "void E.M<T>(T, int)"
+  IL_0010:  nop
+  IL_0011:  ret
+}
+""");
+    }
+
+    [Fact]
+    public void Invocation_RValueReceiver_05()
+    {
+        // sibling of IndexerAccess_Get_RValueReceiver_05
+        // 'ref T' (struct) extension receiver
+        var src = """
+using System.Threading.Tasks;
+
+static class E
+{
+    extension<T>(ref T x) where T : struct
+    {
+        public void M(int i) { }
+    }
+}
+
+struct S1
+{
+    public int F1;
+}
+
+class Program
+{
+    static async Task Main()
+    {
+        Test2<S1>();
+
+        System.Console.Write(":");
+
+        await Test3<S1>();
+    }
+
+    static void Test2<T>() where T : struct
+    {
+        GetT<T>().M(GetArg());
+    }
+
+    static T GetT<T>() => (T)(object)new S1 { F1 = 3 };
+
+    static int GetArg() => 42;
+
+    static async Task Test3<T>() where T : struct
+    {
+        GetT<T>().M(await GetArgAsync());
+    }
+
+    static async Task<int> GetArgAsync()
+    {
+        await Task.Yield();
+        return 42;
+    }
+}
+""";
+
+        var comp = CreateCompilation([src], options: TestOptions.DebugExe);
+        comp.VerifyEmitDiagnostics(
+            // (29,9): error CS1510: A ref or out value must be an assignable variable
+            //         GetT<T>().M(GetArg());
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetT<T>()").WithLocation(29, 9),
+            // (38,9): error CS1510: A ref or out value must be an assignable variable
+            //         GetT<T>().M(await GetArgAsync());
+            Diagnostic(ErrorCode.ERR_RefLvalueExpected, "GetT<T>()").WithLocation(38, 9));
+    }
+
+    [Fact]
+    public void Invocation_RValueReceiver_06()
+    {
+        // sibling of IndexerAccess_Get_RValueReceiver_06
+        // unconstrained generic extension receiver with class type at runtime
+        var src = """
+using System.Threading.Tasks;
+
+static class E
+{
+    extension<T>(T x)
+    {
+        public void M(int i) { System.Console.Write($"M:{((C1)(object)x).F1} "); }
+    }
+}
+
+class C1
+{
+    public int F1;
+}
+
+class Program
+{
+    static async Task Main()
+    {
+        Test1<C1>();
+
+        System.Console.Write(", ");
+
+        Test2<C1>();
+
+        System.Console.Write(", ");
+
+        await Test3<C1>();
+    }
+
+    static T GetT<T>() => (T)(object)new C1 { F1 = 3 };
+
+    static void Test1<T>()
+    {
+        GetT<T>().M(GetArg());
+    }
+
+    static void Test2<T>() where T : class
+    {
+        GetT<T>().M(GetArg());
+    }
+
+    static int GetArg() => 42;
+
+    static async Task Test3<T>()
+    {
+        GetT<T>().M(await GetArgAsync());
+    }
+
+    static async Task<int> GetArgAsync()
+    {
+        await Task.Yield();
+        return 42;
+    }
+}
+""";
+
+        var comp = CreateCompilation([src], options: TestOptions.DebugExe);
+        var verifier = CompileAndVerify(comp, expectedOutput: "M:3 , M:3 , M:3").VerifyDiagnostics();
+
+        verifier.VerifyIL("Program.Test1<T>()", """
+{
+  // Code size       18 (0x12)
+  .maxstack  2
+  IL_0000:  nop
+  IL_0001:  call       "T Program.GetT<T>()"
+  IL_0006:  call       "int Program.GetArg()"
+  IL_000b:  call       "void E.M<T>(T, int)"
+  IL_0010:  nop
+  IL_0011:  ret
+}
+""");
+
+        verifier.VerifyIL("Program.Test2<T>()", """
+{
+  // Code size       18 (0x12)
+  .maxstack  2
+  IL_0000:  nop
+  IL_0001:  call       "T Program.GetT<T>()"
+  IL_0006:  call       "int Program.GetArg()"
+  IL_000b:  call       "void E.M<T>(T, int)"
+  IL_0010:  nop
+  IL_0011:  ret
+}
+""");
     }
 }


### PR DESCRIPTION
There were two problems:
1. we need to check whether the receiver is assignable, but the placeholder defaulted to be not assignable. This is illustrated by `ImplicitRangeIndexerAccess_Get_LValueReceiver_02_02` that produced `error CS1510: A ref or out value must be an assignable variable` before fix.
2. complex receivers are for unconstrained generic scenarios, where the reference type case needs special handling (we need to capture the original reference, before it could be mutated, so a plain `ref T` isn't sufficient) and that must be done at runtime (there's an IL pattern we use for that). We were introducing complex receivers at two levels (`GetUnderlyingIndexerOrSliceAccess` for the overall implicit indexer and then in `VisitIndexerAccess`/`MakeIndexerAccess` that it calls for the underlying `this[int]` indexer), but only need one. In some tests, this would crash (`UnreachableException`) in later phases that didn't recognize an expected node shape around complex receivers. `ImplicitIndexIndexerAccess_Get_RValueReceiver_04` illustrates this.

Relates to test plan https://github.com/dotnet/roslyn/issues/81505
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83227)