### PR TITLE
Add Area-Razor label policy for Razor PRs

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -189,6 +189,36 @@ configuration:
       - addLabel:
           label: VSCode
 
+    - description: Adds "Area-Razor" label on PRs that touch src/Razor.
+      triggerOnOwnActions: false
+      if:
+      - payloadType: Pull_Request
+      - isPullRequest
+      - filesMatchPattern:
+          pattern: 'src/Razor/.*'
+          matchAny: true
+      - and:
+        - not:
+            isActivitySender:
+              user: dotnet-bot
+              issueAuthor: False
+        - not:
+            isActivitySender:
+              user: github-actions[bot]
+              issueAuthor: False
+      - or:
+        - isAction:
+            action: Opened
+        - isAction:
+            action: Synchronize
+      - and:
+        - not:
+            hasLabel:
+              label: Area-Razor
+      then:
+      - addLabel:
+          label: Area-Razor
+
     - description: Add "Needs UX Triage" on PRs
       triggerOnOwnActions: false
       if:


### PR DESCRIPTION
## Why
PRs that touch `src/Razor` should be labeled automatically so Razor changes are easier to route and triage.

## What
- Add a new resource management rule alongside the existing PR labeling rules.
- Apply the `Area-Razor` label when a pull request changes files under `src/Razor`.
- Run the rule on `Opened` and `Synchronize`, skip bot-authored PRs, and avoid re-adding the label when it is already present.

## Notes
This follows the same overall shape as the existing `VSCode` labeling policy so the new rule behaves consistently with the repo's current PR automation.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83445)