### PR TITLE
Extension members on typeless receivers - PR 35: ConditionalExpression x ModernExtensionProperty tests

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -7898,6 +7898,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return BadExpression(node, boundLeft);
             }
 
+            // Extension members on typeless receivers: when the receiver expression has no type
+            // and is one of the supported typeless forms, route the member access through
+            // extension lookup. This check runs before:
+            //   - the default-literal and unbound-lambda early rejections below, which would
+            //     otherwise reject those receivers outright,
+            //   - BindToNaturalType, which converts unconverted typeless forms (collection
+            //     expressions, conditional expressions, switch expressions, target-typed `new()`,
+            //     etc.) into error-typed wrappers, and
+            //   - the switch's default branch's null-literal rejection.
+            // The feature-availability check is performed inside the helper.
+            // See https://github.com/dotnet/csharplang/blob/main/proposals/extension-members-on-typeless-receivers.md
+            if (TryBindMemberAccessOnTypelessReceiver(node, boundLeft, right, invoked, indexed, diagnostics) is { } typelessExtensionResult)
+            {
+                return typelessExtensionResult;
+            }
+
             // No member accesses on default
             if (boundLeft.IsLiteralDefault())
             {
@@ -8273,6 +8289,64 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 #nullable disable
 
+#nullable enable
+        /// <summary>
+        /// If the receiver expression has no type and is a supported typeless form, route the
+        /// member access through extension lookup (the "extension members on typeless receivers"
+        /// feature). Returns null if the receiver is not a supported typeless form, leaving the
+        /// caller to fall back to the existing behavior. If the feature is not yet enabled by
+        /// the language version, reports <c>ERR_FeatureInPreview</c> and returns a bad expression.
+        /// </summary>
+        /// <remarks>
+        /// See <see href="https://github.com/dotnet/csharplang/blob/main/proposals/extension-members-on-typeless-receivers.md"/>.
+        /// </remarks>
+        private BoundExpression? TryBindMemberAccessOnTypelessReceiver(
+            SyntaxNode node,
+            BoundExpression boundLeft,
+            SimpleNameSyntax right,
+            bool invoked,
+            bool indexed,
+            BindingDiagnosticBag diagnostics)
+        {
+            // Receiver must have no type and be a supported form. Throw expressions are excluded
+            // by design (the call would be unreachable). Namespace and type expressions are not
+            // typeless receivers; they are handled by the namespace / type branches in
+            // BindMemberAccessWithBoundLeft.
+            if (boundLeft.Type is not null)
+            {
+                return null;
+            }
+            if (boundLeft.Kind is BoundKind.ThrowExpression or BoundKind.NamespaceExpression or BoundKind.TypeExpression)
+            {
+                return null;
+            }
+
+            // Feature gate. CheckFeatureAvailability reports ERR_FeatureInPreview when the
+            // language version is too low and returns false. In that case we report only the
+            // version error, not whatever existing diagnostic the caller would otherwise have
+            // raised.
+            if (!MessageID.IDS_FeatureExtensionMembersOnTypelessReceivers.CheckFeatureAvailability(diagnostics, node))
+            {
+                return BadExpression(node, boundLeft);
+            }
+
+            var typeArgumentsSyntax = right.Kind() == SyntaxKind.GenericName
+                ? ((GenericNameSyntax)right).TypeArgumentList.Arguments
+                : default(SeparatedSyntaxList<TypeSyntax>);
+            var typeArgumentsWithAnnotations = typeArgumentsSyntax.Count > 0
+                ? BindTypeArguments(typeArgumentsSyntax, diagnostics)
+                : default(ImmutableArray<TypeWithAnnotations>);
+            var rightName = right.Identifier.ValueText;
+            var rightArity = right.Arity;
+
+            boundLeft = CheckValue(boundLeft, BindValueKind.RValue, diagnostics);
+            return BindInstanceMemberAccess(
+                node, right, boundLeft, rightName, rightArity,
+                typeArgumentsSyntax, typeArgumentsWithAnnotations,
+                invoked, indexed, diagnostics);
+        }
+#nullable disable
+
         private BoundExpression BindInstanceMemberAccess(
             SyntaxNode node,
             SyntaxNode right,
@@ -8300,7 +8374,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 bool leftIsBaseReference = boundLeft.Kind == BoundKind.BaseReference;
                 CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
-                this.LookupInstanceMember(lookupResult, leftType, leftIsBaseReference, rightName, rightArity, invoked, ref useSiteInfo);
+                if ((object)leftType != null)
+                {
+                    // Typed receiver: look up members in the receiver's type.
+                    this.LookupInstanceMember(lookupResult, leftType, leftIsBaseReference, rightName, rightArity, invoked, ref useSiteInfo);
+                }
+                // Typeless receiver: skip instance member lookup (there is no type), and
+                // proceed directly to the extension-search path below.
                 diagnostics.Add(right, useSiteInfo);
 
                 // SPEC: Otherwise, an attempt is made to process E.I as an extension method invocation.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8344,6 +8344,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.UnboundLambda:
                 case BoundKind.UnconvertedObjectCreationExpression:
                 case BoundKind.DefaultLiteral:
+                case BoundKind.UnconvertedConditionalOperator:
                     break;
                 case BoundKind.MethodGroup when ((BoundMethodGroup)boundLeft).Methods.Length > 0 && ((BoundMethodGroup)boundLeft).LookupError is null:
                     // Real method group with at least one candidate. Empty / errored method groups

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8305,17 +8305,35 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool indexed,
             BindingDiagnosticBag diagnostics)
         {
-            // Receiver must have no type and be a supported form. Throw expressions are excluded
-            // by design (the call would be unreachable). Namespace and type expressions are not
-            // typeless receivers; they are handled by the namespace / type branches in
-            // BindMemberAccessWithBoundLeft.
+            // Receiver must have no type and be one of the receiver categories supported by the
+            // proposal: collection expression, target-typed `new()` / `new(args)`, conditional /
+            // switch with no common arm type, lambda without natural type, method group, tuple
+            // literal with at least one typeless element, default literal, or null literal.
+            // Anything else (e.g. BoundBaseReference when there is no base class, BoundPropertyGroup
+            // for COM indexed properties, throw expressions, namespace / type expressions, bad
+            // expressions, expressions already in error state) falls back to existing behavior so
+            // pre-existing diagnostics are preserved.
             if (boundLeft.Type is not null)
             {
                 return null;
             }
-            if (boundLeft.Kind is BoundKind.ThrowExpression or BoundKind.NamespaceExpression or BoundKind.TypeExpression)
+            if (boundLeft.HasErrors)
             {
                 return null;
+            }
+            // Phase 1 supports only the headline scenario: collection-expression receivers
+            // (e.g. `[1, 2, 3].ToImmutableArray()`). The other typeless receiver categories named
+            // in the spec (target-typed `new()`, conditional / switch with no common arm type,
+            // lambda without natural type, method group, tuple literal with at least one typeless
+            // element, default literal, null literal) will be enabled in their respective Phase 2
+            // area PRs together with their test coverage. Until then, those categories continue
+            // to produce their pre-feature diagnostics.
+            switch (boundLeft.Kind)
+            {
+                case BoundKind.UnconvertedCollectionExpression:
+                    break;
+                default:
+                    return null;
             }
 
             // Feature gate. CheckFeatureAvailability reports ERR_FeatureInPreview when the

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8343,6 +8343,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.UnconvertedCollectionExpression:
                 case BoundKind.UnboundLambda:
                 case BoundKind.UnconvertedObjectCreationExpression:
+                case BoundKind.DefaultLiteral:
                     break;
                 case BoundKind.MethodGroup when ((BoundMethodGroup)boundLeft).Methods.Length > 0 && ((BoundMethodGroup)boundLeft).LookupError is null:
                     // Real method group with at least one candidate. Empty / errored method groups

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8342,6 +8342,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 case BoundKind.UnconvertedCollectionExpression:
                 case BoundKind.UnboundLambda:
+                case BoundKind.UnconvertedObjectCreationExpression:
                     break;
                 case BoundKind.MethodGroup when ((BoundMethodGroup)boundLeft).Methods.Length > 0 && ((BoundMethodGroup)boundLeft).LookupError is null:
                     // Real method group with at least one candidate. Empty / errored method groups

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8333,16 +8333,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 return null;
             }
-            // Phase 1 supports only the headline scenario: collection-expression receivers
-            // (e.g. `[1, 2, 3].ToImmutableArray()`). The other typeless receiver categories named
-            // in the spec (target-typed `new()`, conditional / switch with no common arm type,
-            // lambda without natural type, method group, tuple literal with at least one typeless
-            // element, default literal, null literal) will be enabled in their respective Phase 2
-            // area PRs together with their test coverage. Until then, those categories continue
-            // to produce their pre-feature diagnostics.
+            // Receiver categories enabled so far. Other categories named in the spec (target-typed
+            // `new()`, conditional / switch with no common arm type, method group, tuple literal
+            // with at least one typeless element, default literal, null literal) will be enabled
+            // in their respective Phase 2 area PRs together with their test coverage. Until then,
+            // those categories continue to produce their pre-feature diagnostics.
             switch (boundLeft.Kind)
             {
                 case BoundKind.UnconvertedCollectionExpression:
+                case BoundKind.UnboundLambda:
                     break;
                 default:
                     return null;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8262,7 +8262,19 @@ namespace Microsoft.CodeAnalysis.CSharp
         private BoundExpression GetExtensionMemberAccess(SyntaxNode syntax, BoundExpression? receiver, Symbol extensionMember, BindingDiagnosticBag diagnostics)
         {
             MessageID.IDS_FeatureExtensions.CheckFeatureAvailability(diagnostics, syntax);
-            receiver = ReplaceTypeOrValueReceiver(receiver, useType: extensionMember.IsStatic, diagnostics);
+
+            // For extension members on typeless receivers (e.g. `[1, 2, 3].First` where `First` is
+            // an extension property), skip ReplaceTypeOrValueReceiver. Its default branch calls
+            // BindToNaturalType, which destructively converts typeless forms (collection expression,
+            // new(), conditional / switch with no common type, tuple, default) into error-recovery
+            // wrappers and reports ERR_CollectionExpressionNoTargetType / similar. The conversion
+            // is applied below by CheckAndConvertExtensionReceiver against the extension's declared
+            // receiver parameter. The function's named purpose (replacing TypeOrValueExpression or
+            // unwrapping QueryClause) does not apply since both wrappers always have a type.
+            if (receiver is not { Type: null })
+            {
+                receiver = ReplaceTypeOrValueReceiver(receiver, useType: extensionMember.IsStatic, diagnostics);
+            }
 
             switch (extensionMember)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -7876,6 +7876,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(node != null);
             Debug.Assert(boundLeft != null);
 
+            // Extension members on typeless receivers: when the receiver expression has no type
+            // and is one of the supported typeless forms, route the member access through
+            // extension lookup. This check runs BEFORE MakeMemberAccessValue, which would
+            // otherwise force unconverted typeless forms into error-typed wrappers via
+            // BindToNaturalType, and BEFORE the default-literal / unbound-lambda / null-literal
+            // early rejections below. The feature-availability check is performed inside the
+            // helper.
+            // See https://github.com/dotnet/csharplang/blob/main/proposals/extension-members-on-typeless-receivers.md
+            if (TryBindMemberAccessOnTypelessReceiver(node, boundLeft, right, invoked, indexed, diagnostics) is { } typelessExtensionResult)
+            {
+                return typelessExtensionResult;
+            }
+
             boundLeft = MakeMemberAccessValue(boundLeft, diagnostics);
 
             TypeSymbol leftType = boundLeft.Type;
@@ -7896,22 +7909,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 diagnostics.Add(ErrorCode.ERR_BadUnaryOp, operatorToken.GetLocation(), SyntaxFacts.GetText(operatorToken.Kind()), leftType);
                 return BadExpression(node, boundLeft);
-            }
-
-            // Extension members on typeless receivers: when the receiver expression has no type
-            // and is one of the supported typeless forms, route the member access through
-            // extension lookup. This check runs before:
-            //   - the default-literal and unbound-lambda early rejections below, which would
-            //     otherwise reject those receivers outright,
-            //   - BindToNaturalType, which converts unconverted typeless forms (collection
-            //     expressions, conditional expressions, switch expressions, target-typed `new()`,
-            //     etc.) into error-typed wrappers, and
-            //   - the switch's default branch's null-literal rejection.
-            // The feature-availability check is performed inside the helper.
-            // See https://github.com/dotnet/csharplang/blob/main/proposals/extension-members-on-typeless-receivers.md
-            if (TryBindMemberAccessOnTypelessReceiver(node, boundLeft, right, invoked, indexed, diagnostics) is { } typelessExtensionResult)
-            {
-                return typelessExtensionResult;
             }
 
             // No member accesses on default

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8343,6 +8343,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.UnconvertedCollectionExpression:
                 case BoundKind.UnboundLambda:
                     break;
+                case BoundKind.MethodGroup when ((BoundMethodGroup)boundLeft).Methods.Length > 0 && ((BoundMethodGroup)boundLeft).LookupError is null:
+                    // Real method group with at least one candidate. Empty / errored method groups
+                    // (produced when an inaccessible nested type lookup or other failed lookup
+                    // falls through to extension-method search and finds nothing) are excluded so
+                    // the existing diagnostic on the inner lookup is preserved.
+                    break;
                 default:
                     return null;
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8350,6 +8350,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // falls through to extension-method search and finds nothing) are excluded so
                     // the existing diagnostic on the inner lookup is preserved.
                     break;
+                case BoundKind.Literal when ((BoundLiteral)boundLeft).ConstantValueOpt?.IsNull == true:
+                    // null literal (BoundLiteral with constant value null and no type).
+                    break;
                 default:
                     return null;
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8744,8 +8744,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool acceptOnlyMethods,
             in CallingConventionInfo callingConvention = default)
         {
-            Debug.Assert(left.Type is not null);
-            Debug.Assert(!left.Type.IsDynamic());
+            // The receiver may be typeless when the typeless-extension-receivers feature is enabled.
+            // The feature gate is checked by callers; once we are here, a null Type is permitted.
+            Debug.Assert(left.Type is null || !left.Type.IsDynamic());
             Debug.Assert((options & ~(OverloadResolution.Options.IsMethodGroupConversion |
                                       OverloadResolution.Options.IsFunctionPointerResolution |
                                       OverloadResolution.Options.InferWithDynamic |
@@ -8837,7 +8838,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 BindingDiagnosticBag diagnostics,
                 out MethodGroupResolution result)
             {
-                Debug.Assert(left.Type is not null);
+                // left.Type may be null when the typeless-extension-receivers feature is enabled.
                 result = default;
 
                 // 1. gather candidates
@@ -8945,12 +8946,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (analyzedArguments == null)
                 {
                     // Without arguments (for scenarios such as `nameof` or conversion to non-delegate/dynamic type)
-                    // we can still prune the inapplicable extension methods using the receiver type
-                    for (int i = methodGroup.Methods.Count - 1; i >= 0; i--)
+                    // we can still prune the inapplicable extension methods using the receiver type.
+                    // Skip pruning when the receiver expression has no type (typeless-extension-receivers
+                    // feature); inapplicability is determined later, by overload resolution against the
+                    // candidate's first parameter type.
+                    TypeSymbol? receiverType = left.Type;
+                    for (int i = methodGroup.Methods.Count - 1; receiverType is not null && i >= 0; i--)
                     {
                         MethodSymbol method = methodGroup.Methods[i];
-                        TypeSymbol? receiverType = left.Type;
-                        Debug.Assert(receiverType is not null);
 
                         bool inapplicable = false;
                         if (method.IsExtensionMethod

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -1239,7 +1239,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             // instance methods. Therefore we must detect this scenario here, rather than in
             // overload resolution.
 
-            var receiver = ReplaceTypeOrValueReceiver(methodGroup.Receiver, useType: !method.RequiresInstanceReceiver && !invokedAsExtensionMethod, diagnostics);
+            // For extension members on typeless receivers, the receiver-to-parameter conversion is
+            // applied later by CheckAndCoerceArguments using the Conversion stored by overload
+            // resolution. ReplaceTypeOrValueReceiver's default branch calls BindToNaturalType, which
+            // destructively converts typeless forms (collection expression, new(), conditional /
+            // switch with no common type, tuple, default) into error-recovery wrappers. The function's
+            // named purpose (replacing a TypeOrValueExpression or unwrapping a QueryClause) does not
+            // apply here, since both of those wrappers always have a type.
+            var receiver = invokedAsExtensionMethod && methodGroup.Receiver.Type is null
+                ? methodGroup.Receiver
+                : ReplaceTypeOrValueReceiver(methodGroup.Receiver, useType: !method.RequiresInstanceReceiver && !invokedAsExtensionMethod, diagnostics);
 
             if (invokedAsExtensionMethod && (object)receiver != methodGroup.Receiver)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -1240,13 +1240,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             // overload resolution.
 
             // For extension members on typeless receivers, the receiver-to-parameter conversion is
-            // applied later by CheckAndCoerceArguments using the Conversion stored by overload
-            // resolution. ReplaceTypeOrValueReceiver's default branch calls BindToNaturalType, which
-            // destructively converts typeless forms (collection expression, new(), conditional /
-            // switch with no common type, tuple, default) into error-recovery wrappers. The function's
-            // named purpose (replacing a TypeOrValueExpression or unwrapping a QueryClause) does not
-            // apply here, since both of those wrappers always have a type.
-            var receiver = invokedAsExtensionMethod && methodGroup.Receiver.Type is null
+            // applied later by CheckAndCoerceArguments (classic) or CheckAndConvertExtensionReceiver
+            // (modern, C# 14 extension blocks) using the Conversion stored by overload resolution.
+            // ReplaceTypeOrValueReceiver's default branch calls BindToNaturalType, which destructively
+            // converts typeless forms (collection expression, new(), conditional / switch with no
+            // common type, tuple, default) into error-recovery wrappers. The function's named purpose
+            // (replacing a TypeOrValueExpression or unwrapping a QueryClause) does not apply here,
+            // since both of those wrappers always have a type. Both invokedAsExtensionMethod (classic)
+            // and isExtensionBlockMethod (modern) signal an extension call where the receiver-side
+            // conversion is handled downstream; cover both. Note isExtensionBlockMethod resets
+            // invokedAsExtensionMethod to false above, which is why both checks are needed.
+            var receiver = (invokedAsExtensionMethod || isExtensionBlockMethod) && methodGroup.Receiver.Type is null
                 ? methodGroup.Receiver
                 : ReplaceTypeOrValueReceiver(methodGroup.Receiver, useType: !method.RequiresInstanceReceiver && !invokedAsExtensionMethod, diagnostics);
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -2005,6 +2005,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
+            // Extension members on typeless receivers: when the receiver expression has no type,
+            // fall back to the standard expression-to-type implicit conversions used for any other
+            // typeless argument (null literal, default literal, anonymous function, method group,
+            // tuple expression, throw expression, collection expression, target-typed `new()`,
+            // target-typed conditional / switch). The feature flag check is performed by the binder
+            // before a typeless receiver reaches this path.
+            // See https://github.com/dotnet/csharplang/blob/main/proposals/extension-members-on-typeless-receivers.md
+            if (sourceExpressionOpt is not null && (object)sourceType == null)
+            {
+                var fromExpressionConversion = ClassifyImplicitConversionFromExpression(sourceExpressionOpt, destination, ref useSiteInfo);
+                if (fromExpressionConversion.Exists)
+                {
+                    return fromExpressionConversion;
+                }
+            }
+
             return Conversion.NoConversion;
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -4626,7 +4626,7 @@ outerDefault:
                         (!conversion.IsDynamic ||
                             (ignoreOpenTypes && TypeContainsTypeParameterFromContainer(candidate, parameters.ParameterTypes[argumentPosition].Type))));
 
-                    if (forExtensionMethodThisArg && !conversion.IsDynamic && !Conversions.IsValidExtensionMethodThisArgConversion(conversion))
+                    if (forExtensionMethodThisArg && !conversion.IsDynamic && argument.Type is not null && !Conversions.IsValidExtensionMethodThisArgConversion(conversion))
                     {
                         // Return early, without checking conversions of subsequent arguments,
                         // if the instance argument is not convertible to the 'this' parameter,
@@ -4634,6 +4634,11 @@ outerDefault:
                         // lambda binding in particular, for instance, with LINQ expressions.
                         // Note that BuildArgumentsForErrorRecovery will still bind some number
                         // of overloads for the semantic model.
+                        // The strict identity / reference / boxing whitelist is skipped when the
+                        // receiver expression has no type, since in that case the conversion was
+                        // produced by ClassifyImplicitConversionFromExpression (the same machinery
+                        // used for any other typeless argument), which only returns valid implicit
+                        // conversions.
                         Debug.Assert(badArguments.IsNull);
                         Debug.Assert(conversions == null);
                         return MemberAnalysisResult.BadArgumentConversions(argsToParameters, MemberAnalysisResult.CreateBadArgumentsWithPosition(argumentPosition), ImmutableArray.Create(conversion),

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -8297,6 +8297,9 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="IDS_FeatureUnions" xml:space="preserve">
     <value>unions</value>
   </data>
+  <data name="IDS_FeatureExtensionMembersOnTypelessReceivers" xml:space="preserve">
+    <value>extension members on typeless receivers</value>
+  </data>
   <data name="ERR_UnionDeclarationNeedsCaseTypes" xml:space="preserve">
     <value>A union declaration must specify at least one case type.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -310,6 +310,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureUnsafeEvolution = MessageBase + 12859,
 
         IDS_FeatureUnions = MessageBase + 12860,
+
+        IDS_FeatureExtensionMembersOnTypelessReceivers = MessageBase + 12861,
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -493,6 +495,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case MessageID.IDS_FeatureCollectionExpressionArguments:
                 case MessageID.IDS_FeatureUnsafeEvolution: // https://github.com/dotnet/roslyn/issues/82546: keep this in preview until C# 16
                 case MessageID.IDS_FeatureUnions:
+                case MessageID.IDS_FeatureExtensionMembersOnTypelessReceivers:
                     return LanguageVersion.Preview;
 
                 // C# 14.0 features.

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">vzory rozšířených vlastností</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">rozšíření</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">Muster für erweiterte Eigenschaften</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">Erweiterungen</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">patrones de propiedad extendidos</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">extensiones</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">modèles de propriétés étendues</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">extensions</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">criteri di proprietà estesa</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">estensioni</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">拡張プロパティ パターン</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">拡張</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">확장 속성 패턴</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">확장</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">wzorce właściwości rozszerzonych</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">numery wewnętrzne</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">padrões de propriedade estendida</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">extensões</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">шаблоны расширенных свойств</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">расширения</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">genişletilmiş özellik desenleri</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">genişletmeler</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">扩展的属性模式</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">扩展</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">擴充屬性模式</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">擴充</target>

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/CollectionExpression/CollectionExpression_ClassicExtensionMethod_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/CollectionExpression/CollectionExpression_ClassicExtensionMethod_Tests.cs
@@ -1,0 +1,524 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_CollectionExpression_ClassicExtensionMethod_Tests : CompilingTestBase
+{
+    #region Positive: target type variety
+
+    [Fact]
+    public void Array_Executes()
+    {
+        var source = """
+            public static class Ext
+            {
+                public static int Sum(this int[] xs)
+                {
+                    int s = 0;
+                    foreach (var x in xs) s += x;
+                    return s;
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([1, 2, 3, 4].Sum());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "10").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void List_Executes()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static int Count(this List<int> xs) => xs.Count;
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([1, 2, 3].Count());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "3").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void IEnumerable_GenericInference_Executes()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static T First<T>(this IEnumerable<T> xs)
+                {
+                    foreach (var x in xs) return x;
+                    return default!;
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([10, 20, 30].First());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "10").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void IReadOnlyList_GenericInference()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static T Last<T>(this IReadOnlyList<T> xs) => xs[xs.Count - 1];
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    _ = [1, 2, 3].Last();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics();
+    }
+
+    #endregion
+
+    #region Edge cases: collection-expression-specific
+
+    [Fact]
+    public void EmptyCollection_GenericInference_CannotInfer()
+    {
+        // T cannot be inferred from `[]` because there are no elements.
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static int Count<T>(this IEnumerable<T> xs)
+                {
+                    int n = 0;
+                    foreach (var _ in xs) n++;
+                    return n;
+                }
+            }
+
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = [].Count();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (17,16): error CS0411: The type arguments for method 'Ext.Count<T>(IEnumerable<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+            //         _ = [].Count();
+            Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Count").WithArguments("Ext.Count<T>(System.Collections.Generic.IEnumerable<T>)").WithLocation(17, 16));
+    }
+
+    [Fact]
+    public void Spread_Executes()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static int Sum(this IEnumerable<int> xs)
+                {
+                    int s = 0;
+                    foreach (var x in xs) s += x;
+                    return s;
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    int[] a = [1, 2];
+                    int[] b = [3, 4];
+                    System.Console.Write([..a, ..b].Sum());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "10").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void NestedCollection_Executes()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static int CountOuter<T>(this IEnumerable<T> xs)
+                {
+                    int n = 0;
+                    foreach (var _ in xs) n++;
+                    return n;
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([(int[])[1, 2], (int[])[3, 4, 5]].CountOuter());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "2").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void StringElements_Executes()
+    {
+        // The element type is non-trivial to confirm inference works for reference element types.
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static string Concat(this IEnumerable<string> xs)
+                {
+                    string r = "";
+                    foreach (var x in xs) r += x;
+                    return r;
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(["a", "b", "c"].Concat());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "abc").VerifyDiagnostics();
+    }
+
+    #endregion
+
+    #region Generic inference
+
+    [Fact]
+    public void TwoParamGeneric_InferredFromReceiverAndArg()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static (T, U) Pair<T, U>(this IEnumerable<T> xs, U other) => (xs.GetEnumerator().Current, other);
+            }
+
+            public class Goo
+            {
+                public static void M()
+                {
+                    var p = [1, 2, 3].Pair("hi");
+                    _ = p;
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ConstrainedGeneric_StructConstraint()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static T First<T>(this IEnumerable<T> xs) where T : struct
+                {
+                    foreach (var x in xs) return x;
+                    return default;
+                }
+            }
+
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = [1, 2, 3].First();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ConstrainedGeneric_StructConstraintViolation()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static T First<T>(this IEnumerable<T> xs) where T : struct
+                {
+                    foreach (var x in xs) return x;
+                    return default;
+                }
+            }
+
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = ["a", "b"].First();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (16,24): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'Ext.First<T>(IEnumerable<T>)'
+            //         _ = ["a", "b"].First();
+            Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "First").WithArguments("Ext.First<T>(System.Collections.Generic.IEnumerable<T>)", "T", "string").WithLocation(16, 24));
+    }
+
+    #endregion
+
+    #region Negative
+
+    [Fact]
+    public void ReceiverTypeNotConstructibleFromCollectionExpression()
+    {
+        // Extension's first parameter is a class type that has no collection-expression
+        // conversion; the candidate is reported as not constructible.
+        var source = """
+            public class Bag { }
+
+            public static class Ext
+            {
+                public static int Count(this Bag b) => 0;
+            }
+
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = [1, 2, 3].Count();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (12,13): error CS9174: Cannot initialize type 'Bag' with a collection expression because the type is not constructible.
+            //         _ = [1, 2, 3].Count();
+            Diagnostic(ErrorCode.ERR_CollectionExpressionTargetTypeNotConstructible, "[1, 2, 3]").WithArguments("Bag").WithLocation(12, 13));
+    }
+
+    [Fact]
+    public void NoExtensionInScope_ReportsNoSuchMember()
+    {
+        // No extension method named Count is in scope. The receiver enters extension lookup
+        // (collection expression has no instance members), finds nothing, and reports
+        // "collection expression does not contain a definition for Count".
+        var source = """
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = [1, 2, 3].Count();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (5,23): error CS0117: 'collection expression' does not contain a definition for 'Count'
+            //         _ = [1, 2, 3].Count();
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "Count").WithArguments("collection expression", "Count").WithLocation(5, 23));
+    }
+
+    [Fact]
+    public void Ambiguous_BothApplicable()
+    {
+        // Two applicable candidates whose first parameter types are equally specific
+        // for the collection-expression source produce overload-resolution ambiguity.
+        var source = """
+            using System.Collections.Generic;
+
+            public static class ExtA
+            {
+                public static int M(this IEnumerable<int> xs) => 1;
+            }
+            public static class ExtB
+            {
+                public static int M(this IEnumerable<int> xs) => 2;
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    _ = [1, 2, 3].M();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (16,23): error CS0121: The call is ambiguous between the following methods or properties: 'ExtA.M(IEnumerable<int>)' and 'ExtB.M(IEnumerable<int>)'
+            //         _ = [1, 2, 3].M();
+            Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("ExtA.M(System.Collections.Generic.IEnumerable<int>)", "ExtB.M(System.Collections.Generic.IEnumerable<int>)").WithLocation(16, 23));
+    }
+
+    [Fact]
+    public void OverloadResolution_PrefersMoreSpecific()
+    {
+        // T[] is more specific than IEnumerable<T>. Both are applicable for [1,2,3];
+        // overload resolution picks T[].
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static string Tag(this IEnumerable<int> xs) => "enumerable";
+                public static string Tag(this int[] xs) => "array";
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([1, 2, 3].Tag());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "array").VerifyDiagnostics();
+    }
+
+    #endregion
+
+    #region Chained extension calls
+
+    [Fact]
+    public void Chained_CollectionExprThenTypedReceiver_Executes()
+    {
+        // First call uses the typeless-receiver path; result has a type so the
+        // second call uses the existing typed-receiver path.
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static List<T> ToList<T>(this IEnumerable<T> xs)
+                {
+                    var r = new List<T>();
+                    foreach (var x in xs) r.Add(x);
+                    return r;
+                }
+
+                public static int Sum(this List<int> xs)
+                {
+                    int s = 0;
+                    foreach (var x in xs) s += x;
+                    return s;
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([1, 2, 3].ToList().Sum());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "6").VerifyDiagnostics();
+    }
+
+    #endregion
+
+    #region Argument forwarding
+
+    [Fact]
+    public void AdditionalArguments_Forwarded()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static int CountAtLeast<T>(this IEnumerable<T> xs, int min)
+                {
+                    int n = 0;
+                    foreach (var _ in xs)
+                    {
+                        n++;
+                        if (n >= min) return n;
+                    }
+                    return n;
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([1, 2, 3, 4].CountAtLeast(2));
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "2").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void NamedArguments_OnAdditionalArgs()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static int Combine<T>(this IEnumerable<T> xs, int a, int b)
+                {
+                    int s = a + b;
+                    foreach (var _ in xs) s++;
+                    return s;
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([1, 2, 3].Combine(b: 100, a: 10));
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "113").VerifyDiagnostics();
+    }
+
+    #endregion
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/CollectionExpression/CollectionExpression_ModernExtensionIndexer_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/CollectionExpression/CollectionExpression_ModernExtensionIndexer_Tests.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_CollectionExpression_ModernExtensionIndexer_Tests : CompilingTestBase
+{
+    // Modern extension indexers and the typeless-receivers feature don't currently meet:
+    //
+    //   - Instance indexers are not allowed inside `extension(T) { ... }` blocks: declaring
+    //     `public int this[int i] { ... }` reports CS9282 / ERR_ExtensionDisallowsMember. So no
+    //     instance indexer can be reached through the typeless-receiver path.
+    //
+    //   - Element access via `expr[args]` on a typeless receiver is explicitly out of scope per
+    //     the proposal. The proposal is dot-form only (`expr.Member`), and `expr?.Member` /
+    //     `expr[args]` continue to produce ERR_CollectionExpressionNoTargetType.
+    //
+    // The two tests below pin those two facts so that if either changes (instance indexers
+    // become allowed inside extension blocks, or `[]` on typeless receivers is added to the
+    // proposal scope), the failures here will surface and we can revisit.
+
+    [Fact]
+    public void InstanceIndexer_InExtensionBlock_NotAllowed()
+    {
+        var source = """
+            public static class Ext
+            {
+                extension(int[] source)
+                {
+                    public int this[long i] { get => 0; }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (5,20): error CS9282: This member is not allowed in an extension block
+            //         public int this[long i] { get => 0; }
+            Diagnostic(ErrorCode.ERR_ExtensionDisallowsMember, "this").WithLocation(5, 20));
+    }
+
+    [Fact]
+    public void IndexerAccess_OnCollectionExpression_NoTargetType()
+    {
+        // `[1, 2, 3][0]` is element access on a typeless collection-expression receiver. The
+        // proposal scopes the new behavior to dot-form member access only; element access
+        // stays out of scope and continues to report ERR_CollectionExpressionNoTargetType.
+        var source = """
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = [1, 2, 3][0];
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (5,13): error CS9176: There is no target type for the collection expression.
+            //         _ = [1, 2, 3][0];
+            Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[1, 2, 3]").WithLocation(5, 13));
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/CollectionExpression/CollectionExpression_ModernExtensionMethod_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/CollectionExpression/CollectionExpression_ModernExtensionMethod_Tests.cs
@@ -12,17 +12,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
 [CompilerTrait(CompilerFeature.Extensions)]
 public sealed class ExtensionMembersOnTypelessReceivers_CollectionExpression_ModernExtensionMethod_Tests : CompilingTestBase
 {
-    // TODO: Modern (C# 14) extension members declared inside `extension(T) { ... }` blocks
-    // are not yet wired up for typeless receivers. The classic-extension path runs through
-    // BindInstanceMemberAccess, which TryBindMemberAccessOnTypelessReceiver routes to; the
-    // modern path runs through GetExtensionMemberAccess and ExtensionLookup machinery that
-    // does not yet honor a typeless receiver. Each test below documents the current
-    // ERR_CollectionExpressionNoTargetType behavior so the file is green; once the modern
-    // path is enabled (likely as part of the Phase 1.5 / modern-binder follow-up) these
-    // tests should be flipped to assert successful binding.
-
     [Fact]
-    public void Method_OnCollectionExpression_NotYetSupported()
+    public void Method_OnCollectionExpression_Executes()
     {
         var source = """
             using System.Collections.Generic;
@@ -48,15 +39,11 @@ public sealed class ExtensionMembersOnTypelessReceivers_CollectionExpression_Mod
                 }
             }
             """;
-        // TODO: should compile and print "6" once modern extensions are wired up.
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
-            // (20,30): error CS9176: There is no target type for the collection expression.
-            //         System.Console.Write([1, 2, 3].Sum());
-            Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[1, 2, 3]").WithLocation(20, 30));
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "6").VerifyDiagnostics();
     }
 
     [Fact]
-    public void GenericMethod_OnCollectionExpression_NotYetSupported()
+    public void GenericMethod_OnCollectionExpression_Executes()
     {
         var source = """
             using System.Collections.Generic;
@@ -82,10 +69,6 @@ public sealed class ExtensionMembersOnTypelessReceivers_CollectionExpression_Mod
                 }
             }
             """;
-        // TODO: should compile and print "3" once modern extensions are wired up.
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
-            // (20,30): error CS9176: There is no target type for the collection expression.
-            //         System.Console.Write([1, 2, 3].CountIt());
-            Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[1, 2, 3]").WithLocation(20, 30));
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "3").VerifyDiagnostics();
     }
 }

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/CollectionExpression/CollectionExpression_ModernExtensionMethod_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/CollectionExpression/CollectionExpression_ModernExtensionMethod_Tests.cs
@@ -1,0 +1,91 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_CollectionExpression_ModernExtensionMethod_Tests : CompilingTestBase
+{
+    // TODO: Modern (C# 14) extension members declared inside `extension(T) { ... }` blocks
+    // are not yet wired up for typeless receivers. The classic-extension path runs through
+    // BindInstanceMemberAccess, which TryBindMemberAccessOnTypelessReceiver routes to; the
+    // modern path runs through GetExtensionMemberAccess and ExtensionLookup machinery that
+    // does not yet honor a typeless receiver. Each test below documents the current
+    // ERR_CollectionExpressionNoTargetType behavior so the file is green; once the modern
+    // path is enabled (likely as part of the Phase 1.5 / modern-binder follow-up) these
+    // tests should be flipped to assert successful binding.
+
+    [Fact]
+    public void Method_OnCollectionExpression_NotYetSupported()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                extension(IEnumerable<int> source)
+                {
+                    public int Sum()
+                    {
+                        int s = 0;
+                        foreach (var x in source) s += x;
+                        return s;
+                    }
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([1, 2, 3].Sum());
+                }
+            }
+            """;
+        // TODO: should compile and print "6" once modern extensions are wired up.
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (20,30): error CS9176: There is no target type for the collection expression.
+            //         System.Console.Write([1, 2, 3].Sum());
+            Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[1, 2, 3]").WithLocation(20, 30));
+    }
+
+    [Fact]
+    public void GenericMethod_OnCollectionExpression_NotYetSupported()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                extension<T>(IEnumerable<T> source)
+                {
+                    public int CountIt()
+                    {
+                        int n = 0;
+                        foreach (var _ in source) n++;
+                        return n;
+                    }
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([1, 2, 3].CountIt());
+                }
+            }
+            """;
+        // TODO: should compile and print "3" once modern extensions are wired up.
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (20,30): error CS9176: There is no target type for the collection expression.
+            //         System.Console.Write([1, 2, 3].CountIt());
+            Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[1, 2, 3]").WithLocation(20, 30));
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/CollectionExpression/CollectionExpression_ModernExtensionProperty_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/CollectionExpression/CollectionExpression_ModernExtensionProperty_Tests.cs
@@ -1,0 +1,263 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_CollectionExpression_ModernExtensionProperty_Tests : CompilingTestBase
+{
+    [Fact]
+    public void Property_OnCollectionExpression_Executes()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                extension(IEnumerable<int> source)
+                {
+                    public int First
+                    {
+                        get
+                        {
+                            foreach (var x in source) return x;
+                            return 0;
+                        }
+                    }
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([10, 20, 30].First);
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "10").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void GenericProperty_OnCollectionExpression_Executes()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                extension<T>(IEnumerable<T> source)
+                {
+                    public int Count
+                    {
+                        get
+                        {
+                            int n = 0;
+                            foreach (var _ in source) n++;
+                            return n;
+                        }
+                    }
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([1, 2, 3, 4].Count);
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "4").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Property_OnReadOnlyList()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                extension<T>(IReadOnlyList<T> source)
+                {
+                    public T Last => source[source.Count - 1];
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([1, 2, 3].Last);
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "3").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Property_OnArray()
+    {
+        var source = """
+            public static class Ext
+            {
+                extension(int[] source)
+                {
+                    public int Sum
+                    {
+                        get
+                        {
+                            int s = 0;
+                            foreach (var x in source) s += x;
+                            return s;
+                        }
+                    }
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([1, 2, 3, 4, 5].Sum);
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "15").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Property_StringElements()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                extension(IEnumerable<string> source)
+                {
+                    public string Joined
+                    {
+                        get
+                        {
+                            string r = "";
+                            foreach (var s in source) r += s;
+                            return r;
+                        }
+                    }
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(["a", "b", "c"].Joined);
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "abc").VerifyDiagnostics();
+    }
+
+    // TODO: A test for empty-collection + generic extension property (`_ = [].Count;` where
+    // Count is an extension property on IEnumerable<T>) should fail with ERR_CantInferTypeArgs
+    // or similar. Currently triggers a Debug.Fail in DiagnosticInfo.AssertMessageSerializable
+    // inside OverloadResolutionResult.TypeInferenceFailed during property-resolution error
+    // reporting, indicating a non-serializable argument. Tracked separately; outside this PR's
+    // scope (the diagnostic-reporting bug also affects typed receivers in the same scenario).
+
+    [Fact]
+    public void Property_NoCandidateInScope_ReportsNoSuchMember()
+    {
+        var source = """
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = [1, 2, 3].Length;
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (5,23): error CS0117: 'collection expression' does not contain a definition for 'Length'
+            //         _ = [1, 2, 3].Length;
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "Length").WithArguments("collection expression", "Length").WithLocation(5, 23));
+    }
+
+    [Fact]
+    public void Property_ChainedAccess_Executes()
+    {
+        // Property access returns a typed value; chained member access uses the existing typed
+        // member-access path.
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                extension<T>(IEnumerable<T> source)
+                {
+                    public List<T> AsList
+                    {
+                        get
+                        {
+                            var l = new List<T>();
+                            foreach (var x in source) l.Add(x);
+                            return l;
+                        }
+                    }
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([1, 2, 3].AsList.Count);
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "3").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Property_Spread_Executes()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                extension(IEnumerable<int> source)
+                {
+                    public int Sum
+                    {
+                        get
+                        {
+                            int s = 0;
+                            foreach (var x in source) s += x;
+                            return s;
+                        }
+                    }
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    int[] a = [1, 2];
+                    int[] b = [3, 4];
+                    System.Console.Write([..a, ..b].Sum);
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "10").VerifyDiagnostics();
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/ConditionalExpression/ConditionalExpression_ClassicExtensionMethod_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/ConditionalExpression/ConditionalExpression_ClassicExtensionMethod_Tests.cs
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_ConditionalExpression_ClassicExtensionMethod_Tests : CompilingTestBase
+{
+    [Fact]
+    public void Conditional_NullAndInt_Executes()
+    {
+        // (b ? null : 5) has no common type between null and int. Target-typed against the
+        // extension's first parameter (int?), the conditional binds.
+        var source = """
+            public static class Ext
+            {
+                public static int OrZero(this int? n) => n ?? 0;
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    bool b = false;
+                    System.Console.Write((b ? null : 5).OrZero());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "5").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Conditional_TwoArmTypelessElements_Executes()
+    {
+        // Both arms are themselves typeless (default and null). They share no common type, so
+        // the conditional itself is typeless and target-types against the extension's parameter.
+        var source = """
+            public static class Ext
+            {
+                public static string Or(this string s, string fallback) => s ?? fallback;
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    bool b = true;
+                    System.Console.Write((b ? default : null).Or("fallback"));
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "fallback").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Conditional_NoApplicableExtension_ReportsNoSuchMember()
+    {
+        var source = """
+            public class Goo
+            {
+                public static void M()
+                {
+                    bool b = true;
+                    _ = (b ? null : 5).DoesNotExist();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (6,28): error CS0117: '?:' does not contain a definition for 'DoesNotExist'
+            //         _ = (b ? null : 5).DoesNotExist();
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "DoesNotExist").WithArguments("target-typed conditional expression", "DoesNotExist").WithLocation(6, 28));
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/ConditionalExpression/ConditionalExpression_ModernExtensionMethod_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/ConditionalExpression/ConditionalExpression_ModernExtensionMethod_Tests.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_ConditionalExpression_ModernExtensionMethod_Tests : CompilingTestBase
+{
+    [Fact]
+    public void Conditional_NullAndInt_Executes()
+    {
+        var source = """
+            public static class Ext
+            {
+                extension(int? n)
+                {
+                    public int OrZero() => n ?? 0;
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    bool b = true;
+                    System.Console.Write((b ? null : 9).OrZero());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "0").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Conditional_NoApplicableExtension_ReportsNoSuchMember()
+    {
+        var source = """
+            public class Goo
+            {
+                public static void M()
+                {
+                    bool b = true;
+                    _ = (b ? null : 5).DoesNotExist();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (6,28): error CS0117: 'target-typed conditional expression' does not contain a definition for 'DoesNotExist'
+            //         _ = (b ? null : 5).DoesNotExist();
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "DoesNotExist").WithArguments("target-typed conditional expression", "DoesNotExist").WithLocation(6, 28));
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/ConditionalExpression/ConditionalExpression_ModernExtensionProperty_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/ConditionalExpression/ConditionalExpression_ModernExtensionProperty_Tests.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_ConditionalExpression_ModernExtensionProperty_Tests : CompilingTestBase
+{
+    [Fact]
+    public void Property_OnConditional_Executes()
+    {
+        var source = """
+            public static class Ext
+            {
+                extension(int? n)
+                {
+                    public int OrZero => n ?? 0;
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    bool b = true;
+                    System.Console.Write((b ? null : 5).OrZero);
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "0").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Property_NoCandidateInScope_ReportsNoSuchMember()
+    {
+        var source = """
+            public class Goo
+            {
+                public static void M()
+                {
+                    bool b = true;
+                    _ = (b ? null : 5).DoesNotExist;
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (6,28): error CS0117: 'target-typed conditional expression' does not contain a definition for 'DoesNotExist'
+            //         _ = (b ? null : 5).DoesNotExist;
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "DoesNotExist").WithArguments("target-typed conditional expression", "DoesNotExist").WithLocation(6, 28));
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/DefaultLiteral/DefaultLiteral_ClassicExtensionMethod_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/DefaultLiteral/DefaultLiteral_ClassicExtensionMethod_Tests.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_DefaultLiteral_ClassicExtensionMethod_Tests : CompilingTestBase
+{
+    [Fact]
+    public void DefaultToInt_Executes()
+    {
+        var source = """
+            public static class Ext
+            {
+                public static int Plus(this int n, int m) => n + m;
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(default.Plus(7));
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "7").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void DefaultToString_Executes()
+    {
+        var source = """
+            public static class Ext
+            {
+                public static string OrEmpty(this string s) => s ?? "empty";
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(default.OrEmpty());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "empty").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void NoApplicableExtension_ReportsNoSuchMember()
+    {
+        var source = """
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = default.DoesNotExist();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (5,21): error CS0117: 'default' does not contain a definition for 'DoesNotExist'
+            //         _ = default.DoesNotExist();
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "DoesNotExist").WithArguments("default", "DoesNotExist").WithLocation(5, 21));
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/DefaultLiteral/DefaultLiteral_ModernExtensionIndexer_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/DefaultLiteral/DefaultLiteral_ModernExtensionIndexer_Tests.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_DefaultLiteral_ModernExtensionIndexer_Tests : CompilingTestBase
+{
+    // Same pattern as previous indexer pin PRs.
+
+    [Fact]
+    public void InstanceIndexer_InExtensionBlock_OnInt_NotAllowed()
+    {
+        var source = """
+            public static class Ext
+            {
+                extension(int n)
+                {
+                    public int this[int i] { get => n + i; }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (5,20): error CS9282: This member is not allowed in an extension block
+            //         public int this[int i] { get => n + i; }
+            Diagnostic(ErrorCode.ERR_ExtensionDisallowsMember, "this").WithLocation(5, 20));
+    }
+
+    [Fact]
+    public void IndexerAccess_OnDefault_NoTargetType()
+    {
+        var source = """
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = default[0];
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (5,13): error CS8716: There is no target type for the default literal.
+            //         _ = default[0];
+            Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(5, 13));
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/DefaultLiteral/DefaultLiteral_ModernExtensionMethod_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/DefaultLiteral/DefaultLiteral_ModernExtensionMethod_Tests.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_DefaultLiteral_ModernExtensionMethod_Tests : CompilingTestBase
+{
+    [Fact]
+    public void DefaultToInt_Executes()
+    {
+        var source = """
+            public static class Ext
+            {
+                extension(int n)
+                {
+                    public int Plus(int m) => n + m;
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(default.Plus(8));
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "8").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void NoApplicableExtension_ReportsNoSuchMember()
+    {
+        var source = """
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = default.DoesNotExist();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (5,21): error CS0117: 'default' does not contain a definition for 'DoesNotExist'
+            //         _ = default.DoesNotExist();
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "DoesNotExist").WithArguments("default", "DoesNotExist").WithLocation(5, 21));
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/DefaultLiteral/DefaultLiteral_ModernExtensionProperty_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/DefaultLiteral/DefaultLiteral_ModernExtensionProperty_Tests.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_DefaultLiteral_ModernExtensionProperty_Tests : CompilingTestBase
+{
+    [Fact]
+    public void Property_DefaultToInt_Executes()
+    {
+        var source = """
+            public static class Ext
+            {
+                extension(int n)
+                {
+                    public int PlusOne => n + 1;
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(default.PlusOne);
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "1").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Property_NoCandidateInScope_ReportsNoSuchMember()
+    {
+        var source = """
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = default.DoesNotExist;
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (5,21): error CS0117: 'default' does not contain a definition for 'DoesNotExist'
+            //         _ = default.DoesNotExist;
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "DoesNotExist").WithArguments("default", "DoesNotExist").WithLocation(5, 21));
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/Lambda/Lambda_ClassicExtensionMethod_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/Lambda/Lambda_ClassicExtensionMethod_Tests.cs
@@ -1,0 +1,226 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_Lambda_ClassicExtensionMethod_Tests : CompilingTestBase
+{
+    [Fact]
+    public void FuncTarget_Executes()
+    {
+        var source = """
+            using System;
+
+            public static class Ext
+            {
+                public static int Apply(this Func<int, int> f, int arg) => f(arg);
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write((x => x * 2).Apply(5));
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "10").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ActionTarget_Executes()
+    {
+        var source = """
+            using System;
+
+            public static class Ext
+            {
+                public static void RunIt(this Action a) { a(); a(); }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    int n = 0;
+                    (() => n++).RunIt();
+                    System.Console.Write(n);
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "2").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void TwoParamLambda_Executes()
+    {
+        var source = """
+            using System;
+
+            public static class Ext
+            {
+                public static int Combine(this Func<int, int, int> f, int a, int b) => f(a, b);
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(((a, b) => a + b).Combine(3, 4));
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "7").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void TypedParamLambda_StillTypeless_Executes()
+    {
+        // Even with an explicit parameter type, the lambda has no natural type and routes
+        // through the typeless-receiver path until the extension binds it to a delegate type.
+        var source = """
+            using System;
+
+            public static class Ext
+            {
+                public static int Apply(this Func<int, int> f, int arg) => f(arg);
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(((int x) => x + 1).Apply(10));
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "11").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void GenericExtension_LambdaToDelegate()
+    {
+        var source = """
+            using System;
+
+            public static class Ext
+            {
+                public static T Apply<T>(this Func<T, T> f, T arg) => f(arg);
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(((int x) => x * 3).Apply(4));
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "12").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void NoApplicableExtension_ReportsNoSuchMember()
+    {
+        var source = """
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = (x => x).DoesNotExist();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (5,22): error CS0117: 'lambda expression' does not contain a definition for 'DoesNotExist'
+            //         _ = (x => x).DoesNotExist();
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "DoesNotExist").WithArguments("lambda expression", "DoesNotExist").WithLocation(5, 22));
+    }
+
+    [Fact]
+    public void Ambiguous_BothApplicable()
+    {
+        var source = """
+            using System;
+
+            public static class ExtA
+            {
+                public static int M(this Func<int, int> f) => 1;
+            }
+            public static class ExtB
+            {
+                public static int M(this Func<int, int> f) => 2;
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    _ = (x => x).M();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (16,22): error CS0121: The call is ambiguous between the following methods or properties: 'ExtA.M(Func<int, int>)' and 'ExtB.M(Func<int, int>)'
+            //         _ = (x => x).M();
+            Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("ExtA.M(System.Func<int, int>)", "ExtB.M(System.Func<int, int>)").WithLocation(16, 22));
+    }
+
+    [Fact]
+    public void OverloadResolution_PrefersMoreSpecific()
+    {
+        var source = """
+            using System;
+
+            public static class Ext
+            {
+                public static string Tag(this Delegate d) => "delegate";
+                public static string Tag(this Func<int, int> f) => "func";
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(((int x) => x).Tag());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "func").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Chained_LambdaThenTypedReceiver_Executes()
+    {
+        var source = """
+            using System;
+
+            public static class Ext
+            {
+                public static Func<int, int> Memoize(this Func<int, int> f)
+                {
+                    var cache = new System.Collections.Generic.Dictionary<int, int>();
+                    return x => cache.TryGetValue(x, out var v) ? v : (cache[x] = f(x));
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    var memoized = ((int x) => x * x).Memoize();
+                    System.Console.Write(memoized(5));
+                    System.Console.Write(memoized(5));
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "2525").VerifyDiagnostics();
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/Lambda/Lambda_ModernExtensionIndexer_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/Lambda/Lambda_ModernExtensionIndexer_Tests.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_Lambda_ModernExtensionIndexer_Tests : CompilingTestBase
+{
+    // Modern extension indexers and the typeless-receivers feature don't currently meet:
+    //
+    //   - Instance indexers are not allowed inside `extension(T) { ... }` blocks (CS9282
+    //     ERR_ExtensionDisallowsMember). So no instance indexer can be reached.
+    //
+    //   - Element access via `expr[args]` on a typeless receiver is explicitly out of scope
+    //     per the proposal: dot-form only.
+    //
+    // The two tests below pin those facts. Same pattern as
+    // CollectionExpression_ModernExtensionIndexer_Tests.
+
+    [Fact]
+    public void InstanceIndexer_InExtensionBlock_OnFunc_NotAllowed()
+    {
+        var source = """
+            using System;
+
+            public static class Ext
+            {
+                extension(Func<int, int> f)
+                {
+                    public int this[int i] { get => f(i); }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (7,20): error CS9282: This member is not allowed in an extension block
+            //         public int this[int i] { get => f(i); }
+            Diagnostic(ErrorCode.ERR_ExtensionDisallowsMember, "this").WithLocation(7, 20));
+    }
+
+    [Fact]
+    public void IndexerAccess_OnLambda_BadUnaryOp()
+    {
+        // Element access via `[]` on a lambda is not in scope of this proposal. The lambda
+        // syntax also makes `(x => x)[0]` ambiguous to parse - here it parses as the lambda
+        // itself indexed, which produces a binding-time error since lambda has no indexer.
+        var source = """
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = (x => x)[0];
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (5,13): error CS0021: Cannot apply indexing with [] to an expression of type 'lambda expression'
+            //         _ = (x => x)[0];
+            Diagnostic(ErrorCode.ERR_BadIndexLHS, "(x => x)[0]").WithArguments("lambda expression").WithLocation(5, 13));
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/Lambda/Lambda_ModernExtensionMethod_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/Lambda/Lambda_ModernExtensionMethod_Tests.cs
@@ -1,0 +1,109 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_Lambda_ModernExtensionMethod_Tests : CompilingTestBase
+{
+    [Fact]
+    public void FuncTarget_Executes()
+    {
+        var source = """
+            using System;
+
+            public static class Ext
+            {
+                extension(Func<int, int> f)
+                {
+                    public int Apply(int arg) => f(arg);
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write((x => x * 3).Apply(4));
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "12").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void GenericExtensionBlock_Executes()
+    {
+        var source = """
+            using System;
+
+            public static class Ext
+            {
+                extension<T>(Func<T, T> f)
+                {
+                    public T Apply(T arg) => f(arg);
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(((int x) => x + 100).Apply(5));
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "105").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ActionExtension_Executes()
+    {
+        var source = """
+            using System;
+
+            public static class Ext
+            {
+                extension(Action a)
+                {
+                    public void RunIt() { a(); a(); a(); }
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    int n = 0;
+                    (() => n++).RunIt();
+                    System.Console.Write(n);
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "3").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void NoApplicableExtension_ReportsNoSuchMember()
+    {
+        var source = """
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = (x => x).DoesNotExist();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (5,22): error CS0117: 'lambda expression' does not contain a definition for 'DoesNotExist'
+            //         _ = (x => x).DoesNotExist();
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "DoesNotExist").WithArguments("lambda expression", "DoesNotExist").WithLocation(5, 22));
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/Lambda/Lambda_ModernExtensionProperty_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/Lambda/Lambda_ModernExtensionProperty_Tests.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_Lambda_ModernExtensionProperty_Tests : CompilingTestBase
+{
+    [Fact]
+    public void Property_OnFunc_Executes()
+    {
+        var source = """
+            using System;
+
+            public static class Ext
+            {
+                extension(Func<int, int> f)
+                {
+                    public int AppliedToFive => f(5);
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(((int x) => x * 2).AppliedToFive);
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "10").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void GenericProperty_OnFunc_Executes()
+    {
+        var source = """
+            using System;
+
+            public static class Ext
+            {
+                extension<T>(Func<T, T> f)
+                {
+                    public T AppliedToDefault => f(default!);
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(((int x) => x + 7).AppliedToDefault);
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "7").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Property_NoCandidateInScope_ReportsNoSuchMember()
+    {
+        var source = """
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = (x => x).Length;
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (5,22): error CS0117: 'lambda expression' does not contain a definition for 'Length'
+            //         _ = (x => x).Length;
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "Length").WithArguments("lambda expression", "Length").WithLocation(5, 22));
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/MethodGroup/MethodGroup_ClassicExtensionMethod_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/MethodGroup/MethodGroup_ClassicExtensionMethod_Tests.cs
@@ -1,0 +1,177 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_MethodGroup_ClassicExtensionMethod_Tests : CompilingTestBase
+{
+    [Fact]
+    public void StaticMethodGroup_FuncTarget_Executes()
+    {
+        // The headline scenario from the proposal: SomeMethod.Memoize() / SomeMethod.RunIt(...)
+        // The receiver is a method group; the extension applies to a delegate type.
+        var source = """
+            using System;
+
+            public static class Ext
+            {
+                public static int RunIt(this Func<int, int> f, int arg) => f(arg);
+            }
+
+            public class Goo
+            {
+                public static int Square(int x) => x * x;
+
+                public static void Main()
+                {
+                    System.Console.Write(Square.RunIt(5));
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "25").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void InstanceMethodGroup_FuncTarget_Executes()
+    {
+        var source = """
+            using System;
+
+            public static class Ext
+            {
+                public static int RunIt(this Func<int, int> f, int arg) => f(arg);
+            }
+
+            public class Goo
+            {
+                public int Inc(int x) => x + 1;
+
+                public static void Main()
+                {
+                    var g = new Goo();
+                    System.Console.Write(g.Inc.RunIt(10));
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "11").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void GenericExtension_OnFunc_Executes()
+    {
+        var source = """
+            using System;
+
+            public static class Ext
+            {
+                public static T Apply<T>(this Func<T, T> f, T arg) => f(arg);
+            }
+
+            public class Goo
+            {
+                public static int Triple(int x) => x * 3;
+
+                public static void Main()
+                {
+                    System.Console.Write(Triple.Apply(7));
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "21").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Memoize_Executes()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static Func<int, int> Memoize(this Func<int, int> f)
+                {
+                    var cache = new Dictionary<int, int>();
+                    return x => cache.TryGetValue(x, out var v) ? v : (cache[x] = f(x));
+                }
+            }
+
+            public class Goo
+            {
+                public static int Square(int x) => x * x;
+
+                public static void Main()
+                {
+                    var memoized = Square.Memoize();
+                    System.Console.Write(memoized(6));
+                    System.Console.Write(memoized(6));
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "3636").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void OverloadedMethodGroup_AmbiguousNaturalType_RoutesThroughTypelessPath()
+    {
+        // When the method group is overloaded, it has no natural type. Without the typeless-
+        // receiver feature, this would produce no candidate. With the feature, the lambda is
+        // target-typed against the extension's first parameter type and binds correctly.
+        var source = """
+            using System;
+
+            public static class Ext
+            {
+                public static int RunInt(this Func<int, int> f, int arg) => f(arg);
+            }
+
+            public class Goo
+            {
+                public static int Identity(int x) => x;
+                public static string Identity(string s) => s;
+
+                public static void Main()
+                {
+                    // Identity is overloaded; group has no natural type. Extension takes
+                    // Func<int,int> so target-typing picks the int overload.
+                    System.Console.Write(Identity.RunInt(42));
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "42").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void NoApplicableExtension_ReportsNoSuchMember()
+    {
+        var source = """
+            using System;
+
+            public static class Ext
+            {
+                public static int RunIt(this Func<int, int> f, int arg) => f(arg);
+            }
+
+            public class Goo
+            {
+                public static int Square(int x) => x * x;
+
+                public static void M()
+                {
+                    _ = Square.DoesNotExist();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (14,20): error CS0117: 'method group' does not contain a definition for 'DoesNotExist'
+            //         _ = Square.DoesNotExist();
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "DoesNotExist").WithArguments("method group", "DoesNotExist").WithLocation(14, 20));
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/MethodGroup/MethodGroup_ModernExtensionIndexer_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/MethodGroup/MethodGroup_ModernExtensionIndexer_Tests.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_MethodGroup_ModernExtensionIndexer_Tests : CompilingTestBase
+{
+    // Modern extension indexers and the typeless-receivers feature don't currently meet:
+    //
+    //   - Instance indexers are not allowed inside `extension(T) { ... }` blocks (CS9282
+    //     ERR_ExtensionDisallowsMember).
+    //
+    //   - Element access via `expr[args]` on a typeless receiver is explicitly out of scope
+    //     per the proposal: dot-form only.
+    //
+    // Same pattern as CollectionExpression / Lambda area indexer pin tests.
+
+    [Fact]
+    public void InstanceIndexer_InExtensionBlock_OnFunc_NotAllowed()
+    {
+        var source = """
+            using System;
+
+            public static class Ext
+            {
+                extension(Func<int, int> f)
+                {
+                    public int this[int i] { get => f(i); }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (7,20): error CS9282: This member is not allowed in an extension block
+            //         public int this[int i] { get => f(i); }
+            Diagnostic(ErrorCode.ERR_ExtensionDisallowsMember, "this").WithLocation(7, 20));
+    }
+
+    [Fact]
+    public void IndexerAccess_OnMethodGroup_BadIndexLHS()
+    {
+        var source = """
+            public class Goo
+            {
+                public static int Square(int x) => x * x;
+                public static void M()
+                {
+                    _ = Square[0];
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (6,13): error CS0021: Cannot apply indexing with [] to an expression of type 'method group'
+            //         _ = Square[0];
+            Diagnostic(ErrorCode.ERR_BadIndexLHS, "Square[0]").WithArguments("method group").WithLocation(6, 13));
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/MethodGroup/MethodGroup_ModernExtensionMethod_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/MethodGroup/MethodGroup_ModernExtensionMethod_Tests.cs
@@ -1,0 +1,87 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_MethodGroup_ModernExtensionMethod_Tests : CompilingTestBase
+{
+    [Fact]
+    public void StaticMethodGroup_FuncTarget_Executes()
+    {
+        var source = """
+            using System;
+
+            public static class Ext
+            {
+                extension(Func<int, int> f)
+                {
+                    public int RunIt(int arg) => f(arg);
+                }
+            }
+
+            public class Goo
+            {
+                public static int Square(int x) => x * x;
+
+                public static void Main()
+                {
+                    System.Console.Write(Square.RunIt(6));
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "36").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void GenericExtensionBlock_OnFunc_Executes()
+    {
+        var source = """
+            using System;
+
+            public static class Ext
+            {
+                extension<T>(Func<T, T> f)
+                {
+                    public T Apply(T arg) => f(arg);
+                }
+            }
+
+            public class Goo
+            {
+                public static int Negate(int x) => -x;
+
+                public static void Main()
+                {
+                    System.Console.Write(Negate.Apply(8));
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "-8").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void NoApplicableExtension_ReportsNoSuchMember()
+    {
+        var source = """
+            public class Goo
+            {
+                public static int Square(int x) => x * x;
+                public static void M()
+                {
+                    _ = Square.DoesNotExist();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (6,20): error CS0117: 'method group' does not contain a definition for 'DoesNotExist'
+            //         _ = Square.DoesNotExist();
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "DoesNotExist").WithArguments("method group", "DoesNotExist").WithLocation(6, 20));
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/MethodGroup/MethodGroup_ModernExtensionProperty_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/MethodGroup/MethodGroup_ModernExtensionProperty_Tests.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_MethodGroup_ModernExtensionProperty_Tests : CompilingTestBase
+{
+    [Fact]
+    public void Property_OnFunc_Executes()
+    {
+        var source = """
+            using System;
+
+            public static class Ext
+            {
+                extension(Func<int, int> f)
+                {
+                    public int AppliedToFour => f(4);
+                }
+            }
+
+            public class Goo
+            {
+                public static int Inc(int x) => x + 1;
+
+                public static void Main()
+                {
+                    System.Console.Write(Inc.AppliedToFour);
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "5").VerifyDiagnostics();
+    }
+
+    // TODO: A generic-extension-property test (extension<T>(Func<T,T>) Property) accessed on a
+    // method group hits a Debug.Fail in OverloadResolutionResult.TypeInferenceFailed -> non-
+    // serializable diagnostic argument. Same root cause as the deferred empty-collection +
+    // generic property test; tracked separately, outside this PR's scope.
+
+    [Fact]
+    public void Property_NoCandidateInScope_ReportsNoSuchMember()
+    {
+        var source = """
+            public class Goo
+            {
+                public static int Square(int x) => x * x;
+                public static void M()
+                {
+                    _ = Square.Length;
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (6,20): error CS0117: 'method group' does not contain a definition for 'Length'
+            //         _ = Square.Length;
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "Length").WithArguments("method group", "Length").WithLocation(6, 20));
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/NewExpression/NewExpression_ClassicExtensionMethod_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/NewExpression/NewExpression_ClassicExtensionMethod_Tests.cs
@@ -1,0 +1,112 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_NewExpression_ClassicExtensionMethod_Tests : CompilingTestBase
+{
+    [Fact]
+    public void NewParenless_Executes()
+    {
+        var source = """
+            public class Bag
+            {
+                public int N;
+            }
+
+            public static class Ext
+            {
+                public static int Doubled(this Bag b) => b.N * 2;
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(new().Doubled());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "0").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void NewWithArgs_Executes()
+    {
+        var source = """
+            public class Bag
+            {
+                public int N;
+                public Bag(int n) { N = n; }
+            }
+
+            public static class Ext
+            {
+                public static int Doubled(this Bag b) => b.N * 2;
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(new(7).Doubled());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "14").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void NewWithArgs_ConstructorOverloadResolution_Executes()
+    {
+        var source = """
+            public class Bag
+            {
+                public int N;
+                public Bag() { N = 0; }
+                public Bag(int n, int m) { N = n + m; }
+            }
+
+            public static class Ext
+            {
+                public static int N(this Bag b) => b.N;
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(new(3, 4).N());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "7").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void NoApplicableExtension_ReportsNoSuchMember()
+    {
+        // No extension is in scope. The receiver enters extension lookup via the typeless path,
+        // finds nothing, and reports "new() does not contain a definition for ...".
+        var source = """
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = new().DoesNotExist();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (5,19): error CS0117: 'new()' does not contain a definition for 'DoesNotExist'
+            //         _ = new().DoesNotExist();
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "DoesNotExist").WithArguments("new()", "DoesNotExist").WithLocation(5, 19));
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/NewExpression/NewExpression_ModernExtensionIndexer_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/NewExpression/NewExpression_ModernExtensionIndexer_Tests.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_NewExpression_ModernExtensionIndexer_Tests : CompilingTestBase
+{
+    // Same pattern as the CollectionExpression / Lambda / MethodGroup indexer pin PRs:
+    // instance indexers in extension(T) blocks aren't allowed (CS9282), and `[]` on a typeless
+    // receiver is out of scope per the proposal.
+
+    [Fact]
+    public void InstanceIndexer_InExtensionBlock_NotAllowed()
+    {
+        var source = """
+            public class Bag { public int N; }
+            public static class Ext
+            {
+                extension(Bag b)
+                {
+                    public int this[int i] { get => b.N + i; }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (6,20): error CS9282: This member is not allowed in an extension block
+            //         public int this[int i] { get => b.N + i; }
+            Diagnostic(ErrorCode.ERR_ExtensionDisallowsMember, "this").WithLocation(6, 20));
+    }
+
+    [Fact]
+    public void IndexerAccess_OnNew_ReportsBadIndexLHS()
+    {
+        // `[]` on `new()` doesn't enter the typeless extension path. Without a target type,
+        // `new()` reports the existing diagnostic.
+        var source = """
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = new()[0];
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (5,13): error CS8754: There is no target type for 'new()'
+            //         _ = new()[0];
+            Diagnostic(ErrorCode.ERR_ImplicitObjectCreationNoTargetType, "new()").WithArguments("new()").WithLocation(5, 13));
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/NewExpression/NewExpression_ModernExtensionMethod_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/NewExpression/NewExpression_ModernExtensionMethod_Tests.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_NewExpression_ModernExtensionMethod_Tests : CompilingTestBase
+{
+    [Fact]
+    public void NewParenless_Executes()
+    {
+        var source = """
+            public class Bag { public int N; }
+
+            public static class Ext
+            {
+                extension(Bag b)
+                {
+                    public int Doubled() => b.N * 2;
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(new().Doubled());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "0").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void NewWithArgs_Executes()
+    {
+        var source = """
+            public class Bag { public int N; public Bag(int n) { N = n; } }
+
+            public static class Ext
+            {
+                extension(Bag b)
+                {
+                    public int Triple() => b.N * 3;
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(new(5).Triple());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "15").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void NoApplicableExtension_ReportsNoSuchMember()
+    {
+        var source = """
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = new().DoesNotExist();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (5,19): error CS0117: 'new()' does not contain a definition for 'DoesNotExist'
+            //         _ = new().DoesNotExist();
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "DoesNotExist").WithArguments("new()", "DoesNotExist").WithLocation(5, 19));
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/NewExpression/NewExpression_ModernExtensionProperty_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/NewExpression/NewExpression_ModernExtensionProperty_Tests.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_NewExpression_ModernExtensionProperty_Tests : CompilingTestBase
+{
+    [Fact]
+    public void NewParenless_Property_Executes()
+    {
+        var source = """
+            public class Bag { public int N; }
+
+            public static class Ext
+            {
+                extension(Bag b)
+                {
+                    public int Doubled => b.N * 2;
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(new().Doubled);
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "0").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void NewWithArgs_Property_Executes()
+    {
+        var source = """
+            public class Bag { public int N; public Bag(int n) { N = n; } }
+
+            public static class Ext
+            {
+                extension(Bag b)
+                {
+                    public int Triple => b.N * 3;
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(new(4).Triple);
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "12").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Property_NoCandidateInScope_ReportsNoSuchMember()
+    {
+        var source = """
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = new().DoesNotExist;
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (5,19): error CS0117: 'new()' does not contain a definition for 'DoesNotExist'
+            //         _ = new().DoesNotExist;
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "DoesNotExist").WithArguments("new()", "DoesNotExist").WithLocation(5, 19));
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/NullLiteral/NullLiteral_ClassicExtensionMethod_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/NullLiteral/NullLiteral_ClassicExtensionMethod_Tests.cs
@@ -1,0 +1,127 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_NullLiteral_ClassicExtensionMethod_Tests : CompilingTestBase
+{
+    [Fact]
+    public void NullToReferenceType_Executes()
+    {
+        var source = """
+            public static class Ext
+            {
+                public static string OrEmpty(this string s) => s ?? "empty";
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(null.OrEmpty());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "empty").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void NullToNullableValueType_Executes()
+    {
+        var source = """
+            public static class Ext
+            {
+                public static int OrZero(this int? n) => n ?? 0;
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(null.OrZero());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "0").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void OverloadResolution_PrefersMoreSpecific()
+    {
+        // null is convertible to both string and object; overload resolution picks the more
+        // specific candidate (string).
+        var source = """
+            public static class Ext
+            {
+                public static string Tag(this object o) => "object";
+                public static string Tag(this string s) => "string";
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(null.Tag());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "string").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Ambiguous_TwoUnrelatedReferenceTypes()
+    {
+        // null is convertible to two unrelated reference types; overload resolution reports an
+        // ambiguity.
+        var source = """
+            public class Bag1 { }
+            public class Bag2 { }
+
+            public static class ExtA
+            {
+                public static int M(this Bag1 b) => 1;
+            }
+            public static class ExtB
+            {
+                public static int M(this Bag2 b) => 2;
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    _ = null.M();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (17,18): error CS0121: The call is ambiguous between the following methods or properties: 'ExtA.M(Bag1)' and 'ExtB.M(Bag2)'
+            //         _ = null.M();
+            Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("ExtA.M(Bag1)", "ExtB.M(Bag2)").WithLocation(17, 18));
+    }
+
+    [Fact]
+    public void NoApplicableExtension_ReportsNoSuchMember()
+    {
+        var source = """
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = null.DoesNotExist();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (5,18): error CS0117: '<null>' does not contain a definition for 'DoesNotExist'
+            //         _ = null.DoesNotExist();
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "DoesNotExist").WithArguments("<null>", "DoesNotExist").WithLocation(5, 18));
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/NullLiteral/NullLiteral_ModernExtensionIndexer_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/NullLiteral/NullLiteral_ModernExtensionIndexer_Tests.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_NullLiteral_ModernExtensionIndexer_Tests : CompilingTestBase
+{
+    // Same pattern as previous indexer pin PRs: instance indexers in extension(T) blocks
+    // aren't allowed (CS9282), and `[]` on a typeless receiver is out of scope per the proposal.
+
+    [Fact]
+    public void InstanceIndexer_InExtensionBlock_OnString_NotAllowed()
+    {
+        var source = """
+            public static class Ext
+            {
+                extension(string s)
+                {
+                    public char this[int i] { get => s[i]; }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (5,21): error CS9282: This member is not allowed in an extension block
+            //         public char this[int i] { get => s[i]; }
+            Diagnostic(ErrorCode.ERR_ExtensionDisallowsMember, "this").WithLocation(5, 21));
+    }
+
+    [Fact]
+    public void IndexerAccess_OnNull_BadIndexLHS()
+    {
+        var source = """
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = null[0];
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (5,13): error CS0021: Cannot apply indexing with [] to an expression of type '<null>'
+            //         _ = null[0];
+            Diagnostic(ErrorCode.ERR_BadIndexLHS, "null[0]").WithArguments("<null>").WithLocation(5, 13));
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/NullLiteral/NullLiteral_ModernExtensionMethod_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/NullLiteral/NullLiteral_ModernExtensionMethod_Tests.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_NullLiteral_ModernExtensionMethod_Tests : CompilingTestBase
+{
+    [Fact]
+    public void NullToString_Executes()
+    {
+        var source = """
+            public static class Ext
+            {
+                extension(string s)
+                {
+                    public string OrEmpty() => s ?? "empty";
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(null.OrEmpty());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "empty").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void NullToNullable_Executes()
+    {
+        var source = """
+            public static class Ext
+            {
+                extension(int? n)
+                {
+                    public int OrZero() => n ?? 0;
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(null.OrZero());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "0").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void NoApplicableExtension_ReportsNoSuchMember()
+    {
+        var source = """
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = null.DoesNotExist();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (5,18): error CS0117: '<null>' does not contain a definition for 'DoesNotExist'
+            //         _ = null.DoesNotExist();
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "DoesNotExist").WithArguments("<null>", "DoesNotExist").WithLocation(5, 18));
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/NullLiteral/NullLiteral_ModernExtensionProperty_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/NullLiteral/NullLiteral_ModernExtensionProperty_Tests.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_NullLiteral_ModernExtensionProperty_Tests : CompilingTestBase
+{
+    [Fact]
+    public void Property_NullToString_Executes()
+    {
+        var source = """
+            public static class Ext
+            {
+                extension(string s)
+                {
+                    public string OrEmpty => s ?? "empty";
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(null.OrEmpty);
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "empty").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Property_NoCandidateInScope_ReportsNoSuchMember()
+    {
+        var source = """
+            public class Goo
+            {
+                public static void M()
+                {
+                    _ = null.DoesNotExist;
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (5,18): error CS0117: '<null>' does not contain a definition for 'DoesNotExist'
+            //         _ = null.DoesNotExist;
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "DoesNotExist").WithArguments("<null>", "DoesNotExist").WithLocation(5, 18));
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/Smoke_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/Smoke_Tests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
 [CompilerTrait(CompilerFeature.Extensions)]
 public sealed class ExtensionMembersOnTypelessReceivers_Smoke_Tests : CompilingTestBase
 {
-    [Fact(Skip = "TODO: collection-expression receiver triggers AssertUnderlyingConversionsCheckedRecursive failure during coerceArgument; the CollectionExpression conversion produced by ClassifyImplicitConversionFromExpression is reaching CreateConversion via a path that does not mark its element-wise underlying conversions as checked. Needs investigation of how the receiver flows from BindInstanceMemberAccess through BindInvocationExpressionContinued's CheckAndCoerceArguments. Tracking as the headline scenario for the feature; remaining smoke tests prove the rule itself binds correctly for other typeless forms.")]
+    [Fact]
     public void CollectionExpression_ClassicExtensionMethod_Executes()
     {
         var source = """
@@ -39,7 +39,7 @@ public sealed class ExtensionMembersOnTypelessReceivers_Smoke_Tests : CompilingT
         CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "3").VerifyDiagnostics();
     }
 
-    [Fact]
+    [Fact(Skip = "TODO: enable null-literal receiver in Phase 2 NullLiteral area PRs.")]
     public void NullLiteral_ClassicExtensionMethod_Executes()
     {
         var source = """
@@ -59,7 +59,7 @@ public sealed class ExtensionMembersOnTypelessReceivers_Smoke_Tests : CompilingT
         CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "empty").VerifyDiagnostics();
     }
 
-    [Fact]
+    [Fact(Skip = "TODO: enable lambda-without-natural-type receiver in Phase 2 Lambda area PRs.")]
     public void Lambda_ClassicExtensionMethod_Executes()
     {
         var source = """

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/Smoke_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/Smoke_Tests.cs
@@ -39,7 +39,7 @@ public sealed class ExtensionMembersOnTypelessReceivers_Smoke_Tests : CompilingT
         CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "3").VerifyDiagnostics();
     }
 
-    [Fact(Skip = "TODO: enable null-literal receiver in Phase 2 NullLiteral area PRs.")]
+    [Fact]
     public void NullLiteral_ClassicExtensionMethod_Executes()
     {
         var source = """

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/Smoke_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/Smoke_Tests.cs
@@ -1,0 +1,129 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+[CompilerTrait(CompilerFeature.Extensions)]
+public sealed class ExtensionMembersOnTypelessReceivers_Smoke_Tests : CompilingTestBase
+{
+    [Fact(Skip = "TODO: collection-expression receiver triggers AssertUnderlyingConversionsCheckedRecursive failure during coerceArgument; the CollectionExpression conversion produced by ClassifyImplicitConversionFromExpression is reaching CreateConversion via a path that does not mark its element-wise underlying conversions as checked. Needs investigation of how the receiver flows from BindInstanceMemberAccess through BindInvocationExpressionContinued's CheckAndCoerceArguments. Tracking as the headline scenario for the feature; remaining smoke tests prove the rule itself binds correctly for other typeless forms.")]
+    public void CollectionExpression_ClassicExtensionMethod_Executes()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static int CountIt<T>(this IEnumerable<T> source)
+                {
+                    int count = 0;
+                    foreach (var _ in source) count++;
+                    return count;
+                }
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write([1, 2, 3].CountIt());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "3").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void NullLiteral_ClassicExtensionMethod_Executes()
+    {
+        var source = """
+            public static class Ext
+            {
+                public static string OrEmpty(this string s) => s ?? "empty";
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write(null.OrEmpty());
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "empty").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Lambda_ClassicExtensionMethod_Executes()
+    {
+        var source = """
+            using System;
+
+            public static class Ext
+            {
+                public static int Apply(this Func<int, int> f, int arg) => f(arg);
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    System.Console.Write((x => x * 2).Apply(5));
+                }
+            }
+            """;
+        CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "10").VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ThrowExpression_RemainsError()
+    {
+        var source = """
+            public static class Ext
+            {
+                public static int CountIt(this object obj) => 0;
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    _ = (throw new System.Exception()).CountIt();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (10,14): error CS8115: A throw expression is not allowed in this context.
+            Diagnostic(ErrorCode.ERR_ThrowMisplaced, "throw").WithLocation(10, 14));
+    }
+
+    [Fact]
+    public void LangVersion_CSharp14_ReportsFeaturePreviewError()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public static class Ext
+            {
+                public static int CountIt<T>(this IEnumerable<T> source) => 0;
+            }
+
+            public class Goo
+            {
+                public static void Main()
+                {
+                    _ = [1, 2, 3].CountIt();
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.Regular14).VerifyDiagnostics(
+            // (12,13): error CS9202: Feature 'extension members on typeless receivers' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "[1, 2, 3].CountIt").WithArguments("extension members on typeless receivers").WithLocation(12, 13));
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/Smoke_Tests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionMembersOnTypelessReceivers/Smoke_Tests.cs
@@ -59,7 +59,7 @@ public sealed class ExtensionMembersOnTypelessReceivers_Smoke_Tests : CompilingT
         CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, expectedOutput: "empty").VerifyDiagnostics();
     }
 
-    [Fact(Skip = "TODO: enable lambda-without-natural-type receiver in Phase 2 Lambda area PRs.")]
+    [Fact]
     public void Lambda_ClassicExtensionMethod_Executes()
     {
         var source = """

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
@@ -3459,10 +3459,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 }
                 """;
             var comp = CreateCompilation(new[] { source, s_collectionExtensions });
-            comp.VerifyEmitDiagnostics(
-                // 0.cs(9,17): error CS9176: There is no target type for the collection expression.
-                //         var a = [1, 2, 3].AsArray();
-                Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[1, 2, 3]").WithLocation(9, 17));
+            // Under the extension-members-on-typeless-receivers feature, `[1, 2, 3].AsArray()`
+            // now succeeds: T is inferred as int via the collection-expression conversion to T[].
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -3500,10 +3499,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 }
                 """;
             var comp = CreateCompilation(source);
-            comp.VerifyEmitDiagnostics(
-                // (27,17): error CS9176: There is no target type for the collection expression.
-                //         var b = [4].AsCollection();
-                Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[4]").WithLocation(27, 17));
+            // Under the extension-members-on-typeless-receivers feature, `[4].AsCollection()`
+            // now succeeds: T is inferred as int via the collection-expression conversion to S<T>.
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -3530,13 +3528,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 }
                 """;
             var comp = CreateCompilation(source);
+            // Under the extension-members-on-typeless-receivers feature, `[4].AsCollection()` no
+            // longer reports ERR_CollectionExpressionNoTargetType at the receiver: instead, type
+            // inference is run on the full call (with the collection-expression as the first
+            // argument), and reports the same ERR_CantInferMethTypeArgs as the explicit-form call
+            // because S<T> here implements the non-generic IEnumerable.
             comp.VerifyEmitDiagnostics(
                 // (15,13): error CS0411: The type arguments for method 'Program.AsCollection<T>(S<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         _ = AsCollection([1, 2, 3]);
                 Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "AsCollection").WithArguments("Program.AsCollection<T>(S<T>)").WithLocation(15, 13),
-                // (16,13): error CS9176: There is no target type for the collection expression.
+                // (16,17): error CS0411: The type arguments for method 'Program.AsCollection<T>(S<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         _ = [4].AsCollection();
-                Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[4]").WithLocation(16, 13));
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "AsCollection").WithArguments("Program.AsCollection<T>(S<T>)").WithLocation(16, 17));
         }
 
         [Fact]
@@ -4810,11 +4813,9 @@ static class Program
 }
 """;
             var comp = CreateCompilation(source);
-            comp.VerifyEmitDiagnostics(
-                // (27,17): error CS9176: There is no target type for the collection expression.
-                //         var b = [4].AsCollection();
-                Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[4]").WithLocation(27, 17)
-                );
+            // Under the extension-members-on-typeless-receivers feature, `[4].AsCollection()`
+            // succeeds: T is inferred via the collection-expression conversion to S<T>?.
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -4832,10 +4833,16 @@ static class Program
                 }
                 """;
             var comp = CreateCompilation(source);
+            // Under the extension-members-on-typeless-receivers feature, `[].GetHashCode()` no
+            // longer reports ERR_CollectionExpressionNoTargetType: the collection-expression
+            // receiver enters the extension-method-search path, finds no `GetHashCode` extension,
+            // and reports ERR_NoSuchMember instead. The `?.` and `[]` operators on a typeless
+            // collection expression are out of scope per the spec, so they continue to produce
+            // ERR_CollectionExpressionNoTargetType.
             comp.VerifyEmitDiagnostics(
-                // (5,9): error CS9176: There is no target type for the collection expression.
+                // (5,12): error CS0117: 'collection expression' does not contain a definition for 'GetHashCode'
                 //         [].GetHashCode();
-                Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[]").WithLocation(5, 9),
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "GetHashCode").WithArguments("collection expression", "GetHashCode").WithLocation(5, 12),
                 // (6,9): error CS9176: There is no target type for the collection expression.
                 //         []?.GetHashCode();
                 Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[]").WithLocation(6, 9),
@@ -4859,10 +4866,12 @@ static class Program
                 }
                 """;
             var comp = CreateCompilation(source);
+            // Same pattern as MemberAccess_01: `[1].GetHashCode()` enters the extension-method
+            // search path under the new feature; `?.` and `[]` are out of scope.
             comp.VerifyEmitDiagnostics(
-                // (5,9): error CS9176: There is no target type for the collection expression.
+                // (5,13): error CS0117: 'collection expression' does not contain a definition for 'GetHashCode'
                 //         [1].GetHashCode();
-                Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[1]").WithLocation(5, 9),
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "GetHashCode").WithArguments("collection expression", "GetHashCode").WithLocation(5, 13),
                 // (6,9): error CS9176: There is no target type for the collection expression.
                 //         [2]?.GetHashCode();
                 Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[2]").WithLocation(6, 9),
@@ -4886,10 +4895,11 @@ static class Program
                 }
                 """;
             var comp = CreateCompilation(source);
+            // Same pattern as MemberAccess_01 / _02 (with leading `_ =`).
             comp.VerifyEmitDiagnostics(
-                // (5,13): error CS9176: There is no target type for the collection expression.
+                // (5,16): error CS0117: 'collection expression' does not contain a definition for 'GetHashCode'
                 //         _ = [].GetHashCode();
-                Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[]").WithLocation(5, 13),
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "GetHashCode").WithArguments("collection expression", "GetHashCode").WithLocation(5, 16),
                 // (6,13): error CS9176: There is no target type for the collection expression.
                 //         _ = []?.GetHashCode();
                 Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[]").WithLocation(6, 13),
@@ -4913,10 +4923,11 @@ static class Program
                 }
                 """;
             var comp = CreateCompilation(source);
+            // Same pattern as MemberAccess_02 (with leading `_ =`).
             comp.VerifyEmitDiagnostics(
-                // (5,13): error CS9176: There is no target type for the collection expression.
+                // (5,17): error CS0117: 'collection expression' does not contain a definition for 'GetHashCode'
                 //         _ = [1].GetHashCode();
-                Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[1]").WithLocation(5, 13),
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "GetHashCode").WithArguments("collection expression", "GetHashCode").WithLocation(5, 17),
                 // (6,13): error CS9176: There is no target type for the collection expression.
                 //         _ = [2]?.GetHashCode();
                 Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[2]").WithLocation(6, 13),


### PR DESCRIPTION
Stacked on #83382. Two tests covering modern extension properties on conditional expressions.

This pull request and its description were written by Isaac.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83383)