### PR TITLE
fix: correct Spanish translation 'campo' vs 'archivo' for IDE0044

### DIFF
--- a/src/Analyzers/Core/Analyzers/xlf/AnalyzersResources.es.xlf
+++ b/src/Analyzers/Core/Analyzers/xlf/AnalyzersResources.es.xlf
@@ -193,7 +193,7 @@
       </trans-unit>
       <trans-unit id="Make_field_readonly">
         <source>Make field readonly</source>
-        <target state="translated">Hacer el archivo de solo lectura</target>
+        <target state="translated">Hacer el campo de solo lectura</target>
         <note />
       </trans-unit>
       <trans-unit id="Make_method_synchronous">


### PR DESCRIPTION
Fixes dotnet/roslyn#83338

## Issue
Spanish localization for  (IDE0044) incorrectly uses 'archivo' (file) instead of 'campo' (field).

## Fix
Changed translation from:
- 'Hacer el archivo de solo lectura' (Make the **file** readonly)
To:
- 'Hacer el campo de solo lectura' (Make the **field** readonly)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83427)