### PR TITLE
Fix FAR for partial properties across project references

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
@@ -322,11 +322,16 @@ internal static partial class DependentProjectsFinder
         Contract.ThrowIfNull(project);
         Contract.ThrowIfFalse(project.SupportsCompilation);
 
-        // If our symbol was from a project, then just check if this current project has a direct reference to it.
-        if (symbolOrigination.sourceProject != null)
-            return project.ProjectReferences.Any(p => p.ProjectId == symbolOrigination.sourceProject.Id);
+        // If our symbol was from a project, first check if this current project has a direct project reference to it.
+        // If not, it may still reference the same assembly through metadata (for example, if the project system loaded
+        // the dependency as an output reference instead of a P2P reference).
+        if (symbolOrigination.sourceProject != null &&
+            project.ProjectReferences.Any(p => p.ProjectId == symbolOrigination.sourceProject.Id))
+        {
+            return true;
+        }
 
-        // Otherwise, if the symbol is from metadata, see if the project's compilation references that metadata assembly.
+        // Otherwise, see if the project's compilation references that assembly through metadata.
         return await HasReferenceToAssemblyAsync(
             project, symbolOrigination.assembly.Name, cancellationToken).ConfigureAwait(false);
     }
@@ -343,6 +348,14 @@ internal static partial class DependentProjectsFinder
         foreach (var reference in project.MetadataReferences)
         {
             cancellationToken.ThrowIfCancellationRequested();
+
+            if (reference is CompilationReference compilationReference)
+            {
+                if (string.Equals(compilationReference.Compilation.AssemblyName, assemblyName, StringComparison.OrdinalIgnoreCase))
+                    return true;
+
+                continue;
+            }
 
             if (reference is not PortableExecutableReference peReference)
                 continue;

--- a/src/Workspaces/CoreTest/FindReferencesTests.cs
+++ b/src/Workspaces/CoreTest/FindReferencesTests.cs
@@ -10,7 +10,9 @@ using System.Linq;
 using System.Threading.Tasks;
 using Basic.Reference.Assemblies;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
@@ -467,6 +469,113 @@ public sealed class FindReferencesTests : TestBase
         // A.C.get_Uri
         // A.ITestBase.get_Uri
         Assert.Equal(5, references.Count());
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/82744")]
+    public async Task FindReferences_PartialPropertyFromProjectedMetadataSymbol()
+    {
+        using var workspace = CreateWorkspace();
+        var modelsProjectId = ProjectId.CreateNewId();
+        var reproProjectId = ProjectId.CreateNewId();
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Preview);
+
+        var solution = workspace.CurrentSolution
+            .AddProject(modelsProjectId, "Models", "Models", LanguageNames.CSharp)
+            .AddMetadataReference(modelsProjectId, MscorlibRef)
+            .AddDocument(DocumentId.CreateNewId(modelsProjectId), "MyClass.cs", SourceText.From("""
+                namespace Models;
+
+                public partial class MyClass
+                {
+                    public partial string MyString { get; set; }
+                }
+
+                public partial class MyClass
+                {
+                    public partial string MyString { get => field; set => field = value; }
+                }
+                """))
+            .WithProjectParseOptions(modelsProjectId, parseOptions)
+            .WithProjectCompilationOptions(modelsProjectId, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var modelsProject = solution.GetProject(modelsProjectId);
+        var modelsCompilation = await modelsProject.GetCompilationAsync();
+        var modelsMetadataReference = modelsCompilation.ToMetadataReference();
+
+        solution = solution
+            .AddProject(reproProjectId, "Repro", "Repro", LanguageNames.CSharp)
+            .AddMetadataReference(reproProjectId, MscorlibRef)
+            .AddMetadataReference(reproProjectId, modelsMetadataReference)
+            .AddDocument(DocumentId.CreateNewId(reproProjectId), "Program.cs", SourceText.From("""
+                using Models;
+                using System;
+
+                var obj = new MyClass();
+                if (obj.MyString is not null)
+                {
+                    Console.WriteLine(obj.MyString);
+                }
+                """))
+            .WithProjectParseOptions(reproProjectId, parseOptions)
+            .WithProjectCompilationOptions(reproProjectId, new CSharpCompilationOptions(OutputKind.ConsoleApplication));
+
+        var document = solution.GetProject(reproProjectId).Documents.Single();
+        var text = await document.GetTextAsync();
+        var position = text.ToString().IndexOf("MyString", StringComparison.Ordinal);
+        Assert.True(position >= 0);
+
+        var usageSymbol = Assert.IsAssignableFrom<IPropertySymbol>(await SymbolFinder.FindSymbolAtPositionAsync(document, position));
+        var sourceDefinition = Assert.IsAssignableFrom<IPropertySymbol>(await SymbolFinder.FindSourceDefinitionAsync(usageSymbol, solution));
+        var projectedMetadataCompilation = CSharpCompilation.Create(
+            assemblyName: "ProjectedMetadata",
+            syntaxTrees: [],
+            references: [MscorlibRef, modelsCompilation.EmitToImageReference()],
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var projectedMetadataSymbol = projectedMetadataCompilation.GetTypeByMetadataName("Models.MyClass")
+            .GetMembers("MyString")
+            .OfType<IPropertySymbol>()
+            .Single();
+
+        Assert.Null(projectedMetadataSymbol.PartialDefinitionPart);
+        Assert.Null(projectedMetadataSymbol.PartialImplementationPart);
+        Assert.True(SymbolEquivalenceComparer.Instance.Equals(projectedMetadataSymbol, sourceDefinition));
+        Assert.Equal(usageSymbol.ToTestDisplayString(), projectedMetadataSymbol.ToTestDisplayString());
+
+        var results = (await SymbolFinder.FindReferencesAsync(usageSymbol, solution))
+            .Select(referencedSymbol => FormatReferencedSymbol(referencedSymbol))
+            .OrderBy(static result => result)
+            .ToArray();
+
+        AssertEx.Equal(
+        [
+            "Field: System.String Models.MyClass.<MyString>k__BackingField -> []",
+            "Method: System.String Models.MyClass.MyString.get -> []",
+            "Method: System.String Models.MyClass.MyString.get -> []",
+            "Method: void Models.MyClass.MyString.set -> []",
+            "Method: void Models.MyClass.MyString.set -> []",
+            "Property: System.String Models.MyClass.MyString { get; set; } -> []",
+            "Property: System.String Models.MyClass.MyString { get; set; } -> [Program.cs(4,8)-(4,16) SymbolUsageInfo { ValueUsageInfoOpt = Read, TypeOrNamespaceUsageInfoOpt =  }, Program.cs(6,26)-(6,34) SymbolUsageInfo { ValueUsageInfoOpt = Read, TypeOrNamespaceUsageInfoOpt =  }]",
+        ], results);
+
+        static string FormatReferencedSymbol(ReferencedSymbol referencedSymbol)
+        {
+            var locations = referencedSymbol.Locations
+                .Where(static location => !location.IsImplicit)
+                .OrderBy(static location => location.Document.Name)
+                .ThenBy(static location => location.Location.SourceSpan.Start)
+                .Select(static location => FormatLocation(location));
+
+            return $"{referencedSymbol.Definition.Kind}: {referencedSymbol.Definition.ToTestDisplayString()} -> [{string.Join(", ", locations)}]";
+        }
+
+        static string FormatLocation(ReferenceLocation location)
+        {
+            var lineSpan = location.Location.GetLineSpan();
+            var start = lineSpan.StartLinePosition;
+            var end = lineSpan.EndLinePosition;
+            return $"{location.Document.Name}({start.Line},{start.Character})-({end.Line},{end.Character}) {location.SymbolUsageInfo}";
+        }
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/4936")]

--- a/src/Workspaces/MSBuild/Test/NetCoreTests.cs
+++ b/src/Workspaces/MSBuild/Test/NetCoreTests.cs
@@ -12,7 +12,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Logging;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.UnitTests;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Extensions/Symbols/SymbolEquivalenceComparer.EquivalenceVisitor.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Extensions/Symbols/SymbolEquivalenceComparer.EquivalenceVisitor.cs
@@ -207,8 +207,9 @@ internal sealed partial class SymbolEquivalenceComparer
                     return HaveSameLocation(x, y);
                 }
 
-                if (IsPartialMethodDefinitionPart(x) != IsPartialMethodDefinitionPart(y) ||
-                    IsPartialMethodImplementationPart(x) != IsPartialMethodImplementationPart(y) ||
+                if (!PartialPartsAreEquivalent(
+                        IsPartialMethodDefinitionPart(x), IsPartialMethodImplementationPart(x),
+                        IsPartialMethodDefinitionPart(y), IsPartialMethodImplementationPart(y)) ||
                     x.IsDefinition != y.IsDefinition ||
                     IsConstructedFromSelf(x) != IsConstructedFromSelf(y) ||
                     x.Arity != y.Arity ||
@@ -599,8 +600,9 @@ internal sealed partial class SymbolEquivalenceComparer
                 x.IsIndexer == y.IsIndexer &&
                 x.MetadataName == y.MetadataName &&
                 x.Parameters.Length == y.Parameters.Length &&
-                IsPartialPropertyDefinitionPart(x) == IsPartialPropertyDefinitionPart(y) &&
-                IsPartialPropertyImplementationPart(x) == IsPartialPropertyImplementationPart(y) &&
+                PartialPartsAreEquivalent(
+                    IsPartialPropertyDefinitionPart(x), IsPartialPropertyImplementationPart(x),
+                    IsPartialPropertyDefinitionPart(y), IsPartialPropertyImplementationPart(y)) &&
                 ParametersAreEquivalent(x.Parameters, y.Parameters, equivalentTypesWithDifferingAssemblies) &&
                 AreEquivalent(x.ContainingSymbol, y.ContainingSymbol, equivalentTypesWithDifferingAssemblies);
         }
@@ -609,8 +611,9 @@ internal sealed partial class SymbolEquivalenceComparer
         {
             return
                 x.MetadataName == y.MetadataName &&
-                IsPartialEventDefinitionPart(x) == IsPartialEventDefinitionPart(y) &&
-                IsPartialEventImplementationPart(x) == IsPartialEventImplementationPart(y) &&
+                PartialPartsAreEquivalent(
+                    IsPartialEventDefinitionPart(x), IsPartialEventImplementationPart(x),
+                    IsPartialEventDefinitionPart(y), IsPartialEventImplementationPart(y)) &&
                 AreEquivalent(x.ContainingSymbol, y.ContainingSymbol, equivalentTypesWithDifferingAssemblies);
         }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Extensions/Symbols/SymbolEquivalenceComparer.GetHashCodeVisitor.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Extensions/Symbols/SymbolEquivalenceComparer.GetHashCodeVisitor.cs
@@ -118,13 +118,11 @@ internal sealed partial class SymbolEquivalenceComparer
             }
 
             currentHash =
-                Hash.Combine(IsPartialMethodImplementationPart(x),
-                Hash.Combine(IsPartialMethodDefinitionPart(x),
                 Hash.Combine(x.IsDefinition,
                 Hash.Combine(IsConstructedFromSelf(x),
                 Hash.Combine(x.Arity,
                 Hash.Combine(x.Parameters.Length,
-                Hash.Combine(x.Name, currentHash)))))));
+                Hash.Combine(x.Name, currentHash)))));
 
             var checkContainingType = CheckContainingType(x);
             if (checkContainingType)
@@ -245,9 +243,7 @@ internal sealed partial class SymbolEquivalenceComparer
                 Hash.Combine(x.IsIndexer,
                 Hash.Combine(x.Name,
                 Hash.Combine(x.Parameters.Length,
-                Hash.Combine(IsPartialPropertyImplementationPart(x),
-                Hash.Combine(IsPartialPropertyDefinitionPart(x),
-                GetHashCode(x.ContainingSymbol, currentHash))))));
+                GetHashCode(x.ContainingSymbol, currentHash))));
 
             return CombineHashCodes(x.Parameters, currentHash, _parameterAggregator);
         }
@@ -256,9 +252,7 @@ internal sealed partial class SymbolEquivalenceComparer
         {
             return
                 Hash.Combine(x.Name,
-                Hash.Combine(IsPartialEventImplementationPart(x),
-                Hash.Combine(IsPartialEventDefinitionPart(x),
-                GetHashCode(x.ContainingSymbol, currentHash))));
+                GetHashCode(x.ContainingSymbol, currentHash));
         }
 
         public int CombineHashCodes(ITypeParameterSymbol x, int currentHash)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Extensions/Symbols/SymbolEquivalenceComparer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Extensions/Symbols/SymbolEquivalenceComparer.cs
@@ -254,6 +254,30 @@ internal sealed partial class SymbolEquivalenceComparer : IEqualityComparer<ISym
         => false;
 #endif
 
+    private static bool PartialPartsAreEquivalent(
+        bool xIsDefinitionPart,
+        bool xIsImplementationPart,
+        bool yIsDefinitionPart,
+        bool yIsImplementationPart)
+    {
+        if (xIsDefinitionPart == yIsDefinitionPart &&
+            xIsImplementationPart == yIsImplementationPart)
+        {
+            return true;
+        }
+
+        // Metadata/projected symbols can lose the partial-part information entirely. When that happens,
+        // the symbol should still unify with the source definition part so features like FAR can reach
+        // the real declaration and its references.
+        if (!xIsDefinitionPart && !xIsImplementationPart)
+            return yIsDefinitionPart && !yIsImplementationPart;
+
+        if (!yIsDefinitionPart && !yIsImplementationPart)
+            return xIsDefinitionPart && !xIsImplementationPart;
+
+        return false;
+    }
+
     private static TypeKind GetTypeKind(INamedTypeSymbol x)
         => x.TypeKind switch
         {


### PR DESCRIPTION
Handle projected metadata symbols that lose their partial-part identity, and search dependent projects reached through metadata or output references.

Add a focused Find References regression for dotnet/roslyn#82744 and remove the earlier MSBuild-heavy repro.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83327)