### PR TITLE
Address CG alerts on main

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -304,12 +304,12 @@
     <PackageVersion Include="Microsoft.TeamFoundationServer.Client" Version="19.232.0-preview" />
     <PackageVersion Include="System.Data.SqlClient" Version="$(SystemDataSqlClientVersion)" />
     <!-- fix of vulnerability in 6.0.0 coming via Microsoft.TeamFoundationServer.Client -->
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.0" />
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="8.0.1" />
     <!--
       vs-extension-testing
     -->
-    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.106" />
+    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.213" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="$(MicrosoftCodeAnalysisTestingVersion)" />
 
     <!--

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "10.0.105",
+    "version": "10.0.106",
     "allowPrerelease": false,
     "rollForward": "patch"
   },
   "tools": {
-    "dotnet": "10.0.105",
+    "dotnet": "10.0.106",
     "vs": {
       "version": "17.14.0"
     },

--- a/src/VisualStudio/IntegrationTest/Harness/XUnitShared/Harness/MessageFilter.cs
+++ b/src/VisualStudio/IntegrationTest/Harness/XUnitShared/Harness/MessageFilter.cs
@@ -7,6 +7,7 @@ namespace Xunit.Harness
     using System;
     using System.Runtime.InteropServices;
     using Windows.Win32.Media;
+    using HTASK = Windows.Win32.Foundation.HTASK;
     using IMessageFilter = Windows.Win32.Media.Audio.IMessageFilter;
     using PENDINGMSG = Windows.Win32.System.Com.PENDINGMSG;
     using SERVERCALL = Windows.Win32.System.Com.SERVERCALL;


### PR DESCRIPTION
## Summary
- update the repo SDK pin to 10.0.106
- bump System.Security.Cryptography.Xml to 8.0.3 and pin System.Security.Cryptography.Pkcs to 8.0.1 to satisfy the updated dependency graph
- bump Microsoft.Windows.CsWin32 to 0.3.213 and update the HTASK alias usage required by the newer generated API

## Testing
- full local build succeeded
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83261)