### PR TITLE
Feed MIBC PGO data into ServiceHub CoreComponents crossgen2

### DIFF
--- a/src/Workspaces/Remote/ServiceHub.CoreComponents/CoreComponents.Shared.targets
+++ b/src/Workspaces/Remote/ServiceHub.CoreComponents/CoreComponents.Shared.targets
@@ -200,6 +200,12 @@
       <_R2RPdbOutputDirecotry>$(PdbWorkDir)\%(_CrossgenTargetPaths._RelativeDirectory)</_R2RPdbOutputDirecotry>
     </PropertyGroup>
     <ItemGroup>
+      <!-- Find MIBC PGO data files produced by the CrossGen OptProf pipeline.
+           They are included in the OptimizationInputs drop alongside .ibc files
+           and downloaded to IbcOptimizationDataDir by Arcade's VisualStudio.AcquireOptimizationData.targets. -->
+      <_MibcFiles Condition="'$(IbcOptimizationDataDir)' != ''" Include="$(IbcOptimizationDataDir)**\*.mibc" />
+    </ItemGroup>
+    <ItemGroup>
       <_RspFileLines Include="$(_R2ROptimizeAssemblyPath)" />
       <_RspFileLines Include="--out:$(_R2ROptimizeAssemblyOutputPath)" />
       <_RspFileLines Include="--pdb" />
@@ -207,6 +213,7 @@
       <_RspFileLines Include="--targetarch:$(TargetArch)" />
       <_RspFileLines Include="--optimize" />
       <_RspFileLines Include="--opt-cross-module:*" />
+      <_RspFileLines Include="@(_MibcFiles->'--mibc:%(FullPath)')" />
       <_RspFileLines Include="@(_RuntimeLibraryPathsNotInPublishDir->'--reference:%(FullPath)')" />
       <_RspFileLines Include="@(_CrossgenTargetsAsDependencies->'--reference:%(FullPath)')" />
       <_RspFileLines Include="@(_NonCrossgenTargetsAsDependencies->'--reference:%(FullPath)')" />


### PR DESCRIPTION
The CrossGen OptProf pipeline now produces mergedTrace.mibc with profile-guided optimization data for .NET Core assemblies, but the ServiceHub CoreComponents crossgen2 step was not consuming it. This means R2R compilation used only static heuristics, resulting in excess JIT in the DevHub process.

This change passes the MIBC directory to MSBuild via ServiceHubMibcDataDir
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83301)