### PR TITLE
WIP -- Merge semantic diagnostic passes when member-edit analysis is not applicable

### DIFF
--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
@@ -2494,6 +2494,111 @@ public class C
             End Using
         End Function
 
+        ''' <summary>
+        ''' Verifies that when incremental member-edit analysis falls back to full-document analysis
+        ''' (e.g. no prior cached document), diagnostics from both span-based and document-based
+        ''' semantic analyzers are returned AND that both ran in a single pass (same compilation clone).
+        ''' </summary>
+        <WpfFact>
+        Friend Async Function TestSemanticPassMerge_BothAnalyzerCategoriesReturnDiagnosticsAsync() As Task
+            Dim test = <Workspace>
+                           <Project Language="C#" CommonReferences="true">
+                               <Document><![CDATA[
+class MyClass
+{
+    private readonly int _field;
+
+    void M()
+    {
+        int x = 0;
+    }
+}]]>
+                               </Document>
+                           </Project>
+                       </Workspace>
+
+            Using workspace = TestWorkspace.CreateWorkspace(test, composition:=s_compositionWithMockDiagnosticUpdateSourceRegistrationService)
+                Dim solution = workspace.CurrentSolution
+                Dim project = solution.Projects.Single()
+
+                ' Add a span-based semantic analyzer (IBuiltInAnalyzer with SemanticSpanAnalysis)
+                ' and a document-based semantic analyzer (IBuiltInAnalyzer with SemanticDocumentAnalysis).
+                ' These two categories are disjoint and normally run in separate passes.
+                Dim spanAnalyzer = New BuiltInFieldAnalyzer("SPAN01", DiagnosticAnalyzerCategory.SemanticSpanAnalysis)
+                Dim documentAnalyzer = New BuiltInFieldAnalyzer("DOC01", DiagnosticAnalyzerCategory.SemanticDocumentAnalysis)
+                Dim analyzerReference = New AnalyzerImageReference(
+                    ImmutableArray.Create(Of DiagnosticAnalyzer)(spanAnalyzer, documentAnalyzer))
+                project = project.AddAnalyzerReference(analyzerReference)
+                SerializerService.TestAccessor.AddAnalyzerImageReferences(project.AnalyzerReferences)
+
+                Dim diagnosticService = workspace.Services.GetRequiredService(Of IDiagnosticAnalyzerService)()
+
+                ' Request full-document diagnostics (full span -> range becomes null -> incremental path).
+                ' With no prior cached document, the incremental analyzer falls back to full analysis
+                ' and merges both analyzer sets into a single pass.
+                Dim document = project.Documents.Single()
+                Dim root = Await document.GetSyntaxRootAsync()
+                Dim diagnostics = Await GetDiagnosticsForSpanAsync(diagnosticService, document, root.FullSpan)
+
+                ' Both analyzers should report a diagnostic on _field
+                Dim diagnosticIds = diagnostics.Select(Function(d) d.Id).ToHashSet()
+                Assert.Contains("SPAN01", diagnosticIds)
+                Assert.Contains("DOC01", diagnosticIds)
+
+                ' Both analyzers should have been invoked with the same compilation clone,
+                ' proving they ran in a single merged pass rather than separate passes.
+                Dim spanCompilation = Assert.Single(spanAnalyzer.SeenCompilations)
+                Dim docCompilation = Assert.Single(documentAnalyzer.SeenCompilations)
+                Assert.Same(spanCompilation, docCompilation)
+            End Using
+        End Function
+
+        ''' <summary>
+        ''' Verifies that when only span-based semantic analyzers are present (no document-based
+        ''' analyzers), the merge optimization is not triggered and diagnostics are still returned
+        ''' correctly.
+        ''' </summary>
+        <WpfFact>
+        Friend Async Function TestSemanticPassMerge_OnlySpanAnalyzersReturnsDiagnosticsAsync() As Task
+            Dim test = <Workspace>
+                           <Project Language="C#" CommonReferences="true">
+                               <Document><![CDATA[
+class MyClass
+{
+    private readonly int _field;
+
+    void M()
+    {
+        int x = 0;
+    }
+}]]>
+                               </Document>
+                           </Project>
+                       </Workspace>
+
+            Using workspace = TestWorkspace.CreateWorkspace(test, composition:=s_compositionWithMockDiagnosticUpdateSourceRegistrationService)
+                Dim solution = workspace.CurrentSolution
+                Dim project = solution.Projects.Single()
+
+                ' Add only a span-based semantic analyzer — no document-based analyzer.
+                ' The merge optimization should not activate (nothing to merge).
+                Dim spanAnalyzer = New BuiltInFieldAnalyzer("SPAN01", DiagnosticAnalyzerCategory.SemanticSpanAnalysis)
+                Dim analyzerReference = New AnalyzerImageReference(
+                    ImmutableArray.Create(Of DiagnosticAnalyzer)(spanAnalyzer))
+                project = project.AddAnalyzerReference(analyzerReference)
+                SerializerService.TestAccessor.AddAnalyzerImageReferences(project.AnalyzerReferences)
+
+                Dim diagnosticService = workspace.Services.GetRequiredService(Of IDiagnosticAnalyzerService)()
+
+                Dim document = project.Documents.Single()
+                Dim root = Await document.GetSyntaxRootAsync()
+                Dim diagnostics = Await GetDiagnosticsForSpanAsync(diagnosticService, document, root.FullSpan)
+
+                Dim diagnostic = diagnostics.Single(Function(d) d.Id = "SPAN01")
+                Assert.NotNull(diagnostic)
+            End Using
+        End Function
+
         Private NotInheritable Class AllActionsAnalyzer
             Inherits DiagnosticAnalyzer
 
@@ -2538,6 +2643,57 @@ public class C
                                                                         codeBlockStartContext.RegisterSyntaxNodeAction(Sub(syntaxNodeContext) AnalyzedSyntaxNodesInsideCodeBlock.Add(syntaxNodeContext.Node), SyntaxKind.LocalDeclarationStatement)
                                                                         codeBlockStartContext.RegisterCodeBlockEndAction(Sub(codeBlockEndContext) AnalyzedCodeBlockEndSymbols.Add(codeBlockEndContext.OwningSymbol))
                                                                     End Sub)
+            End Sub
+        End Class
+
+        ''' <summary>
+        ''' Test analyzer that implements <see cref="IBuiltInAnalyzer"/> with a configurable
+        ''' <see cref="DiagnosticAnalyzerCategory"/> and reports a diagnostic on field symbols.
+        ''' Used to test the semantic pass merge optimization where span-based and document-based
+        ''' analyzers are merged into a single pass when incremental analysis falls back.
+        ''' </summary>
+        <DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)>
+        Private NotInheritable Class BuiltInFieldAnalyzer
+            Inherits DiagnosticAnalyzer
+            Implements IBuiltInAnalyzer
+
+            Private ReadOnly _category As DiagnosticAnalyzerCategory
+
+            ''' <summary>
+            ''' Compilation references observed during CompilationStartAction callbacks.
+            ''' Used to verify whether two analyzers ran in the same compilation clone (same pass).
+            ''' </summary>
+            Public SeenCompilations As List(Of CodeAnalysis.Compilation) = New List(Of CodeAnalysis.Compilation)()
+
+            Public Sub New(diagnosticId As String, category As DiagnosticAnalyzerCategory)
+                _category = category
+                Descriptor = New DiagnosticDescriptor(
+                    diagnosticId, "Title", "Message", "Category",
+                    defaultSeverity:=DiagnosticSeverity.Warning,
+                    isEnabledByDefault:=True)
+            End Sub
+
+            Public ReadOnly Property Descriptor As DiagnosticDescriptor
+            Public ReadOnly Property IsHighPriority As Boolean Implements IBuiltInAnalyzer.IsHighPriority
+
+            Public Function GetAnalyzerCategory() As DiagnosticAnalyzerCategory Implements IBuiltInAnalyzer.GetAnalyzerCategory
+                Return _category
+            End Function
+
+            Public Overrides ReadOnly Property SupportedDiagnostics As ImmutableArray(Of DiagnosticDescriptor)
+                Get
+                    Return ImmutableArray.Create(Descriptor)
+                End Get
+            End Property
+
+            Public Overrides Sub Initialize(context As AnalysisContext)
+                context.RegisterCompilationStartAction(
+                    Sub(compilationContext)
+                        SeenCompilations.Add(compilationContext.Compilation)
+                        compilationContext.RegisterSymbolAction(
+                            Sub(symbolContext) symbolContext.ReportDiagnostic(Diagnostic.Create(Descriptor, symbolContext.Symbol.Locations(0))),
+                            SymbolKind.Field)
+                    End Sub)
             End Sub
         End Class
     End Class

--- a/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService.IncrementalMemberEditAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService.IncrementalMemberEditAnalyzer.cs
@@ -51,9 +51,10 @@ internal sealed partial class DiagnosticAnalyzerService
         public void UpdateDocumentWithCachedDiagnostics(Document document)
             => _lastDocumentWithCachedDiagnostics.SetTarget(document);
 
-        public async Task<ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<DiagnosticData>>> ComputeDiagnosticsInProcessAsync(
+        public async Task<(ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<DiagnosticData>> results, bool didMergeAnalyzerComputations)> ComputeDiagnosticsInProcessAsync(
             DocumentAnalysisExecutor executor,
             ImmutableArray<DiagnosticAnalyzer> analyzers,
+            ImmutableArray<DiagnosticAnalyzer> additionalAnalyzersToMergeOnFullAnalysis,
             VersionStamp version,
             CancellationToken cancellationToken)
         {
@@ -71,8 +72,9 @@ internal sealed partial class DiagnosticAnalyzerService
             if (changedMemberAndIdAndSpansAndDocument == null)
             {
                 // This is not a member-edit scenario, so compute full document diagnostics
-                // without incremental analysis.
-                return await ComputeDocumentDiagnosticsCoreInProcessAsync(executor, cancellationToken).ConfigureAwait(false);
+                // without incremental analysis. When document-based analyzers are provided,
+                // merge them into a single pass to avoid duplicate binding costs.
+                return await ComputeMergedDiagnosticsAsync(executor, analyzers, additionalAnalyzersToMergeOnFullAnalysis, cancellationToken).ConfigureAwait(false);
             }
 
             var (changedMember, changedMemberId, newMemberSpans, oldDocument) = changedMemberAndIdAndSpansAndDocument.Value;
@@ -108,7 +110,7 @@ internal sealed partial class DiagnosticAnalyzerService
                 if (spanBasedAnalyzers.Count == 0 && (!compilerAnalyzerData.HasValue || !compilerAnalyzerData.Value.spanBased))
                 {
                     // No incremental span based-analysis to be performed.
-                    return await ComputeDocumentDiagnosticsCoreInProcessAsync(executor, cancellationToken).ConfigureAwait(false);
+                    return await ComputeMergedDiagnosticsAsync(executor, analyzers, additionalAnalyzersToMergeOnFullAnalysis, cancellationToken).ConfigureAwait(false);
                 }
 
                 // Get or create the member spans for all member nodes in the old document.
@@ -120,7 +122,7 @@ internal sealed partial class DiagnosticAnalyzerService
                 await ExecuteCompilerAnalyzerAsync(compilerAnalyzerData, oldMemberSpans, builder).ConfigureAwait(false);
                 await ExecuteSpanBasedAnalyzersAsync(spanBasedAnalyzers, oldMemberSpans, builder).ConfigureAwait(false);
                 await ExecuteDocumentBasedAnalyzersAsync(documentBasedAnalyzers, oldMemberSpans, builder).ConfigureAwait(false);
-                return builder.ToImmutableDictionary();
+                return (builder.ToImmutableDictionary(), didMergeAnalyzerComputations: false);
             }
             finally
             {
@@ -260,6 +262,43 @@ internal sealed partial class DiagnosticAnalyzerService
             {
                 _savedMemberSpans = new MemberSpans(documentId, version, memberSpans);
             }
+        }
+
+        /// <summary>
+        /// Computes full-document diagnostics when incremental member-edit analysis is not applicable.
+        /// When <paramref name="documentAnalyzers"/> is non-empty,
+        /// merges both semantic analyzer sets into a single pass to avoid creating separate compilation
+        /// clones and the associated duplicated binding cost.
+        /// </summary>
+        private static async Task<(ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<DiagnosticData>> results, bool didMergeAnalyzerComputations)> ComputeMergedDiagnosticsAsync(
+            DocumentAnalysisExecutor executor,
+            ImmutableArray<DiagnosticAnalyzer> spanAnalyzers,
+            ImmutableArray<DiagnosticAnalyzer> documentAnalyzers,
+            CancellationToken cancellationToken)
+        {
+            var didMergeAnalyzerComputations = !documentAnalyzers.IsDefaultOrEmpty;
+            if (didMergeAnalyzerComputations)
+            {
+                Debug.Assert(
+                    spanAnalyzers.All(a => !documentAnalyzers.Contains(a)),
+                    "Span and document analyzer sets must be disjoint");
+
+                // Merge both semantic analyzer sets into a single full-document pass.
+                // If executed separately, each pass would create its own compilation clone and independently
+                // trigger binding (the dominant allocation cost for semantic analysis).
+                // By merging, we pay this cost only once.
+                var mergedAnalyzers = spanAnalyzers.AddRange(documentAnalyzers);
+                var mergedScope = new DocumentAnalysisScope(
+                    executor.AnalysisScope.TextDocument,
+                    span: null,
+                    mergedAnalyzers,
+                    executor.AnalysisScope.Kind);
+
+                executor = executor.With(mergedScope);
+            }
+
+            var results = await ComputeDocumentDiagnosticsCoreInProcessAsync(executor, cancellationToken).ConfigureAwait(false);
+            return (results, didMergeAnalyzerComputations);
         }
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService_GetDiagnosticsForSpan.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService_GetDiagnosticsForSpan.cs
@@ -294,9 +294,25 @@ internal sealed partial class DiagnosticAnalyzerService
 
         using var _ = ArrayBuilder<DiagnosticData>.GetInstance(out var list);
 
-        await ComputeDocumentDiagnosticsAsync(this, document, compilationWithAnalyzers, logPerformanceInfo, syntaxAnalyzers, AnalysisKind.Syntax, range, incrementalAnalysis: false, list, cancellationToken).ConfigureAwait(false);
-        await ComputeDocumentDiagnosticsAsync(this, document, compilationWithAnalyzers, logPerformanceInfo, semanticSpanAnalyzers, AnalysisKind.Semantic, range, incrementalAnalysis, list, cancellationToken).ConfigureAwait(false);
-        await ComputeDocumentDiagnosticsAsync(this, document, compilationWithAnalyzers, logPerformanceInfo, semanticDocumentAnalyzers, AnalysisKind.Semantic, span: null, incrementalAnalysis: false, list, cancellationToken).ConfigureAwait(false);
+        await ComputeDocumentDiagnosticsAsync(this, document, compilationWithAnalyzers, logPerformanceInfo, syntaxAnalyzers, AnalysisKind.Syntax, range, list, cancellationToken).ConfigureAwait(false);
+
+        if (incrementalAnalysis)
+        {
+            // Pass document analyzers to the incremental analyzer so that if it cannot perform
+            // member-edit analysis (e.g., structural edits like adding/removing a using directive),
+            // it can merge both semantic analyzer sets into a single pass, avoiding the cost of
+            // each pass independently creating a compilation clone and triggering binding.
+            var didMergeAnalyzerComputations = await ComputeIncrementalDocumentDiagnosticsAsync(this, document, compilationWithAnalyzers, logPerformanceInfo, semanticSpanAnalyzers, AnalysisKind.Semantic, range, additionalAnalyzersToMergeOnFullAnalysis: semanticDocumentAnalyzers, list, cancellationToken).ConfigureAwait(false);
+            if (!didMergeAnalyzerComputations)
+            {
+                await ComputeDocumentDiagnosticsAsync(this, document, compilationWithAnalyzers, logPerformanceInfo, semanticDocumentAnalyzers, AnalysisKind.Semantic, span: null, list, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        else
+        {
+            await ComputeDocumentDiagnosticsAsync(this, document, compilationWithAnalyzers, logPerformanceInfo, semanticSpanAnalyzers, AnalysisKind.Semantic, range, list, cancellationToken).ConfigureAwait(false);
+            await ComputeDocumentDiagnosticsAsync(this, document, compilationWithAnalyzers, logPerformanceInfo, semanticDocumentAnalyzers, AnalysisKind.Semantic, span: null, list, cancellationToken).ConfigureAwait(false);
+        }
 
         return list.ToImmutableAndClear();
 
@@ -308,29 +324,49 @@ internal sealed partial class DiagnosticAnalyzerService
             ImmutableArray<DiagnosticAnalyzer> analyzers,
             AnalysisKind kind,
             TextSpan? span,
-            bool incrementalAnalysis,
             ArrayBuilder<DiagnosticData> list,
             CancellationToken cancellationToken)
         {
             if (analyzers.Length == 0)
                 return;
 
-            Debug.Assert(!incrementalAnalysis || kind == AnalysisKind.Semantic);
-            Debug.Assert(!incrementalAnalysis || analyzers.All(analyzer => analyzer.SupportsSpanBasedSemanticDiagnosticAnalysis()));
+            var analysisScope = new DocumentAnalysisScope(document, span, analyzers, kind);
+            var executor = new DocumentAnalysisExecutor(service, analysisScope, compilationWithAnalyzers, logPerformanceInfo);
+            var version = await GetDiagnosticVersionAsync(document.Project, cancellationToken).ConfigureAwait(false);
+
+            var diagnosticsMap = await ComputeDocumentDiagnosticsCoreInProcessAsync(executor, cancellationToken).ConfigureAwait(false);
+
+            list.AddRange(diagnosticsMap.SelectMany(kvp => kvp.Value));
+        }
+
+        static async Task<bool> ComputeIncrementalDocumentDiagnosticsAsync(
+            DiagnosticAnalyzerService service,
+            TextDocument document,
+            CompilationWithAnalyzers? compilationWithAnalyzers,
+            bool logPerformanceInfo,
+            ImmutableArray<DiagnosticAnalyzer> analyzers,
+            AnalysisKind kind,
+            TextSpan? span,
+            ImmutableArray<DiagnosticAnalyzer> additionalAnalyzersToMergeOnFullAnalysis,
+            ArrayBuilder<DiagnosticData> list,
+            CancellationToken cancellationToken)
+        {
+            if (analyzers.Length == 0)
+                return false;
+
+            Debug.Assert(kind == AnalysisKind.Semantic);
+            Debug.Assert(analyzers.All(analyzer => analyzer.SupportsSpanBasedSemanticDiagnosticAnalysis()));
 
             var analysisScope = new DocumentAnalysisScope(document, span, analyzers, kind);
             var executor = new DocumentAnalysisExecutor(service, analysisScope, compilationWithAnalyzers, logPerformanceInfo);
             var version = await GetDiagnosticVersionAsync(document.Project, cancellationToken).ConfigureAwait(false);
 
-            var computeTask = incrementalAnalysis
-                ? service._incrementalMemberEditAnalyzer.ComputeDiagnosticsInProcessAsync(executor, analyzers, version, cancellationToken)
-                : ComputeDocumentDiagnosticsCoreInProcessAsync(executor, cancellationToken);
-            var diagnosticsMap = await computeTask.ConfigureAwait(false);
-
-            if (incrementalAnalysis)
-                service._incrementalMemberEditAnalyzer.UpdateDocumentWithCachedDiagnostics((Document)document);
+            var (diagnosticsMap, didMergeAnalyzerComputations) = await service._incrementalMemberEditAnalyzer.ComputeDiagnosticsInProcessAsync(
+                executor, analyzers, additionalAnalyzersToMergeOnFullAnalysis, version, cancellationToken).ConfigureAwait(false);
+            service._incrementalMemberEditAnalyzer.UpdateDocumentWithCachedDiagnostics((Document)document);
 
             list.AddRange(diagnosticsMap.SelectMany(kvp => kvp.Value));
+            return didMergeAnalyzerComputations;
         }
     }
 }


### PR DESCRIPTION
When full-document diagnostics are requested with incremental analysis enabled, two separate semantic passes run: one for span-based (built-in) analyzers and one for document-based (public/NuGet) analyzers. Each pass independently clones the compilation and triggers binding — the dominant allocation cost.

When the incremental member-edit analyzer determines it cannot perform span-based analysis (structural edits or no cached prior document), both passes perform identical work. This change merges the two analyzer sets into a single pass in that scenario, eliminating one compilation clone and its associated binding cost (~45% reduction per diagnostic request).

Changes:
 - IncrementalMemberEditAnalyzer.ComputeDiagnosticsInProcessAsync now accepts additionalAnalyzersToMergeOnFullAnalysis and returns whether the merge occurred via a tuple
 - Added ComputeMergedDiagnosticsAsync helper with disjointness assert
 - Split ComputeDocumentDiagnosticsAsync into non-incremental and incremental variants; caller skips the document pass when merge fired
 - Added tests verifying both analyzer categories return diagnostics and that they execute against the same compilation clone (single pass)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83256)