### PR TITLE
Post-snap configuration updates (VS 18.7 → 18.8)

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,7 +5,7 @@
   <!-- Roslyn version -->
   <PropertyGroup>
     <MajorVersion>5</MajorVersion>
-    <MinorVersion>7</MinorVersion>
+    <MinorVersion>8</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <PreReleaseVersionLabel>1</PreReleaseVersionLabel>
     <PreReleaseVersionLabel Condition="'$(DotNetSignType)' == 'test'">$(PreReleaseVersionLabel)-test</PreReleaseVersionLabel>

--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -100,7 +100,7 @@
       "NonShipping"
     ],
     "vsBranch": "main",
-    "insertionCreateDraftPR": false,
+    "insertionCreateDraftPR": true,
     "insertionTitlePrefix": "[InsidersVNext]"
   }
 }

--- a/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.sarif
+++ b/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.Analyzers",
-        "version": "5.7.0",
+        "version": "5.8.0",
         "language": "en-US"
       },
       "rules": {
@@ -724,7 +724,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.CSharp.Analyzers",
-        "version": "5.7.0",
+        "version": "5.8.0",
         "language": "en-US"
       },
       "rules": {
@@ -957,7 +957,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.VisualBasic.Analyzers",
-        "version": "5.7.0",
+        "version": "5.8.0",
         "language": "en-US"
       },
       "rules": {

--- a/src/RoslynAnalyzers/Microsoft.CodeAnalysis.BannedApiAnalyzers/Microsoft.CodeAnalysis.BannedApiAnalyzers.sarif
+++ b/src/RoslynAnalyzers/Microsoft.CodeAnalysis.BannedApiAnalyzers/Microsoft.CodeAnalysis.BannedApiAnalyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.BannedApiAnalyzers",
-        "version": "5.7.0",
+        "version": "5.8.0",
         "language": "en-US"
       },
       "rules": {
@@ -14,7 +14,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers",
-        "version": "5.7.0",
+        "version": "5.8.0",
         "language": "en-US"
       },
       "rules": {
@@ -77,7 +77,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.VisualBasic.BannedApiAnalyzers",
-        "version": "5.7.0",
+        "version": "5.8.0",
         "language": "en-US"
       },
       "rules": {

--- a/src/RoslynAnalyzers/PerformanceSensitiveAnalyzers/Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.sarif
+++ b/src/RoslynAnalyzers/PerformanceSensitiveAnalyzers/Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers",
-        "version": "5.7.0",
+        "version": "5.8.0",
         "language": "en-US"
       },
       "rules": {
@@ -184,7 +184,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers.CodeFixes",
-        "version": "5.7.0",
+        "version": "5.8.0",
         "language": "en-US"
       },
       "rules": {
@@ -193,7 +193,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers",
-        "version": "5.7.0",
+        "version": "5.8.0",
         "language": "en-US"
       },
       "rules": {

--- a/src/RoslynAnalyzers/PublicApiAnalyzers/Microsoft.CodeAnalysis.PublicApiAnalyzers.sarif
+++ b/src/RoslynAnalyzers/PublicApiAnalyzers/Microsoft.CodeAnalysis.PublicApiAnalyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.PublicApiAnalyzers",
-        "version": "5.7.0",
+        "version": "5.8.0",
         "language": "en-US"
       },
       "rules": {
@@ -460,7 +460,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.PublicApiAnalyzers.CodeFixes",
-        "version": "5.7.0",
+        "version": "5.8.0",
         "language": "en-US"
       },
       "rules": {

--- a/src/RoslynAnalyzers/Roslyn.Diagnostics.Analyzers/Roslyn.Diagnostics.Analyzers.sarif
+++ b/src/RoslynAnalyzers/Roslyn.Diagnostics.Analyzers/Roslyn.Diagnostics.Analyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Roslyn.Diagnostics.Analyzers",
-        "version": "5.7.0",
+        "version": "5.8.0",
         "language": "en-US"
       },
       "rules": {
@@ -157,7 +157,7 @@
     {
       "tool": {
         "name": "Roslyn.Diagnostics.CSharp.Analyzers",
-        "version": "5.7.0",
+        "version": "5.8.0",
         "language": "en-US"
       },
       "rules": {
@@ -300,7 +300,7 @@
     {
       "tool": {
         "name": "Roslyn.Diagnostics.VisualBasic.Analyzers",
-        "version": "5.7.0",
+        "version": "5.8.0",
         "language": "en-US"
       },
       "rules": {

--- a/src/RoslynAnalyzers/Text.Analyzers/Text.Analyzers.sarif
+++ b/src/RoslynAnalyzers/Text.Analyzers/Text.Analyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Humanizer",
-        "version": "5.7.0",
+        "version": "5.8.0",
         "language": "en-US"
       },
       "rules": {
@@ -14,7 +14,7 @@
     {
       "tool": {
         "name": "Text.Analyzers",
-        "version": "5.7.0",
+        "version": "5.8.0",
         "language": "en-US"
       },
       "rules": {
@@ -86,7 +86,7 @@
     {
       "tool": {
         "name": "Text.CSharp.Analyzers",
-        "version": "5.7.0",
+        "version": "5.8.0",
         "language": "en-US"
       },
       "rules": {
@@ -95,7 +95,7 @@
     {
       "tool": {
         "name": "Text.VisualBasic.Analyzers",
-        "version": "5.7.0",
+        "version": "5.8.0",
         "language": "en-US"
       },
       "rules": {


### PR DESCRIPTION
Auto-generated by snap skill. Post-snap version bump and config updates.

- Bump Roslyn version 5.7.0 → 5.8.0
- Set insertionCreateDraftPR to true (interim until VS snaps)
- Update SARIF files to 5.8.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83441)