### PR TITLE
Fix regression in CreateFallbackEncoding

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Text/StringTextDecodingTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/StringTextDecodingTests.cs
@@ -341,5 +341,32 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 Assert.Equal('\u2026', sourceText[0]);
             }
         }
+
+        [ConditionalFact(typeof(HasEnglishDefaultEncoding))]
+        public void NonUtf8_MiddleDot()
+        {
+            // Bytes 0xA0 and 0xB7 are invalid UTF-8 but valid in CodePage 1252 (and Latin-1).
+            // 0xA0 = No-Break Space (U+00A0)
+            // 0xB7 = Middle Dot (U+00B7)
+            // Verifies that the fallback encoding correctly decodes these bytes
+            // instead of treating them as invalid UTF-8 replacement characters (U+FFFD).
+            byte[] srcBytes = [0xA0, 0xB7];
+            using var stream = new MemoryStream(srcBytes);
+            var sourceText = EncodedStringText.Create(stream);
+            Assert.Equal(2, sourceText.Length);
+            Assert.Equal('\u00A0', sourceText[0]);
+            Assert.Equal('\u00B7', sourceText[1]);
+        }
+
+        [Fact]
+        public void CreateFallbackEncoding_IsNotUtf8()
+        {
+            // CreateFallbackEncoding should return the system's default ANSI code page,
+            // not UTF-8. The fallback is used when a source file without BOM contains bytes
+            // that are not valid UTF-8. If the fallback is UTF-8, those bytes would be decoded
+            // as replacement characters (U+FFFD) instead of the intended code page characters.
+            var fallback = EncodedStringText.CreateFallbackEncoding();
+            Assert.NotEqual(Encoding.UTF8.CodePage, fallback.CodePage);
+        }
     }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/Text/StringTextDecodingTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/StringTextDecodingTests.cs
@@ -359,14 +359,24 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
-        public void CreateFallbackEncoding_IsNotUtf8()
+        public void CreateFallbackEncoding_IsNotUtf8OnWindows()
         {
-            // CreateFallbackEncoding should return the system's default ANSI code page,
-            // not UTF-8. The fallback is used when a source file without BOM contains bytes
-            // that are not valid UTF-8. If the fallback is UTF-8, those bytes would be decoded
-            // as replacement characters (U+FFFD) instead of the intended code page characters.
             var fallback = EncodedStringText.CreateFallbackEncoding();
-            Assert.NotEqual(Encoding.UTF8.CodePage, fallback.CodePage);
+
+            if (ExecutionConditionUtil.IsWindows)
+            {
+                // On Windows, registering CodePagesEncodingProvider makes GetEncoding(0) return
+                // the real ANSI code page (e.g., 1252) even when the UTF-8 locale setting is enabled.
+                // The fallback is used when a source file without BOM contains bytes that are not
+                // valid UTF-8. If the fallback were UTF-8, those bytes would be decoded as replacement
+                // characters (U+FFFD) instead of the intended code page characters.
+                Assert.NotEqual(Encoding.UTF8.CodePage, fallback.CodePage);
+            }
+            else
+            {
+                // On Linux/macOS there is no ANSI code page, so the fallback is UTF-8.
+                Assert.Equal(Encoding.UTF8.CodePage, fallback.CodePage);
+            }
         }
     }
 }

--- a/src/Compilers/Core/Portable/EncodedStringText.cs
+++ b/src/Compilers/Core/Portable/EncodedStringText.cs
@@ -5,7 +5,6 @@
 using System;
 using System.IO;
 using System.Text;
-using System.Threading;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Text
@@ -46,6 +45,8 @@ namespace Microsoft.CodeAnalysis.Text
                 s_encodingProviderRegistered = true;
             }
 
+            // Try to get the default ANSI code page in the operating system's
+            // regional and language settings, and fall back to 1252 otherwise
             return TryGetCodePageEncoding(0)
                 ?? TryGetCodePageEncoding(1252)
                 ?? Encoding.GetEncoding(name: "Latin1");
@@ -53,51 +54,9 @@ namespace Microsoft.CodeAnalysis.Text
 
         internal static Encoding? TryGetCodePageEncoding(int codePage)
         {
-            // Read to local to avoid race condition when multiple threads fail to get the encoding,
-            // only one of them executes the filter to retry, sets the static field and suppresses retry for the other threads.
-            var encodingProviderRegistered = s_encodingProviderRegistered;
-
             try
             {
                 return Encoding.GetEncoding(codePage);
-            }
-            catch (NotSupportedException) when (!encodingProviderRegistered)
-            {
-                // From documentation:
-                //   - 'GetEncoding' throws NotSupportedException when codepage is not supported by the underlying platform.
-                //   - 'EncodingProvider.Instance' gets an encoding provider for code pages supported
-                //     in the desktop .NET Framework but not by the current underlying platform.
-                //   - 'Encoding.RegisterProvider' makes character encodings available on a platform that does not otherwise support them.
-                //      * Once the encoding provider is registered, the encodings that it supports can be retrieved by calling any
-                //        Encoding.GetEncoding overload.
-                //      * Registering an encoding provider by using the 'RegisterProvider' method also affects the behavior of
-                //        GetEncoding(Int32) when passed an argument of 0.
-                //      * If multiple providers are registered, GetEncoding(Int32) attempts to retrieve the encoding from the most recently
-                //        registered provider first.
-                //      * If the 'RegisterProvider' method is called to register multiple providers that handle the same encoding,
-                //        the last registered provider is the used for all encoding and decoding operations. Any previously registered providers are ignored.
-                //      * If the same encoding provider is used in multiple calls to the 'RegisterProvider' method,
-                //        only the first method call registers the provider. Subsequent calls are ignored.
-                //      
-                //  Given all that:
-                //   - We don't call 'Encoding.RegisterProvider' unconditionally to avoid changing environment
-                //     that is already configured to support the requested codepage. We call it only when we encounter
-                //     a 'NotSupportedException'.
-                //   - We also do not attempt to call 'Encoding.RegisterProvider' more than once.
-                try
-                {
-                    // Ignore any exceptions from an attempt to register the provider.
-                    Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-                }
-                catch
-                {
-                }
-
-                s_encodingProviderRegistered = true;
-
-                // Try to get the encoding again after attempting to register the provider.
-                // Since we set `s_registeredEncodingProvider` to true, we won't get here again.
-                return TryGetCodePageEncoding(codePage);
             }
             catch (Exception)
             {

--- a/src/Compilers/Core/Portable/EncodedStringText.cs
+++ b/src/Compilers/Core/Portable/EncodedStringText.cs
@@ -33,8 +33,19 @@ namespace Microsoft.CodeAnalysis.Text
         /// </summary>
         internal static Encoding CreateFallbackEncoding()
         {
-            // Try to get the default ANSI code page in the operating system's
-            // regional and language settings, and fall back to 1252 otherwise
+            if (!s_encodingProviderRegistered)
+            {
+                try
+                {
+                    Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+                }
+                catch
+                {
+                }
+
+                s_encodingProviderRegistered = true;
+            }
+
             return TryGetCodePageEncoding(0)
                 ?? TryGetCodePageEncoding(1252)
                 ?? Encoding.GetEncoding(name: "Latin1");

--- a/src/Compilers/Core/Portable/EncodedStringText.cs
+++ b/src/Compilers/Core/Portable/EncodedStringText.cs
@@ -32,18 +32,7 @@ namespace Microsoft.CodeAnalysis.Text
         /// </summary>
         internal static Encoding CreateFallbackEncoding()
         {
-            if (!s_encodingProviderRegistered)
-            {
-                try
-                {
-                    Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-                }
-                catch
-                {
-                }
-
-                s_encodingProviderRegistered = true;
-            }
+            EnsureEncodingProviderRegistered();
 
             // Try to get the default ANSI code page in the operating system's
             // regional and language settings, and fall back to 1252 otherwise
@@ -52,8 +41,23 @@ namespace Microsoft.CodeAnalysis.Text
                 ?? Encoding.GetEncoding(name: "Latin1");
         }
 
+        private static void EnsureEncodingProviderRegistered()
+        {
+            if (!s_encodingProviderRegistered)
+            {
+                if (CodePagesEncodingProvider.Instance is { } provider)
+                {
+                    Encoding.RegisterProvider(provider);
+                }
+
+                s_encodingProviderRegistered = true;
+            }
+        }
+
         internal static Encoding? TryGetCodePageEncoding(int codePage)
         {
+            EnsureEncodingProviderRegistered();
+
             try
             {
                 return Encoding.GetEncoding(codePage);


### PR DESCRIPTION
PR #82159 moved `CodePagesEncodingProvider` registration from `CommandLineParser` into `EncodedStringText.TryGetCodePageEncoding`, using a lazy pattern that only registers the provider when `Encoding.GetEncoding` throws `NotSupportedException`. However, `GetEncoding(0)` on .NET Core doesn't throw — it silently returns UTF-8 (code page 65001) when the provider isn't registered. This means `CreateFallbackEncoding()` returns UTF-8 as the fallback encoding, which is useless since UTF-8 is already tried first. Source files with non-UTF-8 bytes (e.g., Latin-1 encoded) get decoded with replacement characters (U+FFFD) instead of the intended characters.

### Fix

- Register `CodePagesEncodingProvider` eagerly in `CreateFallbackEncoding()` before calling `GetEncoding(0)`, so it returns the real system ANSI code page.
- Simplify `TryGetCodePageEncoding` by removing the complicated lazy retry logic — the provider is already registered at entry points (`BuildClient.Run` for compilers, `CreateFallbackEncoding` for other hosts like MSBuildWorkspace).

### Testing

- `CreateFallbackEncoding_IsNotUtf8OnWindows`: asserts the fallback encoding is not UTF-8 on Windows (where a real ANSI code page exists), and is UTF-8 on Linux/macOS (where there is no legacy code page).
- `NonUtf8_MiddleDot`: verifies that bytes `0xA0 0xB7` (invalid UTF-8, valid Latin-1/CP-1252) are decoded as U+00A0 U+00B7, not as replacement characters.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83320)