### PR TITLE
Unsafe evolution: use unsafe keyword to denote requires-unsafe members

### DIFF
--- a/docs/compilers/CSharp/Warnversion Warning Waves.md
+++ b/docs/compilers/CSharp/Warnversion Warning Waves.md
@@ -19,7 +19,6 @@ The compiler shipped with .NET 11 (the C# 15 compiler) contains the following wa
 
 | Warning ID | Description |
 |------------|-------------|
-| CS9368 | [RequiresUnsafeAttribute is only valid under the updated memory safety rules](https://github.com/dotnet/csharplang/issues/9704) |
 | CS9377 | [The 'unsafe' modifier does not have any effect here under the current rules](https://github.com/dotnet/csharplang/issues/9704) |
 
 ## Warning level 10

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -8111,6 +8111,10 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_PPShebangNotOnFirstLine" xml:space="preserve">
     <value>'#!' must be the first characters on the first line of the file</value>
   </data>
+  <data name="ERR_RequiresUnsafeAttributeInSource" xml:space="preserve">
+    <value>Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.</value>
+    <comment>'RequiresUnsafeAttribute' and 'unsafe' should not be localized.</comment>
+  </data>
   <data name="ERR_StructLayoutAndExtendedLayout" xml:space="preserve">
     <value>Use of 'StructLayoutAttribute' and 'ExtendedLayoutAttribute' on the same type is not allowed.</value>
   </data>
@@ -8248,8 +8252,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <comment>'stackalloc' and 'SkipLocalsInit' are identifiers, should not be localized.</comment>
   </data>
   <data name="ERR_UnsafeMemberOperation" xml:space="preserve">
-    <value>'{0}' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'</value>
-    <comment>'RequiresUnsafe' and 'extern' should not be localized.</comment>
+    <value>'{0}' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'</value>
+    <comment>'unsafe' and 'extern' should not be localized.</comment>
   </data>
   <data name="ERR_UnsafeMemberOperationCompat" xml:space="preserve">
     <value>'{0}' must be used in an unsafe context because it has pointers in its signature</value>
@@ -8263,21 +8267,9 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_CallerUnsafeExplicitlyImplementingSafe" xml:space="preserve">
     <value>Unsafe member '{0}' cannot implement safe member '{1}'</value>
   </data>
-  <data name="ERR_RequiresUnsafeAttributeUnsupportedMemberTarget" xml:space="preserve">
-    <value>RequiresUnsafeAttribute cannot be applied to this symbol.</value>
-    <comment>'RequiresUnsafeAttribute' is not localizable</comment>
-  </data>
-  <data name="WRN_RequiresUnsafeAttributeLegacyRules" xml:space="preserve">
-    <value>RequiresUnsafeAttribute is only valid under the updated memory safety rules.</value>
-    <comment>'RequiresUnsafeAttribute' is not localizable</comment>
-  </data>
-  <data name="WRN_RequiresUnsafeAttributeLegacyRules_Title" xml:space="preserve">
-    <value>RequiresUnsafeAttribute is only valid under the updated memory safety rules.</value>
-    <comment>'RequiresUnsafeAttribute' is not localizable</comment>
-  </data>
   <data name="ERR_UnsafeConstructorConstraint" xml:space="preserve">
-    <value>An unsafe context is required for constructor '{0}' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</value>
-    <comment>'RequiresUnsafe', 'extern', and 'new()' should not be localized. {2} is the generic method or type.</comment>
+    <value>An unsafe context is required for constructor '{0}' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</value>
+    <comment>'unsafe', 'extern', and 'new()' should not be localized. {2} is the generic method or type.</comment>
   </data>
   <data name="WRN_UnsafeMeaningless" xml:space="preserve">
     <value>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</value>

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEAssemblyBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEAssemblyBuilder.cs
@@ -47,6 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         private SynthesizedEmbeddedRefSafetyRulesAttributeSymbol _lazyRefSafetyRulesAttribute;
         private SynthesizedEmbeddedMemorySafetyRulesAttributeSymbol _lazyMemorySafetyRulesAttribute;
         private SynthesizedEmbeddedExtensionMarkerAttributeSymbol _lazyExtensionMarkerAttribute;
+        private SynthesizedEmbeddedAttributeSymbol _lazyRequiresUnsafeAttribute;
 
         /// <summary>
         /// The behavior of the C# command-line compiler is as follows:
@@ -115,6 +116,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             builder.AddIfNotNull(_lazyRefSafetyRulesAttribute);
             builder.AddIfNotNull(_lazyMemorySafetyRulesAttribute);
             builder.AddIfNotNull(_lazyExtensionMarkerAttribute);
+            builder.AddIfNotNull(_lazyRequiresUnsafeAttribute);
 
             return builder.ToImmutableAndFree();
         }
@@ -341,6 +343,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             return base.TrySynthesizeRequiresLocationAttribute();
         }
 
+        protected override SynthesizedAttributeData TrySynthesizeRequiresUnsafeAttributeCore()
+        {
+            if ((object)_lazyRequiresUnsafeAttribute != null)
+            {
+                return SynthesizedAttributeData.Create(
+                    Compilation,
+                    _lazyRequiresUnsafeAttribute.Constructors[0],
+                    ImmutableArray<TypedConstant>.Empty,
+                    ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
+            }
+
+            return base.TrySynthesizeRequiresUnsafeAttributeCore();
+        }
+
         protected override SynthesizedAttributeData TrySynthesizeParamCollectionAttribute()
         {
             if ((object)_lazyParamCollectionAttribute != null)
@@ -426,6 +442,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 needsAttributes |= EmbeddableAttributes.MemorySafetyRulesAttribute;
             }
 
+            if (sourceModule.UseUpdatedMemorySafetyRules &&
+                Compilation.CheckIfAttributeShouldBeEmbedded(EmbeddableAttributes.RequiresUnsafeAttribute, diagnostics, Location.None))
+            {
+                needsAttributes |= EmbeddableAttributes.RequiresUnsafeAttribute;
+            }
+
             if (needsAttributes == 0)
             {
                 return;
@@ -455,6 +477,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                     ref _lazyRequiresLocationAttribute,
                     diagnostics,
                     AttributeDescription.RequiresLocationAttribute,
+                    createParameterlessEmbeddedAttributeSymbol);
+            }
+
+            if ((needsAttributes & EmbeddableAttributes.RequiresUnsafeAttribute) != 0)
+            {
+                CreateAttributeIfNeeded(
+                    ref _lazyRequiresUnsafeAttribute,
+                    diagnostics,
+                    AttributeDescription.RequiresUnsafeAttribute,
                     createParameterlessEmbeddedAttributeSymbol);
             }
 

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -1903,6 +1903,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             return Compilation.TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_RequiresLocationAttribute__ctor);
         }
 
+        internal SynthesizedAttributeData TrySynthesizeRequiresUnsafeAttribute()
+        {
+            return TrySynthesizeRequiresUnsafeAttributeCore();
+        }
+
+        protected virtual SynthesizedAttributeData TrySynthesizeRequiresUnsafeAttributeCore()
+        {
+            // For modules, this attribute should be present. Only assemblies generate and embed this type.
+            return Compilation.TrySynthesizeAttribute(WellKnownMember.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor);
+        }
+
         protected virtual SynthesizedAttributeData TrySynthesizeParamCollectionAttribute()
         {
             // For modules, this attribute should be present. Only assemblies generate and embed this type.

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2470,8 +2470,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_CallerUnsafeOverridingSafe = 9364,
         ERR_CallerUnsafeImplicitlyImplementingSafe = 9365,
         ERR_CallerUnsafeExplicitlyImplementingSafe = 9366,
-        ERR_RequiresUnsafeAttributeUnsupportedMemberTarget = 9367,
-        WRN_RequiresUnsafeAttributeLegacyRules = 9368,
 
         ERR_ExpressionTreeContainsUnionConversion = 9369,
         ERR_UnionDeclarationNeedsCaseTypes = 9370,
@@ -2485,6 +2483,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_UnsafeMeaningless = 9377,
 
         ERR_PPShebangNotOnFirstLine = 9378,
+
+        ERR_RequiresUnsafeAttributeInSource = 9379,
 
         // Note: you will need to do the following after adding errors:
         //  1) Update ErrorFacts.IsBuildOnlyDiagnostic (src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs)

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -210,7 +210,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             // docs/compilers/CSharp/Warnversion Warning Waves.md
             switch (code)
             {
-                case ErrorCode.WRN_RequiresUnsafeAttributeLegacyRules:
                 case ErrorCode.WRN_UnsafeMeaningless:
                     // Warning level 11 is exclusively for warnings introduced in the compiler
                     // shipped with dotnet 11 (C# 15) and that can be reported for pre-existing code.
@@ -2579,8 +2578,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 or ErrorCode.ERR_CallerUnsafeOverridingSafe
                 or ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe
                 or ErrorCode.ERR_CallerUnsafeExplicitlyImplementingSafe
-                or ErrorCode.ERR_RequiresUnsafeAttributeUnsupportedMemberTarget
-                or ErrorCode.WRN_RequiresUnsafeAttributeLegacyRules
                 or ErrorCode.ERR_ExpressionTreeContainsUnionConversion
                 or ErrorCode.ERR_UnionDeclarationNeedsCaseTypes
                 or ErrorCode.ERR_NoImplicitConversionToObject
@@ -2590,6 +2587,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 or ErrorCode.ERR_UnionConstructorCallsDefaultConstructor
                 or ErrorCode.ERR_UnsafeConstructorConstraint
                 or ErrorCode.WRN_UnsafeMeaningless
+                or ErrorCode.ERR_RequiresUnsafeAttributeInSource
                     => false,
             };
 #pragma warning restore CS8524 // The switch expression does not handle some values of its input type (it is not exhaustive) involving an unnamed enum value.

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -346,7 +346,6 @@
                 case ErrorCode.WRN_UnscopedRefAttributeOldRules:
                 case ErrorCode.WRN_InterceptsLocationAttributeUnsupportedSignature:
                 case ErrorCode.WRN_RedundantPattern:
-                case ErrorCode.WRN_RequiresUnsafeAttributeLegacyRules:
                 case ErrorCode.WRN_UnsafeMeaningless:
                     return true;
                 default:

--- a/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
@@ -174,6 +174,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool HasSpecialName => InheritsBaseMethodAttributes && BaseMethod.HasSpecialName;
 
         internal sealed override bool IsUnsafe => (DeclarationModifiers & DeclarationModifiers.Unsafe) != 0;
+        internal sealed override bool CanBeCallerUnsafe => true;
 
         // Synthesized methods created from a base method with [SkipLocalsInitAttribute] will also
         // skip locals init where applicable, even if the synthesized method does not inherit attributes.

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/MethodWellKnownAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/MethodWellKnownAttributeData.cs
@@ -60,22 +60,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        private bool _hasRequiresUnsafeAttribute;
-        public bool HasRequiresUnsafeAttribute
-        {
-            get
-            {
-                VerifySealed(expected: true);
-                return _hasRequiresUnsafeAttribute;
-            }
-            set
-            {
-                VerifySealed(expected: false);
-                _hasRequiresUnsafeAttribute = value;
-                SetDataStored();
-            }
-        }
-
         private ImmutableArray<string> _memberNotNullAttributeData = ImmutableArray<string>.Empty;
 
         public void AddNotNullMember(string memberName)

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/PropertyWellKnownAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/PropertyWellKnownAttributeData.cs
@@ -110,22 +110,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        private bool _hasRequiresUnsafeAttribute;
-        public bool HasRequiresUnsafeAttribute
-        {
-            get
-            {
-                VerifySealed(expected: true);
-                return _hasRequiresUnsafeAttribute;
-            }
-            set
-            {
-                VerifySealed(expected: false);
-                _hasRequiresUnsafeAttribute = value;
-                SetDataStored();
-            }
-        }
-
         private ImmutableArray<string> _memberNotNullAttributeData = ImmutableArray<string>.Empty;
 
         public void AddNotNullMember(string memberName)

--- a/src/Compilers/CSharp/Portable/Symbols/CallerUnsafeMode.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/CallerUnsafeMode.cs
@@ -22,7 +22,7 @@ internal enum CallerUnsafeMode
     Implicit,
 
     /// <summary>
-    /// The member is explicitly marked a <see langword="unsafe"/> or <see langword="extern"/> under the updated memory safety rules.
+    /// The member is explicitly marked as <see langword="unsafe"/> or <see langword="extern"/> under the updated memory safety rules.
     /// </summary>
     Explicit,
 }

--- a/src/Compilers/CSharp/Portable/Symbols/CallerUnsafeMode.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/CallerUnsafeMode.cs
@@ -22,7 +22,7 @@ internal enum CallerUnsafeMode
     Implicit,
 
     /// <summary>
-    /// The member is explicitly marked with <see cref="AttributeDescription.RequiresUnsafeAttribute"/> or <see langword="extern"/> under the updated memory safety rules.
+    /// The member is explicitly marked a <see langword="unsafe"/> or <see langword="extern"/> under the updated memory safety rules.
     /// </summary>
     Explicit,
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -546,6 +546,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             EnsureEmbeddableAttributeExists(EmbeddableAttributes.MemorySafetyRulesAttribute, diagnostics, location, modifyCompilation);
         }
 
+        internal void EnsureRequiresUnsafeAttributeExists(BindingDiagnosticBag? diagnostics, Location location, bool modifyCompilation)
+        {
+            EnsureEmbeddableAttributeExists(EmbeddableAttributes.RequiresUnsafeAttribute, diagnostics, location, modifyCompilation);
+        }
+
         internal void EnsureParamCollectionAttributeExists(BindingDiagnosticBag? diagnostics, Location location, bool modifyCompilation)
         {
             EnsureEmbeddableAttributeExists(EmbeddableAttributes.ParamCollectionAttribute, diagnostics, location, modifyCompilation: modifyCompilation);
@@ -686,6 +691,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                         locationOpt,
                         WellKnownType.System_Runtime_CompilerServices_ExtensionMarkerAttribute,
                         WellKnownMember.System_Runtime_CompilerServices_ExtensionMarkerAttribute__ctor);
+
+                case EmbeddableAttributes.RequiresUnsafeAttribute:
+                    return CheckIfAttributeShouldBeEmbedded(
+                        diagnosticsOpt,
+                        locationOpt,
+                        WellKnownType.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute,
+                        WellKnownMember.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor);
 
                 default:
                     throw ExceptionUtilities.UnexpectedValue(attribute);

--- a/src/Compilers/CSharp/Portable/Symbols/EmbeddableAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/EmbeddableAttributes.cs
@@ -22,5 +22,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         ParamCollectionAttribute = 0x400,
         ExtensionMarkerAttribute = 0x800,
         MemorySafetyRulesAttribute = 0x1000,
+        RequiresUnsafeAttribute = 0x2000,
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
@@ -399,6 +399,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     if (containingModule.AttributeMatchesFilter(handle, AttributeDescription.RequiresUnsafeAttribute))
                     {
                         hasRequiresUnsafeAttribute = true;
+                        continue;
                     }
 
                     builder.Add(new PEAttributeData(containingModule, handle));

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
@@ -1095,6 +1095,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     if (containingModule.AttributeMatchesFilter(handle, AttributeDescription.RequiresUnsafeAttribute))
                     {
                         hasRequiresUnsafeAttribute = true;
+                        continue;
                     }
 
                     builder.Add(new PEAttributeData(containingModule, handle));

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
@@ -853,6 +853,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     if (containingModule.AttributeMatchesFilter(handle, AttributeDescription.RequiresUnsafeAttribute))
                     {
                         hasRequiresUnsafeAttribute = true;
+                        continue;
                     }
 
                     builder.Add(new PEAttributeData(containingModule, handle));

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -427,6 +427,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override bool IsInitOnly => false;
 
         internal override bool IsUnsafe => false;
+        internal override bool CanBeCallerUnsafe => false;
 
         public override ImmutableArray<ImmutableArray<TypeWithAnnotations>> GetTypeParameterConstraintTypes() => ImmutableArray<ImmutableArray<TypeWithAnnotations>>.Empty;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     ? unsafeKeyword
                     : Syntax.Modifiers.FirstOrDefault(SyntaxKind.ExternKeyword);
                 var unsafeLocation = unsafeOrExternKeyword != default ? unsafeOrExternKeyword.GetLocation() : location;
-                Binder.GetWellKnownTypeMember(compilation, WellKnownMember.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor, addTo, unsafeLocation);
+                compilation.EnsureRequiresUnsafeAttributeExists(addTo, unsafeLocation, modifyCompilation: false);
             }
 
             ParameterHelpers.EnsureRefKindAttributesExist(compilation, Parameters, addTo, modifyCompilation: false);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -134,7 +134,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     ? unsafeKeyword
                     : Syntax.Modifiers.FirstOrDefault(SyntaxKind.ExternKeyword);
                 var unsafeLocation = unsafeOrExternKeyword != default ? unsafeOrExternKeyword.GetLocation() : location;
-                MessageID.IDS_FeatureUnsafeEvolution.CheckFeatureAvailability(addTo, compilation, unsafeLocation);
                 Binder.GetWellKnownTypeMember(compilation, WellKnownMember.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor, addTo, unsafeLocation);
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -130,8 +130,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (CallerUnsafeMode == CallerUnsafeMode.Explicit)
             {
-                var unsafeKeyword = Syntax.Modifiers.FirstOrDefault(SyntaxKind.UnsafeKeyword);
-                var unsafeLocation = unsafeKeyword != default ? unsafeKeyword.GetLocation() : location;
+                var unsafeOrExternKeyword = Syntax.Modifiers.FirstOrDefault(SyntaxKind.UnsafeKeyword) is { } unsafeKeyword && unsafeKeyword != default
+                    ? unsafeKeyword
+                    : Syntax.Modifiers.FirstOrDefault(SyntaxKind.ExternKeyword);
+                var unsafeLocation = unsafeOrExternKeyword != default ? unsafeOrExternKeyword.GetLocation() : location;
                 MessageID.IDS_FeatureUnsafeEvolution.CheckFeatureAvailability(addTo, compilation, unsafeLocation);
                 Binder.GetWellKnownTypeMember(compilation, WellKnownMember.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor, addTo, unsafeLocation);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -128,11 +128,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var compilation = DeclaringCompilation;
             var location = Syntax.Identifier.GetLocation();
 
-            if (NeedsSynthesizedRequiresUnsafeAttribute)
+            if (CallerUnsafeMode == CallerUnsafeMode.Explicit)
             {
-                Debug.Assert(CallerUnsafeMode == CallerUnsafeMode.Explicit);
-                MessageID.IDS_FeatureUnsafeEvolution.CheckFeatureAvailability(addTo, compilation, location);
-                Binder.GetWellKnownTypeMember(compilation, WellKnownMember.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor, addTo, location);
+                var unsafeKeyword = Syntax.Modifiers.FirstOrDefault(SyntaxKind.UnsafeKeyword);
+                var unsafeLocation = unsafeKeyword != default ? unsafeKeyword.GetLocation() : location;
+                MessageID.IDS_FeatureUnsafeEvolution.CheckFeatureAvailability(addTo, compilation, unsafeLocation);
+                Binder.GetWellKnownTypeMember(compilation, WellKnownMember.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor, addTo, unsafeLocation);
             }
 
             ParameterHelpers.EnsureRefKindAttributesExist(compilation, Parameters, addTo, modifyCompilation: false);
@@ -401,6 +402,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override bool IsExtern => (_declarationModifiers & DeclarationModifiers.Extern) != 0;
 
         internal override bool IsUnsafe => (_declarationModifiers & DeclarationModifiers.Unsafe) != 0;
+        internal override bool CanBeCallerUnsafe => true;
 
         internal bool IsExpressionBodied => Syntax is { Body: null, ExpressionBody: object _ };
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -130,11 +130,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (CallerUnsafeMode == CallerUnsafeMode.Explicit)
             {
-                var unsafeOrExternKeyword = Syntax.Modifiers.FirstOrDefault(SyntaxKind.UnsafeKeyword) is { } unsafeKeyword && unsafeKeyword != default
-                    ? unsafeKeyword
-                    : Syntax.Modifiers.FirstOrDefault(SyntaxKind.ExternKeyword);
-                var unsafeLocation = unsafeOrExternKeyword != default ? unsafeOrExternKeyword.GetLocation() : location;
-                compilation.EnsureRequiresUnsafeAttributeExists(addTo, unsafeLocation, modifyCompilation: false);
+                compilation.EnsureRequiresUnsafeAttributeExists(addTo, Syntax.Modifiers.GetUnsafeOrExternLocation(location), modifyCompilation: false);
             }
 
             ParameterHelpers.EnsureRefKindAttributesExist(compilation, Parameters, addTo, modifyCompilation: false);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ModifierUtils.cs
@@ -605,5 +605,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return false;
             }
         }
+
+        /// <summary>
+        /// Gets the location of the <c>unsafe</c> keyword (preferred) or <c>extern</c> keyword from the given modifiers,
+        /// falling back to <paramref name="fallback"/> if neither is found.
+        /// Used for diagnostics related to <see cref="CallerUnsafeMode.Explicit"/>.
+        /// </summary>
+        internal static Location GetUnsafeOrExternLocation(this SyntaxTokenList modifiers, Location fallback)
+        {
+            var keyword = modifiers.FirstOrDefault(SyntaxKind.UnsafeKeyword) is { } unsafeKeyword && unsafeKeyword != default
+                ? unsafeKeyword
+                : modifiers.FirstOrDefault(SyntaxKind.ExternKeyword);
+            return keyword != default ? keyword.GetLocation() : fallback;
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
@@ -245,6 +245,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 : ((SourceMemberContainerTypeSymbol)ContainingType).IsNullableEnabledForConstructorsAndInitializers(IsStatic);
 
         internal sealed override bool IsUnsafe => (DeclarationModifiers & DeclarationModifiers.Unsafe) != 0;
+        internal sealed override bool CanBeCallerUnsafe => MethodKind != MethodKind.StaticConstructor;
 
         protected override bool AllowRefOrOut
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
@@ -143,6 +143,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         internal sealed override bool IsUnsafe => (DeclarationModifiers & DeclarationModifiers.Unsafe) != 0;
+        internal sealed override bool CanBeCallerUnsafe => false;
 
         public override ImmutableArray<TypeParameterSymbol> TypeParameters
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDestructorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDestructorSymbol.cs
@@ -103,6 +103,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         internal sealed override bool IsUnsafe => (DeclarationModifiers & DeclarationModifiers.Unsafe) != 0;
+        internal sealed override bool CanBeCallerUnsafe => false;
 
         public override ImmutableArray<ParameterSymbol> Parameters
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventAccessorSymbol.cs
@@ -195,6 +195,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             => ImmutableArray<TypeParameterConstraintKind>.Empty;
 
         internal sealed override bool IsUnsafe => (DeclarationModifiers & DeclarationModifiers.Unsafe) != 0;
+        internal sealed override bool CanBeCallerUnsafe => true;
 
         internal Location Location
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -878,7 +878,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     ? unsafeKeyword
                     : modifiers.FirstOrDefault(SyntaxKind.ExternKeyword);
                 var unsafeLocation = unsafeOrExternKeyword != default ? unsafeOrExternKeyword.GetLocation() : location;
-                MessageID.IDS_FeatureUnsafeEvolution.CheckFeatureAvailability(diagnostics, compilation, unsafeLocation);
                 Binder.GetWellKnownTypeMember(compilation, WellKnownMember.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor, diagnostics, unsafeLocation);
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -371,8 +371,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else if (attribute.IsTargetAttribute(AttributeDescription.RequiresUnsafeAttribute))
             {
-                if (ContainingModule.UseUpdatedMemorySafetyRules) MessageID.IDS_FeatureUnsafeEvolution.CheckFeatureAvailability(diagnostics, arguments.AttributeSyntaxOpt!);
-                arguments.GetOrCreateData<CommonEventWellKnownAttributeData>().HasRequiresUnsafeAttribute = true;
+                diagnostics.Add(ErrorCode.ERR_RequiresUnsafeAttributeInSource, arguments.AttributeSyntaxOpt!.Location);
             }
         }
 
@@ -404,9 +403,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeNullableAttributeIfNecessary(this, containingType.GetNullableContextValue(), type));
             }
 
-            if (NeedsSynthesizedRequiresUnsafeAttribute)
+            if (CallerUnsafeMode == CallerUnsafeMode.Explicit)
             {
-                Debug.Assert(CallerUnsafeMode == CallerUnsafeMode.Explicit);
                 AddSynthesizedAttribute(ref attributes, compilation.TrySynthesizeAttribute(WellKnownMember.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor));
             }
         }
@@ -468,31 +466,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return (_modifiers & DeclarationModifiers.Unsafe) != 0; }
         }
 
-        internal bool HasRequiresUnsafeAttribute => GetDecodedWellKnownAttributeData()?.HasRequiresUnsafeAttribute == true;
-
         internal sealed override CallerUnsafeMode CallerUnsafeMode
         {
             get
             {
                 if (ContainingModule.UseUpdatedMemorySafetyRules)
                 {
-                    return HasRequiresUnsafeAttribute || IsExtern
+                    return IsUnsafe || IsExtern
                         ? CallerUnsafeMode.Explicit
                         : CallerUnsafeMode.None;
                 }
 
                 return Type.ContainsPointerOrFunctionPointer()
                     ? CallerUnsafeMode.Implicit : CallerUnsafeMode.None;
-            }
-        }
-
-        private bool NeedsSynthesizedRequiresUnsafeAttribute
-        {
-            get
-            {
-                return ContainingModule.UseUpdatedMemorySafetyRules &&
-                    !HasRequiresUnsafeAttribute &&
-                    IsExtern;
             }
         }
 
@@ -885,11 +871,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 compilation.EnsureNullableAttributeExists(diagnostics, location, modifyCompilation: true);
             }
 
-            if (NeedsSynthesizedRequiresUnsafeAttribute)
+            if (CallerUnsafeMode == CallerUnsafeMode.Explicit)
             {
-                Debug.Assert(CallerUnsafeMode == CallerUnsafeMode.Explicit);
-                MessageID.IDS_FeatureUnsafeEvolution.CheckFeatureAvailability(diagnostics, compilation, location);
-                Binder.GetWellKnownTypeMember(compilation, WellKnownMember.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor, diagnostics, location);
+                var unsafeKeyword = (CSharpSyntaxNode as MemberDeclarationSyntax)?.Modifiers.FirstOrDefault(SyntaxKind.UnsafeKeyword) ?? default;
+                var unsafeLocation = unsafeKeyword != default ? unsafeKeyword.GetLocation() : location;
+                MessageID.IDS_FeatureUnsafeEvolution.CheckFeatureAvailability(diagnostics, compilation, unsafeLocation);
+                Binder.GetWellKnownTypeMember(compilation, WellKnownMember.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor, diagnostics, unsafeLocation);
             }
 
             EventSymbol? explicitlyImplementedEvent = ExplicitInterfaceImplementations.FirstOrDefault();

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -873,8 +873,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (CallerUnsafeMode == CallerUnsafeMode.Explicit)
             {
-                var unsafeKeyword = (CSharpSyntaxNode as MemberDeclarationSyntax)?.Modifiers.FirstOrDefault(SyntaxKind.UnsafeKeyword) ?? default;
-                var unsafeLocation = unsafeKeyword != default ? unsafeKeyword.GetLocation() : location;
+                var modifiers = (CSharpSyntaxNode as MemberDeclarationSyntax)?.Modifiers ?? default;
+                var unsafeOrExternKeyword = modifiers.FirstOrDefault(SyntaxKind.UnsafeKeyword) is { } unsafeKeyword && unsafeKeyword != default
+                    ? unsafeKeyword
+                    : modifiers.FirstOrDefault(SyntaxKind.ExternKeyword);
+                var unsafeLocation = unsafeOrExternKeyword != default ? unsafeOrExternKeyword.GetLocation() : location;
                 MessageID.IDS_FeatureUnsafeEvolution.CheckFeatureAvailability(diagnostics, compilation, unsafeLocation);
                 Binder.GetWellKnownTypeMember(compilation, WellKnownMember.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor, diagnostics, unsafeLocation);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -874,11 +874,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (CallerUnsafeMode == CallerUnsafeMode.Explicit)
             {
                 var modifiers = (CSharpSyntaxNode as MemberDeclarationSyntax)?.Modifiers ?? default;
-                var unsafeOrExternKeyword = modifiers.FirstOrDefault(SyntaxKind.UnsafeKeyword) is { } unsafeKeyword && unsafeKeyword != default
-                    ? unsafeKeyword
-                    : modifiers.FirstOrDefault(SyntaxKind.ExternKeyword);
-                var unsafeLocation = unsafeOrExternKeyword != default ? unsafeOrExternKeyword.GetLocation() : location;
-                compilation.EnsureRequiresUnsafeAttributeExists(diagnostics, unsafeLocation, modifyCompilation: true);
+                compilation.EnsureRequiresUnsafeAttributeExists(diagnostics, modifiers.GetUnsafeOrExternLocation(location), modifyCompilation: true);
             }
 
             EventSymbol? explicitlyImplementedEvent = ExplicitInterfaceImplementations.FirstOrDefault();

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -405,7 +405,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (CallerUnsafeMode == CallerUnsafeMode.Explicit)
             {
-                AddSynthesizedAttribute(ref attributes, compilation.TrySynthesizeAttribute(WellKnownMember.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor));
+                AddSynthesizedAttribute(ref attributes, moduleBuilder.TrySynthesizeRequiresUnsafeAttribute());
             }
         }
 
@@ -878,7 +878,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     ? unsafeKeyword
                     : modifiers.FirstOrDefault(SyntaxKind.ExternKeyword);
                 var unsafeLocation = unsafeOrExternKeyword != default ? unsafeOrExternKeyword.GetLocation() : location;
-                Binder.GetWellKnownTypeMember(compilation, WellKnownMember.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor, diagnostics, unsafeLocation);
+                compilation.EnsureRequiresUnsafeAttributeExists(diagnostics, unsafeLocation, modifyCompilation: true);
             }
 
             EventSymbol? explicitlyImplementedEvent = ExplicitInterfaceImplementations.FirstOrDefault();

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -976,8 +976,11 @@ done:
 
             if (CallerUnsafeMode == CallerUnsafeMode.Explicit)
             {
-                var unsafeKeyword = (syntaxReferenceOpt?.GetSyntax() as MemberDeclarationSyntax)?.Modifiers.FirstOrDefault(SyntaxKind.UnsafeKeyword) ?? default;
-                var unsafeLocation = unsafeKeyword != default ? unsafeKeyword.GetLocation() : _location;
+                var modifiers = (syntaxReferenceOpt?.GetSyntax() as MemberDeclarationSyntax)?.Modifiers ?? default;
+                var unsafeOrExternKeyword = modifiers.FirstOrDefault(SyntaxKind.UnsafeKeyword) is { } unsafeKeyword && unsafeKeyword != default
+                    ? unsafeKeyword
+                    : modifiers.FirstOrDefault(SyntaxKind.ExternKeyword);
+                var unsafeLocation = unsafeOrExternKeyword != default ? unsafeOrExternKeyword.GetLocation() : _location;
                 MessageID.IDS_FeatureUnsafeEvolution.CheckFeatureAvailability(diagnostics, compilation, unsafeLocation);
                 Binder.GetWellKnownTypeMember(compilation, WellKnownMember.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor, diagnostics, unsafeLocation);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -974,11 +974,12 @@ done:
                 compilation.EnsureIsReadOnlyAttributeExists(diagnostics, _location, modifyCompilation: true);
             }
 
-            if (NeedsSynthesizedRequiresUnsafeAttribute)
+            if (CallerUnsafeMode == CallerUnsafeMode.Explicit)
             {
-                Debug.Assert(CallerUnsafeMode == CallerUnsafeMode.Explicit);
-                MessageID.IDS_FeatureUnsafeEvolution.CheckFeatureAvailability(diagnostics, compilation, _location);
-                Binder.GetWellKnownTypeMember(compilation, WellKnownMember.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor, diagnostics, _location);
+                var unsafeKeyword = (syntaxReferenceOpt?.GetSyntax() as MemberDeclarationSyntax)?.Modifiers.FirstOrDefault(SyntaxKind.UnsafeKeyword) ?? default;
+                var unsafeLocation = unsafeKeyword != default ? unsafeKeyword.GetLocation() : _location;
+                MessageID.IDS_FeatureUnsafeEvolution.CheckFeatureAvailability(diagnostics, compilation, unsafeLocation);
+                Binder.GetWellKnownTypeMember(compilation, WellKnownMember.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor, diagnostics, unsafeLocation);
             }
 
             if (compilation.ShouldEmitNullableAttributes(this) &&

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -981,7 +981,7 @@ done:
                     ? unsafeKeyword
                     : modifiers.FirstOrDefault(SyntaxKind.ExternKeyword);
                 var unsafeLocation = unsafeOrExternKeyword != default ? unsafeOrExternKeyword.GetLocation() : _location;
-                Binder.GetWellKnownTypeMember(compilation, WellKnownMember.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor, diagnostics, unsafeLocation);
+                compilation.EnsureRequiresUnsafeAttributeExists(diagnostics, unsafeLocation, modifyCompilation: true);
             }
 
             if (compilation.ShouldEmitNullableAttributes(this) &&

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -977,11 +977,7 @@ done:
             if (CallerUnsafeMode == CallerUnsafeMode.Explicit)
             {
                 var modifiers = (syntaxReferenceOpt?.GetSyntax() as MemberDeclarationSyntax)?.Modifiers ?? default;
-                var unsafeOrExternKeyword = modifiers.FirstOrDefault(SyntaxKind.UnsafeKeyword) is { } unsafeKeyword && unsafeKeyword != default
-                    ? unsafeKeyword
-                    : modifiers.FirstOrDefault(SyntaxKind.ExternKeyword);
-                var unsafeLocation = unsafeOrExternKeyword != default ? unsafeOrExternKeyword.GetLocation() : _location;
-                compilation.EnsureRequiresUnsafeAttributeExists(diagnostics, unsafeLocation, modifyCompilation: true);
+                compilation.EnsureRequiresUnsafeAttributeExists(diagnostics, modifiers.GetUnsafeOrExternLocation(_location), modifyCompilation: true);
             }
 
             if (compilation.ShouldEmitNullableAttributes(this) &&

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -981,7 +981,6 @@ done:
                     ? unsafeKeyword
                     : modifiers.FirstOrDefault(SyntaxKind.ExternKeyword);
                 var unsafeLocation = unsafeOrExternKeyword != default ? unsafeOrExternKeyword.GetLocation() : _location;
-                MessageID.IDS_FeatureUnsafeEvolution.CheckFeatureAvailability(diagnostics, compilation, unsafeLocation);
                 Binder.GetWellKnownTypeMember(compilation, WellKnownMember.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor, diagnostics, unsafeLocation);
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
@@ -100,7 +100,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal abstract bool IsUnsafe { get; }
 
-        internal bool HasRequiresUnsafeAttribute => GetDecodedWellKnownAttributeData()?.HasRequiresUnsafeAttribute == true;
+        /// <summary>
+        /// Whether the method can require callers to be in an unsafe context
+        /// (i.e., can have <see cref="CallerUnsafeMode.Explicit"/>).
+        /// </summary>
+        internal abstract bool CanBeCallerUnsafe { get; }
 
         internal sealed override CallerUnsafeMode CallerUnsafeMode
         {
@@ -110,23 +114,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     Debug.Assert(AssociatedSymbol?.CallerUnsafeMode != CallerUnsafeMode.Implicit);
 
-                    return HasRequiresUnsafeAttribute || IsExtern || AssociatedSymbol?.CallerUnsafeMode == CallerUnsafeMode.Explicit
+                    if (!CanBeCallerUnsafe)
+                    {
+                        return CallerUnsafeMode.None;
+                    }
+
+                    return IsUnsafe || IsExtern || AssociatedSymbol?.CallerUnsafeMode == CallerUnsafeMode.Explicit
                         ? CallerUnsafeMode.Explicit
                         : CallerUnsafeMode.None;
                 }
 
                 return this.HasParameterContainingPointerType() || ReturnType.ContainsPointerOrFunctionPointer()
                     ? CallerUnsafeMode.Implicit : CallerUnsafeMode.None;
-            }
-        }
-
-        protected bool NeedsSynthesizedRequiresUnsafeAttribute
-        {
-            get
-            {
-                return ContainingModule.UseUpdatedMemorySafetyRules &&
-                    !HasRequiresUnsafeAttribute &&
-                    (IsExtern || AssociatedSymbol?.IsExtern == true);
             }
         }
 
@@ -152,9 +151,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             var compilation = target.DeclaringCompilation;
 
-            if (target is SourceMethodSymbol { NeedsSynthesizedRequiresUnsafeAttribute: true })
+            if (target.CallerUnsafeMode == CallerUnsafeMode.Explicit)
             {
-                Debug.Assert(target.CallerUnsafeMode == CallerUnsafeMode.Explicit);
                 AddSynthesizedAttribute(ref attributes, compilation.TrySynthesizeAttribute(WellKnownMember.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor));
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
@@ -153,7 +153,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (target.CallerUnsafeMode == CallerUnsafeMode.Explicit)
             {
-                AddSynthesizedAttribute(ref attributes, compilation.TrySynthesizeAttribute(WellKnownMember.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor));
+                AddSynthesizedAttribute(ref attributes, moduleBuilder.TrySynthesizeRequiresUnsafeAttribute());
             }
 
             if (compilation.ShouldEmitNullableAttributes(target) &&

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -635,23 +635,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else if (attribute.IsTargetAttribute(AttributeDescription.RequiresUnsafeAttribute))
             {
-                if (this.MethodKind is MethodKind.AnonymousFunction or MethodKind.Destructor or MethodKind.LambdaMethod or MethodKind.StaticConstructor)
-                {
-                    diagnostics.Add(ErrorCode.ERR_RequiresUnsafeAttributeUnsupportedMemberTarget, arguments.AttributeSyntaxOpt.Location);
-                }
-                else
-                {
-                    if (ContainingModule.UseUpdatedMemorySafetyRules)
-                    {
-                        MessageID.IDS_FeatureUnsafeEvolution.CheckFeatureAvailability(diagnostics, arguments.AttributeSyntaxOpt);
-                    }
-                    else
-                    {
-                        diagnostics.Add(ErrorCode.WRN_RequiresUnsafeAttributeLegacyRules, arguments.AttributeSyntaxOpt.Location);
-                    }
-
-                    arguments.GetOrCreateData<MethodWellKnownAttributeData>().HasRequiresUnsafeAttribute = true;
-                }
+                diagnostics.Add(ErrorCode.ERR_RequiresUnsafeAttributeInSource, arguments.AttributeSyntaxOpt.Location);
             }
             else if (attribute.IsTargetAttribute(AttributeDescription.InterceptsLocationAttribute))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodOrUserDefinedOperatorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodOrUserDefinedOperatorSymbol.cs
@@ -172,6 +172,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         internal sealed override bool IsUnsafe => (DeclarationModifiers & DeclarationModifiers.Unsafe) != 0;
+        internal sealed override bool CanBeCallerUnsafe => true;
 
         protected abstract int GetParameterCountFromSyntax();
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -471,6 +471,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Whether this accessor or its containing property has an 'unsafe' modifier.
         /// </summary>
         internal sealed override bool IsUnsafe => LocalDeclaredUnsafe || _property.HasUnsafeModifier;
+        internal sealed override bool CanBeCallerUnsafe => true;
 
         /// <summary>
         /// Indicates whether this accessor is readonly due to reasons scoped to itself and its containing property.

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -828,7 +828,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (ContainingModule.UseUpdatedMemorySafetyRules)
                 {
-                    return HasRequiresUnsafeAttribute || IsExtern
+                    return HasUnsafeModifier || IsExtern
                         ? CallerUnsafeMode.Explicit
                         : CallerUnsafeMode.None;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
@@ -1053,7 +1053,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     ? unsafeKeyword
                     : modifiers.FirstOrDefault(SyntaxKind.ExternKeyword);
                 var unsafeLocation = unsafeOrExternKeyword != default ? unsafeOrExternKeyword.GetLocation() : location;
-                Binder.GetWellKnownTypeMember(compilation, WellKnownMember.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor, diagnostics, unsafeLocation);
+                compilation.EnsureRequiresUnsafeAttributeExists(diagnostics, unsafeLocation, modifyCompilation: true);
             }
 
             ParameterHelpers.EnsureRefKindAttributesExist(compilation, Parameters, diagnostics, modifyCompilation: true);
@@ -1436,7 +1436,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (CallerUnsafeMode == CallerUnsafeMode.Explicit)
             {
-                AddSynthesizedAttribute(ref attributes, compilation.TrySynthesizeAttribute(WellKnownMember.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor));
+                AddSynthesizedAttribute(ref attributes, moduleBuilder.TrySynthesizeRequiresUnsafeAttribute());
             }
 
             if (IsRequired)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
@@ -1048,8 +1048,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (CallerUnsafeMode == CallerUnsafeMode.Explicit)
             {
-                var unsafeKeyword = (CSharpSyntaxNode as MemberDeclarationSyntax)?.Modifiers.FirstOrDefault(SyntaxKind.UnsafeKeyword) ?? default;
-                var unsafeLocation = unsafeKeyword != default ? unsafeKeyword.GetLocation() : location;
+                var modifiers = (CSharpSyntaxNode as MemberDeclarationSyntax)?.Modifiers ?? default;
+                var unsafeOrExternKeyword = modifiers.FirstOrDefault(SyntaxKind.UnsafeKeyword) is { } unsafeKeyword && unsafeKeyword != default
+                    ? unsafeKeyword
+                    : modifiers.FirstOrDefault(SyntaxKind.ExternKeyword);
+                var unsafeLocation = unsafeOrExternKeyword != default ? unsafeOrExternKeyword.GetLocation() : location;
                 MessageID.IDS_FeatureUnsafeEvolution.CheckFeatureAvailability(diagnostics, compilation, unsafeLocation);
                 Binder.GetWellKnownTypeMember(compilation, WellKnownMember.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor, diagnostics, unsafeLocation);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
@@ -1053,7 +1053,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     ? unsafeKeyword
                     : modifiers.FirstOrDefault(SyntaxKind.ExternKeyword);
                 var unsafeLocation = unsafeOrExternKeyword != default ? unsafeOrExternKeyword.GetLocation() : location;
-                MessageID.IDS_FeatureUnsafeEvolution.CheckFeatureAvailability(diagnostics, compilation, unsafeLocation);
                 Binder.GetWellKnownTypeMember(compilation, WellKnownMember.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor, diagnostics, unsafeLocation);
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
@@ -1049,11 +1049,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (CallerUnsafeMode == CallerUnsafeMode.Explicit)
             {
                 var modifiers = (CSharpSyntaxNode as MemberDeclarationSyntax)?.Modifiers ?? default;
-                var unsafeOrExternKeyword = modifiers.FirstOrDefault(SyntaxKind.UnsafeKeyword) is { } unsafeKeyword && unsafeKeyword != default
-                    ? unsafeKeyword
-                    : modifiers.FirstOrDefault(SyntaxKind.ExternKeyword);
-                var unsafeLocation = unsafeOrExternKeyword != default ? unsafeOrExternKeyword.GetLocation() : location;
-                compilation.EnsureRequiresUnsafeAttributeExists(diagnostics, unsafeLocation, modifyCompilation: true);
+                compilation.EnsureRequiresUnsafeAttributeExists(diagnostics, modifiers.GetUnsafeOrExternLocation(location), modifyCompilation: true);
             }
 
             ParameterHelpers.EnsureRefKindAttributesExist(compilation, Parameters, diagnostics, modifyCompilation: true);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
@@ -1046,11 +1046,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 compilation.EnsureIsReadOnlyAttributeExists(diagnostics, typeLocation, modifyCompilation: true);
             }
 
-            if (NeedsSynthesizedRequiresUnsafeAttribute)
+            if (CallerUnsafeMode == CallerUnsafeMode.Explicit)
             {
-                Debug.Assert(CallerUnsafeMode == CallerUnsafeMode.Explicit);
-                MessageID.IDS_FeatureUnsafeEvolution.CheckFeatureAvailability(diagnostics, compilation, location);
-                Binder.GetWellKnownTypeMember(compilation, WellKnownMember.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor, diagnostics, location);
+                var unsafeKeyword = (CSharpSyntaxNode as MemberDeclarationSyntax)?.Modifiers.FirstOrDefault(SyntaxKind.UnsafeKeyword) ?? default;
+                var unsafeLocation = unsafeKeyword != default ? unsafeKeyword.GetLocation() : location;
+                MessageID.IDS_FeatureUnsafeEvolution.CheckFeatureAvailability(diagnostics, compilation, unsafeLocation);
+                Binder.GetWellKnownTypeMember(compilation, WellKnownMember.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor, diagnostics, unsafeLocation);
             }
 
             ParameterHelpers.EnsureRefKindAttributesExist(compilation, Parameters, diagnostics, modifyCompilation: true);
@@ -1380,18 +1381,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return (PropertyWellKnownAttributeData)attributesBag.DecodedWellKnownAttributeData;
         }
 
-        internal bool HasRequiresUnsafeAttribute => GetDecodedWellKnownAttributeData()?.HasRequiresUnsafeAttribute == true;
-
-        private bool NeedsSynthesizedRequiresUnsafeAttribute
-        {
-            get
-            {
-                return ContainingModule.UseUpdatedMemorySafetyRules &&
-                    !HasRequiresUnsafeAttribute &&
-                    IsExtern;
-            }
-        }
-
         /// <summary>
         /// Returns data decoded from special early bound well-known attributes applied to the symbol or null if there are no applied attributes.
         /// </summary>
@@ -1443,9 +1432,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeIsReadOnlyAttribute(this));
             }
 
-            if (NeedsSynthesizedRequiresUnsafeAttribute)
+            if (CallerUnsafeMode == CallerUnsafeMode.Explicit)
             {
-                Debug.Assert(CallerUnsafeMode == CallerUnsafeMode.Explicit);
                 AddSynthesizedAttribute(ref attributes, compilation.TrySynthesizeAttribute(WellKnownMember.System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor));
             }
 
@@ -1650,8 +1638,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else if (attribute.IsTargetAttribute(AttributeDescription.RequiresUnsafeAttribute))
             {
-                if (ContainingModule.UseUpdatedMemorySafetyRules) MessageID.IDS_FeatureUnsafeEvolution.CheckFeatureAvailability(diagnostics, arguments.AttributeSyntaxOpt);
-                arguments.GetOrCreateData<PropertyWellKnownAttributeData>().HasRequiresUnsafeAttribute = true;
+                diagnostics.Add(ErrorCode.ERR_RequiresUnsafeAttributeInSource, arguments.AttributeSyntaxOpt.Location);
             }
             else if (attribute.IsTargetAttribute(AttributeDescription.OverloadResolutionPriorityAttribute))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedPrimaryConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedPrimaryConstructor.cs
@@ -96,6 +96,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         internal sealed override bool IsUnsafe => (DeclarationModifiers & DeclarationModifiers.Unsafe) != 0;
+        internal sealed override bool CanBeCallerUnsafe => false;
 
         protected override bool IsWithinExpressionOrBlockBody(int position, out int offset)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSimpleProgramEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSimpleProgramEntryPointSymbol.cs
@@ -150,6 +150,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         internal sealed override bool IsUnsafe => (DeclarationModifiers & DeclarationModifiers.Unsafe) != 0;
+        internal sealed override bool CanBeCallerUnsafe => false;
 
         public override ImmutableArray<ParameterSymbol> Parameters
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSimpleProgramEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSimpleProgramEntryPointSymbol.cs
@@ -150,7 +150,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         internal sealed override bool IsUnsafe => (DeclarationModifiers & DeclarationModifiers.Unsafe) != 0;
-        internal sealed override bool CanBeCallerUnsafe => false;
+        internal sealed override bool CanBeCallerUnsafe
+        {
+            get
+            {
+                Debug.Assert(!IsUnsafe, $"Revisit {nameof(CanBeCallerUnsafe)} implementation if {nameof(SynthesizedSimpleProgramEntryPointSymbol)} can be marked 'unsafe'.");
+                return false;
+            }
+        }
 
         public override ImmutableArray<ParameterSymbol> Parameters
         {

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1497,10 +1497,10 @@
         <target state="translated">#! musí být první znaky na prvním řádku souboru.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_RequiresUnsafeAttributeUnsupportedMemberTarget">
-        <source>RequiresUnsafeAttribute cannot be applied to this symbol.</source>
-        <target state="translated">Atribut RequiresUnsafeAttribute nelze pro tento symbol použít.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
+      <trans-unit id="ERR_RequiresUnsafeAttributeInSource">
+        <source>Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.</source>
+        <target state="new">Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.</target>
+        <note>'RequiresUnsafeAttribute' and 'unsafe' should not be localized.</note>
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportExtendedLayoutTypes">
         <source>The target runtime does not support extended layout types.</source>
@@ -2733,14 +2733,14 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsafeConstructorConstraint">
-        <source>An unsafe context is required for constructor '{0}' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</source>
-        <target state="translated">Nezabezpečený kontext je vyžadován pro konstruktor {0} označený jako „RequiresUnsafe“ nebo „extern“, aby se vyhovělo omezení „new()“ parametru typu „{1}“ v „{2}“</target>
-        <note>'RequiresUnsafe', 'extern', and 'new()' should not be localized. {2} is the generic method or type.</note>
+        <source>An unsafe context is required for constructor '{0}' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</source>
+        <target state="needs-review-translation">Nezabezpečený kontext je vyžadován pro konstruktor {0} označený jako „RequiresUnsafe“ nebo „extern“, aby se vyhovělo omezení „new()“ parametru typu „{1}“ v „{2}“</target>
+        <note>'unsafe', 'extern', and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
-        <source>'{0}' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'</source>
-        <target state="translated">{0} musí být použito v nebezpečném kontextu, protože je označeno jako RequiresUnsafe nebo extern.</target>
-        <note>'RequiresUnsafe' and 'extern' should not be localized.</note>
+        <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'</source>
+        <target state="needs-review-translation">{0} musí být použito v nebezpečném kontextu, protože je označeno jako RequiresUnsafe nebo extern.</target>
+        <note>'unsafe' and 'extern' should not be localized.</note>
       </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperationCompat">
         <source>'{0}' must be used in an unsafe context because it has pointers in its signature</source>
@@ -3931,16 +3931,6 @@
         <source>Struct member returns 'this' or other instance members by reference</source>
         <target state="translated">Člen struktury vrací this nebo jiné členy instance pomocí odkazu</target>
         <note />
-      </trans-unit>
-      <trans-unit id="WRN_RequiresUnsafeAttributeLegacyRules">
-        <source>RequiresUnsafeAttribute is only valid under the updated memory safety rules.</source>
-        <target state="translated">Atribut RequiresUnsafeAttribute je platný pouze v rámci aktualizovaných pravidel zabezpečení paměti.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
-      </trans-unit>
-      <trans-unit id="WRN_RequiresUnsafeAttributeLegacyRules_Title">
-        <source>RequiresUnsafeAttribute is only valid under the updated memory safety rules.</source>
-        <target state="translated">Atribut RequiresUnsafeAttribute je platný pouze v rámci aktualizovaných pravidel zabezpečení paměti.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
       </trans-unit>
       <trans-unit id="WRN_ReturnNotNullIfNotNull">
         <source>Return value must be non-null because parameter '{0}' is non-null.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1497,10 +1497,10 @@
         <target state="translated">"#!" muss die ersten Zeichen in der ersten Zeile der Datei sein</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_RequiresUnsafeAttributeUnsupportedMemberTarget">
-        <source>RequiresUnsafeAttribute cannot be applied to this symbol.</source>
-        <target state="translated">RequiresUnsafeAttribute kann nicht auf dieses Symbol angewendet werden.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
+      <trans-unit id="ERR_RequiresUnsafeAttributeInSource">
+        <source>Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.</source>
+        <target state="new">Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.</target>
+        <note>'RequiresUnsafeAttribute' and 'unsafe' should not be localized.</note>
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportExtendedLayoutTypes">
         <source>The target runtime does not support extended layout types.</source>
@@ -2733,14 +2733,14 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsafeConstructorConstraint">
-        <source>An unsafe context is required for constructor '{0}' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</source>
-        <target state="translated">Für den als 'RequiresUnsafe' oder 'extern' markierten Konstruktor '{0}' ist ein unsicherer Kontext erforderlich, um die 'new()'-Einschränkung des Typparameters '{1}' in '{2}' zu erfüllen.</target>
-        <note>'RequiresUnsafe', 'extern', and 'new()' should not be localized. {2} is the generic method or type.</note>
+        <source>An unsafe context is required for constructor '{0}' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</source>
+        <target state="needs-review-translation">Für den als 'RequiresUnsafe' oder 'extern' markierten Konstruktor '{0}' ist ein unsicherer Kontext erforderlich, um die 'new()'-Einschränkung des Typparameters '{1}' in '{2}' zu erfüllen.</target>
+        <note>'unsafe', 'extern', and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
-        <source>'{0}' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'</source>
-        <target state="translated">„{0}“ muss in einem unsicheren Kontext verwendet werden, da er als „RequiresUnsafe“ oder „extern“ gekennzeichnet ist</target>
-        <note>'RequiresUnsafe' and 'extern' should not be localized.</note>
+        <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'</source>
+        <target state="needs-review-translation">„{0}“ muss in einem unsicheren Kontext verwendet werden, da er als „RequiresUnsafe“ oder „extern“ gekennzeichnet ist</target>
+        <note>'unsafe' and 'extern' should not be localized.</note>
       </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperationCompat">
         <source>'{0}' must be used in an unsafe context because it has pointers in its signature</source>
@@ -3931,16 +3931,6 @@
         <source>Struct member returns 'this' or other instance members by reference</source>
         <target state="translated">Der Strukturmember gibt "this" oder andere Instanzmember als Verweis zurück.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="WRN_RequiresUnsafeAttributeLegacyRules">
-        <source>RequiresUnsafeAttribute is only valid under the updated memory safety rules.</source>
-        <target state="translated">RequiresUnsafeAttribute ist nur unter den aktualisierten Speichersicherheitsregeln gültig.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
-      </trans-unit>
-      <trans-unit id="WRN_RequiresUnsafeAttributeLegacyRules_Title">
-        <source>RequiresUnsafeAttribute is only valid under the updated memory safety rules.</source>
-        <target state="translated">RequiresUnsafeAttribute ist nur unter den aktualisierten Speichersicherheitsregeln gültig.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
       </trans-unit>
       <trans-unit id="WRN_ReturnNotNullIfNotNull">
         <source>Return value must be non-null because parameter '{0}' is non-null.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1497,10 +1497,10 @@
         <target state="translated">"#!" debe ser los primeros caracteres de la primera línea del archivo</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_RequiresUnsafeAttributeUnsupportedMemberTarget">
-        <source>RequiresUnsafeAttribute cannot be applied to this symbol.</source>
-        <target state="translated">RequiresUnsafeAttribute no se puede aplicar a este símbolo.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
+      <trans-unit id="ERR_RequiresUnsafeAttributeInSource">
+        <source>Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.</source>
+        <target state="new">Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.</target>
+        <note>'RequiresUnsafeAttribute' and 'unsafe' should not be localized.</note>
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportExtendedLayoutTypes">
         <source>The target runtime does not support extended layout types.</source>
@@ -2733,14 +2733,14 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsafeConstructorConstraint">
-        <source>An unsafe context is required for constructor '{0}' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</source>
-        <target state="translated">Se requiere un contexto no seguro para que el constructor ''{0}'' marcado como ''RequiresUnsafe'' o 'extern' cumpla la restricción 'new()' del parámetro de tipo ''{1}'' en ''{2}''</target>
-        <note>'RequiresUnsafe', 'extern', and 'new()' should not be localized. {2} is the generic method or type.</note>
+        <source>An unsafe context is required for constructor '{0}' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</source>
+        <target state="needs-review-translation">Se requiere un contexto no seguro para que el constructor ''{0}'' marcado como ''RequiresUnsafe'' o 'extern' cumpla la restricción 'new()' del parámetro de tipo ''{1}'' en ''{2}''</target>
+        <note>'unsafe', 'extern', and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
-        <source>'{0}' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'</source>
-        <target state="translated">''{0}'' debe usarse en un contexto no seguro porque está marcado como ''RequiresUnsafe'' o ''extern''</target>
-        <note>'RequiresUnsafe' and 'extern' should not be localized.</note>
+        <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'</source>
+        <target state="needs-review-translation">''{0}'' debe usarse en un contexto no seguro porque está marcado como ''RequiresUnsafe'' o ''extern''</target>
+        <note>'unsafe' and 'extern' should not be localized.</note>
       </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperationCompat">
         <source>'{0}' must be used in an unsafe context because it has pointers in its signature</source>
@@ -3931,16 +3931,6 @@
         <source>Struct member returns 'this' or other instance members by reference</source>
         <target state="translated">El miembro de estructura devuelve "this" u otros miembros de instancia por referencia</target>
         <note />
-      </trans-unit>
-      <trans-unit id="WRN_RequiresUnsafeAttributeLegacyRules">
-        <source>RequiresUnsafeAttribute is only valid under the updated memory safety rules.</source>
-        <target state="translated">RequiresUnsafeAttribute solo es válido en las reglas de seguridad de memoria actualizadas.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
-      </trans-unit>
-      <trans-unit id="WRN_RequiresUnsafeAttributeLegacyRules_Title">
-        <source>RequiresUnsafeAttribute is only valid under the updated memory safety rules.</source>
-        <target state="translated">RequiresUnsafeAttribute solo es válido en las reglas de seguridad de memoria actualizadas.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
       </trans-unit>
       <trans-unit id="WRN_ReturnNotNullIfNotNull">
         <source>Return value must be non-null because parameter '{0}' is non-null.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1497,10 +1497,10 @@
         <target state="translated">« #! » doivent être les premiers caractères de la première ligne du fichier</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_RequiresUnsafeAttributeUnsupportedMemberTarget">
-        <source>RequiresUnsafeAttribute cannot be applied to this symbol.</source>
-        <target state="translated">RequiresUnsafeAttribute ne peut pas être appliqué à ce symbole.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
+      <trans-unit id="ERR_RequiresUnsafeAttributeInSource">
+        <source>Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.</source>
+        <target state="new">Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.</target>
+        <note>'RequiresUnsafeAttribute' and 'unsafe' should not be localized.</note>
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportExtendedLayoutTypes">
         <source>The target runtime does not support extended layout types.</source>
@@ -2733,14 +2733,14 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsafeConstructorConstraint">
-        <source>An unsafe context is required for constructor '{0}' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</source>
-        <target state="translated">Un contexte non sécurisé est requis pour le constructeur « {0} » marqué comme « RequiresUnsafe » ou « extern » afin de satisfaire la contrainte « new() » du paramètre de type « {1} » dans « {2} »</target>
-        <note>'RequiresUnsafe', 'extern', and 'new()' should not be localized. {2} is the generic method or type.</note>
+        <source>An unsafe context is required for constructor '{0}' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</source>
+        <target state="needs-review-translation">Un contexte non sécurisé est requis pour le constructeur « {0} » marqué comme « RequiresUnsafe » ou « extern » afin de satisfaire la contrainte « new() » du paramètre de type « {1} » dans « {2} »</target>
+        <note>'unsafe', 'extern', and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
-        <source>'{0}' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'</source>
-        <target state="translated">« {0} » doit être utilisé dans un contexte non sécurisé, car il est marqué comme « RequiresUnsafe » ou « extern »</target>
-        <note>'RequiresUnsafe' and 'extern' should not be localized.</note>
+        <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'</source>
+        <target state="needs-review-translation">« {0} » doit être utilisé dans un contexte non sécurisé, car il est marqué comme « RequiresUnsafe » ou « extern »</target>
+        <note>'unsafe' and 'extern' should not be localized.</note>
       </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperationCompat">
         <source>'{0}' must be used in an unsafe context because it has pointers in its signature</source>
@@ -3931,16 +3931,6 @@
         <source>Struct member returns 'this' or other instance members by reference</source>
         <target state="translated">Le membre struct retourne 'this' ou d'autres membres d'instance par référence</target>
         <note />
-      </trans-unit>
-      <trans-unit id="WRN_RequiresUnsafeAttributeLegacyRules">
-        <source>RequiresUnsafeAttribute is only valid under the updated memory safety rules.</source>
-        <target state="translated">RequiresUnsafeAttribute est valide uniquement dans le cadre des règles de sécurité mémoire mises à jour.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
-      </trans-unit>
-      <trans-unit id="WRN_RequiresUnsafeAttributeLegacyRules_Title">
-        <source>RequiresUnsafeAttribute is only valid under the updated memory safety rules.</source>
-        <target state="translated">RequiresUnsafeAttribute est valide uniquement dans le cadre des règles de sécurité mémoire mises à jour.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
       </trans-unit>
       <trans-unit id="WRN_ReturnNotNullIfNotNull">
         <source>Return value must be non-null because parameter '{0}' is non-null.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1497,10 +1497,10 @@
         <target state="translated">'#!' devono essere i primi caratteri nella prima riga del file</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_RequiresUnsafeAttributeUnsupportedMemberTarget">
-        <source>RequiresUnsafeAttribute cannot be applied to this symbol.</source>
-        <target state="translated">Non è possibile applicare RequiresUnsafeAttribute a questo simbolo.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
+      <trans-unit id="ERR_RequiresUnsafeAttributeInSource">
+        <source>Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.</source>
+        <target state="new">Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.</target>
+        <note>'RequiresUnsafeAttribute' and 'unsafe' should not be localized.</note>
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportExtendedLayoutTypes">
         <source>The target runtime does not support extended layout types.</source>
@@ -2733,14 +2733,14 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsafeConstructorConstraint">
-        <source>An unsafe context is required for constructor '{0}' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</source>
-        <target state="translated">Per il costruttore '{0}' contrassegnato come 'RequiresUnsafe' o 'extern' è necessario un contesto unsafe per soddisfare il vincolo 'new()' del parametro di tipo '{1}' in '{2}'</target>
-        <note>'RequiresUnsafe', 'extern', and 'new()' should not be localized. {2} is the generic method or type.</note>
+        <source>An unsafe context is required for constructor '{0}' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</source>
+        <target state="needs-review-translation">Per il costruttore '{0}' contrassegnato come 'RequiresUnsafe' o 'extern' è necessario un contesto unsafe per soddisfare il vincolo 'new()' del parametro di tipo '{1}' in '{2}'</target>
+        <note>'unsafe', 'extern', and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
-        <source>'{0}' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'</source>
-        <target state="translated">'{0}' deve essere usato in un contesto non sicuro perché è contrassegnato come 'RequiresUnsafe' o 'extern'</target>
-        <note>'RequiresUnsafe' and 'extern' should not be localized.</note>
+        <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'</source>
+        <target state="needs-review-translation">'{0}' deve essere usato in un contesto non sicuro perché è contrassegnato come 'RequiresUnsafe' o 'extern'</target>
+        <note>'unsafe' and 'extern' should not be localized.</note>
       </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperationCompat">
         <source>'{0}' must be used in an unsafe context because it has pointers in its signature</source>
@@ -3931,16 +3931,6 @@
         <source>Struct member returns 'this' or other instance members by reference</source>
         <target state="translated">Il membro struct restituisce 'questo' o altri membri di istanza per riferimento</target>
         <note />
-      </trans-unit>
-      <trans-unit id="WRN_RequiresUnsafeAttributeLegacyRules">
-        <source>RequiresUnsafeAttribute is only valid under the updated memory safety rules.</source>
-        <target state="translated">RequiresUnsafeAttribute è valido solo con regole di sicurezza della memoria aggiornate.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
-      </trans-unit>
-      <trans-unit id="WRN_RequiresUnsafeAttributeLegacyRules_Title">
-        <source>RequiresUnsafeAttribute is only valid under the updated memory safety rules.</source>
-        <target state="translated">RequiresUnsafeAttribute è valido solo con regole di sicurezza della memoria aggiornate.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
       </trans-unit>
       <trans-unit id="WRN_ReturnNotNullIfNotNull">
         <source>Return value must be non-null because parameter '{0}' is non-null.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1497,10 +1497,10 @@
         <target state="translated">'#!' はファイルの最初の行の先頭に使用する必要があります</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_RequiresUnsafeAttributeUnsupportedMemberTarget">
-        <source>RequiresUnsafeAttribute cannot be applied to this symbol.</source>
-        <target state="translated">RequiresUnsafeAttribute をこのシンボルに適用することはできません。</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
+      <trans-unit id="ERR_RequiresUnsafeAttributeInSource">
+        <source>Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.</source>
+        <target state="new">Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.</target>
+        <note>'RequiresUnsafeAttribute' and 'unsafe' should not be localized.</note>
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportExtendedLayoutTypes">
         <source>The target runtime does not support extended layout types.</source>
@@ -2733,14 +2733,14 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsafeConstructorConstraint">
-        <source>An unsafe context is required for constructor '{0}' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</source>
-        <target state="translated">'{2}' の型パラメーター '{1}' の 'new()' 制約を満たすには、'requiresUnsafe' または 'extern' としてマークされたコンストラクター '{0}' に unsafe コンテキストが必要です</target>
-        <note>'RequiresUnsafe', 'extern', and 'new()' should not be localized. {2} is the generic method or type.</note>
+        <source>An unsafe context is required for constructor '{0}' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</source>
+        <target state="needs-review-translation">'{2}' の型パラメーター '{1}' の 'new()' 制約を満たすには、'requiresUnsafe' または 'extern' としてマークされたコンストラクター '{0}' に unsafe コンテキストが必要です</target>
+        <note>'unsafe', 'extern', and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
-        <source>'{0}' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'</source>
-        <target state="translated">'requiresUnsafe' または 'extern' としてマークされているため、'{0}' は安全でないコンテキストで使用する必要があります</target>
-        <note>'RequiresUnsafe' and 'extern' should not be localized.</note>
+        <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'</source>
+        <target state="needs-review-translation">'requiresUnsafe' または 'extern' としてマークされているため、'{0}' は安全でないコンテキストで使用する必要があります</target>
+        <note>'unsafe' and 'extern' should not be localized.</note>
       </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperationCompat">
         <source>'{0}' must be used in an unsafe context because it has pointers in its signature</source>
@@ -3931,16 +3931,6 @@
         <source>Struct member returns 'this' or other instance members by reference</source>
         <target state="translated">構造体メンバーは 'this' または他のインスタンス メンバーを参照渡しで返します</target>
         <note />
-      </trans-unit>
-      <trans-unit id="WRN_RequiresUnsafeAttributeLegacyRules">
-        <source>RequiresUnsafeAttribute is only valid under the updated memory safety rules.</source>
-        <target state="translated">RequiresUnsafeAttribute は、更新されたメモリの安全性規則でのみ有効です。</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
-      </trans-unit>
-      <trans-unit id="WRN_RequiresUnsafeAttributeLegacyRules_Title">
-        <source>RequiresUnsafeAttribute is only valid under the updated memory safety rules.</source>
-        <target state="translated">RequiresUnsafeAttribute は、更新されたメモリの安全性規則でのみ有効です。</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
       </trans-unit>
       <trans-unit id="WRN_ReturnNotNullIfNotNull">
         <source>Return value must be non-null because parameter '{0}' is non-null.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1497,10 +1497,10 @@
         <target state="translated">'#!'는 파일의 첫 번째 줄에 있는 첫 번째 문자여야 함</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_RequiresUnsafeAttributeUnsupportedMemberTarget">
-        <source>RequiresUnsafeAttribute cannot be applied to this symbol.</source>
-        <target state="translated">RequiresUnsafeAttribute는 이 기호에 적용할 수 없습니다.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
+      <trans-unit id="ERR_RequiresUnsafeAttributeInSource">
+        <source>Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.</source>
+        <target state="new">Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.</target>
+        <note>'RequiresUnsafeAttribute' and 'unsafe' should not be localized.</note>
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportExtendedLayoutTypes">
         <source>The target runtime does not support extended layout types.</source>
@@ -2733,14 +2733,14 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsafeConstructorConstraint">
-        <source>An unsafe context is required for constructor '{0}' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</source>
-        <target state="translated">'{2}'의 형식 매개 변수 '{1}'의 'new()' 제약 조건을 충족하려면 'RequiresUnsafe' 또는 'extern'으로 표시된 생성자 '{0}'에 안전하지 않은 컨텍스트가 필요합니다.</target>
-        <note>'RequiresUnsafe', 'extern', and 'new()' should not be localized. {2} is the generic method or type.</note>
+        <source>An unsafe context is required for constructor '{0}' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</source>
+        <target state="needs-review-translation">'{2}'의 형식 매개 변수 '{1}'의 'new()' 제약 조건을 충족하려면 'RequiresUnsafe' 또는 'extern'으로 표시된 생성자 '{0}'에 안전하지 않은 컨텍스트가 필요합니다.</target>
+        <note>'unsafe', 'extern', and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
-        <source>'{0}' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'</source>
-        <target state="translated">'{0}'은(는) 'RequiresUnsafe' 또는 'extern'으로 표시되어 있어 안전하지 않은 컨텍스트에서 사용해야 합니다.</target>
-        <note>'RequiresUnsafe' and 'extern' should not be localized.</note>
+        <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'</source>
+        <target state="needs-review-translation">'{0}'은(는) 'RequiresUnsafe' 또는 'extern'으로 표시되어 있어 안전하지 않은 컨텍스트에서 사용해야 합니다.</target>
+        <note>'unsafe' and 'extern' should not be localized.</note>
       </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperationCompat">
         <source>'{0}' must be used in an unsafe context because it has pointers in its signature</source>
@@ -3931,16 +3931,6 @@
         <source>Struct member returns 'this' or other instance members by reference</source>
         <target state="translated">구조체 멤버는 참조로 'this' 또는 다른 인스턴스 멤버를 반환합니다.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="WRN_RequiresUnsafeAttributeLegacyRules">
-        <source>RequiresUnsafeAttribute is only valid under the updated memory safety rules.</source>
-        <target state="translated">RequiresUnsafeAttribute는 업데이트된 메모리 안전 규칙에서만 유효합니다.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
-      </trans-unit>
-      <trans-unit id="WRN_RequiresUnsafeAttributeLegacyRules_Title">
-        <source>RequiresUnsafeAttribute is only valid under the updated memory safety rules.</source>
-        <target state="translated">RequiresUnsafeAttribute는 업데이트된 메모리 안전 규칙에서만 유효합니다.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
       </trans-unit>
       <trans-unit id="WRN_ReturnNotNullIfNotNull">
         <source>Return value must be non-null because parameter '{0}' is non-null.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1497,10 +1497,10 @@
         <target state="translated">„#!” musi stanowić pierwsze znaki w pierwszym wierszu pliku</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_RequiresUnsafeAttributeUnsupportedMemberTarget">
-        <source>RequiresUnsafeAttribute cannot be applied to this symbol.</source>
-        <target state="translated">Nie można zastosować atrybutu RequiresUnsafeAttribute do tego symbolu.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
+      <trans-unit id="ERR_RequiresUnsafeAttributeInSource">
+        <source>Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.</source>
+        <target state="new">Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.</target>
+        <note>'RequiresUnsafeAttribute' and 'unsafe' should not be localized.</note>
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportExtendedLayoutTypes">
         <source>The target runtime does not support extended layout types.</source>
@@ -2733,14 +2733,14 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsafeConstructorConstraint">
-        <source>An unsafe context is required for constructor '{0}' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</source>
-        <target state="translated">Niebezpieczny kontekst jest wymagany dla konstruktora „{0}” oznaczonego jako „RequiresUnsafe” lub „extern”, aby spełnić ograniczenie „new()” parametru typu „{1}” w „{2}”</target>
-        <note>'RequiresUnsafe', 'extern', and 'new()' should not be localized. {2} is the generic method or type.</note>
+        <source>An unsafe context is required for constructor '{0}' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</source>
+        <target state="needs-review-translation">Niebezpieczny kontekst jest wymagany dla konstruktora „{0}” oznaczonego jako „RequiresUnsafe” lub „extern”, aby spełnić ograniczenie „new()” parametru typu „{1}” w „{2}”</target>
+        <note>'unsafe', 'extern', and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
-        <source>'{0}' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'</source>
-        <target state="translated">Atrybut „{0}” musi być używany w niezabezpieczonym kontekście, ponieważ jest oznaczony jako „RequiresUnsafe” lub „extern”</target>
-        <note>'RequiresUnsafe' and 'extern' should not be localized.</note>
+        <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'</source>
+        <target state="needs-review-translation">Atrybut „{0}” musi być używany w niezabezpieczonym kontekście, ponieważ jest oznaczony jako „RequiresUnsafe” lub „extern”</target>
+        <note>'unsafe' and 'extern' should not be localized.</note>
       </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperationCompat">
         <source>'{0}' must be used in an unsafe context because it has pointers in its signature</source>
@@ -3931,16 +3931,6 @@
         <source>Struct member returns 'this' or other instance members by reference</source>
         <target state="translated">Składowa struktury zwraca element „this” lub inne składowe wystąpienia według odwołania</target>
         <note />
-      </trans-unit>
-      <trans-unit id="WRN_RequiresUnsafeAttributeLegacyRules">
-        <source>RequiresUnsafeAttribute is only valid under the updated memory safety rules.</source>
-        <target state="translated">Atrybut RequiresUnsafeAttribute jest prawidłowy tylko w ramach zaktualizowanych reguł zabezpieczeń pamięci.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
-      </trans-unit>
-      <trans-unit id="WRN_RequiresUnsafeAttributeLegacyRules_Title">
-        <source>RequiresUnsafeAttribute is only valid under the updated memory safety rules.</source>
-        <target state="translated">Atrybut RequiresUnsafeAttribute jest prawidłowy tylko w ramach zaktualizowanych reguł zabezpieczeń pamięci.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
       </trans-unit>
       <trans-unit id="WRN_ReturnNotNullIfNotNull">
         <source>Return value must be non-null because parameter '{0}' is non-null.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1497,10 +1497,10 @@
         <target state="translated">''#!'' deve ser o primeiro caractere na primeira linha do arquivo</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_RequiresUnsafeAttributeUnsupportedMemberTarget">
-        <source>RequiresUnsafeAttribute cannot be applied to this symbol.</source>
-        <target state="translated">RequiresUnsafeAttribute não pode ser aplicado a este símbolo.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
+      <trans-unit id="ERR_RequiresUnsafeAttributeInSource">
+        <source>Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.</source>
+        <target state="new">Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.</target>
+        <note>'RequiresUnsafeAttribute' and 'unsafe' should not be localized.</note>
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportExtendedLayoutTypes">
         <source>The target runtime does not support extended layout types.</source>
@@ -2733,14 +2733,14 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsafeConstructorConstraint">
-        <source>An unsafe context is required for constructor '{0}' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</source>
-        <target state="translated">Um contexto não seguro é necessário para o construtor ''{0}'' marcado como ''RequiresUnsafe'' ou ''extern'' para satisfazer a restrição ''new()'' do parâmetro de tipo ''{1}'' em ''{2}''</target>
-        <note>'RequiresUnsafe', 'extern', and 'new()' should not be localized. {2} is the generic method or type.</note>
+        <source>An unsafe context is required for constructor '{0}' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</source>
+        <target state="needs-review-translation">Um contexto não seguro é necessário para o construtor ''{0}'' marcado como ''RequiresUnsafe'' ou ''extern'' para satisfazer a restrição ''new()'' do parâmetro de tipo ''{1}'' em ''{2}''</target>
+        <note>'unsafe', 'extern', and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
-        <source>'{0}' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'</source>
-        <target state="translated">"{0}" deve ser usado em um contexto não seguro porque está marcado como "RequiresUnsafe" ou "extern"</target>
-        <note>'RequiresUnsafe' and 'extern' should not be localized.</note>
+        <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'</source>
+        <target state="needs-review-translation">"{0}" deve ser usado em um contexto não seguro porque está marcado como "RequiresUnsafe" ou "extern"</target>
+        <note>'unsafe' and 'extern' should not be localized.</note>
       </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperationCompat">
         <source>'{0}' must be used in an unsafe context because it has pointers in its signature</source>
@@ -3931,16 +3931,6 @@
         <source>Struct member returns 'this' or other instance members by reference</source>
         <target state="translated">O membro do struct retorna 'this' ou outros membros da instância por referência</target>
         <note />
-      </trans-unit>
-      <trans-unit id="WRN_RequiresUnsafeAttributeLegacyRules">
-        <source>RequiresUnsafeAttribute is only valid under the updated memory safety rules.</source>
-        <target state="translated">RequiresUnsafeAttribute só é válido de acordo com as regras de segurança de memória atualizadas.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
-      </trans-unit>
-      <trans-unit id="WRN_RequiresUnsafeAttributeLegacyRules_Title">
-        <source>RequiresUnsafeAttribute is only valid under the updated memory safety rules.</source>
-        <target state="translated">RequiresUnsafeAttribute só é válido de acordo com as regras de segurança de memória atualizadas.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
       </trans-unit>
       <trans-unit id="WRN_ReturnNotNullIfNotNull">
         <source>Return value must be non-null because parameter '{0}' is non-null.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1497,10 +1497,10 @@
         <target state="translated">"#!" должны быть первыми символами в первой строке файла</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_RequiresUnsafeAttributeUnsupportedMemberTarget">
-        <source>RequiresUnsafeAttribute cannot be applied to this symbol.</source>
-        <target state="translated">RequiresUnsafeAttribute невозможно применить к этому символу.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
+      <trans-unit id="ERR_RequiresUnsafeAttributeInSource">
+        <source>Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.</source>
+        <target state="new">Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.</target>
+        <note>'RequiresUnsafeAttribute' and 'unsafe' should not be localized.</note>
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportExtendedLayoutTypes">
         <source>The target runtime does not support extended layout types.</source>
@@ -2733,14 +2733,14 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsafeConstructorConstraint">
-        <source>An unsafe context is required for constructor '{0}' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</source>
-        <target state="translated">Для конструктора "{0}", помеченного как "RequiresUnsafe" или "extern", требуется небезопасный контекст, чтобы удовлетворить ограничение "new()" параметра типа "{1}" в "{2}"</target>
-        <note>'RequiresUnsafe', 'extern', and 'new()' should not be localized. {2} is the generic method or type.</note>
+        <source>An unsafe context is required for constructor '{0}' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</source>
+        <target state="needs-review-translation">Для конструктора "{0}", помеченного как "RequiresUnsafe" или "extern", требуется небезопасный контекст, чтобы удовлетворить ограничение "new()" параметра типа "{1}" в "{2}"</target>
+        <note>'unsafe', 'extern', and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
-        <source>'{0}' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'</source>
-        <target state="translated">"{0}" должен использоваться в небезопасном контексте, так как он помечен как RequiresUnsafe или extern</target>
-        <note>'RequiresUnsafe' and 'extern' should not be localized.</note>
+        <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'</source>
+        <target state="needs-review-translation">"{0}" должен использоваться в небезопасном контексте, так как он помечен как RequiresUnsafe или extern</target>
+        <note>'unsafe' and 'extern' should not be localized.</note>
       </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperationCompat">
         <source>'{0}' must be used in an unsafe context because it has pointers in its signature</source>
@@ -3931,16 +3931,6 @@
         <source>Struct member returns 'this' or other instance members by reference</source>
         <target state="translated">Элемент структуры возвращает "этот" или другие элементы экземпляра по ссылке</target>
         <note />
-      </trans-unit>
-      <trans-unit id="WRN_RequiresUnsafeAttributeLegacyRules">
-        <source>RequiresUnsafeAttribute is only valid under the updated memory safety rules.</source>
-        <target state="translated">RequiresUnsafeAttribute допустим только в рамках обновленных правил обеспечения безопасности памяти.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
-      </trans-unit>
-      <trans-unit id="WRN_RequiresUnsafeAttributeLegacyRules_Title">
-        <source>RequiresUnsafeAttribute is only valid under the updated memory safety rules.</source>
-        <target state="translated">RequiresUnsafeAttribute допустим только в рамках обновленных правил обеспечения безопасности памяти.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
       </trans-unit>
       <trans-unit id="WRN_ReturnNotNullIfNotNull">
         <source>Return value must be non-null because parameter '{0}' is non-null.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1497,10 +1497,10 @@
         <target state="translated">Dosyanın ilk satırındaki ilk karakterler ‘#!’ olmalıdır</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_RequiresUnsafeAttributeUnsupportedMemberTarget">
-        <source>RequiresUnsafeAttribute cannot be applied to this symbol.</source>
-        <target state="translated">RequiresUnsafeAttribute bu sembole uygulanamaz.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
+      <trans-unit id="ERR_RequiresUnsafeAttributeInSource">
+        <source>Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.</source>
+        <target state="new">Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.</target>
+        <note>'RequiresUnsafeAttribute' and 'unsafe' should not be localized.</note>
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportExtendedLayoutTypes">
         <source>The target runtime does not support extended layout types.</source>
@@ -2733,14 +2733,14 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsafeConstructorConstraint">
-        <source>An unsafe context is required for constructor '{0}' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</source>
-        <target state="translated">'RequiresUnsafe' veya 'extern' olarak işaretlenen '{0}' oluşturucusu için, '{1}' içindeki '{2}' tür parametresinin 'new()' kısıtlamasını karşılamak üzere güvenli olmayan bir bağlam gereklidir</target>
-        <note>'RequiresUnsafe', 'extern', and 'new()' should not be localized. {2} is the generic method or type.</note>
+        <source>An unsafe context is required for constructor '{0}' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</source>
+        <target state="needs-review-translation">'RequiresUnsafe' veya 'extern' olarak işaretlenen '{0}' oluşturucusu için, '{1}' içindeki '{2}' tür parametresinin 'new()' kısıtlamasını karşılamak üzere güvenli olmayan bir bağlam gereklidir</target>
+        <note>'unsafe', 'extern', and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
-        <source>'{0}' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'</source>
-        <target state="translated">'{0}' 'RequiresUnsafe' veya 'extern' olarak işaretlendiği için güvenli olmayan bir bağlamda kullanılmalıdır</target>
-        <note>'RequiresUnsafe' and 'extern' should not be localized.</note>
+        <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'</source>
+        <target state="needs-review-translation">'{0}' 'RequiresUnsafe' veya 'extern' olarak işaretlendiği için güvenli olmayan bir bağlamda kullanılmalıdır</target>
+        <note>'unsafe' and 'extern' should not be localized.</note>
       </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperationCompat">
         <source>'{0}' must be used in an unsafe context because it has pointers in its signature</source>
@@ -3931,16 +3931,6 @@
         <source>Struct member returns 'this' or other instance members by reference</source>
         <target state="translated">Struct üyesi, 'tis' veya diğer örnek üyelerini referans olarak döndürür</target>
         <note />
-      </trans-unit>
-      <trans-unit id="WRN_RequiresUnsafeAttributeLegacyRules">
-        <source>RequiresUnsafeAttribute is only valid under the updated memory safety rules.</source>
-        <target state="translated">RequiresUnsafeAttribute yalnızca güncelleştirilmiş bellek güvenliği kuralları altında geçerlidir.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
-      </trans-unit>
-      <trans-unit id="WRN_RequiresUnsafeAttributeLegacyRules_Title">
-        <source>RequiresUnsafeAttribute is only valid under the updated memory safety rules.</source>
-        <target state="translated">RequiresUnsafeAttribute yalnızca güncelleştirilmiş bellek güvenliği kuralları altında geçerlidir.</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
       </trans-unit>
       <trans-unit id="WRN_ReturnNotNullIfNotNull">
         <source>Return value must be non-null because parameter '{0}' is non-null.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1497,10 +1497,10 @@
         <target state="translated">"#!" 必须是文件第一行的第一个字符</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_RequiresUnsafeAttributeUnsupportedMemberTarget">
-        <source>RequiresUnsafeAttribute cannot be applied to this symbol.</source>
-        <target state="translated">RequiresUnsafeAttribute 无法应用于此符号。</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
+      <trans-unit id="ERR_RequiresUnsafeAttributeInSource">
+        <source>Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.</source>
+        <target state="new">Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.</target>
+        <note>'RequiresUnsafeAttribute' and 'unsafe' should not be localized.</note>
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportExtendedLayoutTypes">
         <source>The target runtime does not support extended layout types.</source>
@@ -2733,14 +2733,14 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsafeConstructorConstraint">
-        <source>An unsafe context is required for constructor '{0}' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</source>
-        <target state="translated">标记为 "RequiresUnsafe" 或 "extern" 的构造函数 "{0}" 需要不安全的上下文以满足 "{2}" 中类型参数 "{1}" 的 "new()" 约束</target>
-        <note>'RequiresUnsafe', 'extern', and 'new()' should not be localized. {2} is the generic method or type.</note>
+        <source>An unsafe context is required for constructor '{0}' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</source>
+        <target state="needs-review-translation">标记为 "RequiresUnsafe" 或 "extern" 的构造函数 "{0}" 需要不安全的上下文以满足 "{2}" 中类型参数 "{1}" 的 "new()" 约束</target>
+        <note>'unsafe', 'extern', and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
-        <source>'{0}' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'</source>
-        <target state="translated">“{0}”必须在不安全的上下文中使用，因为它标记为 "RequiresUnsafe" 或 "extern"</target>
-        <note>'RequiresUnsafe' and 'extern' should not be localized.</note>
+        <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'</source>
+        <target state="needs-review-translation">“{0}”必须在不安全的上下文中使用，因为它标记为 "RequiresUnsafe" 或 "extern"</target>
+        <note>'unsafe' and 'extern' should not be localized.</note>
       </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperationCompat">
         <source>'{0}' must be used in an unsafe context because it has pointers in its signature</source>
@@ -3931,16 +3931,6 @@
         <source>Struct member returns 'this' or other instance members by reference</source>
         <target state="translated">结构成员按引用返回“此”或其他实例成员</target>
         <note />
-      </trans-unit>
-      <trans-unit id="WRN_RequiresUnsafeAttributeLegacyRules">
-        <source>RequiresUnsafeAttribute is only valid under the updated memory safety rules.</source>
-        <target state="translated">RequiresUnsafeAttribute 仅在更新后的内存安全规则下有效。</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
-      </trans-unit>
-      <trans-unit id="WRN_RequiresUnsafeAttributeLegacyRules_Title">
-        <source>RequiresUnsafeAttribute is only valid under the updated memory safety rules.</source>
-        <target state="translated">RequiresUnsafeAttribute 仅在更新后的内存安全规则下有效。</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
       </trans-unit>
       <trans-unit id="WRN_ReturnNotNullIfNotNull">
         <source>Return value must be non-null because parameter '{0}' is non-null.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1497,10 +1497,10 @@
         <target state="translated">'#!' 必須是檔案第一行的第一個字元</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_RequiresUnsafeAttributeUnsupportedMemberTarget">
-        <source>RequiresUnsafeAttribute cannot be applied to this symbol.</source>
-        <target state="translated">RequiresUnsafeAttribute 無法套用至此符號。</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
+      <trans-unit id="ERR_RequiresUnsafeAttributeInSource">
+        <source>Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.</source>
+        <target state="new">Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.</target>
+        <note>'RequiresUnsafeAttribute' and 'unsafe' should not be localized.</note>
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportExtendedLayoutTypes">
         <source>The target runtime does not support extended layout types.</source>
@@ -2733,14 +2733,14 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsafeConstructorConstraint">
-        <source>An unsafe context is required for constructor '{0}' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</source>
-        <target state="translated">建構函式 '{0}' 標記為 'RequiresUnsafe' 或 'extern'，需要不安全的上下文，以符合 '{1}' 中類型參數 '{2}' 的 'new()' 限制</target>
-        <note>'RequiresUnsafe', 'extern', and 'new()' should not be localized. {2} is the generic method or type.</note>
+        <source>An unsafe context is required for constructor '{0}' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</source>
+        <target state="needs-review-translation">建構函式 '{0}' 標記為 'RequiresUnsafe' 或 'extern'，需要不安全的上下文，以符合 '{1}' 中類型參數 '{2}' 的 'new()' 限制</target>
+        <note>'unsafe', 'extern', and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
-        <source>'{0}' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'</source>
-        <target state="translated">'{0}' 必須在不安全的內容中使用，因為它被標示為 'RequiresUnsafe' 或 'extern'</target>
-        <note>'RequiresUnsafe' and 'extern' should not be localized.</note>
+        <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'</source>
+        <target state="needs-review-translation">'{0}' 必須在不安全的內容中使用，因為它被標示為 'RequiresUnsafe' 或 'extern'</target>
+        <note>'unsafe' and 'extern' should not be localized.</note>
       </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperationCompat">
         <source>'{0}' must be used in an unsafe context because it has pointers in its signature</source>
@@ -3931,16 +3931,6 @@
         <source>Struct member returns 'this' or other instance members by reference</source>
         <target state="translated">結構成員藉傳址方式傳回 'this' 或其他執行個體成員</target>
         <note />
-      </trans-unit>
-      <trans-unit id="WRN_RequiresUnsafeAttributeLegacyRules">
-        <source>RequiresUnsafeAttribute is only valid under the updated memory safety rules.</source>
-        <target state="translated">RequiresUnsafeAttribute 只有在更新的記憶體安全規則下才有效。</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
-      </trans-unit>
-      <trans-unit id="WRN_RequiresUnsafeAttributeLegacyRules_Title">
-        <source>RequiresUnsafeAttribute is only valid under the updated memory safety rules.</source>
-        <target state="translated">RequiresUnsafeAttribute 只有在更新的記憶體安全規則下才有效。</target>
-        <note>'RequiresUnsafeAttribute' is not localizable</note>
       </trans-unit>
       <trans-unit id="WRN_ReturnNotNullIfNotNull">
         <source>Return value must be non-null because parameter '{0}' is non-null.</source>

--- a/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests.cs
@@ -9267,15 +9267,15 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             .VerifyDiagnostics(
             [
                 .. commonDiagnostics,
-                // (8,24): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
+                // (8,12): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
                 //     public extern void M2();
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "M2").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(8, 24),
-                // (9,51): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "extern").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(8, 12),
+                // (9,39): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
                 //     [DllImport("test")] public static extern void M3();
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "M3").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(9, 51),
-                // (10,69): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "extern").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(9, 39),
+                // (10,57): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
                 //     [MethodImpl(MethodImplOptions.InternalCall)] public extern void M4();
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "M4").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(10, 69),
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "extern").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(10, 57),
             ]);
 
         CreateCompilation([libSource, RequiresUnsafeAttributeDefinition],
@@ -9289,15 +9289,15 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             .VerifyDiagnostics(
             // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
             Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
-            // (8,24): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            // (8,12): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //     public extern void M2();
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "M2").WithArguments("updated memory safety rules").WithLocation(8, 24),
-            // (9,51): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "extern").WithArguments("updated memory safety rules").WithLocation(8, 12),
+            // (9,39): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //     [DllImport("test")] public static extern void M3();
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "M3").WithArguments("updated memory safety rules").WithLocation(9, 51),
-            // (10,69): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "extern").WithArguments("updated memory safety rules").WithLocation(9, 39),
+            // (10,57): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //     [MethodImpl(MethodImplOptions.InternalCall)] public extern void M4();
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "M4").WithArguments("updated memory safety rules").WithLocation(10, 69));
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "extern").WithArguments("updated memory safety rules").WithLocation(10, 57));
 
         CreateCompilation(libSource,
             parseOptions: TestOptions.RegularNext)
@@ -9833,9 +9833,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CreateCompilation([libSource, callerSource],
             options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
-            // (7,28): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
+            // (7,16): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
             //         static extern void F();
-            Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "F").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(7, 28));
+            Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "extern").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(7, 16));
 
         CreateCompilation([libSource, RequiresUnsafeAttributeDefinition],
             parseOptions: TestOptions.RegularNext,
@@ -9848,9 +9848,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             .VerifyDiagnostics(
             // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
             Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
-            // (7,28): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            // (7,16): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //         static extern void F();
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "F").WithArguments("updated memory safety rules").WithLocation(7, 28));
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "extern").WithArguments("updated memory safety rules").WithLocation(7, 16));
 
         CreateCompilation(libSource,
             parseOptions: TestOptions.RegularNext)
@@ -9914,21 +9914,21 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics([
                 .. commonDiagnostics,
-                // (8,23): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
+                // (8,12): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
                 //     public extern int P2 { set; }
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "P2").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(8, 23),
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "extern").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(8, 12),
                 // (8,28): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
                 //     public extern int P2 { set; }
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "set").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(8, 28),
-                // (9,30): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
+                // (9,19): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
                 //     public static extern int P3 { [DllImport("test")] set; }
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "P3").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(9, 30),
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "extern").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(9, 19),
                 // (9,55): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
                 //     public static extern int P3 { [DllImport("test")] set; }
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "set").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(9, 55),
-                // (10,23): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
+                // (10,12): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
                 //     public extern int P4 { [MethodImpl(MethodImplOptions.InternalCall)] set; }
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "P4").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(10, 23),
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "extern").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(10, 12),
                 // (10,73): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
                 //     public extern int P4 { [MethodImpl(MethodImplOptions.InternalCall)] set; }
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "set").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(10, 73),
@@ -9945,21 +9945,21 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             .VerifyDiagnostics(
             // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
             Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
-            // (8,23): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            // (8,12): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //     public extern int P2 { set; }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "P2").WithArguments("updated memory safety rules").WithLocation(8, 23),
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "extern").WithArguments("updated memory safety rules").WithLocation(8, 12),
             // (8,28): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //     public extern int P2 { set; }
             Diagnostic(ErrorCode.ERR_FeatureInPreview, "set").WithArguments("updated memory safety rules").WithLocation(8, 28),
-            // (9,30): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            // (9,19): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //     public static extern int P3 { [DllImport("test")] set; }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "P3").WithArguments("updated memory safety rules").WithLocation(9, 30),
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "extern").WithArguments("updated memory safety rules").WithLocation(9, 19),
             // (9,55): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //     public static extern int P3 { [DllImport("test")] set; }
             Diagnostic(ErrorCode.ERR_FeatureInPreview, "set").WithArguments("updated memory safety rules").WithLocation(9, 55),
-            // (10,23): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            // (10,12): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //     public extern int P4 { [MethodImpl(MethodImplOptions.InternalCall)] set; }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "P4").WithArguments("updated memory safety rules").WithLocation(10, 23),
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "extern").WithArguments("updated memory safety rules").WithLocation(10, 12),
             // (10,73): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //     public extern int P4 { [MethodImpl(MethodImplOptions.InternalCall)] set; }
             Diagnostic(ErrorCode.ERR_FeatureInPreview, "set").WithArguments("updated memory safety rules").WithLocation(10, 73));
@@ -10127,9 +10127,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             .VerifyDiagnostics(
             [
                 .. commonDiagnostics,
-                // (4,23): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
+                // (4,12): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
                 //     public extern int this[int i] { get; set; }
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "this").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(4, 23),
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "extern").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(4, 12),
                 // (4,37): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
                 //     public extern int this[int i] { get; set; }
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "get").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(4, 37),
@@ -10149,9 +10149,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             .VerifyDiagnostics(
             // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
             Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
-            // (4,23): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            // (4,12): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //     public extern int this[int i] { get; set; }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "this").WithArguments("updated memory safety rules").WithLocation(4, 23),
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "extern").WithArguments("updated memory safety rules").WithLocation(4, 12),
             // (4,37): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //     public extern int this[int i] { get; set; }
             Diagnostic(ErrorCode.ERR_FeatureInPreview, "get").WithArguments("updated memory safety rules").WithLocation(4, 37),
@@ -10509,9 +10509,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics([
                 .. commonDiagnostics,
-                // (4,19): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
+                // (4,12): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
                 //     public extern C();
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "C").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(4, 19),
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "extern").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(4, 12),
             ]);
 
         CreateCompilation([libSource, RequiresUnsafeAttributeDefinition],
@@ -10525,9 +10525,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             .VerifyDiagnostics(
             // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
             Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
-            // (4,19): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            // (4,12): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //     public extern C();
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "C").WithArguments("updated memory safety rules").WithLocation(4, 19));
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "extern").WithArguments("updated memory safety rules").WithLocation(4, 12));
 
         CreateCompilation(libSource,
             parseOptions: TestOptions.RegularNext,
@@ -10683,9 +10683,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics([
                 .. commonDiagnostics,
-                // (4,33): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
+                // (4,12): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
                 //     public extern void operator +=(C c);
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "+=").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(4, 33),
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "extern").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(4, 12),
             ]);
 
         CreateCompilation([libSource, CompilerFeatureRequiredAttribute, RequiresUnsafeAttributeDefinition],
@@ -10699,9 +10699,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             .VerifyDiagnostics(
             // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
             Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
-            // (4,33): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            // (4,12): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //     public extern void operator +=(C c);
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "+=").WithArguments("updated memory safety rules").WithLocation(4, 33));
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "extern").WithArguments("updated memory safety rules").WithLocation(4, 12));
 
         CreateCompilation([libSource, CompilerFeatureRequiredAttribute],
             parseOptions: TestOptions.RegularNext,

--- a/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests.cs
@@ -3369,42 +3369,12 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules()).VerifyDiagnostics(
             // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
             Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
-            // (6,1): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            // unsafe void F() { }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(6, 1),
             // (10,13): error CS0106: The modifier 'unsafe' is not valid for this item
             // unsafe enum E { A }
             Diagnostic(ErrorCode.ERR_BadMemberFlag, "E").WithArguments("unsafe").WithLocation(10, 13),
             // (12,22): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
             // unsafe delegate void D();
-            Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "D").WithLocation(12, 22),
-            // (15,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     unsafe X() { }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(15, 5),
-            // (18,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     unsafe void M() { }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(18, 5),
-            // (19,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     unsafe int P { get; set; }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(19, 5),
-            // (19,20): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     unsafe int P { get; set; }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "get").WithArguments("updated memory safety rules").WithLocation(19, 20),
-            // (19,25): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     unsafe int P { get; set; }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "set").WithArguments("updated memory safety rules").WithLocation(19, 25),
-            // (20,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     unsafe event System.Action E { add { } remove { } }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(20, 5),
-            // (20,36): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     unsafe event System.Action E { add { } remove { } }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "add").WithArguments("updated memory safety rules").WithLocation(20, 36),
-            // (20,44): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     unsafe event System.Action E { add { } remove { } }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "remove").WithArguments("updated memory safety rules").WithLocation(20, 44),
-            // (21,19): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     public static unsafe implicit operator int(X x) => 0;
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(21, 19));
+            Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "D").WithLocation(12, 22));
     }
 
     [Fact]
@@ -3511,9 +3481,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             // (6,26): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
             //     void M1(X<string*[]> x) { }
             Diagnostic(ErrorCode.WRN_ManagedAddr, "x").WithArguments("string").WithLocation(6, 26),
-            // (7,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     unsafe void M2(X<string*[]> x) { }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(7, 5),
             // (7,33): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
             //     unsafe void M2(X<string*[]> x) { }
             Diagnostic(ErrorCode.WRN_ManagedAddr, "x").WithArguments("string").WithLocation(7, 33));
@@ -3606,48 +3573,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             .VerifyDiagnostics(
             // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
             Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
-            // (2,1): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            // unsafe void F() { }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(2, 1),
-            // (5,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     unsafe void M() { }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(5, 5),
-            // (6,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     unsafe int P { get; set; }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(6, 5),
-            // (6,20): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     unsafe int P { get; set; }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "get").WithArguments("updated memory safety rules").WithLocation(6, 20),
-            // (6,25): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     unsafe int P { get; set; }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "set").WithArguments("updated memory safety rules").WithLocation(6, 25),
-            // (8,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     unsafe event System.Action E { add { } remove { } }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(8, 5),
-            // (8,36): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     unsafe event System.Action E { add { } remove { } }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "add").WithArguments("updated memory safety rules").WithLocation(8, 36),
-            // (8,44): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     unsafe event System.Action E { add { } remove { } }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "remove").WithArguments("updated memory safety rules").WithLocation(8, 44),
-            // (9,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     unsafe int this[int i] { get => i; set { } }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(9, 5),
-            // (9,30): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     unsafe int this[int i] { get => i; set { } }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "get").WithArguments("updated memory safety rules").WithLocation(9, 30),
-            // (9,40): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     unsafe int this[int i] { get => i; set { } }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "set").WithArguments("updated memory safety rules").WithLocation(9, 40),
-            // (10,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     unsafe C() { }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(10, 5),
-            // (11,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     unsafe public static C operator +(C c1, C c2) => c1;
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(11, 5),
-            // (12,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     unsafe public void operator +=(C c) { }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(12, 5),
             // (17,22): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
             // unsafe delegate void D();
             Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "D").WithLocation(17, 22));
@@ -3747,14 +3672,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedDiagnostics.Add(
                 // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
                 Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1));
-
-            if (compilationReference is null && unsafeModifier != "")
-            {
-                expectedDiagnostics.Add(
-                    // (3,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                    //     unsafe public void M() => System.Console.Write(111);
-                    Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(3, 5));
-            }
         }
 
         comp.VerifyDiagnostics([.. expectedDiagnostics]);
@@ -4194,15 +4111,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             .VerifyDiagnostics(
             // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
             Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
-            // (4,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     unsafe public virtual void M2() { }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(4, 5),
             // (5,33): error CS9364: Unsafe member 'C.M1()' cannot override safe member 'B.M1()'
             //     unsafe public override void M1() { }
             Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M1").WithArguments("C.M1()", "B.M1()").WithLocation(5, 33),
-            // (5,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     unsafe public override void M1() { }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(5, 5),
             // (1,1): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             // new C().M1();
             Diagnostic(ErrorCode.ERR_FeatureInPreview, "new C().M1()").WithArguments("updated memory safety rules").WithLocation(1, 1));
@@ -9288,16 +9199,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             options: TestOptions.ReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
             // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
-            Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
-            // (8,12): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     public extern void M2();
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "extern").WithArguments("updated memory safety rules").WithLocation(8, 12),
-            // (9,39): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     [DllImport("test")] public static extern void M3();
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "extern").WithArguments("updated memory safety rules").WithLocation(9, 39),
-            // (10,57): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     [MethodImpl(MethodImplOptions.InternalCall)] public extern void M4();
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "extern").WithArguments("updated memory safety rules").WithLocation(10, 57));
+            Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1));
 
         CreateCompilation(libSource,
             parseOptions: TestOptions.RegularNext)
@@ -9847,10 +9749,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             options: TestOptions.ReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
             // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
-            Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
-            // (7,16): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //         static extern void F();
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "extern").WithArguments("updated memory safety rules").WithLocation(7, 16));
+            Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1));
 
         CreateCompilation(libSource,
             parseOptions: TestOptions.RegularNext)
@@ -9944,25 +9843,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             options: TestOptions.ReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
             // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
-            Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
-            // (8,12): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     public extern int P2 { set; }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "extern").WithArguments("updated memory safety rules").WithLocation(8, 12),
-            // (8,28): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     public extern int P2 { set; }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "set").WithArguments("updated memory safety rules").WithLocation(8, 28),
-            // (9,19): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     public static extern int P3 { [DllImport("test")] set; }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "extern").WithArguments("updated memory safety rules").WithLocation(9, 19),
-            // (9,55): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     public static extern int P3 { [DllImport("test")] set; }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "set").WithArguments("updated memory safety rules").WithLocation(9, 55),
-            // (10,12): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     public extern int P4 { [MethodImpl(MethodImplOptions.InternalCall)] set; }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "extern").WithArguments("updated memory safety rules").WithLocation(10, 12),
-            // (10,73): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     public extern int P4 { [MethodImpl(MethodImplOptions.InternalCall)] set; }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "set").WithArguments("updated memory safety rules").WithLocation(10, 73));
+            Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1));
 
         CreateCompilation(libSource,
             parseOptions: TestOptions.RegularNext)
@@ -10148,16 +10029,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
             // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
-            Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
-            // (4,12): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     public extern int this[int i] { get; set; }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "extern").WithArguments("updated memory safety rules").WithLocation(4, 12),
-            // (4,37): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     public extern int this[int i] { get; set; }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "get").WithArguments("updated memory safety rules").WithLocation(4, 37),
-            // (4,42): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     public extern int this[int i] { get; set; }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "set").WithArguments("updated memory safety rules").WithLocation(4, 42));
+            Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1));
 
         CreateCompilation(libSource,
             parseOptions: TestOptions.RegularNext,
@@ -10351,16 +10223,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
             // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
-            Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
-            // (5,46): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     public static extern event System.Action E;
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "E").WithArguments("updated memory safety rules").WithLocation(5, 46),
-            // (5,46): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     public static extern event System.Action E;
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "E").WithArguments("updated memory safety rules").WithLocation(5, 46),
-            // (5,46): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     public static extern event System.Action E;
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "E").WithArguments("updated memory safety rules").WithLocation(5, 46));
+            Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1));
 
         CreateCompilation(libSource,
             parseOptions: TestOptions.RegularNext,
@@ -10524,10 +10387,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
             // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
-            Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
-            // (4,12): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     public extern C();
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "extern").WithArguments("updated memory safety rules").WithLocation(4, 12));
+            Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1));
 
         CreateCompilation(libSource,
             parseOptions: TestOptions.RegularNext,
@@ -10698,10 +10558,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
             // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
-            Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
-            // (4,12): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     public extern void operator +=(C c);
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "extern").WithArguments("updated memory safety rules").WithLocation(4, 12));
+            Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1));
 
         CreateCompilation([libSource, CompilerFeatureRequiredAttribute],
             parseOptions: TestOptions.RegularNext,
@@ -10860,10 +10717,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
             // (1,1): error CS9274: 'MemorySafetyRules' version '2' is not available in C# 14.0. Please use language version 'preview' or greater.
-            Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
-            // (3,12): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            // public unsafe void M() { }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(3, 12));
+            Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1));
 
         CreateCompilation(source,
             parseOptions: TestOptions.Regular14,
@@ -10873,10 +10727,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
             // (3,12): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
             // public unsafe void M() { }
-            Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "unsafe").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(3, 12),
-            // (3,12): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            // public unsafe void M() { }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(3, 12));
+            Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "unsafe").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(3, 12));
 
         foreach (var parseOptions in new[] { TestOptions.RegularPreview, TestOptions.RegularNext })
         {

--- a/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -38,7 +38,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         TargetFramework targetFramework = TargetFramework.Standard,
         DiagnosticDescription[]? expectedDiagnosticsWhenReferencingLegacyLib = null,
         DiagnosticDescription[]? expectedDiagnosticsForLegacyCaller = null,
-        DiagnosticDescription[]? expectedDiagnosticsWithOldLangVersion = null)
+        DiagnosticDescription[]? expectedDiagnosticsWithOldLangVersion = null,
+        bool expectedAttributeIsSynthesized = true)
     {
         optionsDll ??= TestOptions.UnsafeReleaseDll;
         var optionsExe = optionsDll.WithOutputKind(OutputKind.ConsoleApplication);
@@ -111,7 +112,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                     [
                         .. skipSymbolsInSource is [..] ? expectedUnsafeSymbols.Except(skipSymbolsInSource).ToArray() : expectedUnsafeSymbols,
                         .. skipSymbolsInSource is [..] ? expectedSafeSymbols.Except(skipSymbolsInSource).ToArray() : expectedSafeSymbols,
-                    ]);
+                    ],
+                    includesAttributeDefinition: !expectedAttributeIsSynthesized,
+                    isSynthesized: !expectedAttributeIsSynthesized ? false : null);
             })
             .VerifyDiagnostics()
             .GetImageReference();
@@ -141,7 +144,11 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 module,
                 expectedUnsafeSymbols: exceptSymbolsSkippedInSource(expectedUnsafeSymbols),
                 expectedSafeSymbols: exceptSymbolsSkippedInSource(expectedSafeSymbols),
-                expectedUnsafeMode: expectedUnsafeMode);
+                expectedUnsafeMode: expectedUnsafeMode,
+                includesAttributeDefinition: !isSource || !expectedAttributeIsSynthesized,
+                isSynthesized: isSource
+                    ? (!expectedAttributeIsSynthesized ? false : null)
+                    : expectedAttributeIsSynthesized);
 
             [return: NotNullIfNotNull(nameof(original))]
             object[]? exceptSymbolsSkippedInSource(object[]? original)
@@ -256,9 +263,38 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         ModuleSymbol module,
         ReadOnlySpan<object> expectedUnsafeSymbols,
         ReadOnlySpan<object> expectedSafeSymbols,
-        CallerUnsafeMode expectedUnsafeMode = CallerUnsafeMode.Explicit)
+        bool includesAttributeDefinition,
+        CallerUnsafeMode expectedUnsafeMode = CallerUnsafeMode.Explicit,
+        bool? isSynthesized = null)
     {
         const string Name = "RequiresUnsafeAttribute";
+        const string FullName = $"System.Diagnostics.CodeAnalysis.{Name}";
+
+        var type = (NamedTypeSymbol)module.GlobalNamespace.GetMember(FullName);
+
+        if (includesAttributeDefinition)
+        {
+            Assert.NotNull(type);
+            Assert.NotNull(isSynthesized);
+            if (isSynthesized.Value)
+            {
+                var attributeAttributes = type.GetAttributes()
+                    .Select(a => a.AttributeClass.ToTestDisplayString())
+                    .OrderBy(StringComparer.Ordinal);
+                Assert.Equal(
+                    [
+                        "Microsoft.CodeAnalysis.EmbeddedAttribute",
+                        "System.Runtime.CompilerServices.CompilerGeneratedAttribute",
+                    ],
+                    attributeAttributes);
+            }
+
+            Assert.Equal(isSynthesized.Value ? Accessibility.Internal : Accessibility.Public, type.DeclaredAccessibility);
+        }
+        else
+        {
+            Assert.Null(type);
+        }
 
         var seenSymbols = new HashSet<Symbol>();
 
@@ -3344,7 +3380,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         CreateCompilation([source, IsExternalInitTypeDefinition], options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
 
-        CreateCompilation([source, IsExternalInitTypeDefinition, RequiresUnsafeAttributeDefinition], options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules().WithWarningLevel(10)).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation([source, IsExternalInitTypeDefinition], options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules().WithWarningLevel(10)).VerifyDiagnostics(expectedDiagnostics);
 
         expectedDiagnostics =
         [
@@ -3356,15 +3392,15 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "D").WithLocation(12, 22),
         ];
 
-        CreateCompilation([source, IsExternalInitTypeDefinition, RequiresUnsafeAttributeDefinition], options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules()).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation([source, IsExternalInitTypeDefinition], options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules()).VerifyDiagnostics(expectedDiagnostics);
 
-        CreateCompilation([source, IsExternalInitTypeDefinition, RequiresUnsafeAttributeDefinition], options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules().WithWarningLevel(11)).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation([source, IsExternalInitTypeDefinition], options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules().WithWarningLevel(11)).VerifyDiagnostics(expectedDiagnostics);
 
-        CreateCompilation([source, IsExternalInitTypeDefinition, RequiresUnsafeAttributeDefinition],
+        CreateCompilation([source, IsExternalInitTypeDefinition],
             parseOptions: TestOptions.RegularNext,
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules()).VerifyDiagnostics(expectedDiagnostics);
 
-        CreateCompilation([source, IsExternalInitTypeDefinition, RequiresUnsafeAttributeDefinition],
+        CreateCompilation([source, IsExternalInitTypeDefinition],
             parseOptions: TestOptions.Regular14,
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules()).VerifyDiagnostics(
             // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
@@ -3446,15 +3482,15 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             options: TestOptions.UnsafeReleaseExe)
             .VerifyEmitDiagnostics(expectedDiagnostics);
 
-        CreateCompilationWithSpan([source, RequiresUnsafeAttributeDefinition], options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
+        CreateCompilationWithSpan([source], options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyEmitDiagnostics(expectedDiagnostics);
 
-        CreateCompilationWithSpan([source, RequiresUnsafeAttributeDefinition],
+        CreateCompilationWithSpan([source],
             parseOptions: TestOptions.RegularNext,
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyEmitDiagnostics(expectedDiagnostics);
 
-        CreateCompilationWithSpan([source, RequiresUnsafeAttributeDefinition],
+        CreateCompilationWithSpan([source],
             parseOptions: TestOptions.Regular14,
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
@@ -3543,7 +3579,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                     VerifyRequiresUnsafeAttribute(
                         m,
                         expectedUnsafeSymbols: [],
-                        expectedSafeSymbols: [.. safeSymbols, .. unsafeSymbols]);
+                        expectedSafeSymbols: [.. safeSymbols, .. unsafeSymbols],
+                        includesAttributeDefinition: true,
+                        isSynthesized: false);
                 })
                 .VerifyDiagnostics();
         }
@@ -3559,7 +3597,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                     VerifyRequiresUnsafeAttribute(
                         m,
                         expectedUnsafeSymbols: [.. unsafeSymbols],
-                        expectedSafeSymbols: [.. safeSymbols]);
+                        expectedSafeSymbols: [.. safeSymbols],
+                        includesAttributeDefinition: true,
+                        isSynthesized: false);
                 })
                 .VerifyDiagnostics(
                 // (17,22): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
@@ -3612,7 +3652,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         if (compilationReference is { } useCompilationReference)
         {
             var apiCompilation = CreateCompilation(
-                [api, .. unsafeModifier != "" ? new[] { RequiresUnsafeAttributeDefinition } : []],
+                [api],
                 options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules(apiUpdatedRules))
                 .VerifyDiagnostics();
             var apiReference = AsReference(apiCompilation, useCompilationReference);
@@ -3628,7 +3668,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             }
 
             comp = CreateCompilation(
-                [api, caller, .. unsafeModifier != "" ? new[] { RequiresUnsafeAttributeDefinition } : []],
+                [api, caller],
                 parseOptions: TestOptions.Regular.WithLanguageVersion(callerLangVersion),
                 options: TestOptions.ReleaseExe.WithAllowUnsafe(callerAllowUnsafe).WithUpdatedMemorySafetyRules(callerUpdatedRules));
         }
@@ -3699,7 +3739,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 _ = nameof(C.M);
                 unsafe { C.M(1); }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: [Overload("C.M", 1)],
             expectedSafeSymbols: ["C", Overload("C.M", 0)],
             expectedDiagnostics:
@@ -3726,7 +3765,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 c.M1();
                 c.M2();
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C.M2"],
             expectedSafeSymbols: ["C.M1"],
             expectedDiagnostics:
@@ -3750,7 +3788,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             caller: """
                 _ = nameof(C.M);
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C.M"],
             expectedSafeSymbols: ["C"],
             expectedDiagnostics: []);
@@ -3781,7 +3818,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 unsafe { E.M1(123); }
                 unsafe { E.M2(123); }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["E.M1", "E.M2", ExtensionMember("E", "M2")],
             expectedSafeSymbols: [],
             expectedDiagnostics:
@@ -3824,7 +3860,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 c.M3();
                 unsafe { c.M3(); }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C.M3"],
             expectedSafeSymbols: ["C.M1", "C.M2"],
             expectedDiagnostics:
@@ -3849,7 +3884,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 delegate*<void> p1 = &C.M;
                 unsafe { delegate*<void> p2 = &C.M; }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C.M"],
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
@@ -3885,7 +3919,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 delegate void D1();
                 unsafe delegate void D2();
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C.M"],
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
@@ -3922,7 +3955,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 var a = C.M;
                 unsafe { var b = C.M; }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C.M"],
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
@@ -3950,7 +3982,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                     unsafe public static void M() => System.Console.WriteLine("ran");
                 }
                 """,
-                RequiresUnsafeAttributeDefinition,
             ],
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules(),
             expectedOutput: """
@@ -3977,7 +4008,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 Expression<Action> e1 = () => C.M();
                 unsafe { Expression<Action> e2 = () => C.M(); }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C.M"],
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
@@ -4018,7 +4048,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 unsafe { [A(F = 0)] void M3() { } }
                 [A(F = 0)] unsafe void M4() { }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["A.F"],
             expectedSafeSymbols: ["A"],
             expectedDiagnostics:
@@ -4049,7 +4078,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 i.M2();
                 unsafe { i.M2(); }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["I.M2"],
             expectedSafeSymbols: ["I", "I.M1"],
             expectedDiagnostics:
@@ -4094,18 +4122,17 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CompileAndVerifyUnsafe(
             lib: lib,
             caller: caller,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["B.M2"],
             expectedSafeSymbols: ["B.M1"],
             expectedDiagnostics: expectedDiagnostics,
             expectedDiagnosticsWhenReferencingLegacyLib: expectedDiagnostics);
 
-        CreateCompilation([lib, caller, RequiresUnsafeAttributeDefinition],
+        CreateCompilation([lib, caller],
             parseOptions: TestOptions.RegularNext,
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(expectedDiagnostics);
 
-        CreateCompilation([lib, caller, RequiresUnsafeAttributeDefinition],
+        CreateCompilation([lib, caller],
             parseOptions: TestOptions.Regular14,
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
@@ -4172,7 +4199,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
                 class D3 : C;
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["B.M1", "B.M2", "B.M3", "C.M1", "C.M5"],
             expectedSafeSymbols: ["B.M4", "B.M5", "B.M6", "C.M2", "C.M3", "C.M4"],
             expectedDiagnostics:
@@ -4313,7 +4339,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         VerifyRequiresUnsafeAttribute(
             moduleA,
             expectedUnsafeSymbols: ["B.M"],
-            expectedSafeSymbols: ["A", "A.M", "B"]);
+            expectedSafeSymbols: ["A", "A.M", "B"],
+            includesAttributeDefinition: true,
+            isSynthesized: false);
 
         CreateCompilation("""
             var c1 = new C1();
@@ -4422,7 +4450,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                     public void M2() { }
                 }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["I1.M1", "I2.M2"],
             expectedSafeSymbols: ["I1.M2", "I2.M1", "C1.M1", "C1.M2", "C2.I1.M1", "C2.I1.M2"],
             expectedDiagnostics:
@@ -4518,7 +4545,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                     unsafe void M1(D x);
                 }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["B.M2"],
             expectedSafeSymbols: ["B.M1"],
             expectedDiagnostics:
@@ -4575,7 +4601,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                     public override void M2() { }
                 }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["I.M2", "B1.M2"],
             expectedSafeSymbols: ["I.M1", "B1.M1"],
             expectedDiagnostics:
@@ -4674,7 +4699,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                     unsafe public void M1() { }
                 }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["B.M1"],
             expectedSafeSymbols: ["B.M2"],
             expectedDiagnostics: updatedCallerDiagnostics,
@@ -4700,7 +4724,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             """;
 
         CreateCompilation(
-            [getLib("unsafe"), RequiresUnsafeAttributeDefinition],
+            [getLib("unsafe")],
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
             // (10,17): error CS9365: Unsafe member 'C.OnCompleted(Action)' cannot implicitly implement safe member 'INotifyCompletion.OnCompleted(Action)'
@@ -4714,7 +4738,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             caller: """
                 await new C();
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C.IsCompleted", "C.GetAwaiter", "C.GetResult"],
             expectedSafeSymbols: ["C", "C.OnCompleted"],
             expectedDiagnostics:
@@ -4733,7 +4756,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CreateCompilation(
             [
                 lib,
-                RequiresUnsafeAttributeDefinition,
                 """
                 unsafe { await new C(); }
                 """,
@@ -4868,7 +4890,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 M3(1, 2, 3);
                 static unsafe void M3(params C c) { }
                 """,
-            additionalSources: [TestSources.Span, CollectionBuilderAttributeDefinition, RequiresUnsafeAttributeDefinition],
+            additionalSources: [TestSources.Span, CollectionBuilderAttributeDefinition],
             verify: Verification.Skipped,
             expectedUnsafeSymbols: ["C.Create"],
             expectedSafeSymbols: ["C"],
@@ -4922,7 +4944,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 M(1, 2, 3);
                 static void M(params C c) { }
                 """,
-            additionalSources: [TestSources.Span, CollectionBuilderAttributeDefinition, RequiresUnsafeAttributeDefinition],
+            additionalSources: [TestSources.Span, CollectionBuilderAttributeDefinition],
             verify: Verification.Skipped,
             expectedUnsafeSymbols: ["C.GetEnumerator"],
             expectedSafeSymbols: ["C", "C.Create"],
@@ -4960,7 +4982,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 M3(1, 2, 3);
                 static unsafe void M3(params C c) { }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C..ctor"],
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
@@ -5009,7 +5030,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 C c1 = [with(0), 1, 2, 3];
                 unsafe { C c2 = [with(0), 1, 2, 3]; }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C..ctor"],
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
@@ -5058,7 +5078,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
                 class X { public C F; }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C.Add"],
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
@@ -5145,7 +5164,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 foreach (var c in new C()) { }
                 unsafe { foreach (var c in new C()) { } }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C.GetEnumerator"],
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
@@ -5178,7 +5196,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 C c1 = [.. new C()];
                 unsafe { C c2 = [.. new C()]; }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C.GetEnumerator", "C.MoveNext", "C.Current", "C.get_Current"],
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
@@ -5211,7 +5228,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 foreach (var x in new C()) { }
                 unsafe { foreach (var x in new C()) { } }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C.MoveNext"],
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
@@ -5240,7 +5256,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 foreach (var x in new C()) { }
                 unsafe { foreach (var x in new C()) { } }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C.Current", "C.get_Current"],
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
@@ -5267,7 +5282,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 foreach (var x in new C()) { }
                 unsafe { foreach (var x in new C()) { } }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C.get_Current"],
             expectedSafeSymbols: ["C", "C.Current"],
             expectedDiagnostics:
@@ -5294,7 +5308,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 foreach (var x in new C()) { }
                 unsafe { foreach (var x in new C()) { } }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C.set_Current"],
             expectedSafeSymbols: ["C", "C.Current", "C.get_Current"],
             expectedDiagnostics: []);
@@ -5311,7 +5324,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 public int Current => 0;
                 unsafe public void Dispose() { }
             }
-            """, RequiresUnsafeAttributeDefinition],
+            """],
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
             // (6,24): error CS9365: Unsafe member 'C.Dispose()' cannot implicitly implement safe member 'IDisposable.Dispose()'
@@ -5394,6 +5407,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedUnsafeSymbols: ["System.IDisposable.Dispose"],
             expectedSafeSymbols: ["C", "C.Dispose", "System.IDisposable"],
             verify: Verification.FailsPEVerify,
+            expectedAttributeIsSynthesized: false,
             expectedDiagnostics:
             [
                 // (1,1): error CS9362: 'IDisposable.Dispose()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
@@ -5427,7 +5441,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 unsafe { foreach (var y in new S()) { } }
                 unsafe { using (var s = new S()) { } }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             verify: Verification.Skipped,
             expectedUnsafeSymbols: ["S.Dispose"],
             expectedSafeSymbols: ["S"],
@@ -5460,7 +5473,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 await foreach (var x in new C()) { }
                 await using (var c = new C()) { }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C.DisposeAsync"],
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
@@ -5487,7 +5499,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 fixed (int* p = new C2()) { }
                 unsafe { fixed (int* p = new C2()) { } }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C2.GetPinnableReference"],
             expectedSafeSymbols: ["C1", "C1.GetPinnableReference", "C2"],
             expectedDiagnostics:
@@ -5527,7 +5538,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 var (x, y) = new C();
                 unsafe { var (a, b) = new C(); }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C.Deconstruct"],
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
@@ -5557,7 +5567,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 lock (new System.Threading.Lock()) { }
                 unsafe { lock (new System.Threading.Lock()) { } }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             verify: Verification.Skipped,
             expectedUnsafeSymbols: ["System.Threading.Lock.EnterScope", "System.Threading.Lock.Scope.Dispose"],
             expectedSafeSymbols: ["System.Threading.Lock", "System.Threading.Lock.Scope"],
@@ -5589,7 +5598,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 _ = o is (int x, string y);
                 unsafe { _ = o is (int a, string b); }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["System.Runtime.CompilerServices.ITuple.Length", "System.Runtime.CompilerServices.ITuple.get_Length", "System.Runtime.CompilerServices.ITuple.this[]", "System.Runtime.CompilerServices.ITuple.get_Item"],
             expectedSafeSymbols: ["System.Runtime.CompilerServices.ITuple"],
             expectedDiagnostics:
@@ -5621,7 +5629,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 unsafe { log($"a{0}"); };
                 void log(C c) { }
                 """,
-            additionalSources: [InterpolatedStringHandlerAttribute, RequiresUnsafeAttributeDefinition],
+            additionalSources: [InterpolatedStringHandlerAttribute],
             expectedUnsafeSymbols: [Overload("C..ctor", parameterCount: 2), "C.AppendLiteral", "C.AppendFormatted"],
             expectedSafeSymbols: ["C", Overload("C..ctor", parameterCount: 0)],
             expectedDiagnostics:
@@ -5667,7 +5675,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             }
             """, "Interceptor.cs");
 
-        CreateCompilation([source, interceptor, (TestSources.InterceptsLocationAttribute, "Attribute.cs"), RequiresUnsafeAttributeDefinition],
+        CreateCompilation([source, interceptor, (TestSources.InterceptsLocationAttribute, "Attribute.cs")],
             parseOptions: TestOptions.RegularPreview.WithFeature(Feature.InterceptorsNamespaces, "global"),
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(unsafe1.Length > 0
@@ -5700,7 +5708,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 foreach (var x in C.M()) { }
                 unsafe { foreach (var y in C.M()) { } }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C.M"],
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
@@ -5712,14 +5719,16 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         // Test symbols that are only in PE image (hence cannot test them via the helper above).
         var libRef = CreateCompilation(
-            [lib, RequiresUnsafeAttributeDefinition],
+            [lib],
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules().WithMetadataImportOptions(MetadataImportOptions.All))
             .EmitToImageReference();
         var libAssemblySymbol = CreateCompilation("", [libRef]).GetReferencedAssemblySymbol(libRef);
         VerifyRequiresUnsafeAttribute(
             libAssemblySymbol.Modules.Single(),
             expectedUnsafeSymbols: ["C.M"],
-            expectedSafeSymbols: ["C", "C.<M>d__0", "C.<M>d__0.MoveNext"]);
+            expectedSafeSymbols: ["C", "C.<M>d__0", "C.<M>d__0.MoveNext"],
+            includesAttributeDefinition: true,
+            isSynthesized: true);
     }
 
     [Fact]
@@ -5732,7 +5741,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             unsafe static void M1() { }
             static void M2() { }
             """;
-        CreateCompilation([source, RequiresUnsafeAttributeDefinition],
+        CreateCompilation([source],
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
             // (1,1): error CS9362: 'M1()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
@@ -5802,7 +5811,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 "D.Invoke",
                 "D.BeginInvoke",
                 "D.EndInvoke",
-            ]);
+            ],
+            includesAttributeDefinition: true,
+            isSynthesized: true);
     }
 
     [Fact]
@@ -5823,7 +5834,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 unsafe { c.P2 = c.P2 + 123; }
                 """,
             optionsDll: TestOptions.UnsafeReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All),
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C.P2", "C.get_P2", "C.set_P2"],
             expectedSafeSymbols: ["C.P1", "C.get_P1", "C.set_P1", "C.<P1>k__BackingField", "C.<P2>k__BackingField"],
             expectedDiagnostics:
@@ -5852,7 +5862,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 c.P += 123;
                 unsafe { c.P += 123; }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C.P", "C.get_P", "C.set_P"],
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
@@ -5897,7 +5906,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 unsafe { _ = new C { P1 = null, P2 = null, P3 = null, P4 = null }; }
                 unsafe { _ = new C { P1 = { }, P2 = { }, P3 = { }, P4 = { } }; }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C.P1", "C.get_P1", "C.set_P1", "C.get_P2", "C.set_P3"],
             expectedSafeSymbols: ["C", "C.P2", "C.set_P2", "C.P3", "C.get_P3", "C.P4", "C.get_P4", "C.set_P4"],
             expectedDiagnostics:
@@ -5935,7 +5943,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 unsafe { _ = c is { Length: 0 }; }
                 unsafe { _ = c is []; }
                 """,
-            additionalSources: [TestSources.Index, RequiresUnsafeAttributeDefinition],
+            additionalSources: [TestSources.Index],
             expectedUnsafeSymbols: ["C.this[]", "C.get_Item", "C.Length", "C.get_Length"],
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
@@ -5978,7 +5986,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 unsafe { x.P2 = x.P2 + 444; }
                 unsafe { E.get_P2(x); E.set_P2(x, 0); }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: [ExtensionMember("E", "P2"), "E.get_P2", ExtensionMember("E", "get_P2"), "E.set_P2", ExtensionMember("E", "set_P2")],
             expectedSafeSymbols: [ExtensionMember("E", "P1"), "E.get_P1", ExtensionMember("E", "get_P1"), "E.set_P1", ExtensionMember("E", "set_P1")],
             expectedDiagnostics:
@@ -6013,7 +6020,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 c.P2 = c.P1 + c.P2;
                 unsafe { c.P2 = c.P1 + c.P2; }
                 """,
-            additionalSources: [IsExternalInitTypeDefinition, RequiresUnsafeAttributeDefinition],
+            additionalSources: [IsExternalInitTypeDefinition],
             verify: Verification.Skipped,
             expectedUnsafeSymbols: ["C.P2", "C.get_P2", "C.set_P2"],
             expectedSafeSymbols: ["C.P1", "C.get_P1", "C.set_P1"],
@@ -6048,7 +6055,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 unsafe { c.P1 = c.P1 + 123; }
                 unsafe { c.P2 = c.P2 + 123; }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C.get_P1", "C.set_P2"],
             expectedSafeSymbols: ["C.P1", "C.P2", "C.get_P2", "C.set_P1"],
             expectedDiagnostics:
@@ -6061,15 +6067,15 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.P2").WithArguments("C.P2.set").WithLocation(3, 1),
             ]);
 
-        CreateCompilation([lib, RequiresUnsafeAttributeDefinition], parseOptions: TestOptions.Regular14).VerifyEmitDiagnostics(
+        CreateCompilation([lib], parseOptions: TestOptions.Regular14).VerifyEmitDiagnostics(
             // (3,21): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //     public int P1 { unsafe get; set; }
             Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(3, 21),
             // (4,26): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //     public int P2 { get; unsafe set; }
             Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(4, 26));
-        CreateCompilation([lib, RequiresUnsafeAttributeDefinition], parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics();
-        CreateCompilation([lib, RequiresUnsafeAttributeDefinition], parseOptions: TestOptions.RegularPreview).VerifyEmitDiagnostics();
+        CreateCompilation([lib], parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics();
+        CreateCompilation([lib], parseOptions: TestOptions.RegularPreview).VerifyEmitDiagnostics();
     }
 
     [Fact]
@@ -6273,7 +6279,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                     [A(P1 = 0, P2 = 0, P3 = 0, P4 = 0, F = 0)] void M2() { }
                 }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["A.P2", "A.get_P2", "A.set_P2", "A.get_P3", "A.set_P4"],
             expectedSafeSymbols: ["A.P1", "A.get_P1", "A.set_P1", "A.set_P3", "A.get_P4", "A.F"],
             expectedDiagnostics:
@@ -6325,7 +6330,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                     unsafe public override int P3 { get; set; }
                 }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["B.P1", "B.get_P1", "B.set_P1", "B.get_P2"],
             expectedSafeSymbols: ["B.P2", "B.set_P2", "B.P3", "B.get_P3", "B.set_P3"],
             expectedDiagnostics:
@@ -6422,7 +6426,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                     unsafe public int P3 { get; set; }
                 }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["I.P1", "I.get_P1", "I.set_P1", "I.get_P2"],
             expectedSafeSymbols: ["I.P2", "I.set_P2", "I.P3", "I.get_P3", "I.set_P3"],
             expectedDiagnostics:
@@ -6499,7 +6502,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 c2[0] = c2[0] + 123;
                 unsafe { c2[0] = c2[0] + 123; }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C2.this[]", "C2.get_Item", "C2.set_Item"],
             expectedSafeSymbols: ["C1.this[]", "C1.get_Item", "C1.set_Item"],
             expectedDiagnostics:
@@ -6528,7 +6530,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 c[0] += 123;
                 unsafe { c[0] += 123; }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C.this[]", "C.get_Item", "C.set_Item"],
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
@@ -6561,7 +6562,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 unsafe { _ = new C2 { [0] = null, [0] = { } }; }
                 unsafe { _ = new C3 { [0] = null, [0] = { } }; }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C1.this[]", "C1.get_Item", "C1.set_Item", "C2.get_Item", "C3.set_Item"],
             expectedSafeSymbols: ["C1", "C2", "C2.this[]", "C2.set_Item", "C3", "C3.this[]", "C3.get_Item", "C4", "C4.this[]", "C4.get_Item", "C4.set_Item"],
             expectedDiagnostics:
@@ -6605,7 +6605,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 unsafe { c1[0] = c1[0] + 123; }
                 unsafe { c2[0] = c2[0] + 123; }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C1.get_Item", "C2.set_Item"],
             expectedSafeSymbols: ["C1.this[]", "C2.this[]", "C2.get_Item", "C1.set_Item"],
             expectedDiagnostics:
@@ -6618,15 +6617,15 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c2[0]").WithArguments("C2.this[int].set").WithLocation(4, 1),
             ]);
 
-        CreateCompilation([lib, RequiresUnsafeAttributeDefinition], parseOptions: TestOptions.Regular14).VerifyEmitDiagnostics(
+        CreateCompilation([lib], parseOptions: TestOptions.Regular14).VerifyEmitDiagnostics(
             // (3,30): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //     public int this[int i] { unsafe get => i; set { } }
             Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(3, 30),
             // (7,40): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //     public int this[int i] { get => i; unsafe set { } }
             Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(7, 40));
-        CreateCompilation([lib, RequiresUnsafeAttributeDefinition], parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics();
-        CreateCompilation([lib, RequiresUnsafeAttributeDefinition], parseOptions: TestOptions.RegularPreview).VerifyEmitDiagnostics();
+        CreateCompilation([lib], parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics();
+        CreateCompilation([lib], parseOptions: TestOptions.RegularPreview).VerifyEmitDiagnostics();
     }
 
     [Fact]
@@ -6803,7 +6802,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 c.E2 += null;
                 unsafe { c.E2 += null; }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C.E2", "C.add_E2", "C.remove_E2"],
             expectedSafeSymbols: ["C.E1", "C.add_E1", "C.remove_E1"],
             expectedDiagnostics:
@@ -6837,7 +6835,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 }
             }
             """;
-        CreateCompilation([source, RequiresUnsafeAttributeDefinition],
+        CreateCompilation([source],
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
             // (9,9): error CS9362: 'C.E3' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
@@ -6933,7 +6931,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                     public override event System.Action E4 { add { } remove { } }
                 }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["B.E1", "B.add_E1", "B.remove_E1", "B.E2", "B.add_E2", "B.remove_E2"],
             expectedSafeSymbols: ["B.E3", "B.add_E3", "B.remove_E3", "B.E4", "B.add_E4", "B.remove_E4"],
             expectedDiagnostics:
@@ -7016,7 +7013,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                     public event System.Action E2 { add { } remove { } }
                 }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["I.E1", "I.add_E1", "I.remove_E1"],
             expectedSafeSymbols: ["I.E2", "I.add_E2", "I.remove_E2"],
             expectedDiagnostics:
@@ -7072,7 +7068,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 _ = new C3();
                 unsafe { _ = new C3(); }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: [Overload("C..ctor", parameterCount: 0)],
             expectedSafeSymbols: ["C", Overload("C..ctor", parameterCount: 1), "C2", "C2..ctor"],
             expectedDiagnostics:
@@ -7128,7 +7123,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                     unsafe public C5(int x) : base() { }
                 }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["B..ctor"],
             expectedSafeSymbols: ["B"],
             expectedDiagnostics:
@@ -7170,7 +7164,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 unsafe public C(int[] a) : this(0) { }
             }
             """;
-        CreateCompilation([source, RequiresUnsafeAttributeDefinition],
+        CreateCompilation([source],
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
             // (6,19): error CS9362: 'C.C(int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
@@ -7192,7 +7186,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             caller: """
                 _ = C.F;
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             optionsDll: TestOptions.UnsafeReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All),
             expectedUnsafeSymbols: [],
             expectedSafeSymbols: ["C", "C..cctor"],
@@ -7217,7 +7210,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 unsafe { [A] void M3() { } }
                 [A] unsafe void M4() { }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: [Overload("A..ctor", parameterCount: 0)],
             expectedSafeSymbols: ["A", Overload("A..ctor", parameterCount: 1)],
             expectedDiagnostics:
@@ -7249,7 +7241,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 unsafe { _ = new D<C>(); }
                 unsafe { _ = new X(); }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C..ctor"],
             expectedSafeSymbols: ["C", "C.M", "D", "D..ctor"],
             expectedDiagnostics:
@@ -7293,7 +7284,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                     }
                 }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C..ctor"],
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
@@ -7331,7 +7321,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 static void M1<T1, T2, T3>() where T2 : new() { }
                 static void M2<T1, T2, T3>(T1 t1, T2 t2, T3 t3) where T1 : new() where T3 : new() { }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C..ctor"],
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
@@ -7374,7 +7363,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 M<C2>();
                 static void M<T>() where T : new() { }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: [Overload("C1..ctor", parameterCount: 1), "C2..ctor"],
             expectedSafeSymbols: ["C1", Overload("C1..ctor", parameterCount: 0), "C2"],
             expectedDiagnostics:
@@ -7416,7 +7404,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 class D1<T> where T : new() { public static void M1() { } }
                 class D2<T> where T : new() { public static void M2() { } }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C..ctor"],
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
@@ -7454,7 +7441,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 N.D<C> x = new N.D<C>();
                 unsafe { N.D<C> y = new N.D<C>(); }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C..ctor"],
             expectedSafeSymbols: ["C", "N.D", "N.D..ctor"],
             expectedDiagnostics:
@@ -7486,7 +7472,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 D<C>.Nested x = new D<C>.Nested();
                 unsafe { D<C>.Nested y = new D<C>.Nested(); }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C..ctor"],
             expectedSafeSymbols: ["C", "D", "D..ctor", "D.Nested", "D.Nested..ctor"],
             expectedDiagnostics:
@@ -7518,7 +7503,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 D.Nested<C> x = new D.Nested<C>();
                 unsafe { D.Nested<C> y = new D.Nested<C>(); }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C..ctor"],
             expectedSafeSymbols: ["C", "D", "D..ctor", "D.Nested", "D.Nested..ctor"],
             expectedDiagnostics:
@@ -7556,7 +7540,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
                 class X { S<C> f; }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C..ctor"],
             expectedSafeSymbols: ["C", "S", "S..ctor"],
             expectedDiagnostics:
@@ -7619,7 +7602,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                     ~D() { } // implicitly calls base finalizer
                 }
                 """,
-                RequiresUnsafeAttributeDefinition,
             ],
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
@@ -7630,7 +7612,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         VerifyRequiresUnsafeAttribute(
             comp.SourceModule,
             expectedUnsafeSymbols: [],
-            expectedSafeSymbols: ["C.Finalize"]);
+            expectedSafeSymbols: ["C.Finalize"],
+            includesAttributeDefinition: false);
     }
 
     [Fact]
@@ -7650,7 +7633,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 _ = c - c;
                 unsafe { _ = c - c; }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C.op_Subtraction"],
             expectedSafeSymbols: ["C.op_Addition"],
             expectedDiagnostics:
@@ -7685,7 +7667,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 unsafe { _ = c - c; }
                 unsafe { E.op_Subtraction(c, c); }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["E.op_Subtraction", ExtensionMember("E", "op_Subtraction")],
             expectedSafeSymbols: ["E.op_Addition", ExtensionMember("E", "op_Addition")],
             expectedDiagnostics:
@@ -7716,7 +7697,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 c -= c;
                 unsafe { c -= c; }
                 """,
-            additionalSources: [CompilerFeatureRequiredAttribute, RequiresUnsafeAttributeDefinition],
+            additionalSources: [CompilerFeatureRequiredAttribute],
             expectedUnsafeSymbols: ["C.op_SubtractionAssignment"],
             expectedSafeSymbols: ["C.op_AdditionAssignment"],
             expectedDiagnostics:
@@ -7751,7 +7732,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 unsafe { c -= c; }
                 unsafe { E.op_SubtractionAssignment(c, c); }
                 """,
-            additionalSources: [CompilerFeatureRequiredAttribute, RequiresUnsafeAttributeDefinition],
+            additionalSources: [CompilerFeatureRequiredAttribute],
             expectedUnsafeSymbols: ["E.op_SubtractionAssignment", ExtensionMember("E", "op_SubtractionAssignment")],
             expectedSafeSymbols: ["E.op_AdditionAssignment", ExtensionMember("E", "op_AdditionAssignment")],
             expectedDiagnostics:
@@ -7782,7 +7763,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 c--;
                 unsafe { c--; }
                 """,
-            additionalSources: [CompilerFeatureRequiredAttribute, RequiresUnsafeAttributeDefinition],
+            additionalSources: [CompilerFeatureRequiredAttribute],
             expectedUnsafeSymbols: ["C.op_DecrementAssignment"],
             expectedSafeSymbols: ["C.op_IncrementAssignment"],
             expectedDiagnostics:
@@ -7810,7 +7791,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 string s = c;
                 unsafe { string s2 = c; }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: [OverloadByReturnType("C.op_Implicit", "System.String")],
             expectedSafeSymbols: [OverloadByReturnType("C.op_Implicit", "System.Int32")],
             expectedDiagnostics:
@@ -7859,7 +7839,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 m.ReferencedAssemblySymbols.Single(a => a.Name == "lib").Modules.Single(),
                 expectedUnsafeSymbols: [],
                 expectedSafeSymbols: ["C", "C.F", (object)getFunctionPointerType, (object)getFunctionPointerMethod],
-                expectedUnsafeMode: CallerUnsafeMode.Implicit))
+                expectedUnsafeMode: CallerUnsafeMode.Implicit,
+                includesAttributeDefinition: false))
             .VerifyDiagnostics();
 
         CreateCompilation(source,
@@ -7926,7 +7907,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                     int F2 = C.M();
                 }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C.M"],
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
@@ -8008,7 +7988,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 m.ReferencedAssemblySymbols.Single(a => a.Name == "lib").Modules.Single(),
                 expectedUnsafeSymbols: ["C.M2"],
                 expectedSafeSymbols: ["C", "C.M1"],
-                expectedUnsafeMode: CallerUnsafeMode.Implicit))
+                expectedUnsafeMode: CallerUnsafeMode.Implicit,
+                includesAttributeDefinition: false))
             .VerifyDiagnostics();
 
         CreateCompilation(source,
@@ -8078,7 +8059,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 m.ReferencedAssemblySymbols.Single(a => a.Name == "lib").Modules.Single(),
                 expectedUnsafeSymbols: ["C.M2"],
                 expectedSafeSymbols: ["C", "C.M1"],
-                expectedUnsafeMode: CallerUnsafeMode.Implicit))
+                expectedUnsafeMode: CallerUnsafeMode.Implicit,
+                includesAttributeDefinition: false))
             .VerifyDiagnostics();
 
         CreateCompilation(source,
@@ -8141,7 +8123,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 module.ReferencedAssemblySymbols.Single(a => a.Name == "lib").Modules.Single(),
                 expectedUnsafeSymbols: [],
                 expectedSafeSymbols: ["C", "I", "C.M", "D"],
-                expectedUnsafeMode: CallerUnsafeMode.Implicit);
+                expectedUnsafeMode: CallerUnsafeMode.Implicit,
+                includesAttributeDefinition: false);
         }
     }
 
@@ -8182,7 +8165,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             VerifyRequiresUnsafeAttribute(
                 module.ReferencedAssemblySymbols.Single(a => a.Name == "lib").Modules.Single(),
                 expectedUnsafeSymbols: [],
-                expectedSafeSymbols: ["C", "C.M", "I"]);
+                expectedSafeSymbols: ["C", "C.M", "I"],
+                includesAttributeDefinition: false);
         }
     }
 
@@ -8234,7 +8218,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 m.ReferencedAssemblySymbols.Single(a => a.Name == "lib").Modules.Single(),
                 expectedUnsafeSymbols: ["E.M2"],
                 expectedSafeSymbols: ["E", "E.M1"],
-                expectedUnsafeMode: CallerUnsafeMode.Implicit))
+                expectedUnsafeMode: CallerUnsafeMode.Implicit,
+                includesAttributeDefinition: false))
             .VerifyDiagnostics();
 
         CreateCompilation(source,
@@ -8325,7 +8310,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 m.ReferencedAssemblySymbols.Single(a => a.Name == "lib").Modules.Single(),
                 expectedUnsafeSymbols: ["E.M2", ExtensionMember("E", "M2")],
                 expectedSafeSymbols: ["E", "E.M1", ExtensionMember("E", "M1")],
-                expectedUnsafeMode: CallerUnsafeMode.Implicit))
+                expectedUnsafeMode: CallerUnsafeMode.Implicit,
+                includesAttributeDefinition: false))
             .VerifyDiagnostics();
 
         CreateCompilation(source,
@@ -8415,7 +8401,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             }
 
             class D3 : C;
-            """, RequiresUnsafeAttributeDefinition],
+            """],
             [libRef],
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
@@ -8519,7 +8505,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             }
             """;
 
-        CreateCompilation([source, RequiresUnsafeAttributeDefinition],
+        CreateCompilation([source],
             [libRef],
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
@@ -8604,7 +8590,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             }
             """;
 
-        CreateCompilation([source, RequiresUnsafeAttributeDefinition],
+        CreateCompilation([source],
             [libRef],
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
@@ -8716,7 +8702,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 m.ReferencedAssemblySymbols.Single(a => a.Name == "lib").Modules.Single(),
                 expectedUnsafeSymbols: ["C.P2", "C.get_P2", "C.set_P2"],
                 expectedSafeSymbols: ["C", "C.P1", "C.get_P1", "C.set_P1"],
-                expectedUnsafeMode: CallerUnsafeMode.Implicit))
+                expectedUnsafeMode: CallerUnsafeMode.Implicit,
+                includesAttributeDefinition: false))
             .VerifyDiagnostics();
 
         CreateCompilation(source,
@@ -8809,7 +8796,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 m.ReferencedAssemblySymbols.Single(a => a.Name == "lib").Modules.Single(),
                 expectedUnsafeSymbols: [ExtensionMember("E", "P2"), "E.get_P2", ExtensionMember("E", "get_P2"), "E.set_P2", ExtensionMember("E", "set_P2")],
                 expectedSafeSymbols: ["E", ExtensionMember("E", "P1"), "E.get_P1", ExtensionMember("E", "get_P1"), "E.set_P1", ExtensionMember("E", "set_P1")],
-                expectedUnsafeMode: CallerUnsafeMode.Implicit))
+                expectedUnsafeMode: CallerUnsafeMode.Implicit,
+                includesAttributeDefinition: false))
             .VerifyDiagnostics();
 
         CreateCompilation(source,
@@ -8906,7 +8894,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 m.ReferencedAssemblySymbols.Single(a => a.Name == "lib").Modules.Single(),
                 expectedUnsafeSymbols: ["C2.this[]", "C2.get_Item", "C2.set_Item"],
                 expectedSafeSymbols: ["C1", "C2", "C1.this[]", "C1.get_Item", "C1.set_Item"],
-                expectedUnsafeMode: CallerUnsafeMode.Implicit))
+                expectedUnsafeMode: CallerUnsafeMode.Implicit,
+                includesAttributeDefinition: false))
             .VerifyDiagnostics();
 
         CreateCompilation(source,
@@ -8979,7 +8968,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 m.ReferencedAssemblySymbols.Single(a => a.Name == "lib").Modules.Single(),
                 expectedUnsafeSymbols: ["C.E2", "C.add_E2", "C.remove_E2"],
                 expectedSafeSymbols: ["C", "C.E1", "C.add_E1", "C.remove_E1"],
-                expectedUnsafeMode: CallerUnsafeMode.Implicit))
+                expectedUnsafeMode: CallerUnsafeMode.Implicit,
+                includesAttributeDefinition: false))
             .VerifyDiagnostics();
 
         CreateCompilation(source,
@@ -9042,7 +9032,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 m.ReferencedAssemblySymbols.Single(a => a.Name == "lib").Modules.Single(),
                 expectedUnsafeSymbols: [Overload("C..ctor", parameterCount: 1)],
                 expectedSafeSymbols: ["C", Overload("C..ctor", parameterCount: 0)],
-                expectedUnsafeMode: CallerUnsafeMode.Implicit))
+                expectedUnsafeMode: CallerUnsafeMode.Implicit,
+                includesAttributeDefinition: false))
             .VerifyDiagnostics();
 
         CreateCompilation(source,
@@ -9114,7 +9105,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 m.ReferencedAssemblySymbols.Single(a => a.Name == "lib").Modules.Single(),
                 expectedUnsafeSymbols: ["C.op_SubtractionAssignment"],
                 expectedSafeSymbols: ["C", "C.op_AdditionAssignment"],
-                expectedUnsafeMode: CallerUnsafeMode.Implicit))
+                expectedUnsafeMode: CallerUnsafeMode.Implicit,
+                includesAttributeDefinition: false))
             .VerifyDiagnostics();
 
         // https://github.com/dotnet/roslyn/issues/81967: operator invocations involving pointers are allowed outside unsafe context
@@ -9167,7 +9159,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CompileAndVerifyUnsafe(
             libSource,
             callerSource,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             verify: Verification.Skipped,
             expectedUnsafeSymbols: unsafeSymbols,
             expectedSafeSymbols: ["C", "C.M1"],
@@ -9175,26 +9166,14 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         CreateCompilation([libSource, callerSource],
             options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules())
-            .VerifyDiagnostics(
-            [
-                .. commonDiagnostics,
-                // (8,12): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
-                //     public extern void M2();
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "extern").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(8, 12),
-                // (9,39): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
-                //     [DllImport("test")] public static extern void M3();
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "extern").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(9, 39),
-                // (10,57): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
-                //     [MethodImpl(MethodImplOptions.InternalCall)] public extern void M4();
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "extern").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(10, 57),
-            ]);
+            .VerifyDiagnostics(commonDiagnostics);
 
-        CreateCompilation([libSource, RequiresUnsafeAttributeDefinition],
+        CreateCompilation([libSource],
             parseOptions: TestOptions.RegularNext,
             options: TestOptions.ReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyEmitDiagnostics();
 
-        CreateCompilation([libSource, RequiresUnsafeAttributeDefinition],
+        CreateCompilation([libSource],
             parseOptions: TestOptions.Regular14,
             options: TestOptions.ReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
@@ -9227,7 +9206,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             """;
 
         var libUpdated = CreateCompilation(
-            [getLibSource("extern"), RequiresUnsafeAttributeDefinition],
+            [getLibSource("extern")],
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics();
 
@@ -9247,7 +9226,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             VerifyRequiresUnsafeAttribute(
                 libAssemblySymbol.Modules.Single(),
                 expectedUnsafeSymbols: ["C.M"],
-                expectedSafeSymbols: ["C"]);
+                expectedSafeSymbols: ["C"],
+                includesAttributeDefinition: !useCompilationReference,
+                isSynthesized: !useCompilationReference ? true : null);
         }
 
         CreateCompilation(getLibSource("extern")).VerifyDiagnostics();
@@ -9286,7 +9267,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 libAssemblySymbol.Modules.Single(),
                 expectedUnsafeSymbols: ["C.M"],
                 expectedSafeSymbols: ["C"],
-                expectedUnsafeMode: CallerUnsafeMode.Implicit);
+                expectedUnsafeMode: CallerUnsafeMode.Implicit,
+                includesAttributeDefinition: false);
         }
     }
 
@@ -9305,7 +9287,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 var c = new C();
                 c.M();
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             verify: Verification.Skipped,
             expectedUnsafeSymbols: ["C.M"],
             expectedSafeSymbols: ["C"],
@@ -9384,7 +9365,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
                 class D4 : C;
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             verify: Verification.Skipped,
             expectedUnsafeSymbols: unsafeSymbols,
             expectedSafeSymbols: ["B", "B.M4", "B.M5", "B.M6"],
@@ -9648,7 +9628,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                     extern void I.M2();
                 }
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             targetFramework: TargetFramework.Net100,
             verify: Verification.Skipped,
             expectedUnsafeSymbols: ["I.M1"],
@@ -9724,7 +9703,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CompileAndVerifyUnsafe(
             libSource,
             callerSource,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             optionsDll: TestOptions.UnsafeReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All),
             verify: Verification.Skipped,
             expectedUnsafeSymbols: unsafeSymbols,
@@ -9734,17 +9712,14 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         CreateCompilation([libSource, callerSource],
             options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules())
-            .VerifyDiagnostics(
-            // (7,16): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
-            //         static extern void F();
-            Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "extern").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(7, 16));
+            .VerifyDiagnostics();
 
-        CreateCompilation([libSource, RequiresUnsafeAttributeDefinition],
+        CreateCompilation([libSource],
             parseOptions: TestOptions.RegularNext,
             options: TestOptions.ReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyEmitDiagnostics();
 
-        CreateCompilation([libSource, RequiresUnsafeAttributeDefinition],
+        CreateCompilation([libSource],
             parseOptions: TestOptions.Regular14,
             options: TestOptions.ReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
@@ -9803,7 +9778,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CompileAndVerifyUnsafe(
             libSource,
             callerSource,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             verify: Verification.Skipped,
             expectedUnsafeSymbols: unsafeSymbols,
             expectedSafeSymbols: ["C", "C.P1", "C.set_P1"],
@@ -9811,34 +9785,14 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         CreateCompilation([libSource, callerSource],
             options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules())
-            .VerifyDiagnostics([
-                .. commonDiagnostics,
-                // (8,12): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
-                //     public extern int P2 { set; }
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "extern").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(8, 12),
-                // (8,28): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
-                //     public extern int P2 { set; }
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "set").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(8, 28),
-                // (9,19): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
-                //     public static extern int P3 { [DllImport("test")] set; }
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "extern").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(9, 19),
-                // (9,55): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
-                //     public static extern int P3 { [DllImport("test")] set; }
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "set").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(9, 55),
-                // (10,12): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
-                //     public extern int P4 { [MethodImpl(MethodImplOptions.InternalCall)] set; }
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "extern").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(10, 12),
-                // (10,73): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
-                //     public extern int P4 { [MethodImpl(MethodImplOptions.InternalCall)] set; }
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "set").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(10, 73),
-            ]);
+            .VerifyDiagnostics(commonDiagnostics);
 
-        CreateCompilation([libSource, RequiresUnsafeAttributeDefinition],
+        CreateCompilation([libSource],
             parseOptions: TestOptions.RegularNext,
             options: TestOptions.ReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyEmitDiagnostics();
 
-        CreateCompilation([libSource, RequiresUnsafeAttributeDefinition],
+        CreateCompilation([libSource],
             parseOptions: TestOptions.Regular14,
             options: TestOptions.ReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
@@ -9871,7 +9825,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             """;
 
         var libUpdated = CreateCompilation(
-            [getLibSource("extern"), RequiresUnsafeAttributeDefinition],
+            [getLibSource("extern")],
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics();
 
@@ -9891,7 +9845,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             VerifyRequiresUnsafeAttribute(
                 libAssemblySymbol.Modules.Single(),
                 expectedUnsafeSymbols: ["C.P", "C.set_P"],
-                expectedSafeSymbols: ["C"]);
+                expectedSafeSymbols: ["C"],
+                includesAttributeDefinition: !useCompilationReference,
+                isSynthesized: !useCompilationReference ? true : null);
         }
 
         CreateCompilation(getLibSource("extern")).VerifyDiagnostics();
@@ -9930,7 +9886,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 libAssemblySymbol.Modules.Single(),
                 expectedUnsafeSymbols: ["C.P", "C.set_P"],
                 expectedSafeSymbols: ["C"],
-                expectedUnsafeMode: CallerUnsafeMode.Implicit);
+                expectedUnsafeMode: CallerUnsafeMode.Implicit,
+                includesAttributeDefinition: false);
         }
     }
 
@@ -9951,7 +9908,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 c.P1 = 0;
                 c.P2 = 0;
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             verify: Verification.Skipped,
             expectedUnsafeSymbols: ["C.P1", "C.set_P1", "C.P2", "C.set_P2"],
             expectedSafeSymbols: ["C"],
@@ -9997,7 +9953,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CompileAndVerifyUnsafe(
             libSource,
             callerSource,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             verify: Verification.Skipped,
             expectedUnsafeSymbols: unsafeSymbols,
             expectedSafeSymbols: ["C"],
@@ -10005,26 +9960,14 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         CreateCompilation([libSource, callerSource],
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
-            .VerifyDiagnostics(
-            [
-                .. commonDiagnostics,
-                // (4,12): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
-                //     public extern int this[int i] { get; set; }
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "extern").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(4, 12),
-                // (4,37): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
-                //     public extern int this[int i] { get; set; }
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "get").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(4, 37),
-                // (4,42): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
-                //     public extern int this[int i] { get; set; }
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "set").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(4, 42),
-            ]);
+            .VerifyDiagnostics(commonDiagnostics);
 
-        CreateCompilation([libSource, RequiresUnsafeAttributeDefinition],
+        CreateCompilation([libSource],
             parseOptions: TestOptions.RegularNext,
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyEmitDiagnostics();
 
-        CreateCompilation([libSource, RequiresUnsafeAttributeDefinition],
+        CreateCompilation([libSource],
             parseOptions: TestOptions.Regular14,
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
@@ -10059,7 +10002,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             """;
 
         var libUpdated = CreateCompilation(
-            [getLibSource("extern"), RequiresUnsafeAttributeDefinition],
+            [getLibSource("extern")],
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics();
 
@@ -10084,7 +10027,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             VerifyRequiresUnsafeAttribute(
                 libAssemblySymbol.Modules.Single(),
                 expectedUnsafeSymbols: unsafeSymbols,
-                expectedSafeSymbols: ["C"]);
+                expectedSafeSymbols: ["C"],
+                includesAttributeDefinition: !useCompilationReference,
+                isSynthesized: !useCompilationReference ? true : null);
         }
 
         CreateCompilation(getLibSource("extern")).VerifyDiagnostics();
@@ -10126,7 +10071,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 libAssemblySymbol.Modules.Single(),
                 expectedUnsafeSymbols: ["C.this[]", "C.get_Item", "C.set_Item"],
                 expectedSafeSymbols: ["C"],
-                expectedUnsafeMode: CallerUnsafeMode.Implicit);
+                expectedUnsafeMode: CallerUnsafeMode.Implicit,
+                includesAttributeDefinition: false);
         }
     }
 
@@ -10149,7 +10095,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 new C1()[0] = 0;
                 new C2()[0] = 0;
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             verify: Verification.Skipped,
             expectedUnsafeSymbols: ["C1.this[]", "C1.set_Item", "C2.this[]", "C2.set_Item"],
             expectedSafeSymbols: ["C1", "C2"],
@@ -10192,7 +10137,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CompileAndVerifyUnsafe(
             libSource,
             callerSource,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             verify: Verification.Skipped,
             expectedUnsafeSymbols: unsafeSymbols,
             expectedSafeSymbols: ["C"],
@@ -10200,25 +10144,14 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         CreateCompilation([libSource, callerSource],
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
-            .VerifyDiagnostics([
-                .. commonDiagnostics,
-                // (5,46): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
-                //     public static extern event System.Action E;
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "E").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(5, 46),
-                // (5,46): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
-                //     public static extern event System.Action E;
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "E").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(5, 46),
-                // (5,46): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
-                //     public static extern event System.Action E;
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "E").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(5, 46),
-            ]);
+            .VerifyDiagnostics(commonDiagnostics);
 
-        CreateCompilation([libSource, RequiresUnsafeAttributeDefinition],
+        CreateCompilation([libSource],
             parseOptions: TestOptions.RegularNext,
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyEmitDiagnostics();
 
-        CreateCompilation([libSource, RequiresUnsafeAttributeDefinition],
+        CreateCompilation([libSource],
             parseOptions: TestOptions.Regular14,
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
@@ -10253,7 +10186,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             """;
 
         var libUpdated = CreateCompilation(
-            [libSource, RequiresUnsafeAttributeDefinition],
+            [libSource],
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics();
 
@@ -10275,7 +10208,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             VerifyRequiresUnsafeAttribute(
                 libAssemblySymbol.Modules.Single(),
                 expectedUnsafeSymbols: unsafeSymbols,
-                expectedSafeSymbols: ["C"]);
+                expectedSafeSymbols: ["C"],
+                includesAttributeDefinition: !useCompilationReference,
+                isSynthesized: !useCompilationReference ? true : null);
         }
 
         // When compiling the lib under legacy rules, extern members are not unsafe, but members with pointers are.
@@ -10301,7 +10236,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 libAssemblySymbol.Modules.Single(),
                 expectedUnsafeSymbols: ["C.E", "C.add_E", "C.remove_E"],
                 expectedSafeSymbols: ["C"],
-                expectedUnsafeMode: CallerUnsafeMode.Implicit);
+                expectedUnsafeMode: CallerUnsafeMode.Implicit,
+                includesAttributeDefinition: false);
         }
     }
 
@@ -10320,7 +10256,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 C.E += null;
                 C.E -= null;
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             verify: Verification.Skipped,
             expectedUnsafeSymbols: ["C.E", "C.add_E", "C.remove_E"],
             expectedSafeSymbols: ["C"],
@@ -10362,7 +10297,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CompileAndVerifyUnsafe(
             libSource,
             callerSource,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             verify: Verification.Skipped,
             expectedUnsafeSymbols: unsafeSymbols,
             expectedSafeSymbols: ["C"],
@@ -10370,19 +10304,14 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         CreateCompilation([libSource, callerSource],
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
-            .VerifyDiagnostics([
-                .. commonDiagnostics,
-                // (4,12): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
-                //     public extern C();
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "extern").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(4, 12),
-            ]);
+            .VerifyDiagnostics(commonDiagnostics);
 
-        CreateCompilation([libSource, RequiresUnsafeAttributeDefinition],
+        CreateCompilation([libSource],
             parseOptions: TestOptions.RegularNext,
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyEmitDiagnostics();
 
-        CreateCompilation([libSource, RequiresUnsafeAttributeDefinition],
+        CreateCompilation([libSource],
             parseOptions: TestOptions.Regular14,
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
@@ -10416,7 +10345,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             """;
 
         var libUpdated = CreateCompilation(
-            [getLibSource("extern"), RequiresUnsafeAttributeDefinition],
+            [getLibSource("extern")],
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics();
 
@@ -10436,7 +10365,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             VerifyRequiresUnsafeAttribute(
                 libAssemblySymbol.Modules.Single(),
                 expectedUnsafeSymbols: ["C..ctor"],
-                expectedSafeSymbols: ["C"]);
+                expectedSafeSymbols: ["C"],
+                includesAttributeDefinition: !useCompilationReference,
+                isSynthesized: !useCompilationReference ? true : null);
         }
 
         CreateCompilation(getLibSource("extern")).VerifyDiagnostics();
@@ -10475,7 +10406,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 libAssemblySymbol.Modules.Single(),
                 expectedUnsafeSymbols: ["C..ctor"],
                 expectedSafeSymbols: ["C"],
-                expectedUnsafeMode: CallerUnsafeMode.Implicit);
+                expectedUnsafeMode: CallerUnsafeMode.Implicit,
+                includesAttributeDefinition: false);
         }
     }
 
@@ -10493,7 +10425,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             caller: """
                 _ = new C();
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             verify: Verification.Skipped,
             expectedUnsafeSymbols: ["C..ctor"],
             expectedSafeSymbols: ["C"],
@@ -10533,7 +10464,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CompileAndVerifyUnsafe(
             libSource,
             callerSource,
-            additionalSources: [CompilerFeatureRequiredAttribute, RequiresUnsafeAttributeDefinition],
+            additionalSources: [CompilerFeatureRequiredAttribute],
             verify: Verification.Skipped,
             expectedUnsafeSymbols: unsafeSymbols,
             expectedSafeSymbols: ["C"],
@@ -10541,19 +10472,14 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         CreateCompilation([libSource, callerSource, CompilerFeatureRequiredAttribute],
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
-            .VerifyDiagnostics([
-                .. commonDiagnostics,
-                // (4,12): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
-                //     public extern void operator +=(C c);
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "extern").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(4, 12),
-            ]);
+            .VerifyDiagnostics(commonDiagnostics);
 
-        CreateCompilation([libSource, CompilerFeatureRequiredAttribute, RequiresUnsafeAttributeDefinition],
+        CreateCompilation([libSource, CompilerFeatureRequiredAttribute],
             parseOptions: TestOptions.RegularNext,
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyEmitDiagnostics();
 
-        CreateCompilation([libSource, CompilerFeatureRequiredAttribute, RequiresUnsafeAttributeDefinition],
+        CreateCompilation([libSource, CompilerFeatureRequiredAttribute],
             parseOptions: TestOptions.Regular14,
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
@@ -10588,7 +10514,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             """;
 
         var libUpdated = CreateCompilation(
-            [getLibSource("extern"), CompilerFeatureRequiredAttribute, RequiresUnsafeAttributeDefinition],
+            [getLibSource("extern"), CompilerFeatureRequiredAttribute],
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics();
 
@@ -10608,7 +10534,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             VerifyRequiresUnsafeAttribute(
                 libAssemblySymbol.Modules.Single(),
                 expectedUnsafeSymbols: ["C.op_AdditionAssignment"],
-                expectedSafeSymbols: ["C"]);
+                expectedSafeSymbols: ["C"],
+                includesAttributeDefinition: !useCompilationReference,
+                isSynthesized: !useCompilationReference ? true : null);
         }
 
         CreateCompilation([getLibSource("extern"), CompilerFeatureRequiredAttribute]).VerifyDiagnostics();
@@ -10647,7 +10575,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 libAssemblySymbol.Modules.Single(),
                 expectedUnsafeSymbols: ["C.op_AdditionAssignment"],
                 expectedSafeSymbols: ["C"],
-                expectedUnsafeMode: CallerUnsafeMode.Implicit);
+                expectedUnsafeMode: CallerUnsafeMode.Implicit,
+                includesAttributeDefinition: false);
         }
     }
 
@@ -10666,7 +10595,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 var c = new C();
                 c += null;
                 """,
-            additionalSources: [CompilerFeatureRequiredAttribute, RequiresUnsafeAttributeDefinition],
+            additionalSources: [CompilerFeatureRequiredAttribute],
             verify: Verification.Skipped,
             expectedUnsafeSymbols: ["C.op_AdditionAssignment"],
             expectedSafeSymbols: ["C"],
@@ -10679,7 +10608,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
     }
 
     [Fact]
-    public void RequiresUnsafeAttribute_NotSynthesized()
+    public void RequiresUnsafeAttribute_Synthesized()
     {
         var source = """
             public class C
@@ -10696,49 +10625,31 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 symbolValidator: m => VerifyRequiresUnsafeAttribute(
                     m,
                     expectedUnsafeSymbols: [],
-                    expectedSafeSymbols: ["C", "C.M"]))
+                    expectedSafeSymbols: ["C", "C.M"],
+                    includesAttributeDefinition: false))
                 .VerifyDiagnostics();
         }
 
         foreach (var parseOptions in new[] { TestOptions.RegularPreview, TestOptions.RegularNext })
         {
-            CompileAndVerify([source, RequiresUnsafeAttributeDefinition],
+            CompileAndVerify(source,
                 parseOptions: parseOptions,
                 options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules(),
                 symbolValidator: m => VerifyRequiresUnsafeAttribute(
                     m,
                     expectedUnsafeSymbols: ["C.M"],
-                    expectedSafeSymbols: ["C"]))
+                    expectedSafeSymbols: ["C"],
+                    includesAttributeDefinition: true,
+                    isSynthesized: true))
                 .VerifyDiagnostics();
         }
-
-        CreateCompilation([source, RequiresUnsafeAttributeDefinition],
-            parseOptions: TestOptions.Regular14,
-            options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
-            .VerifyDiagnostics(
-            // (1,1): error CS9274: 'MemorySafetyRules' version '2' is not available in C# 14.0. Please use language version 'preview' or greater.
-            Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1));
 
         CreateCompilation(source,
             parseOptions: TestOptions.Regular14,
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
             // (1,1): error CS9274: 'MemorySafetyRules' version '2' is not available in C# 14.0. Please use language version 'preview' or greater.
-            Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
-            // (3,12): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
-            // public unsafe void M() { }
-            Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "unsafe").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(3, 12));
-
-        foreach (var parseOptions in new[] { TestOptions.RegularPreview, TestOptions.RegularNext })
-        {
-            CreateCompilation(source,
-                parseOptions: parseOptions,
-                options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
-                .VerifyDiagnostics(
-                // (3,12): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
-                // public unsafe void M() { }
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "unsafe").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(3, 12));
-        }
+            Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1));
     }
 
     [Fact]
@@ -10759,7 +10670,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 }
             }
             """;
-        var refA = CreateCompilation([sourceA, RequiresUnsafeAttributeDefinition],
+        var refA = CreateCompilation([sourceA],
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics()
             .EmitToImageReference();
@@ -10799,7 +10710,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             symbolValidator: m => VerifyRequiresUnsafeAttribute(
                 m,
                 expectedUnsafeSymbols: [],
-                expectedSafeSymbols: ["C", "C.M"]))
+                expectedSafeSymbols: ["C", "C.M"],
+                includesAttributeDefinition: false))
             .VerifyDiagnostics();
 
         CompileAndVerify([source, RequiresUnsafeAttributeDefinition],
@@ -10807,7 +10719,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             symbolValidator: m => VerifyRequiresUnsafeAttribute(
                 m,
                 expectedUnsafeSymbols: ["C.M"],
-                expectedSafeSymbols: ["C"]))
+                expectedSafeSymbols: ["C"],
+                includesAttributeDefinition: true,
+                isSynthesized: false))
             .VerifyDiagnostics();
     }
 
@@ -10819,7 +10733,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             symbolValidator: m => VerifyRequiresUnsafeAttribute(
                 m,
                 expectedUnsafeSymbols: [],
-                expectedSafeSymbols: [AttributeDescription.RequiresUnsafeAttribute.FullName]))
+                expectedSafeSymbols: [AttributeDescription.RequiresUnsafeAttribute.FullName],
+                includesAttributeDefinition: true,
+                isSynthesized: false))
             .VerifyDiagnostics();
         var ref1 = AsReference(comp, useCompilationReference);
 
@@ -10835,7 +10751,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             symbolValidator: m => VerifyRequiresUnsafeAttribute(
                 m,
                 expectedUnsafeSymbols: ["C.M"],
-                expectedSafeSymbols: ["C"]))
+                expectedSafeSymbols: ["C"],
+                includesAttributeDefinition: false))
             .VerifyDiagnostics();
     }
 
@@ -10855,13 +10772,16 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             }
             """;
 
-        // Ambiguous attribute definitions from references.
-        CreateCompilation(source, [ref1, ref2],
-            options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
-            .VerifyEmitDiagnostics(
-            // (3,5): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
-            //     unsafe public void M() { }
-            Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "unsafe").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(3, 5));
+        // Ambiguous attribute definitions from references, but the compiler synthesizes its own.
+        CompileAndVerify(source, [ref1, ref2],
+            options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules(),
+            symbolValidator: m => VerifyRequiresUnsafeAttribute(
+                m,
+                expectedUnsafeSymbols: ["C.M"],
+                expectedSafeSymbols: ["C"],
+                includesAttributeDefinition: true,
+                isSynthesized: true))
+            .VerifyDiagnostics();
 
         // Also defined in source.
         var lib = CreateCompilation([source, RequiresUnsafeAttributeDefinition], [ref1, ref2],
@@ -11250,7 +11170,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 c.M1();
                 c.M2();
                 """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: ["C.M1", "C.M2"],
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
@@ -11273,7 +11192,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                     unsafe public partial int M() => 0;
                 }
                 """,
-                RequiresUnsafeAttributeDefinition,
             ],
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics();

--- a/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests.cs
@@ -6,7 +6,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Reflection.Metadata;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -30,8 +32,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         ReadOnlySpan<string> additionalSources = default,
         Verification verify = default,
         CallerUnsafeMode expectedUnsafeMode = CallerUnsafeMode.Explicit,
-        object[]? expectedNoAttributeInSource = null,
-        object[]? expectedNoAttributeUnderLegacyRules = null,
         object[]? skipSymbolsInSource = null,
         CSharpParseOptions? parseOptions = null,
         CSharpCompilationOptions? optionsDll = null,
@@ -62,7 +62,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             CreateCompilation([lib, caller, .. additionalSources],
                 targetFramework: targetFramework,
                 parseOptions: TestOptions.Regular14,
-                options: optionsExe.AddSpecificDiagnosticOptions(GetIdForErrorCode(ErrorCode.WRN_RequiresUnsafeAttributeLegacyRules), ReportDiagnostic.Suppress))
+                options: optionsExe)
                 .VerifyDiagnostics(expectedDiagnosticsWithOldLangVersion);
         }
 
@@ -91,25 +91,27 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             CreateCompilation(caller, [libUpdatedRef],
                 targetFramework: targetFramework,
                 parseOptions: parseOptions,
-                options: optionsExe.AddSpecificDiagnosticOptions(GetIdForErrorCode(ErrorCode.WRN_RequiresUnsafeAttributeLegacyRules), ReportDiagnostic.Suppress))
+                options: optionsExe)
                 .VerifyDiagnostics(expectedDiagnosticsForLegacyCaller ?? []);
         }
 
         var libLegacy = CompileAndVerify([lib, .. additionalSources],
             targetFramework: targetFramework,
             parseOptions: parseOptions,
-            options: optionsDll.AddSpecificDiagnosticOptions(GetIdForErrorCode(ErrorCode.WRN_RequiresUnsafeAttributeLegacyRules), ReportDiagnostic.Suppress),
+            options: optionsDll,
             verify: verify,
             symbolValidator: module =>
             {
                 VerifyMemorySafetyRulesAttribute(module, includesAttributeDefinition: false, includesAttributeUse: false);
+                // Under legacy rules, `unsafe` keyword does not make members requires-unsafe.
                 VerifyRequiresUnsafeAttribute(
                     module,
-                    expectedUnsafeSymbols: expectedUnsafeSymbols,
-                    expectedSafeSymbols: expectedSafeSymbols,
-                    expectedNoAttributeInSource: expectedNoAttributeInSource,
-                    expectedNoAttribute: expectedNoAttributeUnderLegacyRules,
-                    expectedUnsafeMode: CallerUnsafeMode.None);
+                    expectedUnsafeSymbols: [],
+                    expectedSafeSymbols:
+                    [
+                        .. skipSymbolsInSource is [..] ? expectedUnsafeSymbols.Except(skipSymbolsInSource).ToArray() : expectedUnsafeSymbols,
+                        .. skipSymbolsInSource is [..] ? expectedSafeSymbols.Except(skipSymbolsInSource).ToArray() : expectedSafeSymbols,
+                    ]);
             })
             .VerifyDiagnostics()
             .GetImageReference();
@@ -124,7 +126,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CreateCompilation(caller, [libLegacy],
             targetFramework: targetFramework,
             parseOptions: parseOptions,
-            options: optionsExe.AddSpecificDiagnosticOptions(GetIdForErrorCode(ErrorCode.WRN_RequiresUnsafeAttributeLegacyRules), ReportDiagnostic.Suppress))
+            options: optionsExe)
             .VerifyEmitDiagnostics(expectedDiagnosticsForLegacyCaller ?? []);
 
         void symbolValidator(ModuleSymbol module)
@@ -139,7 +141,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 module,
                 expectedUnsafeSymbols: exceptSymbolsSkippedInSource(expectedUnsafeSymbols),
                 expectedSafeSymbols: exceptSymbolsSkippedInSource(expectedSafeSymbols),
-                expectedNoAttributeInSource: exceptSymbolsSkippedInSource(expectedNoAttributeInSource),
                 expectedUnsafeMode: expectedUnsafeMode);
 
             [return: NotNullIfNotNull(nameof(original))]
@@ -255,16 +256,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         ModuleSymbol module,
         ReadOnlySpan<object> expectedUnsafeSymbols,
         ReadOnlySpan<object> expectedSafeSymbols,
-        object[]? expectedNoAttributeInSource = null,
-        object[]? expectedNoAttribute = null,
-        object[]? expectedAttribute = null,
         CallerUnsafeMode expectedUnsafeMode = CallerUnsafeMode.Explicit)
     {
         const string Name = "RequiresUnsafeAttribute";
-
-        var expectedNoAttributeInSourceSymbols = (expectedNoAttributeInSource ?? []).SelectAsArray(getSymbol);
-        var expectedNoAttributeSymbols = (expectedNoAttribute ?? []).SelectAsArray(getSymbol);
-        var expectedAttributeSymbols = (expectedAttribute ?? []).SelectAsArray(getSymbol);
 
         var seenSymbols = new HashSet<Symbol>();
 
@@ -278,10 +272,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             verifySymbol(symbol, shouldBeUnsafe: false);
         }
 
-        Assert.All(expectedNoAttributeInSourceSymbols, s => Assert.True(seenSymbols.Contains(s)));
-        Assert.All(expectedNoAttributeSymbols, s => Assert.True(seenSymbols.Contains(s)));
-        Assert.All(expectedAttributeSymbols, s => Assert.True(seenSymbols.Contains(s)));
-
         void verifySymbol(object symbolGetter, bool shouldBeUnsafe)
         {
             var symbol = getSymbol(symbolGetter);
@@ -289,20 +279,37 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             var symbolExpectedUnsafeMode = shouldBeUnsafe ? expectedUnsafeMode : CallerUnsafeMode.None;
             Assert.True(symbolExpectedUnsafeMode == symbol.CallerUnsafeMode, $"Expected {symbol.GetType().Name} '{symbol.ToTestDisplayString()}' to have {nameof(CallerUnsafeMode)}.{symbolExpectedUnsafeMode} (got {symbol.CallerUnsafeMode}).");
 
-            var attribute = symbol.GetAttributes().SingleOrDefault(a => a.AttributeClass?.Name == Name);
-            var associatedAttribute = (symbol as MethodSymbol)?.AssociatedSymbol?.GetAttributes().SingleOrDefault(a => a.AttributeClass?.Name == Name);
-            var hasAttribute = attribute is not null || associatedAttribute is not null;
-            var shouldHaveAttribute = expectedAttributeSymbols.Contains(symbol) ||
-                (shouldBeUnsafe && expectedUnsafeMode != CallerUnsafeMode.Implicit &&
-                (module is not SourceModuleSymbol || !expectedNoAttributeInSourceSymbols.Contains(symbol)) &&
-                !expectedNoAttributeSymbols.Contains(symbol));
-            Assert.True(shouldHaveAttribute == hasAttribute,
-                $"{(shouldHaveAttribute ? "Expected" : "Did not expect")} {symbol.GetType().Name} '{symbol.ToTestDisplayString()}' or its associated symbol to have the attribute.");
+            var hasAttributeInGetAttributes = symbol.GetAttributes().Any(a => a.AttributeClass?.Name == Name);
+            Assert.False(hasAttributeInGetAttributes,
+                $"Did not expect {symbol.GetType().Name} '{symbol.ToTestDisplayString()}' to have the attribute in GetAttributes().");
+
+            // For PE symbols, the attribute should be present in raw metadata when expected.
+            if (module is PEModuleSymbol peModule)
+            {
+                verifyAttributeInMetadata(symbol, shouldBeUnsafe && expectedUnsafeMode == CallerUnsafeMode.Explicit);
+                if (symbol is PEMethodSymbol { AssociatedSymbol: Symbol associatedSymbol })
+                    verifyAttributeInMetadata(associatedSymbol, associatedSymbol.CallerUnsafeMode == CallerUnsafeMode.Explicit);
+
+                void verifyAttributeInMetadata(Symbol s, bool shouldHave)
+                {
+                    EntityHandle? handle = s switch
+                    {
+                        PEMethodSymbol m => (EntityHandle?)m.Handle,
+                        PEPropertySymbol p => p.Handle,
+                        PEEventSymbol e => e.Handle,
+                        _ => null,
+                    };
+
+                    if (handle is { } h)
+                    {
+                        var hasAttributeInMetadata = peModule.Module.HasAttribute(h, AttributeDescription.RequiresUnsafeAttribute);
+                        Assert.True(shouldHave == hasAttributeInMetadata,
+                            $"{(shouldHave ? "Expected" : "Did not expect")} {s.GetType().Name} '{s.ToTestDisplayString()}' to have the attribute in metadata.");
+                    }
+                }
+            }
 
             Assert.True(seenSymbols.Add(symbol), $"Symbol '{symbol.ToTestDisplayString()}' specified multiple times.");
-
-            Assert.True(shouldBeUnsafe || !expectedNoAttributeInSourceSymbols.Contains(symbol),
-                $"Unexpected safe '{symbol.ToTestDisplayString()}' in {nameof(expectedNoAttributeInSource)}.");
         }
 
         Symbol getSymbol(object symbolGetter)
@@ -3337,7 +3344,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         CreateCompilation([source, IsExternalInitTypeDefinition], options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
 
-        CreateCompilation([source, IsExternalInitTypeDefinition], options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules().WithWarningLevel(10)).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation([source, IsExternalInitTypeDefinition, RequiresUnsafeAttributeDefinition], options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules().WithWarningLevel(10)).VerifyDiagnostics(expectedDiagnostics);
 
         expectedDiagnostics =
         [
@@ -3349,25 +3356,55 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "D").WithLocation(12, 22),
         ];
 
-        CreateCompilation([source, IsExternalInitTypeDefinition], options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules()).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation([source, IsExternalInitTypeDefinition, RequiresUnsafeAttributeDefinition], options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules()).VerifyDiagnostics(expectedDiagnostics);
 
-        CreateCompilation([source, IsExternalInitTypeDefinition], options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules().WithWarningLevel(11)).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation([source, IsExternalInitTypeDefinition, RequiresUnsafeAttributeDefinition], options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules().WithWarningLevel(11)).VerifyDiagnostics(expectedDiagnostics);
 
-        CreateCompilation([source, IsExternalInitTypeDefinition],
+        CreateCompilation([source, IsExternalInitTypeDefinition, RequiresUnsafeAttributeDefinition],
             parseOptions: TestOptions.RegularNext,
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules()).VerifyDiagnostics(expectedDiagnostics);
 
-        CreateCompilation([source, IsExternalInitTypeDefinition],
+        CreateCompilation([source, IsExternalInitTypeDefinition, RequiresUnsafeAttributeDefinition],
             parseOptions: TestOptions.Regular14,
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules()).VerifyDiagnostics(
             // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
             Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
+            // (6,1): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            // unsafe void F() { }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(6, 1),
             // (10,13): error CS0106: The modifier 'unsafe' is not valid for this item
             // unsafe enum E { A }
             Diagnostic(ErrorCode.ERR_BadMemberFlag, "E").WithArguments("unsafe").WithLocation(10, 13),
             // (12,22): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
             // unsafe delegate void D();
-            Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "D").WithLocation(12, 22));
+            Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "D").WithLocation(12, 22),
+            // (15,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     unsafe X() { }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(15, 5),
+            // (18,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     unsafe void M() { }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(18, 5),
+            // (19,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     unsafe int P { get; set; }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(19, 5),
+            // (19,20): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     unsafe int P { get; set; }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "get").WithArguments("updated memory safety rules").WithLocation(19, 20),
+            // (19,25): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     unsafe int P { get; set; }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "set").WithArguments("updated memory safety rules").WithLocation(19, 25),
+            // (20,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     unsafe event System.Action E { add { } remove { } }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(20, 5),
+            // (20,36): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     unsafe event System.Action E { add { } remove { } }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "add").WithArguments("updated memory safety rules").WithLocation(20, 36),
+            // (20,44): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     unsafe event System.Action E { add { } remove { } }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "remove").WithArguments("updated memory safety rules").WithLocation(20, 44),
+            // (21,19): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     public static unsafe implicit operator int(X x) => 0;
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(21, 19));
     }
 
     [Fact]
@@ -3439,15 +3476,15 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             options: TestOptions.UnsafeReleaseExe)
             .VerifyEmitDiagnostics(expectedDiagnostics);
 
-        CreateCompilationWithSpan(source, options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
+        CreateCompilationWithSpan([source, RequiresUnsafeAttributeDefinition], options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyEmitDiagnostics(expectedDiagnostics);
 
-        CreateCompilationWithSpan(source,
+        CreateCompilationWithSpan([source, RequiresUnsafeAttributeDefinition],
             parseOptions: TestOptions.RegularNext,
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyEmitDiagnostics(expectedDiagnostics);
 
-        CreateCompilationWithSpan(source,
+        CreateCompilationWithSpan([source, RequiresUnsafeAttributeDefinition],
             parseOptions: TestOptions.Regular14,
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
@@ -3474,6 +3511,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             // (6,26): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
             //     void M1(X<string*[]> x) { }
             Diagnostic(ErrorCode.WRN_ManagedAddr, "x").WithArguments("string").WithLocation(6, 26),
+            // (7,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     unsafe void M2(X<string*[]> x) { }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(7, 5),
             // (7,33): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('string')
             //     unsafe void M2(X<string*[]> x) { }
             Diagnostic(ErrorCode.WRN_ManagedAddr, "x").WithArguments("string").WithLocation(7, 33));
@@ -3486,22 +3526,22 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         [
             """
             #pragma warning disable CS8321 // unused local function
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafe] void F() { }
+            unsafe void F() { }
             class C
             {
-                [System.Diagnostics.CodeAnalysis.RequiresUnsafe] void M() { }
-                [System.Diagnostics.CodeAnalysis.RequiresUnsafe] int P { get; set; }
+                unsafe void M() { }
+                unsafe int P { get; set; }
 
-                [System.Diagnostics.CodeAnalysis.RequiresUnsafe] event System.Action E { add { } remove { } }
-                [System.Diagnostics.CodeAnalysis.RequiresUnsafe] int this[int i] { get => i; set { } }
-                [System.Diagnostics.CodeAnalysis.RequiresUnsafe] C() { }
-                [System.Diagnostics.CodeAnalysis.RequiresUnsafe] public static C operator +(C c1, C c2) => c1;
-                [System.Diagnostics.CodeAnalysis.RequiresUnsafe] public void operator +=(C c) { }
+                unsafe event System.Action E { add { } remove { } }
+                unsafe int this[int i] { get => i; set { } }
+                unsafe C() { }
+                unsafe public static C operator +(C c1, C c2) => c1;
+                unsafe public void operator +=(C c) { }
             #pragma warning disable CS0169 // unused field
-                [System.Diagnostics.CodeAnalysis.RequiresUnsafe] int F;
+                unsafe int F;
             }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafe] class U;
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafe] delegate void D();
+            unsafe class U;
+            unsafe delegate void D();
             """,
             CompilerFeatureRequiredAttribute,
             """
@@ -3524,22 +3564,19 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             "C.op_Addition",
             "C.op_AdditionAssignment",
         ];
-        string[] symbolsWithAttribute = safeSymbols.Except(["C"]).Concat(unsafeSymbols).ToArray();
 
         foreach (var parseOptions in new[] { TestOptions.RegularPreview, TestOptions.RegularNext, TestOptions.Regular14 })
         {
             CompileAndVerify(source,
                 parseOptions: parseOptions,
-                options: TestOptions.UnsafeReleaseExe.WithMetadataImportOptions(MetadataImportOptions.All)
-                    .WithSpecificDiagnosticOptions(GetIdForErrorCode(ErrorCode.WRN_RequiresUnsafeAttributeLegacyRules), ReportDiagnostic.Suppress),
+                options: TestOptions.UnsafeReleaseExe.WithMetadataImportOptions(MetadataImportOptions.All),
                 symbolValidator: m =>
                 {
                     VerifyMemorySafetyRulesAttribute(m, includesAttributeDefinition: false, includesAttributeUse: false);
                     VerifyRequiresUnsafeAttribute(
                         m,
                         expectedUnsafeSymbols: [],
-                        expectedSafeSymbols: [.. safeSymbols, .. unsafeSymbols],
-                        expectedAttribute: symbolsWithAttribute);
+                        expectedSafeSymbols: [.. safeSymbols, .. unsafeSymbols]);
                 })
                 .VerifyDiagnostics();
         }
@@ -3555,10 +3592,12 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                     VerifyRequiresUnsafeAttribute(
                         m,
                         expectedUnsafeSymbols: [.. unsafeSymbols],
-                        expectedSafeSymbols: [.. safeSymbols],
-                        expectedAttribute: symbolsWithAttribute);
+                        expectedSafeSymbols: [.. safeSymbols]);
                 })
-                .VerifyDiagnostics();
+                .VerifyDiagnostics(
+                // (17,22): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+                // unsafe delegate void D();
+                Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "D").WithLocation(17, 22));
         }
 
         CreateCompilation(source,
@@ -3567,30 +3606,51 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             .VerifyDiagnostics(
             // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
             Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
-            // (2,2): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            // [System.Diagnostics.CodeAnalysis.RequiresUnsafe] void F() { }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "System.Diagnostics.CodeAnalysis.RequiresUnsafe").WithArguments("updated memory safety rules").WithLocation(2, 2),
-            // (5,6): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     [System.Diagnostics.CodeAnalysis.RequiresUnsafe] void M() { }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "System.Diagnostics.CodeAnalysis.RequiresUnsafe").WithArguments("updated memory safety rules").WithLocation(5, 6),
-            // (6,6): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     [System.Diagnostics.CodeAnalysis.RequiresUnsafe] int P { get; set; }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "System.Diagnostics.CodeAnalysis.RequiresUnsafe").WithArguments("updated memory safety rules").WithLocation(6, 6),
-            // (8,6): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     [System.Diagnostics.CodeAnalysis.RequiresUnsafe] event System.Action E { add { } remove { } }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "System.Diagnostics.CodeAnalysis.RequiresUnsafe").WithArguments("updated memory safety rules").WithLocation(8, 6),
-            // (9,6): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     [System.Diagnostics.CodeAnalysis.RequiresUnsafe] int this[int i] { get => i; set { } }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "System.Diagnostics.CodeAnalysis.RequiresUnsafe").WithArguments("updated memory safety rules").WithLocation(9, 6),
-            // (10,6): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     [System.Diagnostics.CodeAnalysis.RequiresUnsafe] C() { }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "System.Diagnostics.CodeAnalysis.RequiresUnsafe").WithArguments("updated memory safety rules").WithLocation(10, 6),
-            // (11,6): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     [System.Diagnostics.CodeAnalysis.RequiresUnsafe] public static C operator +(C c1, C c2) => c1;
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "System.Diagnostics.CodeAnalysis.RequiresUnsafe").WithArguments("updated memory safety rules").WithLocation(11, 6),
-            // (12,6): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     [System.Diagnostics.CodeAnalysis.RequiresUnsafe] public void operator +=(C c) { }
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "System.Diagnostics.CodeAnalysis.RequiresUnsafe").WithArguments("updated memory safety rules").WithLocation(12, 6));
+            // (2,1): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            // unsafe void F() { }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(2, 1),
+            // (5,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     unsafe void M() { }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(5, 5),
+            // (6,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     unsafe int P { get; set; }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(6, 5),
+            // (6,20): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     unsafe int P { get; set; }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "get").WithArguments("updated memory safety rules").WithLocation(6, 20),
+            // (6,25): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     unsafe int P { get; set; }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "set").WithArguments("updated memory safety rules").WithLocation(6, 25),
+            // (8,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     unsafe event System.Action E { add { } remove { } }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(8, 5),
+            // (8,36): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     unsafe event System.Action E { add { } remove { } }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "add").WithArguments("updated memory safety rules").WithLocation(8, 36),
+            // (8,44): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     unsafe event System.Action E { add { } remove { } }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "remove").WithArguments("updated memory safety rules").WithLocation(8, 44),
+            // (9,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     unsafe int this[int i] { get => i; set { } }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(9, 5),
+            // (9,30): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     unsafe int this[int i] { get => i; set { } }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "get").WithArguments("updated memory safety rules").WithLocation(9, 30),
+            // (9,40): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     unsafe int this[int i] { get => i; set { } }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "set").WithArguments("updated memory safety rules").WithLocation(9, 40),
+            // (10,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     unsafe C() { }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(10, 5),
+            // (11,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     unsafe public static C operator +(C c1, C c2) => c1;
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(11, 5),
+            // (12,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     unsafe public void operator +=(C c) { }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(12, 5),
+            // (17,22): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            // unsafe delegate void D();
+            Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "D").WithLocation(17, 22));
     }
 
     [Theory, CombinatorialData]
@@ -3603,15 +3663,14 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         bool callerUnsafeBlock,
         bool? compilationReference)
     {
-        var requiresUnsafeAttribute = apiUnsafe && apiUpdatedRules
-            ? "[System.Diagnostics.CodeAnalysis.RequiresUnsafe]"
+        var unsafeModifier = apiUnsafe && apiUpdatedRules
+            ? "unsafe"
             : "";
 
         var api = $$"""
             public class C
             {
-                {{requiresUnsafeAttribute}}
-                public void M() => System.Console.Write(111);
+                {{unsafeModifier}} public void M() => System.Console.Write(111);
             }
             """;
 
@@ -3628,7 +3687,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         if (compilationReference is { } useCompilationReference)
         {
             var apiCompilation = CreateCompilation(
-                [api, .. (apiUnsafe && apiUpdatedRules ? new[] { RequiresUnsafeAttributeDefinition } : [])],
+                [api, .. unsafeModifier != "" ? new[] { RequiresUnsafeAttributeDefinition } : []],
                 options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules(apiUpdatedRules))
                 .VerifyDiagnostics();
             var apiReference = AsReference(apiCompilation, useCompilationReference);
@@ -3644,7 +3703,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             }
 
             comp = CreateCompilation(
-                [api, caller, .. (apiUnsafe && apiUpdatedRules ? new[] { RequiresUnsafeAttributeDefinition } : [])],
+                [api, caller, .. unsafeModifier != "" ? new[] { RequiresUnsafeAttributeDefinition } : []],
                 parseOptions: TestOptions.Regular.WithLanguageVersion(callerLangVersion),
                 options: TestOptions.ReleaseExe.WithAllowUnsafe(callerAllowUnsafe).WithUpdatedMemorySafetyRules(callerUpdatedRules));
         }
@@ -3657,12 +3716,20 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 Diagnostic(ErrorCode.ERR_IllegalUnsafe, "unsafe").WithLocation(2, 1));
         }
 
+        if (!callerAllowUnsafe && compilationReference is null && unsafeModifier != "")
+        {
+            expectedDiagnostics.Add(
+                // (3,24): error CS0227: Unsafe code may only appear if compiling with /unsafe
+                //     unsafe public void M() => System.Console.Write(111);
+                Diagnostic(ErrorCode.ERR_IllegalUnsafe, "M").WithLocation(3, 24));
+        }
+
         if (apiUnsafe && apiUpdatedRules && callerUpdatedRules && !callerUnsafeBlock)
         {
             if (callerLangVersion >= LanguageVersionFacts.CSharpNext)
             {
                 expectedDiagnostics.Add(
-                    // (2,1): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                    // (2,1): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                     // c.M();
                     Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.M()").WithArguments("C.M()").WithLocation(2, 1));
             }
@@ -3675,21 +3742,19 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             }
         }
 
-        // When compiling API and caller together (no compilationReference), the [RequiresUnsafe] attribute
-        // in source also triggers FeatureInPreview if using older language version
-        if (compilationReference is null && apiUnsafe && apiUpdatedRules && callerLangVersion < LanguageVersionFacts.CSharpNext)
-        {
-            expectedDiagnostics.Add(
-                // (3,6): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "System.Diagnostics.CodeAnalysis.RequiresUnsafe").WithArguments("updated memory safety rules").WithLocation(3, 6));
-        }
-
         if (callerUpdatedRules && callerLangVersion < LanguageVersionFacts.CSharpNext)
         {
             expectedDiagnostics.Add(
                 // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
                 Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1));
+
+            if (compilationReference is null && unsafeModifier != "")
+            {
+                expectedDiagnostics.Add(
+                    // (3,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    //     unsafe public void M() => System.Console.Write(111);
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(3, 5));
+            }
         }
 
         comp.VerifyDiagnostics([.. expectedDiagnostics]);
@@ -3708,8 +3773,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 public class C
                 {
                     public static void M() { }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public static void M(int x) { }
+                    unsafe public static void M(int x) { }
                 }
                 """,
             caller: """
@@ -3723,7 +3787,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C", Overload("C.M", 0)],
             expectedDiagnostics:
             [
-                // (2,1): error CS9362: 'C.M(int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,1): error CS9362: 'C.M(int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C.M(1);
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "C.M(1)").WithArguments("C.M(int)").WithLocation(2, 1),
             ]);
@@ -3737,8 +3801,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 public class C
                 {
                     public void M1() { unsafe { M2(); } }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public void M2() { }
+                    unsafe public void M2() { }
                 }
                 """,
             caller: """
@@ -3751,7 +3814,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C.M1"],
             expectedDiagnostics:
             [
-                // (3,1): error CS9362: 'C.M2()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,1): error CS9362: 'C.M2()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.M2();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.M2()").WithArguments("C.M2()").WithLocation(3, 1),
             ]);
@@ -3764,8 +3827,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public class C
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public static void M() { }
+                    unsafe public static void M() { }
                 }
                 """,
             caller: """
@@ -3784,13 +3846,11 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public static class E
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public static void M1(this int x) { }
+                    unsafe public static void M1(this int x) { }
 
                     extension(int x)
                     {
-                        [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                        public void M2() { }
+                        unsafe public void M2() { }
                     }
                 }
                 """,
@@ -3809,16 +3869,16 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: [],
             expectedDiagnostics:
             [
-                // (1,1): error CS9362: 'E.M1(int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,1): error CS9362: 'E.M1(int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // 123.M1();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "123.M1()").WithArguments("E.M1(int)").WithLocation(1, 1),
-                // (2,1): error CS9362: 'E.extension(int).M2()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,1): error CS9362: 'E.extension(int).M2()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // 123.M2();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "123.M2()").WithArguments("E.extension(int).M2()").WithLocation(2, 1),
-                // (3,1): error CS9362: 'E.M1(int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,1): error CS9362: 'E.M1(int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // E.M1(123);
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "E.M1(123)").WithArguments("E.M1(int)").WithLocation(3, 1),
-                // (4,1): error CS9362: 'E.M2(int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (4,1): error CS9362: 'E.M2(int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // E.M2(123);
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "E.M2(123)").WithArguments("E.M2(int)").WithLocation(4, 1),
             ]);
@@ -3837,8 +3897,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                     {
                         yield return 1;
                     }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public void M3() { }
+                    unsafe public void M3() { }
                 }
                 """,
             caller: """
@@ -3853,7 +3912,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C.M1", "C.M2"],
             expectedDiagnostics:
             [
-                // (4,1): error CS9362: 'C.M3()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (4,1): error CS9362: 'C.M3()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.M3();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.M3()").WithArguments("C.M3()").WithLocation(4, 1),
             ]);
@@ -3866,8 +3925,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public static class C
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public static void M() { }
+                    unsafe public static void M() { }
                 }
                 """,
             caller: """
@@ -3879,7 +3937,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
             [
-                // (1,22): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,22): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // delegate*<void> p1 = &C.M;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "&C.M").WithArguments("C.M()").WithLocation(1, 22),
             ],
@@ -3898,8 +3956,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public static class C
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public static void M() { }
+                    unsafe public static void M() { }
                 }
                 """,
             caller: """
@@ -3916,10 +3973,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
             [
-                // (1,8): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,8): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // D1 a = C.M;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "C.M").WithArguments("C.M()").WithLocation(1, 8),
-                // (2,8): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,8): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // D2 b = C.M;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "C.M").WithArguments("C.M()").WithLocation(2, 8),
                 // (7,22): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
@@ -3941,8 +3998,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public static class C
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public static void M() { }
+                    unsafe public static void M() { }
                 }
                 """,
             caller: """
@@ -3954,7 +4010,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
             [
-                // (1,9): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,9): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var a = C.M;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "C.M").WithArguments("C.M()").WithLocation(1, 9),
             ]);
@@ -3974,8 +4030,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
                 static class C
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public static void M() => System.Console.WriteLine("ran");
+                    unsafe public static void M() => System.Console.WriteLine("ran");
                 }
                 """,
                 RequiresUnsafeAttributeDefinition,
@@ -3995,8 +4050,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public static class C
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public static void M() { }
+                    unsafe public static void M() { }
                 }
                 """,
             caller: """
@@ -4011,7 +4065,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
             [
-                // (4,31): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (4,31): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // Expression<Action> e1 = () => C.M();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "C.M()").WithArguments("C.M()").WithLocation(4, 31),
             ]);
@@ -4037,8 +4091,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public class A : System.Attribute
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public void F(int x) { }
+                    unsafe public void F(int x) { }
                 }
                 """,
             caller: """
@@ -4053,7 +4106,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["A"],
             expectedDiagnostics:
             [
-                // (3,4): error CS9362: 'A.F(int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,4): error CS9362: 'A.F(int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // [A(F = 0)] void M2() { }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "F = 0").WithArguments("A.F(int)").WithLocation(3, 4),
                 .. commonDiagnostics,
@@ -4070,8 +4123,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 public interface I
                 {
                     void M1();
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    void M2();
+                    unsafe void M2();
                 }
                 """,
             caller: """
@@ -4085,7 +4137,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["I", "I.M1"],
             expectedDiagnostics:
             [
-                // (3,1): error CS9362: 'I.M2()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,1): error CS9362: 'I.M2()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // i.M2();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "i.M2()").WithArguments("I.M2()").WithLocation(3, 1),
             ]);
@@ -4098,8 +4150,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             public class B
             {
                 public virtual void M1() { }
-                [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                public virtual void M2() { }
+                unsafe public virtual void M2() { }
             }
             """;
 
@@ -4108,20 +4159,19 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
             class C : B
             {
-                [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                public override void M1() { }
+                unsafe public override void M1() { }
                 public override void M2() { }
             }
             """;
 
         var expectedDiagnostics = new[]
         {
-            // (1,1): error CS9362: 'C.M1()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+            // (1,1): error CS9362: 'C.M1()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
             // new C().M1();
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "new C().M1()").WithArguments("C.M1()").WithLocation(1, 1),
-            // (6,26): error CS9364: Unsafe member 'C.M1()' cannot override safe member 'B.M1()'
-            //     public override void M1() { }
-            Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M1").WithArguments("C.M1()", "B.M1()").WithLocation(6, 26),
+            // (5,33): error CS9364: Unsafe member 'C.M1()' cannot override safe member 'B.M1()'
+            //     unsafe public override void M1() { }
+            Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M1").WithArguments("C.M1()", "B.M1()").WithLocation(5, 33),
         };
 
         CompileAndVerifyUnsafe(
@@ -4144,15 +4194,15 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             .VerifyDiagnostics(
             // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
             Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
-            // (4,6): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "System.Diagnostics.CodeAnalysis.RequiresUnsafe").WithArguments("updated memory safety rules").WithLocation(4, 6),
-            // (5,6): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-            //     [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "System.Diagnostics.CodeAnalysis.RequiresUnsafe").WithArguments("updated memory safety rules").WithLocation(5, 6),
-            // (6,26): error CS9364: Unsafe member 'C.M1()' cannot override safe member 'B.M1()'
-            //     public override void M1() { }
-            Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M1").WithArguments("C.M1()", "B.M1()").WithLocation(6, 26),
+            // (4,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     unsafe public virtual void M2() { }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(4, 5),
+            // (5,33): error CS9364: Unsafe member 'C.M1()' cannot override safe member 'B.M1()'
+            //     unsafe public override void M1() { }
+            Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M1").WithArguments("C.M1()", "B.M1()").WithLocation(5, 33),
+            // (5,5): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     unsafe public override void M1() { }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(5, 5),
             // (1,1): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             // new C().M1();
             Diagnostic(ErrorCode.ERR_FeatureInPreview, "new C().M1()").WithArguments("updated memory safety rules").WithLocation(1, 1));
@@ -4165,12 +4215,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public class B
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public virtual void M1() { }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public virtual void M2() { }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public virtual void M3() { }
+                    unsafe public virtual void M1() { }
+                    unsafe public virtual void M2() { }
+                    unsafe public virtual void M3() { }
                     public virtual void M4() { }
                     public virtual void M5() { }
                     public virtual void M6() { }
@@ -4178,13 +4225,11 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
                 public class C : B
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public override void M1() { }
+                    unsafe public override void M1() { }
                     public new virtual void M2() { }
                     public override void M3() { }
                     public override void M4() { }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public new virtual void M5() { }
+                    unsafe public new virtual void M5() { }
                 }
                 """,
             caller: """
@@ -4206,18 +4251,12 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
                 class D2 : C
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public override void M1() { }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public override void M2() { }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public override void M3() { }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public override void M4() { }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public override void M5() { }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public override void M6() { }
+                    unsafe public override void M1() { }
+                    unsafe public override void M2() { }
+                    unsafe public override void M3() { }
+                    unsafe public override void M4() { }
+                    unsafe public override void M5() { }
+                    unsafe public override void M6() { }
                 }
 
                 class D3 : C;
@@ -4227,87 +4266,87 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["B.M4", "B.M5", "B.M6", "C.M2", "C.M3", "C.M4"],
             expectedDiagnostics:
             [
-                // (2,20): error CS9362: 'D2.M1()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,20): error CS9362: 'D2.M1()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M1()").WithArguments("D2.M1()").WithLocation(2, 20),
-                // (2,29): error CS9362: 'D2.M2()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,29): error CS9362: 'D2.M2()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M2()").WithArguments("D2.M2()").WithLocation(2, 29),
-                // (2,38): error CS9362: 'D2.M3()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,38): error CS9362: 'D2.M3()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M3()").WithArguments("D2.M3()").WithLocation(2, 38),
-                // (2,47): error CS9362: 'D2.M4()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,47): error CS9362: 'D2.M4()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M4()").WithArguments("D2.M4()").WithLocation(2, 47),
-                // (2,56): error CS9362: 'D2.M5()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,56): error CS9362: 'D2.M5()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M5()").WithArguments("D2.M5()").WithLocation(2, 56),
-                // (2,65): error CS9362: 'D2.M6()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,65): error CS9362: 'D2.M6()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M6()").WithArguments("D2.M6()").WithLocation(2, 65),
-                // (3,20): error CS9362: 'C.M1()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,20): error CS9362: 'C.M1()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d3 = new D3(); d3.M1(); d3.M2(); d3.M3(); d3.M4(); d3.M5(); d3.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d3.M1()").WithArguments("C.M1()").WithLocation(3, 20),
-                // (3,56): error CS9362: 'C.M5()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,56): error CS9362: 'C.M5()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d3 = new D3(); d3.M1(); d3.M2(); d3.M3(); d3.M4(); d3.M5(); d3.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d3.M5()").WithArguments("C.M5()").WithLocation(3, 56),
-                // (4,11): error CS9362: 'C.M1()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (4,11): error CS9362: 'C.M1()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C c = d1; c.M1(); c.M2(); c.M3(); c.M4(); c.M5(); c.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.M1()").WithArguments("C.M1()").WithLocation(4, 11),
-                // (4,43): error CS9362: 'C.M5()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (4,43): error CS9362: 'C.M5()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C c = d1; c.M1(); c.M2(); c.M3(); c.M4(); c.M5(); c.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.M5()").WithArguments("C.M5()").WithLocation(4, 43),
-                // (14,31): error CS9362: 'C.M1()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (14,31): error CS9362: 'C.M1()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 //     public void BaseCalls() { base.M1(); base.M2(); base.M3(); base.M4(); base.M6(); }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "base.M1()").WithArguments("C.M1()").WithLocation(14, 31),
-                // (22,26): error CS9364: Unsafe member 'D2.M2()' cannot override safe member 'C.M2()'
-                //     public override void M2() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M2").WithArguments("D2.M2()", "C.M2()").WithLocation(22, 26),
-                // (26,26): error CS9364: Unsafe member 'D2.M4()' cannot override safe member 'B.M4()'
-                //     public override void M4() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M4").WithArguments("D2.M4()", "B.M4()").WithLocation(26, 26),
-                // (30,26): error CS9364: Unsafe member 'D2.M6()' cannot override safe member 'B.M6()'
-                //     public override void M6() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M6").WithArguments("D2.M6()", "B.M6()").WithLocation(30, 26),
+                // (20,33): error CS9364: Unsafe member 'D2.M2()' cannot override safe member 'C.M2()'
+                //     unsafe public override void M2() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M2").WithArguments("D2.M2()", "C.M2()").WithLocation(20, 33),
+                // (22,33): error CS9364: Unsafe member 'D2.M4()' cannot override safe member 'B.M4()'
+                //     unsafe public override void M4() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M4").WithArguments("D2.M4()", "B.M4()").WithLocation(22, 33),
+                // (24,33): error CS9364: Unsafe member 'D2.M6()' cannot override safe member 'B.M6()'
+                //     unsafe public override void M6() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M6").WithArguments("D2.M6()", "B.M6()").WithLocation(24, 33),
             ],
             expectedDiagnosticsWhenReferencingLegacyLib:
             [
-                // (2,20): error CS9362: 'D2.M1()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,20): error CS9362: 'D2.M1()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M1()").WithArguments("D2.M1()").WithLocation(2, 20),
-                // (2,29): error CS9362: 'D2.M2()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,29): error CS9362: 'D2.M2()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M2()").WithArguments("D2.M2()").WithLocation(2, 29),
-                // (2,38): error CS9362: 'D2.M3()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,38): error CS9362: 'D2.M3()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M3()").WithArguments("D2.M3()").WithLocation(2, 38),
-                // (2,47): error CS9362: 'D2.M4()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,47): error CS9362: 'D2.M4()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M4()").WithArguments("D2.M4()").WithLocation(2, 47),
-                // (2,56): error CS9362: 'D2.M5()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,56): error CS9362: 'D2.M5()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M5()").WithArguments("D2.M5()").WithLocation(2, 56),
-                // (2,65): error CS9362: 'D2.M6()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,65): error CS9362: 'D2.M6()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M6()").WithArguments("D2.M6()").WithLocation(2, 65),
-                // (20,26): error CS9364: Unsafe member 'D2.M1()' cannot override safe member 'B.M1()'
-                //     public override void M1() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M1").WithArguments("D2.M1()", "B.M1()").WithLocation(20, 26),
-                // (22,26): error CS9364: Unsafe member 'D2.M2()' cannot override safe member 'C.M2()'
-                //     public override void M2() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M2").WithArguments("D2.M2()", "C.M2()").WithLocation(22, 26),
-                // (24,26): error CS9364: Unsafe member 'D2.M3()' cannot override safe member 'B.M3()'
-                //     public override void M3() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M3").WithArguments("D2.M3()", "B.M3()").WithLocation(24, 26),
-                // (26,26): error CS9364: Unsafe member 'D2.M4()' cannot override safe member 'B.M4()'
-                //     public override void M4() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M4").WithArguments("D2.M4()", "B.M4()").WithLocation(26, 26),
-                // (28,26): error CS9364: Unsafe member 'D2.M5()' cannot override safe member 'C.M5()'
-                //     public override void M5() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M5").WithArguments("D2.M5()", "C.M5()").WithLocation(28, 26),
-                // (30,26): error CS9364: Unsafe member 'D2.M6()' cannot override safe member 'B.M6()'
-                //     public override void M6() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M6").WithArguments("D2.M6()", "B.M6()").WithLocation(30, 26),
+                // (19,33): error CS9364: Unsafe member 'D2.M1()' cannot override safe member 'B.M1()'
+                //     unsafe public override void M1() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M1").WithArguments("D2.M1()", "B.M1()").WithLocation(19, 33),
+                // (20,33): error CS9364: Unsafe member 'D2.M2()' cannot override safe member 'C.M2()'
+                //     unsafe public override void M2() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M2").WithArguments("D2.M2()", "C.M2()").WithLocation(20, 33),
+                // (21,33): error CS9364: Unsafe member 'D2.M3()' cannot override safe member 'B.M3()'
+                //     unsafe public override void M3() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M3").WithArguments("D2.M3()", "B.M3()").WithLocation(21, 33),
+                // (22,33): error CS9364: Unsafe member 'D2.M4()' cannot override safe member 'B.M4()'
+                //     unsafe public override void M4() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M4").WithArguments("D2.M4()", "B.M4()").WithLocation(22, 33),
+                // (23,33): error CS9364: Unsafe member 'D2.M5()' cannot override safe member 'C.M5()'
+                //     unsafe public override void M5() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M5").WithArguments("D2.M5()", "C.M5()").WithLocation(23, 33),
+                // (24,33): error CS9364: Unsafe member 'D2.M6()' cannot override safe member 'B.M6()'
+                //     unsafe public override void M6() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M6").WithArguments("D2.M6()", "B.M6()").WithLocation(24, 33),
             ]);
     }
 
@@ -4381,22 +4420,21 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             }
             class C2 : B
             {
-                [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                public override void M() { }
+                unsafe public override void M() { }
             }
             """,
             [refA],
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
-            // (4,1): error CS9362: 'C2.M()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+            // (4,1): error CS9362: 'C2.M()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
             // c2.M();
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c2.M()").WithArguments("C2.M()").WithLocation(4, 1),
-            // (6,1): error CS9362: 'B.M()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+            // (6,1): error CS9362: 'B.M()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
             // b.M();
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "b.M()").WithArguments("B.M()").WithLocation(6, 1),
-            // (17,26): error CS9364: Unsafe member 'C2.M()' cannot override safe member 'A.M()'
-            //     public override void M() { }
-            Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M").WithArguments("C2.M()", "A.M()").WithLocation(17, 26));
+            // (16,33): error CS9364: Unsafe member 'C2.M()' cannot override safe member 'A.M()'
+            //     unsafe public override void M() { }
+            Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M").WithArguments("C2.M()", "A.M()").WithLocation(16, 33));
     }
 
     [Fact]
@@ -4406,16 +4444,14 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public interface I1
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    void M1();
+                    unsafe void M1();
                     void M2();
                 }
 
                 public interface I2
                 {
                     void M1();
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    void M2();
+                    unsafe void M2();
                 }
 
                 public class C1 : I1
@@ -4441,34 +4477,26 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
                 public class C3 : I1
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public void M1() { }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public void M2() { }
+                    unsafe public void M1() { }
+                    unsafe public void M2() { }
                 }
 
                 public class C4 : I1
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    void I1.M1() { }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    void I1.M2() { }
+                    unsafe void I1.M1() { }
+                    unsafe void I1.M2() { }
                 }
 
                 public class C5 : I1, I2
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public void M1() { }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public void M2() { }
+                    unsafe public void M1() { }
+                    unsafe public void M2() { }
                 }
 
                 public class C6 : I2, I1
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public void M1() { }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public void M2() { }
+                    unsafe public void M1() { }
+                    unsafe public void M2() { }
                 }
 
                 public class C7 : I1, I2
@@ -4488,69 +4516,69 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["I1.M2", "I2.M1", "C1.M1", "C1.M2", "C2.I1.M1", "C2.I1.M2"],
             expectedDiagnostics:
             [
-                // (3,1): error CS9362: 'I1.M1()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,1): error CS9362: 'I1.M1()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // i1.M1();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "i1.M1()").WithArguments("I1.M1()").WithLocation(3, 1),
-                // (7,1): error CS9362: 'I2.M2()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (7,1): error CS9362: 'I2.M2()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // i2.M2();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "i2.M2()").WithArguments("I2.M2()").WithLocation(7, 1),
-                // (14,17): error CS9365: Unsafe member 'C3.M2()' cannot implicitly implement safe member 'I1.M2()'
-                //     public void M2() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M2").WithArguments("C3.M2()", "I1.M2()").WithLocation(14, 17),
-                // (22,13): error CS9366: Unsafe member 'C4.I1.M2()' cannot implement safe member 'I1.M2()'
-                //     void I1.M2() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeExplicitlyImplementingSafe, "M2").WithArguments("C4.I1.M2()", "I1.M2()").WithLocation(22, 13),
-                // (28,17): error CS9365: Unsafe member 'C5.M1()' cannot implicitly implement safe member 'I2.M1()'
-                //     public void M1() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M1").WithArguments("C5.M1()", "I2.M1()").WithLocation(28, 17),
-                // (30,17): error CS9365: Unsafe member 'C5.M2()' cannot implicitly implement safe member 'I1.M2()'
-                //     public void M2() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M2").WithArguments("C5.M2()", "I1.M2()").WithLocation(30, 17),
-                // (36,17): error CS9365: Unsafe member 'C6.M1()' cannot implicitly implement safe member 'I2.M1()'
-                //     public void M1() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M1").WithArguments("C6.M1()", "I2.M1()").WithLocation(36, 17),
-                // (38,17): error CS9365: Unsafe member 'C6.M2()' cannot implicitly implement safe member 'I1.M2()'
-                //     public void M2() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M2").WithArguments("C6.M2()", "I1.M2()").WithLocation(38, 17),
+                // (12,24): error CS9365: Unsafe member 'C3.M2()' cannot implicitly implement safe member 'I1.M2()'
+                //     unsafe public void M2() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M2").WithArguments("C3.M2()", "I1.M2()").WithLocation(12, 24),
+                // (18,20): error CS9366: Unsafe member 'C4.I1.M2()' cannot implement safe member 'I1.M2()'
+                //     unsafe void I1.M2() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeExplicitlyImplementingSafe, "M2").WithArguments("C4.I1.M2()", "I1.M2()").WithLocation(18, 20),
+                // (23,24): error CS9365: Unsafe member 'C5.M1()' cannot implicitly implement safe member 'I2.M1()'
+                //     unsafe public void M1() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M1").WithArguments("C5.M1()", "I2.M1()").WithLocation(23, 24),
+                // (24,24): error CS9365: Unsafe member 'C5.M2()' cannot implicitly implement safe member 'I1.M2()'
+                //     unsafe public void M2() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M2").WithArguments("C5.M2()", "I1.M2()").WithLocation(24, 24),
+                // (29,24): error CS9365: Unsafe member 'C6.M1()' cannot implicitly implement safe member 'I2.M1()'
+                //     unsafe public void M1() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M1").WithArguments("C6.M1()", "I2.M1()").WithLocation(29, 24),
+                // (30,24): error CS9365: Unsafe member 'C6.M2()' cannot implicitly implement safe member 'I1.M2()'
+                //     unsafe public void M2() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M2").WithArguments("C6.M2()", "I1.M2()").WithLocation(30, 24),
             ],
             expectedDiagnosticsWhenReferencingLegacyLib:
             [
-                // (12,17): error CS9365: Unsafe member 'C3.M1()' cannot implicitly implement safe member 'I1.M1()'
-                //     public void M1() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M1").WithArguments("C3.M1()", "I1.M1()").WithLocation(12, 17),
-                // (14,17): error CS9365: Unsafe member 'C3.M2()' cannot implicitly implement safe member 'I1.M2()'
-                //     public void M2() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M2").WithArguments("C3.M2()", "I1.M2()").WithLocation(14, 17),
-                // (20,13): error CS9366: Unsafe member 'C4.I1.M1()' cannot implement safe member 'I1.M1()'
-                //     void I1.M1() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeExplicitlyImplementingSafe, "M1").WithArguments("C4.I1.M1()", "I1.M1()").WithLocation(20, 13),
-                // (22,13): error CS9366: Unsafe member 'C4.I1.M2()' cannot implement safe member 'I1.M2()'
-                //     void I1.M2() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeExplicitlyImplementingSafe, "M2").WithArguments("C4.I1.M2()", "I1.M2()").WithLocation(22, 13),
-                // (28,17): error CS9365: Unsafe member 'C5.M1()' cannot implicitly implement safe member 'I1.M1()'
-                //     public void M1() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M1").WithArguments("C5.M1()", "I1.M1()").WithLocation(28, 17),
-                // (28,17): error CS9365: Unsafe member 'C5.M1()' cannot implicitly implement safe member 'I2.M1()'
-                //     public void M1() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M1").WithArguments("C5.M1()", "I2.M1()").WithLocation(28, 17),
-                // (30,17): error CS9365: Unsafe member 'C5.M2()' cannot implicitly implement safe member 'I1.M2()'
-                //     public void M2() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M2").WithArguments("C5.M2()", "I1.M2()").WithLocation(30, 17),
-                // (30,17): error CS9365: Unsafe member 'C5.M2()' cannot implicitly implement safe member 'I2.M2()'
-                //     public void M2() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M2").WithArguments("C5.M2()", "I2.M2()").WithLocation(30, 17),
-                // (36,17): error CS9365: Unsafe member 'C6.M1()' cannot implicitly implement safe member 'I2.M1()'
-                //     public void M1() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M1").WithArguments("C6.M1()", "I2.M1()").WithLocation(36, 17),
-                // (36,17): error CS9365: Unsafe member 'C6.M1()' cannot implicitly implement safe member 'I1.M1()'
-                //     public void M1() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M1").WithArguments("C6.M1()", "I1.M1()").WithLocation(36, 17),
-                // (38,17): error CS9365: Unsafe member 'C6.M2()' cannot implicitly implement safe member 'I2.M2()'
-                //     public void M2() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M2").WithArguments("C6.M2()", "I2.M2()").WithLocation(38, 17),
-                // (38,17): error CS9365: Unsafe member 'C6.M2()' cannot implicitly implement safe member 'I1.M2()'
-                //     public void M2() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M2").WithArguments("C6.M2()", "I1.M2()").WithLocation(38, 17),
+                // (11,24): error CS9365: Unsafe member 'C3.M1()' cannot implicitly implement safe member 'I1.M1()'
+                //     unsafe public void M1() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M1").WithArguments("C3.M1()", "I1.M1()").WithLocation(11, 24),
+                // (12,24): error CS9365: Unsafe member 'C3.M2()' cannot implicitly implement safe member 'I1.M2()'
+                //     unsafe public void M2() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M2").WithArguments("C3.M2()", "I1.M2()").WithLocation(12, 24),
+                // (17,20): error CS9366: Unsafe member 'C4.I1.M1()' cannot implement safe member 'I1.M1()'
+                //     unsafe void I1.M1() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeExplicitlyImplementingSafe, "M1").WithArguments("C4.I1.M1()", "I1.M1()").WithLocation(17, 20),
+                // (18,20): error CS9366: Unsafe member 'C4.I1.M2()' cannot implement safe member 'I1.M2()'
+                //     unsafe void I1.M2() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeExplicitlyImplementingSafe, "M2").WithArguments("C4.I1.M2()", "I1.M2()").WithLocation(18, 20),
+                // (23,24): error CS9365: Unsafe member 'C5.M1()' cannot implicitly implement safe member 'I1.M1()'
+                //     unsafe public void M1() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M1").WithArguments("C5.M1()", "I1.M1()").WithLocation(23, 24),
+                // (23,24): error CS9365: Unsafe member 'C5.M1()' cannot implicitly implement safe member 'I2.M1()'
+                //     unsafe public void M1() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M1").WithArguments("C5.M1()", "I2.M1()").WithLocation(23, 24),
+                // (24,24): error CS9365: Unsafe member 'C5.M2()' cannot implicitly implement safe member 'I1.M2()'
+                //     unsafe public void M2() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M2").WithArguments("C5.M2()", "I1.M2()").WithLocation(24, 24),
+                // (24,24): error CS9365: Unsafe member 'C5.M2()' cannot implicitly implement safe member 'I2.M2()'
+                //     unsafe public void M2() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M2").WithArguments("C5.M2()", "I2.M2()").WithLocation(24, 24),
+                // (29,24): error CS9365: Unsafe member 'C6.M1()' cannot implicitly implement safe member 'I2.M1()'
+                //     unsafe public void M1() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M1").WithArguments("C6.M1()", "I2.M1()").WithLocation(29, 24),
+                // (29,24): error CS9365: Unsafe member 'C6.M1()' cannot implicitly implement safe member 'I1.M1()'
+                //     unsafe public void M1() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M1").WithArguments("C6.M1()", "I1.M1()").WithLocation(29, 24),
+                // (30,24): error CS9365: Unsafe member 'C6.M2()' cannot implicitly implement safe member 'I2.M2()'
+                //     unsafe public void M2() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M2").WithArguments("C6.M2()", "I2.M2()").WithLocation(30, 24),
+                // (30,24): error CS9365: Unsafe member 'C6.M2()' cannot implicitly implement safe member 'I1.M2()'
+                //     unsafe public void M2() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M2").WithArguments("C6.M2()", "I1.M2()").WithLocation(30, 24),
             ]);
     }
 
@@ -4562,8 +4590,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 public class B<T>
                 {
                     public void M1(T x) { }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public void M2(T x) { }
+                    unsafe public void M2(T x) { }
                 }
                 """,
             caller: """
@@ -4577,8 +4604,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
                 interface I
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    void M1(D x);
+                    unsafe void M1(D x);
                 }
                 """,
             additionalSources: [RequiresUnsafeAttributeDefinition],
@@ -4586,7 +4612,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["B.M1"],
             expectedDiagnostics:
             [
-                // (3,1): error CS9362: 'B<D>.M2(D)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,1): error CS9362: 'B<D>.M2(D)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.M2(null);
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.M2(null)").WithArguments("B<D>.M2(D)").WithLocation(3, 1),
             ]);
@@ -4600,15 +4626,13 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 public interface I
                 {
                     void M1();
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    void M2();
+                    unsafe void M2();
                 }
 
                 public class B1 : I
                 {
                     public virtual void M1() { }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public virtual void M2() { }
+                    unsafe public virtual void M2() { }
                 }
                 """,
             caller: """
@@ -4624,22 +4648,19 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
                 class B2 : I
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public virtual void M1() { }
+                    unsafe public virtual void M1() { }
                     public virtual void M2() { }
                 }
 
                 class C1 : B1
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public override void M1() { }
+                    unsafe public override void M1() { }
                     public override void M2() { }
                 }
 
                 class C2 : B1, I
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public override void M1() { }
+                    unsafe public override void M1() { }
                     public override void M2() { }
                 }
                 """,
@@ -4648,45 +4669,45 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["I.M1", "B1.M1"],
             expectedDiagnostics:
             [
-                // (2,1): error CS9362: 'C1.M1()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,1): error CS9362: 'C1.M1()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c1.M1();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c1.M1()").WithArguments("C1.M1()").WithLocation(2, 1),
-                // (6,1): error CS9362: 'B1.M2()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (6,1): error CS9362: 'B1.M2()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // b1.M2();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "b1.M2()").WithArguments("B1.M2()").WithLocation(6, 1),
-                // (9,1): error CS9362: 'I.M2()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (9,1): error CS9362: 'I.M2()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // i.M2();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "i.M2()").WithArguments("I.M2()").WithLocation(9, 1),
-                // (14,25): error CS9365: Unsafe member 'B2.M1()' cannot implicitly implement safe member 'I.M1()'
-                //     public virtual void M1() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M1").WithArguments("B2.M1()", "I.M1()").WithLocation(14, 25),
-                // (21,26): error CS9364: Unsafe member 'C1.M1()' cannot override safe member 'B1.M1()'
-                //     public override void M1() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M1").WithArguments("C1.M1()", "B1.M1()").WithLocation(21, 26),
-                // (28,26): error CS9364: Unsafe member 'C2.M1()' cannot override safe member 'B1.M1()'
-                //     public override void M1() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M1").WithArguments("C2.M1()", "B1.M1()").WithLocation(28, 26),
-                // (28,26): error CS9365: Unsafe member 'C2.M1()' cannot implicitly implement safe member 'I.M1()'
-                //     public override void M1() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M1").WithArguments("C2.M1()", "I.M1()").WithLocation(28, 26),
+                // (13,32): error CS9365: Unsafe member 'B2.M1()' cannot implicitly implement safe member 'I.M1()'
+                //     unsafe public virtual void M1() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M1").WithArguments("B2.M1()", "I.M1()").WithLocation(13, 32),
+                // (19,33): error CS9364: Unsafe member 'C1.M1()' cannot override safe member 'B1.M1()'
+                //     unsafe public override void M1() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M1").WithArguments("C1.M1()", "B1.M1()").WithLocation(19, 33),
+                // (25,33): error CS9364: Unsafe member 'C2.M1()' cannot override safe member 'B1.M1()'
+                //     unsafe public override void M1() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M1").WithArguments("C2.M1()", "B1.M1()").WithLocation(25, 33),
+                // (25,33): error CS9365: Unsafe member 'C2.M1()' cannot implicitly implement safe member 'I.M1()'
+                //     unsafe public override void M1() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M1").WithArguments("C2.M1()", "I.M1()").WithLocation(25, 33),
             ],
             expectedDiagnosticsWhenReferencingLegacyLib:
             [
-                // (2,1): error CS9362: 'C1.M1()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,1): error CS9362: 'C1.M1()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c1.M1();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c1.M1()").WithArguments("C1.M1()").WithLocation(2, 1),
-                // (14,25): error CS9365: Unsafe member 'B2.M1()' cannot implicitly implement safe member 'I.M1()'
-                //     public virtual void M1() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M1").WithArguments("B2.M1()", "I.M1()").WithLocation(14, 25),
-                // (21,26): error CS9364: Unsafe member 'C1.M1()' cannot override safe member 'B1.M1()'
-                //     public override void M1() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M1").WithArguments("C1.M1()", "B1.M1()").WithLocation(21, 26),
-                // (28,26): error CS9364: Unsafe member 'C2.M1()' cannot override safe member 'B1.M1()'
-                //     public override void M1() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M1").WithArguments("C2.M1()", "B1.M1()").WithLocation(28, 26),
-                // (28,26): error CS9365: Unsafe member 'C2.M1()' cannot implicitly implement safe member 'I.M1()'
-                //     public override void M1() { }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M1").WithArguments("C2.M1()", "I.M1()").WithLocation(28, 26),
+                // (13,32): error CS9365: Unsafe member 'B2.M1()' cannot implicitly implement safe member 'I.M1()'
+                //     unsafe public virtual void M1() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M1").WithArguments("B2.M1()", "I.M1()").WithLocation(13, 32),
+                // (19,33): error CS9364: Unsafe member 'C1.M1()' cannot override safe member 'B1.M1()'
+                //     unsafe public override void M1() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M1").WithArguments("C1.M1()", "B1.M1()").WithLocation(19, 33),
+                // (25,33): error CS9364: Unsafe member 'C2.M1()' cannot override safe member 'B1.M1()'
+                //     unsafe public override void M1() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M1").WithArguments("C2.M1()", "B1.M1()").WithLocation(25, 33),
+                // (25,33): error CS9365: Unsafe member 'C2.M1()' cannot implicitly implement safe member 'I.M1()'
+                //     unsafe public override void M1() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M1").WithArguments("C2.M1()", "I.M1()").WithLocation(25, 33),
             ]);
     }
 
@@ -4701,17 +4722,17 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             // (7,17): warning CS0108: 'C1.M1()' hides inherited member 'B.M1()'. Use the new keyword if hiding was intended.
             //     public void M1() { }
             Diagnostic(ErrorCode.WRN_NewRequired, "M1").WithArguments("C1.M1()", "B.M1()").WithLocation(7, 17),
-            // (9,17): warning CS0108: 'C1.M2()' hides inherited member 'B.M2()'. Use the new keyword if hiding was intended.
-            //     public void M2() { }
-            Diagnostic(ErrorCode.WRN_NewRequired, "M2").WithArguments("C1.M2()", "B.M2()").WithLocation(9, 17),
-            // (16,17): error CS0111: Type 'C2' already defines a member called 'M1' with the same parameter types
-            //     public void M1() { }
-            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M1").WithArguments("M1", "C2").WithLocation(16, 17),
+            // (8,24): warning CS0108: 'C1.M2()' hides inherited member 'B.M2()'. Use the new keyword if hiding was intended.
+            //     unsafe public void M2() { }
+            Diagnostic(ErrorCode.WRN_NewRequired, "M2").WithArguments("C1.M2()", "B.M2()").WithLocation(8, 24),
+            // (14,24): error CS0111: Type 'C2' already defines a member called 'M1' with the same parameter types
+            //     unsafe public void M1() { }
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M1").WithArguments("M1", "C2").WithLocation(14, 24),
         ];
 
         DiagnosticDescription[] updatedCallerDiagnostics =
         [
-            // (3,1): error CS9362: 'C1.M2()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+            // (3,1): error CS9362: 'C1.M2()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
             // c.M2();
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.M2()").WithArguments("C1.M2()").WithLocation(3, 1),
             .. commonDiagnostics,
@@ -4721,8 +4742,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public class B
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public void M1() { }
+                    unsafe public void M1() { }
                     public void M2() { }
                 }
                 """,
@@ -4734,15 +4754,13 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 class C1 : B
                 {
                     public void M1() { }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public void M2() { }
+                    unsafe public void M2() { }
                 }
 
                 class C2
                 {
                     public void M1() { }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public void M1() { }
+                    unsafe public void M1() { }
                 }
                 """,
             additionalSources: [RequiresUnsafeAttributeDefinition],
@@ -4762,24 +4780,21 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
             public class C : INotifyCompletion
             {
-                [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                public bool IsCompleted => false;
-                [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                public C GetAwaiter() => this;
-                [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                public void GetResult() { }
+                unsafe public bool IsCompleted => false;
+                unsafe public C GetAwaiter() => this;
+                unsafe public void GetResult() { }
                 {{onCompletedAttribute}}
                 public void OnCompleted(Action continuation) { }
             }
             """;
 
         CreateCompilation(
-            [getLib("[System.Diagnostics.CodeAnalysis.RequiresUnsafe]"), RequiresUnsafeAttributeDefinition],
+            [getLib("unsafe"), RequiresUnsafeAttributeDefinition],
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
-            // (13,17): error CS9365: Unsafe member 'C.OnCompleted(Action)' cannot implicitly implement safe member 'INotifyCompletion.OnCompleted(Action)'
-            //     public void OnCompleted(Action continuation) { }
-            Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "OnCompleted").WithArguments("C.OnCompleted(System.Action)", "System.Runtime.CompilerServices.INotifyCompletion.OnCompleted(System.Action)").WithLocation(13, 17));
+            // (10,17): error CS9365: Unsafe member 'C.OnCompleted(Action)' cannot implicitly implement safe member 'INotifyCompletion.OnCompleted(Action)'
+            //     unsafe public void OnCompleted(Action continuation) { }
+            Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "OnCompleted").WithArguments("C.OnCompleted(System.Action)", "System.Runtime.CompilerServices.INotifyCompletion.OnCompleted(System.Action)").WithLocation(10, 17));
 
         var lib = getLib("");
 
@@ -4793,13 +4808,13 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C", "C.OnCompleted"],
             expectedDiagnostics:
             [
-                // (1,1): error CS9362: 'C.GetAwaiter()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,1): error CS9362: 'C.GetAwaiter()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // await new C();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "await new C()").WithArguments("C.GetAwaiter()").WithLocation(1, 1),
-                // (1,1): error CS9362: 'C.IsCompleted.get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,1): error CS9362: 'C.IsCompleted.get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // await new C();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "await new C()").WithArguments("C.IsCompleted.get").WithLocation(1, 1),
-                // (1,1): error CS9362: 'C.GetResult()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,1): error CS9362: 'C.GetResult()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // await new C();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "await new C()").WithArguments("C.GetResult()").WithLocation(1, 1),
             ]);
@@ -4852,8 +4867,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 public interface INotifyCompletion;
                 public static class AsyncHelpers
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public static void AwaitAwaiter<TAwaiter>(TAwaiter awaiter) where TAwaiter : INotifyCompletion { }
+                    unsafe public static void AwaitAwaiter<TAwaiter>(TAwaiter awaiter) where TAwaiter : INotifyCompletion { }
                 }
             }
             namespace System.Threading.Tasks
@@ -4886,7 +4900,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             parseOptions: WithRuntimeAsync(TestOptions.RegularPreview),
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
-            // (7,15): error CS9362: 'AsyncHelpers.AwaitAwaiter<Task>(Task)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+            // (7,15): error CS9362: 'AsyncHelpers.AwaitAwaiter<Task>(Task)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
             //         await new Task();
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "new Task()").WithArguments("System.Runtime.CompilerServices.AsyncHelpers.AwaitAwaiter<System.Threading.Tasks.Task>(System.Threading.Tasks.Task)").WithLocation(7, 15));
 
@@ -4923,8 +4937,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 [CollectionBuilder(typeof(C), nameof(Create))]
                 public class C : IEnumerable<int>
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public static C Create(ReadOnlySpan<int> s) => new C();
+                    unsafe public static C Create(ReadOnlySpan<int> s) => new C();
                     public IEnumerator<int> GetEnumerator() => throw null;
                     IEnumerator IEnumerable.GetEnumerator() => throw null;
                 }
@@ -4950,18 +4963,27 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
             [
-                // (1,8): error CS9362: 'C.Create(ReadOnlySpan<int>)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,8): error CS9362: 'C.Create(ReadOnlySpan<int>)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C c1 = [1, 2, 3];
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "[1, 2, 3]").WithArguments("C.Create(System.ReadOnlySpan<int>)").WithLocation(1, 8),
-                // (2,1): error CS9362: 'C.Create(ReadOnlySpan<int>)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,1): error CS9362: 'C.Create(ReadOnlySpan<int>)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // M(1, 2, 3);
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "M(1, 2, 3)").WithArguments("C.Create(System.ReadOnlySpan<int>)").WithLocation(2, 1),
-                // (3,15): error CS9362: 'C.Create(ReadOnlySpan<int>)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,15): error CS9362: 'C.Create(ReadOnlySpan<int>)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // static void M(params C c) { }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "params C c").WithArguments("C.Create(System.ReadOnlySpan<int>)").WithLocation(3, 15),
-                // (12,1): error CS9362: 'C.Create(ReadOnlySpan<int>)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (12,1): error CS9362: 'C.Create(ReadOnlySpan<int>)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // M3(1, 2, 3);
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "M3(1, 2, 3)").WithArguments("C.Create(System.ReadOnlySpan<int>)").WithLocation(12, 1),
+                // (12,1): error CS9362: 'M3(params C)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+                // M3(1, 2, 3);
+                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "M3(1, 2, 3)").WithArguments("M3(params C)").WithLocation(12, 1),
+            ],
+            expectedDiagnosticsWhenReferencingLegacyLib:
+            [
+                // (12,1): error CS9362: 'M3(params C)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+                // M3(1, 2, 3);
+                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "M3(1, 2, 3)").WithArguments("M3(params C)").WithLocation(12, 1),
             ]);
     }
 
@@ -4979,8 +5001,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 public class C : IEnumerable<int>
                 {
                     public static C Create(ReadOnlySpan<int> s) => new C();
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public IEnumerator<int> GetEnumerator() => null;
+                    unsafe public IEnumerator<int> GetEnumerator() => null;
                     IEnumerator<int> IEnumerable<int>.GetEnumerator() => null;
                     IEnumerator IEnumerable.GetEnumerator() => null;
                 }
@@ -5007,8 +5028,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
                 public class C : IEnumerable<int>
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public C() { }
+                    unsafe public C() { }
                     public void Add(int x) { }
                     public IEnumerator<int> GetEnumerator() => throw null;
                     IEnumerator IEnumerable.GetEnumerator() => throw null;
@@ -5034,18 +5054,27 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
             [
-                // (1,8): error CS9362: 'C.C()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,8): error CS9362: 'C.C()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C c1 = [1, 2, 3];
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "[1, 2, 3]").WithArguments("C.C()").WithLocation(1, 8),
-                // (2,1): error CS9362: 'C.C()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,1): error CS9362: 'C.C()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // M1(1, 2, 3);
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "M1(1, 2, 3)").WithArguments("C.C()").WithLocation(2, 1),
-                // (3,16): error CS9362: 'C.C()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,16): error CS9362: 'C.C()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // static void M1(params C c) { }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "params C c").WithArguments("C.C()").WithLocation(3, 16),
-                // (12,1): error CS9362: 'C.C()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (12,1): error CS9362: 'C.C()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // M3(1, 2, 3);
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "M3(1, 2, 3)").WithArguments("C.C()").WithLocation(12, 1),
+                // (12,1): error CS9362: 'M3(params C)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+                // M3(1, 2, 3);
+                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "M3(1, 2, 3)").WithArguments("M3(params C)").WithLocation(12, 1),
+            ],
+            expectedDiagnosticsWhenReferencingLegacyLib:
+            [
+                // (12,1): error CS9362: 'M3(params C)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+                // M3(1, 2, 3);
+                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "M3(1, 2, 3)").WithArguments("M3(params C)").WithLocation(12, 1),
             ]);
     }
 
@@ -5059,8 +5088,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
                 public class C : IEnumerable<int>
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public C(int i) { }
+                    unsafe public C(int i) { }
                     public void Add(int x) { }
                     public IEnumerator<int> GetEnumerator() => throw null;
                     IEnumerator IEnumerable.GetEnumerator() => throw null;
@@ -5075,7 +5103,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
             [
-                // (1,9): error CS9362: 'C.C(int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,9): error CS9362: 'C.C(int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C c1 = [with(0), 1, 2, 3];
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "with(0)").WithArguments("C.C(int)").WithLocation(1, 9),
             ]);
@@ -5091,8 +5119,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
                 public class C : IEnumerable<int>
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public void Add(int x) { }
+                    unsafe public void Add(int x) { }
                     public IEnumerator<int> GetEnumerator() => throw null;
                     IEnumerator IEnumerable.GetEnumerator() => throw null;
                 }
@@ -5125,57 +5152,66 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
             [
-                // (1,9): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,9): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C c1 = [1, 2, 3];
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "1").WithArguments("C.Add(int)").WithLocation(1, 9),
-                // (1,12): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,12): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C c1 = [1, 2, 3];
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "2").WithArguments("C.Add(int)").WithLocation(1, 12),
-                // (1,15): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,15): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C c1 = [1, 2, 3];
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "3").WithArguments("C.Add(int)").WithLocation(1, 15),
-                // (2,16): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,16): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C c2 = new() { 1, 2, 3 };
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "1").WithArguments("C.Add(int)").WithLocation(2, 16),
-                // (2,19): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,19): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C c2 = new() { 1, 2, 3 };
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "2").WithArguments("C.Add(int)").WithLocation(2, 19),
-                // (2,22): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,22): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C c2 = new() { 1, 2, 3 };
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "3").WithArguments("C.Add(int)").WithLocation(2, 22),
-                // (3,12): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,12): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C c3 = [.. new C()];
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "new C()").WithArguments("C.Add(int)").WithLocation(3, 12),
-                // (4,22): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (4,22): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // X x1 = new() { F = { 1, 2, 3 } };
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "1").WithArguments("C.Add(int)").WithLocation(4, 22),
-                // (4,25): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (4,25): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // X x1 = new() { F = { 1, 2, 3 } };
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "2").WithArguments("C.Add(int)").WithLocation(4, 25),
-                // (4,28): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (4,28): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // X x1 = new() { F = { 1, 2, 3 } };
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "3").WithArguments("C.Add(int)").WithLocation(4, 28),
-                // (5,4): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (5,4): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // M1(1, 2, 3);
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "1").WithArguments("C.Add(int)").WithLocation(5, 4),
-                // (5,7): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (5,7): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // M1(1, 2, 3);
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "2").WithArguments("C.Add(int)").WithLocation(5, 7),
-                // (5,10): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (5,10): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // M1(1, 2, 3);
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "3").WithArguments("C.Add(int)").WithLocation(5, 10),
-                // (6,16): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (6,16): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // static void M1(params C c) { }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "params C c").WithArguments("C.Add(int)").WithLocation(6, 16),
-                // (18,4): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (18,1): error CS9362: 'M3(params C)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+                // M3(1, 2, 3);
+                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "M3(1, 2, 3)").WithArguments("M3(params C)").WithLocation(18, 1),
+                // (18,4): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // M3(1, 2, 3);
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "1").WithArguments("C.Add(int)").WithLocation(18, 4),
-                // (18,7): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (18,7): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // M3(1, 2, 3);
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "2").WithArguments("C.Add(int)").WithLocation(18, 7),
-                // (18,10): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (18,10): error CS9362: 'C.Add(int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // M3(1, 2, 3);
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "3").WithArguments("C.Add(int)").WithLocation(18, 10),
+            ],
+            expectedDiagnosticsWhenReferencingLegacyLib:
+            [
+                // (18,1): error CS9362: 'M3(params C)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+                // M3(1, 2, 3);
+                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "M3(1, 2, 3)").WithArguments("M3(params C)").WithLocation(18, 1),
             ]);
     }
 
@@ -5189,8 +5225,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
                 public class C : IEnumerable<int>
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public IEnumerator<int> GetEnumerator() => null;
+                    unsafe public IEnumerator<int> GetEnumerator() => null;
                     IEnumerator<int> IEnumerable<int>.GetEnumerator() => null;
                     IEnumerator IEnumerable.GetEnumerator() => null;
                 }
@@ -5204,7 +5239,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
             [
-                // (1,1): error CS9362: 'C.GetEnumerator()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,1): error CS9362: 'C.GetEnumerator()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // foreach (var c in new C()) { }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "foreach").WithArguments("C.GetEnumerator()").WithLocation(1, 1),
             ]);
@@ -5221,12 +5256,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 public class C : IEnumerable<int>
                 {
                     public void Add(int x) { }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public C GetEnumerator() => this;
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public bool MoveNext() => false;
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public int Current => 0;
+                    unsafe public C GetEnumerator() => this;
+                    unsafe public bool MoveNext() => false;
+                    unsafe public int Current => 0;
                     IEnumerator<int> IEnumerable<int>.GetEnumerator() => null;
                     IEnumerator IEnumerable.GetEnumerator() => null;
                 }
@@ -5240,13 +5272,13 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
             [
-                // (1,9): error CS9362: 'C.GetEnumerator()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,9): error CS9362: 'C.GetEnumerator()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C c1 = [.. new C()];
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "..").WithArguments("C.GetEnumerator()").WithLocation(1, 9),
-                // (1,9): error CS9362: 'C.MoveNext()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,9): error CS9362: 'C.MoveNext()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C c1 = [.. new C()];
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "..").WithArguments("C.MoveNext()").WithLocation(1, 9),
-                // (1,9): error CS9362: 'C.Current.get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,9): error CS9362: 'C.Current.get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C c1 = [.. new C()];
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "..").WithArguments("C.Current.get").WithLocation(1, 9),
             ]);
@@ -5260,8 +5292,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 public class C
                 {
                     public C GetEnumerator() => this;
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public bool MoveNext() => false;
+                    unsafe public bool MoveNext() => false;
                     public int Current => 0;
                 }
                 """,
@@ -5274,7 +5305,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
             [
-                // (1,1): error CS9362: 'C.MoveNext()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,1): error CS9362: 'C.MoveNext()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // foreach (var x in new C()) { }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "foreach").WithArguments("C.MoveNext()").WithLocation(1, 1),
             ]);
@@ -5291,8 +5322,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 {
                     public C GetEnumerator() => this;
                     public bool MoveNext() => false;
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public int Current {{getter}}
+                    unsafe public int Current {{getter}}
                 }
                 """,
             caller: """
@@ -5304,7 +5334,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
             [
-                // (1,1): error CS9362: 'C.Current.get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,1): error CS9362: 'C.Current.get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // foreach (var x in new C()) { }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "foreach").WithArguments("C.Current.get").WithLocation(1, 1),
             ]);
@@ -5319,7 +5349,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 {
                     public C GetEnumerator() => this;
                     public bool MoveNext() => false;
-                    public int Current { [System.Diagnostics.CodeAnalysis.RequiresUnsafe] get => 0; }
+                    public int Current { unsafe get => 0; }
                 }
                 """,
             caller: """
@@ -5331,7 +5361,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C", "C.Current"],
             expectedDiagnostics:
             [
-                // (1,1): error CS9362: 'C.Current.get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,1): error CS9362: 'C.Current.get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // foreach (var x in new C()) { }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "foreach").WithArguments("C.Current.get").WithLocation(1, 1),
             ]);
@@ -5346,7 +5376,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 {
                     public C GetEnumerator() => this;
                     public bool MoveNext() => false;
-                    public int Current { get => 0; [System.Diagnostics.CodeAnalysis.RequiresUnsafe] set { } }
+                    public int Current { get => 0; unsafe set { } }
                 }
                 """,
             caller: """
@@ -5368,15 +5398,14 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 public C GetEnumerator() => this;
                 public bool MoveNext() => false;
                 public int Current => 0;
-                [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                public void Dispose() { }
+                unsafe public void Dispose() { }
             }
             """, RequiresUnsafeAttributeDefinition],
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
-            // (7,17): error CS9365: Unsafe member 'C.Dispose()' cannot implicitly implement safe member 'IDisposable.Dispose()'
-            //     public unsafe void Dispose() { }
-            Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "Dispose").WithArguments("C.Dispose()", "System.IDisposable.Dispose()").WithLocation(7, 17));
+            // (6,24): error CS9365: Unsafe member 'C.Dispose()' cannot implicitly implement safe member 'IDisposable.Dispose()'
+            //     unsafe public void Dispose() { }
+            Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "Dispose").WithArguments("C.Dispose()", "System.IDisposable.Dispose()").WithLocation(6, 24));
     }
 
     [Fact]
@@ -5411,8 +5440,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                     public enum AttributeTargets;
                     public interface IDisposable
                     {
-                        [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                        void Dispose();
+                        unsafe void Dispose();
                     }
                 }
 
@@ -5457,13 +5485,13 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             verify: Verification.FailsPEVerify,
             expectedDiagnostics:
             [
-                // (1,1): error CS9362: 'IDisposable.Dispose()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,1): error CS9362: 'IDisposable.Dispose()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // foreach (var x in new C()) { }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "foreach").WithArguments("System.IDisposable.Dispose()").WithLocation(1, 1),
-                // (2,8): error CS9362: 'IDisposable.Dispose()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,8): error CS9362: 'IDisposable.Dispose()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // using (var c = new C()) { }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "var c = new C()").WithArguments("System.IDisposable.Dispose()").WithLocation(2, 8),
-                // (3,43): error CS9362: 'IDisposable.Dispose()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,43): error CS9362: 'IDisposable.Dispose()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // System.Collections.Generic.List<int> l = [.. new C()];
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "..").WithArguments("System.IDisposable.Dispose()").WithLocation(3, 43),
             ]);
@@ -5479,8 +5507,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                     public S GetEnumerator() => this;
                     public bool MoveNext() => false;
                     public int Current => 0;
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public void Dispose() { }
+                    unsafe public void Dispose() { }
                 }
                 """,
             caller: """
@@ -5495,10 +5522,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["S"],
             expectedDiagnostics:
             [
-                // (1,1): error CS9362: 'S.Dispose()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,1): error CS9362: 'S.Dispose()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // foreach (var x in new S()) { }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "foreach (var x in new S()) { }").WithArguments("S.Dispose()").WithLocation(1, 1),
-                // (2,8): error CS9362: 'S.Dispose()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,8): error CS9362: 'S.Dispose()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // using (var s = new S()) { }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "var s = new S()").WithArguments("S.Dispose()").WithLocation(2, 8),
             ]);
@@ -5515,8 +5542,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                     public C GetAsyncEnumerator() => this;
                     public Task<bool> MoveNextAsync() => null;
                     public int Current => 0;
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public Task DisposeAsync() => null;
+                    unsafe public Task DisposeAsync() => null;
                 }
                 """,
             caller: """
@@ -5528,10 +5554,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
             [
-                // (1,1): error CS9362: 'C.DisposeAsync()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,1): error CS9362: 'C.DisposeAsync()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // await foreach (var x in new C()) { }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "await foreach (var x in new C()) { }").WithArguments("C.DisposeAsync()").WithLocation(1, 1),
-                // (2,14): error CS9362: 'C.DisposeAsync()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,14): error CS9362: 'C.DisposeAsync()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // await using (var c = new C()) { }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "var c = new C()").WithArguments("C.DisposeAsync()").WithLocation(2, 14),
             ]);
@@ -5543,7 +5569,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CompileAndVerifyUnsafe(
             lib: """
                 public class C1 { public ref int GetPinnableReference() => throw null; }
-                public class C2 { [System.Diagnostics.CodeAnalysis.RequiresUnsafe] public ref int GetPinnableReference() => throw null; }
+                public class C2 { unsafe public ref int GetPinnableReference() => throw null; }
                 """,
             caller: """
                 fixed (int* p = new C1()) { }
@@ -5555,7 +5581,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C1", "C1.GetPinnableReference", "C2"],
             expectedDiagnostics:
             [
-                // (2,17): error CS9362: 'C2.GetPinnableReference()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,17): error CS9362: 'C2.GetPinnableReference()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // fixed (int* p = new C2()) { }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "new C2()").WithArguments("C2.GetPinnableReference()").WithLocation(2, 17),
             ],
@@ -5583,8 +5609,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public class C
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public void Deconstruct(out int x, out int y) { x = y = 0; }
+                    unsafe public void Deconstruct(out int x, out int y) { x = y = 0; }
                 }
                 """,
             caller: """
@@ -5596,7 +5621,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
             [
-                // (1,14): error CS9362: 'C.Deconstruct(out int, out int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,14): error CS9362: 'C.Deconstruct(out int, out int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var (x, y) = new C();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "new C()").WithArguments("C.Deconstruct(out int, out int)").WithLocation(1, 14),
             ]);
@@ -5610,12 +5635,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 namespace System.Threading;
                 public class Lock
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public Scope EnterScope() => new();
+                    unsafe public Scope EnterScope() => new();
                     public ref struct Scope
                     {
-                        [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                        public void Dispose() { }
+                        unsafe public void Dispose() { }
                     }
                 }
                 """,
@@ -5629,10 +5652,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["System.Threading.Lock", "System.Threading.Lock.Scope"],
             expectedDiagnostics:
             [
-                // (1,7): error CS9362: 'Lock.EnterScope()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,7): error CS9362: 'Lock.EnterScope()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // lock (new System.Threading.Lock()) { }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "new System.Threading.Lock()").WithArguments("System.Threading.Lock.EnterScope()").WithLocation(1, 7),
-                // (1,7): error CS9362: 'Lock.Scope.Dispose()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,7): error CS9362: 'Lock.Scope.Dispose()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // lock (new System.Threading.Lock()) { }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "new System.Threading.Lock()").WithArguments("System.Threading.Lock.Scope.Dispose()").WithLocation(1, 7),
             ]);
@@ -5646,10 +5669,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 namespace System.Runtime.CompilerServices;
                 public interface ITuple
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    int Length { get; }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    object this[int index] { get; }
+                    unsafe int Length { get; }
+                    unsafe object this[int index] { get; }
                 }
                 """,
             caller: """
@@ -5662,10 +5683,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["System.Runtime.CompilerServices.ITuple"],
             expectedDiagnostics:
             [
-                // (2,10): error CS9362: 'ITuple.Length.get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,10): error CS9362: 'ITuple.Length.get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // _ = o is (int x, string y);
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "(int x, string y)").WithArguments("System.Runtime.CompilerServices.ITuple.Length.get").WithLocation(2, 10),
-                // (2,10): error CS9362: 'ITuple.this[int].get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,10): error CS9362: 'ITuple.this[int].get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // _ = o is (int x, string y);
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "(int x, string y)").WithArguments("System.Runtime.CompilerServices.ITuple.this[int].get").WithLocation(2, 10),
             ]);
@@ -5679,12 +5700,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 [System.Runtime.CompilerServices.InterpolatedStringHandler]
                 public struct C
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public C(int literalLength, int formattedCount) { }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public void AppendLiteral(string s) { }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public void AppendFormatted<T>(T t) { }
+                    unsafe public C(int literalLength, int formattedCount) { }
+                    unsafe public void AppendLiteral(string s) { }
+                    unsafe public void AppendFormatted<T>(T t) { }
                 }
                 """,
             caller: """
@@ -5697,13 +5715,13 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C", Overload("C..ctor", parameterCount: 0)],
             expectedDiagnostics:
             [
-                // (1,7): error CS9362: 'C.AppendLiteral(string)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,7): error CS9362: 'C.AppendLiteral(string)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // log($"a{0}");
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "a").WithArguments("C.AppendLiteral(string)").WithLocation(1, 7),
-                // (1,8): error CS9362: 'C.AppendFormatted<int>(int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,8): error CS9362: 'C.AppendFormatted<int>(int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // log($"a{0}");
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "{0}").WithArguments("C.AppendFormatted<int>(int)").WithLocation(1, 8),
-                // (1,5): error CS9362: 'C.C(int, int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,5): error CS9362: 'C.C(int, int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // log($"a{0}");
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, @"$""a{0}""").WithArguments("C.C(int, int)").WithLocation(1, 5),
             ]);
@@ -5711,8 +5729,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
     [Theory, CombinatorialData]
     public void Member_Interceptor(
-        [CombinatorialValues("[System.Diagnostics.CodeAnalysis.RequiresUnsafe]", "")] string unsafe1,
-        [CombinatorialValues("[System.Diagnostics.CodeAnalysis.RequiresUnsafe]", "")] string unsafe2)
+        [CombinatorialValues("unsafe", "")] string unsafe1,
+        [CombinatorialValues("unsafe", "")] string unsafe2)
     {
         var source = ($$"""
             C.M();
@@ -5743,7 +5761,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(unsafe1.Length > 0
             ? [
-                // Program.cs(1,1): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // Program.cs(1,1): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C.M();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "C.M()").WithArguments("C.M()").WithLocation(1, 1),
             ]
@@ -5758,8 +5776,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
             public static class C
             {
-                [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                public static IEnumerable<int> M()
+                unsafe public static IEnumerable<int> M()
                 {
                     yield return 1;
                 }
@@ -5777,7 +5794,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
             [
-                // (1,19): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,19): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // foreach (var x in C.M()) { }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "C.M()").WithArguments("C.M()").WithLocation(1, 19),
             ]);
@@ -5801,14 +5818,13 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             M1();
             M2();
             unsafe { M1(); }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-            static void M1() { }
+            unsafe static void M1() { }
             static void M2() { }
             """;
         CreateCompilation([source, RequiresUnsafeAttributeDefinition],
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
-            // (1,1): error CS9362: 'M1()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+            // (1,1): error CS9362: 'M1()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
             // M1();
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "M1()").WithArguments("M1()").WithLocation(1, 1));
     }
@@ -5817,15 +5833,30 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
     public void Member_Lambda()
     {
         var source = """
-            var lam = [System.Diagnostics.CodeAnalysis.RequiresUnsafe] () => { };
+            System.Action lam = unsafe () => { };
             lam();
             """;
-        CreateCompilation([source, RequiresUnsafeAttributeDefinition],
-            options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
+        CreateCompilation(source,
+            options: TestOptions.UnsafeReleaseExe)
             .VerifyDiagnostics(
-            // (1,12): error CS9367: RequiresUnsafeAttribute cannot be applied to this symbol.
-            // var lam = [System.Diagnostics.CodeAnalysis.RequiresUnsafe] () => { };
-            Diagnostic(ErrorCode.ERR_RequiresUnsafeAttributeUnsupportedMemberTarget, "System.Diagnostics.CodeAnalysis.RequiresUnsafe").WithLocation(1, 12));
+            // (1,21): error CS1525: Invalid expression term 'unsafe'
+            // System.Action lam = unsafe () => { };
+            Diagnostic(ErrorCode.ERR_InvalidExprTerm, "unsafe").WithArguments("unsafe").WithLocation(1, 21),
+            // (1,21): error CS1002: ; expected
+            // System.Action lam = unsafe () => { };
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "unsafe").WithLocation(1, 21),
+            // (1,29): error CS8124: Tuple must contain at least two elements.
+            // System.Action lam = unsafe () => { };
+            Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(1, 29),
+            // (1,31): error CS1001: Identifier expected
+            // System.Action lam = unsafe () => { };
+            Diagnostic(ErrorCode.ERR_IdentifierExpected, "=>").WithLocation(1, 31),
+            // (1,34): error CS1525: Invalid expression term '{'
+            // System.Action lam = unsafe () => { };
+            Diagnostic(ErrorCode.ERR_InvalidExprTerm, "{").WithArguments("{").WithLocation(1, 34),
+            // (1,34): error CS1002: ; expected
+            // System.Action lam = unsafe () => { };
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "{").WithLocation(1, 34));
     }
 
     [Fact]
@@ -5871,8 +5902,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 public class C
                 {
                     public int P1 { get; set; }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public int P2 { get; set; }
+                    unsafe public int P2 { get; set; }
                 }
                 """,
             caller: """
@@ -5887,10 +5917,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C.P1", "C.get_P1", "C.set_P1", "C.<P1>k__BackingField", "C.<P2>k__BackingField"],
             expectedDiagnostics:
             [
-                // (3,1): error CS9362: 'C.P2.set' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,1): error CS9362: 'C.P2.set' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.P2 = c.P2 + 123;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.P2").WithArguments("C.P2.set").WithLocation(3, 1),
-                // (3,8): error CS9362: 'C.P2.get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,8): error CS9362: 'C.P2.get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.P2 = c.P2 + 123;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.P2").WithArguments("C.P2.get").WithLocation(3, 8)
             ]);
@@ -5903,8 +5933,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public class C
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public int P { get; set; }
+                    unsafe public int P { get; set; }
                 }
                 """,
             caller: """
@@ -5917,10 +5946,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
             [
-                // (2,1): error CS9362: 'C.P.set' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,1): error CS9362: 'C.P.set' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.P += 123;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.P").WithArguments("C.P.set").WithLocation(2, 1),
-                // (2,1): error CS9362: 'C.P.get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,1): error CS9362: 'C.P.get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.P += 123;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.P").WithArguments("C.P.get").WithLocation(2, 1),
             ]);
@@ -5933,10 +5962,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public class C
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public C P1 { get; set; }
-                    public C P2 { [System.Diagnostics.CodeAnalysis.RequiresUnsafe] get; set; }
-                    public C P3 { get; [System.Diagnostics.CodeAnalysis.RequiresUnsafe] set; }
+                    unsafe public C P1 { get; set; }
+                    public C P2 { unsafe get; set; }
+                    public C P3 { get; unsafe set; }
                     public C P4 { get; set; }
                 }
                 """,
@@ -5963,16 +5991,16 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C", "C.P2", "C.set_P2", "C.P3", "C.get_P3", "C.P4", "C.get_P4", "C.set_P4"],
             expectedDiagnostics:
             [
-                // (3,5): error CS9362: 'C.P1.set' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,5): error CS9362: 'C.P1.set' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 //     P1 = null,
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "P1").WithArguments("C.P1.set").WithLocation(3, 5),
-                // (5,5): error CS9362: 'C.P3.set' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (5,5): error CS9362: 'C.P3.set' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 //     P3 = null,
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "P3").WithArguments("C.P3.set").WithLocation(5, 5),
-                // (10,5): error CS9362: 'C.P1.get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (10,5): error CS9362: 'C.P1.get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 //     P1 = { },
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "P1").WithArguments("C.P1.get").WithLocation(10, 5),
-                // (11,5): error CS9362: 'C.P2.get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (11,5): error CS9362: 'C.P2.get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 //     P2 = { },
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "P2").WithArguments("C.P2.get").WithLocation(11, 5),
             ]);
@@ -5985,10 +6013,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public class C
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public int this[int i] => 0;
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public int Length => 0;
+                    unsafe public int this[int i] => 0;
+                    unsafe public int Length => 0;
                 }
                 """,
             caller: """
@@ -6003,16 +6029,16 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
             [
-                 // (2,12): error CS9362: 'C.Length.get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                 // (2,12): error CS9362: 'C.Length.get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // _ = c is { Length: 0 };
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "Length:").WithArguments("C.Length.get").WithLocation(2, 12),
-                // (3,10): error CS9362: 'C.Length.get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,10): error CS9362: 'C.Length.get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // _ = c is [];
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "[]").WithArguments("C.Length.get").WithLocation(3, 10),
-                // (3,10): error CS9362: 'C.Length.get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,10): error CS9362: 'C.Length.get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // _ = c is [];
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "[]").WithArguments("C.Length.get").WithLocation(3, 10),
-                // (3,10): error CS9362: 'C.this[int].get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,10): error CS9362: 'C.this[int].get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // _ = c is [];
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "[]").WithArguments("C.this[int].get").WithLocation(3, 10),
             ]);
@@ -6028,8 +6054,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                     extension(int x)
                     {
                         public int P1 { get => x; set { } }
-                        [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                        public int P2 { get => x; set { } }
+                        unsafe public int P2 { get => x; set { } }
                     }
                 }
                 """,
@@ -6045,19 +6070,18 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: [ExtensionMember("E", "P2"), "E.get_P2", ExtensionMember("E", "get_P2"), "E.set_P2", ExtensionMember("E", "set_P2")],
             expectedSafeSymbols: [ExtensionMember("E", "P1"), "E.get_P1", ExtensionMember("E", "get_P1"), "E.set_P1", ExtensionMember("E", "set_P1")],
-            expectedNoAttributeInSource: ["E.get_P2", "E.set_P2"],
             expectedDiagnostics:
             [
-                // (3,1): error CS9362: 'E.extension(int).P2.set' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,1): error CS9362: 'E.extension(int).P2.set' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // x.P2 = x.P2 + 333;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "x.P2").WithArguments("E.extension(int).P2.set").WithLocation(3, 1),
-                // (3,8): error CS9362: 'E.extension(int).P2.get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,8): error CS9362: 'E.extension(int).P2.get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // x.P2 = x.P2 + 333;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "x.P2").WithArguments("E.extension(int).P2.get").WithLocation(3, 8),
-                // (5,1): error CS9362: 'E.get_P2(int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (5,1): error CS9362: 'E.get_P2(int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // E.get_P2(x); E.set_P2(x, 0);
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "E.get_P2(x)").WithArguments("E.get_P2(int)").WithLocation(5, 1),
-                // (5,14): error CS9362: 'E.set_P2(int, int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (5,14): error CS9362: 'E.set_P2(int, int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // E.get_P2(x); E.set_P2(x, 0);
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "E.set_P2(x, 0)").WithArguments("E.set_P2(int, int)").WithLocation(5, 14),
             ]);
@@ -6070,8 +6094,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public record C(int P1, int P2)
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public int P2 { get; set; } = P2;
+                    unsafe public int P2 { get; set; } = P2;
                 }
                 """,
             caller: """
@@ -6085,10 +6108,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C.P1", "C.get_P1", "C.set_P1"],
             expectedDiagnostics:
             [
-                // (2,1): error CS9362: 'C.P2.set' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,1): error CS9362: 'C.P2.set' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.P2 = c.P1 + c.P2;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.P2").WithArguments("C.P2.set").WithLocation(2, 1),
-                // (2,15): error CS9362: 'C.P2.get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,15): error CS9362: 'C.P2.get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.P2 = c.P1 + c.P2;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.P2").WithArguments("C.P2.get").WithLocation(2, 15),
             ]);
@@ -6100,8 +6123,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         var lib = """
             public class C
             {
-                public int P1 { [System.Diagnostics.CodeAnalysis.RequiresUnsafe] get; set; }
-                public int P2 { get; [System.Diagnostics.CodeAnalysis.RequiresUnsafe] set; }
+                public int P1 { unsafe get; set; }
+                public int P2 { get; unsafe set; }
             }
             """;
 
@@ -6119,27 +6142,23 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C.P1", "C.P2", "C.get_P2", "C.set_P1"],
             expectedDiagnostics:
             [
-                // (2,8): error CS9362: 'C.P1.get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,8): error CS9362: 'C.P1.get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.P1 = c.P1 + 123;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.P1").WithArguments("C.P1.get").WithLocation(2, 8),
-                // (3,1): error CS9362: 'C.P2.set' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,1): error CS9362: 'C.P2.set' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.P2 = c.P2 + 123;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.P2").WithArguments("C.P2.set").WithLocation(3, 1),
             ]);
 
-        var expectedDiagnostics = new[]
-        {
-            // (3,22): warning CS9368: RequiresUnsafeAttribute is only valid under the updated memory safety rules.
-            //     public int P1 { [System.Diagnostics.CodeAnalysis.RequiresUnsafe] get; set; }
-            Diagnostic(ErrorCode.WRN_RequiresUnsafeAttributeLegacyRules, "System.Diagnostics.CodeAnalysis.RequiresUnsafe").WithLocation(3, 22),
-            // (4,27): warning CS9368: RequiresUnsafeAttribute is only valid under the updated memory safety rules.
-            //     public int P2 { get; [System.Diagnostics.CodeAnalysis.RequiresUnsafe] set; }
-            Diagnostic(ErrorCode.WRN_RequiresUnsafeAttributeLegacyRules, "System.Diagnostics.CodeAnalysis.RequiresUnsafe").WithLocation(4, 27),
-        };
-
-        CreateCompilation([lib, RequiresUnsafeAttributeDefinition], parseOptions: TestOptions.Regular14).VerifyEmitDiagnostics(expectedDiagnostics);
-        CreateCompilation([lib, RequiresUnsafeAttributeDefinition], parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics(expectedDiagnostics);
-        CreateCompilation([lib, RequiresUnsafeAttributeDefinition], parseOptions: TestOptions.RegularPreview).VerifyEmitDiagnostics(expectedDiagnostics);
+        CreateCompilation([lib, RequiresUnsafeAttributeDefinition], parseOptions: TestOptions.Regular14).VerifyEmitDiagnostics(
+            // (3,21): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     public int P1 { unsafe get; set; }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(3, 21),
+            // (4,26): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     public int P2 { get; unsafe set; }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(4, 26));
+        CreateCompilation([lib, RequiresUnsafeAttributeDefinition], parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics();
+        CreateCompilation([lib, RequiresUnsafeAttributeDefinition], parseOptions: TestOptions.RegularPreview).VerifyEmitDiagnostics();
     }
 
     [Fact]
@@ -6303,24 +6322,17 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
     public void Member_Property_Field()
     {
         CreateCompilation(
-            [
-                """
-                class C
-                {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    int P1 => field;
-
-                    [field: System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    int P2 => field;
-                }
-                """,
-                RequiresUnsafeAttributeDefinition,
-            ],
-            options: TestOptions.ReleaseDll.WithUpdatedMemorySafetyRules())
+            """
+            class C
+            {
+                unsafe int P => field;
+            }
+            """,
+            options: TestOptions.ReleaseDll)
             .VerifyDiagnostics(
-            // (6,13): error CS0592: Attribute 'System.Diagnostics.CodeAnalysis.RequiresUnsafe' is not valid on this declaration type. It is only valid on 'constructor, method, property, indexer, event' declarations.
-            //     [field: System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-            Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "System.Diagnostics.CodeAnalysis.RequiresUnsafe").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafe", "constructor, method, property, indexer, event").WithLocation(6, 13));
+            // (3,16): error CS0227: Unsafe code may only appear if compiling with /unsafe
+            //     unsafe int P => field;
+            Diagnostic(ErrorCode.ERR_IllegalUnsafe, "P").WithLocation(3, 16));
     }
 
     [Fact]
@@ -6331,10 +6343,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 public class A : System.Attribute
                 {
                     public int P1 { get; set; }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public int P2 { get; set; }
-                    public int P3 { [System.Diagnostics.CodeAnalysis.RequiresUnsafe] get; set; }
-                    public int P4 { get; [System.Diagnostics.CodeAnalysis.RequiresUnsafe] set; }
+                    unsafe public int P2 { get; set; }
+                    public int P3 { unsafe get; set; }
+                    public int P4 { get; unsafe set; }
                     public unsafe int F;
                 }
                 """,
@@ -6356,16 +6367,16 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["A.P1", "A.get_P1", "A.set_P1", "A.set_P3", "A.get_P4", "A.F"],
             expectedDiagnostics:
             [
-                // (2,12): error CS9362: 'A.P2.set' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,12): error CS9362: 'A.P2.set' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // [A(P1 = 0, P2 = 0, P3 = 0, P4 = 0, F = 0)] class C1;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "P2 = 0").WithArguments("A.P2.set").WithLocation(2, 12),
-                // (2,28): error CS9362: 'A.P4.set' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,28): error CS9362: 'A.P4.set' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // [A(P1 = 0, P2 = 0, P3 = 0, P4 = 0, F = 0)] class C1;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "P4 = 0").WithArguments("A.P4.set").WithLocation(2, 28),
-                // (6,16): error CS9362: 'A.P2.set' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (6,16): error CS9362: 'A.P2.set' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 //     [A(P1 = 0, P2 = 0, P3 = 0, P4 = 0, F = 0)] void M1() { }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "P2 = 0").WithArguments("A.P2.set").WithLocation(6, 16),
-                // (6,32): error CS9362: 'A.P4.set' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (6,32): error CS9362: 'A.P4.set' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 //     [A(P1 = 0, P2 = 0, P3 = 0, P4 = 0, F = 0)] void M1() { }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "P4 = 0").WithArguments("A.P4.set").WithLocation(6, 32),
             ]);
@@ -6378,9 +6389,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public class B
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public virtual int P1 { get; set; }
-                    public virtual int P2 { [System.Diagnostics.CodeAnalysis.RequiresUnsafe] get; set; }
+                    unsafe public virtual int P1 { get; set; }
+                    public virtual int P2 { unsafe get; set; }
                     public virtual int P3 { get; set; }
                 }
                 """,
@@ -6393,18 +6403,15 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 class C1 : B
                 {
                     public override int P1 { get; set; }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public override int P2 { get; set; }
-                    public override int P3 { [System.Diagnostics.CodeAnalysis.RequiresUnsafe] get; set; }
+                    unsafe public override int P2 { get; set; }
+                    public override int P3 { unsafe get; set; }
                 }
 
                 class C2 : B
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public override int P1 { get; set; }
-                    public override int P2 { [System.Diagnostics.CodeAnalysis.RequiresUnsafe] get; set; }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public override int P3 { get; set; }
+                    unsafe public override int P1 { get; set; }
+                    public override int P2 { unsafe get; set; }
+                    unsafe public override int P3 { get; set; }
                 }
                 """,
             additionalSources: [RequiresUnsafeAttributeDefinition],
@@ -6412,63 +6419,63 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["B.P2", "B.set_P2", "B.P3", "B.get_P3", "B.set_P3"],
             expectedDiagnostics:
             [
-                // (3,1): error CS9362: 'C1.P2.set' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,1): error CS9362: 'C1.P2.set' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.P2 = c.P2 + 123;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.P2").WithArguments("C1.P2.set").WithLocation(3, 1),
-                // (3,8): error CS9362: 'C1.P2.get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,8): error CS9362: 'C1.P2.get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.P2 = c.P2 + 123;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.P2").WithArguments("C1.P2.get").WithLocation(3, 8),
-                // (4,8): error CS9362: 'C1.P3.get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (4,8): error CS9362: 'C1.P3.get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.P3 = c.P3 + 123;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.P3").WithArguments("C1.P3.get").WithLocation(4, 8),
-                // (10,35): error CS9364: Unsafe member 'C1.P2.set' cannot override safe member 'B.P2.set'
-                //     public override int P2 { get; set; }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "set").WithArguments("C1.P2.set", "B.P2.set").WithLocation(10, 35),
-                // (11,79): error CS9364: Unsafe member 'C1.P3.get' cannot override safe member 'B.P3.get'
-                //     public override int P3 { [System.Diagnostics.CodeAnalysis.RequiresUnsafe] get; set; }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "get").WithArguments("C1.P3.get", "B.P3.get").WithLocation(11, 79),
-                // (20,30): error CS9364: Unsafe member 'C2.P3.get' cannot override safe member 'B.P3.get'
-                //     public override int P3 { get; set; }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "get").WithArguments("C2.P3.get", "B.P3.get").WithLocation(20, 30),
-                // (20,35): error CS9364: Unsafe member 'C2.P3.set' cannot override safe member 'B.P3.set'
-                //     public override int P3 { get; set; }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "set").WithArguments("C2.P3.set", "B.P3.set").WithLocation(20, 35),
+                // (9,42): error CS9364: Unsafe member 'C1.P2.set' cannot override safe member 'B.P2.set'
+                //     unsafe public override int P2 { get; set; }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "set").WithArguments("C1.P2.set", "B.P2.set").WithLocation(9, 42),
+                // (10,37): error CS9364: Unsafe member 'C1.P3.get' cannot override safe member 'B.P3.get'
+                //     public override int P3 { unsafe get; set; }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "get").WithArguments("C1.P3.get", "B.P3.get").WithLocation(10, 37),
+                // (17,37): error CS9364: Unsafe member 'C2.P3.get' cannot override safe member 'B.P3.get'
+                //     unsafe public override int P3 { get; set; }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "get").WithArguments("C2.P3.get", "B.P3.get").WithLocation(17, 37),
+                // (17,42): error CS9364: Unsafe member 'C2.P3.set' cannot override safe member 'B.P3.set'
+                //     unsafe public override int P3 { get; set; }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "set").WithArguments("C2.P3.set", "B.P3.set").WithLocation(17, 42),
             ],
             expectedDiagnosticsWhenReferencingLegacyLib:
             [
-                // (3,1): error CS9362: 'C1.P2.set' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,1): error CS9362: 'C1.P2.set' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.P2 = c.P2 + 123;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.P2").WithArguments("C1.P2.set").WithLocation(3, 1),
-                // (3,8): error CS9362: 'C1.P2.get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,8): error CS9362: 'C1.P2.get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.P2 = c.P2 + 123;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.P2").WithArguments("C1.P2.get").WithLocation(3, 8),
-                // (4,8): error CS9362: 'C1.P3.get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (4,8): error CS9362: 'C1.P3.get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.P3 = c.P3 + 123;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.P3").WithArguments("C1.P3.get").WithLocation(4, 8),
-                // (10,30): error CS9364: Unsafe member 'C1.P2.get' cannot override safe member 'B.P2.get'
-                //     public override int P2 { get; set; }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "get").WithArguments("C1.P2.get", "B.P2.get").WithLocation(10, 30),
-                // (10,35): error CS9364: Unsafe member 'C1.P2.set' cannot override safe member 'B.P2.set'
-                //     public override int P2 { get; set; }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "set").WithArguments("C1.P2.set", "B.P2.set").WithLocation(10, 35),
-                // (11,79): error CS9364: Unsafe member 'C1.P3.get' cannot override safe member 'B.P3.get'
-                //     public override int P3 { [System.Diagnostics.CodeAnalysis.RequiresUnsafe] get; set; }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "get").WithArguments("C1.P3.get", "B.P3.get").WithLocation(11, 79),
-                // (17,30): error CS9364: Unsafe member 'C2.P1.get' cannot override safe member 'B.P1.get'
-                //     public override int P1 { get; set; }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "get").WithArguments("C2.P1.get", "B.P1.get").WithLocation(17, 30),
-                // (17,35): error CS9364: Unsafe member 'C2.P1.set' cannot override safe member 'B.P1.set'
-                //     public override int P1 { get; set; }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "set").WithArguments("C2.P1.set", "B.P1.set").WithLocation(17, 35),
-                // (18,79): error CS9364: Unsafe member 'C2.P2.get' cannot override safe member 'B.P2.get'
-                //     public override int P2 { [System.Diagnostics.CodeAnalysis.RequiresUnsafe] get; set; }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "get").WithArguments("C2.P2.get", "B.P2.get").WithLocation(18, 79),
-                // (20,30): error CS9364: Unsafe member 'C2.P3.get' cannot override safe member 'B.P3.get'
-                //     public override int P3 { get; set; }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "get").WithArguments("C2.P3.get", "B.P3.get").WithLocation(20, 30),
-                // (20,35): error CS9364: Unsafe member 'C2.P3.set' cannot override safe member 'B.P3.set'
-                //     public override int P3 { get; set; }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "set").WithArguments("C2.P3.set", "B.P3.set").WithLocation(20, 35),
+                // (9,37): error CS9364: Unsafe member 'C1.P2.get' cannot override safe member 'B.P2.get'
+                //     unsafe public override int P2 { get; set; }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "get").WithArguments("C1.P2.get", "B.P2.get").WithLocation(9, 37),
+                // (9,42): error CS9364: Unsafe member 'C1.P2.set' cannot override safe member 'B.P2.set'
+                //     unsafe public override int P2 { get; set; }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "set").WithArguments("C1.P2.set", "B.P2.set").WithLocation(9, 42),
+                // (10,37): error CS9364: Unsafe member 'C1.P3.get' cannot override safe member 'B.P3.get'
+                //     public override int P3 { unsafe get; set; }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "get").WithArguments("C1.P3.get", "B.P3.get").WithLocation(10, 37),
+                // (15,37): error CS9364: Unsafe member 'C2.P1.get' cannot override safe member 'B.P1.get'
+                //     unsafe public override int P1 { get; set; }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "get").WithArguments("C2.P1.get", "B.P1.get").WithLocation(15, 37),
+                // (15,42): error CS9364: Unsafe member 'C2.P1.set' cannot override safe member 'B.P1.set'
+                //     unsafe public override int P1 { get; set; }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "set").WithArguments("C2.P1.set", "B.P1.set").WithLocation(15, 42),
+                // (16,37): error CS9364: Unsafe member 'C2.P2.get' cannot override safe member 'B.P2.get'
+                //     public override int P2 { unsafe get; set; }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "get").WithArguments("C2.P2.get", "B.P2.get").WithLocation(16, 37),
+                // (17,37): error CS9364: Unsafe member 'C2.P3.get' cannot override safe member 'B.P3.get'
+                //     unsafe public override int P3 { get; set; }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "get").WithArguments("C2.P3.get", "B.P3.get").WithLocation(17, 37),
+                // (17,42): error CS9364: Unsafe member 'C2.P3.set' cannot override safe member 'B.P3.set'
+                //     unsafe public override int P3 { get; set; }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "set").WithArguments("C2.P3.set", "B.P3.set").WithLocation(17, 42),
             ]);
     }
 
@@ -6479,9 +6486,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public interface I
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    int P1 { get; set; }
-                    int P2 { [System.Diagnostics.CodeAnalysis.RequiresUnsafe] get; set; }
+                    unsafe int P1 { get; set; }
+                    int P2 { unsafe get; set; }
                     int P3 { get; set; }
                 }
                 """,
@@ -6494,18 +6500,15 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 class C1 : I
                 {
                     public int P1 { get; set; }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public int P2 { get; set; }
-                    public int P3 { [System.Diagnostics.CodeAnalysis.RequiresUnsafe] get; set; }
+                    unsafe public int P2 { get; set; }
+                    public int P3 { unsafe get; set; }
                 }
 
                 class C2 : I
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public int P1 { get; set; }
-                    public int P2 { [System.Diagnostics.CodeAnalysis.RequiresUnsafe] get; set; }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public int P3 { get; set; }
+                    unsafe public int P1 { get; set; }
+                    public int P2 { unsafe get; set; }
+                    unsafe public int P3 { get; set; }
                 }
                 """,
             additionalSources: [RequiresUnsafeAttributeDefinition],
@@ -6513,54 +6516,54 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["I.P2", "I.set_P2", "I.P3", "I.get_P3", "I.set_P3"],
             expectedDiagnostics:
             [
-                // (2,1): error CS9362: 'I.P1.set' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,1): error CS9362: 'I.P1.set' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // i.P1 = i.P1 + 123;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "i.P1").WithArguments("I.P1.set").WithLocation(2, 1),
-                // (2,8): error CS9362: 'I.P1.get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,8): error CS9362: 'I.P1.get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // i.P1 = i.P1 + 123;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "i.P1").WithArguments("I.P1.get").WithLocation(2, 8),
-                // (3,8): error CS9362: 'I.P2.get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,8): error CS9362: 'I.P2.get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // i.P2 = i.P2 + 123;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "i.P2").WithArguments("I.P2.get").WithLocation(3, 8),
-                // (10,26): error CS9365: Unsafe member 'C1.P2.set' cannot implicitly implement safe member 'I.P2.set'
-                //     public int P2 { get; set; }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "set").WithArguments("C1.P2.set", "I.P2.set").WithLocation(10, 26),
-                // (11,70): error CS9365: Unsafe member 'C1.P3.get' cannot implicitly implement safe member 'I.P3.get'
-                //     public int P3 { [System.Diagnostics.CodeAnalysis.RequiresUnsafe] get; set; }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "get").WithArguments("C1.P3.get", "I.P3.get").WithLocation(11, 70),
-                // (20,21): error CS9365: Unsafe member 'C2.P3.get' cannot implicitly implement safe member 'I.P3.get'
-                //     public int P3 { get; set; }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "get").WithArguments("C2.P3.get", "I.P3.get").WithLocation(20, 21),
-                // (20,26): error CS9365: Unsafe member 'C2.P3.set' cannot implicitly implement safe member 'I.P3.set'
-                //     public int P3 { get; set; }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "set").WithArguments("C2.P3.set", "I.P3.set").WithLocation(20, 26),
+                // (9,33): error CS9365: Unsafe member 'C1.P2.set' cannot implicitly implement safe member 'I.P2.set'
+                //     unsafe public int P2 { get; set; }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "set").WithArguments("C1.P2.set", "I.P2.set").WithLocation(9, 33),
+                // (10,28): error CS9365: Unsafe member 'C1.P3.get' cannot implicitly implement safe member 'I.P3.get'
+                //     public int P3 { unsafe get; set; }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "get").WithArguments("C1.P3.get", "I.P3.get").WithLocation(10, 28),
+                // (17,28): error CS9365: Unsafe member 'C2.P3.get' cannot implicitly implement safe member 'I.P3.get'
+                //     unsafe public int P3 { get; set; }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "get").WithArguments("C2.P3.get", "I.P3.get").WithLocation(17, 28),
+                // (17,33): error CS9365: Unsafe member 'C2.P3.set' cannot implicitly implement safe member 'I.P3.set'
+                //     unsafe public int P3 { get; set; }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "set").WithArguments("C2.P3.set", "I.P3.set").WithLocation(17, 33),
             ],
             expectedDiagnosticsWhenReferencingLegacyLib:
             [
-                // (10,21): error CS9365: Unsafe member 'C1.P2.get' cannot implicitly implement safe member 'I.P2.get'
-                //     public int P2 { get; set; }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "get").WithArguments("C1.P2.get", "I.P2.get").WithLocation(10, 21),
-                // (10,26): error CS9365: Unsafe member 'C1.P2.set' cannot implicitly implement safe member 'I.P2.set'
-                //     public int P2 { get; set; }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "set").WithArguments("C1.P2.set", "I.P2.set").WithLocation(10, 26),
-                // (11,70): error CS9365: Unsafe member 'C1.P3.get' cannot implicitly implement safe member 'I.P3.get'
-                //     public int P3 { [System.Diagnostics.CodeAnalysis.RequiresUnsafe] get; set; }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "get").WithArguments("C1.P3.get", "I.P3.get").WithLocation(11, 70),
-                // (17,21): error CS9365: Unsafe member 'C2.P1.get' cannot implicitly implement safe member 'I.P1.get'
-                //     public int P1 { get; set; }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "get").WithArguments("C2.P1.get", "I.P1.get").WithLocation(17, 21),
-                // (17,26): error CS9365: Unsafe member 'C2.P1.set' cannot implicitly implement safe member 'I.P1.set'
-                //     public int P1 { get; set; }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "set").WithArguments("C2.P1.set", "I.P1.set").WithLocation(17, 26),
-                // (18,70): error CS9365: Unsafe member 'C2.P2.get' cannot implicitly implement safe member 'I.P2.get'
-                //     public int P2 { [System.Diagnostics.CodeAnalysis.RequiresUnsafe] get; set; }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "get").WithArguments("C2.P2.get", "I.P2.get").WithLocation(18, 70),
-                // (20,21): error CS9365: Unsafe member 'C2.P3.get' cannot implicitly implement safe member 'I.P3.get'
-                //     public int P3 { get; set; }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "get").WithArguments("C2.P3.get", "I.P3.get").WithLocation(20, 21),
-                // (20,26): error CS9365: Unsafe member 'C2.P3.set' cannot implicitly implement safe member 'I.P3.set'
-                //     public int P3 { get; set; }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "set").WithArguments("C2.P3.set", "I.P3.set").WithLocation(20, 26),
+                // (9,28): error CS9365: Unsafe member 'C1.P2.get' cannot implicitly implement safe member 'I.P2.get'
+                //     unsafe public int P2 { get; set; }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "get").WithArguments("C1.P2.get", "I.P2.get").WithLocation(9, 28),
+                // (9,33): error CS9365: Unsafe member 'C1.P2.set' cannot implicitly implement safe member 'I.P2.set'
+                //     unsafe public int P2 { get; set; }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "set").WithArguments("C1.P2.set", "I.P2.set").WithLocation(9, 33),
+                // (10,28): error CS9365: Unsafe member 'C1.P3.get' cannot implicitly implement safe member 'I.P3.get'
+                //     public int P3 { unsafe get; set; }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "get").WithArguments("C1.P3.get", "I.P3.get").WithLocation(10, 28),
+                // (15,28): error CS9365: Unsafe member 'C2.P1.get' cannot implicitly implement safe member 'I.P1.get'
+                //     unsafe public int P1 { get; set; }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "get").WithArguments("C2.P1.get", "I.P1.get").WithLocation(15, 28),
+                // (15,33): error CS9365: Unsafe member 'C2.P1.set' cannot implicitly implement safe member 'I.P1.set'
+                //     unsafe public int P1 { get; set; }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "set").WithArguments("C2.P1.set", "I.P1.set").WithLocation(15, 33),
+                // (16,28): error CS9365: Unsafe member 'C2.P2.get' cannot implicitly implement safe member 'I.P2.get'
+                //     public int P2 { unsafe get; set; }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "get").WithArguments("C2.P2.get", "I.P2.get").WithLocation(16, 28),
+                // (17,28): error CS9365: Unsafe member 'C2.P3.get' cannot implicitly implement safe member 'I.P3.get'
+                //     unsafe public int P3 { get; set; }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "get").WithArguments("C2.P3.get", "I.P3.get").WithLocation(17, 28),
+                // (17,33): error CS9365: Unsafe member 'C2.P3.set' cannot implicitly implement safe member 'I.P3.set'
+                //     unsafe public int P3 { get; set; }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "set").WithArguments("C2.P3.set", "I.P3.set").WithLocation(17, 33),
             ]);
     }
 
@@ -6575,8 +6578,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 }
                 public class C2
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public int this[int i] { get => i; set { } }
+                    unsafe public int this[int i] { get => i; set { } }
                 }
                 """,
             caller: """
@@ -6591,10 +6593,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C1.this[]", "C1.get_Item", "C1.set_Item"],
             expectedDiagnostics:
             [
-                // (4,1): error CS9362: 'C2.this[int].set' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (4,1): error CS9362: 'C2.this[int].set' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c2[0] = c2[0] + 123;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c2[0]").WithArguments("C2.this[int].set").WithLocation(4, 1),
-                // (4,9): error CS9362: 'C2.this[int].get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (4,9): error CS9362: 'C2.this[int].get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c2[0] = c2[0] + 123;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c2[0]").WithArguments("C2.this[int].get").WithLocation(4, 9),
             ]);
@@ -6607,8 +6609,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public class C
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public int this[int i] { get => i; set { } }
+                    unsafe public int this[int i] { get => i; set { } }
                 }
                 """,
             caller: """
@@ -6621,10 +6622,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
             [
-                // (2,1): error CS9362: 'C.this[int].set' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,1): error CS9362: 'C.this[int].set' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c[0] += 123;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c[0]").WithArguments("C.this[int].set").WithLocation(2, 1),
-                // (2,1): error CS9362: 'C.this[int].get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,1): error CS9362: 'C.this[int].get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c[0] += 123;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c[0]").WithArguments("C.this[int].get").WithLocation(2, 1),
             ]);
@@ -6635,9 +6636,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
     {
         CompileAndVerifyUnsafe(
             lib: """
-                public class C1 { [System.Diagnostics.CodeAnalysis.RequiresUnsafe] public object this[int i] { get => null; set { } } }
-                public class C2 { public object this[int i] { [System.Diagnostics.CodeAnalysis.RequiresUnsafe] get => null; set { } } }
-                public class C3 { public object this[int i] { get => null; [System.Diagnostics.CodeAnalysis.RequiresUnsafe] set { } } }
+                public class C1 { unsafe public object this[int i] { get => null; set { } } }
+                public class C2 { public object this[int i] { unsafe get => null; set { } } }
+                public class C3 { public object this[int i] { get => null; unsafe set { } } }
                 public class C4 { public object this[int i] { get => null; set { } } }
                 """,
             caller: """
@@ -6654,16 +6655,16 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C1", "C2", "C2.this[]", "C2.set_Item", "C3", "C3.this[]", "C3.get_Item", "C4", "C4.this[]", "C4.get_Item", "C4.set_Item"],
             expectedDiagnostics:
             [
-                // (1,14): error CS9362: 'C1.this[int].set' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,14): error CS9362: 'C1.this[int].set' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // _ = new C1 { [0] = null, [0] = { } };
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "[0]").WithArguments("C1.this[int].set").WithLocation(1, 14),
-                // (1,26): error CS9362: 'C1.this[int].get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,26): error CS9362: 'C1.this[int].get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // _ = new C1 { [0] = null, [0] = { } };
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "[0]").WithArguments("C1.this[int].get").WithLocation(1, 26),
-                // (2,26): error CS9362: 'C2.this[int].get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,26): error CS9362: 'C2.this[int].get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // _ = new C2 { [0] = null, [0] = { } };
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "[0]").WithArguments("C2.this[int].get").WithLocation(2, 26),
-                // (3,14): error CS9362: 'C3.this[int].set' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,14): error CS9362: 'C3.this[int].set' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // _ = new C3 { [0] = null, [0] = { } };
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "[0]").WithArguments("C3.this[int].set").WithLocation(3, 14),
             ]);
@@ -6675,11 +6676,11 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         var lib = """
             public class C1
             {
-                public int this[int i] { [System.Diagnostics.CodeAnalysis.RequiresUnsafe] get => i; set { } }
+                public int this[int i] { unsafe get => i; set { } }
             }
             public class C2
             {
-                public int this[int i] { get => i; [System.Diagnostics.CodeAnalysis.RequiresUnsafe] set { } }
+                public int this[int i] { get => i; unsafe set { } }
             }
             """;
 
@@ -6698,26 +6699,23 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C1.this[]", "C2.this[]", "C2.get_Item", "C1.set_Item"],
             expectedDiagnostics:
             [
-                // (2,9): error CS9362: 'C1.this[int].get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,9): error CS9362: 'C1.this[int].get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c1[0] = c1[0] + 123;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c1[0]").WithArguments("C1.this[int].get").WithLocation(2, 9),
-                // (4,1): error CS9362: 'C2.this[int].set' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (4,1): error CS9362: 'C2.this[int].set' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c2[0] = c2[0] + 123;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c2[0]").WithArguments("C2.this[int].set").WithLocation(4, 1),
             ]);
 
-        var expectedDiagnostics = new[]
-        {
-            // (3,31): warning CS9368: RequiresUnsafeAttribute is only valid under the updated memory safety rules.
-            //     public int this[int i] { [System.Diagnostics.CodeAnalysis.RequiresUnsafe] get => i; set { } }
-            Diagnostic(ErrorCode.WRN_RequiresUnsafeAttributeLegacyRules, "System.Diagnostics.CodeAnalysis.RequiresUnsafe").WithLocation(3, 31),
-            // (7,41): warning CS9368: RequiresUnsafeAttribute is only valid under the updated memory safety rules.
-            //     public int this[int i] { get => i; [System.Diagnostics.CodeAnalysis.RequiresUnsafe] set { } }
-            Diagnostic(ErrorCode.WRN_RequiresUnsafeAttributeLegacyRules, "System.Diagnostics.CodeAnalysis.RequiresUnsafe").WithLocation(7, 41),
-        };
-
-        CreateCompilation([lib, RequiresUnsafeAttributeDefinition], parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics(expectedDiagnostics);
-        CreateCompilation([lib, RequiresUnsafeAttributeDefinition], parseOptions: TestOptions.RegularPreview).VerifyEmitDiagnostics(expectedDiagnostics);
+        CreateCompilation([lib, RequiresUnsafeAttributeDefinition], parseOptions: TestOptions.Regular14).VerifyEmitDiagnostics(
+            // (3,30): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     public int this[int i] { unsafe get => i; set { } }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(3, 30),
+            // (7,40): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     public int this[int i] { get => i; unsafe set { } }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(7, 40));
+        CreateCompilation([lib, RequiresUnsafeAttributeDefinition], parseOptions: TestOptions.RegularNext).VerifyEmitDiagnostics();
+        CreateCompilation([lib, RequiresUnsafeAttributeDefinition], parseOptions: TestOptions.RegularPreview).VerifyEmitDiagnostics();
     }
 
     [Fact]
@@ -6872,7 +6870,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             // (3,30): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //     public int this[int i] { unsafe get => i; set { } }
             Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(3, 30),
-            // (4,41): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            // (4,51): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //     public int this[int i, int j] { get => i + j; unsafe set { } }
             Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(4, 51));
     }
@@ -6885,8 +6883,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 public class C
                 {
                     public event System.Action E1 { add { } remove { } }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public event System.Action E2 { add { } remove { } }
+                    unsafe public event System.Action E2 { add { } remove { } }
                 }
                 """,
             caller: """
@@ -6900,7 +6897,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C.E1", "C.add_E1", "C.remove_E1"],
             expectedDiagnostics:
             [
-                // (3,6): error CS9362: 'C.E2.add' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,6): error CS9362: 'C.E2.add' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.E2 += null;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "+=").WithArguments("C.E2.add").WithLocation(3, 6),
             ]);
@@ -6909,7 +6906,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             class C
             {
                 event System.Action E1, E2;
-                [System.Diagnostics.CodeAnalysis.RequiresUnsafe] event System.Action E3, E4;
+                unsafe event System.Action E3, E4;
                 void M()
                 {
                     E1();
@@ -6932,16 +6929,16 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CreateCompilation([source, RequiresUnsafeAttributeDefinition],
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
-            // (9,9): error CS9362: 'C.E3' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+            // (9,9): error CS9362: 'C.E3' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
             //         E3();
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "E3").WithArguments("C.E3").WithLocation(9, 9),
-            // (10,9): error CS9362: 'C.E4' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+            // (10,9): error CS9362: 'C.E4' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
             //         E4();
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "E4").WithArguments("C.E4").WithLocation(10, 9),
-            // (14,9): error CS9362: 'C.E3' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+            // (14,9): error CS9362: 'C.E3' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
             //         E3 = null;
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "E3").WithArguments("C.E3").WithLocation(14, 9),
-            // (15,9): error CS9362: 'C.E4' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+            // (15,9): error CS9362: 'C.E4' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
             //         E4 = null;
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "E4").WithArguments("C.E4").WithLocation(15, 9));
     }
@@ -6949,31 +6946,21 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
     [Fact]
     public void Member_Event_Accessors()
     {
-        CompileAndVerifyUnsafe(
-            lib: """
-                public class C
-                {
-                    public event System.Action E1 { [System.Diagnostics.CodeAnalysis.RequiresUnsafe] add { } remove { } }
-                    public event System.Action E2 { add { } [System.Diagnostics.CodeAnalysis.RequiresUnsafe] remove { } }
-                }
-                """,
-            caller: """
-                var c = new C();
-                c.E1 += null; c.E1 -= null;
-                c.E2 += null; c.E2 -= null;
-                """,
-            additionalSources: [RequiresUnsafeAttributeDefinition],
-            expectedUnsafeSymbols: ["C.add_E1", "C.remove_E2"],
-            expectedSafeSymbols: ["C.E1", "C.remove_E1", "C.E2", "C.add_E2"],
-            expectedDiagnostics:
-            [
-                // (2,6): error CS9362: 'C.E1.add' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
-                // c.E1 += null; c.E1 -= null;
-                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "+=").WithArguments("C.E1.add").WithLocation(2, 6),
-                // (3,20): error CS9362: 'C.E2.remove' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
-                // c.E2 += null; c.E2 -= null;
-                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "-=").WithArguments("C.E2.remove").WithLocation(3, 20),
-            ]);
+        CreateCompilation("""
+            public class C
+            {
+                public event System.Action E1 { unsafe add { } remove { } }
+                public event System.Action E2 { add { } unsafe remove { } }
+            }
+            """,
+            options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
+            .VerifyDiagnostics(
+            // (3,37): error CS1609: Modifiers cannot be placed on event accessor declarations
+            //     public event System.Action E1 { unsafe add { } remove { } }
+            Diagnostic(ErrorCode.ERR_NoModifiersOnAccessor, "unsafe").WithLocation(3, 37),
+            // (4,45): error CS1609: Modifiers cannot be placed on event accessor declarations
+            //     public event System.Action E2 { add { } unsafe remove { } }
+            Diagnostic(ErrorCode.ERR_NoModifiersOnAccessor, "unsafe").WithLocation(4, 45));
     }
 
     [Fact]
@@ -7004,10 +6991,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 #pragma warning disable CS0067 // unused event
                 public class B
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public virtual event System.Action E1;
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public virtual event System.Action E2 { add { } remove { } }
+                    unsafe public virtual event System.Action E1;
+                    unsafe public virtual event System.Action E2 { add { } remove { } }
                     public virtual event System.Action E3;
                     public virtual event System.Action E4 { add { } remove { } }
                 }
@@ -7025,18 +7010,14 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 {
                     public override event System.Action E1;
                     public override event System.Action E2 { add { } remove { } }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public override event System.Action E3;
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public override event System.Action E4 { add { } remove { } }
+                    unsafe public override event System.Action E3;
+                    unsafe public override event System.Action E4 { add { } remove { } }
                 }
 
                 class C2 : B
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public override event System.Action E1;
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public override event System.Action E2 { add { } remove { } }
+                    unsafe public override event System.Action E1;
+                    unsafe public override event System.Action E2 { add { } remove { } }
                     public override event System.Action E3;
                     public override event System.Action E4 { add { } remove { } }
                 }
@@ -7046,39 +7027,39 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["B.E3", "B.add_E3", "B.remove_E3", "B.E4", "B.add_E4", "B.remove_E4"],
             expectedDiagnostics:
             [
-                // (4,6): error CS9362: 'C1.E3.add' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (4,6): error CS9362: 'C1.E3.add' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.E3 += null;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "+=").WithArguments("C1.E3.add").WithLocation(4, 6),
-                // (5,6): error CS9362: 'C1.E4.add' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (5,6): error CS9362: 'C1.E4.add' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.E4 += null;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "+=").WithArguments("C1.E4.add").WithLocation(5, 6),
-                // (14,41): error CS9364: Unsafe member 'C1.E3' cannot override safe member 'B.E3'
-                //     public override event System.Action E3;
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "E3").WithArguments("C1.E3", "B.E3").WithLocation(14, 41),
-                // (16,41): error CS9364: Unsafe member 'C1.E4' cannot override safe member 'B.E4'
-                //     public override event System.Action E4 { add { } remove { } }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "E4").WithArguments("C1.E4", "B.E4").WithLocation(16, 41),
+                // (13,48): error CS9364: Unsafe member 'C1.E3' cannot override safe member 'B.E3'
+                //     unsafe public override event System.Action E3;
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "E3").WithArguments("C1.E3", "B.E3").WithLocation(13, 48),
+                // (14,48): error CS9364: Unsafe member 'C1.E4' cannot override safe member 'B.E4'
+                //     unsafe public override event System.Action E4 { add { } remove { } }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "E4").WithArguments("C1.E4", "B.E4").WithLocation(14, 48),
             ],
             expectedDiagnosticsWhenReferencingLegacyLib:
             [
-                // (4,6): error CS9362: 'C1.E3.add' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (4,6): error CS9362: 'C1.E3.add' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.E3 += null;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "+=").WithArguments("C1.E3.add").WithLocation(4, 6),
-                // (5,6): error CS9362: 'C1.E4.add' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (5,6): error CS9362: 'C1.E4.add' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.E4 += null;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "+=").WithArguments("C1.E4.add").WithLocation(5, 6),
-                // (14,41): error CS9364: Unsafe member 'C1.E3' cannot override safe member 'B.E3'
-                //     public override event System.Action E3;
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "E3").WithArguments("C1.E3", "B.E3").WithLocation(14, 41),
-                // (16,41): error CS9364: Unsafe member 'C1.E4' cannot override safe member 'B.E4'
-                //     public override event System.Action E4 { add { } remove { } }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "E4").WithArguments("C1.E4", "B.E4").WithLocation(16, 41),
-                // (22,41): error CS9364: Unsafe member 'C2.E1' cannot override safe member 'B.E1'
-                //     public override event System.Action E1;
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "E1").WithArguments("C2.E1", "B.E1").WithLocation(22, 41),
-                // (24,41): error CS9364: Unsafe member 'C2.E2' cannot override safe member 'B.E2'
-                //     public override event System.Action E2 { add { } remove { } }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "E2").WithArguments("C2.E2", "B.E2").WithLocation(24, 41),
+                // (13,48): error CS9364: Unsafe member 'C1.E3' cannot override safe member 'B.E3'
+                //     unsafe public override event System.Action E3;
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "E3").WithArguments("C1.E3", "B.E3").WithLocation(13, 48),
+                // (14,48): error CS9364: Unsafe member 'C1.E4' cannot override safe member 'B.E4'
+                //     unsafe public override event System.Action E4 { add { } remove { } }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "E4").WithArguments("C1.E4", "B.E4").WithLocation(14, 48),
+                // (19,48): error CS9364: Unsafe member 'C2.E1' cannot override safe member 'B.E1'
+                //     unsafe public override event System.Action E1;
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "E1").WithArguments("C2.E1", "B.E1").WithLocation(19, 48),
+                // (20,48): error CS9364: Unsafe member 'C2.E2' cannot override safe member 'B.E2'
+                //     unsafe public override event System.Action E2 { add { } remove { } }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "E2").WithArguments("C2.E2", "B.E2").WithLocation(20, 48),
             ]);
     }
 
@@ -7089,8 +7070,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public interface I
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    event System.Action E1;
+                    unsafe event System.Action E1;
                     event System.Action E2;
                 }
                 """,
@@ -7104,28 +7084,24 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 class C1 : I
                 {
                     public event System.Action E1;
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public event System.Action E2;
+                    unsafe public event System.Action E2;
                 }
 
                 class C2 : I
                 {
                     public event System.Action E1 { add { } remove { } }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public event System.Action E2 { add { } remove { } }
+                    unsafe public event System.Action E2 { add { } remove { } }
                 }
 
                 class C3 : I
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public event System.Action E1;
+                    unsafe public event System.Action E1;
                     public event System.Action E2;
                 }
 
                 class C4 : I
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public event System.Action E1 { add { } remove { } }
+                    unsafe public event System.Action E1 { add { } remove { } }
                     public event System.Action E2 { add { } remove { } }
                 }
                 """,
@@ -7134,30 +7110,30 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["I.E2", "I.add_E2", "I.remove_E2"],
             expectedDiagnostics:
             [
-                // (2,6): error CS9362: 'I.E1.add' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,6): error CS9362: 'I.E1.add' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // i.E1 += null;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "+=").WithArguments("I.E1.add").WithLocation(2, 6),
-                // (11,32): error CS9365: Unsafe member 'C1.E2' cannot implicitly implement safe member 'I.E2'
-                //     public event System.Action E2;
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "E2").WithArguments("C1.E2", "I.E2").WithLocation(11, 32),
-                // (18,32): error CS9365: Unsafe member 'C2.E2' cannot implicitly implement safe member 'I.E2'
-                //     public event System.Action E2 { add { } remove { } }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "E2").WithArguments("C2.E2", "I.E2").WithLocation(18, 32),
+                // (10,39): error CS9365: Unsafe member 'C1.E2' cannot implicitly implement safe member 'I.E2'
+                //     unsafe public event System.Action E2;
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "E2").WithArguments("C1.E2", "I.E2").WithLocation(10, 39),
+                // (16,39): error CS9365: Unsafe member 'C2.E2' cannot implicitly implement safe member 'I.E2'
+                //     unsafe public event System.Action E2 { add { } remove { } }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "E2").WithArguments("C2.E2", "I.E2").WithLocation(16, 39),
             ],
             expectedDiagnosticsWhenReferencingLegacyLib:
             [
-                // (11,32): error CS9365: Unsafe member 'C1.E2' cannot implicitly implement safe member 'I.E2'
-                //     public event System.Action E2;
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "E2").WithArguments("C1.E2", "I.E2").WithLocation(11, 32),
-                // (18,32): error CS9365: Unsafe member 'C2.E2' cannot implicitly implement safe member 'I.E2'
-                //     public event System.Action E2 { add { } remove { } }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "E2").WithArguments("C2.E2", "I.E2").WithLocation(18, 32),
-                // (24,32): error CS9365: Unsafe member 'C3.E1' cannot implicitly implement safe member 'I.E1'
-                //     public event System.Action E1;
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "E1").WithArguments("C3.E1", "I.E1").WithLocation(24, 32),
-                // (31,32): error CS9365: Unsafe member 'C4.E1' cannot implicitly implement safe member 'I.E1'
-                //     public event System.Action E1 { add { } remove { } }
-                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "E1").WithArguments("C4.E1", "I.E1").WithLocation(31, 32),
+                // (10,39): error CS9365: Unsafe member 'C1.E2' cannot implicitly implement safe member 'I.E2'
+                //     unsafe public event System.Action E2;
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "E2").WithArguments("C1.E2", "I.E2").WithLocation(10, 39),
+                // (16,39): error CS9365: Unsafe member 'C2.E2' cannot implicitly implement safe member 'I.E2'
+                //     unsafe public event System.Action E2 { add { } remove { } }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "E2").WithArguments("C2.E2", "I.E2").WithLocation(16, 39),
+                // (21,39): error CS9365: Unsafe member 'C3.E1' cannot implicitly implement safe member 'I.E1'
+                //     unsafe public event System.Action E1;
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "E1").WithArguments("C3.E1", "I.E1").WithLocation(21, 39),
+                // (27,39): error CS9365: Unsafe member 'C4.E1' cannot implicitly implement safe member 'I.E1'
+                //     unsafe public event System.Action E1 { add { } remove { } }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "E1").WithArguments("C4.E1", "I.E1").WithLocation(27, 39),
             ]);
     }
 
@@ -7169,14 +7145,13 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 public class C
                 {
                     public C(int i) { }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public C() { }
+                    unsafe public C() { }
                 }
                 public unsafe class C2(int x)
                 {
                     int _x = x;
                 }
-                [method: System.Diagnostics.CodeAnalysis.RequiresUnsafe] public class C3();
+                public class C3 { unsafe public C3() { } }
                 """,
             caller: """
                 _ = new C(0);
@@ -7191,10 +7166,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C", Overload("C..ctor", parameterCount: 1), "C2", "C2..ctor"],
             expectedDiagnostics:
             [
-                // (2,5): error CS9362: 'C.C()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,5): error CS9362: 'C.C()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // _ = new C();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "new C()").WithArguments("C.C()").WithLocation(2, 5),
-                // (5,5): error CS9362: 'C3.C3()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (5,5): error CS9362: 'C3.C3()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // _ = new C3();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "new C3()").WithArguments("C3.C3()").WithLocation(5, 5),
             ]);
@@ -7207,8 +7182,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public class B
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public B() { }
+                    unsafe public B() { }
                 }
                 """,
             caller: """
@@ -7239,10 +7213,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
                 class C5 : B
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public C5() { }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public C5(int x) : base() { }
+                    unsafe public C5() { }
+                    unsafe public C5(int x) : base() { }
                 }
                 """,
             additionalSources: [RequiresUnsafeAttributeDefinition],
@@ -7250,33 +7222,25 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["B"],
             expectedDiagnostics:
             [
-                // (5,5): error CS9362: 'C5.C5()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (5,5): error CS9362: 'C5.C5()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // _ = new C5();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "new C5()").WithArguments("C5.C5()").WithLocation(5, 5),
-                // (10,1): error CS9362: 'B.B()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (10,1): error CS9362: 'B.B()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // class C1 : B;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "class C1 : B;").WithArguments("B.B()").WithLocation(10, 1),
-                // (13,5): error CS9362: 'B.B()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (13,5): error CS9362: 'B.B()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 //     public C2() { }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "public C2() { }").WithArguments("B.B()").WithLocation(13, 5),
-                // (14,22): error CS9362: 'B.B()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (14,22): error CS9362: 'B.B()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 //     public C2(int x) : base() { }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, ": base()").WithArguments("B.B()").WithLocation(14, 22),
-                // (16,14): error CS9362: 'B.B()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (16,14): error CS9362: 'B.B()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // class D1() : B();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "B()").WithArguments("B.B()").WithLocation(16, 14),
-                // (28,5): error CS9362: 'B.B()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
-                //     [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                //     public C5() { }
-                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, @"[System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-    public C5() { }").WithArguments("B.B()").WithLocation(28, 5),
-                // (31,22): error CS9362: 'B.B()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
-                //     public C5(int x) : base() { }
-                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, ": base()").WithArguments("B.B()").WithLocation(31, 22),
             ],
             expectedDiagnosticsWhenReferencingLegacyLib:
             [
-                // (5,5): error CS9362: 'C5.C5()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (5,5): error CS9362: 'C5.C5()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // _ = new C5();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "new C5()").WithArguments("C5.C5()").WithLocation(5, 5),
             ]);
@@ -7289,45 +7253,39 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             class C
             {
                 public C() { }
-                [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                public C(int x) { }
+                unsafe public C(int x) { }
                 public C(string s) : this() { }
                 public C(C c) : this(0) { }
-                [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                public C(int[] a) : this(0) { }
+                unsafe public C(int[] a) : this(0) { }
             }
             """;
         CreateCompilation([source, RequiresUnsafeAttributeDefinition],
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
-            // (7,19): error CS9362: 'C.C(int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+            // (6,19): error CS9362: 'C.C(int)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
             //     public C(C c) : this(0) { }
-            Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, ": this(0)").WithArguments("C.C(int)").WithLocation(7, 19),
-            // (9,23): error CS9362: 'C.C(int)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
-            //     public C(int[] a) : this(0) { }
-            Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, ": this(0)").WithArguments("C.C(int)").WithLocation(9, 23));
+            Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, ": this(0)").WithArguments("C.C(int)").WithLocation(6, 19));
     }
 
     [Fact]
     public void Member_Constructor_Static()
     {
-        CreateCompilation(
-            [
-                """
+        CompileAndVerifyUnsafe(
+            lib: """
                 public class C
                 {
                     public static readonly int F = 42;
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    static C() { }
+                    unsafe static C() { }
                 }
                 """,
-                RequiresUnsafeAttributeDefinition,
-            ],
-            options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
-            .VerifyDiagnostics(
-            // (4,6): error CS9367: RequiresUnsafeAttribute cannot be applied to this symbol.
-            //     [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-            Diagnostic(ErrorCode.ERR_RequiresUnsafeAttributeUnsupportedMemberTarget, "System.Diagnostics.CodeAnalysis.RequiresUnsafe").WithLocation(4, 6));
+            caller: """
+                _ = C.F;
+                """,
+            additionalSources: [RequiresUnsafeAttributeDefinition],
+            optionsDll: TestOptions.UnsafeReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All),
+            expectedUnsafeSymbols: [],
+            expectedSafeSymbols: ["C", "C..cctor"],
+            expectedDiagnostics: []);
     }
 
     [Fact]
@@ -7337,8 +7295,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public class A : System.Attribute
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public A() { }
+                    unsafe public A() { }
                     public A(int x) { }
                 }
                 """,
@@ -7354,7 +7311,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["A", Overload("A..ctor", parameterCount: 1)],
             expectedDiagnostics:
             [
-                // (2,2): error CS9362: 'A.A()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,2): error CS9362: 'A.A()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // [A] void M1() { }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "A").WithArguments("A.A()").WithLocation(2, 2),
             ]);
@@ -7367,8 +7324,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public class C
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public C() { }
+                    unsafe public C() { }
                     public static void M<T>() where T : new() { }
                 }
                 public class D<T> where T : new();
@@ -7387,13 +7343,13 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C", "C.M", "D", "D..ctor"],
             expectedDiagnostics:
             [
-                // (1,7): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'D<T>'
+                // (1,7): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'D<T>'
                 // using X = D<C>;
                 Diagnostic(ErrorCode.ERR_UnsafeConstructorConstraint, "X").WithArguments("C.C()", "T", "D<T>").WithLocation(1, 7),
-                // (2,1): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'C.M<T>()'
+                // (2,1): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'C.M<T>()'
                 // C.M<C>();
                 Diagnostic(ErrorCode.ERR_UnsafeConstructorConstraint, "C.M<C>()").WithArguments("C.C()", "T", "C.M<T>()").WithLocation(2, 1),
-                // (3,9): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'D<T>'
+                // (3,9): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'D<T>'
                 // _ = new D<C>();
                 Diagnostic(ErrorCode.ERR_UnsafeConstructorConstraint, "D<C>").WithArguments("C.C()", "T", "D<T>").WithLocation(3, 9),
             ]);
@@ -7406,8 +7362,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public class C
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public C() { }
+                    unsafe public C() { }
                 }
                 """,
             caller: """
@@ -7432,13 +7387,13 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
             [
-                // (1,9): error CS9502: 'C.C()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,9): error CS9502: 'C.C()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var c = new C();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "new C()").WithArguments("C.C()").WithLocation(1, 9),
-                // (2,5): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'E.extension<T>(T).P1.get'
+                // (2,5): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'E.extension<T>(T).P1.get'
                 // _ = c.P1;
                 Diagnostic(ErrorCode.ERR_UnsafeConstructorConstraint, "c.P1").WithArguments("C.C()", "T", "E.extension<T>(T).P1.get").WithLocation(2, 5),
-                // (3,5): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'E.extension<T>(T).P2.get'
+                // (3,5): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'E.extension<T>(T).P2.get'
                 // _ = C.P2;
                 Diagnostic(ErrorCode.ERR_UnsafeConstructorConstraint, "C.P2").WithArguments("C.C()", "T", "E.extension<T>(T).P2.get").WithLocation(3, 5),
             ]);
@@ -7451,8 +7406,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public class C
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public C() { }
+                    unsafe public C() { }
                 }
                 """,
             caller: """
@@ -7471,19 +7425,19 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
             [
-                // (2,1): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T2' in 'M1<T1, T2, T3>()'
+                // (2,1): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T2' in 'M1<T1, T2, T3>()'
                 // M1<int, C, int>();
                 Diagnostic(ErrorCode.ERR_UnsafeConstructorConstraint, "M1<int, C, int>()").WithArguments("C.C()", "T2", "M1<T1, T2, T3>()").WithLocation(2, 1),
-                // (3,1): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T1' in 'M2<T1, T2, T3>(T1, T2, T3)'
+                // (3,1): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T1' in 'M2<T1, T2, T3>(T1, T2, T3)'
                 // M2<C, C, C>(null, null, null);
                 Diagnostic(ErrorCode.ERR_UnsafeConstructorConstraint, "M2<C, C, C>(null, null, null)").WithArguments("C.C()", "T1", "M2<T1, T2, T3>(T1, T2, T3)").WithLocation(3, 1),
-                // (3,1): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T3' in 'M2<T1, T2, T3>(T1, T2, T3)'
+                // (3,1): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T3' in 'M2<T1, T2, T3>(T1, T2, T3)'
                 // M2<C, C, C>(null, null, null);
                 Diagnostic(ErrorCode.ERR_UnsafeConstructorConstraint, "M2<C, C, C>(null, null, null)").WithArguments("C.C()", "T3", "M2<T1, T2, T3>(T1, T2, T3)").WithLocation(3, 1),
-                // (6,1): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T1' in 'M2<T1, T2, T3>(T1, T2, T3)'
+                // (6,1): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T1' in 'M2<T1, T2, T3>(T1, T2, T3)'
                 // M2(c, c, c);
                 Diagnostic(ErrorCode.ERR_UnsafeConstructorConstraint, "M2(c, c, c)").WithArguments("C.C()", "T1", "M2<T1, T2, T3>(T1, T2, T3)").WithLocation(6, 1),
-                // (6,1): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T3' in 'M2<T1, T2, T3>(T1, T2, T3)'
+                // (6,1): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T3' in 'M2<T1, T2, T3>(T1, T2, T3)'
                 // M2(c, c, c);
                 Diagnostic(ErrorCode.ERR_UnsafeConstructorConstraint, "M2(c, c, c)").WithArguments("C.C()", "T3", "M2<T1, T2, T3>(T1, T2, T3)").WithLocation(6, 1),
             ]);
@@ -7496,11 +7450,13 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public class C1
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public C1(int x) { }
+                    unsafe public C1(int x) { }
                     public C1() { }
                 }
-                [method: System.Diagnostics.CodeAnalysis.RequiresUnsafe] public class C2();
+                public class C2
+                {
+                    unsafe public C2() { }
+                }
                 """,
             caller: """
                 M<C1>();
@@ -7509,10 +7465,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 """,
             additionalSources: [RequiresUnsafeAttributeDefinition],
             expectedUnsafeSymbols: [Overload("C1..ctor", parameterCount: 1), "C2..ctor"],
-            expectedSafeSymbols: [Overload("C1..ctor", parameterCount: 0)],
+            expectedSafeSymbols: ["C1", Overload("C1..ctor", parameterCount: 0), "C2"],
             expectedDiagnostics:
             [
-                // (2,1): error CS9376: An unsafe context is required for constructor 'C2.C2()' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'M<T>()'
+                // (2,1): error CS9376: An unsafe context is required for constructor 'C2.C2()' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'M<T>()'
                 // M<C2>();
                 Diagnostic(ErrorCode.ERR_UnsafeConstructorConstraint, "M<C2>()").WithArguments("C2.C2()", "T", "M<T>()").WithLocation(2, 1),
             ]);
@@ -7525,8 +7481,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public class C
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public C() { }
+                    unsafe public C() { }
                 }
                 """,
             caller: """
@@ -7555,16 +7510,16 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
             [
-                // (1,14): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'D1<T>'
+                // (1,14): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'D1<T>'
                 // using static D1<C>;
                 Diagnostic(ErrorCode.ERR_UnsafeConstructorConstraint, "D1<C>").WithArguments("C.C()", "T", "D1<T>").WithLocation(1, 14),
-                // (3,7): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'D1<T>'
+                // (3,7): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'D1<T>'
                 // using X1 = D1<C>;
                 Diagnostic(ErrorCode.ERR_UnsafeConstructorConstraint, "X1").WithArguments("C.C()", "T", "D1<T>").WithLocation(3, 7),
-                // (10,1): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'D1<T>'
+                // (10,1): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'D1<T>'
                 // D1<C>.M1();
                 Diagnostic(ErrorCode.ERR_UnsafeConstructorConstraint, "D1<C>").WithArguments("C.C()", "T", "D1<T>").WithLocation(10, 1),
-                // (16,1): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'D2<T>'
+                // (16,1): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'D2<T>'
                 // D2<C>.M2();
                 Diagnostic(ErrorCode.ERR_UnsafeConstructorConstraint, "D2<C>").WithArguments("C.C()", "T", "D2<T>").WithLocation(16, 1),
             ]);
@@ -7577,8 +7532,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public class C
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public C() { }
+                    unsafe public C() { }
                 }
                 namespace N
                 {
@@ -7594,10 +7548,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C", "N.D", "N.D..ctor"],
             expectedDiagnostics:
             [
-                // (1,1): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'D<T>'
+                // (1,1): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'D<T>'
                 // N.D<C> x = new N.D<C>();
                 Diagnostic(ErrorCode.ERR_UnsafeConstructorConstraint, "N.D<C>").WithArguments("C.C()", "T", "N.D<T>").WithLocation(1, 1),
-                // (1,16): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'D<T>'
+                // (1,16): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'D<T>'
                 // N.D<C> x = new N.D<C>();
                 Diagnostic(ErrorCode.ERR_UnsafeConstructorConstraint, "N.D<C>").WithArguments("C.C()", "T", "N.D<T>").WithLocation(1, 16),
             ]);
@@ -7610,8 +7564,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public class C
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public C() { }
+                    unsafe public C() { }
                 }
                 public class D<T> where T : new()
                 {
@@ -7627,10 +7580,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C", "D", "D..ctor", "D.Nested", "D.Nested..ctor"],
             expectedDiagnostics:
             [
-                // (1,1): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'D<T>'
+                // (1,1): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'D<T>'
                 // D<C>.Nested x = new D<C>.Nested();
                 Diagnostic(ErrorCode.ERR_UnsafeConstructorConstraint, "D<C>").WithArguments("C.C()", "T", "D<T>").WithLocation(1, 1),
-                // (1,21): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'D<T>'
+                // (1,21): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'D<T>'
                 // D<C>.Nested x = new D<C>.Nested();
                 Diagnostic(ErrorCode.ERR_UnsafeConstructorConstraint, "D<C>").WithArguments("C.C()", "T", "D<T>").WithLocation(1, 21),
             ]);
@@ -7643,8 +7596,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public class C
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public C() { }
+                    unsafe public C() { }
                 }
                 public class D
                 {
@@ -7660,10 +7612,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C", "D", "D..ctor", "D.Nested", "D.Nested..ctor"],
             expectedDiagnostics:
             [
-                // (1,1): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'D.Nested<T>'
+                // (1,1): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'D.Nested<T>'
                 // D.Nested<C> x = new D.Nested<C>();
                 Diagnostic(ErrorCode.ERR_UnsafeConstructorConstraint, "D.Nested<C>").WithArguments("C.C()", "T", "D.Nested<T>").WithLocation(1, 1),
-                // (1,21): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'D.Nested<T>'
+                // (1,21): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'D.Nested<T>'
                 // D.Nested<C> x = new D.Nested<C>();
                 Diagnostic(ErrorCode.ERR_UnsafeConstructorConstraint, "D.Nested<C>").WithArguments("C.C()", "T", "D.Nested<T>").WithLocation(1, 21),
             ]);
@@ -7676,8 +7628,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public class C
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public C() { }
+                    unsafe public C() { }
                 }
                 public struct S<T> where T : new();
                 """,
@@ -7699,12 +7650,45 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C", "S", "S..ctor"],
             expectedDiagnostics:
             [
-                // (2,15): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'S<T>'
+                // (2,9): error CS9362: 'M(S<C>)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+                // var s = M(new S<C>());
+                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "M(new S<C>())").WithArguments("M(S<C>)").WithLocation(2, 9),
+                // (2,15): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'S<T>'
                 // var s = M(new S<C>());
                 Diagnostic(ErrorCode.ERR_UnsafeConstructorConstraint, "S<C>").WithArguments("C.C()", "T", "S<T>").WithLocation(2, 15),
-                // (5,11): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'RequiresUnsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'S<T>'
+                // (3,1): error CS9362: 'M(S<C>)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+                // M(new());
+                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "M(new())").WithArguments("M(S<C>)").WithLocation(3, 1),
+                // (4,1): error CS9362: 'M(S<C>)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+                // M(default);
+                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "M(default)").WithArguments("M(S<C>)").WithLocation(4, 1),
+                // (5,1): error CS9362: 'M(S<C>)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+                // M(default(S<C>));
+                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "M(default(S<C>))").WithArguments("M(S<C>)").WithLocation(5, 1),
+                // (5,11): error CS9376: An unsafe context is required for constructor 'C.C()' marked as 'unsafe' or 'extern' to satisfy the 'new()' constraint of type parameter 'T' in 'S<T>'
                 // M(default(S<C>));
                 Diagnostic(ErrorCode.ERR_UnsafeConstructorConstraint, "S<C>").WithArguments("C.C()", "T", "S<T>").WithLocation(5, 11),
+                // (6,1): error CS9362: 'M(S<C>)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+                // M(s with { });
+                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "M(s with { })").WithArguments("M(S<C>)").WithLocation(6, 1),
+            ],
+            expectedDiagnosticsWhenReferencingLegacyLib:
+            [
+                // (2,9): error CS9362: 'M(S<C>)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+                // var s = M(new S<C>());
+                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "M(new S<C>())").WithArguments("M(S<C>)").WithLocation(2, 9),
+                // (3,1): error CS9362: 'M(S<C>)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+                // M(new());
+                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "M(new())").WithArguments("M(S<C>)").WithLocation(3, 1),
+                // (4,1): error CS9362: 'M(S<C>)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+                // M(default);
+                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "M(default)").WithArguments("M(S<C>)").WithLocation(4, 1),
+                // (5,1): error CS9362: 'M(S<C>)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+                // M(default(S<C>));
+                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "M(default(S<C>))").WithArguments("M(S<C>)").WithLocation(5, 1),
+                // (6,1): error CS9362: 'M(S<C>)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+                // M(s with { });
+                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "M(s with { })").WithArguments("M(S<C>)").WithLocation(6, 1),
             ]);
     }
 
@@ -7716,8 +7700,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 """
                 class C
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    ~C() { }
+                    unsafe ~C() { }
                     void M() { Finalize(); }
                 }
                 class D : C
@@ -7729,18 +7712,14 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             ],
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
-            // (3,6): error CS9367: RequiresUnsafeAttribute cannot be applied to this symbol.
-            //     [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-            Diagnostic(ErrorCode.ERR_RequiresUnsafeAttributeUnsupportedMemberTarget, "System.Diagnostics.CodeAnalysis.RequiresUnsafe").WithLocation(3, 6),
-            // (5,16): error CS0245: Destructors and object.Finalize cannot be called directly. Consider calling IDisposable.Dispose if available.
+            // (4,16): error CS0245: Destructors and object.Finalize cannot be called directly. Consider calling IDisposable.Dispose if available.
             //     void M() { Finalize(); }
-            Diagnostic(ErrorCode.ERR_CallingFinalizeDeprecated, "Finalize()").WithLocation(5, 16));
+            Diagnostic(ErrorCode.ERR_CallingFinalizeDeprecated, "Finalize()").WithLocation(4, 16));
 
         VerifyRequiresUnsafeAttribute(
             comp.SourceModule,
             expectedUnsafeSymbols: [],
-            expectedSafeSymbols: ["C.Finalize"],
-            expectedAttribute: ["C.Finalize"]);
+            expectedSafeSymbols: ["C.Finalize"]);
     }
 
     [Fact]
@@ -7751,8 +7730,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 public class C
                 {
                     public static C operator +(C c1, C c2) => c1;
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public static C operator -(C c1, C c2) => c1;
+                    unsafe public static C operator -(C c1, C c2) => c1;
                 }
                 """,
             caller: """
@@ -7766,7 +7744,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C.op_Addition"],
             expectedDiagnostics:
             [
-                // (3,5): error CS9362: 'C.operator -(C, C)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,5): error CS9362: 'C.operator -(C, C)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // _ = c - c;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c - c").WithArguments("C.operator -(C, C)").WithLocation(3, 5),
             ]);
@@ -7783,8 +7761,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                     extension(C)
                     {
                         public static C operator +(C c1, C c2) => c1;
-                        [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                        public static C operator -(C c1, C c2) => c1;
+                        unsafe public static C operator -(C c1, C c2) => c1;
                     }
                 }
                 """,
@@ -7802,10 +7779,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["E.op_Addition", ExtensionMember("E", "op_Addition")],
             expectedDiagnostics:
             [
-                // (3,5): error CS9362: 'E.extension(C).operator -(C, C)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,5): error CS9362: 'E.extension(C).operator -(C, C)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // _ = c - c;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c - c").WithArguments("E.extension(C).operator -(C, C)").WithLocation(3, 5),
-                // (5,1): error CS9362: 'E.op_Subtraction(C, C)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (5,1): error CS9362: 'E.op_Subtraction(C, C)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // E.op_Subtraction(c, c);
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "E.op_Subtraction(c, c)").WithArguments("E.op_Subtraction(C, C)").WithLocation(5, 1),
             ]);
@@ -7819,8 +7796,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 public class C
                 {
                     public void operator +=(C c) { }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public void operator -=(C c) { }
+                    unsafe public void operator -=(C c) { }
                 }
                 """,
             caller: """
@@ -7834,7 +7810,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C.op_AdditionAssignment"],
             expectedDiagnostics:
             [
-                // (3,1): error CS9362: 'C.operator -=(C)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,1): error CS9362: 'C.operator -=(C)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c -= c;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c -= c").WithArguments("C.operator -=(C)").WithLocation(3, 1),
             ]);
@@ -7851,8 +7827,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                     extension(C c1)
                     {
                         public void operator +=(C c2) { }
-                        [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                        public void operator -=(C c2) { }
+                        unsafe public void operator -=(C c2) { }
                     }
                 }
                 """,
@@ -7870,10 +7845,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["E.op_AdditionAssignment", ExtensionMember("E", "op_AdditionAssignment")],
             expectedDiagnostics:
             [
-                // (3,1): error CS9362: 'E.extension(C).operator -=(C)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,1): error CS9362: 'E.extension(C).operator -=(C)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c -= c;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c -= c").WithArguments("E.extension(C).operator -=(C)").WithLocation(3, 1),
-                // (5,1): error CS9362: 'E.op_SubtractionAssignment(C, C)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (5,1): error CS9362: 'E.op_SubtractionAssignment(C, C)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // E.op_SubtractionAssignment(c, c);
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "E.op_SubtractionAssignment(c, c)").WithArguments("E.op_SubtractionAssignment(C, C)").WithLocation(5, 1),
             ]);
@@ -7887,8 +7862,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 public class C
                 {
                     public void operator ++() { }
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public void operator --() { }
+                    unsafe public void operator --() { }
                 }
                 """,
             caller: """
@@ -7902,7 +7876,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C.op_IncrementAssignment"],
             expectedDiagnostics:
             [
-                // (3,1): error CS9362: 'C.operator --()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,1): error CS9362: 'C.operator --()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c--;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c--").WithArguments("C.operator --()").WithLocation(3, 1),
             ]);
@@ -7916,8 +7890,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 public class C
                 {
                     public static implicit operator int(C c) => 0;
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public static implicit operator string(C c) => "";
+                    unsafe public static implicit operator string(C c) => "";
                 }
                 """,
             caller: """
@@ -7931,7 +7904,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: [OverloadByReturnType("C.op_Implicit", "System.Int32")],
             expectedDiagnostics:
             [
-                // (3,12): error CS9362: 'C.implicit operator string(C)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,12): error CS9362: 'C.implicit operator string(C)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // string s = c;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c").WithArguments("C.implicit operator string(C)").WithLocation(3, 12),
             ]);
@@ -8023,8 +7996,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             lib: """
                 public class C
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public static int M() => 0;
+                    unsafe public static int M() => 0;
                 }
                 """,
             caller: """
@@ -8051,7 +8023,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 // (4,14): error CS9360: This operation may only be used in an unsafe context
                 //     int F1 = *default(int*);
                 Diagnostic(ErrorCode.ERR_UnsafeOperation, "*").WithLocation(4, 14),
-                // (5,14): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (5,14): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 //     int F2 = C.M();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "C.M()").WithArguments("C.M()").WithLocation(5, 14),
             ],
@@ -8504,7 +8476,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             .VerifyDiagnostics();
         var libRef = AsReference(lib, useCompilationReference);
 
-        CreateCompilation("""
+        CreateCompilation(["""
             var d1 = new D1(); d1.M1(); d1.M2(); d1.M3(); d1.M4(); d1.M5(); d1.M6();
             var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
             var d3 = new D3(); d3.M1(); d3.M2(); d3.M3(); d3.M4(); d3.M5(); d3.M6();
@@ -8532,10 +8504,28 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             }
 
             class D3 : C;
-            """,
+            """, RequiresUnsafeAttributeDefinition],
             [libRef],
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
+            // (2,20): error CS9362: 'D2.M1()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+            // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
+            Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M1()").WithArguments("D2.M1()").WithLocation(2, 20),
+            // (2,29): error CS9362: 'D2.M2()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+            // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
+            Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M2()").WithArguments("D2.M2()").WithLocation(2, 29),
+            // (2,38): error CS9362: 'D2.M3()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+            // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
+            Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M3()").WithArguments("D2.M3()").WithLocation(2, 38),
+            // (2,47): error CS9362: 'D2.M4()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+            // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
+            Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M4()").WithArguments("D2.M4()").WithLocation(2, 47),
+            // (2,56): error CS9362: 'D2.M5()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+            // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
+            Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M5()").WithArguments("D2.M5()").WithLocation(2, 56),
+            // (2,65): error CS9362: 'D2.M6()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+            // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
+            Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M6()").WithArguments("D2.M6()").WithLocation(2, 65),
             // (3,20): error CS9363: 'C.M1()' must be used in an unsafe context because it has pointers in its signature
             // var d3 = new D3(); d3.M1(); d3.M2(); d3.M3(); d3.M4(); d3.M5(); d3.M6();
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperationCompat, "d3.M1()").WithArguments("C.M1()").WithLocation(3, 20),
@@ -8562,7 +8552,16 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperationCompat, "base.M2()").WithArguments("C.M2()").WithLocation(14, 42),
             // (14,53): error CS9363: 'B.M3()' must be used in an unsafe context because it has pointers in its signature
             //     public void BaseCalls() { base.M1(); base.M2(); base.M3(); base.M4(); base.M5(); base.M6(); }
-            Diagnostic(ErrorCode.ERR_UnsafeMemberOperationCompat, "base.M3()").WithArguments("B.M3()").WithLocation(14, 53));
+            Diagnostic(ErrorCode.ERR_UnsafeMemberOperationCompat, "base.M3()").WithArguments("B.M3()").WithLocation(14, 53),
+            // (22,33): error CS9364: Unsafe member 'D2.M4()' cannot override safe member 'B.M4()'
+            //     public unsafe override void M4() { }
+            Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M4").WithArguments("D2.M4()", "B.M4()").WithLocation(22, 33),
+            // (23,33): error CS9364: Unsafe member 'D2.M5()' cannot override safe member 'C.M5()'
+            //     public unsafe override void M5() { }
+            Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M5").WithArguments("D2.M5()", "C.M5()").WithLocation(23, 33),
+            // (24,33): error CS9364: Unsafe member 'D2.M6()' cannot override safe member 'B.M6()'
+            //     public unsafe override void M6() { }
+            Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M6").WithArguments("D2.M6()", "B.M6()").WithLocation(24, 33));
     }
 
     [Theory, CombinatorialData]
@@ -8609,13 +8608,19 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             }
             """;
 
-        CreateCompilation(source,
+        CreateCompilation([source, RequiresUnsafeAttributeDefinition],
             [libRef],
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
             // (2,1): error CS9363: 'I.M1()' must be used in an unsafe context because it has pointers in its signature
             // i.M1();
-            Diagnostic(ErrorCode.ERR_UnsafeMemberOperationCompat, "i.M1()").WithArguments("I.M1()").WithLocation(2, 1));
+            Diagnostic(ErrorCode.ERR_UnsafeMemberOperationCompat, "i.M1()").WithArguments("I.M1()").WithLocation(2, 1),
+            // (20,24): error CS9365: Unsafe member 'C3.M2()' cannot implicitly implement safe member 'I.M2()'
+            //     public unsafe void M2() { }
+            Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M2").WithArguments("C3.M2()", "I.M2()").WithLocation(20, 24),
+            // (26,19): error CS9366: Unsafe member 'C4.I.M2()' cannot implement safe member 'I.M2()'
+            //     unsafe void I.M2() { }
+            Diagnostic(ErrorCode.ERR_CallerUnsafeExplicitlyImplementingSafe, "M2").WithArguments("C4.I.M2()", "I.M2()").WithLocation(26, 19));
 
         CreateCompilation(source,
             [libRef],
@@ -8688,10 +8693,22 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             }
             """;
 
-        CreateCompilation(source,
+        CreateCompilation([source, RequiresUnsafeAttributeDefinition],
             [libRef],
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
-            .VerifyDiagnostics();
+            .VerifyDiagnostics(
+            // (19,26): error CS9365: Unsafe member 'C3.M1()' cannot implicitly implement safe member 'I<int*[]>.M1()'
+            //     public unsafe int*[] M1() => null;
+            Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M1").WithArguments("C3.M1()", "I<int*[]>.M1()").WithLocation(19, 26),
+            // (20,24): error CS9365: Unsafe member 'C3.M2()' cannot implicitly implement safe member 'I<int*[]>.M2()'
+            //     public unsafe void M2() { }
+            Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M2").WithArguments("C3.M2()", "I<int*[]>.M2()").WithLocation(20, 24),
+            // (25,29): error CS9366: Unsafe member 'C4.I<int*[]>.M1()' cannot implement safe member 'I<int*[]>.M1()'
+            //     unsafe int*[] I<int*[]>.M1() => null;
+            Diagnostic(ErrorCode.ERR_CallerUnsafeExplicitlyImplementingSafe, "M1").WithArguments("C4.I<int*[]>.M1()", "I<int*[]>.M1()").WithLocation(25, 29),
+            // (26,27): error CS9366: Unsafe member 'C4.I<int*[]>.M2()' cannot implement safe member 'I<int*[]>.M2()'
+            //     unsafe void I<int*[]>.M2() { }
+            Diagnostic(ErrorCode.ERR_CallerUnsafeExplicitlyImplementingSafe, "M2").WithArguments("C4.I<int*[]>.M2()", "I<int*[]>.M2()").WithLocation(26, 27));
 
         CreateCompilation(source,
             [libRef],
@@ -9225,13 +9242,13 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         var commonDiagnostics = new[]
         {
-            // (3,1): error CS9362: 'C.M2()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+            // (3,1): error CS9362: 'C.M2()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
             // c.M2();
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.M2()").WithArguments("C.M2()").WithLocation(3, 1),
-            // (4,1): error CS9362: 'C.M3()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+            // (4,1): error CS9362: 'C.M3()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
             // C.M3();
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "C.M3()").WithArguments("C.M3()").WithLocation(4, 1),
-            // (5,1): error CS9362: 'C.M4()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+            // (5,1): error CS9362: 'C.M4()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
             // c.M4();
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.M4()").WithArguments("C.M4()").WithLocation(5, 1),
         };
@@ -9243,8 +9260,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             verify: Verification.Skipped,
             expectedUnsafeSymbols: unsafeSymbols,
             expectedSafeSymbols: ["C", "C.M1"],
-            expectedNoAttributeInSource: unsafeSymbols,
-            expectedNoAttributeUnderLegacyRules: unsafeSymbols,
             expectedDiagnostics: commonDiagnostics);
 
         CreateCompilation([libSource, callerSource],
@@ -9322,7 +9337,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 [libUpdatedRef],
                 options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
                 .VerifyDiagnostics(
-                // (2,1): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,1): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.M();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.M()").WithArguments("C.M()").WithLocation(2, 1))
                 .GetReferencedAssemblySymbol(libUpdatedRef);
@@ -9330,8 +9345,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             VerifyRequiresUnsafeAttribute(
                 libAssemblySymbol.Modules.Single(),
                 expectedUnsafeSymbols: ["C.M"],
-                expectedSafeSymbols: ["C"],
-                expectedNoAttributeInSource: ["C.M"]);
+                expectedSafeSymbols: ["C"]);
         }
 
         CreateCompilation(getLibSource("extern")).VerifyDiagnostics();
@@ -9379,10 +9393,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
     {
         CompileAndVerifyUnsafe(
             lib: """
+                #pragma warning disable CS0626 // extern without attributes
                 public class C
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public extern void M();
+                    unsafe public extern void M();
                 }
                 """,
             caller: """
@@ -9395,7 +9409,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
             [
-                // (2,1): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,1): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.M();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.M()").WithArguments("C.M()").WithLocation(2, 1),
             ]);
@@ -9472,76 +9486,98 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             verify: Verification.Skipped,
             expectedUnsafeSymbols: unsafeSymbols,
             expectedSafeSymbols: ["B", "B.M4", "B.M5", "B.M6"],
-            expectedNoAttributeInSource: unsafeSymbols,
-            expectedNoAttributeUnderLegacyRules: unsafeSymbols,
             expectedDiagnostics:
             [
-                // (4,20): error CS9362: 'D3.M1()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,20): error CS9362: 'D2.M1()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+                // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
+                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M1()").WithArguments("D2.M1()").WithLocation(3, 20),
+                // (3,29): error CS9362: 'D2.M2()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+                // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
+                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M2()").WithArguments("D2.M2()").WithLocation(3, 29),
+                // (3,38): error CS9362: 'D2.M3()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+                // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
+                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M3()").WithArguments("D2.M3()").WithLocation(3, 38),
+                // (3,47): error CS9362: 'D2.M4()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+                // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
+                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M4()").WithArguments("D2.M4()").WithLocation(3, 47),
+                // (3,56): error CS9362: 'D2.M5()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+                // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
+                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M5()").WithArguments("D2.M5()").WithLocation(3, 56),
+                // (3,65): error CS9362: 'D2.M6()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+                // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
+                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M6()").WithArguments("D2.M6()").WithLocation(3, 65),
+                // (4,20): error CS9362: 'D3.M1()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d3 = new D3(); d3.M1(); d3.M2(); d3.M3(); d3.M4(); d3.M5(); d3.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d3.M1()").WithArguments("D3.M1()").WithLocation(4, 20),
-                // (4,29): error CS9362: 'D3.M2()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (4,29): error CS9362: 'D3.M2()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d3 = new D3(); d3.M1(); d3.M2(); d3.M3(); d3.M4(); d3.M5(); d3.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d3.M2()").WithArguments("D3.M2()").WithLocation(4, 29),
-                // (4,38): error CS9362: 'D3.M3()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (4,38): error CS9362: 'D3.M3()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d3 = new D3(); d3.M1(); d3.M2(); d3.M3(); d3.M4(); d3.M5(); d3.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d3.M3()").WithArguments("D3.M3()").WithLocation(4, 38),
-                // (4,47): error CS9362: 'D3.M4()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (4,47): error CS9362: 'D3.M4()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d3 = new D3(); d3.M1(); d3.M2(); d3.M3(); d3.M4(); d3.M5(); d3.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d3.M4()").WithArguments("D3.M4()").WithLocation(4, 47),
-                // (4,56): error CS9362: 'D3.M5()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (4,56): error CS9362: 'D3.M5()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d3 = new D3(); d3.M1(); d3.M2(); d3.M3(); d3.M4(); d3.M5(); d3.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d3.M5()").WithArguments("D3.M5()").WithLocation(4, 56),
-                // (4,65): error CS9362: 'D3.M6()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (4,65): error CS9362: 'D3.M6()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d3 = new D3(); d3.M1(); d3.M2(); d3.M3(); d3.M4(); d3.M5(); d3.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d3.M6()").WithArguments("D3.M6()").WithLocation(4, 65),
-                // (5,20): error CS9362: 'C.M1()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (5,20): error CS9362: 'C.M1()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d4 = new D4(); d4.M1(); d4.M2(); d4.M3(); d4.M4(); d4.M5(); d4.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d4.M1()").WithArguments("C.M1()").WithLocation(5, 20),
-                // (5,29): error CS9362: 'C.M2()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (5,29): error CS9362: 'C.M2()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d4 = new D4(); d4.M1(); d4.M2(); d4.M3(); d4.M4(); d4.M5(); d4.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d4.M2()").WithArguments("C.M2()").WithLocation(5, 29),
-                // (5,38): error CS9362: 'B.M3()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (5,38): error CS9362: 'B.M3()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d4 = new D4(); d4.M1(); d4.M2(); d4.M3(); d4.M4(); d4.M5(); d4.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d4.M3()").WithArguments("B.M3()").WithLocation(5, 38),
-                // (5,47): error CS9362: 'C.M4()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (5,47): error CS9362: 'C.M4()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d4 = new D4(); d4.M1(); d4.M2(); d4.M3(); d4.M4(); d4.M5(); d4.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d4.M4()").WithArguments("C.M4()").WithLocation(5, 47),
-                // (5,56): error CS9362: 'C.M5()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (5,56): error CS9362: 'C.M5()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d4 = new D4(); d4.M1(); d4.M2(); d4.M3(); d4.M4(); d4.M5(); d4.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d4.M5()").WithArguments("C.M5()").WithLocation(5, 56),
-                // (6,11): error CS9362: 'C.M1()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (6,11): error CS9362: 'C.M1()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C c = d1; c.M1(); c.M2(); c.M3(); c.M4(); c.M5(); c.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.M1()").WithArguments("C.M1()").WithLocation(6, 11),
-                // (6,19): error CS9362: 'C.M2()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (6,19): error CS9362: 'C.M2()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C c = d1; c.M1(); c.M2(); c.M3(); c.M4(); c.M5(); c.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.M2()").WithArguments("C.M2()").WithLocation(6, 19),
-                // (6,27): error CS9362: 'B.M3()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (6,27): error CS9362: 'B.M3()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C c = d1; c.M1(); c.M2(); c.M3(); c.M4(); c.M5(); c.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.M3()").WithArguments("B.M3()").WithLocation(6, 27),
-                // (6,35): error CS9362: 'C.M4()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (6,35): error CS9362: 'C.M4()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C c = d1; c.M1(); c.M2(); c.M3(); c.M4(); c.M5(); c.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.M4()").WithArguments("C.M4()").WithLocation(6, 35),
-                // (6,43): error CS9362: 'C.M5()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (6,43): error CS9362: 'C.M5()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C c = d1; c.M1(); c.M2(); c.M3(); c.M4(); c.M5(); c.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.M5()").WithArguments("C.M5()").WithLocation(6, 43),
                 // (12,33): error CS9364: Unsafe member 'C.M4()' cannot override safe member 'B.M4()'
                 //     public extern override void M4();
                 Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M4").WithArguments("C.M4()", "B.M4()").WithLocation(12, 33),
-                // (24,31): error CS9362: 'C.M1()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (24,31): error CS9362: 'C.M1()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 //     public void BaseCalls() { base.M1(); base.M2(); base.M3(); base.M4(); base.M5(); base.M6(); }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "base.M1()").WithArguments("C.M1()").WithLocation(24, 31),
-                // (24,42): error CS9362: 'C.M2()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (24,42): error CS9362: 'C.M2()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 //     public void BaseCalls() { base.M1(); base.M2(); base.M3(); base.M4(); base.M5(); base.M6(); }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "base.M2()").WithArguments("C.M2()").WithLocation(24, 42),
-                // (24,53): error CS9362: 'B.M3()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (24,53): error CS9362: 'B.M3()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 //     public void BaseCalls() { base.M1(); base.M2(); base.M3(); base.M4(); base.M5(); base.M6(); }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "base.M3()").WithArguments("B.M3()").WithLocation(24, 53),
-                // (24,64): error CS9362: 'C.M4()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (24,64): error CS9362: 'C.M4()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 //     public void BaseCalls() { base.M1(); base.M2(); base.M3(); base.M4(); base.M5(); base.M6(); }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "base.M4()").WithArguments("C.M4()").WithLocation(24, 64),
-                // (24,75): error CS9362: 'C.M5()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (24,75): error CS9362: 'C.M5()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 //     public void BaseCalls() { base.M1(); base.M2(); base.M3(); base.M4(); base.M5(); base.M6(); }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "base.M5()").WithArguments("C.M5()").WithLocation(24, 75),
+                // (32,33): error CS9364: Unsafe member 'D2.M4()' cannot override safe member 'B.M4()'
+                //     public unsafe override void M4() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M4").WithArguments("D2.M4()", "B.M4()").WithLocation(32, 33),
+                // (34,33): error CS9364: Unsafe member 'D2.M6()' cannot override safe member 'B.M6()'
+                //     public unsafe override void M6() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M6").WithArguments("D2.M6()", "B.M6()").WithLocation(34, 33),
                 // (42,33): error CS9364: Unsafe member 'D3.M4()' cannot override safe member 'B.M4()'
                 //     public extern override void M4();
                 Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M4").WithArguments("D3.M4()", "B.M4()").WithLocation(42, 33),
@@ -9551,46 +9587,64 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             ],
             expectedDiagnosticsWhenReferencingLegacyLib:
             [
-                // (4,20): error CS9362: 'D3.M1()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,20): error CS9362: 'D2.M1()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+                // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
+                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M1()").WithArguments("D2.M1()").WithLocation(3, 20),
+                // (3,29): error CS9362: 'D2.M2()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+                // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
+                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M2()").WithArguments("D2.M2()").WithLocation(3, 29),
+                // (3,38): error CS9362: 'D2.M3()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+                // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
+                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M3()").WithArguments("D2.M3()").WithLocation(3, 38),
+                // (3,47): error CS9362: 'D2.M4()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+                // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
+                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M4()").WithArguments("D2.M4()").WithLocation(3, 47),
+                // (3,56): error CS9362: 'D2.M5()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+                // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
+                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M5()").WithArguments("D2.M5()").WithLocation(3, 56),
+                // (3,65): error CS9362: 'D2.M6()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
+                // var d2 = new D2(); d2.M1(); d2.M2(); d2.M3(); d2.M4(); d2.M5(); d2.M6();
+                Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d2.M6()").WithArguments("D2.M6()").WithLocation(3, 65),
+                // (4,20): error CS9362: 'D3.M1()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d3 = new D3(); d3.M1(); d3.M2(); d3.M3(); d3.M4(); d3.M5(); d3.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d3.M1()").WithArguments("D3.M1()").WithLocation(4, 20),
-                // (4,29): error CS9362: 'D3.M2()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (4,29): error CS9362: 'D3.M2()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d3 = new D3(); d3.M1(); d3.M2(); d3.M3(); d3.M4(); d3.M5(); d3.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d3.M2()").WithArguments("D3.M2()").WithLocation(4, 29),
-                // (4,38): error CS9362: 'D3.M3()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (4,38): error CS9362: 'D3.M3()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d3 = new D3(); d3.M1(); d3.M2(); d3.M3(); d3.M4(); d3.M5(); d3.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d3.M3()").WithArguments("D3.M3()").WithLocation(4, 38),
-                // (4,47): error CS9362: 'D3.M4()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (4,47): error CS9362: 'D3.M4()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d3 = new D3(); d3.M1(); d3.M2(); d3.M3(); d3.M4(); d3.M5(); d3.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d3.M4()").WithArguments("D3.M4()").WithLocation(4, 47),
-                // (4,56): error CS9362: 'D3.M5()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (4,56): error CS9362: 'D3.M5()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d3 = new D3(); d3.M1(); d3.M2(); d3.M3(); d3.M4(); d3.M5(); d3.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d3.M5()").WithArguments("D3.M5()").WithLocation(4, 56),
-                // (4,65): error CS9362: 'D3.M6()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (4,65): error CS9362: 'D3.M6()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d3 = new D3(); d3.M1(); d3.M2(); d3.M3(); d3.M4(); d3.M5(); d3.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d3.M6()").WithArguments("D3.M6()").WithLocation(4, 65),
-                // (5,20): error CS9362: 'C.M1()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (5,20): error CS9362: 'C.M1()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d4 = new D4(); d4.M1(); d4.M2(); d4.M3(); d4.M4(); d4.M5(); d4.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d4.M1()").WithArguments("C.M1()").WithLocation(5, 20),
-                // (5,29): error CS9362: 'C.M2()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (5,29): error CS9362: 'C.M2()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d4 = new D4(); d4.M1(); d4.M2(); d4.M3(); d4.M4(); d4.M5(); d4.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d4.M2()").WithArguments("C.M2()").WithLocation(5, 29),
-                // (5,47): error CS9362: 'C.M4()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (5,47): error CS9362: 'C.M4()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d4 = new D4(); d4.M1(); d4.M2(); d4.M3(); d4.M4(); d4.M5(); d4.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d4.M4()").WithArguments("C.M4()").WithLocation(5, 47),
-                // (5,56): error CS9362: 'C.M5()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (5,56): error CS9362: 'C.M5()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // var d4 = new D4(); d4.M1(); d4.M2(); d4.M3(); d4.M4(); d4.M5(); d4.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "d4.M5()").WithArguments("C.M5()").WithLocation(5, 56),
-                // (6,11): error CS9362: 'C.M1()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (6,11): error CS9362: 'C.M1()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C c = d1; c.M1(); c.M2(); c.M3(); c.M4(); c.M5(); c.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.M1()").WithArguments("C.M1()").WithLocation(6, 11),
-                // (6,19): error CS9362: 'C.M2()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (6,19): error CS9362: 'C.M2()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C c = d1; c.M1(); c.M2(); c.M3(); c.M4(); c.M5(); c.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.M2()").WithArguments("C.M2()").WithLocation(6, 19),
-                // (6,35): error CS9362: 'C.M4()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (6,35): error CS9362: 'C.M4()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C c = d1; c.M1(); c.M2(); c.M3(); c.M4(); c.M5(); c.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.M4()").WithArguments("C.M4()").WithLocation(6, 35),
-                // (6,43): error CS9362: 'C.M5()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (6,43): error CS9362: 'C.M5()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C c = d1; c.M1(); c.M2(); c.M3(); c.M4(); c.M5(); c.M6();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.M5()").WithArguments("C.M5()").WithLocation(6, 43),
                 // (10,33): error CS9364: Unsafe member 'C.M1()' cannot override safe member 'B.M1()'
@@ -9599,18 +9653,30 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 // (12,33): error CS9364: Unsafe member 'C.M4()' cannot override safe member 'B.M4()'
                 //     public extern override void M4();
                 Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M4").WithArguments("C.M4()", "B.M4()").WithLocation(12, 33),
-                // (24,31): error CS9362: 'C.M1()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (24,31): error CS9362: 'C.M1()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 //     public void BaseCalls() { base.M1(); base.M2(); base.M3(); base.M4(); base.M5(); base.M6(); }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "base.M1()").WithArguments("C.M1()").WithLocation(24, 31),
-                // (24,42): error CS9362: 'C.M2()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (24,42): error CS9362: 'C.M2()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 //     public void BaseCalls() { base.M1(); base.M2(); base.M3(); base.M4(); base.M5(); base.M6(); }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "base.M2()").WithArguments("C.M2()").WithLocation(24, 42),
-                // (24,64): error CS9362: 'C.M4()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (24,64): error CS9362: 'C.M4()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 //     public void BaseCalls() { base.M1(); base.M2(); base.M3(); base.M4(); base.M5(); base.M6(); }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "base.M4()").WithArguments("C.M4()").WithLocation(24, 64),
-                // (24,75): error CS9362: 'C.M5()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (24,75): error CS9362: 'C.M5()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 //     public void BaseCalls() { base.M1(); base.M2(); base.M3(); base.M4(); base.M5(); base.M6(); }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "base.M5()").WithArguments("C.M5()").WithLocation(24, 75),
+                // (29,33): error CS9364: Unsafe member 'D2.M1()' cannot override safe member 'B.M1()'
+                //     public unsafe override void M1() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M1").WithArguments("D2.M1()", "B.M1()").WithLocation(29, 33),
+                // (31,33): error CS9364: Unsafe member 'D2.M3()' cannot override safe member 'B.M3()'
+                //     public unsafe override void M3() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M3").WithArguments("D2.M3()", "B.M3()").WithLocation(31, 33),
+                // (32,33): error CS9364: Unsafe member 'D2.M4()' cannot override safe member 'B.M4()'
+                //     public unsafe override void M4() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M4").WithArguments("D2.M4()", "B.M4()").WithLocation(32, 33),
+                // (34,33): error CS9364: Unsafe member 'D2.M6()' cannot override safe member 'B.M6()'
+                //     public unsafe override void M6() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M6").WithArguments("D2.M6()", "B.M6()").WithLocation(34, 33),
                 // (39,33): error CS9364: Unsafe member 'D3.M1()' cannot override safe member 'B.M1()'
                 //     public extern override void M1();
                 Diagnostic(ErrorCode.ERR_CallerUnsafeOverridingSafe, "M1").WithArguments("D3.M1()", "B.M1()").WithLocation(39, 33),
@@ -9685,13 +9751,17 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             verify: Verification.Skipped,
             expectedUnsafeSymbols: ["I.M1"],
             expectedSafeSymbols: ["I", "I.M2"],
-            expectedNoAttributeInSource: ["I.M1"],
-            expectedNoAttributeUnderLegacyRules: ["I.M1"],
             expectedDiagnostics:
             [
-                // (3,1): error CS9362: 'I.M1()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,1): error CS9362: 'I.M1()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // i.M1();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "i.M1()").WithArguments("I.M1()").WithLocation(3, 1),
+                // (21,24): error CS9365: Unsafe member 'C3.M2()' cannot implicitly implement safe member 'I.M2()'
+                //     public unsafe void M2() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M2").WithArguments("C3.M2()", "I.M2()").WithLocation(21, 24),
+                // (27,19): error CS9366: Unsafe member 'C4.I.M2()' cannot implement safe member 'I.M2()'
+                //     unsafe void I.M2() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeExplicitlyImplementingSafe, "M2").WithArguments("C4.I.M2()", "I.M2()").WithLocation(27, 19),
                 // (33,24): error CS9365: Unsafe member 'C5.M2()' cannot implicitly implement safe member 'I.M2()'
                 //     public extern void M2();
                 Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M2").WithArguments("C5.M2()", "I.M2()").WithLocation(33, 24),
@@ -9701,6 +9771,18 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             ],
             expectedDiagnosticsWhenReferencingLegacyLib:
             [
+                // (20,24): error CS9365: Unsafe member 'C3.M1()' cannot implicitly implement safe member 'I.M1()'
+                //     public unsafe void M1() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M1").WithArguments("C3.M1()", "I.M1()").WithLocation(20, 24),
+                // (21,24): error CS9365: Unsafe member 'C3.M2()' cannot implicitly implement safe member 'I.M2()'
+                //     public unsafe void M2() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M2").WithArguments("C3.M2()", "I.M2()").WithLocation(21, 24),
+                // (26,19): error CS9366: Unsafe member 'C4.I.M1()' cannot implement safe member 'I.M1()'
+                //     unsafe void I.M1() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeExplicitlyImplementingSafe, "M1").WithArguments("C4.I.M1()", "I.M1()").WithLocation(26, 19),
+                // (27,19): error CS9366: Unsafe member 'C4.I.M2()' cannot implement safe member 'I.M2()'
+                //     unsafe void I.M2() { }
+                Diagnostic(ErrorCode.ERR_CallerUnsafeExplicitlyImplementingSafe, "M2").WithArguments("C4.I.M2()", "I.M2()").WithLocation(27, 19),
                 // (32,24): error CS9365: Unsafe member 'C5.M1()' cannot implicitly implement safe member 'I.M1()'
                 //     public extern void M1();
                 Diagnostic(ErrorCode.ERR_CallerUnsafeImplicitlyImplementingSafe, "M1").WithArguments("C5.M1()", "I.M1()").WithLocation(32, 24),
@@ -9745,8 +9827,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             verify: Verification.Skipped,
             expectedUnsafeSymbols: unsafeSymbols,
             expectedSafeSymbols: ["C"],
-            expectedNoAttributeInSource: unsafeSymbols,
-            expectedNoAttributeUnderLegacyRules: unsafeSymbols,
             skipSymbolsInSource: unsafeSymbols,
             expectedDiagnostics: []);
 
@@ -9810,13 +9890,13 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         var commonDiagnostics = new[]
         {
-            // (3,1): error CS9362: 'C.P2.set' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+            // (3,1): error CS9362: 'C.P2.set' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
             // c.P2 = 0;
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.P2").WithArguments("C.P2.set").WithLocation(3, 1),
-            // (4,1): error CS9362: 'C.P3.set' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+            // (4,1): error CS9362: 'C.P3.set' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
             // C.P3 = 0;
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "C.P3").WithArguments("C.P3.set").WithLocation(4, 1),
-            // (5,1): error CS9362: 'C.P4.set' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+            // (5,1): error CS9362: 'C.P4.set' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
             // c.P4 = 0;
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.P4").WithArguments("C.P4.set").WithLocation(5, 1),
         };
@@ -9828,8 +9908,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             verify: Verification.Skipped,
             expectedUnsafeSymbols: unsafeSymbols,
             expectedSafeSymbols: ["C", "C.P1", "C.set_P1"],
-            expectedNoAttributeInSource: unsafeSymbols,
-            expectedNoAttributeUnderLegacyRules: unsafeSymbols,
             expectedDiagnostics: commonDiagnostics);
 
         CreateCompilation([libSource, callerSource],
@@ -9924,7 +10002,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 [libUpdatedRef],
                 options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
                 .VerifyDiagnostics(
-                // (2,1): error CS9362: 'C.P.set' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,1): error CS9362: 'C.P.set' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.P = null;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.P").WithArguments("C.P.set").WithLocation(2, 1))
                 .GetReferencedAssemblySymbol(libUpdatedRef);
@@ -9932,8 +10010,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             VerifyRequiresUnsafeAttribute(
                 libAssemblySymbol.Modules.Single(),
                 expectedUnsafeSymbols: ["C.P", "C.set_P"],
-                expectedSafeSymbols: ["C"],
-                expectedNoAttributeInSource: ["C.P", "C.set_P"]);
+                expectedSafeSymbols: ["C"]);
         }
 
         CreateCompilation(getLibSource("extern")).VerifyDiagnostics();
@@ -9984,9 +10061,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 #pragma warning disable CS0626 // extern without attributes
                 public class C
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public extern int P1 { set; }
-                    public extern int P2 { [System.Diagnostics.CodeAnalysis.RequiresUnsafe] set; }
+                    unsafe public extern int P1 { set; }
+                    public extern int P2 { unsafe set; }
                 }
                 """,
             caller: """
@@ -9998,14 +10074,12 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             verify: Verification.Skipped,
             expectedUnsafeSymbols: ["C.P1", "C.set_P1", "C.P2", "C.set_P2"],
             expectedSafeSymbols: ["C"],
-            expectedNoAttributeInSource: ["C.P2"],
-            expectedNoAttributeUnderLegacyRules: ["C.P2"],
             expectedDiagnostics:
             [
-                // (2,1): error CS9362: 'C.P1.set' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,1): error CS9362: 'C.P1.set' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.P1 = 0;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.P1").WithArguments("C.P1.set").WithLocation(2, 1),
-                // (3,1): error CS9362: 'C.P2.set' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,1): error CS9362: 'C.P2.set' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.P2 = 0;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.P2").WithArguments("C.P2.set").WithLocation(3, 1),
             ]);
@@ -10031,10 +10105,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         var commonDiagnostics = new[]
         {
-            // (2,1): error CS9362: 'C.this[int].set' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+            // (2,1): error CS9362: 'C.this[int].set' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
             // c[0] = c[0] + 123;
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c[0]").WithArguments("C.this[int].set").WithLocation(2, 1),
-            // (2,8): error CS9362: 'C.this[int].get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+            // (2,8): error CS9362: 'C.this[int].get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
             // c[0] = c[0] + 123;
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c[0]").WithArguments("C.this[int].get").WithLocation(2, 8),
         };
@@ -10046,8 +10120,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             verify: Verification.Skipped,
             expectedUnsafeSymbols: unsafeSymbols,
             expectedSafeSymbols: ["C"],
-            expectedNoAttributeInSource: unsafeSymbols,
-            expectedNoAttributeUnderLegacyRules: unsafeSymbols,
             expectedDiagnostics: commonDiagnostics);
 
         CreateCompilation([libSource, callerSource],
@@ -10127,10 +10199,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 [libUpdatedRef],
                 options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
                 .VerifyDiagnostics(
-                // (2,1): error CS9362: 'C.this[int].set' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,1): error CS9362: 'C.this[int].set' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c[0] = c[0] + 123;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c[0]").WithArguments("C.this[int].set").WithLocation(2, 1),
-                // (2,8): error CS9362: 'C.this[int].get' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,8): error CS9362: 'C.this[int].get' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c[0] = c[0] + 123;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c[0]").WithArguments("C.this[int].get").WithLocation(2, 8))
                 .GetReferencedAssemblySymbol(libUpdatedRef);
@@ -10140,8 +10212,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             VerifyRequiresUnsafeAttribute(
                 libAssemblySymbol.Modules.Single(),
                 expectedUnsafeSymbols: unsafeSymbols,
-                expectedSafeSymbols: ["C"],
-                expectedNoAttributeInSource: unsafeSymbols);
+                expectedSafeSymbols: ["C"]);
         }
 
         CreateCompilation(getLibSource("extern")).VerifyDiagnostics();
@@ -10195,12 +10266,11 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 #pragma warning disable CS0626 // extern without attributes
                 public class C1
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public extern int this[int i] { set; }
+                    unsafe public extern int this[int i] { set; }
                 }
                 public class C2
                 {
-                    public extern int this[int i] { [System.Diagnostics.CodeAnalysis.RequiresUnsafe] set; }
+                    public extern int this[int i] { unsafe set; }
                 }
                 """,
             caller: """
@@ -10211,8 +10281,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             verify: Verification.Skipped,
             expectedUnsafeSymbols: ["C1.this[]", "C1.set_Item", "C2.this[]", "C2.set_Item"],
             expectedSafeSymbols: ["C1", "C2"],
-            expectedNoAttributeInSource: ["C2.this[]"],
-            expectedNoAttributeUnderLegacyRules: ["C2.this[]"],
             expectedDiagnostics:
             [
                 // (1,1): error CS9362: 'C1.this[int].set' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
@@ -10244,7 +10312,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         var commonDiagnostics = new[]
         {
-            // (1,5): error CS9362: 'C.E.add' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+            // (1,5): error CS9362: 'C.E.add' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
             // C.E += null;
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "+=").WithArguments("C.E.add").WithLocation(1, 5),
         };
@@ -10256,8 +10324,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             verify: Verification.Skipped,
             expectedUnsafeSymbols: unsafeSymbols,
             expectedSafeSymbols: ["C"],
-            expectedNoAttributeInSource: unsafeSymbols,
-            expectedNoAttributeUnderLegacyRules: unsafeSymbols,
             expectedDiagnostics: commonDiagnostics);
 
         CreateCompilation([libSource, callerSource],
@@ -10336,7 +10402,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 [libUpdatedRef],
                 options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
                 .VerifyDiagnostics(
-                // (1,5): error CS9362: 'C.E.add' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,5): error CS9362: 'C.E.add' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C.E += null;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "+=").WithArguments("C.E.add").WithLocation(1, 5))
                 .GetReferencedAssemblySymbol(libUpdatedRef);
@@ -10346,8 +10412,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             VerifyRequiresUnsafeAttribute(
                 libAssemblySymbol.Modules.Single(),
                 expectedUnsafeSymbols: unsafeSymbols,
-                expectedSafeSymbols: ["C"],
-                expectedNoAttributeInSource: unsafeSymbols);
+                expectedSafeSymbols: ["C"]);
         }
 
         // When compiling the lib under legacy rules, extern members are not unsafe, but members with pointers are.
@@ -10385,8 +10450,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 #pragma warning disable CS0626 // extern without attributes
                 public class C
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public static extern event System.Action E;
+                    unsafe public static extern event System.Action E;
                 }
                 """,
             caller: """
@@ -10399,10 +10463,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
             [
-                // (1,5): error CS9362: 'C.E.add' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,5): error CS9362: 'C.E.add' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C.E += null;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "+=").WithArguments("C.E.add").WithLocation(1, 5),
-                // (2,5): error CS9362: 'C.E.remove' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,5): error CS9362: 'C.E.remove' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // C.E -= null;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "-=").WithArguments("C.E.remove").WithLocation(2, 5),
             ]);
@@ -10427,7 +10491,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         var commonDiagnostics = new[]
         {
-            // (1,5): error CS9362: 'C.C()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+            // (1,5): error CS9362: 'C.C()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
             // _ = new C();
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "new C()").WithArguments("C.C()").WithLocation(1, 5),
         };
@@ -10439,8 +10503,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             verify: Verification.Skipped,
             expectedUnsafeSymbols: unsafeSymbols,
             expectedSafeSymbols: ["C"],
-            expectedNoAttributeInSource: unsafeSymbols,
-            expectedNoAttributeUnderLegacyRules: unsafeSymbols,
             expectedDiagnostics: commonDiagnostics);
 
         CreateCompilation([libSource, callerSource],
@@ -10506,7 +10568,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 [libUpdatedRef],
                 options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
                 .VerifyDiagnostics(
-                // (1,5): error CS9362: 'C.C(int*)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,5): error CS9362: 'C.C(int*)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // _ = new C(null);
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "new C(null)").WithArguments("C.C(int*)").WithLocation(1, 5))
                 .GetReferencedAssemblySymbol(libUpdatedRef);
@@ -10514,8 +10576,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             VerifyRequiresUnsafeAttribute(
                 libAssemblySymbol.Modules.Single(),
                 expectedUnsafeSymbols: ["C..ctor"],
-                expectedSafeSymbols: ["C"],
-                expectedNoAttributeInSource: ["C..ctor"]);
+                expectedSafeSymbols: ["C"]);
         }
 
         CreateCompilation(getLibSource("extern")).VerifyDiagnostics();
@@ -10563,10 +10624,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
     {
         CompileAndVerifyUnsafe(
             lib: """
+                #pragma warning disable CS0824 // extern constructor
                 public class C
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public extern C();
+                    unsafe public extern C();
                 }
                 """,
             caller: """
@@ -10578,7 +10639,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
             [
-                // (1,5): error CS9362: 'C.C()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (1,5): error CS9362: 'C.C()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // _ = new C();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "new C()").WithArguments("C.C()").WithLocation(1, 5),
             ]);
@@ -10604,7 +10665,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         var commonDiagnostics = new[]
         {
-            // (2,1): error CS9362: 'C.operator +=(C)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+            // (2,1): error CS9362: 'C.operator +=(C)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
             // c += c;
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c += c").WithArguments("C.operator +=(C)").WithLocation(2, 1),
         };
@@ -10616,8 +10677,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             verify: Verification.Skipped,
             expectedUnsafeSymbols: unsafeSymbols,
             expectedSafeSymbols: ["C"],
-            expectedNoAttributeInSource: unsafeSymbols,
-            expectedNoAttributeUnderLegacyRules: unsafeSymbols,
             expectedDiagnostics: commonDiagnostics);
 
         CreateCompilation([libSource, callerSource, CompilerFeatureRequiredAttribute],
@@ -10684,7 +10743,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 [libUpdatedRef],
                 options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules())
                 .VerifyDiagnostics(
-                // (2,1): error CS9362: 'C.operator +=(int*)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,1): error CS9362: 'C.operator +=(int*)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c += null;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c += null").WithArguments("C.operator +=(int*)").WithLocation(2, 1))
                 .GetReferencedAssemblySymbol(libUpdatedRef);
@@ -10692,8 +10751,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             VerifyRequiresUnsafeAttribute(
                 libAssemblySymbol.Modules.Single(),
                 expectedUnsafeSymbols: ["C.op_AdditionAssignment"],
-                expectedSafeSymbols: ["C"],
-                expectedNoAttributeInSource: ["C.op_AdditionAssignment"]);
+                expectedSafeSymbols: ["C"]);
         }
 
         CreateCompilation([getLibSource("extern"), CompilerFeatureRequiredAttribute]).VerifyDiagnostics();
@@ -10741,10 +10799,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
     {
         CompileAndVerifyUnsafe(
             lib: """
+                #pragma warning disable CS0626 // extern without attributes
                 public class C
                 {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    public extern void operator +=(C c);
+                    unsafe public extern void operator +=(C c);
                 }
                 """,
             caller: """
@@ -10757,199 +10815,79 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
             [
-                // (2,1): error CS9362: 'C.operator +=(C)' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,1): error CS9362: 'C.operator +=(C)' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c += null;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c += null").WithArguments("C.operator +=(C)").WithLocation(2, 1),
             ]);
     }
 
     [Fact]
-    public void RequiresUnsafeAttribute_Applied()
-    {
-        var source = """
-            class C
-            {
-                [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                void M1() { }
-                void M2() { }
-            }
-            """;
-
-        var expectedDiagnostics = new[]
-        {
-            // (3,6): warning CS9368: RequiresUnsafeAttribute is only valid under the updated memory safety rules.
-            //     [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-            Diagnostic(ErrorCode.WRN_RequiresUnsafeAttributeLegacyRules, "System.Diagnostics.CodeAnalysis.RequiresUnsafe").WithLocation(3, 6),
-        };
-
-        CreateCompilation([source, RequiresUnsafeAttributeDefinition],
-            options: TestOptions.UnsafeReleaseDll.WithWarningLevel(10))
-            .VerifyEmitDiagnostics();
-        CreateCompilation([source, RequiresUnsafeAttributeDefinition],
-            options: TestOptions.UnsafeReleaseDll.WithWarningLevel(11))
-            .VerifyEmitDiagnostics(expectedDiagnostics);
-
-        CompileAndVerify([source, RequiresUnsafeAttributeDefinition],
-            options: TestOptions.UnsafeReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All),
-            symbolValidator: m => VerifyRequiresUnsafeAttribute(
-                m,
-                expectedUnsafeSymbols: ["C.M1"],
-                expectedSafeSymbols: ["C", "C.M2"],
-                expectedUnsafeMode: CallerUnsafeMode.None))
-            .VerifyDiagnostics(expectedDiagnostics);
-
-        var ref1 = CompileAndVerify([source, RequiresUnsafeAttributeDefinition],
-            options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules().WithMetadataImportOptions(MetadataImportOptions.All),
-            symbolValidator: m => VerifyRequiresUnsafeAttribute(
-                m,
-                expectedUnsafeSymbols: ["C.M1"],
-                expectedSafeSymbols: ["C", "C.M2"]))
-            .VerifyDiagnostics()
-            .GetImageReference();
-
-        CompileAndVerify("", [ref1],
-            options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules().WithMetadataImportOptions(MetadataImportOptions.All),
-            symbolValidator: m => VerifyRequiresUnsafeAttribute(
-                m,
-                expectedUnsafeSymbols: [],
-                expectedSafeSymbols: []))
-            .VerifyDiagnostics();
-
-        var source2 = """
-            class B
-            {
-                void M3() { }
-                [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                void M4() { }
-            }
-            """;
-
-        CompileAndVerify(source2, [ref1],
-            options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules().WithMetadataImportOptions(MetadataImportOptions.All),
-            symbolValidator: m => VerifyRequiresUnsafeAttribute(
-                m,
-                expectedUnsafeSymbols: ["B.M4"],
-                expectedSafeSymbols: ["B", "B.M3"]))
-            .VerifyDiagnostics();
-
-        CompileAndVerify([source, RequiresUnsafeAttributeDefinition],
-            options: TestOptions.ReleaseModule.WithAllowUnsafe(true).WithMetadataImportOptions(MetadataImportOptions.All),
-            verify: Verification.Skipped,
-            symbolValidator: m => VerifyRequiresUnsafeAttribute(
-                m,
-                expectedUnsafeSymbols: ["C.M1"],
-                expectedSafeSymbols: ["C", "C.M2"],
-                expectedUnsafeMode: CallerUnsafeMode.None))
-            .VerifyDiagnostics(expectedDiagnostics);
-
-        CreateCompilation([source, MemorySafetyRulesAttributeDefinition],
-            options: TestOptions.ReleaseModule.WithAllowUnsafe(true).WithUpdatedMemorySafetyRules())
-            .VerifyDiagnostics(
-            // (3,38): error CS0234: The type or namespace name 'RequiresUnsafeAttribute' does not exist in the namespace 'System.Diagnostics.CodeAnalysis' (are you missing an assembly reference?)
-            //     [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-            Diagnostic(ErrorCode.ERR_DottedTypeNameNotFoundInNS, "RequiresUnsafe").WithArguments("RequiresUnsafeAttribute", "System.Diagnostics.CodeAnalysis").WithLocation(3, 38),
-            // (3,38): error CS0234: The type or namespace name 'RequiresUnsafe' does not exist in the namespace 'System.Diagnostics.CodeAnalysis' (are you missing an assembly reference?)
-            //     [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-            Diagnostic(ErrorCode.ERR_DottedTypeNameNotFoundInNS, "RequiresUnsafe").WithArguments("RequiresUnsafe", "System.Diagnostics.CodeAnalysis").WithLocation(3, 38));
-    }
-
-    [Fact]
-    public void RequiresUnsafeAttribute_NotApplied()
+    public void RequiresUnsafeAttribute_NotSynthesized()
     {
         var source = """
             public class C
             {
-                public void M() { }
+                public unsafe void M() { }
             }
             """;
 
-        CompileAndVerify(source,
-            symbolValidator: m => VerifyRequiresUnsafeAttribute(
-                m,
-                expectedUnsafeSymbols: [],
-                expectedSafeSymbols: ["C", "C.M"]))
-            .VerifyDiagnostics();
-
-        CompileAndVerify(source,
-            options: TestOptions.ReleaseDll.WithUpdatedMemorySafetyRules(),
-            symbolValidator: m => VerifyRequiresUnsafeAttribute(
-                m,
-                expectedUnsafeSymbols: [],
-                expectedSafeSymbols: ["C", "C.M"]))
-            .VerifyDiagnostics();
-
-        CompileAndVerify([source, MemorySafetyRulesAttributeDefinition],
-            options: TestOptions.ReleaseModule.WithUpdatedMemorySafetyRules(),
-            verify: Verification.Skipped,
-            symbolValidator: m => VerifyRequiresUnsafeAttribute(
-                m,
-                expectedUnsafeSymbols: [],
-                expectedSafeSymbols: ["C", "C.M"]))
-            .VerifyDiagnostics();
-    }
-
-    [Fact]
-    public void RequiresUnsafeAttribute_LocalFunction()
-    {
-        var source = """
-            #pragma warning disable CS8321 // Local function is declared but never used
-            class C
-            {
-                void M()
-                {
-                    [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                    void M1() { }
-                    void M2() { }
-                }
-            }
-            """;
-
-        var m1 = "C.<M>g__M1|0_0";
-        var m2 = "C.<M>g__M2|0_1";
-
-        var expectedDiagnostics = new[]
+        foreach (var parseOptions in new[] { TestOptions.RegularPreview, TestOptions.RegularNext, TestOptions.Regular14 })
         {
-            // (6,10): warning CS9368: RequiresUnsafeAttribute is only valid under the updated memory safety rules.
-            //         [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-            Diagnostic(ErrorCode.WRN_RequiresUnsafeAttributeLegacyRules, "System.Diagnostics.CodeAnalysis.RequiresUnsafe").WithLocation(6, 10),
-        };
+            CompileAndVerify(source,
+                parseOptions: parseOptions,
+                options: TestOptions.UnsafeReleaseDll,
+                symbolValidator: m => VerifyRequiresUnsafeAttribute(
+                    m,
+                    expectedUnsafeSymbols: [],
+                    expectedSafeSymbols: ["C", "C.M"]))
+                .VerifyDiagnostics();
+        }
 
-        CompileAndVerify([source, RequiresUnsafeAttributeDefinition],
-            options: TestOptions.UnsafeReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All),
-            symbolValidator: m => VerifyRequiresUnsafeAttribute(
-                m,
-                expectedUnsafeSymbols: [m1],
-                expectedSafeSymbols: [m2],
-                expectedUnsafeMode: CallerUnsafeMode.None))
-            .VerifyDiagnostics(expectedDiagnostics);
+        foreach (var parseOptions in new[] { TestOptions.RegularPreview, TestOptions.RegularNext })
+        {
+            CompileAndVerify([source, RequiresUnsafeAttributeDefinition],
+                parseOptions: parseOptions,
+                options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules(),
+                symbolValidator: m => VerifyRequiresUnsafeAttribute(
+                    m,
+                    expectedUnsafeSymbols: ["C.M"],
+                    expectedSafeSymbols: ["C"]))
+                .VerifyDiagnostics();
+        }
 
-        CompileAndVerify([source, RequiresUnsafeAttributeDefinition],
-            options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules().WithMetadataImportOptions(MetadataImportOptions.All),
-            symbolValidator: m => VerifyRequiresUnsafeAttribute(
-                m,
-                expectedUnsafeSymbols: [m1],
-                expectedSafeSymbols: [m2]))
-            .VerifyDiagnostics();
+        CreateCompilation([source, RequiresUnsafeAttributeDefinition],
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
+            .VerifyDiagnostics(
+            // (1,1): error CS9274: 'MemorySafetyRules' version '2' is not available in C# 14.0. Please use language version 'preview' or greater.
+            Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
+            // (3,12): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            // public unsafe void M() { }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(3, 12));
 
-        CompileAndVerify([source, RequiresUnsafeAttributeDefinition],
-            options: TestOptions.ReleaseModule.WithAllowUnsafe(true).WithMetadataImportOptions(MetadataImportOptions.All),
-            verify: Verification.Skipped,
-            symbolValidator: m => VerifyRequiresUnsafeAttribute(
-                m,
-                expectedUnsafeSymbols: [m1],
-                expectedSafeSymbols: [m2],
-                expectedUnsafeMode: CallerUnsafeMode.None))
-            .VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source,
+            parseOptions: TestOptions.Regular14,
+            options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
+            .VerifyDiagnostics(
+            // (1,1): error CS9274: 'MemorySafetyRules' version '2' is not available in C# 14.0. Please use language version 'preview' or greater.
+            Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
+            // (3,12): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
+            // public unsafe void M() { }
+            Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "unsafe").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(3, 12),
+            // (3,12): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            // public unsafe void M() { }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "unsafe").WithArguments("updated memory safety rules").WithLocation(3, 12));
 
-        CreateCompilation([source, MemorySafetyRulesAttributeDefinition],
-            options: TestOptions.ReleaseModule.WithAllowUnsafe(true).WithUpdatedMemorySafetyRules())
-            .VerifyEmitDiagnostics(
-            // (6,42): error CS0234: The type or namespace name 'RequiresUnsafeAttribute' does not exist in the namespace 'System.Diagnostics.CodeAnalysis' (are you missing an assembly reference?)
-            //         [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-            Diagnostic(ErrorCode.ERR_DottedTypeNameNotFoundInNS, "RequiresUnsafe").WithArguments("RequiresUnsafeAttribute", "System.Diagnostics.CodeAnalysis").WithLocation(6, 42),
-            // (6,42): error CS0234: The type or namespace name 'RequiresUnsafe' does not exist in the namespace 'System.Diagnostics.CodeAnalysis' (are you missing an assembly reference?)
-            //         [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-            Diagnostic(ErrorCode.ERR_DottedTypeNameNotFoundInNS, "RequiresUnsafe").WithArguments("RequiresUnsafe", "System.Diagnostics.CodeAnalysis").WithLocation(6, 42));
+        foreach (var parseOptions in new[] { TestOptions.RegularPreview, TestOptions.RegularNext })
+        {
+            CreateCompilation(source,
+                parseOptions: parseOptions,
+                options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
+                .VerifyDiagnostics(
+                // (3,12): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
+                // public unsafe void M() { }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "unsafe").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(3, 12));
+        }
     }
 
     [Fact]
@@ -10961,8 +10899,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             using System.Reflection;
             public class A
             {
-                [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                public void M1() { }
+                unsafe public void M1() { }
                 public void M2() { }
                 public static void RequiresUnsafe(MethodInfo method)
                 {
@@ -10979,8 +10916,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         var sourceB = """
             class B : A
             {
-                [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                public void M3() { }
+                unsafe public void M3() { }
                 public void M4() { }
                 static void Main()
                 {
@@ -11003,22 +10939,17 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         var source = """
             public class C
             {
-                [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                public void M() { }
+                unsafe public void M() { }
             }
             """;
 
-        CompileAndVerify([source, RequiresUnsafeAttributeDefinition],
+        CompileAndVerify(source,
             options: TestOptions.UnsafeReleaseDll,
             symbolValidator: m => VerifyRequiresUnsafeAttribute(
                 m,
-                expectedUnsafeSymbols: ["C.M"],
-                expectedSafeSymbols: ["C"],
-                expectedUnsafeMode: CallerUnsafeMode.None))
-            .VerifyDiagnostics(
-            // (3,6): warning CS9368: RequiresUnsafeAttribute is only valid under the updated memory safety rules.
-            //     [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-            Diagnostic(ErrorCode.WRN_RequiresUnsafeAttributeLegacyRules, "System.Diagnostics.CodeAnalysis.RequiresUnsafe").WithLocation(3, 6));
+                expectedUnsafeSymbols: [],
+                expectedSafeSymbols: ["C", "C.M"]))
+            .VerifyDiagnostics();
 
         CompileAndVerify([source, RequiresUnsafeAttributeDefinition],
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules(),
@@ -11044,8 +10975,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         var source = """
             public class C
             {
-                [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                public void M() { }
+                unsafe public void M() { }
             }
             """;
 
@@ -11070,26 +11000,22 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         var source = """
             public class C
             {
-                [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-                public void M() { }
+                unsafe public void M() { }
             }
             """;
 
         // Ambiguous attribute definitions from references.
         CreateCompilation(source, [ref1, ref2],
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
-            .VerifyDiagnostics(
-            // (3,38): error CS0433: The type 'RequiresUnsafeAttribute' exists in both 'lib1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' and 'lib2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'
-            //     [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-            Diagnostic(ErrorCode.ERR_SameFullNameAggAgg, "RequiresUnsafe").WithArguments("lib1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", "System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", "lib2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(3, 38));
+            .VerifyEmitDiagnostics(
+            // (3,5): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute..ctor'
+            //     unsafe public void M() { }
+            Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "unsafe").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", ".ctor").WithLocation(3, 5));
 
         // Also defined in source.
         var lib = CreateCompilation([source, RequiresUnsafeAttributeDefinition], [ref1, ref2],
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
-            .VerifyDiagnostics(
-            // (3,38): warning CS0436: The type 'RequiresUnsafeAttribute' in '' conflicts with the imported type 'RequiresUnsafeAttribute' in 'lib1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in ''.
-            //     [System.Diagnostics.CodeAnalysis.RequiresUnsafe]
-            Diagnostic(ErrorCode.WRN_SameFullNameThisAggAgg, "RequiresUnsafe").WithArguments("", "System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute", "lib1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", "System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute").WithLocation(3, 38));
+            .VerifyDiagnostics();
 
         CreateCompilation("""
             new C().M();
@@ -11097,7 +11023,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             [AsReference(lib, useCompilationReference)],
             options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
-            // (1,1): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+            // (1,1): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
             // new C().M();
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "new C().M()").WithArguments("C.M()").WithLocation(1, 1));
     }
@@ -11160,7 +11086,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             [AsReference(lib, useCompilationReference), ref1, ref2, corlibRef],
             options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
-            // (1,1): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+            // (1,1): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
             // new C().M();
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "new C().M()").WithArguments("C.M()").WithLocation(1, 1));
     }
@@ -11254,7 +11180,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CreateCompilation(sourceB, [refA],
             options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
-            // (1,1): error CS9362: 'A.M()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+            // (1,1): error CS9362: 'A.M()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
             // A.M();
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "A.M()").WithArguments("A.M()").WithLocation(1, 1));
     }
@@ -11302,7 +11228,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CreateCompilation(sourceB, [refA],
             options: TestOptions.ReleaseExe.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
-            // (1,1): error CS9362: 'A.M()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+            // (1,1): error CS9362: 'A.M()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
             // A.M();
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "A.M()").WithArguments("A.M()").WithLocation(1, 1));
     }
@@ -11357,53 +11283,57 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             CompilerFeatureRequiredAttribute,
         ];
 
-        var commonErrors = new[]
+        var sourceErrors = new[]
         {
-            // (14,6): error CS9367: RequiresUnsafeAttribute cannot be applied to this symbol.
-            //     [RequiresUnsafeAttribute] ~C() { }
-            Diagnostic(ErrorCode.ERR_RequiresUnsafeAttributeUnsupportedMemberTarget, "RequiresUnsafeAttribute").WithLocation(14, 6),
-            // (15,6): error CS9367: RequiresUnsafeAttribute cannot be applied to this symbol.
-            //     [RequiresUnsafeAttribute] static C() { }
-            Diagnostic(ErrorCode.ERR_RequiresUnsafeAttributeUnsupportedMemberTarget, "RequiresUnsafeAttribute").WithLocation(15, 6),
-            // (23,27): error CS9367: RequiresUnsafeAttribute cannot be applied to this symbol.
-            //     void L() { var lam = [RequiresUnsafeAttribute] () => { }; }
-            Diagnostic(ErrorCode.ERR_RequiresUnsafeAttributeUnsupportedMemberTarget, "RequiresUnsafeAttribute").WithLocation(23, 27),
-        };
-
-        var commonWarnings = new[]
-        {
-            // (4,6): warning CS9368: RequiresUnsafeAttribute is only valid under the updated memory safety rules.
+            // (4,6): error CS9379: Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.
             //     [RequiresUnsafeAttribute] void M() { }
-            Diagnostic(ErrorCode.WRN_RequiresUnsafeAttributeLegacyRules, "RequiresUnsafeAttribute").WithLocation(4, 6),
-            // (7,15): warning CS9368: RequiresUnsafeAttribute is only valid under the updated memory safety rules.
+            Diagnostic(ErrorCode.ERR_RequiresUnsafeAttributeInSource, "RequiresUnsafeAttribute").WithLocation(4, 6),
+            // (5,6): error CS9379: Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.
+            //     [RequiresUnsafeAttribute] int P1 { get; set; }
+            Diagnostic(ErrorCode.ERR_RequiresUnsafeAttributeInSource, "RequiresUnsafeAttribute").WithLocation(5, 6),
+            // (7,15): error CS9379: Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.
             //     int P3 { [RequiresUnsafeAttribute] get; [RequiresUnsafeAttribute] set; }
-            Diagnostic(ErrorCode.WRN_RequiresUnsafeAttributeLegacyRules, "RequiresUnsafeAttribute").WithLocation(7, 15),
-            // (7,46): warning CS9368: RequiresUnsafeAttribute is only valid under the updated memory safety rules.
+            Diagnostic(ErrorCode.ERR_RequiresUnsafeAttributeInSource, "RequiresUnsafeAttribute").WithLocation(7, 15),
+            // (7,46): error CS9379: Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.
             //     int P3 { [RequiresUnsafeAttribute] get; [RequiresUnsafeAttribute] set; }
-            Diagnostic(ErrorCode.WRN_RequiresUnsafeAttributeLegacyRules, "RequiresUnsafeAttribute").WithLocation(7, 46),
-            // (11,31): warning CS9368: RequiresUnsafeAttribute is only valid under the updated memory safety rules.
+            Diagnostic(ErrorCode.ERR_RequiresUnsafeAttributeInSource, "RequiresUnsafeAttribute").WithLocation(7, 46),
+            // (9,6): error CS9379: Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.
+            //     [RequiresUnsafeAttribute] event System.Action E1;
+            Diagnostic(ErrorCode.ERR_RequiresUnsafeAttributeInSource, "RequiresUnsafeAttribute").WithLocation(9, 6),
+            // (11,31): error CS9379: Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.
             //     event System.Action E3 { [RequiresUnsafeAttribute] add { } [RequiresUnsafeAttribute] remove { } }
-            Diagnostic(ErrorCode.WRN_RequiresUnsafeAttributeLegacyRules, "RequiresUnsafeAttribute").WithLocation(11, 31),
-            // (11,65): warning CS9368: RequiresUnsafeAttribute is only valid under the updated memory safety rules.
+            Diagnostic(ErrorCode.ERR_RequiresUnsafeAttributeInSource, "RequiresUnsafeAttribute").WithLocation(11, 31),
+            // (11,65): error CS9379: Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.
             //     event System.Action E3 { [RequiresUnsafeAttribute] add { } [RequiresUnsafeAttribute] remove { } }
-            Diagnostic(ErrorCode.WRN_RequiresUnsafeAttributeLegacyRules, "RequiresUnsafeAttribute").WithLocation(11, 65),
-            // (13,6): warning CS9368: RequiresUnsafeAttribute is only valid under the updated memory safety rules.
+            Diagnostic(ErrorCode.ERR_RequiresUnsafeAttributeInSource, "RequiresUnsafeAttribute").WithLocation(11, 65),
+            // (12,6): error CS9379: Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.
+            //     [RequiresUnsafeAttribute] int this[int i] { get => i; set { } }
+            Diagnostic(ErrorCode.ERR_RequiresUnsafeAttributeInSource, "RequiresUnsafeAttribute").WithLocation(12, 6),
+            // (13,6): error CS9379: Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.
             //     [RequiresUnsafeAttribute] C() { }
-            Diagnostic(ErrorCode.WRN_RequiresUnsafeAttributeLegacyRules, "RequiresUnsafeAttribute").WithLocation(13, 6),
-            // (16,6): warning CS9368: RequiresUnsafeAttribute is only valid under the updated memory safety rules.
+            Diagnostic(ErrorCode.ERR_RequiresUnsafeAttributeInSource, "RequiresUnsafeAttribute").WithLocation(13, 6),
+            // (16,6): error CS9379: Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.
             //     [RequiresUnsafeAttribute] public static C operator +(C c1, C c2) => c1;
-            Diagnostic(ErrorCode.WRN_RequiresUnsafeAttributeLegacyRules, "RequiresUnsafeAttribute").WithLocation(16, 6),
-            // (17,6): warning CS9368: RequiresUnsafeAttribute is only valid under the updated memory safety rules.
+            Diagnostic(ErrorCode.ERR_RequiresUnsafeAttributeInSource, "RequiresUnsafeAttribute").WithLocation(16, 6),
+            // (17,6): error CS9379: Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.
             //     [RequiresUnsafeAttribute] public void operator +=(C c) { }
-            Diagnostic(ErrorCode.WRN_RequiresUnsafeAttributeLegacyRules, "RequiresUnsafeAttribute").WithLocation(17, 6),
+            Diagnostic(ErrorCode.ERR_RequiresUnsafeAttributeInSource, "RequiresUnsafeAttribute").WithLocation(17, 6),
+            // (14,6): error CS9379: Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.
+            //     [RequiresUnsafeAttribute] ~C() { }
+            Diagnostic(ErrorCode.ERR_RequiresUnsafeAttributeInSource, "RequiresUnsafeAttribute").WithLocation(14, 6),
+            // (15,6): error CS9379: Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.
+            //     [RequiresUnsafeAttribute] static C() { }
+            Diagnostic(ErrorCode.ERR_RequiresUnsafeAttributeInSource, "RequiresUnsafeAttribute").WithLocation(15, 6),
+            // (23,27): error CS9379: Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.
+            //     void L() { var lam = [RequiresUnsafeAttribute] () => { }; }
+            Diagnostic(ErrorCode.ERR_RequiresUnsafeAttributeInSource, "RequiresUnsafeAttribute").WithLocation(23, 27),
         };
 
         CreateCompilation(source, [ref1],
             options: TestOptions.ReleaseDll.WithUpdatedMemorySafetyRules(updatedRules))
             .VerifyDiagnostics(
             [
-                .. commonErrors,
-                .. (updatedRules ? default(ReadOnlySpan<DiagnosticDescription>) : commonWarnings),
+                .. sourceErrors,
             ]);
 
         var comp2 = CreateCompilation(RequiresUnsafeAttributeDefinition).VerifyDiagnostics();
@@ -11413,8 +11343,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             options: TestOptions.ReleaseDll.WithUpdatedMemorySafetyRules(updatedRules))
             .VerifyDiagnostics(
             [
-                .. commonErrors,
-                .. (updatedRules ? default(ReadOnlySpan<DiagnosticDescription>) : commonWarnings),
+                .. sourceErrors,
                 // (3,12): error CS0592: Attribute 'RequiresUnsafeAttribute' is not valid on this declaration type. It is only valid on 'constructor, method, property, indexer, event' declarations.
                 // [assembly: RequiresUnsafeAttribute]
                 Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "RequiresUnsafeAttribute").WithArguments("RequiresUnsafeAttribute", "constructor, method, property, indexer, event").WithLocation(3, 12),
@@ -11456,14 +11385,13 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
     {
         CompileAndVerifyUnsafe(
             lib: """
-                using System.Diagnostics.CodeAnalysis;
                 public partial class C
                 {
-                    [RequiresUnsafe] public partial int M1();
-                    public partial int M1() => 0;
-            
-                    public partial int M2();
-                    [RequiresUnsafe] public partial int M2() => 0;
+                    unsafe public partial int M1();
+                    unsafe public partial int M1() => 0;
+
+                    unsafe public partial int M2();
+                    unsafe public partial int M2() => 0;
                 }
                 """,
             caller: """
@@ -11476,30 +11404,27 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedSafeSymbols: ["C"],
             expectedDiagnostics:
             [
-                // (2,1): error CS9362: 'C.M1()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (2,1): error CS9362: 'C.M1()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.M1();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.M1()").WithArguments("C.M1()").WithLocation(2, 1),
-                // (3,1): error CS9362: 'C.M2()' must be used in an unsafe context because it is marked as 'RequiresUnsafe' or 'extern'
+                // (3,1): error CS9362: 'C.M2()' must be used in an unsafe context because it is marked as 'unsafe' or 'extern'
                 // c.M2();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "c.M2()").WithArguments("C.M2()").WithLocation(3, 1),
             ]);
 
+        // Both partial declarations agree on `unsafe`.
         CreateCompilation(
             [
                 """
-                using System.Diagnostics.CodeAnalysis;
                 partial class C
                 {
-                    [RequiresUnsafe] public partial int M();
-                    [RequiresUnsafe] public partial int M() => 0;
+                    unsafe public partial int M();
+                    unsafe public partial int M() => 0;
                 }
                 """,
                 RequiresUnsafeAttributeDefinition,
             ],
-            options: TestOptions.ReleaseDll.WithUpdatedMemorySafetyRules())
-            .VerifyDiagnostics(
-            // (5,6): error CS0579: Duplicate 'RequiresUnsafe' attribute
-            //     [RequiresUnsafe] public partial int M() => 0;
-            Diagnostic(ErrorCode.ERR_DuplicateAttribute, "RequiresUnsafe").WithArguments("RequiresUnsafe").WithLocation(5, 6));
+            options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
+            .VerifyDiagnostics();
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -481,7 +481,6 @@ class X
                             // These are the warnings introduced with the warning "wave" shipped with dotnet 10 and C# 14.
                             Assert.Equal(10, ErrorFacts.GetWarningLevel(errorCode));
                             break;
-                        case ErrorCode.WRN_RequiresUnsafeAttributeLegacyRules:
                         case ErrorCode.WRN_UnsafeMeaningless:
                             // These are the warnings introduced with the warning "wave" shipped with dotnet 11 and C# 15.
                             Assert.Equal(11, ErrorFacts.GetWarningLevel(errorCode));

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonEventWellKnownAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonEventWellKnownAttributeData.cs
@@ -11,22 +11,6 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     internal class CommonEventWellKnownAttributeData : WellKnownAttributeData, ISkipLocalsInitAttributeTarget
     {
-        private bool _hasRequiresUnsafeAttribute;
-        public bool HasRequiresUnsafeAttribute
-        {
-            get
-            {
-                VerifySealed(expected: true);
-                return _hasRequiresUnsafeAttribute;
-            }
-            set
-            {
-                VerifySealed(expected: false);
-                _hasRequiresUnsafeAttribute = value;
-                SetDataStored();
-            }
-        }
-
         private bool _hasSpecialNameAttribute;
         public bool HasSpecialNameAttribute
         {


### PR DESCRIPTION
1. The `unsafe` modifier on a member (or `extern`) marks it as `CallerUnsafeMode.Explicit` (replacing what the attribute previously did).
2. Applying `[RequiresUnsafeAttribute]` in source now produces a hard error (`ERR_RequiresUnsafeAttributeInSource`).
3. The compiler synthesizes and embeds `RequiresUnsafeAttribute` into assemblies rather than requiring it from the framework.
4. The attribute is hidden from `GetAttributes()` on PE symbols since it's a metadata encoding detail.

Test plan: https://github.com/dotnet/roslyn/issues/81207
Relevant speclet change: https://github.com/dotnet/csharplang/pull/10091

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83295)