### PR TITLE
Allow purging compiler cache

### DIFF
--- a/docs/compilers/Design/compiler-output-cache-experiment.md
+++ b/docs/compilers/Design/compiler-output-cache-experiment.md
@@ -92,6 +92,8 @@ The current layout is:
       refassembly
       xmldoc
       <dll name>.key
+      created
+      last-used
 ```
 
 Where:
@@ -101,6 +103,8 @@ Where:
 - `refassembly` is the emitted reference assembly, when one exists
 - `xmldoc` is the emitted XML documentation file, when one exists
 - `<dll name>.key` contains the full deterministic key text
+- `created` contains a round-trip UTC timestamp (`O` format) recording when the entry was first stored
+- `last-used` contains a round-trip UTC timestamp updated on every cache hit and on initial store
 
 Only outputs that actually exist for a successful compilation are stored. Optional outputs are omitted when the compilation did not produce them.
 
@@ -138,6 +142,77 @@ When `ROSLYN_CACHE_PATH` is used, the client also logs that it normalized the en
 
 On a miss, Roslyn may also log diffs against recent prior key files for the same output name. This is intended to help explain why two apparently similar builds did not reuse the same cached result.
 
+## Cache management
+
+The compiler server binary (`VBCSCompiler`) exposes commands for inspecting and cleaning up the on-disk cache. These are intended for local use and CI integration while the experiment is being evaluated.
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `-cachestats` | Show cache statistics for all entries. |
+| `-cachestats:<timestamp>` | Show cache statistics, classifying entries relative to the given UTC timestamp. |
+| `-cachestatsverbosity:<0\|1\|2>` | Control the detail level of `-cachestats` output. `0` (default) shows totals only, `1` groups by DLL name, `2` lists individual entries. |
+| `-purgecache` | Delete all cache entries. |
+| `-purgecache:<timestamp>` | Delete cache entries whose `last-used` time is older than the given UTC timestamp. |
+| `-cachepath:<path>` | Override the cache directory for `-cachestats` and `-purgecache` (defaults to the standard cache location). |
+
+Timestamps are parsed with `DateTimeOffset.TryParse` using `InvariantCulture` and round-trip kind, so ISO 8601 strings such as `2026-04-22T10:00:00Z` work.
+
+### How `-cachestats` classifies entries
+
+The optional timestamp on `-cachestats` is a boundary used to classify each cache entry into one of three buckets:
+
+- **Hit** — the entry existed *before* the timestamp and was *used on or after* it (a cache reuse).
+- **Store** — the entry was *created on or after* the timestamp (a cache miss that produced a new entry).
+- **Untouched** — the entry existed *before* the timestamp and was *not used after* it.
+
+When no timestamp is given, all entries are classified relative to the start of time (`DateTimeOffset.MinValue`), so every entry will appear as either a hit or a store.
+
+### Workflow: understanding cache efficiency over a period
+
+To see how effective the cache has been over the last 30 days:
+
+```shell
+VBCSCompiler -cachestats:2026-03-23T00:00:00Z
+```
+
+Example output:
+
+```text
+Cache: /tmp/roslyn-cache
+  Hits (reused):  450
+  Stores (new):    50
+  Untouched:      500
+```
+
+This tells you that 450 compilations were served from cache, 50 new entries were stored, and 500 older entries were not used during that period. The untouched count is exactly what a corresponding purge would delete.
+
+```shell
+# Purge entries not used since that date
+VBCSCompiler -purgecache:2026-03-23T00:00:00Z
+
+# To delete everything, omit the timestamp
+VBCSCompiler -purgecache
+```
+
+### Workflow: CI build summary
+
+In CI, record the build start time before invoking the build, then use it to get a summary of what the cache did during that specific build:
+
+```shell
+# Record the start time
+BUILD_START=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Run the build (with cache enabled)
+dotnet build -p:Features=use-global-cache
+
+# Show what the cache did during this build
+VBCSCompiler -cachestats:$BUILD_START
+```
+
+Because the timestamp is set to the moment before the build started, every entry created or used during the build is classified as a hit or store for that build. As long as no other builds run in parallel against the same cache, the result is effectively a per-build cache summary.
+
 ## Current limitations
 
 The experiment currently has several important limitations:
@@ -154,7 +229,7 @@ Areas still under evaluation include:
 
 - correctness of the deterministic key as a cache identity for all relevant build scenarios
 - whether the current treatment of `PathMap` and other deterministic inputs is sufficient for the scenarios where this experiment is expected to be useful
-- disk growth and cache cleanup policy
+- disk growth and whether the current manual purge commands should be supplemented with automatic cleanup
 - behavior across SDK, compiler, or machine-environment changes
 - whether the current request-level enablement mechanism should remain the right shape long term
 - what, if any, parts of the on-disk format should become durable

--- a/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
+++ b/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
@@ -11,7 +11,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Globalization;
 using Microsoft.CodeAnalysis.CommandLine;
-using System.Runtime.InteropServices;
 using System.Collections.Specialized;
 using Microsoft.CodeAnalysis.ErrorReporting;
 
@@ -32,14 +31,18 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             _logger = logger;
         }
 
-        internal int Run(string? pipeName, bool shutdown, TimeSpan? keepAlive)
+        internal int Run(string? pipeName, bool shutdown, DateTime? purgeCacheCutoff, bool cacheStats, bool cacheStatsVerbose, TimeSpan? keepAlive)
         {
             var cancellationTokenSource = new CancellationTokenSource();
             Console.CancelKeyPress += (sender, e) => { cancellationTokenSource.Cancel(); };
 
-            return shutdown
-                ? RunShutdown(pipeName, cancellationToken: cancellationTokenSource.Token)
-                : RunServer(pipeName, keepAlive: keepAlive, cancellationToken: cancellationTokenSource.Token);
+            if (shutdown)
+                return RunShutdown(pipeName, cancellationToken: cancellationTokenSource.Token);
+            if (purgeCacheCutoff is not null)
+                return RunPurgeCache(purgeCacheCutoff.Value);
+            if (cacheStats)
+                return RunCacheStats(cacheStatsVerbose);
+            return RunServer(pipeName, keepAlive: keepAlive, cancellationToken: cancellationTokenSource.Token);
         }
 
         internal static TimeSpan GetDefaultKeepAlive(ICompilerServerLogger logger, NameValueCollection? appSettings = null)
@@ -169,6 +172,41 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         }
 
         /// <summary>
+        /// Purges cache entries from the default cache directory.
+        /// Entries whose <c>last-used</c> timestamp is older than <paramref name="cutoff"/> are deleted.
+        /// </summary>
+        internal int RunPurgeCache(DateTime cutoff)
+        {
+            var cachePath = CompilationCache.GetDefaultCachePath();
+            if (cachePath is null)
+            {
+                Console.Error.WriteLine("Cannot determine cache path.");
+                return CommonCompiler.Failed;
+            }
+
+            var result = CompilationCache.PurgeEntries(cachePath, cutoff, _logger);
+            Console.WriteLine(result);
+            return CommonCompiler.Succeeded;
+        }
+
+        /// <summary>
+        /// Displays cache statistics from the default cache directory.
+        /// </summary>
+        internal int RunCacheStats(bool verbose)
+        {
+            var cachePath = CompilationCache.GetDefaultCachePath();
+            if (cachePath is null)
+            {
+                Console.Error.WriteLine("Cannot determine cache path.");
+                return CommonCompiler.Failed;
+            }
+
+            var stats = CompilationCache.GetCacheStats(cachePath);
+            Console.WriteLine(stats.FormatSummary(cachePath, verbose));
+            return CommonCompiler.Succeeded;
+        }
+
+        /// <summary>
         /// Parses the command-line arguments for the build server.
         /// </summary>
         /// <remarks>
@@ -178,12 +216,17 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         ///   <item><description><c>-timeout:&lt;seconds&gt;</c> — keep-alive in seconds; <c>0</c> means infinite (no timeout).</description></item>
         ///   <item><description><c>-log:&lt;path&gt;</c> — path to the log file.</description></item>
         ///   <item><description><c>-shutdown</c> — request the server to shut down.</description></item>
+        ///   <item><description><c>-purgecache</c> / <c>-purgecache:&lt;timestamp&gt;</c> — purge cache entries not used since the given UTC timestamp (or all entries if no timestamp is given).</description></item>
+        ///   <item><description><c>-cachestats</c> / <c>-cachestats:verbose</c> — display compilation cache statistics.</description></item>
         /// </list>
         /// </remarks>
-        internal static bool ParseCommandLine(string[] args, out string? pipeName, out bool shutdown, out TimeSpan? timeout, out string? logFilePath)
+        internal static bool ParseCommandLine(string[] args, out string? pipeName, out bool shutdown, out DateTime? purgeCacheCutoff, out bool cacheStats, out bool cacheStatsVerbose, out TimeSpan? timeout, out string? logFilePath)
         {
             pipeName = null;
             shutdown = false;
+            purgeCacheCutoff = null;
+            cacheStats = false;
+            cacheStatsVerbose = false;
             timeout = null;
             logFilePath = null;
 
@@ -221,6 +264,29 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 else if (arg == "-shutdown")
                 {
                     shutdown = true;
+                }
+                else if (arg == "-purgecache")
+                {
+                    purgeCacheCutoff = DateTime.UtcNow;
+                }
+                else if (argSpan.StartsWith("-purgecache:".AsSpan(), StringComparison.Ordinal))
+                {
+                    var value = argSpan["-purgecache:".Length..].ToString();
+                    if (!DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed))
+                    {
+                        return false;
+                    }
+
+                    purgeCacheCutoff = parsed.ToUniversalTime();
+                }
+                else if (arg == "-cachestats")
+                {
+                    cacheStats = true;
+                }
+                else if (arg == "-cachestats:verbose")
+                {
+                    cacheStats = true;
+                    cacheStatsVerbose = true;
                 }
                 else
                 {

--- a/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
+++ b/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
@@ -268,7 +268,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 }
                 else if (arg == "-purgecache")
                 {
-                    purgeCacheCutoff = DateTime.UtcNow;
+                    purgeCacheCutoff = DateTime.MaxValue;
                 }
                 else if (argSpan.StartsWith("-purgecache:".AsSpan(), StringComparison.Ordinal))
                 {

--- a/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
+++ b/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             _logger = logger;
         }
 
-        internal int Run(string? pipeName, bool shutdown, DateTime? purgeCacheCutoff, DateTime? cacheStatsSince, int cacheStatsVerbosity, TimeSpan? keepAlive)
+        internal int Run(string? pipeName, bool shutdown, DateTimeOffset? purgeCacheCutoff, DateTimeOffset? cacheStatsSince, int cacheStatsVerbosity, TimeSpan? keepAlive)
         {
             var cancellationTokenSource = new CancellationTokenSource();
             Console.CancelKeyPress += (sender, e) => { cancellationTokenSource.Cancel(); };
@@ -175,7 +175,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         /// Purges cache entries from the default cache directory.
         /// Entries whose <c>last-used</c> timestamp is older than <paramref name="cutoff"/> are deleted.
         /// </summary>
-        internal int RunPurgeCache(DateTime cutoff)
+        internal int RunPurgeCache(DateTimeOffset cutoff)
         {
             var cachePath = CompilationCache.GetDefaultCachePath();
             if (cachePath is null)
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         /// <summary>
         /// Displays cache statistics from the default cache directory.
         /// </summary>
-        internal int RunCacheStats(DateTime since, int verbosity)
+        internal int RunCacheStats(DateTimeOffset since, int verbosity)
         {
             var cachePath = CompilationCache.GetDefaultCachePath();
             if (cachePath is null)
@@ -221,7 +221,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         ///   <item><description><c>-cachestatsverbosity:&lt;0|1|2&gt;</c> — cache stats verbosity level (0 = totals, 1 = grouped by DLL, 2 = individual entries). Defaults to 0.</description></item>
         /// </list>
         /// </remarks>
-        internal static bool ParseCommandLine(string[] args, out string? pipeName, out bool shutdown, out DateTime? purgeCacheCutoff, out DateTime? cacheStatsSince, out int cacheStatsVerbosity, out TimeSpan? timeout, out string? logFilePath)
+        internal static bool ParseCommandLine(string[] args, out string? pipeName, out bool shutdown, out DateTimeOffset? purgeCacheCutoff, out DateTimeOffset? cacheStatsSince, out int cacheStatsVerbosity, out TimeSpan? timeout, out string? logFilePath)
         {
             pipeName = null;
             shutdown = false;
@@ -268,12 +268,12 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 }
                 else if (arg == "-purgecache")
                 {
-                    purgeCacheCutoff = DateTime.MaxValue;
+                    purgeCacheCutoff = DateTimeOffset.MaxValue;
                 }
                 else if (argSpan.StartsWith("-purgecache:".AsSpan(), StringComparison.Ordinal))
                 {
                     var value = argSpan["-purgecache:".Length..].ToString();
-                    if (!DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed))
+                    if (!DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed))
                     {
                         return false;
                     }
@@ -282,12 +282,12 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 }
                 else if (arg == "-cachestats")
                 {
-                    cacheStatsSince = DateTime.MinValue;
+                    cacheStatsSince = DateTimeOffset.MinValue;
                 }
                 else if (argSpan.StartsWith("-cachestats:".AsSpan(), StringComparison.Ordinal))
                 {
                     var value = argSpan["-cachestats:".Length..].ToString();
-                    if (!DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed))
+                    if (!DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed))
                     {
                         return false;
                     }

--- a/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
+++ b/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             _logger = logger;
         }
 
-        internal int Run(string? pipeName, bool shutdown, DateTimeOffset? purgeCacheCutoff, DateTimeOffset? cacheStatsSince, int cacheStatsVerbosity, TimeSpan? keepAlive)
+        internal int Run(string? pipeName, bool shutdown, DateTimeOffset? purgeCacheCutoff, DateTimeOffset? cacheStatsSince, int cacheStatsVerbosity, string? cachePath, TimeSpan? keepAlive)
         {
             var cancellationTokenSource = new CancellationTokenSource();
             Console.CancelKeyPress += (sender, e) => { cancellationTokenSource.Cancel(); };
@@ -39,9 +39,9 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             if (shutdown)
                 return RunShutdown(pipeName, cancellationToken: cancellationTokenSource.Token);
             if (purgeCacheCutoff is not null)
-                return RunPurgeCache(purgeCacheCutoff.Value);
+                return RunPurgeCache(purgeCacheCutoff.Value, cachePath);
             if (cacheStatsSince is not null)
-                return RunCacheStats(cacheStatsSince.Value, cacheStatsVerbosity);
+                return RunCacheStats(cacheStatsSince.Value, cacheStatsVerbosity, cachePath);
             return RunServer(pipeName, keepAlive: keepAlive, cancellationToken: cancellationTokenSource.Token);
         }
 
@@ -172,12 +172,12 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         }
 
         /// <summary>
-        /// Purges cache entries from the default cache directory.
+        /// Purges cache entries from the cache directory.
         /// Entries whose <c>last-used</c> timestamp is older than <paramref name="cutoff"/> are deleted.
         /// </summary>
-        internal int RunPurgeCache(DateTimeOffset cutoff)
+        internal int RunPurgeCache(DateTimeOffset cutoff, string? cachePath)
         {
-            var cachePath = CompilationCache.GetDefaultCachePath();
+            cachePath ??= CompilationCache.GetDefaultCachePath();
             if (cachePath is null)
             {
                 Console.Error.WriteLine("Cannot determine cache path.");
@@ -190,11 +190,11 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         }
 
         /// <summary>
-        /// Displays cache statistics from the default cache directory.
+        /// Displays cache statistics from the cache directory.
         /// </summary>
-        internal int RunCacheStats(DateTimeOffset since, int verbosity)
+        internal int RunCacheStats(DateTimeOffset since, int verbosity, string? cachePath)
         {
-            var cachePath = CompilationCache.GetDefaultCachePath();
+            cachePath ??= CompilationCache.GetDefaultCachePath();
             if (cachePath is null)
             {
                 Console.Error.WriteLine("Cannot determine cache path.");
@@ -219,15 +219,17 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         ///   <item><description><c>-purgecache</c> / <c>-purgecache:&lt;timestamp&gt;</c> — purge cache entries not used since the given UTC timestamp (or all entries if no timestamp is given).</description></item>
         ///   <item><description><c>-cachestats</c> / <c>-cachestats:&lt;timestamp&gt;</c> — display compilation cache statistics since the given UTC timestamp (or since the start of time if no timestamp is given).</description></item>
         ///   <item><description><c>-cachestatsverbosity:&lt;0|1|2&gt;</c> — cache stats verbosity level (0 = totals, 1 = grouped by DLL, 2 = individual entries). Defaults to 0.</description></item>
+        ///   <item><description><c>-cachepath:&lt;path&gt;</c> — override the cache directory for <c>-purgecache</c> and <c>-cachestats</c>.</description></item>
         /// </list>
         /// </remarks>
-        internal static bool ParseCommandLine(string[] args, out string? pipeName, out bool shutdown, out DateTimeOffset? purgeCacheCutoff, out DateTimeOffset? cacheStatsSince, out int cacheStatsVerbosity, out TimeSpan? timeout, out string? logFilePath)
+        internal static bool ParseCommandLine(string[] args, out string? pipeName, out bool shutdown, out DateTimeOffset? purgeCacheCutoff, out DateTimeOffset? cacheStatsSince, out int cacheStatsVerbosity, out string? cachePath, out TimeSpan? timeout, out string? logFilePath)
         {
             pipeName = null;
             shutdown = false;
             purgeCacheCutoff = null;
             cacheStatsSince = null;
             cacheStatsVerbosity = 0;
+            cachePath = null;
             timeout = null;
             logFilePath = null;
 
@@ -304,6 +306,16 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                     }
 
                     cacheStatsVerbosity = parsedVerbosity;
+                }
+                else if (argSpan.StartsWith("-cachepath:".AsSpan(), StringComparison.Ordinal))
+                {
+                    var value = argSpan["-cachepath:".Length..].ToString();
+                    if (value.Length == 0)
+                    {
+                        return false;
+                    }
+
+                    cachePath = value;
                 }
                 else
                 {

--- a/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
+++ b/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             _logger = logger;
         }
 
-        internal int Run(string? pipeName, bool shutdown, DateTime? purgeCacheCutoff, bool cacheStats, bool cacheStatsVerbose, TimeSpan? keepAlive)
+        internal int Run(string? pipeName, bool shutdown, DateTime? purgeCacheCutoff, DateTime? cacheStatsSince, int cacheStatsVerbosity, TimeSpan? keepAlive)
         {
             var cancellationTokenSource = new CancellationTokenSource();
             Console.CancelKeyPress += (sender, e) => { cancellationTokenSource.Cancel(); };
@@ -40,8 +40,8 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 return RunShutdown(pipeName, cancellationToken: cancellationTokenSource.Token);
             if (purgeCacheCutoff is not null)
                 return RunPurgeCache(purgeCacheCutoff.Value);
-            if (cacheStats)
-                return RunCacheStats(cacheStatsVerbose);
+            if (cacheStatsSince is not null)
+                return RunCacheStats(cacheStatsSince.Value, cacheStatsVerbosity);
             return RunServer(pipeName, keepAlive: keepAlive, cancellationToken: cancellationTokenSource.Token);
         }
 
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         /// <summary>
         /// Displays cache statistics from the default cache directory.
         /// </summary>
-        internal int RunCacheStats(bool verbose)
+        internal int RunCacheStats(DateTime since, int verbosity)
         {
             var cachePath = CompilationCache.GetDefaultCachePath();
             if (cachePath is null)
@@ -201,8 +201,8 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 return CommonCompiler.Failed;
             }
 
-            var stats = CompilationCache.GetCacheStats(cachePath);
-            Console.WriteLine(stats.FormatSummary(cachePath, verbose));
+            var stats = CompilationCache.GetCacheStats(cachePath, since);
+            Console.WriteLine(stats.FormatSummary(cachePath, verbosity));
             return CommonCompiler.Succeeded;
         }
 
@@ -217,16 +217,17 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         ///   <item><description><c>-log:&lt;path&gt;</c> — path to the log file.</description></item>
         ///   <item><description><c>-shutdown</c> — request the server to shut down.</description></item>
         ///   <item><description><c>-purgecache</c> / <c>-purgecache:&lt;timestamp&gt;</c> — purge cache entries not used since the given UTC timestamp (or all entries if no timestamp is given).</description></item>
-        ///   <item><description><c>-cachestats</c> / <c>-cachestats:verbose</c> — display compilation cache statistics.</description></item>
+        ///   <item><description><c>-cachestats</c> / <c>-cachestats:&lt;timestamp&gt;</c> — display compilation cache statistics since the given UTC timestamp (or since the start of time if no timestamp is given).</description></item>
+        ///   <item><description><c>-verbosity:&lt;0|1|2&gt;</c> — cache stats verbosity level (0 = totals, 1 = grouped by DLL, 2 = individual entries). Defaults to 0.</description></item>
         /// </list>
         /// </remarks>
-        internal static bool ParseCommandLine(string[] args, out string? pipeName, out bool shutdown, out DateTime? purgeCacheCutoff, out bool cacheStats, out bool cacheStatsVerbose, out TimeSpan? timeout, out string? logFilePath)
+        internal static bool ParseCommandLine(string[] args, out string? pipeName, out bool shutdown, out DateTime? purgeCacheCutoff, out DateTime? cacheStatsSince, out int cacheStatsVerbosity, out TimeSpan? timeout, out string? logFilePath)
         {
             pipeName = null;
             shutdown = false;
             purgeCacheCutoff = null;
-            cacheStats = false;
-            cacheStatsVerbose = false;
+            cacheStatsSince = null;
+            cacheStatsVerbosity = 0;
             timeout = null;
             logFilePath = null;
 
@@ -281,12 +282,28 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 }
                 else if (arg == "-cachestats")
                 {
-                    cacheStats = true;
+                    cacheStatsSince = DateTime.MinValue;
                 }
-                else if (arg == "-cachestats:verbose")
+                else if (argSpan.StartsWith("-cachestats:".AsSpan(), StringComparison.Ordinal))
                 {
-                    cacheStats = true;
-                    cacheStatsVerbose = true;
+                    var value = argSpan["-cachestats:".Length..].ToString();
+                    if (!DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed))
+                    {
+                        return false;
+                    }
+
+                    cacheStatsSince = parsed.ToUniversalTime();
+                }
+                else if (argSpan.StartsWith("-verbosity:".AsSpan(), StringComparison.Ordinal))
+                {
+                    var value = argSpan["-verbosity:".Length..].ToString();
+                    if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedVerbosity) ||
+                        parsedVerbosity < 0 || parsedVerbosity > 2)
+                    {
+                        return false;
+                    }
+
+                    cacheStatsVerbosity = parsedVerbosity;
                 }
                 else
                 {

--- a/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
+++ b/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
@@ -31,18 +31,18 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             _logger = logger;
         }
 
-        internal int Run(string? pipeName, bool shutdown, DateTimeOffset? purgeCacheCutoff, DateTimeOffset? cacheStatsSince, int cacheStatsVerbosity, string? cachePath, TimeSpan? keepAlive)
+        internal int Run(BuildServerCommandLineOptions options)
         {
             var cancellationTokenSource = new CancellationTokenSource();
             Console.CancelKeyPress += (sender, e) => { cancellationTokenSource.Cancel(); };
 
-            if (shutdown)
-                return RunShutdown(pipeName, cancellationToken: cancellationTokenSource.Token);
-            if (purgeCacheCutoff is not null)
-                return RunPurgeCache(purgeCacheCutoff.Value, cachePath);
-            if (cacheStatsSince is not null)
-                return RunCacheStats(cacheStatsSince.Value, cacheStatsVerbosity, cachePath);
-            return RunServer(pipeName, keepAlive: keepAlive, cancellationToken: cancellationTokenSource.Token);
+            if (options.Shutdown)
+                return RunShutdown(options.PipeName, cancellationToken: cancellationTokenSource.Token);
+            if (options.PurgeCacheCutoff is not null)
+                return RunPurgeCache(options.PurgeCacheCutoff.Value, options.CachePath);
+            if (options.CacheStatsSince is not null)
+                return RunCacheStats(options.CacheStatsSince.Value, options.CacheStatsVerbosity, options.CachePath);
+            return RunServer(options.PipeName, keepAlive: options.KeepAlive, cancellationToken: cancellationTokenSource.Token);
         }
 
         internal static TimeSpan GetDefaultKeepAlive(ICompilerServerLogger logger, NameValueCollection? appSettings = null)
@@ -222,16 +222,10 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         ///   <item><description><c>-cachepath:&lt;path&gt;</c> — override the cache directory for <c>-purgecache</c> and <c>-cachestats</c>.</description></item>
         /// </list>
         /// </remarks>
-        internal static bool ParseCommandLine(string[] args, out string? pipeName, out bool shutdown, out DateTimeOffset? purgeCacheCutoff, out DateTimeOffset? cacheStatsSince, out int cacheStatsVerbosity, out string? cachePath, out TimeSpan? timeout, out string? logFilePath)
+        internal static bool ParseCommandLine(string[] args, out BuildServerCommandLineOptions options)
         {
-            pipeName = null;
-            shutdown = false;
-            purgeCacheCutoff = null;
-            cacheStatsSince = null;
-            cacheStatsVerbosity = 0;
-            cachePath = null;
-            timeout = null;
-            logFilePath = null;
+            options = new BuildServerCommandLineOptions();
+            var hasOperation = false;
 
             foreach (var arg in args)
             {
@@ -248,7 +242,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 var argSpan = arg.AsSpan();
                 if (argSpan.StartsWith(pipeArgPrefix.AsSpan(), StringComparison.Ordinal))
                 {
-                    pipeName = argSpan[pipeArgPrefix.Length..].ToString();
+                    options.PipeName = argSpan[pipeArgPrefix.Length..].ToString();
                 }
                 else if (argSpan.StartsWith(timeoutArgPrefix.AsSpan(), StringComparison.Ordinal))
                 {
@@ -259,7 +253,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                         return false;
                     }
 
-                    timeout = parsedTimeout == 0 ? Timeout.InfiniteTimeSpan : TimeSpan.FromSeconds(parsedTimeout);
+                    options.KeepAlive = parsedTimeout == 0 ? Timeout.InfiniteTimeSpan : TimeSpan.FromSeconds(parsedTimeout);
                 }
                 else if (argSpan.StartsWith(logArgPrefix.AsSpan(), StringComparison.Ordinal))
                 {
@@ -269,39 +263,69 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                         return false;
                     }
 
-                    logFilePath = parsedLogFilePath.ToString();
+                    options.LogFilePath = parsedLogFilePath.ToString();
                 }
                 else if (arg == shutdownArg)
                 {
-                    shutdown = true;
+                    if (hasOperation)
+                    {
+                        return false;
+                    }
+
+                    hasOperation = true;
+                    options.Shutdown = true;
                 }
                 else if (arg == purgeCacheArg)
                 {
-                    purgeCacheCutoff = DateTimeOffset.MaxValue;
+                    if (hasOperation)
+                    {
+                        return false;
+                    }
+
+                    hasOperation = true;
+                    options.PurgeCacheCutoff = DateTimeOffset.MaxValue;
                 }
                 else if (argSpan.StartsWith(purgeCacheArgPrefix.AsSpan(), StringComparison.Ordinal))
                 {
+                    if (hasOperation)
+                    {
+                        return false;
+                    }
+
                     var value = argSpan[purgeCacheArgPrefix.Length..].ToString();
                     if (!DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed))
                     {
                         return false;
                     }
 
-                    purgeCacheCutoff = parsed.ToUniversalTime();
+                    hasOperation = true;
+                    options.PurgeCacheCutoff = parsed.ToUniversalTime();
                 }
                 else if (arg == cacheStatsArg)
                 {
-                    cacheStatsSince = DateTimeOffset.MinValue;
+                    if (hasOperation)
+                    {
+                        return false;
+                    }
+
+                    hasOperation = true;
+                    options.CacheStatsSince = DateTimeOffset.MinValue;
                 }
                 else if (argSpan.StartsWith(cacheStatsArgPrefix.AsSpan(), StringComparison.Ordinal))
                 {
+                    if (hasOperation)
+                    {
+                        return false;
+                    }
+
                     var value = argSpan[cacheStatsArgPrefix.Length..].ToString();
                     if (!DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed))
                     {
                         return false;
                     }
 
-                    cacheStatsSince = parsed.ToUniversalTime();
+                    hasOperation = true;
+                    options.CacheStatsSince = parsed.ToUniversalTime();
                 }
                 else if (argSpan.StartsWith(cacheStatsVerbosityArgPrefix.AsSpan(), StringComparison.Ordinal))
                 {
@@ -312,7 +336,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                         return false;
                     }
 
-                    cacheStatsVerbosity = parsedVerbosity;
+                    options.CacheStatsVerbosity = parsedVerbosity;
                 }
                 else if (argSpan.StartsWith(cachePathArgPrefix.AsSpan(), StringComparison.Ordinal))
                 {
@@ -322,7 +346,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                         return false;
                     }
 
-                    cachePath = value;
+                    options.CachePath = value;
                 }
                 else
                 {
@@ -332,5 +356,17 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
             return true;
         }
+    }
+
+    internal sealed class BuildServerCommandLineOptions
+    {
+        internal string? PipeName { get; set; }
+        internal bool Shutdown { get; set; }
+        internal DateTimeOffset? PurgeCacheCutoff { get; set; }
+        internal DateTimeOffset? CacheStatsSince { get; set; }
+        internal int CacheStatsVerbosity { get; set; }
+        internal string? CachePath { get; set; }
+        internal TimeSpan? KeepAlive { get; set; }
+        internal string? LogFilePath { get; set; }
     }
 }

--- a/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
+++ b/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
@@ -238,6 +238,13 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 const string pipeArgPrefix = "-pipename:";
                 const string timeoutArgPrefix = "-timeout:";
                 const string logArgPrefix = "-log:";
+                const string shutdownArg = "-shutdown";
+                const string purgeCacheArg = "-purgecache";
+                const string purgeCacheArgPrefix = purgeCacheArg + ":";
+                const string cacheStatsArg = "-cachestats";
+                const string cacheStatsArgPrefix = cacheStatsArg + ":";
+                const string cacheStatsVerbosityArgPrefix = "-cachestatsverbosity:";
+                const string cachePathArgPrefix = "-cachepath:";
                 var argSpan = arg.AsSpan();
                 if (argSpan.StartsWith(pipeArgPrefix.AsSpan(), StringComparison.Ordinal))
                 {
@@ -264,17 +271,17 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
                     logFilePath = parsedLogFilePath.ToString();
                 }
-                else if (arg == "-shutdown")
+                else if (arg == shutdownArg)
                 {
                     shutdown = true;
                 }
-                else if (arg == "-purgecache")
+                else if (arg == purgeCacheArg)
                 {
                     purgeCacheCutoff = DateTimeOffset.MaxValue;
                 }
-                else if (argSpan.StartsWith("-purgecache:".AsSpan(), StringComparison.Ordinal))
+                else if (argSpan.StartsWith(purgeCacheArgPrefix.AsSpan(), StringComparison.Ordinal))
                 {
-                    var value = argSpan["-purgecache:".Length..].ToString();
+                    var value = argSpan[purgeCacheArgPrefix.Length..].ToString();
                     if (!DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed))
                     {
                         return false;
@@ -282,13 +289,13 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
                     purgeCacheCutoff = parsed.ToUniversalTime();
                 }
-                else if (arg == "-cachestats")
+                else if (arg == cacheStatsArg)
                 {
                     cacheStatsSince = DateTimeOffset.MinValue;
                 }
-                else if (argSpan.StartsWith("-cachestats:".AsSpan(), StringComparison.Ordinal))
+                else if (argSpan.StartsWith(cacheStatsArgPrefix.AsSpan(), StringComparison.Ordinal))
                 {
-                    var value = argSpan["-cachestats:".Length..].ToString();
+                    var value = argSpan[cacheStatsArgPrefix.Length..].ToString();
                     if (!DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed))
                     {
                         return false;
@@ -296,9 +303,9 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
                     cacheStatsSince = parsed.ToUniversalTime();
                 }
-                else if (argSpan.StartsWith("-cachestatsverbosity:".AsSpan(), StringComparison.Ordinal))
+                else if (argSpan.StartsWith(cacheStatsVerbosityArgPrefix.AsSpan(), StringComparison.Ordinal))
                 {
-                    var value = argSpan["-cachestatsverbosity:".Length..].ToString();
+                    var value = argSpan[cacheStatsVerbosityArgPrefix.Length..].ToString();
                     if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedVerbosity) ||
                         parsedVerbosity < 0 || parsedVerbosity > 2)
                     {
@@ -307,9 +314,9 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
                     cacheStatsVerbosity = parsedVerbosity;
                 }
-                else if (argSpan.StartsWith("-cachepath:".AsSpan(), StringComparison.Ordinal))
+                else if (argSpan.StartsWith(cachePathArgPrefix.AsSpan(), StringComparison.Ordinal))
                 {
-                    var value = argSpan["-cachepath:".Length..].ToString();
+                    var value = argSpan[cachePathArgPrefix.Length..].ToString();
                     if (value.Length == 0)
                     {
                         return false;

--- a/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
+++ b/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
@@ -201,7 +201,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 return CommonCompiler.Failed;
             }
 
-            var stats = CompilationCache.GetCacheStats(cachePath, since);
+            var stats = CompilationCache.GetCacheStats(cachePath, since, _logger);
             Console.WriteLine(stats.FormatSummary(cachePath, verbosity));
             return CommonCompiler.Succeeded;
         }
@@ -218,7 +218,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         ///   <item><description><c>-shutdown</c> — request the server to shut down.</description></item>
         ///   <item><description><c>-purgecache</c> / <c>-purgecache:&lt;timestamp&gt;</c> — purge cache entries not used since the given UTC timestamp (or all entries if no timestamp is given).</description></item>
         ///   <item><description><c>-cachestats</c> / <c>-cachestats:&lt;timestamp&gt;</c> — display compilation cache statistics since the given UTC timestamp (or since the start of time if no timestamp is given).</description></item>
-        ///   <item><description><c>-verbosity:&lt;0|1|2&gt;</c> — cache stats verbosity level (0 = totals, 1 = grouped by DLL, 2 = individual entries). Defaults to 0.</description></item>
+        ///   <item><description><c>-cachestatsverbosity:&lt;0|1|2&gt;</c> — cache stats verbosity level (0 = totals, 1 = grouped by DLL, 2 = individual entries). Defaults to 0.</description></item>
         /// </list>
         /// </remarks>
         internal static bool ParseCommandLine(string[] args, out string? pipeName, out bool shutdown, out DateTime? purgeCacheCutoff, out DateTime? cacheStatsSince, out int cacheStatsVerbosity, out TimeSpan? timeout, out string? logFilePath)
@@ -294,9 +294,9 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
                     cacheStatsSince = parsed.ToUniversalTime();
                 }
-                else if (argSpan.StartsWith("-verbosity:".AsSpan(), StringComparison.Ordinal))
+                else if (argSpan.StartsWith("-cachestatsverbosity:".AsSpan(), StringComparison.Ordinal))
                 {
-                    var value = argSpan["-verbosity:".Length..].ToString();
+                    var value = argSpan["-cachestatsverbosity:".Length..].ToString();
                     if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedVerbosity) ||
                         parsedVerbosity < 0 || parsedVerbosity > 2)
                     {

--- a/src/Compilers/Server/VBCSCompiler/CompilationCache.cs
+++ b/src/Compilers/Server/VBCSCompiler/CompilationCache.cs
@@ -587,9 +587,13 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         }
 
         /// <summary>
-        /// Computes cache statistics for all entries under <paramref name="cachePath"/>.
+        /// Computes cache hit/miss statistics for entries under <paramref name="cachePath"/>
+        /// since the given <paramref name="since"/> cutoff.
+        /// An entry is a <b>hit</b> if it was created before <paramref name="since"/>
+        /// and used (last-used &gt;= since).  It is a <b>store</b> (miss) if created
+        /// after <paramref name="since"/>.  Otherwise it is <b>untouched</b>.
         /// </summary>
-        internal static CacheStats GetCacheStats(string cachePath)
+        internal static CacheStats GetCacheStats(string cachePath, DateTime since)
         {
             var stats = new CacheStats();
             if (!Directory.Exists(cachePath))
@@ -613,8 +617,21 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
                         var created = GetCreatedTimeUtc(entryDir);
                         var lastUsed = GetLastUsedTimeUtc(entryDir);
-                        stats.TotalEntries++;
-                        stats.Details.Add((dllName, dirName, created, lastUsed));
+
+                        if (created >= since)
+                        {
+                            stats.Stores++;
+                            stats.StoreDetails.Add((dllName, dirName, created, lastUsed));
+                        }
+                        else if (lastUsed >= since)
+                        {
+                            stats.Hits++;
+                            stats.HitDetails.Add((dllName, dirName, created, lastUsed));
+                        }
+                        else
+                        {
+                            stats.Untouched++;
+                        }
                     }
                 }
             }
@@ -628,39 +645,60 @@ namespace Microsoft.CodeAnalysis.CompilerServer
     }
 
     /// <summary>
-    /// Aggregated cache statistics for a single cache root.
+    /// Aggregated cache hit/miss statistics for a single cache root.
     /// </summary>
     internal sealed class CacheStats
     {
-        public int TotalEntries { get; set; }
-        public List<(string DllName, string HashKey, DateTime Created, DateTime LastUsed)> Details { get; } = new();
+        public int Hits { get; set; }
+        public int Stores { get; set; }
+        public int Untouched { get; set; }
+        public List<(string DllName, string HashKey, DateTime Created, DateTime LastUsed)> HitDetails { get; } = new();
+        public List<(string DllName, string HashKey, DateTime Created, DateTime LastUsed)> StoreDetails { get; } = new();
 
-        public string FormatSummary(string cachePath, bool verbose)
+        /// <summary>
+        /// Formats a human-readable summary of the statistics.
+        /// <paramref name="verbosity"/>: 0 = totals only, 1 = grouped by DLL, 2 = individual entries.
+        /// </summary>
+        public string FormatSummary(string cachePath, int verbosity)
         {
             var sb = new StringBuilder();
             sb.AppendLine($"Cache: {cachePath}");
-            sb.AppendLine($"  Total entries: {TotalEntries}");
+            sb.AppendLine($"  Hits (reused):  {Hits}");
+            sb.AppendLine($"  Stores (new):   {Stores}");
+            sb.AppendLine($"  Untouched:      {Untouched}");
 
-            if (TotalEntries > 0)
+            if (verbosity >= 1)
             {
-                var byDll = Details
-                    .GroupBy(d => d.DllName, StringComparer.OrdinalIgnoreCase)
-                    .OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase);
-
-                foreach (var group in byDll)
-                {
-                    sb.AppendLine($"  {group.Key}: {group.Count()} entries");
-                    if (verbose)
-                    {
-                        foreach (var (_, hashKey, created, lastUsed) in group)
-                        {
-                            sb.AppendLine($"    {hashKey} (created: {created:u}, last used: {lastUsed:u})");
-                        }
-                    }
-                }
+                FormatGrouped(sb, "Hit", HitDetails, verbosity);
+                FormatGrouped(sb, "Store", StoreDetails, verbosity);
             }
 
             return sb.ToString().TrimEnd();
+        }
+
+        private static void FormatGrouped(StringBuilder sb, string label, List<(string DllName, string HashKey, DateTime Created, DateTime LastUsed)> details, int verbosity)
+        {
+            if (details.Count == 0)
+            {
+                return;
+            }
+
+            var byDll = details
+                .GroupBy(d => d.DllName, StringComparer.OrdinalIgnoreCase)
+                .OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase);
+
+            sb.AppendLine($"  {label} details:");
+            foreach (var group in byDll)
+            {
+                sb.AppendLine($"    {group.Key} ({group.Count()})");
+                if (verbosity >= 2)
+                {
+                    foreach (var (_, hashKey, created, lastUsed) in group)
+                    {
+                        sb.AppendLine($"      {hashKey} (created: {created:u}, last used: {lastUsed:u})");
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Compilers/Server/VBCSCompiler/CompilationCache.cs
+++ b/src/Compilers/Server/VBCSCompiler/CompilationCache.cs
@@ -177,7 +177,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 }
 
                 logger.Log($"Cache hit: {dllName} [{hashKey}]");
-                TouchLastUsed(entryDir);
+                TouchLastUsed(entryDir, logger);
                 File.Copy(cachedAssemblyPath, outputFiles.AssemblyPath, overwrite: true);
                 copyIfNeeded(entryDir, PdbFileName, outputFiles.PdbPath);
                 copyIfNeeded(entryDir, RefAssemblyFileName, outputFiles.RefAssemblyPath);
@@ -324,7 +324,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 Directory.Move(stagingDir, cacheDir);
                 stagingDir = null;
 
-                TouchLastUsed(cacheDir);
+                TouchLastUsed(cacheDir, logger);
                 logger.Log($"Cache stored: {dllName} [{hashKey}]");
             }
             catch (Exception ex)
@@ -440,16 +440,17 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         /// the file so that it survives copies/uploads that do not preserve file-system
         /// metadata.  Errors are silently ignored — this is best-effort bookkeeping.
         /// </summary>
-        private static void TouchLastUsed(string entryDir)
+        private static void TouchLastUsed(string entryDir, ICompilerServerLogger logger)
         {
             try
             {
                 var path = Path.Combine(entryDir, LastUsedFileName);
                 File.WriteAllText(path, DateTime.UtcNow.ToString("O"));
             }
-            catch
+            catch (Exception ex)
             {
                 // Best effort — don't fail a compilation because of bookkeeping.
+                logger.LogException(ex, $"Failed to update last-used for {entryDir}");
             }
         }
 
@@ -486,7 +487,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                             continue;
                         }
 
-                        var lastUsed = GetLastUsedTimeUtc(entryDir);
+                        var lastUsed = GetLastUsedTimeUtc(entryDir, logger);
                         if (lastUsed >= cutoff)
                         {
                             totalKept++;
@@ -537,7 +538,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         /// timestamp stored inside the <c>last-used</c> file.  Falls back to the
         /// directory creation time when the file is missing or unreadable.
         /// </summary>
-        internal static DateTime GetLastUsedTimeUtc(string entryDir)
+        internal static DateTime GetLastUsedTimeUtc(string entryDir, ICompilerServerLogger logger)
         {
             var lastUsedPath = Path.Combine(entryDir, LastUsedFileName);
             try
@@ -551,9 +552,10 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                     }
                 }
             }
-            catch
+            catch (Exception ex)
             {
                 // Fall through to directory time.
+                logger.Log($"Failed to read last-used for {entryDir}: {ex.Message}");
             }
 
             return Directory.GetCreationTimeUtc(entryDir);
@@ -564,7 +566,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         /// <c>created</c> file.  Falls back to the directory creation time when the
         /// file is missing or unreadable.
         /// </summary>
-        internal static DateTime GetCreatedTimeUtc(string entryDir)
+        internal static DateTime GetCreatedTimeUtc(string entryDir, ICompilerServerLogger logger)
         {
             var createdPath = Path.Combine(entryDir, CreatedFileName);
             try
@@ -578,9 +580,10 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                     }
                 }
             }
-            catch
+            catch (Exception ex)
             {
                 // Fall through to directory time.
+                logger.Log($"Failed to read created time for {entryDir}: {ex.Message}");
             }
 
             return Directory.GetCreationTimeUtc(entryDir);
@@ -593,7 +596,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         /// and used (last-used &gt;= since).  It is a <b>store</b> (miss) if created
         /// after <paramref name="since"/>.  Otherwise it is <b>untouched</b>.
         /// </summary>
-        internal static CacheStats GetCacheStats(string cachePath, DateTime since)
+        internal static CacheStats GetCacheStats(string cachePath, DateTime since, ICompilerServerLogger logger)
         {
             var stats = new CacheStats();
             if (!Directory.Exists(cachePath))
@@ -615,8 +618,8 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                             continue;
                         }
 
-                        var created = GetCreatedTimeUtc(entryDir);
-                        var lastUsed = GetLastUsedTimeUtc(entryDir);
+                        var created = GetCreatedTimeUtc(entryDir, logger);
+                        var lastUsed = GetLastUsedTimeUtc(entryDir, logger);
 
                         if (created >= since)
                         {
@@ -635,9 +638,10 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                     }
                 }
             }
-            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            catch (Exception ex)
             {
                 // Best effort.
+                logger.Log($"Failed to enumerate cache stats for {cachePath}: {ex.Message}");
             }
 
             return stats;

--- a/src/Compilers/Server/VBCSCompiler/CompilationCache.cs
+++ b/src/Compilers/Server/VBCSCompiler/CompilationCache.cs
@@ -320,7 +320,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 tryCopyOptional(outputFiles.XmlDocPath, Path.Combine(stagingDir, XmlDocFileName));
 
                 File.WriteAllText(Path.Combine(stagingDir, dllName + ".key"), deterministicKey, Encoding.UTF8);
-                File.WriteAllText(Path.Combine(stagingDir, CreatedFileName), DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture));
+                File.WriteAllText(Path.Combine(stagingDir, CreatedFileName), DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture));
                 Directory.Move(stagingDir, cacheDir);
                 stagingDir = null;
 
@@ -446,7 +446,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             try
             {
                 var path = Path.Combine(entryDir, LastUsedFileName);
-                File.WriteAllText(path, DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture));
+                File.WriteAllText(path, DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture));
             }
             catch (Exception ex)
             {
@@ -461,7 +461,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         /// use the directory creation time instead.
         /// Returns a human-readable summary.
         /// </summary>
-        internal static string PurgeEntries(string cachePath, DateTime cutoff, ICompilerServerLogger logger)
+        internal static string PurgeEntries(string cachePath, DateTimeOffset cutoff, ICompilerServerLogger logger)
         {
             if (!Directory.Exists(cachePath))
             {
@@ -539,7 +539,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         /// timestamp stored inside the <c>last-used</c> file.  Falls back to the
         /// directory creation time when the file is missing or unreadable.
         /// </summary>
-        internal static DateTime GetLastUsedTimeUtc(string entryDir, ICompilerServerLogger logger)
+        internal static DateTimeOffset GetLastUsedTimeUtc(string entryDir, ICompilerServerLogger logger)
         {
             var lastUsedPath = Path.Combine(entryDir, LastUsedFileName);
             try
@@ -547,7 +547,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 if (File.Exists(lastUsedPath))
                 {
                     var text = File.ReadAllText(lastUsedPath).Trim();
-                    if (DateTime.TryParse(text, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed))
+                    if (DateTimeOffset.TryParse(text, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed))
                     {
                         return parsed.ToUniversalTime();
                     }
@@ -559,7 +559,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 logger.Log($"Failed to read last-used for {entryDir}: {ex.Message}");
             }
 
-            return Directory.GetCreationTimeUtc(entryDir);
+            return new DateTimeOffset(Directory.GetCreationTimeUtc(entryDir), TimeSpan.Zero);
         }
 
         /// <summary>
@@ -567,7 +567,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         /// <c>created</c> file.  Falls back to the directory creation time when the
         /// file is missing or unreadable.
         /// </summary>
-        internal static DateTime GetCreatedTimeUtc(string entryDir, ICompilerServerLogger logger)
+        internal static DateTimeOffset GetCreatedTimeUtc(string entryDir, ICompilerServerLogger logger)
         {
             var createdPath = Path.Combine(entryDir, CreatedFileName);
             try
@@ -575,7 +575,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 if (File.Exists(createdPath))
                 {
                     var text = File.ReadAllText(createdPath).Trim();
-                    if (DateTime.TryParse(text, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed))
+                    if (DateTimeOffset.TryParse(text, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed))
                     {
                         return parsed.ToUniversalTime();
                     }
@@ -587,7 +587,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 logger.Log($"Failed to read created time for {entryDir}: {ex.Message}");
             }
 
-            return Directory.GetCreationTimeUtc(entryDir);
+            return new DateTimeOffset(Directory.GetCreationTimeUtc(entryDir), TimeSpan.Zero);
         }
 
         /// <summary>
@@ -597,7 +597,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         /// and used (last-used &gt;= since).  It is a <b>store</b> (miss) if created
         /// after <paramref name="since"/>.  Otherwise it is <b>untouched</b>.
         /// </summary>
-        internal static CacheStats GetCacheStats(string cachePath, DateTime since, ICompilerServerLogger logger)
+        internal static CacheStats GetCacheStats(string cachePath, DateTimeOffset since, ICompilerServerLogger logger)
         {
             var stats = new CacheStats();
             if (!Directory.Exists(cachePath))
@@ -657,8 +657,8 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         public int Hits { get; set; }
         public int Stores { get; set; }
         public int Untouched { get; set; }
-        public List<(string DllName, string HashKey, DateTime Created, DateTime LastUsed)> HitDetails { get; } = new();
-        public List<(string DllName, string HashKey, DateTime Created, DateTime LastUsed)> StoreDetails { get; } = new();
+        public List<(string DllName, string HashKey, DateTimeOffset Created, DateTimeOffset LastUsed)> HitDetails { get; } = new();
+        public List<(string DllName, string HashKey, DateTimeOffset Created, DateTimeOffset LastUsed)> StoreDetails { get; } = new();
 
         /// <summary>
         /// Formats a human-readable summary of the statistics.
@@ -681,7 +681,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             return sb.ToString().TrimEnd();
         }
 
-        private static void FormatGrouped(StringBuilder sb, string label, List<(string DllName, string HashKey, DateTime Created, DateTime LastUsed)> details, int verbosity)
+        private static void FormatGrouped(StringBuilder sb, string label, List<(string DllName, string HashKey, DateTimeOffset Created, DateTimeOffset LastUsed)> details, int verbosity)
         {
             if (details.Count == 0)
             {

--- a/src/Compilers/Server/VBCSCompiler/CompilationCache.cs
+++ b/src/Compilers/Server/VBCSCompiler/CompilationCache.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -320,7 +320,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 tryCopyOptional(outputFiles.XmlDocPath, Path.Combine(stagingDir, XmlDocFileName));
 
                 File.WriteAllText(Path.Combine(stagingDir, dllName + ".key"), deterministicKey, Encoding.UTF8);
-                File.WriteAllText(Path.Combine(stagingDir, CreatedFileName), DateTime.UtcNow.ToString("O"));
+                File.WriteAllText(Path.Combine(stagingDir, CreatedFileName), DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture));
                 Directory.Move(stagingDir, cacheDir);
                 stagingDir = null;
 
@@ -438,14 +438,15 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         /// Writes the current UTC timestamp into the <c>last-used</c> marker file in the
         /// given cache entry directory.  The timestamp is stored as round-trip text inside
         /// the file so that it survives copies/uploads that do not preserve file-system
-        /// metadata.  Errors are silently ignored — this is best-effort bookkeeping.
+        /// metadata.  Errors are logged and otherwise ignored — this is best-effort
+        /// bookkeeping.
         /// </summary>
         private static void TouchLastUsed(string entryDir, ICompilerServerLogger logger)
         {
             try
             {
                 var path = Path.Combine(entryDir, LastUsedFileName);
-                File.WriteAllText(path, DateTime.UtcNow.ToString("O"));
+                File.WriteAllText(path, DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture));
             }
             catch (Exception ex)
             {
@@ -519,7 +520,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                     }
                     catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
                     {
-                        // Best effort
+                        logger.Log($"Cache purge: failed to remove empty directory {dllName}: {ex.Message}");
                     }
                 }
             }
@@ -546,7 +547,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 if (File.Exists(lastUsedPath))
                 {
                     var text = File.ReadAllText(lastUsedPath).Trim();
-                    if (DateTime.TryParse(text, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.RoundtripKind, out var parsed))
+                    if (DateTime.TryParse(text, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed))
                     {
                         return parsed.ToUniversalTime();
                     }
@@ -574,7 +575,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 if (File.Exists(createdPath))
                 {
                     var text = File.ReadAllText(createdPath).Trim();
-                    if (DateTime.TryParse(text, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.RoundtripKind, out var parsed))
+                    if (DateTime.TryParse(text, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed))
                     {
                         return parsed.ToUniversalTime();
                     }

--- a/src/Compilers/Server/VBCSCompiler/CompilationCache.cs
+++ b/src/Compilers/Server/VBCSCompiler/CompilationCache.cs
@@ -53,6 +53,8 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         private const string PdbFileName = "pdb";
         private const string RefAssemblyFileName = "refassembly";
         private const string XmlDocFileName = "xmldoc";
+        private const string LastUsedFileName = "last-used";
+        private const string CreatedFileName = "created";
 
         private readonly string _cachePath;
 
@@ -76,6 +78,19 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             logger.Log($"Compilation cache enabled at: {cachePath}");
             return new CompilationCache(cachePath);
         }
+
+        /// <summary>
+        /// Returns the cache root path, if set.
+        /// </summary>
+        internal string CachePath => _cachePath;
+
+        /// <summary>
+        /// Returns the default cache path used when no explicit path is configured.
+        /// This is the same location that <see cref="TryCreate"/> would use as a fallback.
+        /// Returns <see langword="null"/> when <c>LocalApplicationData</c> is unavailable.
+        /// </summary>
+        internal static string? GetDefaultCachePath()
+            => PathUtilities.GetTempCachePath(DefaultCacheDirectoryName);
 
         private static string? GetCachePath(IReadOnlyDictionary<string, string> features, ICompilerServerLogger logger)
         {
@@ -162,6 +177,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 }
 
                 logger.Log($"Cache hit: {dllName} [{hashKey}]");
+                TouchLastUsed(entryDir);
                 File.Copy(cachedAssemblyPath, outputFiles.AssemblyPath, overwrite: true);
                 copyIfNeeded(entryDir, PdbFileName, outputFiles.PdbPath);
                 copyIfNeeded(entryDir, RefAssemblyFileName, outputFiles.RefAssemblyPath);
@@ -304,9 +320,11 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 tryCopyOptional(outputFiles.XmlDocPath, Path.Combine(stagingDir, XmlDocFileName));
 
                 File.WriteAllText(Path.Combine(stagingDir, dllName + ".key"), deterministicKey, Encoding.UTF8);
+                File.WriteAllText(Path.Combine(stagingDir, CreatedFileName), DateTime.UtcNow.ToString("O"));
                 Directory.Move(stagingDir, cacheDir);
                 stagingDir = null;
 
+                TouchLastUsed(cacheDir);
                 logger.Log($"Cache stored: {dllName} [{hashKey}]");
             }
             catch (Exception ex)
@@ -414,6 +432,235 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
                 return lines;
             }
+        }
+
+        /// <summary>
+        /// Writes the current UTC timestamp into the <c>last-used</c> marker file in the
+        /// given cache entry directory.  The timestamp is stored as round-trip text inside
+        /// the file so that it survives copies/uploads that do not preserve file-system
+        /// metadata.  Errors are silently ignored — this is best-effort bookkeeping.
+        /// </summary>
+        private static void TouchLastUsed(string entryDir)
+        {
+            try
+            {
+                var path = Path.Combine(entryDir, LastUsedFileName);
+                File.WriteAllText(path, DateTime.UtcNow.ToString("O"));
+            }
+            catch
+            {
+                // Best effort — don't fail a compilation because of bookkeeping.
+            }
+        }
+
+        /// <summary>
+        /// Deletes cache entries under <paramref name="cachePath"/> whose <c>last-used</c>
+        /// marker is older than <paramref name="cutoff"/>. Entries without a marker file
+        /// use the directory creation time instead.
+        /// Returns a human-readable summary.
+        /// </summary>
+        internal static string PurgeEntries(string cachePath, DateTime cutoff, ICompilerServerLogger logger)
+        {
+            if (!Directory.Exists(cachePath))
+            {
+                return $"Cache directory does not exist: {cachePath}";
+            }
+
+            var totalDeleted = 0;
+            var totalKept = 0;
+            var totalErrors = 0;
+
+            try
+            {
+                foreach (var dllDir in Directory.EnumerateDirectories(cachePath))
+                {
+                    var dllName = Path.GetFileName(dllDir);
+
+                    foreach (var entryDir in Directory.EnumerateDirectories(dllDir))
+                    {
+                        var dirName = Path.GetFileName(entryDir);
+
+                        // Skip staging directories (they end with .tmp)
+                        if (dirName.EndsWith(".tmp", StringComparison.OrdinalIgnoreCase))
+                        {
+                            continue;
+                        }
+
+                        var lastUsed = GetLastUsedTimeUtc(entryDir);
+                        if (lastUsed >= cutoff)
+                        {
+                            totalKept++;
+                        }
+                        else
+                        {
+                            try
+                            {
+                                Directory.Delete(entryDir, recursive: true);
+                                totalDeleted++;
+                                logger.Log($"Cache purge: deleted {dllName}/{dirName} (last used {lastUsed:u})");
+                            }
+                            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                            {
+                                totalErrors++;
+                                logger.Log($"Cache purge: failed to delete {dllName}/{dirName}: {ex.Message}");
+                            }
+                        }
+                    }
+
+                    // Remove the dllName directory if it's now empty
+                    try
+                    {
+                        if (Directory.Exists(dllDir) && !Directory.EnumerateFileSystemEntries(dllDir).Any())
+                        {
+                            Directory.Delete(dllDir);
+                            logger.Log($"Cache purge: removed empty directory {dllName}");
+                        }
+                    }
+                    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                    {
+                        // Best effort
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                logger.Log($"Cache purge: error enumerating {cachePath}: {ex.Message}");
+            }
+
+            var summary = $"Cache purge complete. Deleted: {totalDeleted}, Kept: {totalKept}, Errors: {totalErrors}";
+            logger.Log(summary);
+            return summary;
+        }
+
+        /// <summary>
+        /// Returns the UTC time a cache entry was last used by reading the round-trip
+        /// timestamp stored inside the <c>last-used</c> file.  Falls back to the
+        /// directory creation time when the file is missing or unreadable.
+        /// </summary>
+        internal static DateTime GetLastUsedTimeUtc(string entryDir)
+        {
+            var lastUsedPath = Path.Combine(entryDir, LastUsedFileName);
+            try
+            {
+                if (File.Exists(lastUsedPath))
+                {
+                    var text = File.ReadAllText(lastUsedPath).Trim();
+                    if (DateTime.TryParse(text, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.RoundtripKind, out var parsed))
+                    {
+                        return parsed.ToUniversalTime();
+                    }
+                }
+            }
+            catch
+            {
+                // Fall through to directory time.
+            }
+
+            return Directory.GetCreationTimeUtc(entryDir);
+        }
+
+        /// <summary>
+        /// Returns the UTC time a cache entry was originally created by reading the
+        /// <c>created</c> file.  Falls back to the directory creation time when the
+        /// file is missing or unreadable.
+        /// </summary>
+        internal static DateTime GetCreatedTimeUtc(string entryDir)
+        {
+            var createdPath = Path.Combine(entryDir, CreatedFileName);
+            try
+            {
+                if (File.Exists(createdPath))
+                {
+                    var text = File.ReadAllText(createdPath).Trim();
+                    if (DateTime.TryParse(text, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.RoundtripKind, out var parsed))
+                    {
+                        return parsed.ToUniversalTime();
+                    }
+                }
+            }
+            catch
+            {
+                // Fall through to directory time.
+            }
+
+            return Directory.GetCreationTimeUtc(entryDir);
+        }
+
+        /// <summary>
+        /// Computes cache statistics for all entries under <paramref name="cachePath"/>.
+        /// </summary>
+        internal static CacheStats GetCacheStats(string cachePath)
+        {
+            var stats = new CacheStats();
+            if (!Directory.Exists(cachePath))
+            {
+                return stats;
+            }
+
+            try
+            {
+                foreach (var dllDir in Directory.EnumerateDirectories(cachePath))
+                {
+                    var dllName = Path.GetFileName(dllDir);
+
+                    foreach (var entryDir in Directory.EnumerateDirectories(dllDir))
+                    {
+                        var dirName = Path.GetFileName(entryDir);
+                        if (dirName.EndsWith(".tmp", StringComparison.OrdinalIgnoreCase))
+                        {
+                            continue;
+                        }
+
+                        var created = GetCreatedTimeUtc(entryDir);
+                        var lastUsed = GetLastUsedTimeUtc(entryDir);
+                        stats.TotalEntries++;
+                        stats.Details.Add((dllName, dirName, created, lastUsed));
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // Best effort.
+            }
+
+            return stats;
+        }
+    }
+
+    /// <summary>
+    /// Aggregated cache statistics for a single cache root.
+    /// </summary>
+    internal sealed class CacheStats
+    {
+        public int TotalEntries { get; set; }
+        public List<(string DllName, string HashKey, DateTime Created, DateTime LastUsed)> Details { get; } = new();
+
+        public string FormatSummary(string cachePath, bool verbose)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"Cache: {cachePath}");
+            sb.AppendLine($"  Total entries: {TotalEntries}");
+
+            if (TotalEntries > 0)
+            {
+                var byDll = Details
+                    .GroupBy(d => d.DllName, StringComparer.OrdinalIgnoreCase)
+                    .OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase);
+
+                foreach (var group in byDll)
+                {
+                    sb.AppendLine($"  {group.Key}: {group.Count()} entries");
+                    if (verbose)
+                    {
+                        foreach (var (_, hashKey, created, lastUsed) in group)
+                        {
+                            sb.AppendLine($"    {hashKey} (created: {created:u}, last used: {lastUsed:u})");
+                        }
+                    }
+                }
+            }
+
+            return sb.ToString().TrimEnd();
         }
     }
 }

--- a/src/Compilers/Server/VBCSCompiler/CompilationCacheUtilities.cs
+++ b/src/Compilers/Server/VBCSCompiler/CompilationCacheUtilities.cs
@@ -2,13 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Immutable;
+using System.IO;
 using System.Threading;
 using Microsoft.CodeAnalysis.CommandLine;
 using Microsoft.CodeAnalysis.Diagnostics;
-
-using System;
-using System.IO;
 
 namespace Microsoft.CodeAnalysis.CompilerServer
 {

--- a/src/Compilers/Server/VBCSCompiler/CompilationCacheUtilities.cs
+++ b/src/Compilers/Server/VBCSCompiler/CompilationCacheUtilities.cs
@@ -2,12 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Immutable;
-using System.IO;
 using System.Threading;
 using Microsoft.CodeAnalysis.CommandLine;
 using Microsoft.CodeAnalysis.Diagnostics;
+
+using System;
+using System.IO;
 
 namespace Microsoft.CodeAnalysis.CompilerServer
 {

--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         {
             // Pre-parse arguments to extract the log file path and other values so the logger can be
             // initialized with the correct path before the controller is created.
-            if (!BuildServerController.ParseCommandLine(args, out var pipeName, out var shutdown, out var keepAlive, out var logFilePath))
+            if (!BuildServerController.ParseCommandLine(args, out var pipeName, out var shutdown, out var purgeCacheCutoff, out var cacheStats, out var cacheStatsVerbose, out var keepAlive, out var logFilePath))
             {
                 return CommonCompiler.Failed;
             }
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             try
             {
                 var controller = new BuildServerController(logger);
-                return controller.Run(pipeName, shutdown, keepAlive);
+                return controller.Run(pipeName, shutdown, purgeCacheCutoff, cacheStats, cacheStatsVerbose, keepAlive);
             }
             catch (Exception e)
             {

--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         {
             // Pre-parse arguments to extract the log file path and other values so the logger can be
             // initialized with the correct path before the controller is created.
-            if (!BuildServerController.ParseCommandLine(args, out var pipeName, out var shutdown, out var purgeCacheCutoff, out var cacheStatsSince, out var cacheStatsVerbosity, out var keepAlive, out var logFilePath))
+            if (!BuildServerController.ParseCommandLine(args, out var pipeName, out var shutdown, out var purgeCacheCutoff, out var cacheStatsSince, out var cacheStatsVerbosity, out var cachePath, out var keepAlive, out var logFilePath))
             {
                 return CommonCompiler.Failed;
             }
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             try
             {
                 var controller = new BuildServerController(logger);
-                return controller.Run(pipeName, shutdown, purgeCacheCutoff, cacheStatsSince, cacheStatsVerbosity, keepAlive);
+                return controller.Run(pipeName, shutdown, purgeCacheCutoff, cacheStatsSince, cacheStatsVerbosity, cachePath, keepAlive);
             }
             catch (Exception e)
             {

--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
@@ -14,12 +14,12 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         {
             // Pre-parse arguments to extract the log file path and other values so the logger can be
             // initialized with the correct path before the controller is created.
-            if (!BuildServerController.ParseCommandLine(args, out var pipeName, out var shutdown, out var purgeCacheCutoff, out var cacheStatsSince, out var cacheStatsVerbosity, out var cachePath, out var keepAlive, out var logFilePath))
+            if (!BuildServerController.ParseCommandLine(args, out var options))
             {
                 return CommonCompiler.Failed;
             }
 
-            using var logger = new CompilerServerLogger($"VBCSCompiler {Process.GetCurrentProcess().Id}", logFilePath);
+            using var logger = new CompilerServerLogger($"VBCSCompiler {Process.GetCurrentProcess().Id}", options.LogFilePath);
 
 #if BOOTSTRAP
             ExitingTraceListener.Install(logger);
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             try
             {
                 var controller = new BuildServerController(logger);
-                return controller.Run(pipeName, shutdown, purgeCacheCutoff, cacheStatsSince, cacheStatsVerbosity, cachePath, keepAlive);
+                return controller.Run(options);
             }
             catch (Exception e)
             {

--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         {
             // Pre-parse arguments to extract the log file path and other values so the logger can be
             // initialized with the correct path before the controller is created.
-            if (!BuildServerController.ParseCommandLine(args, out var pipeName, out var shutdown, out var purgeCacheCutoff, out var cacheStats, out var cacheStatsVerbose, out var keepAlive, out var logFilePath))
+            if (!BuildServerController.ParseCommandLine(args, out var pipeName, out var shutdown, out var purgeCacheCutoff, out var cacheStatsSince, out var cacheStatsVerbosity, out var keepAlive, out var logFilePath))
             {
                 return CommonCompiler.Failed;
             }
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             try
             {
                 var controller = new BuildServerController(logger);
-                return controller.Run(pipeName, shutdown, purgeCacheCutoff, cacheStats, cacheStatsVerbose, keepAlive);
+                return controller.Run(pipeName, shutdown, purgeCacheCutoff, cacheStatsSince, cacheStatsVerbosity, keepAlive);
             }
             catch (Exception e)
             {

--- a/src/Compilers/Server/VBCSCompilerTests/CompilationCacheTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilationCacheTests.cs
@@ -450,6 +450,238 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         }
 
         [Fact]
+        public void TryRestoreCachedResult_TouchesLastUsedFile()
+        {
+            var cacheDir = Temp.CreateDirectory().Path;
+            var cache = CreateCache(cacheDir);
+            var dllName = "Tracked.dll";
+            var hashKey = "tracked_hash";
+            var outputDir = Temp.CreateDirectory().Path;
+
+            var entryDir = Path.Combine(cacheDir, dllName, hashKey);
+            Directory.CreateDirectory(entryDir);
+            File.WriteAllBytes(Path.Combine(entryDir, "assembly"), [1, 2, 3]);
+
+            var outputFiles = new CompilationOutputFiles
+            {
+                AssemblyPath = Path.Combine(outputDir, dllName),
+            };
+
+            var result = cache.TryRestoreCachedResult(dllName, hashKey, outputFiles, _logger);
+            Assert.True(result);
+
+            // The last-used file should exist after a cache hit
+            var lastUsedPath = Path.Combine(entryDir, "last-used");
+            Assert.True(File.Exists(lastUsedPath));
+        }
+
+        [Fact]
+        public void TryStoreResult_TouchesLastUsedFile()
+        {
+            var cacheDir = Temp.CreateDirectory().Path;
+            var cache = CreateCache(cacheDir);
+            var dllName = "Stored.dll";
+            var hashKey = CompilationCache.ComputeHashKey("stored key");
+
+            var outputDir = Temp.CreateDirectory().Path;
+            var assemblyPath = Path.Combine(outputDir, dllName);
+            File.WriteAllBytes(assemblyPath, [10, 20]);
+
+            var outputFiles = new CompilationOutputFiles { AssemblyPath = assemblyPath };
+            cache.TryStoreResult(dllName, hashKey, outputFiles, "stored key", _logger);
+
+            // The last-used file should exist after a store
+            var entryDir = Path.Combine(cacheDir, dllName, hashKey);
+            var lastUsedPath = Path.Combine(entryDir, "last-used");
+            Assert.True(File.Exists(lastUsedPath));
+        }
+
+        [Fact]
+        public void TryStoreResult_WritesCreatedFile()
+        {
+            var cacheDir = Temp.CreateDirectory().Path;
+            var cache = CreateCache(cacheDir);
+            var dllName = "Created.dll";
+            var hashKey = CompilationCache.ComputeHashKey("created key");
+
+            var outputDir = Temp.CreateDirectory().Path;
+            var assemblyPath = Path.Combine(outputDir, dllName);
+            File.WriteAllBytes(assemblyPath, [10, 20]);
+
+            var outputFiles = new CompilationOutputFiles { AssemblyPath = assemblyPath };
+            cache.TryStoreResult(dllName, hashKey, outputFiles, "created key", _logger);
+
+            var entryDir = Path.Combine(cacheDir, dllName, hashKey);
+            var createdPath = Path.Combine(entryDir, "created");
+            Assert.True(File.Exists(createdPath));
+            var text = File.ReadAllText(createdPath).Trim();
+            Assert.True(DateTime.TryParse(text, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.RoundtripKind, out var parsed));
+            Assert.True(parsed <= DateTime.UtcNow);
+            Assert.True(parsed > DateTime.UtcNow.AddMinutes(-1));
+        }
+
+        [Fact]
+        public void GetCacheStats_CountsAllEntries()
+        {
+            var cacheDir = Temp.CreateDirectory().Path;
+            var now = DateTime.UtcNow;
+
+            // Create several entries
+            var entry1 = Path.Combine(cacheDir, "A.dll", "hash1");
+            Directory.CreateDirectory(entry1);
+            File.WriteAllBytes(Path.Combine(entry1, "assembly"), [1]);
+            File.WriteAllText(Path.Combine(entry1, "created"), now.AddHours(-1).ToString("O"));
+            File.WriteAllText(Path.Combine(entry1, "last-used"), now.AddSeconds(1).ToString("O"));
+
+            var entry2 = Path.Combine(cacheDir, "B.dll", "hash2");
+            Directory.CreateDirectory(entry2);
+            File.WriteAllBytes(Path.Combine(entry2, "assembly"), [2]);
+            File.WriteAllText(Path.Combine(entry2, "created"), now.AddSeconds(1).ToString("O"));
+            File.WriteAllText(Path.Combine(entry2, "last-used"), now.AddSeconds(1).ToString("O"));
+
+            var entry3 = Path.Combine(cacheDir, "C.dll", "hash3");
+            Directory.CreateDirectory(entry3);
+            File.WriteAllBytes(Path.Combine(entry3, "assembly"), [3]);
+            File.WriteAllText(Path.Combine(entry3, "created"), now.AddHours(-2).ToString("O"));
+            File.WriteAllText(Path.Combine(entry3, "last-used"), now.AddHours(-1).ToString("O"));
+
+            var stats = CompilationCache.GetCacheStats(cacheDir);
+            Assert.Equal(3, stats.TotalEntries);
+            Assert.Equal(3, stats.Details.Count);
+            Assert.Contains(stats.Details, d => d.DllName == "A.dll");
+            Assert.Contains(stats.Details, d => d.DllName == "B.dll");
+            Assert.Contains(stats.Details, d => d.DllName == "C.dll");
+        }
+
+        [Fact]
+        public void GetCacheStats_VerboseSummaryIncludesTimestamps()
+        {
+            var cacheDir = Temp.CreateDirectory().Path;
+            var now = DateTime.UtcNow;
+
+            var entry = Path.Combine(cacheDir, "MyLib.dll", "hash_abc");
+            Directory.CreateDirectory(entry);
+            File.WriteAllBytes(Path.Combine(entry, "assembly"), [1]);
+            File.WriteAllText(Path.Combine(entry, "created"), now.AddHours(-2).ToString("O"));
+            File.WriteAllText(Path.Combine(entry, "last-used"), now.ToString("O"));
+
+            var stats = CompilationCache.GetCacheStats(cacheDir);
+            var summary = stats.FormatSummary(cacheDir, verbose: true);
+
+            Assert.Contains("MyLib.dll: 1 entries", summary);
+            Assert.Contains("hash_abc", summary);
+            Assert.Contains("created:", summary);
+            Assert.Contains("last used:", summary);
+        }
+
+        [Fact]
+        public void PurgeEntries_DeletesOldEntries()
+        {
+            var cacheDir = Temp.CreateDirectory().Path;
+
+            var oldEntry = Path.Combine(cacheDir, "Old.dll", "hash_old");
+            Directory.CreateDirectory(oldEntry);
+            File.WriteAllBytes(Path.Combine(oldEntry, "assembly"), [1, 2, 3]);
+            File.WriteAllText(Path.Combine(oldEntry, "last-used"), DateTime.UtcNow.AddHours(-2).ToString("O"));
+
+            var newEntry = Path.Combine(cacheDir, "New.dll", "hash_new");
+            Directory.CreateDirectory(newEntry);
+            File.WriteAllBytes(Path.Combine(newEntry, "assembly"), [4, 5, 6]);
+            File.WriteAllText(Path.Combine(newEntry, "last-used"), DateTime.UtcNow.ToString("O"));
+
+            var result = CompilationCache.PurgeEntries(cacheDir, DateTime.UtcNow.AddHours(-1), _logger);
+
+            Assert.Contains("Deleted: 1", result);
+            Assert.Contains("Kept: 1", result);
+            Assert.False(Directory.Exists(oldEntry));
+            Assert.True(Directory.Exists(newEntry));
+        }
+
+        [Fact]
+        public void PurgeEntries_KeepsAllRecentEntries()
+        {
+            var cacheDir = Temp.CreateDirectory().Path;
+
+            var entry1 = Path.Combine(cacheDir, "A.dll", "hash1");
+            var entry2 = Path.Combine(cacheDir, "B.dll", "hash2");
+            Directory.CreateDirectory(entry1);
+            File.WriteAllBytes(Path.Combine(entry1, "assembly"), [1]);
+            File.WriteAllText(Path.Combine(entry1, "last-used"), DateTime.UtcNow.ToString("O"));
+            Directory.CreateDirectory(entry2);
+            File.WriteAllBytes(Path.Combine(entry2, "assembly"), [2]);
+            File.WriteAllText(Path.Combine(entry2, "last-used"), DateTime.UtcNow.ToString("O"));
+
+            var result = CompilationCache.PurgeEntries(cacheDir, DateTime.UtcNow.AddHours(-1), _logger);
+
+            Assert.Contains("Deleted: 0", result);
+            Assert.Contains("Kept: 2", result);
+            Assert.True(Directory.Exists(entry1));
+            Assert.True(Directory.Exists(entry2));
+        }
+
+        [Fact]
+        public void PurgeEntries_RemovesEmptyDllDirectories()
+        {
+            var cacheDir = Temp.CreateDirectory().Path;
+
+            var dllDir = Path.Combine(cacheDir, "Orphan.dll");
+            var entryDir = Path.Combine(dllDir, "hash_orphan");
+            Directory.CreateDirectory(entryDir);
+            File.WriteAllBytes(Path.Combine(entryDir, "assembly"), [1]);
+            File.WriteAllText(Path.Combine(entryDir, "last-used"), DateTime.UtcNow.AddHours(-2).ToString("O"));
+
+            var result = CompilationCache.PurgeEntries(cacheDir, DateTime.UtcNow.AddHours(-1), _logger);
+
+            Assert.Contains("Deleted: 1", result);
+            Assert.False(Directory.Exists(dllDir), "Empty DLL directory should be removed");
+        }
+
+        [Fact]
+        public void PurgeEntries_SkipsStagingDirectories()
+        {
+            var cacheDir = Temp.CreateDirectory().Path;
+
+            var dllDir = Path.Combine(cacheDir, "Lib.dll");
+            var stagingDir = Path.Combine(dllDir, "somehash.abc123.tmp");
+            Directory.CreateDirectory(stagingDir);
+
+            var usedDir = Path.Combine(dllDir, "hash_used");
+            Directory.CreateDirectory(usedDir);
+            File.WriteAllBytes(Path.Combine(usedDir, "assembly"), [1]);
+            File.WriteAllText(Path.Combine(usedDir, "last-used"), DateTime.UtcNow.ToString("O"));
+
+            var result = CompilationCache.PurgeEntries(cacheDir, DateTime.UtcNow.AddHours(-1), _logger);
+
+            Assert.Contains("Deleted: 0", result);
+            Assert.True(Directory.Exists(stagingDir), "Staging directories should not be deleted");
+        }
+
+        [Fact]
+        public void PurgeEntries_HandlesMixedOldAndNewEntries()
+        {
+            var cacheDir = Temp.CreateDirectory().Path;
+
+            var dllDir = Path.Combine(cacheDir, "Lib.dll");
+            var oldEntry = Path.Combine(dllDir, "hash_old");
+            Directory.CreateDirectory(oldEntry);
+            File.WriteAllBytes(Path.Combine(oldEntry, "assembly"), [1]);
+            File.WriteAllText(Path.Combine(oldEntry, "last-used"), DateTime.UtcNow.AddHours(-2).ToString("O"));
+
+            var newEntry = Path.Combine(dllDir, "hash_current");
+            Directory.CreateDirectory(newEntry);
+            File.WriteAllBytes(Path.Combine(newEntry, "assembly"), [2]);
+            File.WriteAllText(Path.Combine(newEntry, "last-used"), DateTime.UtcNow.ToString("O"));
+
+            var result = CompilationCache.PurgeEntries(cacheDir, DateTime.UtcNow.AddHours(-1), _logger);
+
+            Assert.Contains("Deleted: 1", result);
+            Assert.Contains("Kept: 1", result);
+            Assert.True(Directory.Exists(newEntry));
+            Assert.False(Directory.Exists(oldEntry));
+            Assert.True(Directory.Exists(dllDir));
+        }
+
+        [Fact]
         public void GetDeterministicKey_DiffersWithSourceLink()
         {
             var compilation = CSharpCompilation.Create(

--- a/src/Compilers/Server/VBCSCompilerTests/CompilationCacheTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilationCacheTests.cs
@@ -545,16 +545,17 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             File.WriteAllText(Path.Combine(entry3, "created"), now.AddHours(-2).ToString("O"));
             File.WriteAllText(Path.Combine(entry3, "last-used"), now.AddHours(-1).ToString("O"));
 
-            var stats = CompilationCache.GetCacheStats(cacheDir);
-            Assert.Equal(3, stats.TotalEntries);
-            Assert.Equal(3, stats.Details.Count);
-            Assert.Contains(stats.Details, d => d.DllName == "A.dll");
-            Assert.Contains(stats.Details, d => d.DllName == "B.dll");
-            Assert.Contains(stats.Details, d => d.DllName == "C.dll");
+            // Since = now => entry1 is a hit (created before, used after), entry2 is a store (created after), entry3 is untouched
+            var stats = CompilationCache.GetCacheStats(cacheDir, now);
+            Assert.Equal(1, stats.Hits);
+            Assert.Equal(1, stats.Stores);
+            Assert.Equal(1, stats.Untouched);
+            Assert.Contains(stats.HitDetails, d => d.DllName == "A.dll");
+            Assert.Contains(stats.StoreDetails, d => d.DllName == "B.dll");
         }
 
         [Fact]
-        public void GetCacheStats_VerboseSummaryIncludesTimestamps()
+        public void GetCacheStats_VerboseSummaryIncludesGroupedDlls()
         {
             var cacheDir = Temp.CreateDirectory().Path;
             var now = DateTime.UtcNow;
@@ -565,10 +566,32 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             File.WriteAllText(Path.Combine(entry, "created"), now.AddHours(-2).ToString("O"));
             File.WriteAllText(Path.Combine(entry, "last-used"), now.ToString("O"));
 
-            var stats = CompilationCache.GetCacheStats(cacheDir);
-            var summary = stats.FormatSummary(cacheDir, verbose: true);
+            var stats = CompilationCache.GetCacheStats(cacheDir, now);
+            var summary = stats.FormatSummary(cacheDir, verbosity: 1);
 
-            Assert.Contains("MyLib.dll: 1 entries", summary);
+            Assert.Contains("Hits (reused):  1", summary);
+            Assert.Contains("Hit details:", summary);
+            Assert.Contains("MyLib.dll (1)", summary);
+            // Verbosity 1 does not show individual hash keys
+            Assert.DoesNotContain("hash_abc", summary);
+        }
+
+        [Fact]
+        public void GetCacheStats_Verbosity2ShowsIndividualEntries()
+        {
+            var cacheDir = Temp.CreateDirectory().Path;
+            var now = DateTime.UtcNow;
+
+            var entry = Path.Combine(cacheDir, "MyLib.dll", "hash_abc");
+            Directory.CreateDirectory(entry);
+            File.WriteAllBytes(Path.Combine(entry, "assembly"), [1]);
+            File.WriteAllText(Path.Combine(entry, "created"), now.AddHours(-2).ToString("O"));
+            File.WriteAllText(Path.Combine(entry, "last-used"), now.ToString("O"));
+
+            var stats = CompilationCache.GetCacheStats(cacheDir, now);
+            var summary = stats.FormatSummary(cacheDir, verbosity: 2);
+
+            Assert.Contains("MyLib.dll (1)", summary);
             Assert.Contains("hash_abc", summary);
             Assert.Contains("created:", summary);
             Assert.Contains("last used:", summary);

--- a/src/Compilers/Server/VBCSCompilerTests/CompilationCacheTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilationCacheTests.cs
@@ -546,7 +546,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             File.WriteAllText(Path.Combine(entry3, "last-used"), now.AddHours(-1).ToString("O"));
 
             // Since = now => entry1 is a hit (created before, used after), entry2 is a store (created after), entry3 is untouched
-            var stats = CompilationCache.GetCacheStats(cacheDir, now);
+            var stats = CompilationCache.GetCacheStats(cacheDir, now, _logger);
             Assert.Equal(1, stats.Hits);
             Assert.Equal(1, stats.Stores);
             Assert.Equal(1, stats.Untouched);
@@ -566,7 +566,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             File.WriteAllText(Path.Combine(entry, "created"), now.AddHours(-2).ToString("O"));
             File.WriteAllText(Path.Combine(entry, "last-used"), now.ToString("O"));
 
-            var stats = CompilationCache.GetCacheStats(cacheDir, now);
+            var stats = CompilationCache.GetCacheStats(cacheDir, now, _logger);
             var summary = stats.FormatSummary(cacheDir, verbosity: 1);
 
             Assert.Contains("Hits (reused):  1", summary);
@@ -588,7 +588,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             File.WriteAllText(Path.Combine(entry, "created"), now.AddHours(-2).ToString("O"));
             File.WriteAllText(Path.Combine(entry, "last-used"), now.ToString("O"));
 
-            var stats = CompilationCache.GetCacheStats(cacheDir, now);
+            var stats = CompilationCache.GetCacheStats(cacheDir, now, _logger);
             var summary = stats.FormatSummary(cacheDir, verbosity: 2);
 
             Assert.Contains("MyLib.dll (1)", summary);

--- a/src/Compilers/Server/VBCSCompilerTests/CompilationCacheTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilationCacheTests.cs
@@ -515,16 +515,16 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             var createdPath = Path.Combine(entryDir, "created");
             Assert.True(File.Exists(createdPath));
             var text = File.ReadAllText(createdPath).Trim();
-            Assert.True(DateTime.TryParse(text, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.RoundtripKind, out var parsed));
-            Assert.True(parsed <= DateTime.UtcNow);
-            Assert.True(parsed > DateTime.UtcNow.AddMinutes(-1));
+            Assert.True(DateTimeOffset.TryParse(text, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.RoundtripKind, out var parsed));
+            Assert.True(parsed <= DateTimeOffset.UtcNow);
+            Assert.True(parsed > DateTimeOffset.UtcNow.AddMinutes(-1));
         }
 
         [Fact]
         public void GetCacheStats_CountsAllEntries()
         {
             var cacheDir = Temp.CreateDirectory().Path;
-            var now = DateTime.UtcNow;
+            var now = DateTimeOffset.UtcNow;
 
             // Create several entries
             var entry1 = Path.Combine(cacheDir, "A.dll", "hash1");
@@ -558,7 +558,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         public void GetCacheStats_VerboseSummaryIncludesGroupedDlls()
         {
             var cacheDir = Temp.CreateDirectory().Path;
-            var now = DateTime.UtcNow;
+            var now = DateTimeOffset.UtcNow;
 
             var entry = Path.Combine(cacheDir, "MyLib.dll", "hash_abc");
             Directory.CreateDirectory(entry);
@@ -580,7 +580,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         public void GetCacheStats_Verbosity2ShowsIndividualEntries()
         {
             var cacheDir = Temp.CreateDirectory().Path;
-            var now = DateTime.UtcNow;
+            var now = DateTimeOffset.UtcNow;
 
             var entry = Path.Combine(cacheDir, "MyLib.dll", "hash_abc");
             Directory.CreateDirectory(entry);
@@ -605,14 +605,14 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             var oldEntry = Path.Combine(cacheDir, "Old.dll", "hash_old");
             Directory.CreateDirectory(oldEntry);
             File.WriteAllBytes(Path.Combine(oldEntry, "assembly"), [1, 2, 3]);
-            File.WriteAllText(Path.Combine(oldEntry, "last-used"), DateTime.UtcNow.AddHours(-2).ToString("O"));
+            File.WriteAllText(Path.Combine(oldEntry, "last-used"), DateTimeOffset.UtcNow.AddHours(-2).ToString("O"));
 
             var newEntry = Path.Combine(cacheDir, "New.dll", "hash_new");
             Directory.CreateDirectory(newEntry);
             File.WriteAllBytes(Path.Combine(newEntry, "assembly"), [4, 5, 6]);
-            File.WriteAllText(Path.Combine(newEntry, "last-used"), DateTime.UtcNow.ToString("O"));
+            File.WriteAllText(Path.Combine(newEntry, "last-used"), DateTimeOffset.UtcNow.ToString("O"));
 
-            var result = CompilationCache.PurgeEntries(cacheDir, DateTime.UtcNow.AddHours(-1), _logger);
+            var result = CompilationCache.PurgeEntries(cacheDir, DateTimeOffset.UtcNow.AddHours(-1), _logger);
 
             Assert.Contains("Deleted: 1", result);
             Assert.Contains("Kept: 1", result);
@@ -629,12 +629,12 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             var entry2 = Path.Combine(cacheDir, "B.dll", "hash2");
             Directory.CreateDirectory(entry1);
             File.WriteAllBytes(Path.Combine(entry1, "assembly"), [1]);
-            File.WriteAllText(Path.Combine(entry1, "last-used"), DateTime.UtcNow.ToString("O"));
+            File.WriteAllText(Path.Combine(entry1, "last-used"), DateTimeOffset.UtcNow.ToString("O"));
             Directory.CreateDirectory(entry2);
             File.WriteAllBytes(Path.Combine(entry2, "assembly"), [2]);
-            File.WriteAllText(Path.Combine(entry2, "last-used"), DateTime.UtcNow.ToString("O"));
+            File.WriteAllText(Path.Combine(entry2, "last-used"), DateTimeOffset.UtcNow.ToString("O"));
 
-            var result = CompilationCache.PurgeEntries(cacheDir, DateTime.UtcNow.AddHours(-1), _logger);
+            var result = CompilationCache.PurgeEntries(cacheDir, DateTimeOffset.UtcNow.AddHours(-1), _logger);
 
             Assert.Contains("Deleted: 0", result);
             Assert.Contains("Kept: 2", result);
@@ -651,9 +651,9 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             var entryDir = Path.Combine(dllDir, "hash_orphan");
             Directory.CreateDirectory(entryDir);
             File.WriteAllBytes(Path.Combine(entryDir, "assembly"), [1]);
-            File.WriteAllText(Path.Combine(entryDir, "last-used"), DateTime.UtcNow.AddHours(-2).ToString("O"));
+            File.WriteAllText(Path.Combine(entryDir, "last-used"), DateTimeOffset.UtcNow.AddHours(-2).ToString("O"));
 
-            var result = CompilationCache.PurgeEntries(cacheDir, DateTime.UtcNow.AddHours(-1), _logger);
+            var result = CompilationCache.PurgeEntries(cacheDir, DateTimeOffset.UtcNow.AddHours(-1), _logger);
 
             Assert.Contains("Deleted: 1", result);
             Assert.False(Directory.Exists(dllDir), "Empty DLL directory should be removed");
@@ -671,9 +671,9 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             var usedDir = Path.Combine(dllDir, "hash_used");
             Directory.CreateDirectory(usedDir);
             File.WriteAllBytes(Path.Combine(usedDir, "assembly"), [1]);
-            File.WriteAllText(Path.Combine(usedDir, "last-used"), DateTime.UtcNow.ToString("O"));
+            File.WriteAllText(Path.Combine(usedDir, "last-used"), DateTimeOffset.UtcNow.ToString("O"));
 
-            var result = CompilationCache.PurgeEntries(cacheDir, DateTime.UtcNow.AddHours(-1), _logger);
+            var result = CompilationCache.PurgeEntries(cacheDir, DateTimeOffset.UtcNow.AddHours(-1), _logger);
 
             Assert.Contains("Deleted: 0", result);
             Assert.True(Directory.Exists(stagingDir), "Staging directories should not be deleted");
@@ -688,14 +688,14 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             var oldEntry = Path.Combine(dllDir, "hash_old");
             Directory.CreateDirectory(oldEntry);
             File.WriteAllBytes(Path.Combine(oldEntry, "assembly"), [1]);
-            File.WriteAllText(Path.Combine(oldEntry, "last-used"), DateTime.UtcNow.AddHours(-2).ToString("O"));
+            File.WriteAllText(Path.Combine(oldEntry, "last-used"), DateTimeOffset.UtcNow.AddHours(-2).ToString("O"));
 
             var newEntry = Path.Combine(dllDir, "hash_current");
             Directory.CreateDirectory(newEntry);
             File.WriteAllBytes(Path.Combine(newEntry, "assembly"), [2]);
-            File.WriteAllText(Path.Combine(newEntry, "last-used"), DateTime.UtcNow.ToString("O"));
+            File.WriteAllText(Path.Combine(newEntry, "last-used"), DateTimeOffset.UtcNow.ToString("O"));
 
-            var result = CompilationCache.PurgeEntries(cacheDir, DateTime.UtcNow.AddHours(-1), _logger);
+            var result = CompilationCache.PurgeEntries(cacheDir, DateTimeOffset.UtcNow.AddHours(-1), _logger);
 
             Assert.Contains("Deleted: 1", result);
             Assert.Contains("Kept: 1", result);

--- a/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
@@ -410,12 +410,13 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             private DateTimeOffset? _purgeCacheCutoff;
             private DateTimeOffset? _cacheStatsSince;
             private int _cacheStatsVerbosity;
+            private string _cachePath;
             private TimeSpan? _timeout;
             private string _logFilePath;
 
             private bool Parse(params string[] args)
             {
-                return BuildServerController.ParseCommandLine(args, out _pipeName, out _shutdown, out _purgeCacheCutoff, out _cacheStatsSince, out _cacheStatsVerbosity, out _timeout, out _logFilePath);
+                return BuildServerController.ParseCommandLine(args, out _pipeName, out _shutdown, out _purgeCacheCutoff, out _cacheStatsSince, out _cacheStatsVerbosity, out _cachePath, out _timeout, out _logFilePath);
             }
 
             [Fact]
@@ -536,6 +537,13 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 Assert.True(Parse("-pipename:test", "-cachestats"));
                 Assert.Equal("test", _pipeName);
                 Assert.Equal(DateTimeOffset.MinValue, _cacheStatsSince);
+            }
+
+            [Fact]
+            public void CachePath()
+            {
+                Assert.True(Parse("-cachestats", "-cachepath:/tmp/cache"));
+                Assert.Equal("/tmp/cache", _cachePath);
             }
 
             [Fact]

--- a/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
@@ -416,7 +416,16 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 
             private bool Parse(params string[] args)
             {
-                return BuildServerController.ParseCommandLine(args, out _pipeName, out _shutdown, out _purgeCacheCutoff, out _cacheStatsSince, out _cacheStatsVerbosity, out _cachePath, out _timeout, out _logFilePath);
+                var result = BuildServerController.ParseCommandLine(args, out var options);
+                _pipeName = options.PipeName;
+                _shutdown = options.Shutdown;
+                _purgeCacheCutoff = options.PurgeCacheCutoff;
+                _cacheStatsSince = options.CacheStatsSince;
+                _cacheStatsVerbosity = options.CacheStatsVerbosity;
+                _cachePath = options.CachePath;
+                _timeout = options.KeepAlive;
+                _logFilePath = options.LogFilePath;
+                return result;
             }
 
             [Fact]
@@ -537,6 +546,15 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 Assert.True(Parse("-pipename:test", "-cachestats"));
                 Assert.Equal("test", _pipeName);
                 Assert.Equal(DateTimeOffset.MinValue, _cacheStatsSince);
+            }
+
+            [Fact]
+            public void RejectsConflictingOperations()
+            {
+                Assert.False(Parse("-shutdown", "-purgecache"));
+                Assert.False(Parse("-shutdown", "-cachestats"));
+                Assert.False(Parse("-purgecache", "-cachestats"));
+                Assert.False(Parse("-shutdown", "-shutdown"));
             }
 
             [Fact]

--- a/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
@@ -511,7 +511,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             [Fact]
             public void CacheStatsWithVerbosity()
             {
-                Assert.True(Parse("-cachestats", "-verbosity:1"));
+                Assert.True(Parse("-cachestats", "-cachestatsverbosity:1"));
                 Assert.Equal(DateTime.MinValue, _cacheStatsSince);
                 Assert.Equal(1, _cacheStatsVerbosity);
             }
@@ -519,7 +519,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             [Fact]
             public void CacheStatsWithVerbosity2()
             {
-                Assert.True(Parse("-cachestats:2025-01-15T10:00:00Z", "-verbosity:2"));
+                Assert.True(Parse("-cachestats:2025-01-15T10:00:00Z", "-cachestatsverbosity:2"));
                 Assert.Equal(new DateTime(2025, 1, 15, 10, 0, 0, DateTimeKind.Utc), _cacheStatsSince);
                 Assert.Equal(2, _cacheStatsVerbosity);
             }
@@ -527,7 +527,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             [Fact]
             public void CacheStatsBadVerbosity()
             {
-                Assert.False(Parse("-cachestats", "-verbosity:3"));
+                Assert.False(Parse("-cachestats", "-cachestatsverbosity:3"));
             }
 
             [Fact]

--- a/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
@@ -407,12 +407,15 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         {
             private string _pipeName;
             private bool _shutdown;
+            private DateTime? _purgeCacheCutoff;
+            private bool _cacheStats;
+            private bool _cacheStatsVerbose;
             private TimeSpan? _timeout;
             private string _logFilePath;
 
             private bool Parse(params string[] args)
             {
-                return BuildServerController.ParseCommandLine(args, out _pipeName, out _shutdown, out _timeout, out _logFilePath);
+                return BuildServerController.ParseCommandLine(args, out _pipeName, out _shutdown, out _purgeCacheCutoff, out _cacheStats, out _cacheStatsVerbose, out _timeout, out _logFilePath);
             }
 
             [Fact]
@@ -421,6 +424,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 Assert.True(Parse());
                 Assert.Null(_pipeName);
                 Assert.False(_shutdown);
+                Assert.Null(_purgeCacheCutoff);
                 Assert.Null(_timeout);
                 Assert.Null(_logFilePath);
             }
@@ -447,6 +451,63 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 Assert.True(Parse("-pipename:test", "-shutdown"));
                 Assert.Equal("test", _pipeName);
                 Assert.True(_shutdown);
+            }
+
+            [Fact]
+            public void PurgeCache()
+            {
+                Assert.True(Parse("-purgecache"));
+                Assert.Null(_pipeName);
+                Assert.NotNull(_purgeCacheCutoff);
+                Assert.False(_shutdown);
+            }
+
+            [Fact]
+            public void PipeAndPurgeCache()
+            {
+                Assert.True(Parse("-pipename:test", "-purgecache"));
+                Assert.Equal("test", _pipeName);
+                Assert.NotNull(_purgeCacheCutoff);
+            }
+
+            [Fact]
+            public void PurgeCacheWithTimestamp()
+            {
+                Assert.True(Parse("-purgecache:2026-04-10T12:00:00Z"));
+                Assert.NotNull(_purgeCacheCutoff);
+                Assert.Equal(new DateTime(2026, 4, 10, 12, 0, 0, DateTimeKind.Utc), _purgeCacheCutoff.Value);
+            }
+
+            [Fact]
+            public void PurgeCacheWithBadTimestamp()
+            {
+                Assert.False(Parse("-purgecache:notadate"));
+            }
+
+            [Fact]
+            public void CacheStats()
+            {
+                Assert.True(Parse("-cachestats"));
+                Assert.True(_cacheStats);
+                Assert.False(_cacheStatsVerbose);
+                Assert.False(_shutdown);
+                Assert.Null(_purgeCacheCutoff);
+            }
+
+            [Fact]
+            public void CacheStatsVerbose()
+            {
+                Assert.True(Parse("-cachestats:verbose"));
+                Assert.True(_cacheStats);
+                Assert.True(_cacheStatsVerbose);
+            }
+
+            [Fact]
+            public void PipeAndCacheStats()
+            {
+                Assert.True(Parse("-pipename:test", "-cachestats"));
+                Assert.Equal("test", _pipeName);
+                Assert.True(_cacheStats);
             }
 
             [Fact]

--- a/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
@@ -408,14 +408,14 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             private string _pipeName;
             private bool _shutdown;
             private DateTime? _purgeCacheCutoff;
-            private bool _cacheStats;
-            private bool _cacheStatsVerbose;
+            private DateTime? _cacheStatsSince;
+            private int _cacheStatsVerbosity;
             private TimeSpan? _timeout;
             private string _logFilePath;
 
             private bool Parse(params string[] args)
             {
-                return BuildServerController.ParseCommandLine(args, out _pipeName, out _shutdown, out _purgeCacheCutoff, out _cacheStats, out _cacheStatsVerbose, out _timeout, out _logFilePath);
+                return BuildServerController.ParseCommandLine(args, out _pipeName, out _shutdown, out _purgeCacheCutoff, out _cacheStatsSince, out _cacheStatsVerbosity, out _timeout, out _logFilePath);
             }
 
             [Fact]
@@ -488,18 +488,46 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             public void CacheStats()
             {
                 Assert.True(Parse("-cachestats"));
-                Assert.True(_cacheStats);
-                Assert.False(_cacheStatsVerbose);
+                Assert.Equal(DateTime.MinValue, _cacheStatsSince);
+                Assert.Equal(0, _cacheStatsVerbosity);
                 Assert.False(_shutdown);
                 Assert.Null(_purgeCacheCutoff);
             }
 
             [Fact]
-            public void CacheStatsVerbose()
+            public void CacheStatsWithTimestamp()
             {
-                Assert.True(Parse("-cachestats:verbose"));
-                Assert.True(_cacheStats);
-                Assert.True(_cacheStatsVerbose);
+                Assert.True(Parse("-cachestats:2025-01-15T10:00:00Z"));
+                Assert.Equal(new DateTime(2025, 1, 15, 10, 0, 0, DateTimeKind.Utc), _cacheStatsSince);
+                Assert.Equal(0, _cacheStatsVerbosity);
+            }
+
+            [Fact]
+            public void CacheStatsWithBadTimestamp()
+            {
+                Assert.False(Parse("-cachestats:notadate"));
+            }
+
+            [Fact]
+            public void CacheStatsWithVerbosity()
+            {
+                Assert.True(Parse("-cachestats", "-verbosity:1"));
+                Assert.Equal(DateTime.MinValue, _cacheStatsSince);
+                Assert.Equal(1, _cacheStatsVerbosity);
+            }
+
+            [Fact]
+            public void CacheStatsWithVerbosity2()
+            {
+                Assert.True(Parse("-cachestats:2025-01-15T10:00:00Z", "-verbosity:2"));
+                Assert.Equal(new DateTime(2025, 1, 15, 10, 0, 0, DateTimeKind.Utc), _cacheStatsSince);
+                Assert.Equal(2, _cacheStatsVerbosity);
+            }
+
+            [Fact]
+            public void CacheStatsBadVerbosity()
+            {
+                Assert.False(Parse("-cachestats", "-verbosity:3"));
             }
 
             [Fact]
@@ -507,7 +535,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             {
                 Assert.True(Parse("-pipename:test", "-cachestats"));
                 Assert.Equal("test", _pipeName);
-                Assert.True(_cacheStats);
+                Assert.Equal(DateTime.MinValue, _cacheStatsSince);
             }
 
             [Fact]

--- a/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
@@ -407,8 +407,8 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         {
             private string _pipeName;
             private bool _shutdown;
-            private DateTime? _purgeCacheCutoff;
-            private DateTime? _cacheStatsSince;
+            private DateTimeOffset? _purgeCacheCutoff;
+            private DateTimeOffset? _cacheStatsSince;
             private int _cacheStatsVerbosity;
             private TimeSpan? _timeout;
             private string _logFilePath;
@@ -475,7 +475,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             {
                 Assert.True(Parse("-purgecache:2026-04-10T12:00:00Z"));
                 Assert.NotNull(_purgeCacheCutoff);
-                Assert.Equal(new DateTime(2026, 4, 10, 12, 0, 0, DateTimeKind.Utc), _purgeCacheCutoff.Value);
+                Assert.Equal(new DateTimeOffset(2026, 4, 10, 12, 0, 0, TimeSpan.Zero), _purgeCacheCutoff.Value);
             }
 
             [Fact]
@@ -488,7 +488,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             public void CacheStats()
             {
                 Assert.True(Parse("-cachestats"));
-                Assert.Equal(DateTime.MinValue, _cacheStatsSince);
+                Assert.Equal(DateTimeOffset.MinValue, _cacheStatsSince);
                 Assert.Equal(0, _cacheStatsVerbosity);
                 Assert.False(_shutdown);
                 Assert.Null(_purgeCacheCutoff);
@@ -498,7 +498,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             public void CacheStatsWithTimestamp()
             {
                 Assert.True(Parse("-cachestats:2025-01-15T10:00:00Z"));
-                Assert.Equal(new DateTime(2025, 1, 15, 10, 0, 0, DateTimeKind.Utc), _cacheStatsSince);
+                Assert.Equal(new DateTimeOffset(2025, 1, 15, 10, 0, 0, TimeSpan.Zero), _cacheStatsSince);
                 Assert.Equal(0, _cacheStatsVerbosity);
             }
 
@@ -512,7 +512,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             public void CacheStatsWithVerbosity()
             {
                 Assert.True(Parse("-cachestats", "-cachestatsverbosity:1"));
-                Assert.Equal(DateTime.MinValue, _cacheStatsSince);
+                Assert.Equal(DateTimeOffset.MinValue, _cacheStatsSince);
                 Assert.Equal(1, _cacheStatsVerbosity);
             }
 
@@ -520,7 +520,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             public void CacheStatsWithVerbosity2()
             {
                 Assert.True(Parse("-cachestats:2025-01-15T10:00:00Z", "-cachestatsverbosity:2"));
-                Assert.Equal(new DateTime(2025, 1, 15, 10, 0, 0, DateTimeKind.Utc), _cacheStatsSince);
+                Assert.Equal(new DateTimeOffset(2025, 1, 15, 10, 0, 0, TimeSpan.Zero), _cacheStatsSince);
                 Assert.Equal(2, _cacheStatsVerbosity);
             }
 
@@ -535,7 +535,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             {
                 Assert.True(Parse("-pipename:test", "-cachestats"));
                 Assert.Equal("test", _pipeName);
-                Assert.Equal(DateTime.MinValue, _cacheStatsSince);
+                Assert.Equal(DateTimeOffset.MinValue, _cacheStatsSince);
             }
 
             [Fact]


### PR DESCRIPTION
Motivation: the cache just keeps growing:

| Build ID | Date | Total Content | Chunks |
 |----------|------|---------------|--------|
 | [1370546](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1370546) | Apr 8 | **1,820.4 MB** | 41,030 |
 | [1370974](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1370974) | Apr 8 | **1,839.3 MB** | 41,396 |
 | [1372749](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1372749) | Apr 9 | **6,938.8 MB** | 154,681 |
 | [1374610](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1374610) | Apr 10 | **11,853.8 MB** | 264,535 |
 | [1379925](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1379925) | Apr 15 | **15,241.8 MB** | 426,363 |
 | [1382378](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1382378) | Apr 16 | **19,913.3 MB** | 446,774 |
 | [1383824](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1383824) | Apr 17 | **21,166.2 MB** | 473,620 |
 | [1385070](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1385070) | Apr 18 | **22,869.8 MB** | 641,505 |

Once this PR is merged and an official toolset package is available, I will follow up with running the purge in CI.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83242)