### PR TITLE
Make ISourceLinkService a workspace service

### DIFF
--- a/src/EditorFeatures/CSharpTest/PdbSourceDocument/PdbFileLocatorServiceTests.cs
+++ b/src/EditorFeatures/CSharpTest/PdbSourceDocument/PdbFileLocatorServiceTests.cs
@@ -33,9 +33,9 @@ public sealed class PdbFileLocatorServiceTests : AbstractPdbSourceDocumentTests
             File.Move(GetPdbPath(path), pdbFilePath);
 
             var sourceLinkService = new TestSourceLinkService(pdbFilePath: pdbFilePath);
-            var service = new PdbFileLocatorService(sourceLinkService, logger: null);
+            var service = new PdbFileLocatorService(logger: null);
 
-            using var result = await service.GetDocumentDebugInfoReaderAsync(GetDllPath(path), useDefaultSymbolServers: false, new TelemetryMessage(CancellationToken.None), CancellationToken.None);
+            using var result = await service.GetDocumentDebugInfoReaderAsync(GetDllPath(path), useDefaultSymbolServers: false, new TelemetryMessage(CancellationToken.None), sourceLinkService, CancellationToken.None);
 
             Assert.NotNull(result);
         });
@@ -60,9 +60,9 @@ public sealed class PdbFileLocatorServiceTests : AbstractPdbSourceDocumentTests
             File.Move(GetPdbPath(path), pdbFilePath);
 
             var sourceLinkService = new TestSourceLinkService(pdbFilePath);
-            var service = new PdbFileLocatorService(sourceLinkService, logger: null);
+            var service = new PdbFileLocatorService(logger: null);
 
-            using var result = await service.GetDocumentDebugInfoReaderAsync(GetDllPath(path), useDefaultSymbolServers: false, new TelemetryMessage(CancellationToken.None), CancellationToken.None);
+            using var result = await service.GetDocumentDebugInfoReaderAsync(GetDllPath(path), useDefaultSymbolServers: false, new TelemetryMessage(CancellationToken.None), sourceLinkService, CancellationToken.None);
 
             Assert.Null(result);
         });
@@ -85,9 +85,9 @@ public sealed class PdbFileLocatorServiceTests : AbstractPdbSourceDocumentTests
             File.Move(GetPdbPath(path), pdbFilePath);
 
             var sourceLinkService = new TestSourceLinkService(pdbFilePath: null);
-            var service = new PdbFileLocatorService(sourceLinkService, logger: null);
+            var service = new PdbFileLocatorService(logger: null);
 
-            using var result = await service.GetDocumentDebugInfoReaderAsync(GetDllPath(path), useDefaultSymbolServers: false, new TelemetryMessage(CancellationToken.None), CancellationToken.None);
+            using var result = await service.GetDocumentDebugInfoReaderAsync(GetDllPath(path), useDefaultSymbolServers: false, new TelemetryMessage(CancellationToken.None), sourceLinkService, CancellationToken.None);
 
             Assert.Null(result);
         });

--- a/src/EditorFeatures/CSharpTest/PdbSourceDocument/PdbSourceDocumentLoaderServiceTests.cs
+++ b/src/EditorFeatures/CSharpTest/PdbSourceDocument/PdbSourceDocumentLoaderServiceTests.cs
@@ -35,14 +35,14 @@ public sealed class PdbSourceDocumentLoaderServiceTests : AbstractPdbSourceDocum
             var sourceFilePath = Path.Combine(path, "SourceLink.cs");
             File.Move(GetSourceFilePath(path), sourceFilePath);
 
-            var sourceLinkService = new Lazy<ISourceLinkService>(() => new TestSourceLinkService(sourceFilePath: sourceFilePath));
-            var service = new PdbSourceDocumentLoaderService(sourceLinkService, logger: null);
+            var sourceLinkService = new TestSourceLinkService(sourceFilePath: sourceFilePath);
+            var service = new PdbSourceDocumentLoaderService(logger: null);
 
             using var hash = SHA256.Create();
             var fileHash = hash.ComputeHash(File.ReadAllBytes(sourceFilePath));
 
             var sourceDocument = new SourceDocument("goo.cs", Text.SourceHashAlgorithms.Default, [.. fileHash], null, "https://sourcelink");
-            var result = await service.LoadSourceDocumentAsync(path, sourceDocument, Encoding.UTF8, new TelemetryMessage(CancellationToken.None), useExtendedTimeout: false, CancellationToken.None);
+            var result = await service.LoadSourceDocumentAsync(path, sourceDocument, Encoding.UTF8, new TelemetryMessage(CancellationToken.None), useExtendedTimeout: false, sourceLinkService, CancellationToken.None);
 
             Assert.NotNull(result);
             Assert.Equal(sourceFilePath, result!.FilePath);
@@ -66,11 +66,11 @@ public sealed class PdbSourceDocumentLoaderServiceTests : AbstractPdbSourceDocum
             var sourceFilePath = Path.Combine(path, "SourceLink.cs");
             File.Move(GetSourceFilePath(path), sourceFilePath);
 
-            var sourceLinkService = new Lazy<ISourceLinkService>(() => new TestSourceLinkService(sourceFilePath: sourceFilePath));
-            var service = new PdbSourceDocumentLoaderService(sourceLinkService, logger: null);
+            var sourceLinkService = new TestSourceLinkService(sourceFilePath: sourceFilePath);
+            var service = new PdbSourceDocumentLoaderService(logger: null);
 
             var sourceDocument = new SourceDocument("goo.cs", Text.SourceHashAlgorithm.None, default, null, SourceLinkUrl: null);
-            var result = await service.LoadSourceDocumentAsync(path, sourceDocument, Encoding.UTF8, new TelemetryMessage(CancellationToken.None), useExtendedTimeout: false, CancellationToken.None);
+            var result = await service.LoadSourceDocumentAsync(path, sourceDocument, Encoding.UTF8, new TelemetryMessage(CancellationToken.None), useExtendedTimeout: false, sourceLinkService, CancellationToken.None);
 
             Assert.Null(result);
         });

--- a/src/Features/Core/Portable/PdbSourceDocument/IPdbFileLocatorService.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/IPdbFileLocatorService.cs
@@ -10,5 +10,5 @@ namespace Microsoft.CodeAnalysis.PdbSourceDocument;
 
 internal interface IPdbFileLocatorService
 {
-    Task<DocumentDebugInfoReader?> GetDocumentDebugInfoReaderAsync(string dllPath, bool useDefaultSymbolServers, TelemetryMessage telemetry, CancellationToken cancellationToken);
+    Task<DocumentDebugInfoReader?> GetDocumentDebugInfoReaderAsync(string dllPath, bool useDefaultSymbolServers, TelemetryMessage telemetry, ISourceLinkService? sourceLinkService, CancellationToken cancellationToken);
 }

--- a/src/Features/Core/Portable/PdbSourceDocument/IPdbSourceDocumentLoaderService.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/IPdbSourceDocumentLoaderService.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.PdbSourceDocument;
 
 internal interface IPdbSourceDocumentLoaderService
 {
-    Task<SourceFileInfo?> LoadSourceDocumentAsync(string tempFilePath, SourceDocument sourceDocument, Encoding encoding, TelemetryMessage telemetry, bool useExtendedTimeout, CancellationToken cancellationToken);
+    Task<SourceFileInfo?> LoadSourceDocumentAsync(string tempFilePath, SourceDocument sourceDocument, Encoding encoding, TelemetryMessage telemetry, bool useExtendedTimeout, ISourceLinkService? sourceLinkService, CancellationToken cancellationToken);
 }
 
 /// <param name="FilePath">The path to the source file on disk</param>

--- a/src/Features/Core/Portable/PdbSourceDocument/ISourceLinkService.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/ISourceLinkService.cs
@@ -5,10 +5,11 @@
 using System.Reflection.PortableExecutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.CodeAnalysis.PdbSourceDocument;
 
-internal interface ISourceLinkService
+internal interface ISourceLinkService : IWorkspaceService
 {
     Task<SourceFilePathResult?> GetSourceFilePathAsync(string url, string relativePath, CancellationToken cancellationToken);
 

--- a/src/Features/Core/Portable/PdbSourceDocument/PdbFileLocatorService.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/PdbFileLocatorService.cs
@@ -19,15 +19,13 @@ namespace Microsoft.CodeAnalysis.PdbSourceDocument;
 [method: ImportingConstructor]
 [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code")]
 internal sealed class PdbFileLocatorService(
-    [Import(AllowDefault = true)] ISourceLinkService? sourceLinkService,
     [Import(AllowDefault = true)] IPdbSourceDocumentLogger? logger) : IPdbFileLocatorService
 {
     private const int SymbolLocatorTimeout = 2000;
 
-    private readonly ISourceLinkService? _sourceLinkService = sourceLinkService;
     private readonly IPdbSourceDocumentLogger? _logger = logger;
 
-    public async Task<DocumentDebugInfoReader?> GetDocumentDebugInfoReaderAsync(string dllPath, bool useDefaultSymbolServers, TelemetryMessage telemetry, CancellationToken cancellationToken)
+    public async Task<DocumentDebugInfoReader?> GetDocumentDebugInfoReaderAsync(string dllPath, bool useDefaultSymbolServers, TelemetryMessage telemetry, ISourceLinkService? sourceLinkService, CancellationToken cancellationToken)
     {
         var dllStream = IOUtilities.PerformIO(() => ReadFileIfExists(dllPath));
         if (dllStream is null)
@@ -59,7 +57,7 @@ internal sealed class PdbFileLocatorService(
 
             if (result is null)
             {
-                if (_sourceLinkService is null)
+                if (sourceLinkService is null)
                 {
                     _logger?.Log(FeaturesResources.Could_not_find_PDB_on_disk_or_embedded);
                 }
@@ -67,7 +65,7 @@ internal sealed class PdbFileLocatorService(
                 {
                     var delay = Task.Delay(SymbolLocatorTimeout, cancellationToken);
                     // Call the debugger to find the PDB from a symbol server etc.
-                    var pdbResultTask = _sourceLinkService.GetPdbFilePathAsync(dllPath, peReader, useDefaultSymbolServers, cancellationToken);
+                    var pdbResultTask = sourceLinkService.GetPdbFilePathAsync(dllPath, peReader, useDefaultSymbolServers, cancellationToken);
 
                     var winner = await Task.WhenAny(pdbResultTask, delay).ConfigureAwait(false);
 

--- a/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentLoaderService.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentLoaderService.cs
@@ -22,26 +22,20 @@ namespace Microsoft.CodeAnalysis.PdbSourceDocument;
 [method: ImportingConstructor]
 [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code")]
 internal sealed class PdbSourceDocumentLoaderService(
-    [Import(AllowDefault = true)] Lazy<ISourceLinkService>? sourceLinkService,
     [Import(AllowDefault = true)] IPdbSourceDocumentLogger? logger) : IPdbSourceDocumentLoaderService
 {
     private const int SourceLinkTimeout = 1000;
     private const int ExtendedSourceLinkTimeout = 4000;
 
-    /// <summary>
-    /// Lazy import ISourceLinkService because it can cause debugger 
-    /// binaries to be eagerly loaded even if they are never used.
-    /// </summary>
-    private readonly Lazy<ISourceLinkService>? _sourceLinkService = sourceLinkService;
     private readonly IPdbSourceDocumentLogger? _logger = logger;
 
-    public async Task<SourceFileInfo?> LoadSourceDocumentAsync(string tempFilePath, SourceDocument sourceDocument, Encoding encoding, TelemetryMessage telemetry, bool useExtendedTimeout, CancellationToken cancellationToken)
+    public async Task<SourceFileInfo?> LoadSourceDocumentAsync(string tempFilePath, SourceDocument sourceDocument, Encoding encoding, TelemetryMessage telemetry, bool useExtendedTimeout, ISourceLinkService? sourceLinkService, CancellationToken cancellationToken)
     {
         // First we try getting "local" files, either from embedded source or a local file on disk
         // and if they don't work we call the debugger to download a file from SourceLink info
         return TryGetEmbeddedSourceFile(tempFilePath, sourceDocument, encoding, telemetry) ??
             TryGetOriginalFile(sourceDocument, encoding, telemetry) ??
-            await TryGetSourceLinkFileAsync(sourceDocument, encoding, telemetry, useExtendedTimeout, cancellationToken).ConfigureAwait(false);
+            await TryGetSourceLinkFileAsync(sourceDocument, encoding, telemetry, useExtendedTimeout, sourceLinkService, cancellationToken).ConfigureAwait(false);
     }
 
     private SourceFileInfo? TryGetEmbeddedSourceFile(string tempFilePath, SourceDocument sourceDocument, Encoding encoding, TelemetryMessage telemetry)
@@ -122,9 +116,9 @@ internal sealed class PdbSourceDocumentLoaderService(
         return null;
     }
 
-    private async Task<SourceFileInfo?> TryGetSourceLinkFileAsync(SourceDocument sourceDocument, Encoding encoding, TelemetryMessage telemetry, bool useExtendedTimeout, CancellationToken cancellationToken)
+    private async Task<SourceFileInfo?> TryGetSourceLinkFileAsync(SourceDocument sourceDocument, Encoding encoding, TelemetryMessage telemetry, bool useExtendedTimeout, ISourceLinkService? sourceLinkService, CancellationToken cancellationToken)
     {
-        if (sourceDocument.SourceLinkUrl is null || _sourceLinkService is null)
+        if (sourceDocument.SourceLinkUrl is null || sourceLinkService is null)
             return null;
 
         var timeout = useExtendedTimeout ? ExtendedSourceLinkTimeout : SourceLinkTimeout;
@@ -133,7 +127,7 @@ internal sealed class PdbSourceDocumentLoaderService(
         var relativePath = Path.GetFileName(sourceDocument.FilePath);
 
         var delay = Task.Delay(timeout, cancellationToken);
-        var sourceFileTask = _sourceLinkService.Value.GetSourceFilePathAsync(sourceDocument.SourceLinkUrl, relativePath, cancellationToken);
+        var sourceFileTask = sourceLinkService.GetSourceFilePathAsync(sourceDocument.SourceLinkUrl, relativePath, cancellationToken);
 
         var winner = await Task.WhenAny(sourceFileTask, delay).ConfigureAwait(false);
 

--- a/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentMetadataAsSourceFileProvider.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentMetadataAsSourceFileProvider.cs
@@ -170,10 +170,12 @@ internal sealed class PdbSourceDocumentMetadataAsSourceFileProvider(
         ImmutableDictionary<string, string> pdbCompilationOptions;
         ImmutableArray<SourceDocument> sourceDocuments;
 
+        var sourceLinkService = sourceWorkspace.Services.GetService<ISourceLinkService>();
+
         try
         {
             // We know we have a DLL, call and see if we can find metadata readers for it, and for the PDB (wherever it may be)
-            using var documentDebugInfoReader = await _pdbFileLocatorService.GetDocumentDebugInfoReaderAsync(dllPath, options.AlwaysUseDefaultSymbolServers, telemetryMessage, cancellationToken).ConfigureAwait(false);
+            using var documentDebugInfoReader = await _pdbFileLocatorService.GetDocumentDebugInfoReaderAsync(dllPath, options.AlwaysUseDefaultSymbolServers, telemetryMessage, sourceLinkService, cancellationToken).ConfigureAwait(false);
             if (documentDebugInfoReader is null)
                 return null;
 
@@ -246,7 +248,7 @@ internal sealed class PdbSourceDocumentMetadataAsSourceFileProvider(
         // we can't provide any results, so there is no point adding a project to the workspace etc.
         var useExtendedTimeout = _sourceLinkEnabledProjects.Contains(projectId);
         var encoding = defaultEncoding ?? Encoding.UTF8;
-        var sourceFileInfoTasks = sourceDocuments.Select(sd => _pdbSourceDocumentLoaderService.LoadSourceDocumentAsync(tempFilePath, sd, encoding, telemetryMessage, useExtendedTimeout, cancellationToken)).ToArray();
+        var sourceFileInfoTasks = sourceDocuments.Select(sd => _pdbSourceDocumentLoaderService.LoadSourceDocumentAsync(tempFilePath, sd, encoding, telemetryMessage, useExtendedTimeout, sourceLinkService, cancellationToken)).ToArray();
         var sourceFileInfos = await Task.WhenAll(sourceFileInfoTasks).ConfigureAwait(false);
         if (sourceFileInfos is null || sourceFileInfos.Where(t => t is null).Any())
             return null;

--- a/src/VisualStudio/Core/Def/PdbSourceDocument/SourceLinkService.cs
+++ b/src/VisualStudio/Core/Def/PdbSourceDocument/SourceLinkService.cs
@@ -13,7 +13,7 @@ using Microsoft.VisualStudio.Debugger.Contracts.SymbolLocator;
 
 namespace Microsoft.VisualStudio.LanguageServices.PdbSourceDocument;
 
-[Export(typeof(ISourceLinkService)), Shared]
+[ExportWorkspaceService(typeof(ISourceLinkService), ServiceLayer.Host), Shared]
 internal sealed class SourceLinkService : AbstractSourceLinkService
 {
     private readonly IDebuggerSymbolLocatorService _debuggerSymbolLocatorService;

--- a/src/VisualStudio/DevKit/Impl/SourceLink/VSCodeSourceLinkService.cs
+++ b/src/VisualStudio/DevKit/Impl/SourceLink/VSCodeSourceLinkService.cs
@@ -3,11 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.BrokeredServices;
-using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.PdbSourceDocument;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.Debugger.Contracts.SourceLink;
@@ -16,12 +14,9 @@ using Microsoft.VisualStudio.LanguageServices.PdbSourceDocument;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Services.SourceLink;
 
-[Export(typeof(ISourceLinkService)), Shared]
-[method: ImportingConstructor]
-[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class VSCodeSourceLinkService(IServiceBrokerProvider serviceBrokerProvider, IPdbSourceDocumentLogger logger) : AbstractSourceLinkService
+internal sealed class VSCodeSourceLinkService(IServiceBroker serviceBroker, IPdbSourceDocumentLogger? logger) : AbstractSourceLinkService
 {
-    private readonly IServiceBroker _serviceBroker = serviceBrokerProvider.ServiceBroker;
+    private readonly IServiceBroker _serviceBroker = serviceBroker;
 
     protected override async Task<SymbolLocatorResult?> LocateSymbolFileAsync(SymbolLocatorPdbInfo pdbInfo, SymbolLocatorSearchFlags flags, CancellationToken cancellationToken)
     {

--- a/src/VisualStudio/DevKit/Impl/SourceLink/VSCodeSourceLinkServiceFactory.cs
+++ b/src/VisualStudio/DevKit/Impl/SourceLink/VSCodeSourceLinkServiceFactory.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis.BrokeredServices;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.PdbSourceDocument;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Services.SourceLink;
+
+[ExportWorkspaceServiceFactory(typeof(ISourceLinkService), ServiceLayer.Host), Shared]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class VSCodeSourceLinkServiceFactory(
+    IServiceBrokerProvider serviceBrokerProvider,
+    [Import(AllowDefault = true)] IPdbSourceDocumentLogger? logger) : IWorkspaceServiceFactory
+{
+    public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
+        => new VSCodeSourceLinkService(serviceBrokerProvider.ServiceBroker, logger);
+}


### PR DESCRIPTION
ISourceLinkService now extends IWorkspaceService so it can be resolved from workspace services instead of being directly MEF-imported.

VS: SourceLinkService uses [ExportWorkspaceService] with direct MEF imports of debugger services (unchanged behavior).

LSP: New VSCodeSourceLinkServiceFactory (IWorkspaceServiceFactory) creates VSCodeSourceLinkService instances. The factory MEF-imports IServiceBrokerProvider for now; the broker provisioning will be refactored separately.

PdbFileLocatorService and PdbSourceDocumentLoaderService no longer import ISourceLinkService via MEF. Instead, the orchestrator (PdbSourceDocumentMetadataAsSourceFileProvider) resolves it from sourceWorkspace.Services and passes it as a method parameter.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83276)