### PR TITLE
Eliminate double-serialization in SystemTextJsonLanguageServer

### DIFF
--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/SystemTextJsonLanguageServer.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/SystemTextJsonLanguageServer.cs
@@ -71,7 +71,7 @@ internal abstract class SystemTextJsonLanguageServer<TRequestContext>(
         /// StreamJsonRpc entry point for handlers with no parameters.
         /// Unlike Newtonsoft, we have to differentiate instead of using default parameters.
         /// </summary>
-        private Task<JsonElement?> ExecuteRequest0Async(CancellationToken cancellationToken = default)
+        private Task<object?> ExecuteRequest0Async(CancellationToken cancellationToken = default)
         {
             return ExecuteRequestAsync(null, cancellationToken);
         }
@@ -79,19 +79,20 @@ internal abstract class SystemTextJsonLanguageServer<TRequestContext>(
         /// <summary>
         /// StreamJsonRpc entry point for handlers with parameters (and any response) type.
         /// </summary>
-        private async Task<JsonElement?> ExecuteRequestAsync(JsonElement? request, CancellationToken cancellationToken = default)
+        /// <remarks>
+        /// Returns the handler's typed result directly as <see cref="object"/> rather than
+        /// pre-serializing it into a <see cref="JsonElement"/>. StreamJsonRpc will serialize the
+        /// result to the wire using <see cref="JsonSerializer"/> with the runtime type's converter,
+        /// producing identical JSON. Returning <see cref="object"/> avoids a redundant
+        /// serialize-then-reserialize round-trip that <see cref="JsonSerializer.SerializeToElement(object?, Type, JsonSerializerOptions?)"/>
+        /// would otherwise cause (object → byte[] → JsonDocument → JsonElement → wire bytes).
+        /// </remarks>
+        private async Task<object?> ExecuteRequestAsync(JsonElement? request, CancellationToken cancellationToken = default)
         {
             var queue = target.GetRequestExecutionQueue();
             var lspServices = target.GetLspServices();
 
-            var result = await InvokeAsync(queue, request, lspServices, cancellationToken).ConfigureAwait(false);
-            if (result is null)
-            {
-                return null;
-            }
-
-            var serializedResult = JsonSerializer.SerializeToElement(result, target._jsonSerializerOptions);
-            return serializedResult;
+            return await InvokeAsync(queue, request, lspServices, cancellationToken).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
SystemTextJsonDelegatingEntryPoint.ExecuteRequestAsync was calling JsonSerializer.SerializeToElement(result) to convert handler results into a JsonElement before returning to StreamJsonRpc. This caused a full serialize → byte[] → JsonDocument → JsonElement round-trip, only for StreamJsonRpc to immediately re-serialize that JsonElement back to wire bytes. Every LSP response paid this cost.

The fix returns the handler's typed result directly as object. StreamJsonRpc serializes it to the wire using JsonSerializer.Serialize(writer, value, declaredType, options), which invokes the same runtime-type converters — producing identical JSON output with zero intermediate allocations.

Why this is safe: The previous SerializeToElement(result, options) already received result as object (from InvokeAsync), so it was already relying on STJ's object→runtime-type dispatch. We're removing the redundant intermediate step, not changing the serialization path. The entry point methods are private, accessed only via MethodInfo name-based reflection — return type changes don't affect lookup.

PIT impact: Identified via RazorEditingTests.CompletionInCohostingForComponents, scenario 0300.Completion. Eliminates ~12 MB of System.Byte[] and JsonDocument allocations in the devenv process from semantic tokens and completion responses.

*** Before ***
<img width="1439" height="276" alt="image" src="https://github.com/user-attachments/assets/b7978400-9109-47ae-aa53-eb206faefb98" />

*** After ***
<img width="1427" height="274" alt="image" src="https://github.com/user-attachments/assets/4289c002-cb54-4771-af01-1a890936e39d" />

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83417)