### PR TITLE
[Code review] Compiler changes for extension members on typeless receivers

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8300,21 +8300,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
 #nullable enable
         /// <summary>
-        /// A method-group receiver is "valid" for the typeless-extension-receiver path when its
-        /// lookup was viable and produced at least one candidate. This is the same conceptual
-        /// gate that <see cref="GetUniqueSignatureFromMethodGroup(BoundMethodGroup, out bool)"/>
-        /// applies to the instance-method branch when computing whether a method group could
-        /// naturally have a delegate type (the inlined <c>ResultKind == LookupResultKind.Viable</c>
-        /// guard around its instance-methods loop). The natural-type code adds a
-        /// signature-uniqueness check on top, which we don't need here. Inaccessible lookups,
-        /// ambiguous lookups, and empty / errored method groups (e.g. inaccessible nested-type
-        /// lookups that fell through to extension search and found nothing) fall back to the
-        /// existing diagnostic instead of being routed through the new feature.
-        /// </summary>
-        private static bool IsValidMethodGroupReceiver(BoundMethodGroup methodGroup)
-            => methodGroup.ResultKind == LookupResultKind.Viable && methodGroup.Methods.Length > 0;
-
-        /// <summary>
         /// If the receiver expression has no type and is a supported typeless form, route the
         /// member access through extension lookup (the "extension members on typeless receivers"
         /// feature). Returns null if the receiver is not a supported typeless form, leaving the
@@ -8355,7 +8340,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.UnconvertedSwitchExpression:
                 case BoundKind.TupleLiteral:
                     break;
-                case BoundKind.MethodGroup when IsValidMethodGroupReceiver((BoundMethodGroup)boundLeft):
+                // A method-group receiver is "valid" for the typeless-extension-receiver path when
+                // its lookup was viable and produced at least one candidate. This is the same
+                // conceptual gate that GetUniqueSignatureFromMethodGroup applies to the instance-
+                // method branch when computing whether a method group could naturally have a
+                // delegate type (the inlined ResultKind == LookupResultKind.Viable guard around
+                // its instance-methods loop). The natural-type code adds a signature-uniqueness
+                // check on top, which we don't need here. Inaccessible lookups, ambiguous lookups,
+                // and empty / errored method groups (e.g. inaccessible nested-type lookups that
+                // fell through to extension search and found nothing) fall back to the existing
+                // diagnostic instead of being routed through the new feature.
+                case BoundKind.MethodGroup when boundLeft is BoundMethodGroup { ResultKind: LookupResultKind.Viable, Methods.Length: > 0 }:
                     break;
                 case BoundKind.Literal when boundLeft.IsLiteralNull():
                     break;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8300,14 +8300,16 @@ namespace Microsoft.CodeAnalysis.CSharp
 
 #nullable enable
         /// <summary>
-        /// A method-group receiver is "valid" for the typeless-extension-receiver path when it has
-        /// at least one candidate method and no lookup error. Empty / errored method groups
-        /// (produced when an inaccessible nested-type lookup or other failed lookup falls through
-        /// to extension-method search and finds nothing) should fall back to the existing
-        /// diagnostic instead of being routed through the new feature.
+        /// A method-group receiver is "valid" for the typeless-extension-receiver path when its
+        /// lookup was viable and produced at least one candidate. This is the same gate that
+        /// <see cref="GetMethodGroupDelegateType(BoundMethodGroup)"/> uses to decide whether a
+        /// method group could naturally have a delegate type. Inaccessible lookups, ambiguous
+        /// lookups, and empty / errored method groups (e.g. inaccessible nested-type lookups that
+        /// fell through to extension search and found nothing) fall back to the existing diagnostic
+        /// instead of being routed through the new feature.
         /// </summary>
         private static bool IsValidMethodGroupReceiver(BoundMethodGroup methodGroup)
-            => methodGroup.Methods.Length > 0 && methodGroup.LookupError is null;
+            => methodGroup.ResultKind == LookupResultKind.Viable && methodGroup.Methods.Length > 0;
 
         /// <summary>
         /// If the receiver expression has no type and is a supported typeless form, route the

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8301,12 +8301,15 @@ namespace Microsoft.CodeAnalysis.CSharp
 #nullable enable
         /// <summary>
         /// A method-group receiver is "valid" for the typeless-extension-receiver path when its
-        /// lookup was viable and produced at least one candidate. This is the same gate that
-        /// <see cref="GetMethodGroupDelegateType(BoundMethodGroup)"/> uses to decide whether a
-        /// method group could naturally have a delegate type. Inaccessible lookups, ambiguous
-        /// lookups, and empty / errored method groups (e.g. inaccessible nested-type lookups that
-        /// fell through to extension search and found nothing) fall back to the existing diagnostic
-        /// instead of being routed through the new feature.
+        /// lookup was viable and produced at least one candidate. This is the same conceptual
+        /// gate that <see cref="GetUniqueSignatureFromMethodGroup(BoundMethodGroup, out bool)"/>
+        /// applies to the instance-method branch when computing whether a method group could
+        /// naturally have a delegate type (the inlined <c>ResultKind == LookupResultKind.Viable</c>
+        /// guard around its instance-methods loop). The natural-type code adds a
+        /// signature-uniqueness check on top, which we don't need here. Inaccessible lookups,
+        /// ambiguous lookups, and empty / errored method groups (e.g. inaccessible nested-type
+        /// lookups that fell through to extension search and found nothing) fall back to the
+        /// existing diagnostic instead of being routed through the new feature.
         /// </summary>
         private static bool IsValidMethodGroupReceiver(BoundMethodGroup methodGroup)
             => methodGroup.ResultKind == LookupResultKind.Viable && methodGroup.Methods.Length > 0;
@@ -8360,15 +8363,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return null;
             }
 
-            var typeArgumentsSyntax = right.Kind() == SyntaxKind.GenericName
-                ? ((GenericNameSyntax)right).TypeArgumentList.Arguments
-                : default(SeparatedSyntaxList<TypeSyntax>);
-            var typeArgumentsWithAnnotations = typeArgumentsSyntax.Count > 0
-                ? BindTypeArguments(typeArgumentsSyntax, diagnostics)
-                : default(ImmutableArray<TypeWithAnnotations>);
-            var rightName = right.Identifier.ValueText;
-            var rightArity = right.Arity;
-
             // Only route through the new feature when there is at least one extension member
             // candidate by this name in scope. Without this check, every typo on a typeless
             // receiver (e.g. `(() => {}).GetType()`) would emit a misleading "feature is in
@@ -8377,6 +8371,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             // lets the caller's existing kind-specific rejections (ERR_BadUnaryOp on a lambda,
             // ERR_BadOpOnNullOrDefaultOrNew on default, ERR_CollectionExpressionNoTargetType
             // through BindToNaturalType, etc.) produce their pre-feature diagnostics.
+            var rightName = right.Identifier.ValueText;
+            var rightArity = right.Arity;
             if (!HasExtensionMemberCandidateInScope(rightName, rightArity))
             {
                 return null;
@@ -8388,6 +8384,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             // language version, even when the version diagnostic is reported.
             MessageID.IDS_FeatureExtensionMembersOnTypelessReceivers.CheckFeatureAvailability(diagnostics, node);
 
+            var typeArgumentsSyntax = right is GenericNameSyntax { TypeArgumentList.Arguments: var arguments } ? arguments : default;
+            var typeArgumentsWithAnnotations = typeArgumentsSyntax.Count > 0 ? BindTypeArguments(typeArgumentsSyntax, diagnostics) : default;
             boundLeft = CheckValue(boundLeft, BindValueKind.RValue, diagnostics);
             return BindInstanceMemberAccess(
                 node, right, boundLeft, rightName, rightArity,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -7876,6 +7876,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(node != null);
             Debug.Assert(boundLeft != null);
 
+            // Extension members on typeless receivers: when the receiver expression has no type
+            // and is one of the supported typeless forms, route the member access through
+            // extension lookup. This check runs BEFORE MakeMemberAccessValue, which would
+            // otherwise force unconverted typeless forms into error-typed wrappers via
+            // BindToNaturalType, and BEFORE the default-literal / unbound-lambda / null-literal
+            // early rejections below. The feature-availability check is performed inside the
+            // helper.
+            // See https://github.com/dotnet/csharplang/blob/main/proposals/extension-members-on-typeless-receivers.md
+            if (TryBindMemberAccessOnTypelessReceiver(node, boundLeft, right, invoked, indexed, diagnostics) is { } typelessExtensionResult)
+            {
+                return typelessExtensionResult;
+            }
+
             boundLeft = MakeMemberAccessValue(boundLeft, diagnostics);
 
             TypeSymbol leftType = boundLeft.Type;
@@ -8249,7 +8262,19 @@ namespace Microsoft.CodeAnalysis.CSharp
         private BoundExpression GetExtensionMemberAccess(SyntaxNode syntax, BoundExpression? receiver, Symbol extensionMember, BindingDiagnosticBag diagnostics)
         {
             MessageID.IDS_FeatureExtensions.CheckFeatureAvailability(diagnostics, syntax);
-            receiver = ReplaceTypeOrValueReceiver(receiver, useType: extensionMember.IsStatic, diagnostics);
+
+            // For extension members on typeless receivers (e.g. `[1, 2, 3].First` where `First` is
+            // an extension property), skip ReplaceTypeOrValueReceiver. Its default branch calls
+            // BindToNaturalType, which destructively converts typeless forms (collection expression,
+            // new(), conditional / switch with no common type, tuple, default) into error-recovery
+            // wrappers and reports ERR_CollectionExpressionNoTargetType / similar. The conversion
+            // is applied below by CheckAndConvertExtensionReceiver against the extension's declared
+            // receiver parameter. The function's named purpose (replacing TypeOrValueExpression or
+            // unwrapping QueryClause) does not apply since both wrappers always have a type.
+            if (receiver is not { Type: null })
+            {
+                receiver = ReplaceTypeOrValueReceiver(receiver, useType: extensionMember.IsStatic, diagnostics);
+            }
 
             switch (extensionMember)
             {
@@ -8270,6 +8295,93 @@ namespace Microsoft.CodeAnalysis.CSharp
                 default:
                     throw ExceptionUtilities.UnexpectedValue(extensionMember.Kind);
             }
+        }
+#nullable disable
+
+#nullable enable
+        /// <summary>
+        /// A method-group receiver is "valid" for the typeless-extension-receiver path when it has
+        /// at least one candidate method and no lookup error. Empty / errored method groups
+        /// (produced when an inaccessible nested-type lookup or other failed lookup falls through
+        /// to extension-method search and finds nothing) should fall back to the existing
+        /// diagnostic instead of being routed through the new feature.
+        /// </summary>
+        private static bool IsValidMethodGroupReceiver(BoundMethodGroup methodGroup)
+            => methodGroup.Methods.Length > 0 && methodGroup.LookupError is null;
+
+        /// <summary>
+        /// If the receiver expression has no type and is a supported typeless form, route the
+        /// member access through extension lookup (the "extension members on typeless receivers"
+        /// feature). Returns null if the receiver is not a supported typeless form, leaving the
+        /// caller to fall back to the existing behavior. The feature-availability check reports
+        /// <c>ERR_FeatureInPreview</c> when the language version is too low but binding continues
+        /// either way, so the SemanticModel and downstream features see the call as bound.
+        /// </summary>
+        /// <remarks>
+        /// See <see href="https://github.com/dotnet/csharplang/blob/main/proposals/extension-members-on-typeless-receivers.md"/>.
+        /// </remarks>
+        private BoundExpression? TryBindMemberAccessOnTypelessReceiver(
+            SyntaxNode node,
+            BoundExpression boundLeft,
+            SimpleNameSyntax right,
+            bool invoked,
+            bool indexed,
+            BindingDiagnosticBag diagnostics)
+        {
+            // Receiver must have no type and be one of the receiver categories supported by the
+            // proposal: collection expression, target-typed `new()` / `new(args)`, conditional /
+            // switch with no common arm type, lambda without natural type, method group, tuple
+            // literal with at least one typeless element, default literal, or null literal.
+            // Anything else (e.g. BoundBaseReference when there is no base class, BoundPropertyGroup
+            // for COM indexed properties, throw expressions, namespace / type expressions, bad
+            // expressions, expressions already in error state) falls back to existing behavior so
+            // pre-existing diagnostics are preserved.
+            if (boundLeft.Type is not null)
+            {
+                return null;
+            }
+            if (boundLeft.HasErrors)
+            {
+                return null;
+            }
+            switch (boundLeft.Kind)
+            {
+                case BoundKind.UnconvertedCollectionExpression:
+                case BoundKind.UnboundLambda:
+                case BoundKind.UnconvertedObjectCreationExpression:
+                case BoundKind.DefaultLiteral:
+                case BoundKind.UnconvertedConditionalOperator:
+                case BoundKind.UnconvertedSwitchExpression:
+                case BoundKind.TupleLiteral:
+                    break;
+                case BoundKind.MethodGroup when IsValidMethodGroupReceiver((BoundMethodGroup)boundLeft):
+                    break;
+                case BoundKind.Literal when boundLeft.IsLiteralNull():
+                    break;
+                default:
+                    return null;
+            }
+
+            // Feature-availability check reports ERR_FeatureInPreview when the language version is
+            // too low. Binding continues regardless, matching the established convention in this
+            // file - so the SemanticModel and downstream features see the call as bound on every
+            // language version, even when the version diagnostic is reported.
+            MessageID.IDS_FeatureExtensionMembersOnTypelessReceivers.CheckFeatureAvailability(diagnostics, node);
+
+            var typeArgumentsSyntax = right.Kind() == SyntaxKind.GenericName
+                ? ((GenericNameSyntax)right).TypeArgumentList.Arguments
+                : default(SeparatedSyntaxList<TypeSyntax>);
+            var typeArgumentsWithAnnotations = typeArgumentsSyntax.Count > 0
+                ? BindTypeArguments(typeArgumentsSyntax, diagnostics)
+                : default(ImmutableArray<TypeWithAnnotations>);
+            var rightName = right.Identifier.ValueText;
+            var rightArity = right.Arity;
+
+            boundLeft = CheckValue(boundLeft, BindValueKind.RValue, diagnostics);
+            return BindInstanceMemberAccess(
+                node, right, boundLeft, rightName, rightArity,
+                typeArgumentsSyntax, typeArgumentsWithAnnotations,
+                invoked, indexed, diagnostics);
         }
 #nullable disable
 
@@ -8300,7 +8412,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 bool leftIsBaseReference = boundLeft.Kind == BoundKind.BaseReference;
                 CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
-                this.LookupInstanceMember(lookupResult, leftType, leftIsBaseReference, rightName, rightArity, invoked, ref useSiteInfo);
+                if ((object)leftType != null)
+                {
+                    // Typed receiver: look up members in the receiver's type.
+                    this.LookupInstanceMember(lookupResult, leftType, leftIsBaseReference, rightName, rightArity, invoked, ref useSiteInfo);
+                }
+                // Typeless receiver: skip instance member lookup (there is no type), and
+                // proceed directly to the extension-search path below.
                 diagnostics.Add(right, useSiteInfo);
 
                 // SPEC: Otherwise, an attempt is made to process E.I as an extension method invocation.
@@ -8744,8 +8862,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool acceptOnlyMethods,
             in CallingConventionInfo callingConvention = default)
         {
-            Debug.Assert(left.Type is not null);
-            Debug.Assert(!left.Type.IsDynamic());
+            // The receiver may be typeless when the typeless-extension-receivers feature is enabled.
+            // The feature gate is checked by callers; once we are here, a null Type is permitted.
+            Debug.Assert(left.Type is null || !left.Type.IsDynamic());
             Debug.Assert((options & ~(OverloadResolution.Options.IsMethodGroupConversion |
                                       OverloadResolution.Options.IsFunctionPointerResolution |
                                       OverloadResolution.Options.InferWithDynamic |
@@ -8837,7 +8956,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 BindingDiagnosticBag diagnostics,
                 out MethodGroupResolution result)
             {
-                Debug.Assert(left.Type is not null);
+                // left.Type may be null when the typeless-extension-receivers feature is enabled.
                 result = default;
 
                 // 1. gather candidates
@@ -8945,12 +9064,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (analyzedArguments == null)
                 {
                     // Without arguments (for scenarios such as `nameof` or conversion to non-delegate/dynamic type)
-                    // we can still prune the inapplicable extension methods using the receiver type
-                    for (int i = methodGroup.Methods.Count - 1; i >= 0; i--)
+                    // we can still prune the inapplicable extension methods using the receiver type.
+                    // Skip pruning when the receiver expression has no type (typeless-extension-receivers
+                    // feature); inapplicability is determined later, by overload resolution against the
+                    // candidate's first parameter type.
+                    TypeSymbol? receiverType = left.Type;
+                    for (int i = methodGroup.Methods.Count - 1; receiverType is not null && i >= 0; i--)
                     {
                         MethodSymbol method = methodGroup.Methods[i];
-                        TypeSymbol? receiverType = left.Type;
-                        Debug.Assert(receiverType is not null);
 
                         bool inapplicable = false;
                         if (method.IsExtensionMethod

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8336,13 +8336,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             // literal with at least one typeless element, default literal, or null literal.
             // Anything else (e.g. BoundBaseReference when there is no base class, BoundPropertyGroup
             // for COM indexed properties, throw expressions, namespace / type expressions, bad
-            // expressions, expressions already in error state) falls back to existing behavior so
-            // pre-existing diagnostics are preserved.
+            // expressions) falls back to existing behavior so pre-existing diagnostics are
+            // preserved.
             if (boundLeft.Type is not null)
-            {
-                return null;
-            }
-            if (boundLeft.HasErrors)
             {
                 return null;
             }
@@ -8364,12 +8360,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return null;
             }
 
-            // Feature-availability check reports ERR_FeatureInPreview when the language version is
-            // too low. Binding continues regardless, matching the established convention in this
-            // file - so the SemanticModel and downstream features see the call as bound on every
-            // language version, even when the version diagnostic is reported.
-            MessageID.IDS_FeatureExtensionMembersOnTypelessReceivers.CheckFeatureAvailability(diagnostics, node);
-
             var typeArgumentsSyntax = right.Kind() == SyntaxKind.GenericName
                 ? ((GenericNameSyntax)right).TypeArgumentList.Arguments
                 : default(SeparatedSyntaxList<TypeSyntax>);
@@ -8379,11 +8369,65 @@ namespace Microsoft.CodeAnalysis.CSharp
             var rightName = right.Identifier.ValueText;
             var rightArity = right.Arity;
 
+            // Only route through the new feature when there is at least one extension member
+            // candidate by this name in scope. Without this check, every typo on a typeless
+            // receiver (e.g. `(() => {}).GetType()`) would emit a misleading "feature is in
+            // Preview" diagnostic on older language versions, suggesting that a version upgrade
+            // would help when no extension would have applied either way. Falling back to null
+            // lets the caller's existing kind-specific rejections (ERR_BadUnaryOp on a lambda,
+            // ERR_BadOpOnNullOrDefaultOrNew on default, ERR_CollectionExpressionNoTargetType
+            // through BindToNaturalType, etc.) produce their pre-feature diagnostics.
+            if (!HasExtensionMemberCandidateInScope(rightName, rightArity))
+            {
+                return null;
+            }
+
+            // Feature-availability check reports ERR_FeatureInPreview when the language version is
+            // too low. Binding continues regardless, matching the established convention in this
+            // file - so the SemanticModel and downstream features see the call as bound on every
+            // language version, even when the version diagnostic is reported.
+            MessageID.IDS_FeatureExtensionMembersOnTypelessReceivers.CheckFeatureAvailability(diagnostics, node);
+
             boundLeft = CheckValue(boundLeft, BindValueKind.RValue, diagnostics);
             return BindInstanceMemberAccess(
                 node, right, boundLeft, rightName, rightArity,
                 typeArgumentsSyntax, typeArgumentsWithAnnotations,
                 invoked, indexed, diagnostics);
+        }
+
+        /// <summary>
+        /// Returns true if any extension member with the given name is in scope. Used to decide
+        /// whether a typeless-receiver member access should route through the new feature path.
+        /// Walks <see cref="ExtensionScopes"/> and short-circuits on the first match, so the cost
+        /// is no greater than the work the regular extension lookup would do anyway.
+        /// </summary>
+        private bool HasExtensionMemberCandidateInScope(string name, int arity)
+        {
+            LookupOptions options = arity == 0 ? LookupOptions.AllMethodsOnArityZero : LookupOptions.Default;
+            var singleLookupResults = ArrayBuilder<SingleLookupResult>.GetInstance();
+            CompoundUseSiteInfo<AssemblySymbol> discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
+
+            try
+            {
+                foreach (var scope in new ExtensionScopes(this))
+                {
+                    singleLookupResults.Clear();
+                    scope.Binder.EnumerateAllExtensionMembersInSingleBinder(
+                        singleLookupResults, name, arity, options,
+                        originalBinder: this,
+                        ref discardedUseSiteInfo, ref discardedUseSiteInfo);
+
+                    if (singleLookupResults.Count > 0)
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+            finally
+            {
+                singleLookupResults.Free();
+            }
         }
 #nullable disable
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -7885,9 +7885,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // helper.
             // See https://github.com/dotnet/csharplang/blob/main/proposals/extension-members-on-typeless-receivers.md
             if (TryBindMemberAccessOnTypelessReceiver(node, boundLeft, right, invoked, indexed, diagnostics) is { } typelessExtensionResult)
-            {
                 return typelessExtensionResult;
-            }
 
             boundLeft = MakeMemberAccessValue(boundLeft, diagnostics);
 
@@ -8327,9 +8325,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             // expressions) falls back to existing behavior so pre-existing diagnostics are
             // preserved.
             if (boundLeft.Type is not null)
-            {
                 return null;
-            }
+
             switch (boundLeft.Kind)
             {
                 case BoundKind.UnconvertedCollectionExpression:
@@ -8369,9 +8366,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var rightName = right.Identifier.ValueText;
             var rightArity = right.Arity;
             if (!HasExtensionMemberCandidateInScope(rightName, rightArity))
-            {
                 return null;
-            }
 
             // Feature-availability check reports ERR_FeatureInPreview when the language version is
             // too low. Binding continues regardless, matching the established convention in this
@@ -8411,10 +8406,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                         ref discardedUseSiteInfo, ref discardedUseSiteInfo);
 
                     if (singleLookupResults.Count > 0)
-                    {
                         return true;
-                    }
                 }
+
                 return false;
             }
             finally

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -1239,7 +1239,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             // instance methods. Therefore we must detect this scenario here, rather than in
             // overload resolution.
 
-            var receiver = ReplaceTypeOrValueReceiver(methodGroup.Receiver, useType: !method.RequiresInstanceReceiver && !invokedAsExtensionMethod, diagnostics);
+            // For extension members on typeless receivers, the receiver-to-parameter conversion is
+            // applied later by CheckAndCoerceArguments (classic) or CheckAndConvertExtensionReceiver
+            // (modern, C# 14 extension blocks) using the Conversion stored by overload resolution.
+            // ReplaceTypeOrValueReceiver's default branch calls BindToNaturalType, which destructively
+            // converts typeless forms (collection expression, new(), conditional / switch with no
+            // common type, tuple, default) into error-recovery wrappers. The function's named purpose
+            // (replacing a TypeOrValueExpression or unwrapping a QueryClause) does not apply here,
+            // since both of those wrappers always have a type. Both invokedAsExtensionMethod (classic)
+            // and isExtensionBlockMethod (modern) signal an extension call where the receiver-side
+            // conversion is handled downstream; cover both. Note isExtensionBlockMethod resets
+            // invokedAsExtensionMethod to false above, which is why both checks are needed.
+            var receiver = (invokedAsExtensionMethod || isExtensionBlockMethod) && methodGroup.Receiver.Type is null
+                ? methodGroup.Receiver
+                : ReplaceTypeOrValueReceiver(methodGroup.Receiver, useType: !method.RequiresInstanceReceiver && !invokedAsExtensionMethod, diagnostics);
 
             if (invokedAsExtensionMethod && (object)receiver != methodGroup.Receiver)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -853,9 +853,25 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 // casting the dynamic arguments or calling the extension method without the extension method
                                 // syntax.
 
-                                Debug.Assert(methodGroup.ReceiverOpt != null && (object)methodGroup.ReceiverOpt.Type != null);
+                                Debug.Assert(methodGroup.ReceiverOpt != null);
 
-                                Error(diagnostics, ErrorCode.ERR_BadArgTypeDynamicExtension, syntax, methodGroup.ReceiverOpt.Type, methodGroup.Name);
+                                // For typeless receivers (collection expression, lambda, method group, etc.) the receiver
+                                // has no Type but Display gives a user-friendly description like "collection expression"
+                                // or "lambda expression". Fall back to that when Type is null. We also force the receiver
+                                // through BindToNaturalType so the bad-call result we hand to flow analysis doesn't carry
+                                // an unconverted child that would trip its "expressions should have been converted" assert.
+                                object receiverDisplay = (object)methodGroup.ReceiverOpt.Type ?? methodGroup.ReceiverOpt.Display;
+                                Error(diagnostics, ErrorCode.ERR_BadArgTypeDynamicExtension, syntax, receiverDisplay, methodGroup.Name);
+
+                                if (methodGroup.ReceiverOpt.Type is null)
+                                {
+                                    var convertedReceiver = BindToNaturalType(methodGroup.ReceiverOpt, diagnostics);
+                                    methodGroup = methodGroup.Update(
+                                        methodGroup.TypeArgumentsOpt, methodGroup.Name, methodGroup.Methods,
+                                        methodGroup.LookupSymbolOpt, methodGroup.LookupError, methodGroup.Flags,
+                                        methodGroup.FunctionType, convertedReceiver, methodGroup.ResultKind);
+                                }
+
                                 result = CreateBadCall(syntax, methodGroup, methodGroup.ResultKind, analyzedArguments);
                             }
                             else

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -2005,6 +2005,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
+            // Extension members on typeless receivers: when the receiver expression has no type,
+            // fall back to the standard expression-to-type implicit conversions used for any other
+            // typeless argument (null literal, default literal, anonymous function, method group,
+            // tuple expression, throw expression, collection expression, target-typed `new()`,
+            // target-typed conditional / switch). The feature flag check is performed by the binder
+            // before a typeless receiver reaches this path.
+            // See https://github.com/dotnet/csharplang/blob/main/proposals/extension-members-on-typeless-receivers.md
+            if (sourceExpressionOpt is not null && (object)sourceType == null)
+            {
+                var fromExpressionConversion = ClassifyImplicitConversionFromExpression(sourceExpressionOpt, destination, ref useSiteInfo);
+                if (fromExpressionConversion.Exists)
+                {
+                    return fromExpressionConversion;
+                }
+            }
+
             return Conversion.NoConversion;
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -4626,7 +4626,7 @@ outerDefault:
                         (!conversion.IsDynamic ||
                             (ignoreOpenTypes && TypeContainsTypeParameterFromContainer(candidate, parameters.ParameterTypes[argumentPosition].Type))));
 
-                    if (forExtensionMethodThisArg && !conversion.IsDynamic && !Conversions.IsValidExtensionMethodThisArgConversion(conversion))
+                    if (forExtensionMethodThisArg && !conversion.IsDynamic && argument.Type is not null && !Conversions.IsValidExtensionMethodThisArgConversion(conversion))
                     {
                         // Return early, without checking conversions of subsequent arguments,
                         // if the instance argument is not convertible to the 'this' parameter,
@@ -4634,6 +4634,11 @@ outerDefault:
                         // lambda binding in particular, for instance, with LINQ expressions.
                         // Note that BuildArgumentsForErrorRecovery will still bind some number
                         // of overloads for the semantic model.
+                        // The strict identity / reference / boxing whitelist is skipped when the
+                        // receiver expression has no type, since in that case the conversion was
+                        // produced by ClassifyImplicitConversionFromExpression (the same machinery
+                        // used for any other typeless argument), which only returns valid implicit
+                        // conversions.
                         Debug.Assert(badArguments.IsNull);
                         Debug.Assert(conversions == null);
                         return MemberAnalysisResult.BadArgumentConversions(argsToParameters, MemberAnalysisResult.CreateBadArgumentsWithPosition(argumentPosition), ImmutableArray.Create(conversion),

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -8297,6 +8297,9 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="IDS_FeatureUnions" xml:space="preserve">
     <value>unions</value>
   </data>
+  <data name="IDS_FeatureExtensionMembersOnTypelessReceivers" xml:space="preserve">
+    <value>extension members on typeless receivers</value>
+  </data>
   <data name="ERR_UnionDeclarationNeedsCaseTypes" xml:space="preserve">
     <value>A union declaration must specify at least one case type.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -310,6 +310,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureUnsafeEvolution = MessageBase + 12859,
 
         IDS_FeatureUnions = MessageBase + 12860,
+
+        IDS_FeatureExtensionMembersOnTypelessReceivers = MessageBase + 12861,
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -493,6 +495,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case MessageID.IDS_FeatureCollectionExpressionArguments:
                 case MessageID.IDS_FeatureUnsafeEvolution: // https://github.com/dotnet/roslyn/issues/82546: keep this in preview until C# 16
                 case MessageID.IDS_FeatureUnions:
+                case MessageID.IDS_FeatureExtensionMembersOnTypelessReceivers:
                     return LanguageVersion.Preview;
 
                 // C# 14.0 features.

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">vzory rozšířených vlastností</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">rozšíření</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">Muster für erweiterte Eigenschaften</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">Erweiterungen</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">patrones de propiedad extendidos</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">extensiones</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">modèles de propriétés étendues</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">extensions</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">criteri di proprietà estesa</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">estensioni</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">拡張プロパティ パターン</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">拡張</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">확장 속성 패턴</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">확장</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">wzorce właściwości rozszerzonych</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">numery wewnętrzne</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">padrões de propriedade estendida</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">extensões</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">шаблоны расширенных свойств</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">расширения</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">genişletilmiş özellik desenleri</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">genişletmeler</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">扩展的属性模式</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">扩展</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -2937,6 +2937,11 @@
         <target state="translated">擴充屬性模式</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureExtensionMembersOnTypelessReceivers">
+        <source>extension members on typeless receivers</source>
+        <target state="new">extension members on typeless receivers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureExtensions">
         <source>extensions</source>
         <target state="translated">擴充</target>

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
@@ -3459,10 +3459,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 }
                 """;
             var comp = CreateCompilation(new[] { source, s_collectionExtensions });
-            comp.VerifyEmitDiagnostics(
-                // 0.cs(9,17): error CS9176: There is no target type for the collection expression.
-                //         var a = [1, 2, 3].AsArray();
-                Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[1, 2, 3]").WithLocation(9, 17));
+            // Under the extension-members-on-typeless-receivers feature, `[1, 2, 3].AsArray()`
+            // now succeeds: T is inferred as int via the collection-expression conversion to T[].
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -3500,10 +3499,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 }
                 """;
             var comp = CreateCompilation(source);
-            comp.VerifyEmitDiagnostics(
-                // (27,17): error CS9176: There is no target type for the collection expression.
-                //         var b = [4].AsCollection();
-                Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[4]").WithLocation(27, 17));
+            // Under the extension-members-on-typeless-receivers feature, `[4].AsCollection()`
+            // now succeeds: T is inferred as int via the collection-expression conversion to S<T>.
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -3530,13 +3528,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 }
                 """;
             var comp = CreateCompilation(source);
+            // Under the extension-members-on-typeless-receivers feature, `[4].AsCollection()` no
+            // longer reports ERR_CollectionExpressionNoTargetType at the receiver: instead, type
+            // inference is run on the full call (with the collection-expression as the first
+            // argument), and reports the same ERR_CantInferMethTypeArgs as the explicit-form call
+            // because S<T> here implements the non-generic IEnumerable.
             comp.VerifyEmitDiagnostics(
                 // (15,13): error CS0411: The type arguments for method 'Program.AsCollection<T>(S<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         _ = AsCollection([1, 2, 3]);
                 Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "AsCollection").WithArguments("Program.AsCollection<T>(S<T>)").WithLocation(15, 13),
-                // (16,13): error CS9176: There is no target type for the collection expression.
+                // (16,17): error CS0411: The type arguments for method 'Program.AsCollection<T>(S<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         _ = [4].AsCollection();
-                Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[4]").WithLocation(16, 13));
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "AsCollection").WithArguments("Program.AsCollection<T>(S<T>)").WithLocation(16, 17));
         }
 
         [Fact]
@@ -4810,11 +4813,9 @@ static class Program
 }
 """;
             var comp = CreateCompilation(source);
-            comp.VerifyEmitDiagnostics(
-                // (27,17): error CS9176: There is no target type for the collection expression.
-                //         var b = [4].AsCollection();
-                Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[4]").WithLocation(27, 17)
-                );
+            // Under the extension-members-on-typeless-receivers feature, `[4].AsCollection()`
+            // succeeds: T is inferred via the collection-expression conversion to S<T>?.
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -4832,10 +4833,16 @@ static class Program
                 }
                 """;
             var comp = CreateCompilation(source);
+            // Under the extension-members-on-typeless-receivers feature, `[].GetHashCode()` no
+            // longer reports ERR_CollectionExpressionNoTargetType: the collection-expression
+            // receiver enters the extension-method-search path, finds no `GetHashCode` extension,
+            // and reports ERR_NoSuchMember instead. The `?.` and `[]` operators on a typeless
+            // collection expression are out of scope per the spec, so they continue to produce
+            // ERR_CollectionExpressionNoTargetType.
             comp.VerifyEmitDiagnostics(
-                // (5,9): error CS9176: There is no target type for the collection expression.
+                // (5,12): error CS0117: 'collection expression' does not contain a definition for 'GetHashCode'
                 //         [].GetHashCode();
-                Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[]").WithLocation(5, 9),
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "GetHashCode").WithArguments("collection expression", "GetHashCode").WithLocation(5, 12),
                 // (6,9): error CS9176: There is no target type for the collection expression.
                 //         []?.GetHashCode();
                 Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[]").WithLocation(6, 9),
@@ -4859,10 +4866,12 @@ static class Program
                 }
                 """;
             var comp = CreateCompilation(source);
+            // Same pattern as MemberAccess_01: `[1].GetHashCode()` enters the extension-method
+            // search path under the new feature; `?.` and `[]` are out of scope.
             comp.VerifyEmitDiagnostics(
-                // (5,9): error CS9176: There is no target type for the collection expression.
+                // (5,13): error CS0117: 'collection expression' does not contain a definition for 'GetHashCode'
                 //         [1].GetHashCode();
-                Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[1]").WithLocation(5, 9),
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "GetHashCode").WithArguments("collection expression", "GetHashCode").WithLocation(5, 13),
                 // (6,9): error CS9176: There is no target type for the collection expression.
                 //         [2]?.GetHashCode();
                 Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[2]").WithLocation(6, 9),
@@ -4886,10 +4895,11 @@ static class Program
                 }
                 """;
             var comp = CreateCompilation(source);
+            // Same pattern as MemberAccess_01 / _02 (with leading `_ =`).
             comp.VerifyEmitDiagnostics(
-                // (5,13): error CS9176: There is no target type for the collection expression.
+                // (5,16): error CS0117: 'collection expression' does not contain a definition for 'GetHashCode'
                 //         _ = [].GetHashCode();
-                Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[]").WithLocation(5, 13),
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "GetHashCode").WithArguments("collection expression", "GetHashCode").WithLocation(5, 16),
                 // (6,13): error CS9176: There is no target type for the collection expression.
                 //         _ = []?.GetHashCode();
                 Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[]").WithLocation(6, 13),
@@ -4913,10 +4923,11 @@ static class Program
                 }
                 """;
             var comp = CreateCompilation(source);
+            // Same pattern as MemberAccess_02 (with leading `_ =`).
             comp.VerifyEmitDiagnostics(
-                // (5,13): error CS9176: There is no target type for the collection expression.
+                // (5,17): error CS0117: 'collection expression' does not contain a definition for 'GetHashCode'
                 //         _ = [1].GetHashCode();
-                Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[1]").WithLocation(5, 13),
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "GetHashCode").WithArguments("collection expression", "GetHashCode").WithLocation(5, 17),
                 // (6,13): error CS9176: There is no target type for the collection expression.
                 //         _ = [2]?.GetHashCode();
                 Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, "[2]").WithLocation(6, 13),


### PR DESCRIPTION
Championed issue: TBD
Speclet: TBD
Test plan: TBD

## Summary

Internal review aid. Combines the production code changes from the entire stack of upstream draft PRs into a single self-contained commit so the binder + feature flag changes can be reviewed end-to-end without sifting through test additions. Will be closed once the code is approved; the upstream stack remains intact.

Scope (20 files, no new test files):

- **Binder_Expressions.cs** - \`TryBindMemberAccessOnTypelessReceiver\` helper + inclusion list, \`GetExtensionMemberAccess\` relaxation, \`BindInstanceMemberAccess\` typeless-\`leftType\` branch, \`ResolveExtension\` assertion / pruning relaxations.
- **Binder_Invocation.cs** - skip \`ReplaceTypeOrValueReceiver\` for typeless extension receivers (covers both classic \`invokedAsExtensionMethod\` and modern \`isExtensionBlockMethod\` paths).
- **ConversionsBase.cs** - classic extension this-arg conversion fallback to \`ClassifyImplicitConversionFromExpression\` when the source has no type.
- **OverloadResolution.cs** - skip the strict identity / reference / boxing whitelist for the extension this-arg when \`argument.Type is null\`.
- **MessageID + CSharpResources.resx + 13 xlf** - new \`IDS_FeatureExtensionMembersOnTypelessReceivers\` preview feature flag.
- **CollectionExpressionTests.cs** - 8 obsolete pre-feature error expectations updated to match the new feature behavior.

Mirrors the union of the code in:

- #83348 (Phase 1 product: feature flag + collection-expression support)
- #83352 (Modern extensions binder support)
- #83355, #83360, #83365, #83370, #83375, #83380, #83385, #83390 (one-line inclusion-list additions per receiver category: lambda, method group, \`new()\`, null literal, default literal, conditional, switch, tuple).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83407)