### PR TITLE
Fix property pattern completion filtering out member being edited

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
@@ -646,4 +646,90 @@ public sealed class PropertySubpatternCompletionProviderTests : AbstractCSharpCo
                 }
             }
             """, "MaxValue");
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/82606")]
+    public async Task EditingExistingSubpatternName_ShowsCurrentMember()
+    {
+        var markup =
+            """
+            class C
+            {
+                public int Prop { get; set; }
+                public int PropExtra { get; set; }
+
+                void M()
+                {
+                    _ = this is C { Prop$$: 1 };
+                }
+            }
+            """;
+        await VerifyItemExistsAsync(markup, "Prop", displayTextSuffix: "");
+        await VerifyItemExistsAsync(markup, "PropExtra", displayTextSuffix: "");
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/82606")]
+    public async Task EditingExistingSubpatternName_StillFiltersOtherTestedMembers()
+    {
+        var markup =
+            """
+            class Program
+            {
+                public int P1 { get; set; }
+                public int P2 { get; set; }
+                public int P2Other { get; set; }
+
+                void M()
+                {
+                    _ = this is Program { P1: 1, P2$$: 2 }
+                }
+            }
+            """;
+        await VerifyItemExistsAsync(markup, "P2", displayTextSuffix: "");
+        await VerifyItemExistsAsync(markup, "P2Other", displayTextSuffix: "");
+        await VerifyItemIsAbsentAsync(markup, "P1");
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/82606")]
+    public async Task EditingExistingSubpatternName_MiddleOfName()
+    {
+        var markup =
+            """
+            class C
+            {
+                public int Prop { get; set; }
+                public int PropExtra { get; set; }
+
+                void M()
+                {
+                    _ = this is C { Pr$$op: 1 };
+                }
+            }
+            """;
+        await VerifyItemExistsAsync(markup, "Prop", displayTextSuffix: "");
+        await VerifyItemExistsAsync(markup, "PropExtra", displayTextSuffix: "");
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/82606")]
+    public async Task EditingExistingSubpatternName_InSwitchStatement()
+    {
+        var markup =
+            """
+            class C
+            {
+                public int Prop { get; set; }
+                public int PropExtra { get; set; }
+
+                void M()
+                {
+                    switch (this)
+                    {
+                        case C { Prop$$: 1 }:
+                            break;
+                    }
+                }
+            }
+            """;
+        await VerifyItemExistsAsync(markup, "Prop", displayTextSuffix: "");
+        await VerifyItemExistsAsync(markup, "PropExtra", displayTextSuffix: "");
+    }
 }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/PropertySubPatternCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/PropertySubPatternCompletionProvider.cs
@@ -46,9 +46,10 @@ internal sealed class PropertySubpatternCompletionProvider : LSPCompletionProvid
         var tree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
 
         // For `is { Property.Property2.$$`, we get:
-        // - the property pattern clause `{ ... }` and
-        // - the member access before the last dot `Property.Property2` (or null)
-        var (propertyPatternClause, memberAccess) = TryGetPropertyPatternClause(tree, position, cancellationToken);
+        // - the property pattern clause `{ ... }`,
+        // - the member access before the last dot `Property.Property2` (or null), and
+        // - the subpattern currently being edited (or null) so it can be excluded from the "already tested members" filter
+        var (propertyPatternClause, memberAccess, editingSubpattern) = TryGetPropertyPatternClause(tree, position, cancellationToken);
         if (propertyPatternClause is null)
         {
             return;
@@ -72,9 +73,13 @@ internal sealed class PropertySubpatternCompletionProvider : LSPCompletionProvid
 
         if (memberAccess is null)
         {
-            // Filter out those members that have already been typed as simple (not extended) properties
-            var alreadyTestedMembers = new HashSet<string>(propertyPatternClause.Subpatterns.Select(
-                p => p.NameColon?.Name.Identifier.ValueText).Where(s => !string.IsNullOrEmpty(s))!);
+            // Filter out those members that have already been typed as simple (not extended) properties.
+            // If we're currently editing an existing subpattern name (cursor at `IsCompleted$$:` in `{ IsCompleted: true }`),
+            // exclude it so the member being edited still appears in the completion list.
+            var alreadyTestedMembers = new HashSet<string>(propertyPatternClause.Subpatterns
+                .Where(p => p != editingSubpattern)
+                .Select(p => p.NameColon?.Name.Identifier.ValueText)
+                .Where(s => !string.IsNullOrEmpty(s))!);
 
             members = members.WhereAsArray(m => !alreadyTestedMembers.Contains(m.Name));
         }
@@ -162,7 +167,7 @@ internal sealed class PropertySubpatternCompletionProvider : LSPCompletionProvid
 
     public override ImmutableHashSet<char> TriggerCharacters { get; } = CompletionUtilities.CommonTriggerCharacters.Add(' ');
 
-    private static (PropertyPatternClauseSyntax?, ExpressionSyntax?) TryGetPropertyPatternClause(SyntaxTree tree, int position, CancellationToken cancellationToken)
+    private static (PropertyPatternClauseSyntax?, ExpressionSyntax?, SubpatternSyntax? editingSubpattern) TryGetPropertyPatternClause(SyntaxTree tree, int position, CancellationToken cancellationToken)
     {
         if (tree.IsInNonUserCode(position, cancellationToken))
         {
@@ -170,12 +175,22 @@ internal sealed class PropertySubpatternCompletionProvider : LSPCompletionProvid
         }
 
         var token = tree.FindTokenOnLeftOfPosition(position, cancellationToken);
+        var tokenBeforeAdjustment = token;
         token = token.GetPreviousTokenIfTouchingWord(position);
+
+        // Check whether the original token was the name of a subpattern being edited
+        // (e.g., `{ IsCompleted$$: true }`). We need to know this so the caller can exclude it from
+        // the "already tested members" filter and keep showing the member in the completion list.
+        SubpatternSyntax? editingSubpattern = null;
+        if (tokenBeforeAdjustment.Parent is IdentifierNameSyntax { Parent: NameColonSyntax { Parent: SubpatternSyntax subpattern } })
+        {
+            editingSubpattern = subpattern;
+        }
 
         if (token.Kind() is SyntaxKind.CommaToken or SyntaxKind.OpenBraceToken)
         {
             return token.Parent is PropertyPatternClauseSyntax { Parent: PatternSyntax } propertyPatternClause
-                ? (propertyPatternClause, null)
+                ? (propertyPatternClause, null, editingSubpattern)
                 : default;
         }
 
@@ -184,7 +199,7 @@ internal sealed class PropertySubpatternCompletionProvider : LSPCompletionProvid
             // is { Property1.$$ }
             // is { Property1.$$  Property1.Property2: ... } // typing before an existing pattern
             return token.Parent is MemberAccessExpressionSyntax memberAccess && IsExtendedPropertyPattern(memberAccess, out var propertyPatternClause)
-                ? (propertyPatternClause, memberAccess.Expression)
+                ? (propertyPatternClause, memberAccess.Expression, editingSubpattern)
                 : default;
         }
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/82606


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83230)