### PR TITLE
Pre-load lazily-loaded assemblies before assembly snapshots

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerAssemblyLoaderTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerAssemblyLoaderTests.cs
@@ -1158,7 +1158,7 @@ Delta: Epsilon: Test E
         /// Test the case where a utility is loaded by multiple analyzers at different versions. Ensure that no matter
         /// what order we load the analyzers we correctly resolve the utility version.
         /// </summary>
-        [ConditionalTheory(typeof(DesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/79352")]
+        [Theory]
         [CombinatorialData]
         public void AssemblyLoading_MultipleVersions_AnalyzerDependency(AnalyzerTestKind kind, bool normalOrder)
         {

--- a/src/Compilers/Core/CodeAnalysisTest/InvokeUtil.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/InvokeUtil.cs
@@ -81,6 +81,9 @@ namespace Microsoft.CodeAnalysis.UnitTests
             {
                 // When using the actual compiler load context (the one shared by all of our unit tests) the test
                 // did not load any additional assemblies that could interfere with later tests.
+                //
+                // If this assertion fails due to a normal test assembly, like xunit.assert, being loaded after the snapshot, then 
+                // add that assembly to the list of assemblies loaded before the snapshot is taken.
                 AssertEx.SetEqual(compilerContextAssemblies, loader.CompilerLoadContext.Assemblies.SelectAsArray(a => a.FullName));
             }
         }

--- a/src/Compilers/Core/CodeAnalysisTest/InvokeUtil.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/InvokeUtil.cs
@@ -8,10 +8,10 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -64,13 +64,13 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             var loader = new AnalyzerAssemblyLoader(pathResolvers, assemblyResolvers, compilerLoadContext: null);
 
-            // Ensure that test infrastructure assemblies (e.g. DiffPlex and its transitive
-            // dependencies such as Microsoft.Win32.Registry) are already loaded before we
-            // take the snapshot below.  AssertEx has static fields that initialize DiffPlex
-            // on first use; if that first use happens *after* the snapshot is taken then
-            // those assemblies show up as unexpected additions and the assertion at the end
-            // of this method fails intermittently (most visibly in the LoadStream variant).
-            RuntimeHelpers.RunClassConstructor(typeof(AssertEx).TypeHandle);
+            // Ensure that test infrastructure assemblies are already loaded before we
+            // take the snapshot below. These are lazily loaded on first use, and if
+            // that first use happens *after* the snapshot is taken then those assemblies
+            // show up as unexpected additions and the assertion at the end of this method
+            // fails intermittently.
+            TestHelpers.EnsureAssemblyLoaded("Microsoft.CodeAnalysis.Test.Utilities", typeof(AssertEx).TypeHandle);
+            TestHelpers.EnsureAssemblyLoaded("Microsoft.CodeAnalysis.CSharp.Test.Utilities", typeof(TestOptions).TypeHandle);
 
             var compilerContextAssemblies = loader.CompilerLoadContext.Assemblies.SelectAsArray(a => a.FullName);
             try

--- a/src/Compilers/Test/Core/TestHelpers.cs
+++ b/src/Compilers/Test/Core/TestHelpers.cs
@@ -12,6 +12,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Xml.Linq;
@@ -23,6 +24,24 @@ namespace Roslyn.Test.Utilities
 {
     public static class TestHelpers
     {
+        /// <summary>
+        /// Ensures that the assembly containing <paramref name="typeHandle"/> is loaded into
+        /// the current process via <see cref="RuntimeHelpers.RunClassConstructor"/>. The
+        /// <paramref name="assemblyName"/> is validated against the actual assembly name so
+        /// that callers are forced to update both if the type moves to a different assembly.
+        /// </summary>
+        /// <remarks>
+        /// This is used before taking assembly snapshots in tests that verify no unexpected
+        /// assemblies are loaded during test execution. Without this, lazily-loaded assemblies
+        /// can appear as unexpected additions after the snapshot.
+        /// </remarks>
+        public static void EnsureAssemblyLoaded(string assemblyName, RuntimeTypeHandle typeHandle)
+        {
+            var type = Type.GetTypeFromHandle(typeHandle);
+            Debug.Assert(type.Assembly.GetName().Name == assemblyName, $"Expected assembly '{assemblyName}' but type '{type.FullName}' is in '{type.Assembly.GetName().Name}'");
+            RuntimeHelpers.RunClassConstructor(typeHandle);
+        }
+
         /// <summary>
         /// A long timeout used to avoid hangs in tests, where a test failure manifests as an operation never occurring.
         /// </summary>

--- a/src/Tools/ExternalAccess/RazorTest/RazorAnalyzerAssemblyResolverTests.cs
+++ b/src/Tools/ExternalAccess/RazorTest/RazorAnalyzerAssemblyResolverTests.cs
@@ -46,7 +46,11 @@ public sealed class RazorAnalyzerAssemblyResolverTests : IDisposable
     {
         TempRoot.Dispose();
 
-        // This test should not change the set of assemblies loaded in the current context.
+        // This test should not be loading any of the razor assemblies into the test assembly load context. That
+        // would indicate a bug in our product code where it was incorrectly using the default load context.
+        // 
+        // Note: if this test fails due to a normal test assembly, like xunit.assert, being loaded after the 
+        // snapshot, then add that assembly to the list of assemblies loaded in the constructor above.
         var count = AssemblyLoadContext.GetLoadContext(this.GetType().Assembly)!.Assemblies.SelectAsArray(a => a.FullName);
         AssertEx.SetEqual(InitialAssemblies, count);
     }

--- a/src/Tools/ExternalAccess/RazorTest/RazorAnalyzerAssemblyResolverTests.cs
+++ b/src/Tools/ExternalAccess/RazorTest/RazorAnalyzerAssemblyResolverTests.cs
@@ -9,7 +9,6 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.Loader;
 using System.Text;
 using System.Threading.Tasks;
@@ -29,6 +28,17 @@ public sealed class RazorAnalyzerAssemblyResolverTests : IDisposable
 
     public RazorAnalyzerAssemblyResolverTests()
     {
+        // Ensure that test infrastructure and compilation assemblies are already loaded
+        // before we take the snapshot below. These are lazily loaded on first use, and
+        // if that first use happens *after* the snapshot is taken then those assemblies
+        // show up as unexpected additions and the assertion in Dispose fails.
+        TestHelpers.EnsureAssemblyLoaded("Microsoft.CodeAnalysis.CSharp", typeof(CSharpCompilation).TypeHandle);
+        TestHelpers.EnsureAssemblyLoaded("Basic.Reference.Assemblies.NetStandard20", typeof(NetStandard20).TypeHandle);
+        TestHelpers.EnsureAssemblyLoaded("Microsoft.CodeAnalysis.ExternalAccess.Razor.Features", typeof(RazorAnalyzerAssemblyResolver).TypeHandle);
+        TestHelpers.EnsureAssemblyLoaded("Microsoft.CodeAnalysis.Test.Utilities", typeof(AssertEx).TypeHandle);
+        TestHelpers.EnsureAssemblyLoaded("xunit.assert", typeof(Assert).TypeHandle);
+        TestHelpers.EnsureAssemblyLoaded("System.Threading.Tasks.Parallel", typeof(System.Threading.Tasks.Parallel).TypeHandle);
+
         InitialAssemblies = AssemblyLoadContext.GetLoadContext(this.GetType().Assembly)!.Assemblies.SelectAsArray(a => a.FullName);
     }
 
@@ -96,7 +106,7 @@ public sealed class RazorAnalyzerAssemblyResolverTests : IDisposable
     /// platform DLL, like the object pool, will be in the VS platform directory. Need to fall back
     /// to the compiler context to find those.
     /// </summary>
-    [ConditionalFact(typeof(DesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/79352")]
+    [Fact]
     public void FallbackToCompilerContext()
     {
         var dir1 = TempRoot.CreateDirectory().Path;
@@ -130,7 +140,7 @@ public sealed class RazorAnalyzerAssemblyResolverTests : IDisposable
         });
     }
 
-    [ConditionalFact(typeof(DesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/79352")]
+    [Fact]
     public void FirstLoadWins()
     {
         var dir1 = TempRoot.CreateDirectory().Path;
@@ -154,7 +164,7 @@ public sealed class RazorAnalyzerAssemblyResolverTests : IDisposable
         });
     }
 
-    [ConditionalFact(typeof(DesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/79352")]
+    [Fact]
     public void ChooseServiceHubFolder()
     {
         var dir = TempRoot.CreateDirectory().Path;


### PR DESCRIPTION
Tests that validate no new assemblies are loaded into the CompilerLoadContext / test ALC were failing because certain assemblies were lazily loaded after the snapshot was taken.

In AnalyzerAssemblyLoaderTests (InvokeUtil), the test lambda references TestOptions.DebugDll from Microsoft.CodeAnalysis.CSharp.Test.Utilities. When the lambda is JIT-compiled during reflection invocation, that assembly gets loaded after the snapshot. Fix: pre-load it with RuntimeHelpers.RunClassConstructor(typeof(TestOptions).TypeHandle).

In RazorAnalyzerAssemblyResolverTests, multiple assemblies (CSharpCompilation, NetStandard20, xunit.assert, Parallel, etc.) were lazily loaded on first test execution. Fix: pre-load them all in the constructor before capturing the snapshot.

Re-enabled all disabled tests referencing this issue.

closes #79352
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83247)