### PR TITLE
Improve ensure-sources-synced.cs script

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -488,7 +488,7 @@ stages:
         inputs:
           command: 'custom'
           custom: 'run'
-          arguments: '--file $(Build.SourcesDirectory)/eng/ensure-sources-synced.cs'
+          arguments: '--file $(Build.SourcesDirectory)/eng/ensure-sources-synced.cs -- --verify'
 
       - powershell: eng/validate-code-formatting.ps1 -ci -rootDirectory $(Build.SourcesDirectory)\src -includeDirectories Compilers\CSharp\Portable\Generated\, Compilers\VisualBasic\Portable\Generated\, ExpressionEvaluator\VisualBasic\Source\ResultProvider\Generated\
         displayName: Validate Generated Syntax Files

--- a/eng/ensure-sources-synced.cs
+++ b/eng/ensure-sources-synced.cs
@@ -14,9 +14,7 @@ using System.Text.Json;
 //   dotnet run --file eng/ensure-sources-synced.cs -- --verify
 //   dotnet run --file eng/ensure-sources-synced.cs -- --update
 //
-// Default mode when no args are passed:
-//   - CI: verify
-//   - Local: update
+// Default mode when no args are passed: update
 
 try
 {
@@ -156,14 +154,7 @@ static async Task MainAsync(string[] args)
 
 static SyncMode ParseMode(string[] args)
 {
-    if (args.Length == 0)
-    {
-        var onCi = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI"))
-            || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TF_BUILD"));
-        return onCi ? SyncMode.Verify : SyncMode.Update;
-    }
-
-    if (args is ["--update"])
+    if (args is [] or ["--update"])
         return SyncMode.Update;
 
     if (args is ["--verify"])

--- a/eng/ensure-sources-synced.cs
+++ b/eng/ensure-sources-synced.cs
@@ -63,16 +63,8 @@ static async Task MainAsync(string[] args)
         includeFile: static name => string.Equals(name, "SourcePackage.editorconfig", StringComparison.OrdinalIgnoreCase),
         mapRelativePath: static _ => ".editorconfig").ConfigureAwait(false);
 
-    var xlfFiles = await GetDirectoryFilesAsync(
-        httpClient,
-        sdkCommit,
-        githubDirectoryPath: "src/Cli/Microsoft.DotNet.FileBasedPrograms/xlf",
-        includeFile: static name => name.EndsWith(".xlf", StringComparison.OrdinalIgnoreCase),
-        mapRelativePath: static name => $"xlf/{name}").ConfigureAwait(false);
-
     var sourcePackageFiles = sourceFiles
         .Concat(editorConfigFiles)
-        .Concat(xlfFiles)
         .ToList();
     if (sourcePackageFiles.Count == 0) throw new InvalidOperationException("No source files found in dotnet/sdk.");
 
@@ -118,8 +110,7 @@ static async Task MainAsync(string[] args)
     if (Directory.Exists(localSourceDir))
     {
         var localMirrorFiles = Directory.GetFiles(localSourceDir, "*", SearchOption.AllDirectories)
-            .Where(f => f.EndsWith(".xlf", StringComparison.OrdinalIgnoreCase)
-                || extensions.Any(ext => f.EndsWith(ext, StringComparison.OrdinalIgnoreCase)))
+            .Where(f => extensions.Any(ext => f.EndsWith(ext, StringComparison.OrdinalIgnoreCase)))
             .Select(f => Path.GetRelativePath(localSourceDir, f).Replace('\\', '/'))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 

--- a/eng/ensure-sources-synced.cs
+++ b/eng/ensure-sources-synced.cs
@@ -167,7 +167,8 @@ static SyncMode ParseMode(string[] args)
 {
     if (args.Length == 0)
     {
-        var onCi = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI"));
+        var onCi = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI"))
+            || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TF_BUILD"));
         return onCi ? SyncMode.Verify : SyncMode.Update;
     }
 


### PR DESCRIPTION
1. Ensure it correctly verifies in CI.
2. Ignore xlf files. Those are translated independently in roslyn repo, and so are expected to be out of sync with the sdk repo. They should be checked to be in sync with their corresponding resx by other CI checks.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83271)