### PR TITLE
Fix tag helper attribute completion with ParentTag constraint

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/TagHelperCompletionProvider.cs
@@ -174,7 +174,12 @@ internal class TagHelperCompletionProvider(ITagHelperCompletionService tagHelper
         TagHelperDocumentContext tagHelperDocumentContext,
         RazorCompletionOptions options)
     {
-        var ancestors = containingAttribute.Parent.Ancestors();
+        // containingAttribute.Parent is the start tag, and its Parent is the containing element.
+        // We need ancestors of the containing element to correctly resolve ParentTag constraints.
+        // Without this, GetNearestAncestorTagInfo would return the containing element itself as the
+        // "parent", which breaks tag helpers that use ParentTag (e.g., [HtmlTargetElement("header", ParentTag = "container")]).
+        var containingElement = containingAttribute.Parent?.Parent;
+        var ancestors = containingElement?.Ancestors() ?? [];
         var nonDirectiveAttributeTagHelpers = tagHelperDocumentContext.TagHelpers.Where(
             static tagHelper => !tagHelper.BoundAttributes.Any(static attribute => attribute.IsDirectiveAttribute));
         var filteredContext = TagHelperDocumentContext.GetOrCreate(tagHelperDocumentContext.Prefix, nonDirectiveAttributeTagHelpers);

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
@@ -504,6 +504,97 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
     }
 
     [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/11512")]
+    public async Task ParentTagConstraint_AttributeCompletedWhenParentMatches()
+    {
+        // A tag helper with ParentTag constraint should have its attributes shown in completion
+        // when the element is inside the correct parent.
+        await VerifyCompletionListAsync(
+            input: """
+                @addTagHelper *, SomeProject
+                <container><header $$></header></container>
+                """,
+            completionContext: new VSInternalCompletionContext()
+            {
+                InvokeKind = VSInternalCompletionInvokeKind.Explicit,
+                TriggerKind = CompletionTriggerKind.Invoked
+            },
+            expectedItemLabels: ["priority"],
+            htmlItemLabels: ["style"],
+            fileKind: RazorFileKind.Legacy,
+            additionalFiles: [("TestTagHelper.cs", """
+                using Microsoft.AspNetCore.Razor.TagHelpers;
+
+                namespace SomeProject
+                {
+                    [HtmlTargetElement("container")]
+                    public class ContainerTagHelper : TagHelper
+                    {
+                        public override void Process(TagHelperContext context, TagHelperOutput output)
+                        {
+                        }
+                    }
+
+                    [HtmlTargetElement("header", ParentTag = "container")]
+                    public class HeaderTagHelper : TagHelper
+                    {
+                        public string Priority { get; set; }
+
+                        public override void Process(TagHelperContext context, TagHelperOutput output)
+                        {
+                        }
+                    }
+                }
+                """)]);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/11512")]
+    public async Task ParentTagConstraint_AttributeNotCompletedWhenParentDoesNotMatch()
+    {
+        // A tag helper with ParentTag constraint should NOT have its attributes shown
+        // when the element is inside the wrong parent.
+        await VerifyCompletionListAsync(
+            input: """
+                @addTagHelper *, SomeProject
+                <div><header $$></header></div>
+                """,
+            completionContext: new VSInternalCompletionContext()
+            {
+                InvokeKind = VSInternalCompletionInvokeKind.Explicit,
+                TriggerKind = CompletionTriggerKind.Invoked
+            },
+            unexpectedItemLabels: ["priority"],
+            expectedItemLabels: ["style"],
+            htmlItemLabels: ["style"],
+            fileKind: RazorFileKind.Legacy,
+            additionalFiles: [("TestTagHelper.cs", """
+                using Microsoft.AspNetCore.Razor.TagHelpers;
+
+                namespace SomeProject
+                {
+                    [HtmlTargetElement("container")]
+                    public class ContainerTagHelper : TagHelper
+                    {
+                        public override void Process(TagHelperContext context, TagHelperOutput output)
+                        {
+                        }
+                    }
+
+                    [HtmlTargetElement("header", ParentTag = "container")]
+                    public class HeaderTagHelper : TagHelper
+                    {
+                        public string Priority { get; set; }
+
+                        public override void Process(TagHelperContext context, TagHelperOutput output)
+                        {
+                        }
+                    }
+                }
+                """)]);
+    }
+
+    [Fact]
     public async Task HtmlCompletionFailure_ReturnsIncompleteEmptyList()
     {
         // When the HTML language server fails to respond (e.g., not yet initialized on first document open),

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/TagHelperCompletionProviderTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/TagHelperCompletionProviderTest.cs
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.CodeAnalysis.Razor.Completion;
+
+public class TagHelperCompletionProviderTest(ITestOutputHelper testOutput) : ToolingTestBase(testOutput)
+{
+    [Fact]
+    public void GetCompletionItems_ParentTagConstraint_AttributeCompletedWhenParentMatches()
+    {
+        // Arrange - use SimpleTagHelpers which includes a "SomeChild" tag helper
+        // that requires ParentTag = "test1" and has a bound attribute "attribute".
+        // Legacy file kind requires @addTagHelper directive for tag helper resolution.
+        var tagHelpers = SimpleTagHelpers.Default;
+
+        var testCode = new TestCode("@addTagHelper *, TestAssembly\n<test1><SomeChild $$></SomeChild></test1>");
+        var codeDocument = CreateCodeDocument(testCode.Text, tagHelpers);
+        var syntaxTree = codeDocument.GetRequiredTagHelperRewrittenSyntaxTree();
+        var tagHelperContext = codeDocument.GetRequiredTagHelperContext();
+
+        var owner = syntaxTree.Root.FindInnermostNode(testCode.Position, includeWhitespace: true, walkMarkersBack: true);
+        owner = AbstractRazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, testCode.Position);
+
+        var context = new RazorCompletionContext(
+            codeDocument,
+            testCode.Position,
+            owner,
+            syntaxTree,
+            tagHelperContext,
+            CompletionReason.Invoked,
+            new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true, UseVsCodeCompletionCommitCharacters: false));
+
+        var provider = new TagHelperCompletionProvider(new TagHelperCompletionService());
+
+        // Act
+        var completions = provider.GetCompletionItems(context);
+
+        // Assert - The "attribute" bound attribute should appear in completions because
+        // the SomeChild tag is inside test1, satisfying the ParentTag constraint
+        var childAttrCompletion = completions.FirstOrDefault(c => c.DisplayText == "attribute");
+        Assert.NotNull(childAttrCompletion);
+    }
+
+    [Fact]
+    public void GetCompletionItems_ParentTagConstraint_AttributeNotCompletedWhenParentDoesNotMatch()
+    {
+        // Arrange - SomeChild requires ParentTag="test1", but we put it inside "div" instead
+        var tagHelpers = SimpleTagHelpers.Default;
+
+        var testCode = new TestCode("@addTagHelper *, TestAssembly\n<div><SomeChild $$></SomeChild></div>");
+        var codeDocument = CreateCodeDocument(testCode.Text, tagHelpers);
+        var syntaxTree = codeDocument.GetRequiredTagHelperRewrittenSyntaxTree();
+        var tagHelperContext = codeDocument.GetRequiredTagHelperContext();
+
+        var owner = syntaxTree.Root.FindInnermostNode(testCode.Position, includeWhitespace: true, walkMarkersBack: true);
+        owner = AbstractRazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, testCode.Position);
+
+        var context = new RazorCompletionContext(
+            codeDocument,
+            testCode.Position,
+            owner,
+            syntaxTree,
+            tagHelperContext,
+            CompletionReason.Invoked,
+            new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true, UseVsCodeCompletionCommitCharacters: false));
+
+        var provider = new TagHelperCompletionProvider(new TagHelperCompletionService());
+
+        // Act
+        var completions = provider.GetCompletionItems(context);
+
+        // Assert - The "attribute" should NOT appear because the parent is div, not test1
+        var childAttrCompletion = completions.FirstOrDefault(c => c.DisplayText == "attribute");
+        Assert.Null(childAttrCompletion);
+    }
+
+    private static RazorCodeDocument CreateCodeDocument(string text, TagHelperCollection tagHelpers)
+    {
+        var sourceDocument = TestRazorSourceDocument.Create(text);
+        var projectEngine = RazorProjectEngine.Create(builder =>
+        {
+            builder.ConfigureParserOptions(builder =>
+            {
+                builder.UseRoslynTokenizer = true;
+            });
+        });
+
+        return projectEngine.Process(sourceDocument, RazorFileKind.Legacy, importSources: default, tagHelpers);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/11512

Summary

Tag helper attributes were not appearing in completion lists when the tag helper used a ParentTag constraint (e.g., [HtmlTargetElement("header", ParentTag = "container")]).

Root Cause

In TagHelperCompletionProvider.GetAttributeCompletions(), the ancestor chain was built from containingAttribute.Parent.Ancestors(). Since .Parent is the start tag, .Ancestors() yields the current element as the first ancestor — so GetNearestAncestorTagInfo returned the element itself rather than its actual parent. This caused SatisfiesParentTag() to always fail for constrained tag helpers.

Fix

Navigate through the containing element (containingAttribute.Parent?.Parent) before calling .Ancestors(), matching the existing correct pattern in HoverFactory.cs.

Testing

Added two tests validating ParentTag completion (positive and negative cases). All 218 existing completion tests pass.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83455)