### PR TITLE
Extension members on typeless receivers - Phase 2 #3: tests for CollectionExpression x ModernExtensionProperty

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -7898,6 +7898,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return BadExpression(node, boundLeft);
             }
 
+            // Extension members on typeless receivers: when the receiver expression has no type
+            // and is one of the supported typeless forms, route the member access through
+            // extension lookup. This check runs before:
+            //   - the default-literal and unbound-lambda early rejections below, which would
+            //     otherwise reject those receivers outright,
+            //   - BindToNaturalType, which converts unconverted typeless forms (collection
+            //     expressions, conditional expressions, switch expressions, target-typed `new()`,
+            //     etc.) into error-typed wrappers, and
+            //   - the switch's default branch's null-literal rejection.
+            // The feature-availability check is performed inside the helper.
+            // See https://github.com/dotnet/csharplang/blob/main/proposals/extension-members-on-typeless-receivers.md
+            if (TryBindMemberAccessOnTypelessReceiver(node, boundLeft, right, invoked, indexed, diagnostics) is { } typelessExtensionResult)
+            {
+                return typelessExtensionResult;
+            }
+
             // No member accesses on default
             if (boundLeft.IsLiteralDefault())
             {
@@ -8273,6 +8289,64 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 #nullable disable
 
+#nullable enable
+        /// <summary>
+        /// If the receiver expression has no type and is a supported typeless form, route the
+        /// member access through extension lookup (the "extension members on typeless receivers"
+        /// feature). Returns null if the receiver is not a supported typeless form, leaving the
+        /// caller to fall back to the existing behavior. If the feature is not yet enabled by
+        /// the language version, reports <c>ERR_FeatureInPreview</c> and returns a bad expression.
+        /// </summary>
+        /// <remarks>
+        /// See <see href="https://github.com/dotnet/csharplang/blob/main/proposals/extension-members-on-typeless-receivers.md"/>.
+        /// </remarks>
+        private BoundExpression? TryBindMemberAccessOnTypelessReceiver(
+            SyntaxNode node,
+            BoundExpression boundLeft,
+            SimpleNameSyntax right,
+            bool invoked,
+            bool indexed,
+            BindingDiagnosticBag diagnostics)
+        {
+            // Receiver must have no type and be a supported form. Throw expressions are excluded
+            // by design (the call would be unreachable). Namespace and type expressions are not
+            // typeless receivers; they are handled by the namespace / type branches in
+            // BindMemberAccessWithBoundLeft.
+            if (boundLeft.Type is not null)
+            {
+                return null;
+            }
+            if (boundLeft.Kind is BoundKind.ThrowExpression or BoundKind.NamespaceExpression or BoundKind.TypeExpression)
+            {
+                return null;
+            }
+
+            // Feature gate. CheckFeatureAvailability reports ERR_FeatureInPreview when the
+            // language version is too low and returns false. In that case we report only the
+            // version error, not whatever existing diagnostic the caller would otherwise have
+            // raised.
+            if (!MessageID.IDS_FeatureExtensionMembersOnTypelessReceivers.CheckFeatureAvailability(diagnostics, node))
+            {
+                return BadExpression(node, boundLeft);
+            }
+
+            var typeArgumentsSyntax = right.Kind() == SyntaxKind.GenericName
+                ? ((GenericNameSyntax)right).TypeArgumentList.Arguments
+                : default(SeparatedSyntaxList<TypeSyntax>);
+            var typeArgumentsWithAnnotations = typeArgumentsSyntax.Count > 0
+                ? BindTypeArguments(typeArgumentsSyntax, diagnostics)
+                : default(ImmutableArray<TypeWithAnnotations>);
+            var rightName = right.Identifier.ValueText;
+            var rightArity = right.Arity;
+
+            boundLeft = CheckValue(boundLeft, BindValueKind.RValue, diagnostics);
+            return BindInstanceMemberAccess(
+                node, right, boundLeft, rightName, rightArity,
+                typeArgumentsSyntax, typeArgumentsWithAnnotations,
+                invoked, indexed, diagnostics);
+        }
+#nullable disable
+
         private BoundExpression BindInstanceMemberAccess(
             SyntaxNode node,
             SyntaxNode right,
@@ -8300,7 +8374,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 bool leftIsBaseReference = boundLeft.Kind == BoundKind.BaseReference;
                 CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
-                this.LookupInstanceMember(lookupResult, leftType, leftIsBaseReference, rightName, rightArity, invoked, ref useSiteInfo);
+                if ((object)leftType != null)
+                {
+                    // Typed receiver: look up members in the receiver's type.
+                    this.LookupInstanceMember(lookupResult, leftType, leftIsBaseReference, rightName, rightArity, invoked, ref useSiteInfo);
+                }
+                // Typeless receiver: skip instance member lookup (there is no type), and
+                // proceed directly to the extension-search path below.
                 diagnostics.Add(right, useSiteInfo);
 
                 // SPEC: Otherwise, an attempt is made to process E.I as an extension method invocation.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8305,17 +8305,35 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool indexed,
             BindingDiagnosticBag diagnostics)
         {
-            // Receiver must have no type and be a supported form. Throw expressions are excluded
-            // by design (the call would be unreachable). Namespace and type expressions are not
-            // typeless receivers; they are handled by the namespace / type branches in
-            // BindMemberAccessWithBoundLeft.
+            // Receiver must have no type and be one of the receiver categories supported by the
+            // proposal: collection expression, target-typed `new()` / `new(args)`, conditional /
+            // switch with no common arm type, lambda without natural type, method group, tuple
+            // literal with at least one typeless element, default literal, or null literal.
+            // Anything else (e.g. BoundBaseReference when there is no base class, BoundPropertyGroup
+            // for COM indexed properties, throw expressions, namespace / type expressions, bad
+            // expressions, expressions already in error state) falls back to existing behavior so
+            // pre-existing diagnostics are preserved.
             if (boundLeft.Type is not null)
             {
                 return null;
             }
-            if (boundLeft.Kind is BoundKind.ThrowExpression or BoundKind.NamespaceExpression or BoundKind.TypeExpression)
+            if (boundLeft.HasErrors)
             {
                 return null;
+            }
+            // Phase 1 supports only the headline scenario: collection-expression receivers
+            // (e.g. `[1, 2, 3].ToImmutableArray()`). The other typeless receiver categories named
+            // in the spec (target-typed `new()`, conditional / switch with no common arm type,
+            // lambda without natural type, method group, tuple literal with at least one typeless
+            // element, default literal, null literal) will be enabled in their respective Phase 2
+            // area PRs together with their test coverage. Until then, those categories continue
+            // to produce their pre-feature diagnostics.
+            switch (boundLeft.Kind)
+            {
+                case BoundKind.UnconvertedCollectionExpression:
+                    break;
+                default:
+                    return null;
             }
 
             // Feature gate. CheckFeatureAvailability reports ERR_FeatureInPreview when the

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8262,7 +8262,19 @@ namespace Microsoft.CodeAnalysis.CSharp
         private BoundExpression GetExtensionMemberAccess(SyntaxNode syntax, BoundExpression? receiver, Symbol extensionMember, BindingDiagnosticBag diagnostics)
         {
             MessageID.IDS_FeatureExtensions.CheckFeatureAvailability(diagnostics, syntax);
-            receiver = ReplaceTypeOrValueReceiver(receiver, useType: extensionMember.IsStatic, diagnostics);
+
+            // For extension members on typeless receivers (e.g. `[1, 2, 3].First` where `First` is
+            // an extension property), skip ReplaceTypeOrValueReceiver. Its default branch calls
+            // BindToNaturalType, which destructively converts typeless forms (collection expression,
+            // new(), conditional / switch with no common type, tuple, default) into error-recovery
+            // wrappers and reports ERR_CollectionExpressionNoTargetType / similar. The conversion
+            // is applied below by CheckAndConvertExtensionReceiver against the extension's declared
+            // receiver parameter. The function's named purpose (replacing TypeOrValueExpression or
+            // unwrapping QueryClause) does not apply since both wrappers always have a type.
+            if (receiver is not { Type: null })
+            {
+                receiver = ReplaceTypeOrValueReceiver(receiver, useType: extensionMember.IsStatic, diagnostics);
+            }
 
             switch (extensionMember)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -7876,6 +7876,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(node != null);
             Debug.Assert(boundLeft != null);
 
+            // Extension members on typeless receivers: when the receiver expression has no type
+            // and is one of the supported typeless forms, route the member access through
+            // extension lookup. This check runs BEFORE MakeMemberAccessValue, which would
+            // otherwise force unconverted typeless forms into error-typed wrappers via
+            // BindToNaturalType, and BEFORE the default-literal / unbound-lambda / null-literal
+            // early rejections below. The feature-availability check is performed inside the
+            // helper.
+            // See https://github.com/dotnet/csharplang/blob/main/proposals/extension-members-on-typeless-receivers.md
+            if (TryBindMemberAccessOnTypelessReceiver(node, boundLeft, right, invoked, indexed, diagnostics) is { } typelessExtensionResult)
+            {
+                return typelessExtensionResult;
+            }
+
             boundLeft = MakeMemberAccessValue(boundLeft, diagnostics);
 
             TypeSymbol leftType = boundLeft.Type;
@@ -7896,22 +7909,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 diagnostics.Add(ErrorCode.ERR_BadUnaryOp, operatorToken.GetLocation(), SyntaxFacts.GetText(operatorToken.Kind()), leftType);
                 return BadExpression(node, boundLeft);
-            }
-
-            // Extension members on typeless receivers: when the receiver expression has no type
-            // and is one of the supported typeless forms, route the member access through
-            // extension lookup. This check runs before:
-            //   - the default-literal and unbound-lambda early rejections below, which would
-            //     otherwise reject those receivers outright,
-            //   - BindToNaturalType, which converts unconverted typeless forms (collection
-            //     expressions, conditional expressions, switch expressions, target-typed `new()`,
-            //     etc.) into error-typed wrappers, and
-            //   - the switch's default branch's null-literal rejection.
-            // The feature-availability check is performed inside the helper.
-            // See https://github.com/dotnet/csharplang/blob/main/proposals/extension-members-on-typeless-receivers.md
-            if (TryBindMemberAccessOnTypelessReceiver(node, boundLeft, right, invoked, indexed, diagnostics) is { } typelessExtensionResult)
-            {
-                return typelessExtensionResult;
             }
 
             // No member accesses on default

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8744,8 +8744,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool acceptOnlyMethods,
             in CallingConventionInfo callingConvention = default)
         {
-            Debug.Assert(left.Type is not null);
-            Debug.Assert(!left.Type.IsDynamic());
+            // The receiver may be typeless when the typeless-extension-receivers feature is enabled.
+            // The feature gate is checked by callers; once we are here, a null Type is permitted.
+            Debug.Assert(left.Type is null || !left.Type.IsDynamic());
             Debug.Assert((options & ~(OverloadResolution.Options.IsMethodGroupConversion |
                                       OverloadResolution.Options.IsFunctionPointerResolution |
                                       OverloadResolution.Options.InferWithDynamic |
@@ -8837,7 +8838,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 BindingDiagnosticBag diagnostics,
                 out MethodGroupResolution result)
             {
-                Debug.Assert(left.Type is not null);
+                // left.Type may be null when the typeless-extension-receivers feature is enabled.
                 result = default;
 
                 // 1. gather candidates
@@ -8945,12 +8946,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (analyzedArguments == null)
                 {
                     // Without arguments (for scenarios such as `nameof` or conversion to non-delegate/dynamic type)
-                    // we can still prune the inapplicable extension methods using the receiver type
-                    for (int i = methodGroup.Methods.Count - 1; i >= 0; i--)
+                    // we can still prune the inapplicable extension methods using the receiver type.
+                    // Skip pruning when the receiver expression has no type (typeless-extension-receivers
+                    // feature); inapplicability is determined later, by overload resolution against the
+                    // candidate's first parameter type.
+                    TypeSymbol? receiverType = left.Type;
+                    for (int i = methodGroup.Methods.Count - 1; receiverType is not null && i >= 0; i--)
                     {
                         MethodSymbol method = methodGroup.Methods[i];
-                        TypeSymbol? receiverType = left.Type;
-                        Debug.Assert(receiverType is not null);
 
                         bool inapplicable = false;
                         if (method.IsExtensionMethod

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -1239,7 +1239,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             // instance methods. Therefore we must detect this scenario here, rather than in
             // overload resolution.
 
-            var receiver = ReplaceTypeOrValueReceiver(methodGroup.Receiver, useType: !method.RequiresInstanceReceiver && !invokedAsExtensionMethod, diagnostics);
+            // For extension members on typeless receivers, the receiver-to-parameter conversion is
+            // applied later by CheckAndCoerceArguments using the Conversion stored by overload
+            // resolution. ReplaceTypeOrValueReceiver's default branch calls BindToNaturalType, which
+            // destructively converts typeless forms (collection expression, new(), conditional /
+            // switch with no common type, tuple, default) into error-recovery wrappers. The function's
+            // named purpose (replacing a TypeOrValueExpression or unwrapping a QueryClause) does not
+            // apply here, since both of those wrappers always have a type.
+            var receiver = invokedAsExtensionMethod && methodGroup.Receiver.Type is null
+                ? methodGroup.Receiver
+                : ReplaceTypeOrValueReceiver(methodGroup.Receiver, useType: !method.RequiresInstanceReceiver && !invokedAsExtensionMethod, diagnostics);
 
             if (invokedAsExtensionMethod && (object)receiver != methodGroup.Receiver)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -1240,13 +1240,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             // overload resolution.
 
             // For extension members on typeless receivers, the receiver-to-parameter conversion is
-            // applied later by CheckAndCoerceArguments using the Conversion stored by overload
-            // resolution. ReplaceTypeOrValueReceiver's default branch calls BindToNaturalType, which
-            // destructively converts typeless forms (collection expression, new(), conditional /
-            // switch with no common type, tuple, default) into error-recovery wrappers. The function's
-            // named purpose (replacing a TypeOrValueExpression or unwrapping a QueryClause) does not
-            // apply here, since both of those wrappers always have a type.
-            var receiver = invokedAsExtensionMethod && methodGroup.Receiver.Type is null
+            // applied later by CheckAndCoerceArguments (classic) or CheckAndConvertExtensionReceiver
+            // (modern, C# 14 extension blocks) using the Conversion stored by overload resolution.
+            // ReplaceTypeOrValueReceiver's default branch calls BindToNaturalType, which destructively
+            // converts typeless forms (collection expression, new(), conditional / switch with no
+            // common type, tuple, default) into error-recovery wrappers. The function's named purpose
+            // (replacing a TypeOrValueExpression or unwrapping a QueryClause) does not apply here,
+            // since both of those wrappers always have a type. Both invokedAsExtensionMethod (classic)
+            // and isExtensionBlockMethod (modern) signal an extension call where the receiver-side
+            // conversion is handled downstream; cover both. Note isExtensionBlockMethod resets
+            // invokedAsExtensionMethod to false above, which is why both checks are needed.
+            var receiver = (invokedAsExtensionMethod || isExtensionBlockMethod) && methodGroup.Receiver.Type is null
                 ? methodGroup.Receiver
                 : ReplaceTypeOrValueReceiver(methodGroup.Receiver, useType: !method.RequiresInstanceReceiver && !invokedAsExtensionMethod, diagnostics);
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -2005,6 +2005,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
+            // Extension members on typeless receivers: when the receiver expression has no type,
+            // fall back to the standard expression-to-type implicit conversions used for any other
+            // typeless argument (null literal, default literal, anonymous function, method group,
+            // tuple expression, throw expression, collection expression, target-typed `new()`,
+            // target-typed conditional / switch). The feature flag check is performed by the binder
+            // before a typeless receiver reaches this path.
+            // See https://github.com/dotnet/csharplang/blob/main/proposals/extension-members-on-typeless-receivers.md
+            if (sourceExpressionOpt is not null && (object)sourceType == null)
+            {
+                var fromExpressionConversion = ClassifyImplicitConversionFromExpression(sourceExpressionOpt, destination, ref useSiteInfo);
+                if (fromExpressionConversion.Exists)
+                {
+                    return fromExpressionConversion;
+                }
+            }
+
             return Conversion.NoConversion;
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -4626,7 +4626,7 @@ outerDefault:
                         (!conversion.IsDynamic ||
                             (ignoreOpenTypes && TypeContainsTypeParameterFromContainer(candidate, parameters.ParameterTypes[argumentPosition].Type))));
 
-                    if (forExtensionMethodThisArg && !conversion.IsDynamic && !Conversions.IsValidExtensionMethodThisArgConversion(conversion))
+                    if (forExtensionMethodThisArg && !conversion.IsDynamic && argument.Type is not null && !Conversions.IsValidExtensionMethodThisArgConversion(conversion))
                     {
                         // Return early, without checking conversions of subsequent arguments,
                         // if the instance argument is not convertible to the 'this' parameter,
@@ -4634,6 +4634,11 @@ outerDefault:
                         // lambda binding in particular, for instance, with LINQ expressions.
                         // Note that BuildArgumentsForErrorRecovery will still bind some number
                         // of overloads for the semantic model.
+                        // The strict identity / reference / boxing whitelist is skipped when the
+                        // receiver expression has no type, since in that case the conversion was
+                        // produced by ClassifyImplicitConversionFromExpression (the same machinery
+                        // used for any other typeless argument), which only returns valid implicit
+                        // conversions.
                         Debug.Assert(badArguments.IsNull);
                         Debug.Assert(conversions == null);
                         return MemberAnalysisResult.BadArgumentConversions(argsToParameters, MemberAnalysisResult.CreateBadArgumentsWithPosition(argumentPosition), ImmutableArray.Create(conversion),

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -8297,6 +8297,9 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="IDS_FeatureUnions" xml:space="preserve">
     <value>unions</value>
   </data>
+  <data name="IDS_FeatureExtensionMembersOnTypelessReceivers" xml:space="preserve">
+    <value>extension members on typeless receivers</value>
+  </data>
   <data name="ERR_UnionDeclarationNeedsCaseTypes" xml:space="preserve">
     <value>A union declaration must specify at least one case type.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -310,6 +310,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureUnsafeEvolution = MessageBase + 12859,
 
         IDS_FeatureUnions = MessageBase + 12860,
+
+        IDS_FeatureExtensionMembersOnTypelessReceivers = MessageBase + 12861,
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -493,6 +495,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case MessageID.IDS_FeatureCollectionExpressionArguments:
                 case MessageID.IDS_FeatureUnsafeEvolution: // https://github.com/dotnet/roslyn/issues/82546: keep this in preview until C# 16
                 case MessageID.IDS_FeatureUnions:
+                case MessageID.IDS_FeatureExtensionMembersOnTypelessReceivers:
                     return LanguageVersion.Preview;
 
                 // C# 14.0 features.

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">vzory rozšířených vlastností</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">rozšíření</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">Muster für erweiterte Eigenschaften</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">Erweiterungen</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">patrones de propiedad extendidos</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">extensiones</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">modèles de propriétés étendues</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">extensions</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">criteri di proprietà estesa</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">estensioni</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">拡張プロパティ パターン</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">拡張</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">확장 속성 패턴</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">확장</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">wzorce właściwości rozszerzonych</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">numery wewnętrzne</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">padrões de propriedade estendida</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">extensões</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">шаблоны расширенных свойств</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">расширения</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">genişletilmiş özellik desenleri</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">genişletmeler</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">扩展的属性模式</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">扩展</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">擴充屬性模式</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">擴充</target>

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/CollectionExpression/CollectionExpression_ClassicExtensionMethod_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/CollectionExpression/CollectionExpression_ClassicExtensionMethod_Tests.cs
@@ -1,0 +1,524 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_CollectionExpression_ClassicExtensionMethod_Tests : CompilingTestBase
+{
+    #region Positive: target type variety
+
+    [Fact]
+    public void Array_Executes()
+    {
+        var source = """
+            public static class Ext
+            {
+                public static int Sum(this int[] xs)
+                {
+                    int s = 0;
+                    foreach (var x in xs) s += x;
+                    return s;
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([1, 2, 3, 4].Sum());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "10").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void List_Executes()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static int Count(this List<int> xs) => xs.Count;
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([1, 2, 3].Count());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "3").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void IEnumerable_GenericInference_Executes()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static T First<T>(this IEnumerable<T> xs)
+                {
+                    foreach (var x in xs) return x;
+                    return default!;
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([10, 20, 30].First());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "10").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void IReadOnlyList_GenericInference()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static T Last<T>(this IReadOnlyList<T> xs) => xs[xs.Count - 1];
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    _ = [1, 2, 3].Last();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics();
+    }
+
+    #endregion
+
+    #region Edge cases: collection-expression-specific
+
+    [Fact]
+    public void EmptyCollection_GenericInference_CannotInfer()
+    {
+        // T cannot be inferred from `[]` because there are no elements.
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static int Count<T>(this IEnumerable<T> xs)
+                {
+                    int n = 0;
+                    foreach (var _ in xs) n++;
+                    return n;
+                }
+            }
+
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = [].Count();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (17,16): error CS0411: The type arguments for method 'Ext.Count<T>(IEnumerable<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+            //         _ = [].Count();
+            Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Count").WithArguments("Ext.Count<T>(System.Collections.Generic.IEnumerable<T>)").WithLocation(17, 16));
+    }
+
+    [Fact]
+    public void Spread_Executes()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static int Sum(this IEnumerable<int> xs)
+                {
+                    int s = 0;
+                    foreach (var x in xs) s += x;
+                    return s;
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    int[] a = [1, 2];
+                    int[] b = [3, 4];
+                    System.Console.Write([..a, ..b].Sum());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "10").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void NestedCollection_Executes()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static int CountOuter<T>(this IEnumerable<T> xs)
+                {
+                    int n = 0;
+                    foreach (var _ in xs) n++;
+                    return n;
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([(int[])[1, 2], (int[])[3, 4, 5]].CountOuter());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "2").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void StringElements_Executes()
+    {
+        // The element type is non-trivial to confirm inference works for reference element types.
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static string Concat(this IEnumerable<string> xs)
+                {
+                    string r = "";
+                    foreach (var x in xs) r += x;
+                    return r;
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(["a", "b", "c"].Concat());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "abc").VerifyDiagnostics();
+    }
+
+    #endregion
+
+    #region Generic inference
+
+    [Fact]
+    public void TwoParamGeneric_InferredFromReceiverAndArg()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static (T, U) Pair<T, U>(this IEnumerable<T> xs, U other) => (xs.GetEnumerator().Current, other);
+            }
+
+            public class Goo
+            {
+                public static void M()
+                {
+                    var p = [1, 2, 3].Pair("hi");
+                    _ = p;
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ConstrainedGeneric_StructConstraint()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static T First<T>(this IEnumerable<T> xs) where T : struct
+                {
+                    foreach (var x in xs) return x;
+                    return default;
+                }
+            }
+
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = [1, 2, 3].First();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ConstrainedGeneric_StructConstraintViolation()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static T First<T>(this IEnumerable<T> xs) where T : struct
+                {
+                    foreach (var x in xs) return x;
+                    return default;
+                }
+            }
+
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = ["a", "b"].First();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (16,24): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'Ext.First<T>(IEnumerable<T>)'
+            //         _ = ["a", "b"].First();
+            Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "First").WithArguments("Ext.First<T>(System.Collections.Generic.IEnumerable<T>)", "T", "string").WithLocation(16, 24));
+    }
+
+    #endregion
+
+    #region Negative
+
+    [Fact]
+    public void ReceiverTypeNotConstructibleFromCollectionExpression()
+    {
+        // Extension's first parameter is a class type that has no collection-expression
+        // conversion; the candidate is reported as not constructible.
+        var source = """
+            public class Bag { }
+
+            public static class Ext
+            {
+                public static int Count(this Bag b) => 0;
+            }
+
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = [1, 2, 3].Count();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (12,13): error CS9174: Cannot initialize type 'Bag' with a collection expression because the type is not constructible.
+            //         _ = [1, 2, 3].Count();
+            Diagnostic(ErrorCode.ERR_CollectionExpressionTargetTypeNotConstructible, "[1, 2, 3]").WithArguments("Bag").WithLocation(12, 13));
+    }
+
+    [Fact]
+    public void NoExtensionInScope_ReportsNoSuchMember()
+    {
+        // No extension method named Count is in scope. The receiver enters extension lookup
+        // (collection expression has no instance members), finds nothing, and reports
+        // "collection expression does not contain a definition for Count".
+        var source = """
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = [1, 2, 3].Count();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (5,23): error CS0117: 'collection expression' does not contain a definition for 'Count'
+            //         _ = [1, 2, 3].Count();
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "Count").WithArguments("collection expression", "Count").WithLocation(5, 23));
+    }
+
+    [Fact]
+    public void Ambiguous_BothApplicable()
+    {
+        // Two applicable candidates whose first parameter types are equally specific
+        // for the collection-expression source produce overload-resolution ambiguity.
+        var source = """
+            using System.Collections.Generic;
+
+            public static class ExtA
+            {
+                public static int M(this IEnumerable<int> xs) => 1;
+            }
+            public static class ExtB
+            {
+                public static int M(this IEnumerable<int> xs) => 2;
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    _ = [1, 2, 3].M();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (16,23): error CS0121: The call is ambiguous between the following methods or properties: 'ExtA.M(IEnumerable<int>)' and 'ExtB.M(IEnumerable<int>)'
+            //         _ = [1, 2, 3].M();
+            Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("ExtA.M(System.Collections.Generic.IEnumerable<int>)", "ExtB.M(System.Collections.Generic.IEnumerable<int>)").WithLocation(16, 23));
+    }
+
+    [Fact]
+    public void OverloadResolution_PrefersMoreSpecific()
+    {
+        // T[] is more specific than IEnumerable<T>. Both are applicable for [1,2,3];
+        // overload resolution picks T[].
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static string Tag(this IEnumerable<int> xs) => "enumerable";
+                public static string Tag(this int[] xs) => "array";
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([1, 2, 3].Tag());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "array").VerifyDiagnostics();
+    }
+
+    #endregion
+
+    #region Chained extension calls
+
+    [Fact]
+    public void Chained_CollectionExprThenTypedReceiver_Executes()
+    {
+        // First call uses the typeless-receiver path; result has a type so the
+        // second call uses the existing typed-receiver path.
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static List<T> ToList<T>(this IEnumerable<T> xs)
+                {
+                    var r = new List<T>();
+                    foreach (var x in xs) r.Add(x);
+                    return r;
+                }
+
+                public static int Sum(this List<int> xs)
+                {
+                    int s = 0;
+                    foreach (var x in xs) s += x;
+                    return s;
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([1, 2, 3].ToList().Sum());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "6").VerifyDiagnostics();
+    }
+
+    #endregion
+
+    #region Argument forwarding
+
+    [Fact]
+    public void AdditionalArguments_Forwarded()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static int CountAtLeast<T>(this IEnumerable<T> xs, int min)
+                {
+                    int n = 0;
+                    foreach (var _ in xs)
+                    {
+                        n++;
+                        if (n >= min) return n;
+                    }
+                    return n;
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([1, 2, 3, 4].CountAtLeast(2));
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "2").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void NamedArguments_OnAdditionalArgs()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static int Combine<T>(this IEnumerable<T> xs, int a, int b)
+                {
+                    int s = a + b;
+                    foreach (var _ in xs) s++;
+                    return s;
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([1, 2, 3].Combine(b: 100, a: 10));
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "113").VerifyDiagnostics();
+    }
+
+    #endregion
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/CollectionExpression/CollectionExpression_ModernExtensionMethod_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/CollectionExpression/CollectionExpression_ModernExtensionMethod_Tests.cs
@@ -12,17 +12,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
 [CompilerTrait(CompilerFeature.Extensions)]
 public sealed class ExtensionMembersOnTypelessReceivers_CollectionExpression_ModernExtensionMethod_Tests : CompilingTestBase
 {
-    // TODO: Modern (C# 14) extension members declared inside `extension(T) { ... }` blocks
-    // are not yet wired up for typeless receivers. The classic-extension path runs through
-    // BindInstanceMemberAccess, which TryBindMemberAccessOnTypelessReceiver routes to; the
-    // modern path runs through GetExtensionMemberAccess and ExtensionLookup machinery that
-    // does not yet honor a typeless receiver. Each test below documents the current
-    // ERR_CollectionExpressionNoTargetType behavior so the file is green; once the modern
-    // path is enabled (likely as part of the Phase 1.5 / modern-binder follow-up) these
-    // tests should be flipped to assert successful binding.
-
     [Fact]
-    public void Method_OnCollectionExpression_NotYetSupported()
+    public void Method_OnCollectionExpression_Executes()
     {
         var source = """
             using System.Collections.Generic;
@@ -48,15 +39,11 @@ public sealed class ExtensionMembersOnTypelessReceivers_CollectionExpression_Mod
                 }
             }
             """;
-        // TODO: should compile and print "6" once modern extensions are wired up.
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
-            // (20,30): error CS9176: There is no target type for the collection expression.
-            //         System.Console.Write([1, 2, 3].Sum());
-            Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[1, 2, 3]").WithLocation(20, 30));
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "6").VerifyDiagnostics();
     }
 
     [Fact]
-    public void GenericMethod_OnCollectionExpression_NotYetSupported()
+    public void GenericMethod_OnCollectionExpression_Executes()
     {
         var source = """
             using System.Collections.Generic;
@@ -82,10 +69,6 @@ public sealed class ExtensionMembersOnTypelessReceivers_CollectionExpression_Mod
                 }
             }
             """;
-        // TODO: should compile and print "3" once modern extensions are wired up.
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
-            // (20,30): error CS9176: There is no target type for the collection expression.
-            //         System.Console.Write([1, 2, 3].CountIt());
-            Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[1, 2, 3]").WithLocation(20, 30));
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "3").VerifyDiagnostics();
     }
 }

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/CollectionExpression/CollectionExpression_ModernExtensionMethod_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/CollectionExpression/CollectionExpression_ModernExtensionMethod_Tests.cs
@@ -1,0 +1,91 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_CollectionExpression_ModernExtensionMethod_Tests : CompilingTestBase
+{
+    // TODO: Modern (C# 14) extension members declared inside `extension(T) { ... }` blocks
+    // are not yet wired up for typeless receivers. The classic-extension path runs through
+    // BindInstanceMemberAccess, which TryBindMemberAccessOnTypelessReceiver routes to; the
+    // modern path runs through GetExtensionMemberAccess and ExtensionLookup machinery that
+    // does not yet honor a typeless receiver. Each test below documents the current
+    // ERR_CollectionExpressionNoTargetType behavior so the file is green; once the modern
+    // path is enabled (likely as part of the Phase 1.5 / modern-binder follow-up) these
+    // tests should be flipped to assert successful binding.
+
+    [Fact]
+    public void Method_OnCollectionExpression_NotYetSupported()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                extension(IEnumerable<int> source)
+                {
+                    public int Sum()
+                    {
+                        int s = 0;
+                        foreach (var x in source) s += x;
+                        return s;
+                    }
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([1, 2, 3].Sum());
+                }
+            }
+            """;
+        // TODO: should compile and print "6" once modern extensions are wired up.
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (20,30): error CS9176: There is no target type for the collection expression.
+            //         System.Console.Write([1, 2, 3].Sum());
+            Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[1, 2, 3]").WithLocation(20, 30));
+    }
+
+    [Fact]
+    public void GenericMethod_OnCollectionExpression_NotYetSupported()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                extension<T>(IEnumerable<T> source)
+                {
+                    public int CountIt()
+                    {
+                        int n = 0;
+                        foreach (var _ in source) n++;
+                        return n;
+                    }
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([1, 2, 3].CountIt());
+                }
+            }
+            """;
+        // TODO: should compile and print "3" once modern extensions are wired up.
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (20,30): error CS9176: There is no target type for the collection expression.
+            //         System.Console.Write([1, 2, 3].CountIt());
+            Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[1, 2, 3]").WithLocation(20, 30));
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/CollectionExpression/CollectionExpression_ModernExtensionProperty_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/CollectionExpression/CollectionExpression_ModernExtensionProperty_Tests.cs
@@ -1,0 +1,263 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_CollectionExpression_ModernExtensionProperty_Tests : CompilingTestBase
+{
+    [Fact]
+    public void Property_OnCollectionExpression_Executes()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                extension(IEnumerable<int> source)
+                {
+                    public int First
+                    {
+                        get
+                        {
+                            foreach (var x in source) return x;
+                            return 0;
+                        }
+                    }
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([10, 20, 30].First);
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "10").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void GenericProperty_OnCollectionExpression_Executes()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                extension<T>(IEnumerable<T> source)
+                {
+                    public int Count
+                    {
+                        get
+                        {
+                            int n = 0;
+                            foreach (var _ in source) n++;
+                            return n;
+                        }
+                    }
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([1, 2, 3, 4].Count);
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "4").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Property_OnReadOnlyList()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                extension<T>(IReadOnlyList<T> source)
+                {
+                    public T Last => source[source.Count - 1];
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([1, 2, 3].Last);
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "3").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Property_OnArray()
+    {
+        var source = """
+            public static class Ext
+            {
+                extension(int[] source)
+                {
+                    public int Sum
+                    {
+                        get
+                        {
+                            int s = 0;
+                            foreach (var x in source) s += x;
+                            return s;
+                        }
+                    }
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([1, 2, 3, 4, 5].Sum);
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "15").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Property_StringElements()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                extension(IEnumerable<string> source)
+                {
+                    public string Joined
+                    {
+                        get
+                        {
+                            string r = "";
+                            foreach (var s in source) r += s;
+                            return r;
+                        }
+                    }
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(["a", "b", "c"].Joined);
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "abc").VerifyDiagnostics();
+    }
+
+    // TODO: A test for empty-collection + generic extension property (`_ = [].Count;` where
+    // Count is an extension property on IEnumerable<T>) should fail with ERR_CantInferTypeArgs
+    // or similar. Currently triggers a Debug.Fail in DiagnosticInfo.AssertMessageSerializable
+    // inside OverloadResolutionResult.TypeInferenceFailed during property-resolution error
+    // reporting, indicating a non-serializable argument. Tracked separately; outside this PR's
+    // scope (the diagnostic-reporting bug also affects typed receivers in the same scenario).
+
+    [Fact]
+    public void Property_NoCandidateInScope_ReportsNoSuchMember()
+    {
+        var source = """
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = [1, 2, 3].Length;
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (5,23): error CS0117: 'collection expression' does not contain a definition for 'Length'
+            //         _ = [1, 2, 3].Length;
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "Length").WithArguments("collection expression", "Length").WithLocation(5, 23));
+    }
+
+    [Fact]
+    public void Property_ChainedAccess_Executes()
+    {
+        // Property access returns a typed value; chained member access uses the existing typed
+        // member-access path.
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                extension<T>(IEnumerable<T> source)
+                {
+                    public List<T> AsList
+                    {
+                        get
+                        {
+                            var l = new List<T>();
+                            foreach (var x in source) l.Add(x);
+                            return l;
+                        }
+                    }
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([1, 2, 3].AsList.Count);
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "3").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Property_Spread_Executes()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                extension(IEnumerable<int> source)
+                {
+                    public int Sum
+                    {
+                        get
+                        {
+                            int s = 0;
+                            foreach (var x in source) s += x;
+                            return s;
+                        }
+                    }
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    int[] a = [1, 2];
+                    int[] b = [3, 4];
+                    System.Console.Write([..a, ..b].Sum);
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "10").VerifyDiagnostics();
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/Smoke_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/Smoke_Tests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
 [CompilerTrait(CompilerFeature.Extensions)]
 public sealed class ExtensionMembersOnTypelessReceivers_Smoke_Tests : CompilingTestBase
 {
-    [Fact(Skip = "TODO: collection-expression receiver triggers AssertUnderlyingConversionsCheckedRecursive failure during coerceArgument; the CollectionExpression conversion produced by ClassifyImplicitConversionFromExpression is reaching CreateConversion via a path that does not mark its element-wise underlying conversions as checked. Needs investigation of how the receiver flows from BindInstanceMemberAccess through BindInvocationExpressionContinued's CheckAndCoerceArguments. Tracking as the headline scenario for the feature; remaining smoke tests prove the rule itself binds correctly for other typeless forms.")]
+    [Fact]
     public void CollectionExpression_ClassicExtensionMethod_Executes()
     {
         var source = """
@@ -39,7 +39,7 @@ public sealed class ExtensionMembersOnTypelessReceivers_Smoke_Tests : CompilingT
         CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "3").VerifyDiagnostics();
     }
 
-    [Fact]
+    [Fact(Skip = "TODO: enable null-literal receiver in Phase 2 NullLiteral area PRs.")]
     public void NullLiteral_ClassicExtensionMethod_Executes()
     {
         var source = """
@@ -59,7 +59,7 @@ public sealed class ExtensionMembersOnTypelessReceivers_Smoke_Tests : CompilingT
         CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "empty").VerifyDiagnostics();
     }
 
-    [Fact]
+    [Fact(Skip = "TODO: enable lambda-without-natural-type receiver in Phase 2 Lambda area PRs.")]
     public void Lambda_ClassicExtensionMethod_Executes()
     {
         var source = """

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/Smoke_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/Smoke_Tests.cs
@@ -1,0 +1,129 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_Smoke_Tests : CompilingTestBase
+{
+    [Fact(Skip = "TODO: collection-expression receiver triggers AssertUnderlyingConversionsCheckedRecursive failure during coerceArgument; the CollectionExpression conversion produced by ClassifyImplicitConversionFromExpression is reaching CreateConversion via a path that does not mark its element-wise underlying conversions as checked. Needs investigation of how the receiver flows from BindInstanceMemberAccess through BindInvocationExpressionContinued's CheckAndCoerceArguments. Tracking as the headline scenario for the feature; remaining smoke tests prove the rule itself binds correctly for other typeless forms.")]
+    public void CollectionExpression_ClassicExtensionMethod_Executes()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static int CountIt<T>(this IEnumerable<T> source)
+                {
+                    int count = 0;
+                    foreach (var _ in source) count++;
+                    return count;
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([1, 2, 3].CountIt());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "3").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void NullLiteral_ClassicExtensionMethod_Executes()
+    {
+        var source = """
+            public static class Ext
+            {
+                public static string OrEmpty(this string s) => s ?? "empty";
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(null.OrEmpty());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "empty").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Lambda_ClassicExtensionMethod_Executes()
+    {
+        var source = """
+            using System;
+
+            public static class Ext
+            {
+                public static int Apply(this Func<int, int> f, int arg) => f(arg);
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write((x => x * 2).Apply(5));
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "10").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ThrowExpression_RemainsError()
+    {
+        var source = """
+            public static class Ext
+            {
+                public static int CountIt(this object obj) => 0;
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    _ = (throw new System.Exception()).CountIt();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (10,14): error CS8115: A throw expression is not allowed in this context.
+            Diagnostic(ErrorCode.ERR_ThrowMisplaced, "throw").WithLocation(10, 14));
+    }
+
+    [Fact]
+    public void LangVersion_CSharp14_ReportsFeaturePreviewError()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static int CountIt<T>(this IEnumerable<T> source) => 0;
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    _ = [1, 2, 3].CountIt();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.Regular14).VerifyDiagnostics(
+            // (12,13): error CS9202: Feature 'extension members on typeless receivers' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "[1, 2, 3].CountIt").WithArguments("extension members on typeless receivers").WithLocation(12, 13));
+    }
+}

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
@@ -3459,10 +3459,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 }
                 """;
             var comp = CreateCompilation(new[] { source, s_collectionExtensions });
-            comp.VerifyEmitDiagnostics(
-                // 0.cs(9,17): error CS9176: There is no target type for the collection expression.
-                //         var a = [1, 2, 3].AsArray();
-                Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[1, 2, 3]").WithLocation(9, 17));
+            // Under the extension-members-on-typeless-receivers feature, `[1, 2, 3].AsArray()`
+            // now succeeds: T is inferred as int via the collection-expression conversion to T[].
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -3500,10 +3499,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 }
                 """;
             var comp = CreateCompilation(source);
-            comp.VerifyEmitDiagnostics(
-                // (27,17): error CS9176: There is no target type for the collection expression.
-                //         var b = [4].AsCollection();
-                Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[4]").WithLocation(27, 17));
+            // Under the extension-members-on-typeless-receivers feature, `[4].AsCollection()`
+            // now succeeds: T is inferred as int via the collection-expression conversion to S<T>.
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -3530,13 +3528,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 }
                 """;
             var comp = CreateCompilation(source);
+            // Under the extension-members-on-typeless-receivers feature, `[4].AsCollection()` no
+            // longer reports ERR_CollectionExpressionNoTargetType at the receiver: instead, type
+            // inference is run on the full call (with the collection-expression as the first
+            // argument), and reports the same ERR_CantInferMethTypeArgs as the explicit-form call
+            // because S<T> here implements the non-generic IEnumerable.
             comp.VerifyEmitDiagnostics(
                 // (15,13): error CS0411: The type arguments for method 'Program.AsCollection<T>(S<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         _ = AsCollection([1, 2, 3]);
                 Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "AsCollection").WithArguments("Program.AsCollection<T>(S<T>)").WithLocation(15, 13),
-                // (16,13): error CS9176: There is no target type for the collection expression.
+                // (16,17): error CS0411: The type arguments for method 'Program.AsCollection<T>(S<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         _ = [4].AsCollection();
-                Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[4]").WithLocation(16, 13));
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "AsCollection").WithArguments("Program.AsCollection<T>(S<T>)").WithLocation(16, 17));
         }
 
         [Fact]
@@ -4810,11 +4813,9 @@ static class Program
 }
 """;
             var comp = CreateCompilation(source);
-            comp.VerifyEmitDiagnostics(
-                // (27,17): error CS9176: There is no target type for the collection expression.
-                //         var b = [4].AsCollection();
-                Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[4]").WithLocation(27, 17)
-                );
+            // Under the extension-members-on-typeless-receivers feature, `[4].AsCollection()`
+            // succeeds: T is inferred via the collection-expression conversion to S<T>?.
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -4832,10 +4833,16 @@ static class Program
                 }
                 """;
             var comp = CreateCompilation(source);
+            // Under the extension-members-on-typeless-receivers feature, `[].GetHashCode()` no
+            // longer reports ERR_CollectionExpressionNoTargetType: the collection-expression
+            // receiver enters the extension-method-search path, finds no `GetHashCode` extension,
+            // and reports ERR_NoSuchMember instead. The `?.` and `[]` operators on a typeless
+            // collection expression are out of scope per the spec, so they continue to produce
+            // ERR_CollectionExpressionNoTargetType.
             comp.VerifyEmitDiagnostics(
-                // (5,9): error CS9176: There is no target type for the collection expression.
+                // (5,12): error CS0117: 'collection expression' does not contain a definition for 'GetHashCode'
                 //         [].GetHashCode();
-                Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[]").WithLocation(5, 9),
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "GetHashCode").WithArguments("collection expression", "GetHashCode").WithLocation(5, 12),
                 // (6,9): error CS9176: There is no target type for the collection expression.
                 //         []?.GetHashCode();
                 Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[]").WithLocation(6, 9),
@@ -4859,10 +4866,12 @@ static class Program
                 }
                 """;
             var comp = CreateCompilation(source);
+            // Same pattern as MemberAccess_01: `[1].GetHashCode()` enters the extension-method
+            // search path under the new feature; `?.` and `[]` are out of scope.
             comp.VerifyEmitDiagnostics(
-                // (5,9): error CS9176: There is no target type for the collection expression.
+                // (5,13): error CS0117: 'collection expression' does not contain a definition for 'GetHashCode'
                 //         [1].GetHashCode();
-                Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[1]").WithLocation(5, 9),
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "GetHashCode").WithArguments("collection expression", "GetHashCode").WithLocation(5, 13),
                 // (6,9): error CS9176: There is no target type for the collection expression.
                 //         [2]?.GetHashCode();
                 Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[2]").WithLocation(6, 9),
@@ -4886,10 +4895,11 @@ static class Program
                 }
                 """;
             var comp = CreateCompilation(source);
+            // Same pattern as MemberAccess_01 / _02 (with leading `_ =`).
             comp.VerifyEmitDiagnostics(
-                // (5,13): error CS9176: There is no target type for the collection expression.
+                // (5,16): error CS0117: 'collection expression' does not contain a definition for 'GetHashCode'
                 //         _ = [].GetHashCode();
-                Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[]").WithLocation(5, 13),
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "GetHashCode").WithArguments("collection expression", "GetHashCode").WithLocation(5, 16),
                 // (6,13): error CS9176: There is no target type for the collection expression.
                 //         _ = []?.GetHashCode();
                 Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[]").WithLocation(6, 13),
@@ -4913,10 +4923,11 @@ static class Program
                 }
                 """;
             var comp = CreateCompilation(source);
+            // Same pattern as MemberAccess_02 (with leading `_ =`).
             comp.VerifyEmitDiagnostics(
-                // (5,13): error CS9176: There is no target type for the collection expression.
+                // (5,17): error CS0117: 'collection expression' does not contain a definition for 'GetHashCode'
                 //         _ = [1].GetHashCode();
-                Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[1]").WithLocation(5, 13),
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "GetHashCode").WithArguments("collection expression", "GetHashCode").WithLocation(5, 17),
                 // (6,13): error CS9176: There is no target type for the collection expression.
                 //         _ = [2]?.GetHashCode();
                 Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[2]").WithLocation(6, 13),


### PR DESCRIPTION
Stacked on #83352, which is stacked on #83350, #83349, #83348.

Eight tests covering C#14 modern extension properties accessed on a collection-expression receiver. Confidence-focused, not exhaustive.

  - Basic property access on \`IEnumerable<T>\` with execution.
  - Generic extension property with execution (\`Count<T>\`).
  - Get-only property on \`IReadOnlyList<T>\`, \`int[]\`, \`IEnumerable<string>\`.
  - Chained property access (typeless receiver -> typed result -> typed access).
  - Spread elements feeding the collection-expression receiver.
  - Negative: no candidate in scope reports \`ERR_NoSuchMember\`.

Six tests use \`CompileAndVerify\` with \`expectedOutput\` to confirm the lowered code executes correctly, not just that it binds.

A ninth test for empty-collection + generic extension property is deferred (TODO comment in the file): it triggers a \`Debug.Fail\` in \`OverloadResolutionResult.TypeInferenceFailed\` during property-resolution error reporting. That diagnostic-reporting bug also affects typed receivers in the same scenario, so it's tracked separately and out of scope here.

This pull request and its description were written by Isaac.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83353)