### PR TITLE
Fix InvalidCastException in document highlights for constructor references

### DIFF
--- a/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
+++ b/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
@@ -173,7 +173,12 @@ internal abstract partial class AbstractDocumentHighlightsService :
             var constructorParts1 = constructor.OriginalDefinition.GetAllMethodSymbolsOfPartialParts();
             references = references.WhereAsArray(r =>
             {
-                var constructorParts2 = ((IMethodSymbol)r.Definition).GetAllMethodSymbolsOfPartialParts();
+                // FindReferences on a constructor cascades to the containing type; keep those
+                // non-method definitions as-is since the partial-parts dedup is method-only.
+                if (r.Definition is not IMethodSymbol methodSymbol)
+                    return true;
+
+                var constructorParts2 = methodSymbol.GetAllMethodSymbolsOfPartialParts();
                 return constructorParts1.Intersect(constructorParts2).Any();
             });
         }

--- a/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
+++ b/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
@@ -173,8 +173,8 @@ internal abstract partial class AbstractDocumentHighlightsService :
             var constructorParts1 = constructor.OriginalDefinition.GetAllMethodSymbolsOfPartialParts();
             references = references.WhereAsArray(r =>
             {
-                // FindReferences on a constructor cascades to the containing type; keep those
-                // non-method definitions as-is since the partial-parts dedup is method-only.
+                // For delegate constructors, FindReferences remaps the search to the delegate type,
+                // so r.Definition can be an INamedTypeSymbol. Skip the partial-parts dedup for those.
                 if (r.Definition is not IMethodSymbol methodSymbol)
                     return true;
 

--- a/src/LanguageServer/ProtocolUnitTests/Highlights/DocumentHighlightTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Highlights/DocumentHighlightTests.cs
@@ -148,6 +148,26 @@ public sealed class DocumentHighlightTests(ITestOutputHelper testOutputHelper)
         Assert.Equal(expectedLocations[0].Range, results[0].Range);
     }
 
+    [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/83245")]
+    public async Task TestGetDocumentHighlightAsync_DelegateConstructor(bool lspMutatingWorkspace)
+    {
+        var markup =
+            """
+            using System;
+            class C
+            {
+                void M()
+                {
+                    var z = new {|caret:|}Comparison<int>((a, b) => 0);
+                }
+            }
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(markup, lspMutatingWorkspace);
+
+        var results = await RunGetDocumentHighlightAsync(testLspServer, testLspServer.GetLocations("caret").Single());
+        Assert.NotNull(results);
+    }
+
     private static async Task<LSP.DocumentHighlight[]> RunGetDocumentHighlightAsync(TestLspServer testLspServer, LSP.Location caret)
     {
         var results = await testLspServer.ExecuteRequestAsync<LSP.TextDocumentPositionParams, LSP.DocumentHighlight[]>(LSP.Methods.TextDocumentDocumentHighlightName,


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/83245
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83246)