### PR TITLE
Tidy compound assignment in initializer binder and tests

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -5945,13 +5945,34 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // access is rooted at the initializer placeholder, which object-initializer lowering
                         // substitutes with the real receiver at emit time. Event `+`/`-` dispatch falls out of
                         // BindCompoundAssignmentCore's existing `left.Kind == BoundKind.EventAccess` branch.
-                        _ = BindObjectInitializerMember(
+                        BoundExpression boundLeft = BindObjectInitializerMember(
                             initializer, implicitReceiver, diagnostics,
                             valueKindOverride: BindValueKind.CompoundAssignment,
                             out BoundExpression rawAccess);
 
                         if (rawAccess == null)
                             break;
+
+                        // BindObjectInitializerMemberCommon records value-kind failures (CS0200 on get-only,
+                        // CS0154 on set-only, CS0191 on readonly, CS8331 on ref-readonly, etc.) on the
+                        // BoundObjectInitializerMember wrapper but does not propagate hasErrors back to the
+                        // raw access. Wrap the raw access in a bad expression in that case so downstream
+                        // operator resolution and flow analysis see a known-bad left rather than asserting.
+                        if (boundLeft != null && boundLeft.HasAnyErrors && !rawAccess.HasAnyErrors)
+                        {
+                            rawAccess = ToBadExpression(rawAccess, LookupResultKind.NotAVariable);
+                        }
+
+                        // Per spec, the compound_assignment_operator branch of member_initializer admits only
+                        // *expression*, not the nested initializer form. The parser is permissive (it produces a
+                        // nested ObjectInitializerExpression / CollectionInitializerExpression on the RHS), so we
+                        // reject the shape here. Returning directly avoids falling through to the default case,
+                        // which would re-bind the whole assignment and crash trying to bind the brace-list RHS.
+                        if (initializer.Right is InitializerExpressionSyntax)
+                        {
+                            Error(diagnostics, ErrorCode.ERR_InvalidInitializerElementInitializer, initializer);
+                            return BindToTypeForErrorRecovery(ToBadExpression(rawAccess, LookupResultKind.NotAValue));
+                        }
 
                         BoundExpression boundRight = BindValue(initializer.Right, diagnostics, BindValueKind.RValue);
 
@@ -6244,6 +6265,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                     resultKind = isRhsNestedInitializer ? LookupResultKind.NotAValue : LookupResultKind.NotAVariable;
                 }
             }
+
+#if DEBUG
+            // CheckValueKind above validates the value-kind for this member access but does not set the
+            // WasPropertyBackingFieldAccessChecked flag that the BindValue -> CheckValue path normally sets.
+            // The compound-assignment-in-initializer path hands the raw access to BindCompoundAssignmentCore
+            // rather than wrapping it in BoundObjectInitializerMember, so the post-bind walker in
+            // MethodCompiler would otherwise find an unchecked BoundPropertyAccess. boundMember is freshly
+            // built here and not shared with other binding paths, so a direct set is safe.
+            if (boundMember is BoundPropertyAccess { WasPropertyBackingFieldAccessChecked: false } pa)
+            {
+                pa.WasPropertyBackingFieldAccessChecked = true;
+            }
+#endif
 
             rawAccess = boundMember;
             return new BoundObjectInitializerMember(

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -6269,13 +6269,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
 #if DEBUG
-            // CheckValueKind above validates the value-kind for this member access but does not set the
-            // WasPropertyBackingFieldAccessChecked flag that the BindValue -> CheckValue path normally sets.
-            // The compound-assignment-in-initializer path hands the raw access to BindCompoundAssignmentCore
-            // rather than wrapping it in BoundObjectInitializerMember, so the post-bind walker in
-            // MethodCompiler would otherwise find an unchecked BoundPropertyAccess. boundMember is freshly
-            // built here and not shared with other binding paths, so a direct set is safe.
-            if (boundMember is BoundPropertyAccess { WasPropertyBackingFieldAccessChecked: false } pa)
+            // On the non-compound path the BoundPropertyAccess is hidden inside BoundObjectInitializerMember
+            // and the walker in MethodCompiler never inspects it, so the flag is not needed there. On the
+            // compound-assignment path we hand the raw access to BindCompoundAssignmentCore unwrapped, so the
+            // walker sees it directly and asserts unless the flag is set. CheckValueKind above performs the
+            // validation but doesn't set the flag (only the BindValue -> CheckValue path does); set it here
+            // for the compound case. boundMember is freshly built in this method, so the direct set is safe.
+            if (valueKind == BindValueKind.CompoundAssignment &&
+                boundMember is BoundPropertyAccess { WasPropertyBackingFieldAccessChecked: false } pa)
             {
                 pa.WasPropertyBackingFieldAccessChecked = true;
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -5933,30 +5933,29 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var initializer = (AssignmentExpressionSyntax)memberInitializer;
                         MessageID.IDS_FeatureCompoundAssignmentInInitializer.CheckFeatureAvailability(diagnostics, initializer.OperatorToken);
 
-                        BoundExpression boundLeft = BindObjectInitializerMember(
+                        // Bind the member access via the usual object-initializer member machinery so that
+                        // indexer default arguments, accessor-kind tracking, interpolated-string-handler checks,
+                        // and BindValueKind.CompoundAssignment (read + write, init-allowed on the placeholder) all
+                        // get applied. We then hand the raw access (BoundPropertyAccess / BoundFieldAccess /
+                        // BoundEventAccess / BoundIndexerAccess / BoundDynamicObjectInitializerMember / ...) to
+                        // BindCompoundAssignmentCore rather than the BoundObjectInitializerMember wrapper. The
+                        // wrapper exists to drive simple-assignment lowering; CheckValueKind does not have a
+                        // case for it, so passing it here would cause shouldTryUserDefinedInstanceOperator to
+                        // falsely return false and skip user-defined in-place `operator +=` resolution. The raw
+                        // access is rooted at the initializer placeholder, which object-initializer lowering
+                        // substitutes with the real receiver at emit time. Event `+`/`-` dispatch falls out of
+                        // BindCompoundAssignmentCore's existing `left.Kind == BoundKind.EventAccess` branch.
+                        _ = BindObjectInitializerMember(
                             initializer, implicitReceiver, diagnostics,
                             valueKindOverride: BindValueKind.CompoundAssignment,
                             out BoundExpression rawAccess);
 
-                        if (boundLeft == null)
+                        if (rawAccess == null)
                             break;
 
                         BoundExpression boundRight = BindValue(initializer.Right, diagnostics, BindValueKind.RValue);
 
-                        // Event target with `+=` / `-=` routes directly to BindEventAssignment, which takes
-                        // the unwrapped BoundEventAccess and produces BoundEventAssignmentOperator.
-                        if (rawAccess is BoundEventAccess eventAccess)
-                        {
-                            var kindOperator = SyntaxKindToBinaryOperatorKind(initializer.Kind()).Operator();
-                            if (kindOperator is BinaryOperatorKind.Addition or BinaryOperatorKind.Subtraction)
-                            {
-                                return BindEventAssignment(initializer, eventAccess, boundRight, kindOperator, diagnostics);
-                            }
-                            // Other compound ops on an event target fall through to BindCompoundAssignmentCore,
-                            // which reports CS0019 (no `operator *`, etc. on a delegate type).
-                        }
-
-                        return BindCompoundAssignmentCore(initializer, boundLeft, boundRight, diagnostics);
+                        return BindCompoundAssignmentCore(initializer, rawAccess, boundRight, diagnostics);
                     }
 
                 // We fall back on simply binding the name as an expression for proper recovery

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -5950,33 +5950,35 @@ namespace Microsoft.CodeAnalysis.CSharp
                             valueKindOverride: BindValueKind.CompoundAssignment,
                             out BoundExpression rawAccess);
 
-                        if (rawAccess == null)
-                            break;
-
-                        // BindObjectInitializerMemberCommon records value-kind failures (CS0200 on get-only,
-                        // CS0154 on set-only, CS0191 on readonly, CS8331 on ref-readonly, etc.) on the
-                        // BoundObjectInitializerMember wrapper but does not propagate hasErrors back to the
-                        // raw access. Wrap the raw access in a bad expression in that case so downstream
-                        // operator resolution and flow analysis see a known-bad left rather than asserting.
-                        if (boundLeft != null && boundLeft.HasAnyErrors && !rawAccess.HasAnyErrors)
+                        if (rawAccess != null)
                         {
-                            rawAccess = ToBadExpression(rawAccess, LookupResultKind.NotAVariable);
+                            // BindObjectInitializerMemberCommon records value-kind failures (CS0200 on get-only,
+                            // CS0154 on set-only, CS0191 on readonly, CS8331 on ref-readonly, etc.) on the
+                            // BoundObjectInitializerMember wrapper but does not propagate hasErrors back to the
+                            // raw access. Wrap the raw access in a bad expression in that case so downstream
+                            // operator resolution and flow analysis see a known-bad left rather than asserting.
+                            if (boundLeft != null && boundLeft.HasAnyErrors && !rawAccess.HasAnyErrors)
+                            {
+                                rawAccess = ToBadExpression(rawAccess, LookupResultKind.NotAVariable);
+                            }
+
+                            // Per spec, the compound_assignment_operator branch of member_initializer admits only
+                            // *expression*, not the nested initializer form. The parser is permissive (it produces a
+                            // nested ObjectInitializerExpression / CollectionInitializerExpression on the RHS), so
+                            // we reject the shape here. Returning directly avoids falling through to the default
+                            // case, which would re-bind the whole assignment and crash trying to bind the brace-list
+                            // RHS.
+                            if (initializer.Right is InitializerExpressionSyntax)
+                            {
+                                Error(diagnostics, ErrorCode.ERR_InvalidInitializerElementInitializer, initializer);
+                                return BindToTypeForErrorRecovery(ToBadExpression(rawAccess, LookupResultKind.NotAValue));
+                            }
+
+                            BoundExpression boundRight = BindValue(initializer.Right, diagnostics, BindValueKind.RValue);
+
+                            return BindCompoundAssignmentCore(initializer, rawAccess, boundRight, diagnostics);
                         }
-
-                        // Per spec, the compound_assignment_operator branch of member_initializer admits only
-                        // *expression*, not the nested initializer form. The parser is permissive (it produces a
-                        // nested ObjectInitializerExpression / CollectionInitializerExpression on the RHS), so we
-                        // reject the shape here. Returning directly avoids falling through to the default case,
-                        // which would re-bind the whole assignment and crash trying to bind the brace-list RHS.
-                        if (initializer.Right is InitializerExpressionSyntax)
-                        {
-                            Error(diagnostics, ErrorCode.ERR_InvalidInitializerElementInitializer, initializer);
-                            return BindToTypeForErrorRecovery(ToBadExpression(rawAccess, LookupResultKind.NotAValue));
-                        }
-
-                        BoundExpression boundRight = BindValue(initializer.Right, diagnostics, BindValueKind.RValue);
-
-                        return BindCompoundAssignmentCore(initializer, rawAccess, boundRight, diagnostics);
+                        break;
                     }
 
                 // We fall back on simply binding the name as an expression for proper recovery

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -5850,8 +5850,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var initializers = ArrayBuilder<BoundExpression>.GetInstance(initializerSyntax.Expressions.Count);
 
-            // Member name map to report duplicate assignments to a field/property.
-            var memberNameMap = PooledHashSet<string>.GetInstance();
+            // Per-name initializer state used to enforce the duplicate-member rules from
+            // https://github.com/dotnet/csharplang/blob/main/proposals/compound-assignment-in-initializer-and-with.md :
+            // at most one `=` per field/property target, any number of compound assignments, and `=` must appear
+            // before any compound assignment for the same target. Event (BoundEventAssignmentOperator) and indexer
+            // (ImplicitElementAccess) targets are unrestricted.
+            var memberNameMap = PooledDictionary<string, MemberInitializerState>.GetInstance();
             foreach (var memberInitializer in initializerSyntax.Expressions)
             {
                 BoundExpression boundMemberInitializer = BindInitializerMemberAssignment(
@@ -5861,12 +5865,20 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 ReportDuplicateObjectMemberInitializers(boundMemberInitializer, memberNameMap, diagnostics);
             }
+            memberNameMap.Free();
 
             return new BoundObjectInitializerExpression(
                 initializerSyntax,
                 implicitReceiver,
                 initializers.ToImmutableAndFree(),
                 initializerType);
+        }
+
+        private enum MemberInitializerState
+        {
+            None = 0,
+            SeenEquals = 1,
+            SeenCompound = 2,
         }
 
         private BoundExpression BindInitializerMemberAssignment(
@@ -5904,6 +5916,47 @@ namespace Microsoft.CodeAnalysis.CSharp
                             return BindAssignment(initializer, boundLeft, boundRight, isRef, diagnostics);
                         }
                         break;
+                    }
+
+                case SyntaxKind.AddAssignmentExpression:
+                case SyntaxKind.SubtractAssignmentExpression:
+                case SyntaxKind.MultiplyAssignmentExpression:
+                case SyntaxKind.DivideAssignmentExpression:
+                case SyntaxKind.ModuloAssignmentExpression:
+                case SyntaxKind.AndAssignmentExpression:
+                case SyntaxKind.OrAssignmentExpression:
+                case SyntaxKind.ExclusiveOrAssignmentExpression:
+                case SyntaxKind.LeftShiftAssignmentExpression:
+                case SyntaxKind.RightShiftAssignmentExpression:
+                case SyntaxKind.UnsignedRightShiftAssignmentExpression:
+                    {
+                        var initializer = (AssignmentExpressionSyntax)memberInitializer;
+                        MessageID.IDS_FeatureCompoundAssignmentInInitializer.CheckFeatureAvailability(diagnostics, initializer.OperatorToken);
+
+                        BoundExpression boundLeft = BindObjectInitializerMember(
+                            initializer, implicitReceiver, diagnostics,
+                            valueKindOverride: BindValueKind.CompoundAssignment,
+                            out BoundExpression rawAccess);
+
+                        if (boundLeft == null)
+                            break;
+
+                        BoundExpression boundRight = BindValue(initializer.Right, diagnostics, BindValueKind.RValue);
+
+                        // Event target with `+=` / `-=` routes directly to BindEventAssignment, which takes
+                        // the unwrapped BoundEventAccess and produces BoundEventAssignmentOperator.
+                        if (rawAccess is BoundEventAccess eventAccess)
+                        {
+                            var kindOperator = SyntaxKindToBinaryOperatorKind(initializer.Kind()).Operator();
+                            if (kindOperator is BinaryOperatorKind.Addition or BinaryOperatorKind.Subtraction)
+                            {
+                                return BindEventAssignment(initializer, eventAccess, boundRight, kindOperator, diagnostics);
+                            }
+                            // Other compound ops on an event target fall through to BindCompoundAssignmentCore,
+                            // which reports CS0019 (no `operator *`, etc. on a delegate type).
+                        }
+
+                        return BindCompoundAssignmentCore(initializer, boundLeft, boundRight, diagnostics);
                     }
 
                 // We fall back on simply binding the name as an expression for proper recovery
@@ -5946,15 +5999,33 @@ namespace Microsoft.CodeAnalysis.CSharp
             AssignmentExpressionSyntax namedAssignment,
             BoundObjectOrCollectionValuePlaceholder implicitReceiver,
             BindingDiagnosticBag diagnostics)
+            => BindObjectInitializerMember(namedAssignment, implicitReceiver, diagnostics, valueKindOverride: null, out _);
+
+        /// <summary>
+        /// Binds the left side of a member initializer. When <paramref name="valueKindOverride"/> is supplied,
+        /// it replaces the normally-computed <see cref="BindValueKind"/> (used by the compound-assignment
+        /// path to request <see cref="BindValueKind.CompoundAssignment"/>). <paramref name="rawAccess"/>
+        /// receives the underlying member access (e.g. <see cref="BoundFieldAccess"/>, <see cref="BoundPropertyAccess"/>,
+        /// <see cref="BoundEventAccess"/>, indexer / implicit-indexer / dynamic / array / pointer forms) before
+        /// wrapping in <see cref="BoundObjectInitializerMember"/>, so callers can dispatch on the member kind
+        /// (e.g. route event targets to <c>BindEventAssignment</c>).
+        /// </summary>
+        private BoundExpression BindObjectInitializerMember(
+            AssignmentExpressionSyntax namedAssignment,
+            BoundObjectOrCollectionValuePlaceholder implicitReceiver,
+            BindingDiagnosticBag diagnostics,
+            BindValueKind? valueKindOverride,
+            out BoundExpression rawAccess)
         {
             var leftSyntax = namedAssignment.Left;
             SyntaxKind rhsKind = namedAssignment.Right.Kind();
             bool isRef = rhsKind is SyntaxKind.RefExpression;
             bool isRhsNestedInitializer = rhsKind is SyntaxKind.ObjectInitializerExpression or SyntaxKind.CollectionInitializerExpression;
-            BindValueKind valueKind = isRhsNestedInitializer ? BindValueKind.RValue : (isRef ? BindValueKind.RefAssignable : BindValueKind.Assignable);
+            BindValueKind valueKind = valueKindOverride
+                ?? (isRhsNestedInitializer ? BindValueKind.RValue : (isRef ? BindValueKind.RefAssignable : BindValueKind.Assignable));
 
             return BindObjectInitializerMemberCommon(
-                leftSyntax, implicitReceiver, valueKind, isRhsNestedInitializer, diagnostics);
+                leftSyntax, implicitReceiver, valueKind, isRhsNestedInitializer, diagnostics, out rawAccess);
         }
 
         // returns BadBoundExpression or BoundObjectInitializerMember or BoundDynamicObjectInitializerMember or BoundImplicitIndexerAccess or BoundArrayAccess or BoundPointerElementAccess
@@ -5964,7 +6035,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BindingDiagnosticBag diagnostics)
         {
             return BindObjectInitializerMemberCommon(
-                leftSyntax, implicitReceiver, BindValueKind.Assignable, false, diagnostics);
+                leftSyntax, implicitReceiver, BindValueKind.Assignable, false, diagnostics, out _);
         }
 
         // returns BadBoundExpression or BoundObjectInitializerMember or BoundDynamicObjectInitializerMember or BoundImplicitIndexerAccess or BoundArrayAccess or BoundPointerElementAccess
@@ -5973,8 +6044,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundObjectOrCollectionValuePlaceholder implicitReceiver,
             BindValueKind valueKind,
             bool isRhsNestedInitializer,
-            BindingDiagnosticBag diagnostics)
+            BindingDiagnosticBag diagnostics,
+            out BoundExpression rawAccess)
         {
+            rawAccess = null;
+
             BoundExpression boundMember;
             LookupResultKind resultKind;
             bool hasErrors;
@@ -5989,6 +6063,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     // D = { ..., <identifier> = <expr>, ... }, where D : dynamic
                     boundMember = new BoundDynamicObjectInitializerMember(leftSyntax, memberName.Identifier.Text, implicitReceiver.Type, initializerType, hasErrors: false);
+                    rawAccess = boundMember;
                     return CheckValue(boundMember, valueKind, diagnostics);
                 }
                 else
@@ -6133,6 +6208,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         hasErrors |= !CheckNestedObjectInitializerPropertySymbol(property, leftSyntax, diagnostics, hasErrors, ref resultKind);
                     }
 
+                    rawAccess = boundMember;
                     return hasErrors ? boundMember : CheckValue(boundMember, valueKind, diagnostics);
 
                 case BoundKind.DynamicObjectInitializerMember:
@@ -6150,9 +6226,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 case BoundKind.ArrayAccess:
                 case BoundKind.PointerElementAccess:
+                    rawAccess = boundMember;
                     return CheckValue(boundMember, valueKind, diagnostics);
 
                 default:
+                    rawAccess = boundMember;
                     return BadObjectInitializerMemberAccess(boundMember, implicitReceiver, leftSyntax, diagnostics, valueKind, hasErrors);
             }
 
@@ -6168,6 +6246,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
+            rawAccess = boundMember;
             return new BoundObjectInitializerMember(
                 leftSyntax,
                 boundMember.ExpressionSymbol,
@@ -6249,31 +6328,55 @@ namespace Microsoft.CodeAnalysis.CSharp
             return ToBadExpression(boundMember, (valueKind == BindValueKind.RValue) ? LookupResultKind.NotAValue : LookupResultKind.NotAVariable);
         }
 
-        private static void ReportDuplicateObjectMemberInitializers(BoundExpression boundMemberInitializer, HashSet<string> memberNameMap, BindingDiagnosticBag diagnostics)
+        private static void ReportDuplicateObjectMemberInitializers(
+            BoundExpression boundMemberInitializer,
+            Dictionary<string, MemberInitializerState> memberNameMap,
+            BindingDiagnosticBag diagnostics)
         {
             Debug.Assert(memberNameMap != null);
 
-            // SPEC:    It is an error for an object initializer to include more than one member initializer for the same field or property.
+            // SPEC:    For any given field or property target, at most one member initializer may use the `=` operator.
+            // SPEC:    Any number of member initializers using a compound_assignment_operator are permitted for the
+            // SPEC:    same target. If both are present for the same target, the `=` member initializer shall appear
+            // SPEC:    in lexical order before any compound_assignment_operator member initializer for that target.
+            // SPEC:    No such restriction applies to event or indexer targets.
 
-            if (!boundMemberInitializer.HasAnyErrors)
+            if (boundMemberInitializer.HasAnyErrors)
+                return;
+
+            // Event targets are unrestricted: += / -= on an event binds as BoundEventAssignmentOperator, which
+            // we skip entirely. The field-like-event `Event = null` spec-violation form binds as
+            // BoundAssignmentOperator wrapping a BoundObjectInitializerMember and is tracked like a field below.
+            if (boundMemberInitializer is BoundEventAssignmentOperator)
+                return;
+
+            if (boundMemberInitializer.Syntax is not AssignmentExpressionSyntax namedAssignment)
+                return;
+
+            // Only identifier-named targets participate in the duplicate rules. Indexer targets
+            // (`[args] = ...` / `[args] += ...`) are unrestricted.
+            if (namedAssignment.Left is not IdentifierNameSyntax memberNameSyntax)
+                return;
+
+            var memberName = memberNameSyntax.Identifier.ValueText;
+            bool isSimpleAssignment = namedAssignment.Kind() == SyntaxKind.SimpleAssignmentExpression;
+
+            memberNameMap.TryGetValue(memberName, out var state);
+            if (isSimpleAssignment)
             {
-                // SPEC:    A member initializer that specifies an expression after the equals sign is processed in the same way as an assignment (7.17.1) to the field or property.
-
-                var memberInitializerSyntax = boundMemberInitializer.Syntax;
-
-                Debug.Assert(memberInitializerSyntax.Kind() == SyntaxKind.SimpleAssignmentExpression);
-                var namedAssignment = (AssignmentExpressionSyntax)memberInitializerSyntax;
-
-                var memberNameSyntax = namedAssignment.Left as IdentifierNameSyntax;
-                if (memberNameSyntax != null)
+                // A second `=`, or a `=` that follows any compound assignment for the same target, is an error.
+                if (state != MemberInitializerState.None)
                 {
-                    var memberName = memberNameSyntax.Identifier.ValueText;
-
-                    if (!memberNameMap.Add(memberName))
-                    {
-                        Error(diagnostics, ErrorCode.ERR_MemberAlreadyInitialized, memberNameSyntax, memberName);
-                    }
+                    Error(diagnostics, ErrorCode.ERR_MemberAlreadyInitialized, memberNameSyntax, memberName);
                 }
+
+                memberNameMap[memberName] = MemberInitializerState.SeenEquals;
+            }
+            else
+            {
+                // Compound forms are unrestricted for the same target; just record that a compound appeared
+                // so a later `=` for the same target can be flagged.
+                memberNameMap[memberName] = MemberInitializerState.SeenCompound;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -23,18 +23,30 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundExpression BindCompoundAssignment(AssignmentExpressionSyntax node, BindingDiagnosticBag diagnostics)
         {
+            node.Left.CheckDeconstructionCompatibleArgument(diagnostics);
+
+            BoundExpression left = BindValue(node.Left, diagnostics, GetBinaryAssignmentKind(node.Kind()));
+            ReportSuppressionIfNeeded(left, diagnostics);
+            BoundExpression right = BindValue(node.Right, diagnostics, BindValueKind.RValue);
+
+            return BindCompoundAssignmentCore(node, left, right, diagnostics);
+        }
+
+        /// <summary>
+        /// Binds a compound assignment given an already-bound left and right. Used by
+        /// <see cref="BindCompoundAssignment"/> for the ordinary expression path, and by
+        /// <c>BindInitializerMemberAssignment</c> for compound member initializers where the left
+        /// has already been bound as a <see cref="BoundObjectInitializerMember"/>.
+        /// </summary>
+        private BoundExpression BindCompoundAssignmentCore(AssignmentExpressionSyntax node, BoundExpression left, BoundExpression right, BindingDiagnosticBag diagnostics)
+        {
             OperatorResolutionForReporting operatorResolutionForReporting = default;
-            BoundExpression result = bindCompoundAssignment(node, ref operatorResolutionForReporting, diagnostics);
+            BoundExpression result = bindCompoundAssignmentCore(node, left, right, ref operatorResolutionForReporting, diagnostics);
             operatorResolutionForReporting.Free();
             return result;
 
-            BoundExpression bindCompoundAssignment(AssignmentExpressionSyntax node, ref OperatorResolutionForReporting operatorResolutionForReporting, BindingDiagnosticBag diagnostics)
+            BoundExpression bindCompoundAssignmentCore(AssignmentExpressionSyntax node, BoundExpression left, BoundExpression right, ref OperatorResolutionForReporting operatorResolutionForReporting, BindingDiagnosticBag diagnostics)
             {
-                node.Left.CheckDeconstructionCompatibleArgument(diagnostics);
-
-                BoundExpression left = BindValue(node.Left, diagnostics, GetBinaryAssignmentKind(node.Kind()));
-                ReportSuppressionIfNeeded(left, diagnostics);
-                BoundExpression right = BindValue(node.Right, diagnostics, BindValueKind.RValue);
                 BinaryOperatorKind kind = SyntaxKindToBinaryOperatorKind(node.Kind());
 
                 // If either operand is bad, don't try to do binary operator overload resolution; that will just

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -8297,6 +8297,9 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="IDS_FeatureUnions" xml:space="preserve">
     <value>unions</value>
   </data>
+  <data name="IDS_FeatureCompoundAssignmentInInitializer" xml:space="preserve">
+    <value>compound assignment in object initializer and with expression</value>
+  </data>
   <data name="ERR_UnionDeclarationNeedsCaseTypes" xml:space="preserve">
     <value>A union declaration must specify at least one case type.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -310,6 +310,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureUnsafeEvolution = MessageBase + 12859,
 
         IDS_FeatureUnions = MessageBase + 12860,
+
+        IDS_FeatureCompoundAssignmentInInitializer = MessageBase + 12861,
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -493,6 +495,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case MessageID.IDS_FeatureCollectionExpressionArguments:
                 case MessageID.IDS_FeatureUnsafeEvolution: // https://github.com/dotnet/roslyn/issues/82546: keep this in preview until C# 16
                 case MessageID.IDS_FeatureUnions:
+                case MessageID.IDS_FeatureCompoundAssignmentInInitializer:
                     return LanguageVersion.Preview;
 
                 // C# 14.0 features.

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -13348,13 +13348,56 @@ done:
         private bool IsNamedMemberInitializer()
         {
             // Accept `Identifier =`, `Identifier :` (recovered to `=`), or `Identifier op=` for any compound
-            // assignment operator (including `??=`). Compound operators on member initializers are legal under
-            // the compound-assignment-in-initializer feature; binder checks language version and target legality.
+            // assignment operator (including `??=`, `>>=`, `>>>=`). Compound operators on member initializers
+            // are legal under the compound-assignment-in-initializer feature; binder checks language version
+            // and target legality.
             if (!IsTrueIdentifier())
                 return false;
 
-            var next = this.PeekToken(1).Kind;
-            return next == SyntaxKind.ColonToken || SyntaxFacts.IsAssignmentExpressionOperatorToken(next);
+            var token1 = this.PeekToken(1);
+            if (token1.Kind == SyntaxKind.ColonToken)
+                return true;
+
+            if (SyntaxFacts.IsAssignmentExpressionOperatorToken(token1.Kind))
+                return true;
+
+            // `>>=` and `>>>=` are split by the lexer into multiple tokens to keep nested generic argument
+            // lists parseable. Detect the adjacency pattern here so the named-member path triggers correctly.
+            return IsSplitRightShiftAssignmentAt(position: 1);
+        }
+
+        /// <summary>
+        /// Returns true if the token at <paramref name="position"/> (0 = current, 1 = peek 1, ...) is a
+        /// <c>&gt;</c> that, together with the adjacent token(s), forms a <c>&gt;&gt;=</c> or <c>&gt;&gt;&gt;=</c>
+        /// compound assignment operator. Adjacency is determined by <see cref="NoTriviaBetween"/>.
+        /// </summary>
+        private bool IsSplitRightShiftAssignmentAt(int position)
+        {
+            var token1 = this.PeekToken(position);
+            if (token1.Kind != SyntaxKind.GreaterThanToken)
+                return false;
+
+            var token2 = this.PeekToken(position + 1);
+            if (!NoTriviaBetween(token1, token2))
+                return false;
+
+            if (token2.Kind == SyntaxKind.GreaterThanEqualsToken)
+            {
+                // `>` then `>=` → `>>=`
+                return true;
+            }
+
+            if (token2.Kind == SyntaxKind.GreaterThanToken)
+            {
+                var token3 = this.PeekToken(position + 2);
+                if (NoTriviaBetween(token2, token3) && token3.Kind == SyntaxKind.GreaterThanEqualsToken)
+                {
+                    // `>` then `>` then `>=` → `>>>=`
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private bool IsDictionaryInitializer()
@@ -13579,9 +13622,9 @@ done:
 
         /// <summary>
         /// Consume the operator token that separates the target and value of a member initializer.
-        /// Accepts `=`, `:` (recovered to `=`), and any compound assignment operator (including `??=`).
-        /// Returns the eaten token plus the matching <see cref="SyntaxKind"/> for the produced
-        /// <see cref="AssignmentExpressionSyntax"/>.
+        /// Accepts `=`, `:` (recovered to `=`), and any compound assignment operator (including `??=`,
+        /// `>>=`, and `>>>=` which the lexer splits into multiple tokens). Returns the eaten token plus
+        /// the matching <see cref="SyntaxKind"/> for the produced <see cref="AssignmentExpressionSyntax"/>.
         /// </summary>
         private (SyntaxToken operatorToken, SyntaxKind assignmentKind) EatMemberInitializerOperatorToken()
         {
@@ -13589,6 +13632,16 @@ done:
             if (kind == SyntaxKind.ColonToken)
             {
                 return (this.EatTokenAsKind(SyntaxKind.EqualsToken), SyntaxKind.SimpleAssignmentExpression);
+            }
+
+            // `>>=` and `>>>=` are split into separate tokens by the lexer to keep nested generic argument
+            // lists parseable. Reuse the expression parser's merger to reconstruct the single token.
+            if (IsSplitRightShiftAssignmentAt(position: 0))
+            {
+                var mergedKind = this.PeekToken(1).Kind == SyntaxKind.GreaterThanEqualsToken
+                    ? SyntaxKind.GreaterThanGreaterThanEqualsToken
+                    : SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken;
+                return (EatExpressionOperatorToken(mergedKind), SyntaxFacts.GetAssignmentExpression(mergedKind));
             }
 
             if (SyntaxFacts.IsAssignmentExpressionOperatorToken(kind))

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -13593,12 +13593,12 @@ done:
         private AssignmentExpressionSyntax ParseObjectInitializerNamedAssignment()
         {
             var name = this.ParseIdentifierName();
-            var (operatorToken, assignmentKind) = this.EatMemberInitializerOperatorToken();
+            var operatorToken = this.EatMemberInitializerOperatorToken();
 
             // Nested `{ ... }` initializer shape is only legal on the `=` branch, but we accept it for any operator
             // during parsing so the tree is well-formed for resilience. Binder rejects the non-`=` nested form.
             return _syntaxFactory.AssignmentExpression(
-                assignmentKind,
+                SyntaxFacts.GetAssignmentExpression(operatorToken.Kind),
                 name,
                 operatorToken,
                 this.CurrentToken.Kind == SyntaxKind.OpenBraceToken
@@ -13609,10 +13609,10 @@ done:
         private AssignmentExpressionSyntax ParseDictionaryInitializer()
         {
             var elementAccess = _syntaxFactory.ImplicitElementAccess(this.ParseBracketedArgumentList());
-            var (operatorToken, assignmentKind) = this.EatMemberInitializerOperatorToken();
+            var operatorToken = this.EatMemberInitializerOperatorToken();
 
             return _syntaxFactory.AssignmentExpression(
-                assignmentKind,
+                SyntaxFacts.GetAssignmentExpression(operatorToken.Kind),
                 elementAccess,
                 operatorToken,
                 this.CurrentToken.Kind == SyntaxKind.OpenBraceToken
@@ -13623,15 +13623,16 @@ done:
         /// <summary>
         /// Consume the operator token that separates the target and value of a member initializer.
         /// Accepts `=`, `:` (recovered to `=`), and any compound assignment operator (including `??=`,
-        /// `>>=`, and `>>>=` which the lexer splits into multiple tokens). Returns the eaten token plus
-        /// the matching <see cref="SyntaxKind"/> for the produced <see cref="AssignmentExpressionSyntax"/>.
+        /// `>>=`, and `>>>=` which the lexer splits into multiple tokens). The returned token's
+        /// <see cref="SyntaxToken.Kind"/> maps to the produced <see cref="AssignmentExpressionSyntax"/>
+        /// kind via <see cref="SyntaxFacts.GetAssignmentExpression(SyntaxKind)"/>.
         /// </summary>
-        private (SyntaxToken operatorToken, SyntaxKind assignmentKind) EatMemberInitializerOperatorToken()
+        private SyntaxToken EatMemberInitializerOperatorToken()
         {
             var kind = this.CurrentToken.Kind;
             if (kind == SyntaxKind.ColonToken)
             {
-                return (this.EatTokenAsKind(SyntaxKind.EqualsToken), SyntaxKind.SimpleAssignmentExpression);
+                return this.EatTokenAsKind(SyntaxKind.EqualsToken);
             }
 
             // `>>=` and `>>>=` are split into separate tokens by the lexer to keep nested generic argument
@@ -13641,16 +13642,16 @@ done:
                 var mergedKind = this.PeekToken(1).Kind == SyntaxKind.GreaterThanEqualsToken
                     ? SyntaxKind.GreaterThanGreaterThanEqualsToken
                     : SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken;
-                return (EatExpressionOperatorToken(mergedKind), SyntaxFacts.GetAssignmentExpression(mergedKind));
+                return EatExpressionOperatorToken(mergedKind);
             }
 
             if (SyntaxFacts.IsAssignmentExpressionOperatorToken(kind))
             {
-                return (this.EatToken(), SyntaxFacts.GetAssignmentExpression(kind));
+                return this.EatToken();
             }
 
             // Fall back to expecting `=` for recovery; eats whatever is current as a missing `=`.
-            return (this.EatToken(SyntaxKind.EqualsToken), SyntaxKind.SimpleAssignmentExpression);
+            return this.EatToken(SyntaxKind.EqualsToken);
         }
 
         private InitializerExpressionSyntax ParseComplexElementInitializer()

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -13347,7 +13347,14 @@ done:
 
         private bool IsNamedMemberInitializer()
         {
-            return IsTrueIdentifier() && this.PeekToken(1).Kind is SyntaxKind.EqualsToken or SyntaxKind.ColonToken;
+            // Accept `Identifier =`, `Identifier :` (recovered to `=`), or `Identifier op=` for any compound
+            // assignment operator (including `??=`). Compound operators on member initializers are legal under
+            // the compound-assignment-in-initializer feature; binder checks language version and target legality.
+            if (!IsTrueIdentifier())
+                return false;
+
+            var next = this.PeekToken(1).Kind;
+            return next == SyntaxKind.ColonToken || SyntaxFacts.IsAssignmentExpressionOperatorToken(next);
         }
 
         private bool IsDictionaryInitializer()
@@ -13484,12 +13491,12 @@ done:
                     return true;
 
                 // We have at least one initializer expression. If at least one initializer expression is a named
-                // assignment, this is an object initializer. Otherwise, this is a collection initializer.
+                // assignment (simple or compound) targeting an identifier or implicit element access, this is an
+                // object initializer. Otherwise, this is a collection initializer.
                 for (int i = 0, n = initializers.Count; i < n; i++)
                 {
                     if (initializers[i] is AssignmentExpressionSyntax
                         {
-                            Kind: SyntaxKind.SimpleAssignmentExpression,
                             Left.Kind: SyntaxKind.IdentifierName or SyntaxKind.ImplicitElementAccess,
                         })
                     {
@@ -13542,12 +13549,15 @@ done:
 
         private AssignmentExpressionSyntax ParseObjectInitializerNamedAssignment()
         {
+            var name = this.ParseIdentifierName();
+            var (operatorToken, assignmentKind) = this.EatMemberInitializerOperatorToken();
+
+            // Nested `{ ... }` initializer shape is only legal on the `=` branch, but we accept it for any operator
+            // during parsing so the tree is well-formed for resilience. Binder rejects the non-`=` nested form.
             return _syntaxFactory.AssignmentExpression(
-                SyntaxKind.SimpleAssignmentExpression,
-                this.ParseIdentifierName(),
-                this.CurrentToken.Kind == SyntaxKind.ColonToken
-                    ? this.EatTokenAsKind(SyntaxKind.EqualsToken)
-                    : this.EatToken(SyntaxKind.EqualsToken),
+                assignmentKind,
+                name,
+                operatorToken,
                 this.CurrentToken.Kind == SyntaxKind.OpenBraceToken
                     ? this.ParseObjectOrCollectionInitializer()
                     : this.ParsePossibleRefExpression());
@@ -13555,13 +13565,39 @@ done:
 
         private AssignmentExpressionSyntax ParseDictionaryInitializer()
         {
+            var elementAccess = _syntaxFactory.ImplicitElementAccess(this.ParseBracketedArgumentList());
+            var (operatorToken, assignmentKind) = this.EatMemberInitializerOperatorToken();
+
             return _syntaxFactory.AssignmentExpression(
-                SyntaxKind.SimpleAssignmentExpression,
-                _syntaxFactory.ImplicitElementAccess(this.ParseBracketedArgumentList()),
-                this.EatToken(SyntaxKind.EqualsToken),
+                assignmentKind,
+                elementAccess,
+                operatorToken,
                 this.CurrentToken.Kind == SyntaxKind.OpenBraceToken
                     ? this.ParseObjectOrCollectionInitializer()
                     : this.ParsePossibleRefExpression());
+        }
+
+        /// <summary>
+        /// Consume the operator token that separates the target and value of a member initializer.
+        /// Accepts `=`, `:` (recovered to `=`), and any compound assignment operator (including `??=`).
+        /// Returns the eaten token plus the matching <see cref="SyntaxKind"/> for the produced
+        /// <see cref="AssignmentExpressionSyntax"/>.
+        /// </summary>
+        private (SyntaxToken operatorToken, SyntaxKind assignmentKind) EatMemberInitializerOperatorToken()
+        {
+            var kind = this.CurrentToken.Kind;
+            if (kind == SyntaxKind.ColonToken)
+            {
+                return (this.EatTokenAsKind(SyntaxKind.EqualsToken), SyntaxKind.SimpleAssignmentExpression);
+            }
+
+            if (SyntaxFacts.IsAssignmentExpressionOperatorToken(kind))
+            {
+                return (this.EatToken(), SyntaxFacts.GetAssignmentExpression(kind));
+            }
+
+            // Fall back to expecting `=` for recovery; eats whatever is current as a missing `=`.
+            return (this.EatToken(SyntaxKind.EqualsToken), SyntaxKind.SimpleAssignmentExpression);
         }
 
         private InitializerExpressionSyntax ParseComplexElementInitializer()

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -13363,21 +13363,21 @@ done:
 
             // `>>=` and `>>>=` are split by the lexer into multiple tokens to keep nested generic argument
             // lists parseable. Detect the adjacency pattern here so the named-member path triggers correctly.
-            return IsSplitRightShiftAssignmentAt(position: 1);
+            return IsSplitRightShiftAssignmentAt(peekIndex: 1);
         }
 
         /// <summary>
-        /// Returns true if the token at <paramref name="position"/> (0 = current, 1 = peek 1, ...) is a
+        /// Returns true if the token at <paramref name="peekIndex"/> (0 = current, 1 = peek 1, ...) is a
         /// <c>&gt;</c> that, together with the adjacent token(s), forms a <c>&gt;&gt;=</c> or <c>&gt;&gt;&gt;=</c>
         /// compound assignment operator. Adjacency is determined by <see cref="NoTriviaBetween"/>.
         /// </summary>
-        private bool IsSplitRightShiftAssignmentAt(int position)
+        private bool IsSplitRightShiftAssignmentAt(int peekIndex)
         {
-            var token1 = this.PeekToken(position);
+            var token1 = this.PeekToken(peekIndex);
             if (token1.Kind != SyntaxKind.GreaterThanToken)
                 return false;
 
-            var token2 = this.PeekToken(position + 1);
+            var token2 = this.PeekToken(peekIndex + 1);
             if (!NoTriviaBetween(token1, token2))
                 return false;
 
@@ -13389,7 +13389,7 @@ done:
 
             if (token2.Kind == SyntaxKind.GreaterThanToken)
             {
-                var token3 = this.PeekToken(position + 2);
+                var token3 = this.PeekToken(peekIndex + 2);
                 if (NoTriviaBetween(token2, token3) && token3.Kind == SyntaxKind.GreaterThanEqualsToken)
                 {
                     // `>` then `>` then `>=` → `>>>=`
@@ -13636,7 +13636,7 @@ done:
 
             // `>>=` and `>>>=` are split into separate tokens by the lexer to keep nested generic argument
             // lists parseable. Reuse the expression parser's merger to reconstruct the single token.
-            if (IsSplitRightShiftAssignmentAt(position: 0))
+            if (IsSplitRightShiftAssignmentAt(peekIndex: 0))
             {
                 var mergedKind = this.PeekToken(1).Kind == SyntaxKind.GreaterThanEqualsToken
                     ? SyntaxKind.GreaterThanGreaterThanEqualsToken

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -13623,9 +13623,9 @@ done:
         /// <summary>
         /// Consume the operator token that separates the target and value of a member initializer.
         /// Accepts `=`, `:` (recovered to `=`), and any compound assignment operator (including `??=`,
-        /// `>>=`, and `>>>=` which the lexer splits into multiple tokens). The returned token's
-        /// <see cref="SyntaxToken.Kind"/> maps to the produced <see cref="AssignmentExpressionSyntax"/>
-        /// kind via <see cref="SyntaxFacts.GetAssignmentExpression(SyntaxKind)"/>.
+        /// `>>=`, and `>>>=` which the lexer splits into multiple tokens). The returned token's kind
+        /// maps to the produced assignment-expression kind via
+        /// <see cref="SyntaxFacts.GetAssignmentExpression(SyntaxKind)"/>.
         /// </summary>
         private SyntaxToken EatMemberInitializerOperatorToken()
         {

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -2917,6 +2917,11 @@
         <target state="translated">výrazy kolekce</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureCompoundAssignmentInInitializer">
+        <source>compound assignment in object initializer and with expression</source>
+        <target state="new">compound assignment in object initializer and with expression</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">kovariantní návratové hodnoty</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -2917,6 +2917,11 @@
         <target state="translated">Sammlungsausdrücke</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureCompoundAssignmentInInitializer">
+        <source>compound assignment in object initializer and with expression</source>
+        <target state="new">compound assignment in object initializer and with expression</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">Covariante Rückgaben</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -2917,6 +2917,11 @@
         <target state="translated">expresiones de colección</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureCompoundAssignmentInInitializer">
+        <source>compound assignment in object initializer and with expression</source>
+        <target state="new">compound assignment in object initializer and with expression</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">valores devueltos de covariante</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -2917,6 +2917,11 @@
         <target state="translated">expressions de collection</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureCompoundAssignmentInInitializer">
+        <source>compound assignment in object initializer and with expression</source>
+        <target state="new">compound assignment in object initializer and with expression</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">retours covariants</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -2917,6 +2917,11 @@
         <target state="translated">espressioni di raccolta</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureCompoundAssignmentInInitializer">
+        <source>compound assignment in object initializer and with expression</source>
+        <target state="new">compound assignment in object initializer and with expression</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">tipi restituiti covarianti</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -2917,6 +2917,11 @@
         <target state="translated">コレクション式</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureCompoundAssignmentInInitializer">
+        <source>compound assignment in object initializer and with expression</source>
+        <target state="new">compound assignment in object initializer and with expression</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">covariant の戻り値</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -2917,6 +2917,11 @@
         <target state="translated">컬렉션 식</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureCompoundAssignmentInInitializer">
+        <source>compound assignment in object initializer and with expression</source>
+        <target state="new">compound assignment in object initializer and with expression</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">공변(covariant) 반환</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -2917,6 +2917,11 @@
         <target state="translated">wyrażenia kolekcji</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureCompoundAssignmentInInitializer">
+        <source>compound assignment in object initializer and with expression</source>
+        <target state="new">compound assignment in object initializer and with expression</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">zwroty kowariantne</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -2917,6 +2917,11 @@
         <target state="translated">expressões de coleção</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureCompoundAssignmentInInitializer">
+        <source>compound assignment in object initializer and with expression</source>
+        <target state="new">compound assignment in object initializer and with expression</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">retornos de covariante</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -2917,6 +2917,11 @@
         <target state="translated">выражения коллекции</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureCompoundAssignmentInInitializer">
+        <source>compound assignment in object initializer and with expression</source>
+        <target state="new">compound assignment in object initializer and with expression</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">ковариантные возвращаемые значения</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -2917,6 +2917,11 @@
         <target state="translated">koleksiyon ifadeleri</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureCompoundAssignmentInInitializer">
+        <source>compound assignment in object initializer and with expression</source>
+        <target state="new">compound assignment in object initializer and with expression</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">birlikte değişken dönüşler</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -2917,6 +2917,11 @@
         <target state="translated">集合表达式</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureCompoundAssignmentInInitializer">
+        <source>compound assignment in object initializer and with expression</source>
+        <target state="new">compound assignment in object initializer and with expression</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">协变返回</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -2917,6 +2917,11 @@
         <target state="translated">集合運算式</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureCompoundAssignmentInInitializer">
+        <source>compound assignment in object initializer and with expression</source>
+        <target state="new">compound assignment in object initializer and with expression</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureCovariantReturnsForOverrides">
         <source>covariant returns</source>
         <target state="translated">Covariant 傳回</target>

--- a/src/Compilers/CSharp/Test/CSharp15/CompoundAssignmentInitializerBindingTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/CompoundAssignmentInitializerBindingTests.cs
@@ -10,10 +10,17 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests;
 
 public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
 {
-    // Tests that use records / init-only setters need System.Runtime.CompilerServices.IsExternalInit;
-    // tests that declare a direct `operator +=` additionally need CompilerFeatureRequiredAttribute.
-    // The NetCoreApp reference set provides both, so every test in this file explicitly passes
-    // `targetFramework: TargetFramework.NetCoreApp` to keep the sources minimal.
+    /// <summary>
+    /// Polyfills for types the default reference set doesn't include: <c>IsExternalInit</c> (records /
+    /// init-only / <c>with</c>), <c>CompilerFeatureRequiredAttribute</c> (user-defined <c>operator +=</c>),
+    /// and <c>Required</c> / <c>SetsRequiredMembers</c> attributes. Bundled into every compilation so
+    /// individual tests don't need to pick a target framework.
+    /// </summary>
+    private static readonly string Polyfills =
+        IsExternalInitTypeDefinition +
+        CompilerFeatureRequiredAttribute +
+        RequiredMemberAttribute +
+        SetsRequiredMembersAttribute;
 
     /// <summary>All 11 compound assignment operators in the spec's `compound_assignment_operator` set.</summary>
     public static TheoryData<string> AllCompoundOperators => new()
@@ -23,23 +30,10 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
         "<<=", ">>=", ">>>=",
     };
 
-    /// <summary>
-    /// Operators that only make sense on integers (shift and bitwise) — useful when narrowing the matrix
-    /// to avoid type-mismatch noise on non-integer targets.
-    /// </summary>
-    public static TheoryData<string> IntegerCompoundOperators => new()
+    /// <summary>Bitwise operators that work on any enum (flags or plain).</summary>
+    public static TheoryData<string> EnumBitwiseOperators => new()
     {
-        "+=", "-=", "*=", "/=", "%=",
         "&=", "|=", "^=",
-        "<<=", ">>=", ">>>=",
-    };
-
-    /// <summary>
-    /// Arithmetic operators (usable on any numeric type including `double`).
-    /// </summary>
-    public static TheoryData<string> ArithmeticCompoundOperators => new()
-    {
-        "+=", "-=", "*=", "/=", "%=",
     };
 
     #region Core operator coverage
@@ -54,7 +48,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make() => new C { P {{op}} 1 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics();
     }
 
     [Theory, MemberData(nameof(AllCompoundOperators))]
@@ -67,7 +61,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make() => new C { F {{op}} 1 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics();
     }
 
     [Theory, MemberData(nameof(AllCompoundOperators))]
@@ -79,7 +73,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make(C r) => r with { P {{op}} 1 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics();
     }
 
     [Theory, MemberData(nameof(AllCompoundOperators))]
@@ -93,7 +87,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make() => new C { [0] {{op}} 1 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics();
     }
 
     #endregion
@@ -110,7 +104,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make() => new C { F += 1 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics();
     }
 
     [Fact]
@@ -123,7 +117,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make() => new C { F += 1 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics(
             // (4,39): error CS0191: A readonly field cannot be assigned to (except in a constructor or init-only setter of the type in which the field is defined or a variable initializer)
             //     public static C Make() => new C { F += 1 };
             Diagnostic(ErrorCode.ERR_AssgReadonly, "F").WithLocation(4, 39));
@@ -139,7 +133,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make() => new C { P += 1 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics(
             // (4,39): error CS0200: Property or indexer 'C.P' cannot be assigned to -- it is read only
             //     public static C Make() => new C { P += 1 };
             Diagnostic(ErrorCode.ERR_AssgReadonlyProp, "P").WithArguments("C.P").WithLocation(4, 39));
@@ -156,7 +150,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make() => new C { P += 1 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics(
             // (5,39): error CS0154: The property or indexer 'C.P' cannot be used in this context because it lacks the get accessor
             //     public static C Make() => new C { P += 1 };
             Diagnostic(ErrorCode.ERR_PropertyLacksGet, "P").WithArguments("C.P").WithLocation(5, 39));
@@ -172,7 +166,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make() => new C { P += 1 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics();
     }
 
     [Fact]
@@ -185,7 +179,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make(C r) => r with { P += 1 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics();
     }
 
     [Fact]
@@ -199,7 +193,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make() => new C { P += 1 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics();
     }
 
     [Fact]
@@ -213,7 +207,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make() => new C { P += 1 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics(
             // (5,39): error CS8331: Cannot assign to property 'C.P' or use it as the right hand side of a ref assignment because it is a readonly variable
             //     public static C Make() => new C { P += 1 };
             Diagnostic(ErrorCode.ERR_AssignReadonlyNotField, "P").WithArguments("property", "P").WithLocation(5, 39));
@@ -229,7 +223,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make() => new C { P += 1 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics(
             // (4,39): error CS1914: Static field or property 'C.P' cannot be assigned in an object initializer
             //     public static C Make() => new C { P += 1 };
             Diagnostic(ErrorCode.ERR_StaticMemberInObjectInitializer, "P").WithArguments("C.P").WithLocation(4, 39));
@@ -246,7 +240,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make() => new C { [0] |= 1, [1] &= 2, [2] += 3 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics();
     }
 
     [Fact]
@@ -260,7 +254,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make(EventHandler h) => new C { E += h, E -= h };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics(
             // (4,31): warning CS0067: The event 'C.E' is never used
             //     public event EventHandler E;
             Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("C.E").WithLocation(4, 31));
@@ -281,7 +275,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make(EventHandler h) => new C { E += h, E -= h };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics();
     }
 
     [Fact]
@@ -294,7 +288,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make() => new C { X += 1 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.StandardAndCSharp)
+        CreateCompilation(source, targetFramework: TargetFramework.StandardAndCSharp)
             .VerifyDiagnostics();
     }
 
@@ -316,7 +310,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make(EventHandler h) => new C { E *= h };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics(
             // (5,53): error CS0019: Operator '*=' cannot be applied to operands of type 'EventHandler' and 'EventHandler'
             //     public static C Make(EventHandler h) => new C { E *= h };
             Diagnostic(ErrorCode.ERR_BadBinaryOps, "E *= h").WithArguments("*=", "System.EventHandler", "System.EventHandler").WithLocation(5, 53));
@@ -333,7 +327,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make(C r, EventHandler h) => r with { E += h };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics(
             // (4,31): warning CS0067: The event 'C.E' is never used
             //     public event EventHandler E;
             Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("C.E").WithLocation(4, 31));
@@ -353,7 +347,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make() => new C { P += 1 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.Regular13, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+        CreateCompilation([source, Polyfills], parseOptions: TestOptions.Regular13).VerifyDiagnostics(
             // (4,41): error CS8652: The feature 'compound assignment in object initializer and with expression' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //     public static C Make() => new C { P += 1 };
             Diagnostic(ErrorCode.ERR_FeatureInPreview, "+=").WithArguments("compound assignment in object initializer and with expression").WithLocation(4, 41));
@@ -372,23 +366,10 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make() => new C { P += 1 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.Regular14, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+        CreateCompilation([source, Polyfills], parseOptions: TestOptions.Regular14).VerifyDiagnostics(
             // (4,41): error CS8652: The feature 'compound assignment in object initializer and with expression' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //     public static C Make() => new C { P += 1 };
             Diagnostic(ErrorCode.ERR_FeatureInPreview, "+=").WithArguments("compound assignment in object initializer and with expression").WithLocation(4, 41));
-    }
-
-    [Fact]
-    public void LangVersion_Preview_Compiles()
-    {
-        var source = """
-            class C
-            {
-                public int P { get; set; }
-                public static C Make() => new C { P += 1 };
-            }
-            """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
     }
 
     [Fact]
@@ -402,7 +383,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
             }
             """;
         // Expect a feature-gate diagnostic on each compound operator token (11 total).
-        CreateCompilation(source, parseOptions: TestOptions.Regular14, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+        CreateCompilation([source, Polyfills], parseOptions: TestOptions.Regular14).VerifyDiagnostics(
             // (4,48): error CS8652: The feature 'compound assignment in object initializer and with expression' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //     public static void M() { var c = new C { P += 1, P -= 1, P *= 1, P /= 1, P %= 1, P &= 1, P |= 1, P ^= 1, P <<= 1, P >>= 1, P >>>= 1 }; }
             Diagnostic(ErrorCode.ERR_FeatureInPreview, "+=").WithArguments("compound assignment in object initializer and with expression").WithLocation(4, 48),
@@ -447,7 +428,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
         // The parser accepted `P ??= 1` for resilience (Phase 1); the binder rejects. The default
         // fallback path binds the whole member-initializer expression as an RValue for recovery, which
         // incidentally produces a CS0120 "object reference required for P" in addition to CS0747.
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics(
             // (4,39): error CS0120: An object reference is required for the non-static field, method, or property 'C.P'
             //     public static C Make() => new C { P ??= 1 };
             Diagnostic(ErrorCode.ERR_ObjectRequired, "P").WithArguments("C.P").WithLocation(4, 39),
@@ -470,7 +451,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make() => new C { P = 1, P = 2 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics(
             // (4,46): error CS1912: Duplicate initialization of member 'P'
             //     public static C Make() => new C { P = 1, P = 2 };
             Diagnostic(ErrorCode.ERR_MemberAlreadyInitialized, "P").WithArguments("P").WithLocation(4, 46));
@@ -486,7 +467,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make() => new C { P = 10, P += 5 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics();
     }
 
     [Fact]
@@ -499,7 +480,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make() => new C { P += 5, P = 10 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics(
             // (4,47): error CS1912: Duplicate initialization of member 'P'
             //     public static C Make() => new C { P += 5, P = 10 };
             Diagnostic(ErrorCode.ERR_MemberAlreadyInitialized, "P").WithArguments("P").WithLocation(4, 47));
@@ -515,7 +496,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make() => new C { P += 5, P += 10, P *= 2 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics();
     }
 
     [Fact]
@@ -528,7 +509,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make() => new C { P = 1, P += 2, P = 3 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics(
             // (4,54): error CS1912: Duplicate initialization of member 'P'
             //     public static C Make() => new C { P = 1, P += 2, P = 3 };
             Diagnostic(ErrorCode.ERR_MemberAlreadyInitialized, "P").WithArguments("P").WithLocation(4, 54));
@@ -547,7 +528,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make() => new C { [0] = 1, [0] += 2, [0] = 3, [0] |= 4 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics();
     }
 
     [Fact]
@@ -561,7 +542,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make(EventHandler a, EventHandler b) => new C { E += a, E += b, E -= a, E += a };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics(
             // (4,31): warning CS0067: The event 'C.E' is never used
             //     public event EventHandler E;
             Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("C.E").WithLocation(4, 31));
@@ -576,7 +557,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make(C r) => r with { P += 1, P = 2 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics(
             // (3,51): error CS1912: Duplicate initialization of member 'P'
             //     public static C Make(C r) => r with { P += 1, P = 2 };
             Diagnostic(ErrorCode.ERR_MemberAlreadyInitialized, "P").WithArguments("P").WithLocation(3, 51));
@@ -596,7 +577,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make(ref int x) => new C { P += ref x };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics(
             // (4,53): error CS1073: Unexpected token 'ref'
             //     public static C Make(ref int x) => new C { P += ref x };
             Diagnostic(ErrorCode.ERR_UnexpectedToken, "ref").WithArguments("ref").WithLocation(4, 53));
@@ -615,13 +596,127 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make() => new C { P += { 1, 2 } };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics(
             // (4,39): error CS1918: Members of property 'C.P' of type 'int' cannot be assigned with an object initializer because it is of a value type
             //     public static C Make() => new C { P += { 1, 2 } };
             Diagnostic(ErrorCode.ERR_ValueTypePropertyInObjectInitializer, "P").WithArguments("C.P", "int").WithLocation(4, 39),
             // (4,39): error CS0747: Invalid initializer member declarator
             //     public static C Make() => new C { P += { 1, 2 } };
             Diagnostic(ErrorCode.ERR_InvalidInitializerElementInitializer, "P += { 1, 2 }").WithLocation(4, 39));
+    }
+
+    #endregion
+
+    #region Enum targets
+
+    [Theory, MemberData(nameof(EnumBitwiseOperators))]
+    public void Enum_FlagsBitwiseCompound_Succeeds(string op)
+    {
+        // Flag-enum bitwise compound is the canonical motivating case: `new Widget { Visibility |= V.Clickable }`.
+        var source = $$"""
+            using System;
+
+            [Flags]
+            enum V { None = 0, Clickable = 1, Visible = 2, Enabled = 4 }
+
+            class C
+            {
+                public V Visibility { get; set; }
+                public static C Make(V flags) => new C { Visibility {{op}} flags };
+            }
+            """;
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Enum_PlusIntLiteral_Succeeds()
+    {
+        // `EnumValue + int` is legal (it shifts the enum by N positions in its underlying type), so
+        // `P += 1` on an enum property works.
+        var source = """
+            enum E { A, B, C }
+            class C
+            {
+                public E P { get; set; }
+                public static C Make() => new C { P += 1 };
+            }
+            """;
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Enum_PlusEnumValue_Fails()
+    {
+        // `EnumValue + EnumValue` is not defined, so `P += E.B` where P is of type E fails with CS0019.
+        // The failure is identical to non-initializer compound on an enum.
+        var source = """
+            enum E { A, B, C }
+            class C
+            {
+                public E P { get; set; }
+                public static C Make() => new C { P += E.B };
+            }
+            """;
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics(
+            // (5,39): error CS0019: Operator '+=' cannot be applied to operands of type 'E' and 'E'
+            //     public static C Make() => new C { P += E.B };
+            Diagnostic(ErrorCode.ERR_BadBinaryOps, "P += E.B").WithArguments("+=", "E", "E").WithLocation(5, 39));
+    }
+
+    [Fact]
+    public void Enum_Multiply_Fails()
+    {
+        // Enums do not participate in multiplication, so `*=` on an enum target is a compile-time error.
+        var source = """
+            enum E { A, B, C }
+            class C
+            {
+                public E P { get; set; }
+                public static C Make() => new C { P *= 2 };
+            }
+            """;
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics(
+            // (5,39): error CS0019: Operator '*=' cannot be applied to operands of type 'E' and 'int'
+            //     public static C Make() => new C { P *= 2 };
+            Diagnostic(ErrorCode.ERR_BadBinaryOps, "P *= 2").WithArguments("*=", "E", "int").WithLocation(5, 39));
+    }
+
+    [Fact]
+    public void Enum_FlagsInWith_Succeeds()
+    {
+        // Flag-enum compound on a record property via `with`.
+        var source = """
+            using System;
+
+            [Flags]
+            enum V { None = 0, Clickable = 1, Visible = 2 }
+
+            record Widget(V Visibility)
+            {
+                public static Widget Set(Widget w, V flags) => w with { Visibility |= flags };
+            }
+            """;
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Enum_MixedSimpleAndBitwiseCompound_Succeeds()
+    {
+        // Spec's "at most one `=`, `=` before any compound" rule applies to enum targets just like any
+        // other field/property. Realistic pattern: set initial flags with `=`, then add more with `|=`.
+        var source = """
+            using System;
+
+            [Flags]
+            enum V { None = 0, Clickable = 1, Visible = 2, Enabled = 4 }
+
+            class C
+            {
+                public V Visibility { get; set; }
+                public static C Make() => new C { Visibility = V.Clickable, Visibility |= V.Visible, Visibility &= ~V.Enabled };
+            }
+            """;
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics();
     }
 
     #endregion
@@ -638,7 +733,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static S Make() => new S { F += 1 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics();
     }
 
     [Fact]
@@ -650,7 +745,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make(C r) => r with { P += 1 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics();
     }
 
     [Fact]
@@ -662,7 +757,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make(C r) => r with { P += 1 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics();
     }
 
     [Fact]
@@ -682,7 +777,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics();
     }
 
     #endregion
@@ -705,7 +800,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make(V v) => new C { Prop += v };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics();
     }
 
     [Fact]
@@ -730,7 +825,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make(V v) => new C { F += v };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics();
     }
 
     [Fact]
@@ -753,7 +848,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make(V v) => new C { F += v };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics();
     }
 
     [Fact]
@@ -774,7 +869,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make(V v) => new C { Prop += v };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics(
             // (10,42): error CS0019: Operator '+=' cannot be applied to operands of type 'V' and 'V'
             //     public static C Make(V v) => new C { Prop += v };
             Diagnostic(ErrorCode.ERR_BadBinaryOps, "Prop += v").WithArguments("+=", "V", "V").WithLocation(10, 42));
@@ -797,7 +892,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make() => new C { P += 1 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics(
             // (4,35): error CS9035: Required member 'C.P' must be set in the object initializer or attribute constructor.
             //     public static C Make() => new C { P += 1 };
             Diagnostic(ErrorCode.ERR_RequiredMemberMustBeSet, "C").WithArguments("C.P").WithLocation(4, 35));
@@ -813,7 +908,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make() => new C { P = 0, P += 1 };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics();
     }
 
     #endregion
@@ -834,7 +929,7 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make(EventHandler h) => new C { P = 10, P += 5, E += h };
             }
             """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+        CreateCompilation([source, Polyfills]).VerifyDiagnostics(
             // (5,31): warning CS0067: The event 'C.E' is never used
             //     public event EventHandler E;
             Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("C.E").WithLocation(5, 31));

--- a/src/Compilers/CSharp/Test/CSharp15/CompoundAssignmentInitializerBindingTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/CompoundAssignmentInitializerBindingTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -13,9 +12,8 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
 {
     // Tests that use records / init-only setters need System.Runtime.CompilerServices.IsExternalInit;
     // tests that declare a direct `operator +=` additionally need CompilerFeatureRequiredAttribute.
-    // The NetCoreApp reference set provides both; using it here keeps the test sources minimal.
-    private CSharpCompilation Compile(string source, CSharpParseOptions parseOptions, TargetFramework targetFramework = TargetFramework.NetCoreApp)
-        => CreateCompilation(source, parseOptions: parseOptions, targetFramework: targetFramework);
+    // The NetCoreApp reference set provides both, so every test in this file explicitly passes
+    // `targetFramework: TargetFramework.NetCoreApp` to keep the sources minimal.
 
     /// <summary>All 11 compound assignment operators in the spec's `compound_assignment_operator` set.</summary>
     public static TheoryData<string> AllCompoundOperators => new()
@@ -403,10 +401,31 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static void M() { var c = new C { P += 1, P -= 1, P *= 1, P /= 1, P %= 1, P &= 1, P |= 1, P ^= 1, P <<= 1, P >>= 1, P >>>= 1 }; }
             }
             """;
-        var compilation = CreateCompilation(source, parseOptions: TestOptions.Regular14, targetFramework: TargetFramework.NetCoreApp);
         // Expect a feature-gate diagnostic on each compound operator token (11 total).
-        var diagnostics = compilation.GetDiagnostics();
-        Assert.Equal(11, diagnostics.Count(d => d.Code == (int)ErrorCode.ERR_FeatureInPreview));
+        CreateCompilation(source, parseOptions: TestOptions.Regular14, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+            // (4,48): error CS8652: The feature 'compound assignment in object initializer and with expression' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     public static void M() { var c = new C { P += 1, P -= 1, P *= 1, P /= 1, P %= 1, P &= 1, P |= 1, P ^= 1, P <<= 1, P >>= 1, P >>>= 1 }; }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "+=").WithArguments("compound assignment in object initializer and with expression").WithLocation(4, 48),
+            // (4,56): error CS8652: ...
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "-=").WithArguments("compound assignment in object initializer and with expression").WithLocation(4, 56),
+            // (4,64): error CS8652: ...
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "*=").WithArguments("compound assignment in object initializer and with expression").WithLocation(4, 64),
+            // (4,72): error CS8652: ...
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "/=").WithArguments("compound assignment in object initializer and with expression").WithLocation(4, 72),
+            // (4,80): error CS8652: ...
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "%=").WithArguments("compound assignment in object initializer and with expression").WithLocation(4, 80),
+            // (4,88): error CS8652: ...
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "&=").WithArguments("compound assignment in object initializer and with expression").WithLocation(4, 88),
+            // (4,96): error CS8652: ...
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "|=").WithArguments("compound assignment in object initializer and with expression").WithLocation(4, 96),
+            // (4,104): error CS8652: ...
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "^=").WithArguments("compound assignment in object initializer and with expression").WithLocation(4, 104),
+            // (4,112): error CS8652: ...
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "<<=").WithArguments("compound assignment in object initializer and with expression").WithLocation(4, 112),
+            // (4,121): error CS8652: ...
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, ">>=").WithArguments("compound assignment in object initializer and with expression").WithLocation(4, 121),
+            // (4,130): error CS8652: ...
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, ">>>=").WithArguments("compound assignment in object initializer and with expression").WithLocation(4, 130));
     }
 
     #endregion
@@ -577,8 +596,10 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make(ref int x) => new C { P += ref x };
             }
             """;
-        var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
-        Assert.NotEmpty(comp.GetDiagnostics());
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+            // (4,53): error CS1073: Unexpected token 'ref'
+            //     public static C Make(ref int x) => new C { P += ref x };
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "ref").WithArguments("ref").WithLocation(4, 53));
     }
 
     [Fact]
@@ -594,8 +615,13 @@ public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
                 public static C Make() => new C { P += { 1, 2 } };
             }
             """;
-        var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
-        Assert.NotEmpty(comp.GetDiagnostics());
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+            // (4,39): error CS1918: Members of property 'C.P' of type 'int' cannot be assigned with an object initializer because it is of a value type
+            //     public static C Make() => new C { P += { 1, 2 } };
+            Diagnostic(ErrorCode.ERR_ValueTypePropertyInObjectInitializer, "P").WithArguments("C.P", "int").WithLocation(4, 39),
+            // (4,39): error CS0747: Invalid initializer member declarator
+            //     public static C Make() => new C { P += { 1, 2 } };
+            Diagnostic(ErrorCode.ERR_InvalidInitializerElementInitializer, "P += { 1, 2 }").WithLocation(4, 39));
     }
 
     #endregion

--- a/src/Compilers/CSharp/Test/CSharp15/CompoundAssignmentInitializerBindingTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/CompoundAssignmentInitializerBindingTests.cs
@@ -1,0 +1,819 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests;
+
+public sealed class CompoundAssignmentInitializerBindingTests : CSharpTestBase
+{
+    // Tests that use records / init-only setters need System.Runtime.CompilerServices.IsExternalInit;
+    // tests that declare a direct `operator +=` additionally need CompilerFeatureRequiredAttribute.
+    // The NetCoreApp reference set provides both; using it here keeps the test sources minimal.
+    private CSharpCompilation Compile(string source, CSharpParseOptions parseOptions, TargetFramework targetFramework = TargetFramework.NetCoreApp)
+        => CreateCompilation(source, parseOptions: parseOptions, targetFramework: targetFramework);
+
+    /// <summary>All 11 compound assignment operators in the spec's `compound_assignment_operator` set.</summary>
+    public static TheoryData<string> AllCompoundOperators => new()
+    {
+        "+=", "-=", "*=", "/=", "%=",
+        "&=", "|=", "^=",
+        "<<=", ">>=", ">>>=",
+    };
+
+    /// <summary>
+    /// Operators that only make sense on integers (shift and bitwise) — useful when narrowing the matrix
+    /// to avoid type-mismatch noise on non-integer targets.
+    /// </summary>
+    public static TheoryData<string> IntegerCompoundOperators => new()
+    {
+        "+=", "-=", "*=", "/=", "%=",
+        "&=", "|=", "^=",
+        "<<=", ">>=", ">>>=",
+    };
+
+    /// <summary>
+    /// Arithmetic operators (usable on any numeric type including `double`).
+    /// </summary>
+    public static TheoryData<string> ArithmeticCompoundOperators => new()
+    {
+        "+=", "-=", "*=", "/=", "%=",
+    };
+
+    #region Core operator coverage
+
+    [Theory, MemberData(nameof(AllCompoundOperators))]
+    public void ObjectInitializer_Property_AllOperators_CompileClean(string op)
+    {
+        var source = $$"""
+            class C
+            {
+                public int P { get; set; }
+                public static C Make() => new C { P {{op}} 1 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+    }
+
+    [Theory, MemberData(nameof(AllCompoundOperators))]
+    public void ObjectInitializer_Field_AllOperators_CompileClean(string op)
+    {
+        var source = $$"""
+            class C
+            {
+                public int F;
+                public static C Make() => new C { F {{op}} 1 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+    }
+
+    [Theory, MemberData(nameof(AllCompoundOperators))]
+    public void WithExpression_AllOperators_CompileClean(string op)
+    {
+        var source = $$"""
+            record C(int P)
+            {
+                public static C Make(C r) => r with { P {{op}} 1 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+    }
+
+    [Theory, MemberData(nameof(AllCompoundOperators))]
+    public void ObjectInitializer_Indexer_AllOperators_CompileClean(string op)
+    {
+        var source = $$"""
+            class C
+            {
+                private int[] _values = new int[10];
+                public int this[int i] { get => _values[i]; set => _values[i] = value; }
+                public static C Make() => new C { [0] {{op}} 1 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+    }
+
+    #endregion
+
+    #region Target kinds
+
+    [Fact]
+    public void Target_WritableInstanceField_Succeeds()
+    {
+        var source = """
+            class C
+            {
+                public int F;
+                public static C Make() => new C { F += 1 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Target_ReadonlyInstanceField_Fails()
+    {
+        var source = """
+            class C
+            {
+                public readonly int F;
+                public static C Make() => new C { F += 1 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+            // (4,39): error CS0191: A readonly field cannot be assigned to (except in a constructor or init-only setter of the type in which the field is defined or a variable initializer)
+            //     public static C Make() => new C { F += 1 };
+            Diagnostic(ErrorCode.ERR_AssgReadonly, "F").WithLocation(4, 39));
+    }
+
+    [Fact]
+    public void Target_GetOnlyAutoProperty_Fails()
+    {
+        var source = """
+            class C
+            {
+                public int P { get; }
+                public static C Make() => new C { P += 1 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+            // (4,39): error CS0200: Property or indexer 'C.P' cannot be assigned to -- it is read only
+            //     public static C Make() => new C { P += 1 };
+            Diagnostic(ErrorCode.ERR_AssgReadonlyProp, "P").WithArguments("C.P").WithLocation(4, 39));
+    }
+
+    [Fact]
+    public void Target_SetOnlyProperty_Fails()
+    {
+        var source = """
+            class C
+            {
+                private int _p;
+                public int P { set { _p = value; } }
+                public static C Make() => new C { P += 1 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+            // (5,39): error CS0154: The property or indexer 'C.P' cannot be used in this context because it lacks the get accessor
+            //     public static C Make() => new C { P += 1 };
+            Diagnostic(ErrorCode.ERR_PropertyLacksGet, "P").WithArguments("C.P").WithLocation(5, 39));
+    }
+
+    [Fact]
+    public void Target_InitOnlyProperty_SucceedsInNew()
+    {
+        var source = """
+            class C
+            {
+                public int P { get; init; }
+                public static C Make() => new C { P += 1 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Target_InitOnlyProperty_SucceedsInWith()
+    {
+        var source = """
+            record C(int V)
+            {
+                public int P { get; init; }
+                public static C Make(C r) => r with { P += 1 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Target_RefReturningProperty_Succeeds()
+    {
+        var source = """
+            class C
+            {
+                private int _p;
+                public ref int P => ref _p;
+                public static C Make() => new C { P += 1 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Target_RefReadonlyProperty_Fails()
+    {
+        var source = """
+            class C
+            {
+                private int _p;
+                public ref readonly int P => ref _p;
+                public static C Make() => new C { P += 1 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+            // (5,39): error CS8331: Cannot assign to property 'C.P' or use it as the right hand side of a ref assignment because it is a readonly variable
+            //     public static C Make() => new C { P += 1 };
+            Diagnostic(ErrorCode.ERR_AssignReadonlyNotField, "P").WithArguments("property", "P").WithLocation(5, 39));
+    }
+
+    [Fact]
+    public void Target_StaticProperty_Fails()
+    {
+        var source = """
+            class C
+            {
+                public static int P { get; set; }
+                public static C Make() => new C { P += 1 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+            // (4,39): error CS1914: Static field or property 'C.P' cannot be assigned in an object initializer
+            //     public static C Make() => new C { P += 1 };
+            Diagnostic(ErrorCode.ERR_StaticMemberInObjectInitializer, "P").WithArguments("C.P").WithLocation(4, 39));
+    }
+
+    [Fact]
+    public void Target_Indexer_DictionaryStyle_Succeeds()
+    {
+        var source = """
+            class C
+            {
+                private int[] _values = new int[10];
+                public int this[int i] { get => _values[i]; set => _values[i] = value; }
+                public static C Make() => new C { [0] |= 1, [1] &= 2, [2] += 3 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Target_FieldLikeEvent_PlusEqualsAndMinusEquals_Succeed()
+    {
+        var source = """
+            using System;
+            class C
+            {
+                public event EventHandler E;
+                public static C Make(EventHandler h) => new C { E += h, E -= h };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+            // (4,31): warning CS0067: The event 'C.E' is never used
+            //     public event EventHandler E;
+            Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("C.E").WithLocation(4, 31));
+    }
+
+    [Fact]
+    public void Target_CustomEvent_PlusEqualsAndMinusEquals_Succeed()
+    {
+        var source = """
+            using System;
+            class C
+            {
+                public event EventHandler E
+                {
+                    add { }
+                    remove { }
+                }
+                public static C Make(EventHandler h) => new C { E += h, E -= h };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Target_DynamicProperty_Succeeds()
+    {
+        var source = """
+            class C
+            {
+                public dynamic X { get; set; }
+                public static C Make() => new C { X += 1 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.StandardAndCSharp)
+            .VerifyDiagnostics();
+    }
+
+    #endregion
+
+    #region Event target constraints
+
+    [Fact]
+    public void Event_NonPlusOrMinusCompound_Fails()
+    {
+        // Per spec: "An *identifier* that names an event is a valid target only in combination with the
+        // `+=` or `-=` operator". Other compound ops fall through BindCompoundAssignmentCore's event branch
+        // and fail via overload resolution on the delegate type (CS0019).
+        var source = """
+            using System;
+            class C
+            {
+                public event EventHandler E;
+                public static C Make(EventHandler h) => new C { E *= h };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+            // (5,53): error CS0019: Operator '*=' cannot be applied to operands of type 'EventHandler' and 'EventHandler'
+            //     public static C Make(EventHandler h) => new C { E *= h };
+            Diagnostic(ErrorCode.ERR_BadBinaryOps, "E *= h").WithArguments("*=", "System.EventHandler", "System.EventHandler").WithLocation(5, 53));
+    }
+
+    [Fact]
+    public void Event_InWith_PlusEquals_Succeeds()
+    {
+        var source = """
+            using System;
+            record C(int V)
+            {
+                public event EventHandler E;
+                public static C Make(C r, EventHandler h) => r with { E += h };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+            // (4,31): warning CS0067: The event 'C.E' is never used
+            //     public event EventHandler E;
+            Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("C.E").WithLocation(4, 31));
+    }
+
+    #endregion
+
+    #region Language version gating
+
+    [Fact]
+    public void LangVersion_CSharp13_Fails()
+    {
+        var source = """
+            class C
+            {
+                public int P { get; set; }
+                public static C Make() => new C { P += 1 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.Regular13, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+            // (4,41): error CS8652: The feature 'compound assignment in object initializer and with expression' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     public static C Make() => new C { P += 1 };
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "+=").WithArguments("compound assignment in object initializer and with expression").WithLocation(4, 41));
+    }
+
+    [Fact]
+    public void LangVersion_CSharp14_Fails()
+    {
+        // At C# 14, user-defined `operator +=` is available (it shipped in C# 14). Our feature is still
+        // Preview-only; this case confirms the gate is specifically our feature, not a cascade from the
+        // user-defined-`+=` feature.
+        var source = """
+            class C
+            {
+                public int P { get; set; }
+                public static C Make() => new C { P += 1 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.Regular14, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+            // (4,41): error CS8652: The feature 'compound assignment in object initializer and with expression' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     public static C Make() => new C { P += 1 };
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "+=").WithArguments("compound assignment in object initializer and with expression").WithLocation(4, 41));
+    }
+
+    [Fact]
+    public void LangVersion_Preview_Compiles()
+    {
+        var source = """
+            class C
+            {
+                public int P { get; set; }
+                public static C Make() => new C { P += 1 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void LangVersion_GatingAppliesToEveryCompoundOperator()
+    {
+        var source = """
+            class C
+            {
+                public int P { get; set; }
+                public static void M() { var c = new C { P += 1, P -= 1, P *= 1, P /= 1, P %= 1, P &= 1, P |= 1, P ^= 1, P <<= 1, P >>= 1, P >>>= 1 }; }
+            }
+            """;
+        var compilation = CreateCompilation(source, parseOptions: TestOptions.Regular14, targetFramework: TargetFramework.NetCoreApp);
+        // Expect a feature-gate diagnostic on each compound operator token (11 total).
+        var diagnostics = compilation.GetDiagnostics();
+        Assert.Equal(11, diagnostics.Count(d => d.Code == (int)ErrorCode.ERR_FeatureInPreview));
+    }
+
+    #endregion
+
+    #region ??= rejected
+
+    [Fact]
+    public void CoalesceAssignment_Rejected()
+    {
+        // `??=` is not in the spec's compound_assignment_operator set. The parser was permissive; the
+        // binder must reject the shape with CS0747 (the existing "invalid initializer member declarator").
+        var source = """
+            class C
+            {
+                public int? P { get; set; }
+                public static C Make() => new C { P ??= 1 };
+            }
+            """;
+        // The parser accepted `P ??= 1` for resilience (Phase 1); the binder rejects. The default
+        // fallback path binds the whole member-initializer expression as an RValue for recovery, which
+        // incidentally produces a CS0120 "object reference required for P" in addition to CS0747.
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+            // (4,39): error CS0120: An object reference is required for the non-static field, method, or property 'C.P'
+            //     public static C Make() => new C { P ??= 1 };
+            Diagnostic(ErrorCode.ERR_ObjectRequired, "P").WithArguments("C.P").WithLocation(4, 39),
+            // (4,39): error CS0747: Invalid initializer member declarator
+            //     public static C Make() => new C { P ??= 1 };
+            Diagnostic(ErrorCode.ERR_InvalidInitializerElementInitializer, "P ??= 1").WithLocation(4, 39));
+    }
+
+    #endregion
+
+    #region Duplicate rules
+
+    [Fact]
+    public void Duplicate_TwoSimpleAssignments_Fails()
+    {
+        var source = """
+            class C
+            {
+                public int P { get; set; }
+                public static C Make() => new C { P = 1, P = 2 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+            // (4,46): error CS1912: Duplicate initialization of member 'P'
+            //     public static C Make() => new C { P = 1, P = 2 };
+            Diagnostic(ErrorCode.ERR_MemberAlreadyInitialized, "P").WithArguments("P").WithLocation(4, 46));
+    }
+
+    [Fact]
+    public void Duplicate_EqualsThenCompound_Succeeds()
+    {
+        var source = """
+            class C
+            {
+                public int P { get; set; }
+                public static C Make() => new C { P = 10, P += 5 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Duplicate_CompoundThenEquals_Fails()
+    {
+        var source = """
+            class C
+            {
+                public int P { get; set; }
+                public static C Make() => new C { P += 5, P = 10 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+            // (4,47): error CS1912: Duplicate initialization of member 'P'
+            //     public static C Make() => new C { P += 5, P = 10 };
+            Diagnostic(ErrorCode.ERR_MemberAlreadyInitialized, "P").WithArguments("P").WithLocation(4, 47));
+    }
+
+    [Fact]
+    public void Duplicate_TwoCompounds_Succeeds()
+    {
+        var source = """
+            class C
+            {
+                public int P { get; set; }
+                public static C Make() => new C { P += 5, P += 10, P *= 2 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Duplicate_EqualsThenCompoundThenEquals_FailsOnlyForSecondEquals()
+    {
+        var source = """
+            class C
+            {
+                public int P { get; set; }
+                public static C Make() => new C { P = 1, P += 2, P = 3 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+            // (4,54): error CS1912: Duplicate initialization of member 'P'
+            //     public static C Make() => new C { P = 1, P += 2, P = 3 };
+            Diagnostic(ErrorCode.ERR_MemberAlreadyInitialized, "P").WithArguments("P").WithLocation(4, 54));
+    }
+
+    [Fact]
+    public void Duplicate_Indexer_Unrestricted()
+    {
+        // Spec: "No such restriction applies to event or indexer targets." Per-indexer-key tracking has
+        // never been done (same-arg repeat has always been legal); same applies with compound.
+        var source = """
+            class C
+            {
+                private int[] _values = new int[10];
+                public int this[int i] { get => _values[i]; set => _values[i] = value; }
+                public static C Make() => new C { [0] = 1, [0] += 2, [0] = 3, [0] |= 4 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Duplicate_Event_Unrestricted()
+    {
+        var source = """
+            using System;
+            class C
+            {
+                public event EventHandler E;
+                public static C Make(EventHandler a, EventHandler b) => new C { E += a, E += b, E -= a, E += a };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+            // (4,31): warning CS0067: The event 'C.E' is never used
+            //     public event EventHandler E;
+            Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("C.E").WithLocation(4, 31));
+    }
+
+    [Fact]
+    public void Duplicate_WithExpression_Property_EnforcesRule()
+    {
+        var source = """
+            record C(int P)
+            {
+                public static C Make(C r) => r with { P += 1, P = 2 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+            // (3,51): error CS1912: Duplicate initialization of member 'P'
+            //     public static C Make(C r) => r with { P += 1, P = 2 };
+            Diagnostic(ErrorCode.ERR_MemberAlreadyInitialized, "P").WithArguments("P").WithLocation(3, 51));
+    }
+
+    #endregion
+
+    #region Misc shape rejections
+
+    [Fact]
+    public void RefOnRhs_Rejected()
+    {
+        var source = """
+            class C
+            {
+                public int P { get; set; }
+                public static C Make(ref int x) => new C { P += ref x };
+            }
+            """;
+        var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
+        Assert.NotEmpty(comp.GetDiagnostics());
+    }
+
+    [Fact]
+    public void NestedCollectionInitializerOnRhs_Rejected()
+    {
+        // Spec note: "The compound_assignment_operator branch admits only expression, so forms such as
+        // P += { 1, 2 } are syntactically ill-formed." The parser is permissive (per Phase 1); the binder
+        // rejects the shape.
+        var source = """
+            class C
+            {
+                public int P { get; set; }
+                public static C Make() => new C { P += { 1, 2 } };
+            }
+            """;
+        var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
+        Assert.NotEmpty(comp.GetDiagnostics());
+    }
+
+    #endregion
+
+    #region Containers
+
+    [Fact]
+    public void Container_Struct_Succeeds()
+    {
+        var source = """
+            struct S
+            {
+                public int F;
+                public static S Make() => new S { F += 1 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Container_RecordClass_With_Succeeds()
+    {
+        var source = """
+            record C(int P)
+            {
+                public static C Make(C r) => r with { P += 1 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Container_RecordStruct_With_Succeeds()
+    {
+        var source = """
+            record struct C(int P)
+            {
+                public static C Make(C r) => r with { P += 1 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Container_AnonymousType_Fails()
+    {
+        // Anonymous-type properties are readonly; compound fails on write. Also, the `new { }` syntax
+        // does not permit member initializers of the form `Name += Expr` grammatically at the
+        // anonymous-type level — those are anonymous-object-member-declarators, a different grammar.
+        var source = """
+            class C
+            {
+                public static void M()
+                {
+                    var a = new { X = 1 };
+                    // `new { X += 1 }` is not legal syntax for anonymous objects.
+                    // Lock down that anonymous types are read-only via their projection initializers.
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+    }
+
+    #endregion
+
+    #region User-defined operators
+
+    [Fact]
+    public void UserDefined_LegacyBinaryOperator_Resolves()
+    {
+        var source = """
+            struct V
+            {
+                public int X;
+                public V(int x) => X = x;
+                public static V operator +(V a, V b) => new V(a.X + b.X);
+            }
+            class C
+            {
+                public V Prop { get; set; }
+                public static C Make(V v) => new C { Prop += v };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void UserDefined_InPlaceCompoundOperator_Resolves_OnField()
+    {
+        // The C# 14 in-place `operator +=` requires a variable location on the left (it's a ref-like
+        // mutating call). Fields qualify; properties-by-value do not. This test pins that the binder
+        // correctly resolves the in-place operator when the target is a field. If the raw-access fix
+        // in BindInitializerMemberAssignment regresses, shouldTryUserDefinedInstanceOperator's
+        // CheckValueKind would return false here and fall back to legacy resolution, which would
+        // fail with CS0019 because there is no `operator +`.
+        var source = """
+            struct V
+            {
+                public int X;
+                public V(int x) => X = x;
+                public void operator +=(V b) { X += b.X; }
+            }
+            class C
+            {
+                public V F;
+                public static C Make(V v) => new C { F += v };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void UserDefined_BothLegacyAndInPlace_OnField_InPlaceWins()
+    {
+        // Pins that when both legacy `operator +` and in-place `operator +=` exist, and the target is
+        // a variable (field), the in-place operator is selected — matching the non-initializer
+        // compound assignment selection rule.
+        var source = """
+            struct V
+            {
+                public int X;
+                public V(int x) => X = x;
+                public static V operator +(V a, V b) => new V(a.X + b.X + 100);
+                public void operator +=(V b) { X += b.X; }
+            }
+            class C
+            {
+                public V F;
+                public static C Make(V v) => new C { F += v };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void UserDefined_InPlaceOnly_OnProperty_FailsBecausePropertyIsNotVariable()
+    {
+        // When the target is a by-value property (not a location), the in-place `operator +=` cannot
+        // apply, and without a legacy `operator +` there is no compound form. Expect CS0019.
+        var source = """
+            struct V
+            {
+                public int X;
+                public V(int x) => X = x;
+                public void operator +=(V b) { X += b.X; }
+            }
+            class C
+            {
+                public V Prop { get; set; }
+                public static C Make(V v) => new C { Prop += v };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+            // (10,42): error CS0019: Operator '+=' cannot be applied to operands of type 'V' and 'V'
+            //     public static C Make(V v) => new C { Prop += v };
+            Diagnostic(ErrorCode.ERR_BadBinaryOps, "Prop += v").WithArguments("+=", "V", "V").WithLocation(10, 42));
+    }
+
+    #endregion
+
+    #region Required members
+
+    [Fact]
+    public void Required_CompoundAlone_DoesNotSatisfy()
+    {
+        // Per the LDM recommendation ("No"): a compound member initializer does NOT discharge the
+        // `required` obligation. With only `P += 1` and no `P = ...`, required-member checking should
+        // still demand P.
+        var source = """
+            class C
+            {
+                public required int P { get; set; }
+                public static C Make() => new C { P += 1 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+            // (4,35): error CS9035: Required member 'C.P' must be set in the object initializer or attribute constructor.
+            //     public static C Make() => new C { P += 1 };
+            Diagnostic(ErrorCode.ERR_RequiredMemberMustBeSet, "C").WithArguments("C.P").WithLocation(4, 35));
+    }
+
+    [Fact]
+    public void Required_EqualsThenCompound_SatisfiesViaEquals()
+    {
+        var source = """
+            class C
+            {
+                public required int P { get; set; }
+                public static C Make() => new C { P = 0, P += 1 };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+    }
+
+    #endregion
+
+    #region Mixed initializer + feature interactions
+
+    [Fact]
+    public void Mixed_EqualsAndCompound_ProducesCorrectBoundShapes()
+    {
+        // Lock down that the binder produces ISimpleAssignmentOperation for `=` and
+        // ICompoundAssignmentOperation (or IEventAssignmentOperation) for compound forms.
+        var source = """
+            using System;
+            class C
+            {
+                public int P { get; set; }
+                public event EventHandler E;
+                public static C Make(EventHandler h) => new C { P = 10, P += 5, E += h };
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics(
+            // (5,31): warning CS0067: The event 'C.E' is never used
+            //     public event EventHandler E;
+            Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("C.E").WithLocation(5, 31));
+    }
+
+
+    #endregion
+}

--- a/src/Compilers/CSharp/Test/CSharp15/CompoundAssignmentInitializerParsingTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/CompoundAssignmentInitializerParsingTests.cs
@@ -1,0 +1,1098 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests;
+
+/// <summary>
+/// Parsing tests for compound assignment in object initializer and <c>with</c> expression
+/// (dotnet/csharplang#9896). The parser changes are permissive: any compound assignment operator
+/// (including <c>??=</c>) is accepted after the target of a named or dictionary member initializer,
+/// and the object-vs-collection classifier recognizes compound assignments as object-initializer
+/// evidence. Language-version gating and target legality live in the binder.
+/// </summary>
+public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
+{
+    public CompoundAssignmentInitializerParsingTests(ITestOutputHelper output) : base(output) { }
+
+    public static TheoryData<string, SyntaxKind, SyntaxKind> CompoundOperators => new()
+    {
+        { "+=",   SyntaxKind.PlusEqualsToken,                         SyntaxKind.AddAssignmentExpression },
+        { "-=",   SyntaxKind.MinusEqualsToken,                        SyntaxKind.SubtractAssignmentExpression },
+        { "*=",   SyntaxKind.AsteriskEqualsToken,                     SyntaxKind.MultiplyAssignmentExpression },
+        { "/=",   SyntaxKind.SlashEqualsToken,                        SyntaxKind.DivideAssignmentExpression },
+        { "%=",   SyntaxKind.PercentEqualsToken,                      SyntaxKind.ModuloAssignmentExpression },
+        { "&=",   SyntaxKind.AmpersandEqualsToken,                    SyntaxKind.AndAssignmentExpression },
+        { "|=",   SyntaxKind.BarEqualsToken,                          SyntaxKind.OrAssignmentExpression },
+        { "^=",   SyntaxKind.CaretEqualsToken,                        SyntaxKind.ExclusiveOrAssignmentExpression },
+        { "<<=",  SyntaxKind.LessThanLessThanEqualsToken,             SyntaxKind.LeftShiftAssignmentExpression },
+        { ">>=",  SyntaxKind.GreaterThanGreaterThanEqualsToken,       SyntaxKind.RightShiftAssignmentExpression },
+        { ">>>=", SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken, SyntaxKind.UnsignedRightShiftAssignmentExpression },
+        // The parser is permissive: `??=` is accepted too. The binder rejects it as not a valid
+        // compound_assignment_operator per the spec.
+        { "??=",  SyntaxKind.QuestionQuestionEqualsToken,             SyntaxKind.CoalesceAssignmentExpression },
+    };
+
+    public static TheoryData<LanguageVersion> AllLanguageVersions => new()
+    {
+        LanguageVersion.CSharp1,
+        LanguageVersion.CSharp2,
+        LanguageVersion.CSharp3,
+        LanguageVersion.CSharp4,
+        LanguageVersion.CSharp5,
+        LanguageVersion.CSharp6,
+        LanguageVersion.CSharp7,
+        LanguageVersion.CSharp7_1,
+        LanguageVersion.CSharp7_2,
+        LanguageVersion.CSharp7_3,
+        LanguageVersion.CSharp8,
+        LanguageVersion.CSharp9,
+        LanguageVersion.CSharp10,
+        LanguageVersion.CSharp11,
+        LanguageVersion.CSharp12,
+        LanguageVersion.CSharp13,
+        LanguageVersion.CSharp14,
+        LanguageVersion.Preview,
+    };
+
+    #region Object initializer: named member
+
+    [Theory, MemberData(nameof(CompoundOperators))]
+    public void ObjectInitializer_NamedMember_AllCompoundOperators(string op, SyntaxKind operatorTokenKind, SyntaxKind assignmentKind)
+    {
+        UsingExpression($"new Foo {{ Prop {op} 1 }}");
+
+        N(SyntaxKind.ObjectCreationExpression);
+        {
+            N(SyntaxKind.NewKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "Foo");
+            }
+            N(SyntaxKind.ObjectInitializerExpression);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(assignmentKind);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Prop");
+                    }
+                    N(operatorTokenKind);
+                    N(SyntaxKind.NumericLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "1");
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+    }
+
+    [Theory, MemberData(nameof(AllLanguageVersions))]
+    public void ObjectInitializer_NamedMember_NoParseDiagnosticsAnyLangVersion(LanguageVersion languageVersion)
+    {
+        UsingExpression(
+            "new Foo { Prop += 1 }",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.ObjectCreationExpression);
+        {
+            N(SyntaxKind.NewKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "Foo");
+            }
+            N(SyntaxKind.ObjectInitializerExpression);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.AddAssignmentExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Prop");
+                    }
+                    N(SyntaxKind.PlusEqualsToken);
+                    N(SyntaxKind.NumericLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "1");
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void ObjectInitializer_NamedMember_MixOfSimpleAndCompound()
+    {
+        UsingExpression("new Foo { Prop = 10, Prop += 5, Event += Handler }");
+
+        N(SyntaxKind.ObjectCreationExpression);
+        {
+            N(SyntaxKind.NewKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "Foo");
+            }
+            N(SyntaxKind.ObjectInitializerExpression);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.SimpleAssignmentExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Prop");
+                    }
+                    N(SyntaxKind.EqualsToken);
+                    N(SyntaxKind.NumericLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "10");
+                    }
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.AddAssignmentExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Prop");
+                    }
+                    N(SyntaxKind.PlusEqualsToken);
+                    N(SyntaxKind.NumericLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "5");
+                    }
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.AddAssignmentExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Event");
+                    }
+                    N(SyntaxKind.PlusEqualsToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Handler");
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void ObjectInitializer_NamedMember_TrailingComma()
+    {
+        UsingExpression("new Foo { Prop += 1, }");
+
+        N(SyntaxKind.ObjectCreationExpression);
+        {
+            N(SyntaxKind.NewKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "Foo");
+            }
+            N(SyntaxKind.ObjectInitializerExpression);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.AddAssignmentExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Prop");
+                    }
+                    N(SyntaxKind.PlusEqualsToken);
+                    N(SyntaxKind.NumericLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "1");
+                    }
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void ObjectInitializer_NamedMember_MissingRightHandSide()
+    {
+        // Parser is resilient: it consumes the operator then expects an expression; on missing
+        // expression it produces a missing identifier so the tree still shapes as compound.
+        UsingExpression("new Foo { Prop += }",
+            // (1,19): error CS1525: Invalid expression term '}'
+            // new Foo { Prop += }
+            Diagnostic(ErrorCode.ERR_InvalidExprTerm, "}").WithArguments("}").WithLocation(1, 19));
+
+        N(SyntaxKind.ObjectCreationExpression);
+        {
+            N(SyntaxKind.NewKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "Foo");
+            }
+            N(SyntaxKind.ObjectInitializerExpression);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.AddAssignmentExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Prop");
+                    }
+                    N(SyntaxKind.PlusEqualsToken);
+                    M(SyntaxKind.IdentifierName);
+                    {
+                        M(SyntaxKind.IdentifierToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void ObjectInitializer_NamedMember_NestedInitializerOnRhs_PermissiveParse()
+    {
+        // The spec note calls `Prop += { 1, 2 }` "syntactically ill-formed", but the parser is
+        // permissive and builds a nested `ObjectInitializerExpression`/`CollectionInitializerExpression`
+        // for resilience. The binder rejects this shape.
+        UsingExpression("new Foo { Prop += { 1, 2 } }");
+
+        N(SyntaxKind.ObjectCreationExpression);
+        {
+            N(SyntaxKind.NewKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "Foo");
+            }
+            N(SyntaxKind.ObjectInitializerExpression);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.AddAssignmentExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Prop");
+                    }
+                    N(SyntaxKind.PlusEqualsToken);
+                    N(SyntaxKind.CollectionInitializerExpression);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.NumericLiteralExpression);
+                        {
+                            N(SyntaxKind.NumericLiteralToken, "1");
+                        }
+                        N(SyntaxKind.CommaToken);
+                        N(SyntaxKind.NumericLiteralExpression);
+                        {
+                            N(SyntaxKind.NumericLiteralToken, "2");
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void ObjectInitializer_NamedMember_RefOnRhs()
+    {
+        // `Prop += ref x` parses: the parser uses `ParsePossibleRefExpression` for the RHS and
+        // produces a `RefExpression` wrapping the identifier. The binder rejects compound+ref.
+        UsingExpression("new Foo { Prop += ref x }");
+
+        N(SyntaxKind.ObjectCreationExpression);
+        {
+            N(SyntaxKind.NewKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "Foo");
+            }
+            N(SyntaxKind.ObjectInitializerExpression);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.AddAssignmentExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Prop");
+                    }
+                    N(SyntaxKind.PlusEqualsToken);
+                    N(SyntaxKind.RefExpression);
+                    {
+                        N(SyntaxKind.RefKeyword);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "x");
+                        }
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void ObjectInitializer_NamedMember_GenericNameOnRhs()
+    {
+        // Arbitrary expression on the RHS: member access, invocation, generic name.
+        UsingExpression("new Foo { Prop += Bar<int>.Baz(x) }");
+
+        N(SyntaxKind.ObjectCreationExpression);
+        {
+            N(SyntaxKind.NewKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "Foo");
+            }
+            N(SyntaxKind.ObjectInitializerExpression);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.AddAssignmentExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Prop");
+                    }
+                    N(SyntaxKind.PlusEqualsToken);
+                    N(SyntaxKind.InvocationExpression);
+                    {
+                        N(SyntaxKind.SimpleMemberAccessExpression);
+                        {
+                            N(SyntaxKind.GenericName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "Bar");
+                                N(SyntaxKind.TypeArgumentList);
+                                {
+                                    N(SyntaxKind.LessThanToken);
+                                    N(SyntaxKind.PredefinedType);
+                                    {
+                                        N(SyntaxKind.IntKeyword);
+                                    }
+                                    N(SyntaxKind.GreaterThanToken);
+                                }
+                            }
+                            N(SyntaxKind.DotToken);
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "Baz");
+                            }
+                        }
+                        N(SyntaxKind.ArgumentList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.Argument);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "x");
+                                }
+                            }
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+    }
+
+    #endregion
+
+    #region Object initializer: dictionary (indexer) member
+
+    [Theory, MemberData(nameof(CompoundOperators))]
+    public void ObjectInitializer_IndexerMember_AllCompoundOperators(string op, SyntaxKind operatorTokenKind, SyntaxKind assignmentKind)
+    {
+        UsingExpression($"new Foo {{ [0] {op} 1 }}");
+
+        N(SyntaxKind.ObjectCreationExpression);
+        {
+            N(SyntaxKind.NewKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "Foo");
+            }
+            N(SyntaxKind.ObjectInitializerExpression);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(assignmentKind);
+                {
+                    N(SyntaxKind.ImplicitElementAccess);
+                    {
+                        N(SyntaxKind.BracketedArgumentList);
+                        {
+                            N(SyntaxKind.OpenBracketToken);
+                            N(SyntaxKind.Argument);
+                            {
+                                N(SyntaxKind.NumericLiteralExpression);
+                                {
+                                    N(SyntaxKind.NumericLiteralToken, "0");
+                                }
+                            }
+                            N(SyntaxKind.CloseBracketToken);
+                        }
+                    }
+                    N(operatorTokenKind);
+                    N(SyntaxKind.NumericLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "1");
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void ObjectInitializer_IndexerMember_MultipleArguments()
+    {
+        UsingExpression("new Foo { [a, b] |= mask }");
+
+        N(SyntaxKind.ObjectCreationExpression);
+        {
+            N(SyntaxKind.NewKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "Foo");
+            }
+            N(SyntaxKind.ObjectInitializerExpression);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.OrAssignmentExpression);
+                {
+                    N(SyntaxKind.ImplicitElementAccess);
+                    {
+                        N(SyntaxKind.BracketedArgumentList);
+                        {
+                            N(SyntaxKind.OpenBracketToken);
+                            N(SyntaxKind.Argument);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "a");
+                                }
+                            }
+                            N(SyntaxKind.CommaToken);
+                            N(SyntaxKind.Argument);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "b");
+                                }
+                            }
+                            N(SyntaxKind.CloseBracketToken);
+                        }
+                    }
+                    N(SyntaxKind.BarEqualsToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "mask");
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+    }
+
+    #endregion
+
+    #region With expression
+
+    [Theory, MemberData(nameof(CompoundOperators))]
+    public void WithExpression_AllCompoundOperators(string op, SyntaxKind operatorTokenKind, SyntaxKind assignmentKind)
+    {
+        UsingExpression($"r with {{ Value {op} 1 }}");
+
+        N(SyntaxKind.WithExpression);
+        {
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "r");
+            }
+            N(SyntaxKind.WithKeyword);
+            N(SyntaxKind.WithInitializerExpression);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(assignmentKind);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Value");
+                    }
+                    N(operatorTokenKind);
+                    N(SyntaxKind.NumericLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "1");
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+    }
+
+    [Theory, MemberData(nameof(AllLanguageVersions))]
+    public void WithExpression_NoParseDiagnosticsAnyLangVersion(LanguageVersion languageVersion)
+    {
+        UsingExpression(
+            "r with { Value -= 1 }",
+            TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        N(SyntaxKind.WithExpression);
+        {
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "r");
+            }
+            N(SyntaxKind.WithKeyword);
+            N(SyntaxKind.WithInitializerExpression);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.SubtractAssignmentExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Value");
+                    }
+                    N(SyntaxKind.MinusEqualsToken);
+                    N(SyntaxKind.NumericLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "1");
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void WithExpression_MixOfSimpleAndCompound()
+    {
+        UsingExpression("r with { Value = 10, Value += 5, Changed += OnChanged }");
+
+        N(SyntaxKind.WithExpression);
+        {
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "r");
+            }
+            N(SyntaxKind.WithKeyword);
+            N(SyntaxKind.WithInitializerExpression);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.SimpleAssignmentExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Value");
+                    }
+                    N(SyntaxKind.EqualsToken);
+                    N(SyntaxKind.NumericLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "10");
+                    }
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.AddAssignmentExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Value");
+                    }
+                    N(SyntaxKind.PlusEqualsToken);
+                    N(SyntaxKind.NumericLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "5");
+                    }
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.AddAssignmentExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Changed");
+                    }
+                    N(SyntaxKind.PlusEqualsToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "OnChanged");
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+    }
+
+    #endregion
+
+    #region Object-vs-collection classification
+
+    [Fact]
+    public void Classifier_AllCompoundMembersAreObjectInitializer()
+    {
+        // Prior to the feature, a brace list containing only non-`=` assignments classified as
+        // `CollectionInitializerExpression`. With the feature, the classifier recognizes compound
+        // assignments with identifier/implicit-element-access targets as object-initializer evidence.
+        UsingExpression("new Foo { Prop += 1, Event += Handler }");
+
+        N(SyntaxKind.ObjectCreationExpression);
+        {
+            N(SyntaxKind.NewKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "Foo");
+            }
+            N(SyntaxKind.ObjectInitializerExpression);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.AddAssignmentExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Prop");
+                    }
+                    N(SyntaxKind.PlusEqualsToken);
+                    N(SyntaxKind.NumericLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "1");
+                    }
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.AddAssignmentExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Event");
+                    }
+                    N(SyntaxKind.PlusEqualsToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Handler");
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Classifier_IndexerCompoundMembersAreObjectInitializer()
+    {
+        UsingExpression("new Foo { [0] |= a, [1] &= b }");
+
+        N(SyntaxKind.ObjectCreationExpression);
+        {
+            N(SyntaxKind.NewKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "Foo");
+            }
+            N(SyntaxKind.ObjectInitializerExpression);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.OrAssignmentExpression);
+                {
+                    N(SyntaxKind.ImplicitElementAccess);
+                    {
+                        N(SyntaxKind.BracketedArgumentList);
+                        {
+                            N(SyntaxKind.OpenBracketToken);
+                            N(SyntaxKind.Argument);
+                            {
+                                N(SyntaxKind.NumericLiteralExpression);
+                                {
+                                    N(SyntaxKind.NumericLiteralToken, "0");
+                                }
+                            }
+                            N(SyntaxKind.CloseBracketToken);
+                        }
+                    }
+                    N(SyntaxKind.BarEqualsToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "a");
+                    }
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.AndAssignmentExpression);
+                {
+                    N(SyntaxKind.ImplicitElementAccess);
+                    {
+                        N(SyntaxKind.BracketedArgumentList);
+                        {
+                            N(SyntaxKind.OpenBracketToken);
+                            N(SyntaxKind.Argument);
+                            {
+                                N(SyntaxKind.NumericLiteralExpression);
+                                {
+                                    N(SyntaxKind.NumericLiteralToken, "1");
+                                }
+                            }
+                            N(SyntaxKind.CloseBracketToken);
+                        }
+                    }
+                    N(SyntaxKind.AmpersandEqualsToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "b");
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Classifier_BareCompoundAssignmentOnNonMemberIsCollectionInitializer()
+    {
+        // `a.b += 1` is a compound assignment, but its left is a `SimpleMemberAccessExpression`,
+        // not an `IdentifierName` or `ImplicitElementAccess`. Per the classifier, this alone is NOT
+        // object-initializer evidence, so the brace list classifies as a collection initializer.
+        UsingExpression("new Foo { a.b += 1 }");
+
+        N(SyntaxKind.ObjectCreationExpression);
+        {
+            N(SyntaxKind.NewKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "Foo");
+            }
+            N(SyntaxKind.CollectionInitializerExpression);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.AddAssignmentExpression);
+                {
+                    N(SyntaxKind.SimpleMemberAccessExpression);
+                    {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "a");
+                        }
+                        N(SyntaxKind.DotToken);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "b");
+                        }
+                    }
+                    N(SyntaxKind.PlusEqualsToken);
+                    N(SyntaxKind.NumericLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "1");
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Classifier_EmptyBracesIsObjectInitializer()
+    {
+        // Classifier pre-existing rule: empty brace list is always an object initializer.
+        UsingExpression("new Foo { }");
+
+        N(SyntaxKind.ObjectCreationExpression);
+        {
+            N(SyntaxKind.NewKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "Foo");
+            }
+            N(SyntaxKind.ObjectInitializerExpression);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+    }
+
+    #endregion
+
+    #region Full top-level usage
+
+    [Fact]
+    public void TopLevel_ObjectInitializer()
+    {
+        UsingTree("""
+            var c = new Counter
+            {
+                Value = 10,
+                Value += 5,
+                Changed += OnChanged,
+                Changed += OnChanged2,
+            };
+            """);
+
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.GlobalStatement);
+            {
+                N(SyntaxKind.LocalDeclarationStatement);
+                {
+                    N(SyntaxKind.VariableDeclaration);
+                    {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "var");
+                        }
+                        N(SyntaxKind.VariableDeclarator);
+                        {
+                            N(SyntaxKind.IdentifierToken, "c");
+                            N(SyntaxKind.EqualsValueClause);
+                            {
+                                N(SyntaxKind.EqualsToken);
+                                N(SyntaxKind.ObjectCreationExpression);
+                                {
+                                    N(SyntaxKind.NewKeyword);
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "Counter");
+                                    }
+                                    N(SyntaxKind.ObjectInitializerExpression);
+                                    {
+                                        N(SyntaxKind.OpenBraceToken);
+                                        N(SyntaxKind.SimpleAssignmentExpression);
+                                        {
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "Value");
+                                            }
+                                            N(SyntaxKind.EqualsToken);
+                                            N(SyntaxKind.NumericLiteralExpression);
+                                            {
+                                                N(SyntaxKind.NumericLiteralToken, "10");
+                                            }
+                                        }
+                                        N(SyntaxKind.CommaToken);
+                                        N(SyntaxKind.AddAssignmentExpression);
+                                        {
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "Value");
+                                            }
+                                            N(SyntaxKind.PlusEqualsToken);
+                                            N(SyntaxKind.NumericLiteralExpression);
+                                            {
+                                                N(SyntaxKind.NumericLiteralToken, "5");
+                                            }
+                                        }
+                                        N(SyntaxKind.CommaToken);
+                                        N(SyntaxKind.AddAssignmentExpression);
+                                        {
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "Changed");
+                                            }
+                                            N(SyntaxKind.PlusEqualsToken);
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "OnChanged");
+                                            }
+                                        }
+                                        N(SyntaxKind.CommaToken);
+                                        N(SyntaxKind.AddAssignmentExpression);
+                                        {
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "Changed");
+                                            }
+                                            N(SyntaxKind.PlusEqualsToken);
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "OnChanged2");
+                                            }
+                                        }
+                                        N(SyntaxKind.CommaToken);
+                                        N(SyntaxKind.CloseBraceToken);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void TopLevel_WithExpression()
+    {
+        UsingTree("""
+            var c = original with { Value -= 1, Changed += OnChanged };
+            """);
+
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.GlobalStatement);
+            {
+                N(SyntaxKind.LocalDeclarationStatement);
+                {
+                    N(SyntaxKind.VariableDeclaration);
+                    {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "var");
+                        }
+                        N(SyntaxKind.VariableDeclarator);
+                        {
+                            N(SyntaxKind.IdentifierToken, "c");
+                            N(SyntaxKind.EqualsValueClause);
+                            {
+                                N(SyntaxKind.EqualsToken);
+                                N(SyntaxKind.WithExpression);
+                                {
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "original");
+                                    }
+                                    N(SyntaxKind.WithKeyword);
+                                    N(SyntaxKind.WithInitializerExpression);
+                                    {
+                                        N(SyntaxKind.OpenBraceToken);
+                                        N(SyntaxKind.SubtractAssignmentExpression);
+                                        {
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "Value");
+                                            }
+                                            N(SyntaxKind.MinusEqualsToken);
+                                            N(SyntaxKind.NumericLiteralExpression);
+                                            {
+                                                N(SyntaxKind.NumericLiteralToken, "1");
+                                            }
+                                        }
+                                        N(SyntaxKind.CommaToken);
+                                        N(SyntaxKind.AddAssignmentExpression);
+                                        {
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "Changed");
+                                            }
+                                            N(SyntaxKind.PlusEqualsToken);
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "OnChanged");
+                                            }
+                                        }
+                                        N(SyntaxKind.CloseBraceToken);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void TopLevel_ImplicitObjectCreation()
+    {
+        // `new() { Prop += 1 }` target-typed form.
+        UsingExpression("new() { Prop += 1 }");
+
+        N(SyntaxKind.ImplicitObjectCreationExpression);
+        {
+            N(SyntaxKind.NewKeyword);
+            N(SyntaxKind.ArgumentList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.ObjectInitializerExpression);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.AddAssignmentExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Prop");
+                    }
+                    N(SyntaxKind.PlusEqualsToken);
+                    N(SyntaxKind.NumericLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "1");
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+    }
+
+    #endregion
+
+    #region Colon recovery
+
+    [Fact]
+    public void ColonRecovery_StillRecoversForSimpleAssignment()
+    {
+        // Pre-existing recovery: `Prop :` is treated as a missing `=`. We preserve this for the
+        // simple-assignment path only; compound forms do not get colon recovery because the spec
+        // has no ambiguity for them.
+        UsingExpression("new Foo { Prop : 1 }",
+            // (1,16): error CS1003: Syntax error, '=' expected
+            // new Foo { Prop : 1 }
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("=").WithLocation(1, 16));
+
+        N(SyntaxKind.ObjectCreationExpression);
+        {
+            N(SyntaxKind.NewKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "Foo");
+            }
+            N(SyntaxKind.ObjectInitializerExpression);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.SimpleAssignmentExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Prop");
+                    }
+                    // `EatTokenAsKind` produces a missing `=` with the `:` attached as skipped trivia.
+                    M(SyntaxKind.EqualsToken);
+                    N(SyntaxKind.NumericLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "1");
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+    }
+
+    #endregion
+}

--- a/src/Compilers/CSharp/Test/CSharp15/CompoundAssignmentInitializerParsingTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/CompoundAssignmentInitializerParsingTests.cs
@@ -100,10 +100,10 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
         EOF();
     }
 
-    [Fact]
-    public void ObjectInitializer_NamedMember_MixOfSimpleAndCompound()
+    [Theory, MemberData(nameof(CompoundOperators))]
+    public void ObjectInitializer_NamedMember_MixOfSimpleAndCompound(string op, SyntaxKind operatorTokenKind, SyntaxKind assignmentKind)
     {
-        UsingExpression("new Foo { Prop = 10, Prop += 5, Event += Handler }");
+        UsingExpression($"new Foo {{ Prop = 10, Prop {op} 5, Event {op} Handler }}");
 
         N(SyntaxKind.ObjectCreationExpression);
         {
@@ -128,26 +128,26 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
                     }
                 }
                 N(SyntaxKind.CommaToken);
-                N(SyntaxKind.AddAssignmentExpression);
+                N(assignmentKind);
                 {
                     N(SyntaxKind.IdentifierName);
                     {
                         N(SyntaxKind.IdentifierToken, "Prop");
                     }
-                    N(SyntaxKind.PlusEqualsToken);
+                    N(operatorTokenKind);
                     N(SyntaxKind.NumericLiteralExpression);
                     {
                         N(SyntaxKind.NumericLiteralToken, "5");
                     }
                 }
                 N(SyntaxKind.CommaToken);
-                N(SyntaxKind.AddAssignmentExpression);
+                N(assignmentKind);
                 {
                     N(SyntaxKind.IdentifierName);
                     {
                         N(SyntaxKind.IdentifierToken, "Event");
                     }
-                    N(SyntaxKind.PlusEqualsToken);
+                    N(operatorTokenKind);
                     N(SyntaxKind.IdentifierName);
                     {
                         N(SyntaxKind.IdentifierToken, "Handler");
@@ -159,10 +159,10 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
         EOF();
     }
 
-    [Fact]
-    public void ObjectInitializer_NamedMember_TrailingComma()
+    [Theory, MemberData(nameof(CompoundOperators))]
+    public void ObjectInitializer_NamedMember_TrailingComma(string op, SyntaxKind operatorTokenKind, SyntaxKind assignmentKind)
     {
-        UsingExpression("new Foo { Prop += 1, }");
+        UsingExpression($"new Foo {{ Prop {op} 1, }}");
 
         N(SyntaxKind.ObjectCreationExpression);
         {
@@ -174,13 +174,13 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
             N(SyntaxKind.ObjectInitializerExpression);
             {
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.AddAssignmentExpression);
+                N(assignmentKind);
                 {
                     N(SyntaxKind.IdentifierName);
                     {
                         N(SyntaxKind.IdentifierToken, "Prop");
                     }
-                    N(SyntaxKind.PlusEqualsToken);
+                    N(operatorTokenKind);
                     N(SyntaxKind.NumericLiteralExpression);
                     {
                         N(SyntaxKind.NumericLiteralToken, "1");
@@ -193,13 +193,13 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
         EOF();
     }
 
-    [Fact]
-    public void ObjectInitializer_NamedMember_MissingRightHandSide()
+    [Theory, MemberData(nameof(CompoundOperators))]
+    public void ObjectInitializer_NamedMember_MissingRightHandSide(string op, SyntaxKind operatorTokenKind, SyntaxKind assignmentKind)
     {
-        UsingExpression("new Foo { Prop += }",
-            // (1,19): error CS1525: Invalid expression term '}'
-            // new Foo { Prop += }
-            Diagnostic(ErrorCode.ERR_InvalidExprTerm, "}").WithArguments("}").WithLocation(1, 19));
+        var source = $"new Foo {{ Prop {op} }}";
+        var closeBracePosition = source.IndexOf('}') + 1;
+        UsingExpression(source,
+            Diagnostic(ErrorCode.ERR_InvalidExprTerm, "}").WithArguments("}").WithLocation(1, closeBracePosition));
 
         N(SyntaxKind.ObjectCreationExpression);
         {
@@ -211,13 +211,13 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
             N(SyntaxKind.ObjectInitializerExpression);
             {
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.AddAssignmentExpression);
+                N(assignmentKind);
                 {
                     N(SyntaxKind.IdentifierName);
                     {
                         N(SyntaxKind.IdentifierToken, "Prop");
                     }
-                    N(SyntaxKind.PlusEqualsToken);
+                    N(operatorTokenKind);
                     M(SyntaxKind.IdentifierName);
                     {
                         M(SyntaxKind.IdentifierToken);
@@ -229,10 +229,10 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
         EOF();
     }
 
-    [Fact]
-    public void ObjectInitializer_NamedMember_NestedInitializerOnRhs_PermissiveParse()
+    [Theory, MemberData(nameof(CompoundOperators))]
+    public void ObjectInitializer_NamedMember_NestedInitializerOnRhs_PermissiveParse(string op, SyntaxKind operatorTokenKind, SyntaxKind assignmentKind)
     {
-        UsingExpression("new Foo { Prop += { 1, 2 } }");
+        UsingExpression($"new Foo {{ Prop {op} {{ 1, 2 }} }}");
 
         N(SyntaxKind.ObjectCreationExpression);
         {
@@ -244,13 +244,13 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
             N(SyntaxKind.ObjectInitializerExpression);
             {
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.AddAssignmentExpression);
+                N(assignmentKind);
                 {
                     N(SyntaxKind.IdentifierName);
                     {
                         N(SyntaxKind.IdentifierToken, "Prop");
                     }
-                    N(SyntaxKind.PlusEqualsToken);
+                    N(operatorTokenKind);
                     N(SyntaxKind.CollectionInitializerExpression);
                     {
                         N(SyntaxKind.OpenBraceToken);
@@ -272,10 +272,10 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
         EOF();
     }
 
-    [Fact]
-    public void ObjectInitializer_NamedMember_RefOnRhs()
+    [Theory, MemberData(nameof(CompoundOperators))]
+    public void ObjectInitializer_NamedMember_RefOnRhs(string op, SyntaxKind operatorTokenKind, SyntaxKind assignmentKind)
     {
-        UsingExpression("new Foo { Prop += ref x }");
+        UsingExpression($"new Foo {{ Prop {op} ref x }}");
 
         N(SyntaxKind.ObjectCreationExpression);
         {
@@ -287,13 +287,13 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
             N(SyntaxKind.ObjectInitializerExpression);
             {
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.AddAssignmentExpression);
+                N(assignmentKind);
                 {
                     N(SyntaxKind.IdentifierName);
                     {
                         N(SyntaxKind.IdentifierToken, "Prop");
                     }
-                    N(SyntaxKind.PlusEqualsToken);
+                    N(operatorTokenKind);
                     N(SyntaxKind.RefExpression);
                     {
                         N(SyntaxKind.RefKeyword);
@@ -309,10 +309,10 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
         EOF();
     }
 
-    [Fact]
-    public void ObjectInitializer_NamedMember_GenericNameOnRhs()
+    [Theory, MemberData(nameof(CompoundOperators))]
+    public void ObjectInitializer_NamedMember_GenericNameOnRhs(string op, SyntaxKind operatorTokenKind, SyntaxKind assignmentKind)
     {
-        UsingExpression("new Foo { Prop += Bar<int>.Baz(x) }");
+        UsingExpression($"new Foo {{ Prop {op} Bar<int>.Baz(x) }}");
 
         N(SyntaxKind.ObjectCreationExpression);
         {
@@ -324,13 +324,13 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
             N(SyntaxKind.ObjectInitializerExpression);
             {
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.AddAssignmentExpression);
+                N(assignmentKind);
                 {
                     N(SyntaxKind.IdentifierName);
                     {
                         N(SyntaxKind.IdentifierToken, "Prop");
                     }
-                    N(SyntaxKind.PlusEqualsToken);
+                    N(operatorTokenKind);
                     N(SyntaxKind.InvocationExpression);
                     {
                         N(SyntaxKind.SimpleMemberAccessExpression);
@@ -422,10 +422,10 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
         EOF();
     }
 
-    [Fact]
-    public void ObjectInitializer_IndexerMember_MultipleArguments()
+    [Theory, MemberData(nameof(CompoundOperators))]
+    public void ObjectInitializer_IndexerMember_MultipleArguments(string op, SyntaxKind operatorTokenKind, SyntaxKind assignmentKind)
     {
-        UsingExpression("new Foo { [a, b] |= mask }");
+        UsingExpression($"new Foo {{ [a, b] {op} mask }}");
 
         N(SyntaxKind.ObjectCreationExpression);
         {
@@ -437,7 +437,7 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
             N(SyntaxKind.ObjectInitializerExpression);
             {
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.OrAssignmentExpression);
+                N(assignmentKind);
                 {
                     N(SyntaxKind.ImplicitElementAccess);
                     {
@@ -462,7 +462,7 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
                             N(SyntaxKind.CloseBracketToken);
                         }
                     }
-                    N(SyntaxKind.BarEqualsToken);
+                    N(operatorTokenKind);
                     N(SyntaxKind.IdentifierName);
                     {
                         N(SyntaxKind.IdentifierToken, "mask");
@@ -546,10 +546,10 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
         EOF();
     }
 
-    [Fact]
-    public void WithExpression_MixOfSimpleAndCompound()
+    [Theory, MemberData(nameof(CompoundOperators))]
+    public void WithExpression_MixOfSimpleAndCompound(string op, SyntaxKind operatorTokenKind, SyntaxKind assignmentKind)
     {
-        UsingExpression("r with { Value = 10, Value += 5, Changed += OnChanged }");
+        UsingExpression($"r with {{ Value = 10, Value {op} 5, Changed {op} OnChanged }}");
 
         N(SyntaxKind.WithExpression);
         {
@@ -574,26 +574,26 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
                     }
                 }
                 N(SyntaxKind.CommaToken);
-                N(SyntaxKind.AddAssignmentExpression);
+                N(assignmentKind);
                 {
                     N(SyntaxKind.IdentifierName);
                     {
                         N(SyntaxKind.IdentifierToken, "Value");
                     }
-                    N(SyntaxKind.PlusEqualsToken);
+                    N(operatorTokenKind);
                     N(SyntaxKind.NumericLiteralExpression);
                     {
                         N(SyntaxKind.NumericLiteralToken, "5");
                     }
                 }
                 N(SyntaxKind.CommaToken);
-                N(SyntaxKind.AddAssignmentExpression);
+                N(assignmentKind);
                 {
                     N(SyntaxKind.IdentifierName);
                     {
                         N(SyntaxKind.IdentifierToken, "Changed");
                     }
-                    N(SyntaxKind.PlusEqualsToken);
+                    N(operatorTokenKind);
                     N(SyntaxKind.IdentifierName);
                     {
                         N(SyntaxKind.IdentifierToken, "OnChanged");
@@ -609,10 +609,10 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
 
     #region Object-vs-collection classification
 
-    [Fact]
-    public void Classifier_AllCompoundMembersAreObjectInitializer()
+    [Theory, MemberData(nameof(CompoundOperators))]
+    public void Classifier_AllCompoundMembersAreObjectInitializer(string op, SyntaxKind operatorTokenKind, SyntaxKind assignmentKind)
     {
-        UsingExpression("new Foo { Prop += 1, Event += Handler }");
+        UsingExpression($"new Foo {{ Prop {op} 1, Event {op} Handler }}");
 
         N(SyntaxKind.ObjectCreationExpression);
         {
@@ -624,26 +624,26 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
             N(SyntaxKind.ObjectInitializerExpression);
             {
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.AddAssignmentExpression);
+                N(assignmentKind);
                 {
                     N(SyntaxKind.IdentifierName);
                     {
                         N(SyntaxKind.IdentifierToken, "Prop");
                     }
-                    N(SyntaxKind.PlusEqualsToken);
+                    N(operatorTokenKind);
                     N(SyntaxKind.NumericLiteralExpression);
                     {
                         N(SyntaxKind.NumericLiteralToken, "1");
                     }
                 }
                 N(SyntaxKind.CommaToken);
-                N(SyntaxKind.AddAssignmentExpression);
+                N(assignmentKind);
                 {
                     N(SyntaxKind.IdentifierName);
                     {
                         N(SyntaxKind.IdentifierToken, "Event");
                     }
-                    N(SyntaxKind.PlusEqualsToken);
+                    N(operatorTokenKind);
                     N(SyntaxKind.IdentifierName);
                     {
                         N(SyntaxKind.IdentifierToken, "Handler");
@@ -655,10 +655,10 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
         EOF();
     }
 
-    [Fact]
-    public void Classifier_IndexerCompoundMembersAreObjectInitializer()
+    [Theory, MemberData(nameof(CompoundOperators))]
+    public void Classifier_IndexerCompoundMembersAreObjectInitializer(string op, SyntaxKind operatorTokenKind, SyntaxKind assignmentKind)
     {
-        UsingExpression("new Foo { [0] |= a, [1] &= b }");
+        UsingExpression($"new Foo {{ [0] {op} a, [1] {op} b }}");
 
         N(SyntaxKind.ObjectCreationExpression);
         {
@@ -670,7 +670,7 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
             N(SyntaxKind.ObjectInitializerExpression);
             {
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.OrAssignmentExpression);
+                N(assignmentKind);
                 {
                     N(SyntaxKind.ImplicitElementAccess);
                     {
@@ -687,14 +687,14 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
                             N(SyntaxKind.CloseBracketToken);
                         }
                     }
-                    N(SyntaxKind.BarEqualsToken);
+                    N(operatorTokenKind);
                     N(SyntaxKind.IdentifierName);
                     {
                         N(SyntaxKind.IdentifierToken, "a");
                     }
                 }
                 N(SyntaxKind.CommaToken);
-                N(SyntaxKind.AndAssignmentExpression);
+                N(assignmentKind);
                 {
                     N(SyntaxKind.ImplicitElementAccess);
                     {
@@ -711,7 +711,7 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
                             N(SyntaxKind.CloseBracketToken);
                         }
                     }
-                    N(SyntaxKind.AmpersandEqualsToken);
+                    N(operatorTokenKind);
                     N(SyntaxKind.IdentifierName);
                     {
                         N(SyntaxKind.IdentifierToken, "b");
@@ -723,12 +723,12 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
         EOF();
     }
 
-    [Fact]
-    public void Classifier_BareCompoundAssignmentOnNonMemberIsCollectionInitializer()
+    [Theory, MemberData(nameof(CompoundOperators))]
+    public void Classifier_BareCompoundAssignmentOnNonMemberIsCollectionInitializer(string op, SyntaxKind operatorTokenKind, SyntaxKind assignmentKind)
     {
         // Left is a `SimpleMemberAccessExpression`, not `IdentifierName`/`ImplicitElementAccess`,
         // so this is not object-initializer evidence.
-        UsingExpression("new Foo { a.b += 1 }");
+        UsingExpression($"new Foo {{ a.b {op} 1 }}");
 
         N(SyntaxKind.ObjectCreationExpression);
         {
@@ -740,7 +740,7 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
             N(SyntaxKind.CollectionInitializerExpression);
             {
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.AddAssignmentExpression);
+                N(assignmentKind);
                 {
                     N(SyntaxKind.SimpleMemberAccessExpression);
                     {
@@ -754,7 +754,7 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
                             N(SyntaxKind.IdentifierToken, "b");
                         }
                     }
-                    N(SyntaxKind.PlusEqualsToken);
+                    N(operatorTokenKind);
                     N(SyntaxKind.NumericLiteralExpression);
                     {
                         N(SyntaxKind.NumericLiteralToken, "1");
@@ -972,10 +972,10 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
         EOF();
     }
 
-    [Fact]
-    public void TopLevel_ImplicitObjectCreation()
+    [Theory, MemberData(nameof(CompoundOperators))]
+    public void TopLevel_ImplicitObjectCreation(string op, SyntaxKind operatorTokenKind, SyntaxKind assignmentKind)
     {
-        UsingExpression("new() { Prop += 1 }");
+        UsingExpression($"new() {{ Prop {op} 1 }}");
 
         N(SyntaxKind.ImplicitObjectCreationExpression);
         {
@@ -988,13 +988,13 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
             N(SyntaxKind.ObjectInitializerExpression);
             {
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.AddAssignmentExpression);
+                N(assignmentKind);
                 {
                     N(SyntaxKind.IdentifierName);
                     {
                         N(SyntaxKind.IdentifierToken, "Prop");
                     }
-                    N(SyntaxKind.PlusEqualsToken);
+                    N(operatorTokenKind);
                     N(SyntaxKind.NumericLiteralExpression);
                     {
                         N(SyntaxKind.NumericLiteralToken, "1");

--- a/src/Compilers/CSharp/Test/CSharp15/CompoundAssignmentInitializerParsingTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/CompoundAssignmentInitializerParsingTests.cs
@@ -9,13 +9,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests;
 
-/// <summary>
-/// Parsing tests for compound assignment in object initializer and <c>with</c> expression
-/// (dotnet/csharplang#9896). The parser changes are permissive: any compound assignment operator
-/// (including <c>??=</c>) is accepted after the target of a named or dictionary member initializer,
-/// and the object-vs-collection classifier recognizes compound assignments as object-initializer
-/// evidence. Language-version gating and target legality live in the binder.
-/// </summary>
 public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
 {
     public CompoundAssignmentInitializerParsingTests(ITestOutputHelper output) : base(output) { }
@@ -33,8 +26,7 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
         { "<<=",  SyntaxKind.LessThanLessThanEqualsToken,             SyntaxKind.LeftShiftAssignmentExpression },
         { ">>=",  SyntaxKind.GreaterThanGreaterThanEqualsToken,       SyntaxKind.RightShiftAssignmentExpression },
         { ">>>=", SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken, SyntaxKind.UnsignedRightShiftAssignmentExpression },
-        // The parser is permissive: `??=` is accepted too. The binder rejects it as not a valid
-        // compound_assignment_operator per the spec.
+        // Parser-permissive: `??=` is accepted; binder rejects per spec.
         { "??=",  SyntaxKind.QuestionQuestionEqualsToken,             SyntaxKind.CoalesceAssignmentExpression },
     };
 
@@ -226,8 +218,6 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
     [Fact]
     public void ObjectInitializer_NamedMember_MissingRightHandSide()
     {
-        // Parser is resilient: it consumes the operator then expects an expression; on missing
-        // expression it produces a missing identifier so the tree still shapes as compound.
         UsingExpression("new Foo { Prop += }",
             // (1,19): error CS1525: Invalid expression term '}'
             // new Foo { Prop += }
@@ -264,9 +254,6 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
     [Fact]
     public void ObjectInitializer_NamedMember_NestedInitializerOnRhs_PermissiveParse()
     {
-        // The spec note calls `Prop += { 1, 2 }` "syntactically ill-formed", but the parser is
-        // permissive and builds a nested `ObjectInitializerExpression`/`CollectionInitializerExpression`
-        // for resilience. The binder rejects this shape.
         UsingExpression("new Foo { Prop += { 1, 2 } }");
 
         N(SyntaxKind.ObjectCreationExpression);
@@ -310,8 +297,6 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
     [Fact]
     public void ObjectInitializer_NamedMember_RefOnRhs()
     {
-        // `Prop += ref x` parses: the parser uses `ParsePossibleRefExpression` for the RHS and
-        // produces a `RefExpression` wrapping the identifier. The binder rejects compound+ref.
         UsingExpression("new Foo { Prop += ref x }");
 
         N(SyntaxKind.ObjectCreationExpression);
@@ -349,7 +334,6 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
     [Fact]
     public void ObjectInitializer_NamedMember_GenericNameOnRhs()
     {
-        // Arbitrary expression on the RHS: member access, invocation, generic name.
         UsingExpression("new Foo { Prop += Bar<int>.Baz(x) }");
 
         N(SyntaxKind.ObjectCreationExpression);
@@ -650,9 +634,6 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
     [Fact]
     public void Classifier_AllCompoundMembersAreObjectInitializer()
     {
-        // Prior to the feature, a brace list containing only non-`=` assignments classified as
-        // `CollectionInitializerExpression`. With the feature, the classifier recognizes compound
-        // assignments with identifier/implicit-element-access targets as object-initializer evidence.
         UsingExpression("new Foo { Prop += 1, Event += Handler }");
 
         N(SyntaxKind.ObjectCreationExpression);
@@ -767,9 +748,8 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
     [Fact]
     public void Classifier_BareCompoundAssignmentOnNonMemberIsCollectionInitializer()
     {
-        // `a.b += 1` is a compound assignment, but its left is a `SimpleMemberAccessExpression`,
-        // not an `IdentifierName` or `ImplicitElementAccess`. Per the classifier, this alone is NOT
-        // object-initializer evidence, so the brace list classifies as a collection initializer.
+        // Left is a `SimpleMemberAccessExpression`, not `IdentifierName`/`ImplicitElementAccess`,
+        // so this is not object-initializer evidence.
         UsingExpression("new Foo { a.b += 1 }");
 
         N(SyntaxKind.ObjectCreationExpression);
@@ -811,7 +791,6 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
     [Fact]
     public void Classifier_EmptyBracesIsObjectInitializer()
     {
-        // Classifier pre-existing rule: empty brace list is always an object initializer.
         UsingExpression("new Foo { }");
 
         N(SyntaxKind.ObjectCreationExpression);
@@ -1018,7 +997,6 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
     [Fact]
     public void TopLevel_ImplicitObjectCreation()
     {
-        // `new() { Prop += 1 }` target-typed form.
         UsingExpression("new() { Prop += 1 }");
 
         N(SyntaxKind.ImplicitObjectCreationExpression);
@@ -1057,9 +1035,6 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
     [Fact]
     public void ColonRecovery_StillRecoversForSimpleAssignment()
     {
-        // Pre-existing recovery: `Prop :` is treated as a missing `=`. We preserve this for the
-        // simple-assignment path only; compound forms do not get colon recovery because the spec
-        // has no ambiguity for them.
         UsingExpression("new Foo { Prop : 1 }",
             // (1,16): error CS1003: Syntax error, '=' expected
             // new Foo { Prop : 1 }
@@ -1081,7 +1056,6 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
                     {
                         N(SyntaxKind.IdentifierToken, "Prop");
                     }
-                    // `EatTokenAsKind` produces a missing `=` with the `:` attached as skipped trivia.
                     M(SyntaxKind.EqualsToken);
                     N(SyntaxKind.NumericLiteralExpression);
                     {

--- a/src/Compilers/CSharp/Test/CSharp15/CompoundAssignmentInitializerParsingTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/CompoundAssignmentInitializerParsingTests.cs
@@ -30,28 +30,6 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
         { "??=",  SyntaxKind.QuestionQuestionEqualsToken,             SyntaxKind.CoalesceAssignmentExpression },
     };
 
-    public static TheoryData<LanguageVersion> AllLanguageVersions => new()
-    {
-        LanguageVersion.CSharp1,
-        LanguageVersion.CSharp2,
-        LanguageVersion.CSharp3,
-        LanguageVersion.CSharp4,
-        LanguageVersion.CSharp5,
-        LanguageVersion.CSharp6,
-        LanguageVersion.CSharp7,
-        LanguageVersion.CSharp7_1,
-        LanguageVersion.CSharp7_2,
-        LanguageVersion.CSharp7_3,
-        LanguageVersion.CSharp8,
-        LanguageVersion.CSharp9,
-        LanguageVersion.CSharp10,
-        LanguageVersion.CSharp11,
-        LanguageVersion.CSharp12,
-        LanguageVersion.CSharp13,
-        LanguageVersion.CSharp14,
-        LanguageVersion.Preview,
-    };
-
     #region Object initializer: named member
 
     [Theory, MemberData(nameof(CompoundOperators))]
@@ -87,7 +65,7 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
         EOF();
     }
 
-    [Theory, MemberData(nameof(AllLanguageVersions))]
+    [Theory, CombinatorialData]
     public void ObjectInitializer_NamedMember_NoParseDiagnosticsAnyLangVersion(LanguageVersion languageVersion)
     {
         UsingExpression(
@@ -533,7 +511,7 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
         EOF();
     }
 
-    [Theory, MemberData(nameof(AllLanguageVersions))]
+    [Theory, CombinatorialData]
     public void WithExpression_NoParseDiagnosticsAnyLangVersion(LanguageVersion languageVersion)
     {
         UsingExpression(

--- a/src/Compilers/CSharp/Test/CSharp15/CompoundAssignmentInitializerParsingTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/CompoundAssignmentInitializerParsingTests.cs
@@ -35,14 +35,14 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
     [Theory, MemberData(nameof(CompoundOperators))]
     public void ObjectInitializer_NamedMember_AllCompoundOperators(string op, SyntaxKind operatorTokenKind, SyntaxKind assignmentKind)
     {
-        UsingExpression($"new Foo {{ Prop {op} 1 }}");
+        UsingExpression($"new Goo {{ Prop {op} 1 }}");
 
         N(SyntaxKind.ObjectCreationExpression);
         {
             N(SyntaxKind.NewKeyword);
             N(SyntaxKind.IdentifierName);
             {
-                N(SyntaxKind.IdentifierToken, "Foo");
+                N(SyntaxKind.IdentifierToken, "Goo");
             }
             N(SyntaxKind.ObjectInitializerExpression);
             {
@@ -69,7 +69,7 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
     public void ObjectInitializer_NamedMember_NoParseDiagnosticsAnyLangVersion(LanguageVersion languageVersion)
     {
         UsingExpression(
-            "new Foo { Prop += 1 }",
+            "new Goo { Prop += 1 }",
             TestOptions.Regular.WithLanguageVersion(languageVersion));
 
         N(SyntaxKind.ObjectCreationExpression);
@@ -77,7 +77,7 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
             N(SyntaxKind.NewKeyword);
             N(SyntaxKind.IdentifierName);
             {
-                N(SyntaxKind.IdentifierToken, "Foo");
+                N(SyntaxKind.IdentifierToken, "Goo");
             }
             N(SyntaxKind.ObjectInitializerExpression);
             {
@@ -103,14 +103,14 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
     [Theory, MemberData(nameof(CompoundOperators))]
     public void ObjectInitializer_NamedMember_MixOfSimpleAndCompound(string op, SyntaxKind operatorTokenKind, SyntaxKind assignmentKind)
     {
-        UsingExpression($"new Foo {{ Prop = 10, Prop {op} 5, Event {op} Handler }}");
+        UsingExpression($"new Goo {{ Prop = 10, Prop {op} 5, Event {op} Handler }}");
 
         N(SyntaxKind.ObjectCreationExpression);
         {
             N(SyntaxKind.NewKeyword);
             N(SyntaxKind.IdentifierName);
             {
-                N(SyntaxKind.IdentifierToken, "Foo");
+                N(SyntaxKind.IdentifierToken, "Goo");
             }
             N(SyntaxKind.ObjectInitializerExpression);
             {
@@ -162,14 +162,14 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
     [Theory, MemberData(nameof(CompoundOperators))]
     public void ObjectInitializer_NamedMember_TrailingComma(string op, SyntaxKind operatorTokenKind, SyntaxKind assignmentKind)
     {
-        UsingExpression($"new Foo {{ Prop {op} 1, }}");
+        UsingExpression($"new Goo {{ Prop {op} 1, }}");
 
         N(SyntaxKind.ObjectCreationExpression);
         {
             N(SyntaxKind.NewKeyword);
             N(SyntaxKind.IdentifierName);
             {
-                N(SyntaxKind.IdentifierToken, "Foo");
+                N(SyntaxKind.IdentifierToken, "Goo");
             }
             N(SyntaxKind.ObjectInitializerExpression);
             {
@@ -196,7 +196,7 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
     [Theory, MemberData(nameof(CompoundOperators))]
     public void ObjectInitializer_NamedMember_MissingRightHandSide(string op, SyntaxKind operatorTokenKind, SyntaxKind assignmentKind)
     {
-        var source = $"new Foo {{ Prop {op} }}";
+        var source = $"new Goo {{ Prop {op} }}";
         var closeBracePosition = source.IndexOf('}') + 1;
         UsingExpression(source,
             Diagnostic(ErrorCode.ERR_InvalidExprTerm, "}").WithArguments("}").WithLocation(1, closeBracePosition));
@@ -206,7 +206,7 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
             N(SyntaxKind.NewKeyword);
             N(SyntaxKind.IdentifierName);
             {
-                N(SyntaxKind.IdentifierToken, "Foo");
+                N(SyntaxKind.IdentifierToken, "Goo");
             }
             N(SyntaxKind.ObjectInitializerExpression);
             {
@@ -232,14 +232,14 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
     [Theory, MemberData(nameof(CompoundOperators))]
     public void ObjectInitializer_NamedMember_NestedInitializerOnRhs_PermissiveParse(string op, SyntaxKind operatorTokenKind, SyntaxKind assignmentKind)
     {
-        UsingExpression($"new Foo {{ Prop {op} {{ 1, 2 }} }}");
+        UsingExpression($"new Goo {{ Prop {op} {{ 1, 2 }} }}");
 
         N(SyntaxKind.ObjectCreationExpression);
         {
             N(SyntaxKind.NewKeyword);
             N(SyntaxKind.IdentifierName);
             {
-                N(SyntaxKind.IdentifierToken, "Foo");
+                N(SyntaxKind.IdentifierToken, "Goo");
             }
             N(SyntaxKind.ObjectInitializerExpression);
             {
@@ -275,14 +275,14 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
     [Theory, MemberData(nameof(CompoundOperators))]
     public void ObjectInitializer_NamedMember_RefOnRhs(string op, SyntaxKind operatorTokenKind, SyntaxKind assignmentKind)
     {
-        UsingExpression($"new Foo {{ Prop {op} ref x }}");
+        UsingExpression($"new Goo {{ Prop {op} ref x }}");
 
         N(SyntaxKind.ObjectCreationExpression);
         {
             N(SyntaxKind.NewKeyword);
             N(SyntaxKind.IdentifierName);
             {
-                N(SyntaxKind.IdentifierToken, "Foo");
+                N(SyntaxKind.IdentifierToken, "Goo");
             }
             N(SyntaxKind.ObjectInitializerExpression);
             {
@@ -312,14 +312,14 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
     [Theory, MemberData(nameof(CompoundOperators))]
     public void ObjectInitializer_NamedMember_GenericNameOnRhs(string op, SyntaxKind operatorTokenKind, SyntaxKind assignmentKind)
     {
-        UsingExpression($"new Foo {{ Prop {op} Bar<int>.Baz(x) }}");
+        UsingExpression($"new Goo {{ Prop {op} Bar<int>.Baz(x) }}");
 
         N(SyntaxKind.ObjectCreationExpression);
         {
             N(SyntaxKind.NewKeyword);
             N(SyntaxKind.IdentifierName);
             {
-                N(SyntaxKind.IdentifierToken, "Foo");
+                N(SyntaxKind.IdentifierToken, "Goo");
             }
             N(SyntaxKind.ObjectInitializerExpression);
             {
@@ -381,14 +381,14 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
     [Theory, MemberData(nameof(CompoundOperators))]
     public void ObjectInitializer_IndexerMember_AllCompoundOperators(string op, SyntaxKind operatorTokenKind, SyntaxKind assignmentKind)
     {
-        UsingExpression($"new Foo {{ [0] {op} 1 }}");
+        UsingExpression($"new Goo {{ [0] {op} 1 }}");
 
         N(SyntaxKind.ObjectCreationExpression);
         {
             N(SyntaxKind.NewKeyword);
             N(SyntaxKind.IdentifierName);
             {
-                N(SyntaxKind.IdentifierToken, "Foo");
+                N(SyntaxKind.IdentifierToken, "Goo");
             }
             N(SyntaxKind.ObjectInitializerExpression);
             {
@@ -425,14 +425,14 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
     [Theory, MemberData(nameof(CompoundOperators))]
     public void ObjectInitializer_IndexerMember_MultipleArguments(string op, SyntaxKind operatorTokenKind, SyntaxKind assignmentKind)
     {
-        UsingExpression($"new Foo {{ [a, b] {op} mask }}");
+        UsingExpression($"new Goo {{ [a, b] {op} mask }}");
 
         N(SyntaxKind.ObjectCreationExpression);
         {
             N(SyntaxKind.NewKeyword);
             N(SyntaxKind.IdentifierName);
             {
-                N(SyntaxKind.IdentifierToken, "Foo");
+                N(SyntaxKind.IdentifierToken, "Goo");
             }
             N(SyntaxKind.ObjectInitializerExpression);
             {
@@ -612,14 +612,14 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
     [Theory, MemberData(nameof(CompoundOperators))]
     public void Classifier_AllCompoundMembersAreObjectInitializer(string op, SyntaxKind operatorTokenKind, SyntaxKind assignmentKind)
     {
-        UsingExpression($"new Foo {{ Prop {op} 1, Event {op} Handler }}");
+        UsingExpression($"new Goo {{ Prop {op} 1, Event {op} Handler }}");
 
         N(SyntaxKind.ObjectCreationExpression);
         {
             N(SyntaxKind.NewKeyword);
             N(SyntaxKind.IdentifierName);
             {
-                N(SyntaxKind.IdentifierToken, "Foo");
+                N(SyntaxKind.IdentifierToken, "Goo");
             }
             N(SyntaxKind.ObjectInitializerExpression);
             {
@@ -658,14 +658,14 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
     [Theory, MemberData(nameof(CompoundOperators))]
     public void Classifier_IndexerCompoundMembersAreObjectInitializer(string op, SyntaxKind operatorTokenKind, SyntaxKind assignmentKind)
     {
-        UsingExpression($"new Foo {{ [0] {op} a, [1] {op} b }}");
+        UsingExpression($"new Goo {{ [0] {op} a, [1] {op} b }}");
 
         N(SyntaxKind.ObjectCreationExpression);
         {
             N(SyntaxKind.NewKeyword);
             N(SyntaxKind.IdentifierName);
             {
-                N(SyntaxKind.IdentifierToken, "Foo");
+                N(SyntaxKind.IdentifierToken, "Goo");
             }
             N(SyntaxKind.ObjectInitializerExpression);
             {
@@ -728,14 +728,14 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
     {
         // Left is a `SimpleMemberAccessExpression`, not `IdentifierName`/`ImplicitElementAccess`,
         // so this is not object-initializer evidence.
-        UsingExpression($"new Foo {{ a.b {op} 1 }}");
+        UsingExpression($"new Goo {{ a.b {op} 1 }}");
 
         N(SyntaxKind.ObjectCreationExpression);
         {
             N(SyntaxKind.NewKeyword);
             N(SyntaxKind.IdentifierName);
             {
-                N(SyntaxKind.IdentifierToken, "Foo");
+                N(SyntaxKind.IdentifierToken, "Goo");
             }
             N(SyntaxKind.CollectionInitializerExpression);
             {
@@ -769,14 +769,14 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
     [Fact]
     public void Classifier_EmptyBracesIsObjectInitializer()
     {
-        UsingExpression("new Foo { }");
+        UsingExpression("new Goo { }");
 
         N(SyntaxKind.ObjectCreationExpression);
         {
             N(SyntaxKind.NewKeyword);
             N(SyntaxKind.IdentifierName);
             {
-                N(SyntaxKind.IdentifierToken, "Foo");
+                N(SyntaxKind.IdentifierToken, "Goo");
             }
             N(SyntaxKind.ObjectInitializerExpression);
             {
@@ -1013,9 +1013,9 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
     [Fact]
     public void ColonRecovery_StillRecoversForSimpleAssignment()
     {
-        UsingExpression("new Foo { Prop : 1 }",
+        UsingExpression("new Goo { Prop : 1 }",
             // (1,16): error CS1003: Syntax error, '=' expected
-            // new Foo { Prop : 1 }
+            // new Goo { Prop : 1 }
             Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("=").WithLocation(1, 16));
 
         N(SyntaxKind.ObjectCreationExpression);
@@ -1023,7 +1023,7 @@ public sealed class CompoundAssignmentInitializerParsingTests : ParsingTests
             N(SyntaxKind.NewKeyword);
             N(SyntaxKind.IdentifierName);
             {
-                N(SyntaxKind.IdentifierToken, "Foo");
+                N(SyntaxKind.IdentifierToken, "Goo");
             }
             N(SyntaxKind.ObjectInitializerExpression);
             {

--- a/src/Compilers/CSharp/Test/CSharp15/Microsoft.CodeAnalysis.CSharp.CSharp15.UnitTests.csproj
+++ b/src/Compilers/CSharp/Test/CSharp15/Microsoft.CodeAnalysis.CSharp.CSharp15.UnitTests.csproj
@@ -20,5 +20,9 @@
     <PackageReference Include="Microsoft.DiaSymReader" />
     <PackageReference Include="Basic.Reference.Assemblies.Net100" />
   </ItemGroup>
+  <ItemGroup Label="Parsing test helpers">
+    <Compile Include="..\Syntax\Parsing\ParsingTests.cs" Link="Parsing\ParsingTests.cs" />
+    <Compile Include="..\Syntax\Parsing\SyntaxExtensions.cs" Link="Parsing\SyntaxExtensions.cs" />
+  </ItemGroup>
   <Import Project="$(RepositoryEngineeringDir)targets\ILAsm.targets" />
 </Project>

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/UnsignedRightShiftTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/UnsignedRightShiftTests.cs
@@ -922,13 +922,22 @@ class C
             var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
                                                  parseOptions: TestOptions.RegularPreview);
 
+            // Prior to the compound-assignment-in-initializer classifier change (dotnet/csharplang#9896,
+            // Phase 1), this brace list classified as a collection initializer and each `x op= 1`
+            // element produced CS0747. With the feature, any `AssignmentExpressionSyntax` whose left is
+            // an `IdentifierName` (or `ImplicitElementAccess`) is object-initializer evidence, so the
+            // list now classifies as an object initializer and the binder reports CS0117 for `x` not
+            // being a member of `List<int>`.
             compilation1.VerifyEmitDiagnostics(
-                // (8,13): error CS0747: Invalid initializer member declarator
+                // (6,13): warning CS0219: The variable 'x' is assigned but its value is never used
+                //         var x = int.MinValue;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x").WithArguments("x").WithLocation(6, 13),
+                // (8,13): error CS0117: 'List<int>' does not contain a definition for 'x'
                 //             x >>= 1,
-                Diagnostic(ErrorCode.ERR_InvalidInitializerElementInitializer, "x >>= 1").WithLocation(8, 13),
-                // (9,13): error CS0747: Invalid initializer member declarator
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "x").WithArguments("System.Collections.Generic.List<int>", "x").WithLocation(8, 13),
+                // (9,13): error CS0117: 'List<int>' does not contain a definition for 'x'
                 //             x >>>= 1 
-                Diagnostic(ErrorCode.ERR_InvalidInitializerElementInitializer, "x >>>= 1").WithLocation(9, 13)
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "x").WithArguments("System.Collections.Generic.List<int>", "x").WithLocation(9, 13)
                 );
         }
 
@@ -1883,13 +1892,20 @@ class C
             var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
                                                  parseOptions: TestOptions.RegularPreview);
 
+            // Classifier change (compound-assignment-in-initializer Phase 1): a brace list whose
+            // only non-`=` assignments have identifier-name lefts now classifies as an object
+            // initializer, so `x` is looked up as a member of `List<int?>` instead of as a local
+            // in a collection-element position. Results in CS0117 rather than CS0747.
             compilation1.VerifyEmitDiagnostics(
-                // (8,13): error CS0747: Invalid initializer member declarator
+                // (6,14): warning CS0219: The variable 'x' is assigned but its value is never used
+                //         int? x = int.MinValue;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x").WithArguments("x").WithLocation(6, 14),
+                // (8,13): error CS0117: 'List<int?>' does not contain a definition for 'x'
                 //             x >>= 1,
-                Diagnostic(ErrorCode.ERR_InvalidInitializerElementInitializer, "x >>= 1").WithLocation(8, 13),
-                // (9,13): error CS0747: Invalid initializer member declarator
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "x").WithArguments("System.Collections.Generic.List<int?>", "x").WithLocation(8, 13),
+                // (9,13): error CS0117: 'List<int?>' does not contain a definition for 'x'
                 //             x >>>= 1 
-                Diagnostic(ErrorCode.ERR_InvalidInitializerElementInitializer, "x >>>= 1").WithLocation(9, 13)
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "x").WithArguments("System.Collections.Generic.List<int?>", "x").WithLocation(9, 13)
                 );
         }
 
@@ -2443,13 +2459,16 @@ class C
             var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
                                                  parseOptions: TestOptions.RegularPreview);
 
+            // Classifier change (compound-assignment-in-initializer Phase 1): a brace list whose
+            // only non-`=` assignments have identifier-name lefts now classifies as an object
+            // initializer; `x` becomes a member lookup on `List<C1>`.
             compilation1.VerifyEmitDiagnostics(
-                // (21,13): error CS0747: Invalid initializer member declarator
+                // (21,13): error CS0117: 'List<C1>' does not contain a definition for 'x'
                 //             x >>= 1,
-                Diagnostic(ErrorCode.ERR_InvalidInitializerElementInitializer, "x >>= 1").WithLocation(21, 13),
-                // (22,13): error CS0747: Invalid initializer member declarator
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "x").WithArguments("System.Collections.Generic.List<C1>", "x").WithLocation(21, 13),
+                // (22,13): error CS0117: 'List<C1>' does not contain a definition for 'x'
                 //             x >>>= 1 
-                Diagnostic(ErrorCode.ERR_InvalidInitializerElementInitializer, "x >>>= 1").WithLocation(22, 13)
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "x").WithArguments("System.Collections.Generic.List<C1>", "x").WithLocation(22, 13)
                 );
         }
 
@@ -2674,13 +2693,19 @@ class C
             var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
                                                  parseOptions: TestOptions.RegularPreview);
 
+            // Classifier change (compound-assignment-in-initializer Phase 1): a brace list whose
+            // only non-`=` assignments have identifier-name lefts now classifies as an object
+            // initializer; `x` becomes a member lookup on `List<C1?>`.
             compilation1.VerifyEmitDiagnostics(
-                // (21,13): error CS0747: Invalid initializer member declarator
+                // (19,13): warning CS0219: The variable 'x' is assigned but its value is never used
+                //         C1? x = new C1();
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x").WithArguments("x").WithLocation(19, 13),
+                // (21,13): error CS0117: 'List<C1?>' does not contain a definition for 'x'
                 //             x >>= 1,
-                Diagnostic(ErrorCode.ERR_InvalidInitializerElementInitializer, "x >>= 1").WithLocation(21, 13),
-                // (22,13): error CS0747: Invalid initializer member declarator
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "x").WithArguments("System.Collections.Generic.List<C1?>", "x").WithLocation(21, 13),
+                // (22,13): error CS0117: 'List<C1?>' does not contain a definition for 'x'
                 //             x >>>= 1 
-                Diagnostic(ErrorCode.ERR_InvalidInitializerElementInitializer, "x >>>= 1").WithLocation(22, 13)
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "x").WithArguments("System.Collections.Generic.List<C1?>", "x").WithLocation(22, 13)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RefFieldParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RefFieldParsingTests.cs
@@ -735,11 +735,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [InlineData(LanguageVersion.CSharp11)]
         public void ObjectInitializer_CompoundAssignment(LanguageVersion languageVersion)
         {
-            // Prior to the compound-assignment-in-initializer feature (dotnet/csharplang#9896) this input
-            // classified as `CollectionInitializerExpression` and the parser emitted `ERR_InvalidExprTerm`
-            // on `ref t`. With the feature, the brace list classifies as `ObjectInitializerExpression`
-            // via the named-member path, which uses `ParsePossibleRefExpression` for the RHS and accepts
-            // the `ref` form silently. The binder rejects `ref` on a compound-assignment RHS later.
             string source = "new S { F += ref t }";
             UsingExpression(source, TestOptions.Regular.WithLanguageVersion(languageVersion));
 
@@ -750,11 +745,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 {
                     N(SyntaxKind.IdentifierToken, "S");
                 }
-                // Prior to the compound-assignment-in-initializer feature (dotnet/csharplang#9896), this
-                // brace list classified as `CollectionInitializerExpression` because only
-                // `SimpleAssignmentExpression` counted as object-initializer evidence. With the feature,
-                // any assignment (compound or simple) with an `IdentifierName` or `ImplicitElementAccess`
-                // on the left triggers the object-initializer classification.
                 N(SyntaxKind.ObjectInitializerExpression);
                 {
                     N(SyntaxKind.OpenBraceToken);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RefFieldParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RefFieldParsingTests.cs
@@ -735,12 +735,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [InlineData(LanguageVersion.CSharp11)]
         public void ObjectInitializer_CompoundAssignment(LanguageVersion languageVersion)
         {
+            // Prior to the compound-assignment-in-initializer feature (dotnet/csharplang#9896) this input
+            // classified as `CollectionInitializerExpression` and the parser emitted `ERR_InvalidExprTerm`
+            // on `ref t`. With the feature, the brace list classifies as `ObjectInitializerExpression`
+            // via the named-member path, which uses `ParsePossibleRefExpression` for the RHS and accepts
+            // the `ref` form silently. The binder rejects `ref` on a compound-assignment RHS later.
             string source = "new S { F += ref t }";
-            UsingExpression(source, TestOptions.Regular.WithLanguageVersion(languageVersion),
-                // (1,14): error CS1525: Invalid expression term 'ref'
-                // new S { F += ref t }
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "ref t").WithArguments("ref").WithLocation(1, 14)
-                );
+            UsingExpression(source, TestOptions.Regular.WithLanguageVersion(languageVersion));
 
             N(SyntaxKind.ObjectCreationExpression);
             {
@@ -749,7 +750,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 {
                     N(SyntaxKind.IdentifierToken, "S");
                 }
-                N(SyntaxKind.CollectionInitializerExpression);
+                // Prior to the compound-assignment-in-initializer feature (dotnet/csharplang#9896), this
+                // brace list classified as `CollectionInitializerExpression` because only
+                // `SimpleAssignmentExpression` counted as object-initializer evidence. With the feature,
+                // any assignment (compound or simple) with an `IdentifierName` or `ImplicitElementAccess`
+                // on the left triggers the object-initializer classification.
+                N(SyntaxKind.ObjectInitializerExpression);
                 {
                     N(SyntaxKind.OpenBraceToken);
                     N(SyntaxKind.AddAssignmentExpression);


### PR DESCRIPTION
Follow-up to #83290. Two small changes.

**Binder code.** Narrow the debug-only `WasPropertyBackingFieldAccessChecked` set in `BindObjectInitializerMemberCommon` to the compound-assignment path. The non-compound path wraps `BoundPropertyAccess` inside `BoundObjectInitializerMember` and the walker in `MethodCompiler` never sees the wrapped access, so the flag-set was only needed when the raw access is handed to `BindCompoundAssignmentCore`. Gated on the `valueKind` the compound branch already passes (`BindValueKind.CompoundAssignment`).

**Binder tests.**

- Add enum target coverage: flag-enum bitwise (`|=` / `&=` / `^=`), plain enum `+=` with an int literal, enum+enum rejection, `*=` rejection, flag-enum in `with`, and the mixed `= then |= then &=` rule on an enum property.
- Drop explicit `parseOptions: TestOptions.RegularPreview` from happy-path tests (preview is the default); remove the now-redundant `LangVersion_Preview_Compiles`. `LangVersion` gating stays on the CS13 / CS14 tests.
- Drop `targetFramework: TargetFramework.NetCoreApp`; bundle `IsExternalInit`, `CompilerFeatureRequiredAttribute`, and `Required` / `SetsRequiredMembersAttribute` (all already on `CSharpTestBase`) into a single `Polyfills` source that every compilation includes, so individual tests don't need to pick a framework.

Target: `main` for review; will retarget to `features/compound-assignment-in-initializer` along with the rest of the stack.

Incremental diff (over #83290): https://github.com/CyrusNajmabadi/roslyn/compare/compound-init-binding...compound-init-binding-cleanup

Stacked:

1. Parse compound assignment operators in object and dictionary member initializers #83288
2. Binding for compound assignment in object initializer and with #83290
3. Binder / tests cleanup **(this PR)**
4. Lowering (coming)
5. Semantic model / IOperation (coming)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83293)