### PR TITLE
Generate Documentation - Dismiss session on caret move before generated proposal

### DIFF
--- a/src/EditorFeatures/Core/DocumentationComments/DocumentationCommentSuggestion.cs
+++ b/src/EditorFeatures/Core/DocumentationComments/DocumentationCommentSuggestion.cs
@@ -62,6 +62,13 @@ internal sealed class DocumentationCommentSuggestion(CopilotGenerateDocumentatio
             Logger.Log(FunctionId.Copilot_Generate_Documentation_Diverged, logLevel: LogLevel.Information);
             await session.DismissAsync(ReasonForDismiss.DismissedAfterBufferChange, cancel).ConfigureAwait(false);
         }
+        // If the caret has moved and no proposal has been generated yet (still showing thinking dots),
+        // dismiss the session so the dots don't follow the caret around.
+        else if (originalProposal is null && reason == ReasonForUpdate.DivergedAfterCaretMove)
+        {
+            Logger.Log(FunctionId.Copilot_Generate_Documentation_Dismissed, logLevel: LogLevel.Information);
+            await session.DismissAsync(ReasonForDismiss.DismissedAfterCaretMove, cancel).ConfigureAwait(false);
+        }
     }
 
     /// <summary>

--- a/src/EditorFeatures/Core/DocumentationComments/DocumentationCommentSuggestion.cs
+++ b/src/EditorFeatures/Core/DocumentationComments/DocumentationCommentSuggestion.cs
@@ -62,10 +62,10 @@ internal sealed class DocumentationCommentSuggestion(CopilotGenerateDocumentatio
             Logger.Log(FunctionId.Copilot_Generate_Documentation_Diverged, logLevel: LogLevel.Information);
             await session.DismissAsync(ReasonForDismiss.DismissedAfterBufferChange, cancel).ConfigureAwait(false);
         }
-        // If the caret has moved and no proposal has been generated yet (still showing thinking dots),
-        // dismiss the session so the dots don't follow the caret around.
         else if (originalProposal is null && reason == ReasonForUpdate.DivergedAfterCaretMove)
         {
+            // If the caret has moved and no proposal has been generated yet (still showing thinking dots),
+            // dismiss the session so the dots don't follow the caret around.
             Logger.Log(FunctionId.Copilot_Generate_Documentation_Dismissed, logLevel: LogLevel.Information);
             await session.DismissAsync(ReasonForDismiss.DismissedAfterCaretMove, cancel).ConfigureAwait(false);
         }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/83162