### PR TITLE
Fix add using code action when there are other directives present

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/IRazorEditService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/IRazorEditService.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,11 +23,13 @@ internal interface IRazorEditService
     /// <param name="textChanges">The text changes to map.</param>
     /// <param name="snapshot">The document snapshot to use for mapping.</param>
     /// <param name="includeCSharpLanguageFeatureEdits">Whether to include edits that might be present in unmapped areas of the generated C# document. These requires extra processing, so pass <see langword="false"/> if the scenario makes them unnecessary/impossible</param>
+    /// <param name="directlyMappedEditFilter">An optional filter applied to directly mapped edits before synthesized Razor language feature edits are added.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     Task<ImmutableArray<RazorTextChange>> MapCSharpEditsAsync(
         ImmutableArray<RazorTextChange> textChanges,
         IDocumentSnapshot snapshot,
         bool includeCSharpLanguageFeatureEdits,
+        Func<RazorTextChange, bool>? directlyMappedEditFilter,
         CancellationToken cancellationToken);
 
     /// <summary>

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/IRazorEditServiceExtensions.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/IRazorEditServiceExtensions.cs
@@ -19,10 +19,11 @@ internal static class IRazorEditServiceExtensions
         CancellationToken cancellationToken)
     {
         var mappedChanges = await service.MapCSharpEditsAsync(
-                textChanges.SelectAsArray(static c => c.ToRazorTextChange()),
-                snapshot,
-                includeCSharpLanguageFeatureEdits: true,
-                cancellationToken).ConfigureAwait(false);
+            textChanges.SelectAsArray(static c => c.ToRazorTextChange()),
+            snapshot,
+            includeCSharpLanguageFeatureEdits: true,
+            directlyMappedEditFilter: null,
+            cancellationToken).ConfigureAwait(false);
 
         return mappedChanges.SelectAsArray(static c => c.ToTextChange());
     }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/RazorEditService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/RazorEditService.cs
@@ -37,13 +37,13 @@ internal abstract partial class RazorEditService(
         ImmutableArray<RazorTextChange> textChanges,
         IDocumentSnapshot snapshot,
         bool includeCSharpLanguageFeatureEdits,
+        Func<RazorTextChange, bool>? directlyMappedEditFilter,
         CancellationToken cancellationToken)
     {
         var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
-        var originalRazorSourceText = codeDocument.Source.Text;
 
         using var edits = new PooledArrayBuilder<RazorTextChange>();
-        AddDirectlyMappedEdits(ref edits.AsRef(), textChanges, codeDocument, cancellationToken, out var skippedEdits);
+        AddDirectlyMappedEdits(ref edits.AsRef(), textChanges, codeDocument, directlyMappedEditFilter, cancellationToken, out var skippedEdits);
 
         if (includeCSharpLanguageFeatureEdits && skippedEdits.Length != 0)
         {
@@ -290,6 +290,7 @@ internal abstract partial class RazorEditService(
         ref PooledArrayBuilder<RazorTextChange> edits,
         ImmutableArray<RazorTextChange> csharpEdits,
         RazorCodeDocument codeDocument,
+        Func<RazorTextChange, bool>? directlyMappedEditFilter,
         CancellationToken cancellationToken,
         out ImmutableArray<RazorTextChange> skippedEdits)
     {
@@ -307,6 +308,11 @@ internal abstract partial class RazorEditService(
             if (TryGetMappedEdit(csharpDocument, csharpEdit) is not { } mappedEdit)
             {
                 skipped.Add(csharpEdit);
+                continue;
+            }
+
+            if (directlyMappedEditFilter?.Invoke(mappedEdit) == false)
+            {
                 continue;
             }
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/RazorEditService_WorkspaceEdit.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/RazorEditService_WorkspaceEdit.cs
@@ -147,7 +147,7 @@ internal partial class RazorEditService
         var razorSourceText = codeDocument.Source.Text;
         var csharpSourceText = codeDocument.GetCSharpSourceText();
         var textChanges = edits.SelectAsArray(csharpSourceText.GetRazorTextChange);
-        var mappedEdits = await MapCSharpEditsAsync(textChanges, documentContext.Snapshot, includeCSharpLanguageFeatureEdits: true, cancellationToken).ConfigureAwait(false);
+        var mappedEdits = await MapCSharpEditsAsync(textChanges, documentContext.Snapshot, includeCSharpLanguageFeatureEdits: true, directlyMappedEditFilter: null, cancellationToken).ConfigureAwait(false);
 
         return mappedEdits.SelectAsArray(razorSourceText.GetTextEdit);
     }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpOnTypeFormattingPass.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpOnTypeFormattingPass.cs
@@ -1153,12 +1153,24 @@ internal sealed class CSharpOnTypeFormattingPass(
         var lastIndex = 0;
         foreach (var mapping in codeDocument.GetRequiredCSharpDocument().SourceMappingsSortedByOriginal)
         {
-            builder.Append(documentText, lastIndex, mapping.OriginalSpan.AbsoluteIndex - lastIndex);
-            builder.Append("<#");
-            builder.Append(documentText, mapping.OriginalSpan.AbsoluteIndex, mapping.OriginalSpan.Length);
-            builder.Append("#>");
+            var originalStart = mapping.OriginalSpan.AbsoluteIndex;
+            var originalEnd = originalStart + mapping.OriginalSpan.Length;
+            if (originalStart > lastIndex)
+            {
+                builder.Append(documentText, lastIndex, originalStart - lastIndex);
+            }
 
-            lastIndex = mapping.OriginalSpan.AbsoluteIndex + mapping.OriginalSpan.Length;
+            // Source mappings can overlap in legacy documents (for example around @page),
+            // so keep the debug rendering best-effort instead of throwing while logging.
+            var mappedStart = Math.Max(originalStart, lastIndex);
+            if (originalEnd > mappedStart)
+            {
+                builder.Append("<#");
+                builder.Append(documentText, mappedStart, originalEnd - mappedStart);
+                builder.Append("#>");
+            }
+
+            lastIndex = Math.Max(lastIndex, originalEnd);
         }
 
         builder.Append(documentText, lastIndex, documentText.Length - lastIndex);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpOnTypeFormattingPass.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpOnTypeFormattingPass.cs
@@ -105,17 +105,20 @@ internal sealed class CSharpOnTypeFormattingPass(
 
         context.Logger?.LogSourceText("FormattedCSharp", originalTextWithChanges);
 
+        var indent = context.GetIndentationLevelString(1);
         var mappedChanges = await _razorEditService.MapCSharpEditsAsync(
             normalizedChanges.SelectAsArray(static c => c.ToRazorTextChange()),
             context.CurrentSnapshot,
             context.IncludeCSharpLanguageFeatureEdits,
+            directlyMappedEditFilter: change => ShouldKeepDirectlyMappedEdit(context, indent, change),
             cancellationToken).ConfigureAwait(false);
 
-        var filteredChanges = FilterCSharpTextChanges(context, mappedChanges.SelectAsArray(static e => e.ToTextChange()));
-        if (filteredChanges.Length == 0)
+        if (mappedChanges.Length == 0)
         {
             return [];
         }
+
+        var filteredChanges = mappedChanges.SelectAsArray(static e => e.ToTextChange());
 
         // Find the lines that were affected by these edits.
         var originalText = codeDocument.Source.Text;
@@ -215,38 +218,30 @@ internal sealed class CSharpOnTypeFormattingPass(
         return newText;
     }
 
-    private static ImmutableArray<TextChange> FilterCSharpTextChanges(FormattingContext context, ImmutableArray<TextChange> changes)
+    private static bool ShouldKeepDirectlyMappedEdit(FormattingContext context, string indent, RazorTextChange change)
     {
-        var indent = context.GetIndentationLevelString(1);
-
-        using var filteredChanges = new PooledArrayBuilder<TextChange>();
-
-        foreach (var change in changes)
+        var span = change.Span.ToTextSpan();
+        if (!ShouldFormat(context, span, allowImplicitStatements: false))
         {
-            if (!ShouldFormat(context, change.Span, allowImplicitStatements: false))
-            {
-                continue;
-            }
-
-            // One extra bit of filtering we do here, is to guard against quirks in runtime code-gen, where source mappings
-            // end after whitespace, rather than design time where they end before. This results in the C# formatter wanting
-            // to insert an indent in what ends up being the middle of a line of Razor code. Since there is no reason to ever
-            // insert anything but a single space in the middle of a line, it's easy to filter them out.
-            if (change.Span.Length == 0 &&
-                change.NewText == indent)
-            {
-                var linePosition = context.SourceText.GetLinePosition(change.Span.Start);
-                var first = context.SourceText.Lines[linePosition.Line].GetFirstNonWhitespaceOffset();
-                if (linePosition.Character > first)
-                {
-                    continue;
-                }
-            }
-
-            filteredChanges.Add(change);
+            return false;
         }
 
-        return filteredChanges.ToImmutable();
+        // One extra bit of filtering we do here, is to guard against quirks in runtime code-gen, where source mappings
+        // end after whitespace, rather than design time where they end before. This results in the C# formatter wanting
+        // to insert an indent in what ends up being the middle of a line of Razor code. Since there is no reason to ever
+        // insert anything but a single space in the middle of a line, it's easy to filter them out.
+        if (span.Length == 0 &&
+            change.NewText == indent)
+        {
+            var linePosition = context.SourceText.GetLinePosition(span.Start);
+            var first = context.SourceText.Lines[linePosition.Line].GetFirstNonWhitespaceOffset();
+            if (linePosition.Character > first)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static int LineDelta(SourceText text, IEnumerable<TextChange> changes, out int firstLine, out int lastLine)

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/AddUsingTests.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/AddUsingTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Xunit;
@@ -29,6 +30,35 @@ public class AddUsingTests(ITestOutputHelper testOutputHelper) : CohostCodeActio
             """;
 
         await VerifyCodeActionAsync(input, expected, LanguageServerConstants.CodeActions.FullyQualify);
+    }
+
+    [Fact]
+    public async Task FullyQualify_LegacyWithPageDirective()
+    {
+        var input = """
+            @page "/"
+
+            @functions
+            {
+                private [||]StringBuilder _x = new StringBuilder();
+            }
+            """;
+
+        var expected = """
+            @page "/"
+
+            @functions
+            {
+                private System.Text.StringBuilder _x = new StringBuilder();
+            }
+            """;
+
+        await VerifyCodeActionAsync(
+            input,
+            expected,
+            LanguageServerConstants.CodeActions.FullyQualify,
+            fileKind: RazorFileKind.Legacy,
+            makeDiagnosticsRequest: true);
     }
 
 #if !VSCODE

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/AddUsingTests.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/AddUsingTests.cs
@@ -203,6 +203,98 @@ public class AddUsingTests(ITestOutputHelper testOutputHelper) : CohostCodeActio
     }
 
     [Fact]
+    public async Task AddUsing_LegacyWithPageDirective()
+    {
+        var input = """
+            @page "/"
+
+            @functions
+            {
+                private [||]StringBuilder _x = new StringBuilder();
+            }
+            """;
+
+        var expected = """
+            @page "/"
+            @using System.Text
+
+            @functions
+            {
+                private StringBuilder _x = new StringBuilder();
+            }
+            """;
+
+        await VerifyCodeActionAsync(
+            input,
+            expected,
+            RazorPredefinedCodeFixProviderNames.AddImport,
+            fileKind: RazorFileKind.Legacy,
+            makeDiagnosticsRequest: true);
+    }
+
+    [Fact]
+    public async Task AddUsing_LegacyWithPageDirectiveAndTagHelpers_HtmlString()
+    {
+        var input = """
+            @page "/"
+            @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+            @{
+             var z = new [||]HtmlString("asdf");
+            }
+            """;
+
+        var expected = """
+            @page "/"
+            @using Microsoft.AspNetCore.Html
+            @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+            @{
+             var z = new HtmlString("asdf");
+            }
+            """;
+
+        await VerifyCodeActionAsync(
+            input,
+            expected,
+            RazorPredefinedCodeFixProviderNames.AddImport,
+            fileKind: RazorFileKind.Legacy,
+            addDefaultImports: false,
+            makeDiagnosticsRequest: true);
+    }
+
+    [Fact]
+    public async Task AddUsing_LegacyWithPageDirectiveWithoutRouteAndTagHelpers_HtmlString()
+    {
+        var input = """
+            @page
+            @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+            @{
+             var z = new [||]HtmlString("asdf");
+            }
+            """;
+
+        var expected = """
+            @page
+            @using Microsoft.AspNetCore.Html
+            @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+            @{
+             var z = new HtmlString("asdf");
+            }
+            """;
+
+        await VerifyCodeActionAsync(
+            input,
+            expected,
+            RazorPredefinedCodeFixProviderNames.AddImport,
+            fileKind: RazorFileKind.Legacy,
+            addDefaultImports: false,
+            makeDiagnosticsRequest: true);
+    }
+
+    [Fact]
     public async Task AddUsing_Typo()
     {
         var input = """


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-dotnettools/issues/3010

I accidentally introduced this bug in one of the cleanup phases of our edit mapping, and sadly it doesn't always repro so our test coverage missed it. Before my cleanup, the ontype formatter would process using directive edits after doing its full formatting pass. When I combined everything together into one big `MapCSharpEditsAsync` call, it moved some of those edits up earlier in the process, but then the ontype formatter could filter them out again.

The fix is to allow ontype formatting to supply a filter so that it only applies to directly mappable edits, leaving the C# language feature edits (what used to be "using directive edits") to always be present, because we trust that the edit mapping service does the right thing.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83448)