### PR TITLE
Replace DataContractJsonSerializer with hand-rolled JSON parsing for diagnostic unnecessary-location indices

### DIFF
--- a/src/Analyzers/Core/Analyzers/Helpers/DiagnosticHelper.cs
+++ b/src/Analyzers/Core/Analyzers/Helpers/DiagnosticHelper.cs
@@ -6,11 +6,9 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
-using System.Runtime.Serialization.Json;
-using System.Text;
 using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics;
@@ -219,16 +217,23 @@ internal static class DiagnosticHelper
 
         static string EncodeIndices(IEnumerable<int> indices, int additionalLocationsLength)
         {
-            // Ensure that the provided tag index is a valid index into additional locations.
-            Contract.ThrowIfFalse(indices.All(idx => idx >= 0 && idx < additionalLocationsLength));
+            using var _ = PooledStringBuilder.GetInstance(out var sb);
 
-            using var stream = new MemoryStream();
-            var serializer = new DataContractJsonSerializer(typeof(IEnumerable<int>));
-            serializer.WriteObject(stream, indices);
+            sb.Append('[');
+            var first = true;
+            foreach (var index in indices)
+            {
+                Contract.ThrowIfFalse(index >= 0 && index < additionalLocationsLength);
+                if (first)
+                    first = false;
+                else
+                    sb.Append(',');
 
-            var jsonBytes = stream.ToArray();
-            stream.Close();
-            return Encoding.UTF8.GetString(jsonBytes, 0, jsonBytes.Length);
+                sb.Append(index);
+            }
+            sb.Append(']');
+
+            return sb.ToString();
         }
     }
 

--- a/src/LanguageServer/Protocol/Features/Diagnostics/DiagnosticDataExtensions.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/DiagnosticDataExtensions.cs
@@ -3,14 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Runtime.Serialization.Json;
-using System.Text;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.ErrorReporting;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Features.Diagnostics;
 
@@ -23,8 +20,30 @@ internal static class DiagnosticDataExtensions
         {
             using var _ = PooledObjects.ArrayBuilder<DiagnosticDataLocation>.GetInstance(out var locationsToTag);
 
-            foreach (var index in GetLocationIndices(unnecessaryIndices))
-                locationsToTag.Add(diagnosticData.AdditionalLocations[index]);
+            try
+            {
+                // Parse a JSON array of non-negative integers (e.g., "[1,2,3]") inline. This replaces
+                // DataContractJsonSerializer which was extremely allocation-heavy for this simple format.
+                if (unnecessaryIndices.Length >= 2 && unnecessaryIndices[0] == '[' && unnecessaryIndices[^1] == ']')
+                {
+                    var start = 1;
+                    var end = unnecessaryIndices.Length - 1;
+                    while (start < end)
+                    {
+                        var commaIndex = unnecessaryIndices.IndexOf(',', start, end - start);
+                        var elementEnd = commaIndex < 0 ? end : commaIndex;
+
+                        var index = unnecessaryIndices.AsSpan(start, elementEnd - start).Trim().ToString().ParseInt();
+
+                        locationsToTag.Add(diagnosticData.AdditionalLocations[index]);
+                        start = elementEnd + 1;
+                    }
+                }
+            }
+            catch (Exception e) when (FatalError.ReportAndCatch(e))
+            {
+                locationsToTag.Clear();
+            }
 
             unnecessaryLocations = locationsToTag.ToImmutable();
             return true;
@@ -32,21 +51,6 @@ internal static class DiagnosticDataExtensions
 
         unnecessaryLocations = null;
         return false;
-
-        static IEnumerable<int> GetLocationIndices(string indicesProperty)
-        {
-            try
-            {
-                using var stream = new MemoryStream(Encoding.UTF8.GetBytes(indicesProperty));
-                var serializer = new DataContractJsonSerializer(typeof(IEnumerable<int>));
-                var result = serializer.ReadObject(stream) as IEnumerable<int>;
-                return result ?? [];
-            }
-            catch (Exception e) when (FatalError.ReportAndCatch(e))
-            {
-                return [];
-            }
-        }
     }
 
     internal static bool TryGetUnnecessaryLocationIndices(

--- a/src/LanguageServer/Protocol/Features/Diagnostics/DiagnosticDataExtensions.cs
+++ b/src/LanguageServer/Protocol/Features/Diagnostics/DiagnosticDataExtensions.cs
@@ -33,7 +33,7 @@ internal static class DiagnosticDataExtensions
                         var commaIndex = unnecessaryIndices.IndexOf(',', start, end - start);
                         var elementEnd = commaIndex < 0 ? end : commaIndex;
 
-                        var index = unnecessaryIndices.AsSpan(start, elementEnd - start).Trim().ToString().ParseInt();
+                        var index = int.Parse(unnecessaryIndices.AsSpan(start, elementEnd - start).Trim().ToString());
 
                         locationsToTag.Add(diagnosticData.AdditionalLocations[index]);
                         start = elementEnd + 1;


### PR DESCRIPTION
The diagnostic pipeline encodes/decodes arrays of integer indices (e.g., [1,2,3]) to identify which additional locations should be faded as "unnecessary." Both the write path (DiagnosticHelper.EncodeIndices) and the read path (DiagnosticDataExtensions.TryGetUnnecessaryDataLocations) previously used DataContractJsonSerializer, which is extremely allocation-heavy for this simple format — allocating MemoryStream, byte[], UTF8 string conversions, and deserializer infrastructure on every diagnostic.

Changes:

 - DiagnosticHelper.EncodeIndices (write path): Replace DataContractJsonSerializer.WriteObject + MemoryStream + Encoding.UTF8.GetString with a PooledStringBuilder that directly appends [index,index,...]. Index validation is now inline in the loop (single enumeration) instead of a separate .All() pass.
 - DiagnosticDataExtensions.TryGetUnnecessaryDataLocations (read path): Replace DataContractJsonSerializer.ReadObject + MemoryStream + Encoding.UTF8.GetBytes with inline parsing that walks the string with IndexOf/AsSpan/int.Parse. Removes the GetLocationIndices local function and the IEnumerable<int>intermediate. Error handling is preserved — on parse failure, the builder is cleared and an empty result is returned.

Both paths are hit in devenv on every diagnostic with the Unnecessary tag (e.g., unused usings), so reducing allocations here is worthwhile.

This became very evident with one of the diagnostic changes I was trying speedometer on and had made things significantly worse. The image below is for allocations under TryGetUnnecessaryDataLocations in a profile from that perf run.

<img width="1457" height="333" alt="image" src="https://github.com/user-attachments/assets/9f8860fd-032d-4580-8d9f-7b2a8266a11f" />
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83344)