### PR TITLE
Fix ArgumentNullException in VB Edit and Continue

### DIFF
--- a/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -2340,8 +2340,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                 areSimilar:=Nothing,
                 cancellationToken)
 
+            ' Using statements with variable declarations do not introduce compiler generated temporary.
             ReportUnmatchedStatements(Of UsingBlockSyntax)(diagnostics, forwardMap, oldActiveStatement, oldEncompassingAncestor, oldModel, newActiveStatement, newEncompassingAncestor, newModel,
-                nodeSelector:=Function(node) node.IsKind(SyntaxKind.UsingBlock),
+                nodeSelector:=Function(node) node.IsKind(SyntaxKind.UsingBlock) AndAlso DirectCast(node, UsingBlockSyntax).UsingStatement.Expression IsNot Nothing,
                 getTypedNodes:=Function(n) OneOrMany.Create(Of SyntaxNode)(n.UsingStatement.Expression),
                 areEquivalent:=Function(n1, n2) AreEquivalentIgnoringLambdaBodies(n1.UsingStatement.Expression, n2.UsingStatement.Expression),
                 areSimilar:=Nothing,

--- a/src/Features/VisualBasicTest/EditAndContinue/ActiveStatementTests.vb
+++ b/src/Features/VisualBasicTest/EditAndContinue/ActiveStatementTests.vb
@@ -3357,6 +3357,68 @@ End Class
                 Diagnostic(RudeEditKind.UpdateAroundActiveStatement, "Using G(Function(a) a)", VBFeaturesResources.Using_statement))
         End Sub
 
+        <Fact>
+        Public Sub Using_VariableDeclaration_Update_Leaf()
+            Dim src1 = "
+Imports System
+Imports System.ComponentModel
+
+Class Test
+    Sub Main()
+        Using x As New Component()
+            <AS:0>Console.WriteLine(""Test"")</AS:0>
+        End Using
+    End Sub
+End Class
+"
+            Dim src2 = "
+Imports System
+Imports System.ComponentModel
+
+Class Test
+    Sub Main()
+        Using x As New Component()
+            <AS:0>Console.WriteLine(""Test2"")</AS:0>
+        End Using
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim active = GetActiveStatements(src1, src2)
+            edits.VerifySemanticDiagnostics(active)
+        End Sub
+
+        <Fact>
+        Public Sub Using_VariableDeclaration_Insert()
+            Dim src1 = "
+Imports System
+Imports System.ComponentModel
+
+Class Test
+    Sub Main()
+        <AS:0>Console.WriteLine(""Test"")</AS:0>
+    End Sub
+End Class
+"
+            Dim src2 = "
+Imports System
+Imports System.ComponentModel
+
+Class Test
+    Sub Main()
+        Using x As New Component()
+            <AS:0>Console.WriteLine(""Test"")</AS:0>
+        End Using
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim active = GetActiveStatements(src1, src2)
+            ' Variable declaration Using blocks don't introduce compiler-generated temporaries,
+            ' so no rude edit is reported for insert.
+            edits.VerifySemanticDiagnostics(active)
+        End Sub
+
 #End Region
 
 #Region "With"


### PR DESCRIPTION
Fix an ArgumentNullException in VB Edit and Continue when editing code inside a Using block that declares a variable (e.g., Using x As New Component()).

The UsingBlockSyntax handler in ReportRudeEditsForAncestorsDeclaringInterStatementTemps unconditionally accessed UsingStatement.Expression, which is Nothing for the variable-declaration form of Using. This null propagated into SemanticModel.GetTypeInfo(), causing the crash (ENC0088).

The fix adds a nodeSelector filter to skip variable-declaration Using blocks, matching the existing C# behavior. These blocks don't introduce compiler-generated temporaries, so the inter-statement temp check is unnecessary.

Adds two tests covering editing and inserting variable-declaration Using blocks around active statements.

Fixes DevCom #11074128
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83250)