### PR TITLE
Dev/toddgrun/fix lsp completion suggestion mode empty filter

### DIFF
--- a/src/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
@@ -195,7 +195,11 @@ internal sealed partial class CompletionHandler : ILspServiceDocumentRequestHand
         var filterReason = GetFilterReason(completionTrigger);
 
         // Determine if the list should be hard selected or soft selected.
-        var isFilterTextAllPunctuation = CompletionService.IsAllPunctuation(filterText);
+        // Guard against empty filter text: IsAllPunctuation returns true for empty strings (vacuously true),
+        // but empty text is not "all punctuation". The in-process equivalent in ItemManager.CompletionListUpdater.IsHardSelectionAsync
+        // has the same guard (_filterText.Length > 0) before calling IsAllPunctuation, and handles the empty
+        // filter text case separately with its own preselection/MRU logic.
+        var isFilterTextAllPunctuation = filterText.Length > 0 && CompletionService.IsAllPunctuation(filterText);
 
         // If we only had punctuation - we set soft selection and the list to be incomplete so we get called back when the user continues typing.
         // If they type something that is not punctuation, we may need to update the hard vs soft selection.

--- a/src/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -408,6 +408,65 @@ public sealed class CompletionTests : AbstractLanguageServerProtocolTests
         Assert.True(results.SuggestionMode);
     }
 
+    [Theory, CombinatorialData]
+    public async Task TestDotTriggerDoesNotSetSuggestionMode(bool mutatingLspWorkspace)
+    {
+        // Typing '.' triggers completion with empty filter text. IsAllPunctuation("") returns true
+        // vacuously, but empty text should not be treated as "all punctuation" — it should produce
+        // hard selection and a complete list, not suggestion mode with isIncomplete.
+        var markup =
+            """
+            using System;
+            class C
+            {
+                void M()
+                {
+                    Console.{|caret:|}
+                }
+            }
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, s_vsCompletionCapabilities);
+        var completionParams = CreateCompletionParams(
+            testLspServer.GetLocations("caret").Single(),
+            invokeKind: LSP.VSInternalCompletionInvokeKind.Typing,
+            triggerCharacter: ".",
+            triggerKind: LSP.CompletionTriggerKind.TriggerCharacter);
+
+        var results = (LSP.VSInternalCompletionList)await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
+        Assert.NotEmpty(results.Items);
+        Assert.False(results.SuggestionMode);
+        Assert.False(results.IsIncomplete);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestUnderscoreTriggerSetsSuggestionModeAndIncomplete(bool mutatingLspWorkspace)
+    {
+        // Typing '_' (punctuation) should set suggestion mode and mark the list as incomplete,
+        // so the server gets called back when the user types a non-punctuation character.
+        var markup =
+            """
+            class C
+            {
+                private int _value;
+                void M()
+                {
+                    _{|caret:|}
+                }
+            }
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, s_vsCompletionCapabilities);
+        var completionParams = CreateCompletionParams(
+            testLspServer.GetLocations("caret").Single(),
+            invokeKind: LSP.VSInternalCompletionInvokeKind.Typing,
+            triggerCharacter: "_",
+            triggerKind: LSP.CompletionTriggerKind.Invoked);
+
+        var results = (LSP.VSInternalCompletionList)await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
+        Assert.NotEmpty(results.Items);
+        Assert.True(results.SuggestionMode);
+        Assert.True(results.IsIncomplete);
+    }
+
     [ConditionalTheory(typeof(IsEnglishLocal)), CombinatorialData]
     public async Task TestGetDateAndTimeCompletionsAsync(bool mutatingLspWorkspace)
     {


### PR DESCRIPTION
Fix spurious suggestion mode in LSP completion for empty filter text

CompletionService.IsAllPunctuation("") returns true (vacuously — empty foreach loop), causing the LSP completion handler to set SuggestionMode = true and isIncomplete = true whenever completion is triggered with empty filter text (e.g., typing .).

This results in a visible "header row" (suggestion mode item) in the completion list that persists even after the user types non-punctuation characters, because the editor does not update suggestion mode on re-query.

The fix adds a filterText.Length > 0 guard before calling IsAllPunctuation, matching the equivalent behavior in the in-process path (ItemManager.CompletionListUpdater.IsHardSelectionAsync), which already has this guard.

Partially fixes https://github.com/dotnet/razor/issues/11569
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83438)