### PR TITLE
Add dotnet/skills marketplace and enable plugins

### DIFF
--- a/.github/copilot/settings.json
+++ b/.github/copilot/settings.json
@@ -1,0 +1,21 @@
+{
+  "extraKnownMarketplaces": {
+    "dotnet-arcade-skills": {
+      "source": {
+        "source": "github",
+        "repo": "dotnet/arcade-skills"
+      }
+    },
+    "dotnet-skills": {
+      "source": {
+        "source": "github",
+        "repo": "dotnet/skills"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "dotnet-dnceng@dotnet-arcade-skills": true,
+    "dotnet@dotnet-skills": true,
+    "dotnet-test@dotnet-skills": true
+  }
+}


### PR DESCRIPTION
This PR adds `.github/copilot/settings.json` to configure Copilot skill marketplaces and enable plugins.\n\n## Changes\n\n- **New file:** `.github/copilot/settings.json`\n- **Extra known marketplaces:**\n  - `dotnet-arcade-skills` → `dotnet/arcade-skills`\n  - `dotnet-skills` → `dotnet/skills`\n- **Enabled plugins:**\n  - `dotnet-dnceng@dotnet-arcade-skills`\n  - `dotnet@dotnet-skills`\n  - `dotnet-test@dotnet-skills`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83273)