### PR TITLE
Add Razor scoped copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,6 +10,7 @@
 - **EditorFeatures** (`src/EditorFeatures/`): Editor-specific implementations and text buffer integration
 - **LanguageServer** (`src/LanguageServer/`): LSP implementation used by VS Code extension
 - **VisualStudio** (`src/VisualStudio/`): VS-specific language services and UI integration
+- **Razor** (`src/Razor/`): Razor compiler and Razor IDE tooling for `.razor`/`.cshtml` files (merged from `dotnet/razor`). The sub-tree kept its internal layout, so source actually lives under `src/Razor/src/Razor/`, `src/Razor/src/Compiler/`, `src/Razor/src/Shared/`, and `src/Razor/src/Analyzers/`. See `.github/instructions/Razor.instructions.md` for razor-specific guidance.
 
 ## Development Workflow
 

--- a/.github/instructions/Razor.instructions.md
+++ b/.github/instructions/Razor.instructions.md
@@ -1,0 +1,89 @@
+---
+applyTo: "src/Razor/**/*.{cs,vb}"
+---
+
+# Razor Tooling and Compiler Instructions for AI Coding Agents
+
+These instructions complement the repository-wide `copilot-instructions.md` and apply to
+all Razor sources under `src/Razor/`. Razor was merged into the Roslyn repo from
+`dotnet/razor`, and most files keep their original sub-tree layout
+(`src/Razor/src/Razor/...`, `src/Razor/src/Compiler/...`, `src/Razor/src/Shared/...`,
+`src/Razor/src/Analyzers/...`).
+
+## Critical Rules
+
+- **Build wrappers**: Be careful passing `-projects` through `build.cmd` or PowerShell wrappers.
+  Do not pass a semicolon-delimited project list through a nested PowerShell command invocation,
+  because PowerShell can treat `;` as a statement separator and open `.csproj` files in
+  Visual Studio. Prefer a single project at a time, or invoke the underlying script in a way
+  that preserves the full `-projects` value as one argument.
+- **Bug fixes**: Look for existing code that already handles the scenario before adding new code.
+  The bug is more likely in existing logic than a missing feature.
+- **Helpers**: Review existing helpers (`UsingDirectiveHelper`, `AddUsingsHelper`, etc.)
+  before writing new utility methods. Don't duplicate.
+- **Avoid blind `dotnet test` over the whole Razor tree**: Razor includes Playwright-based
+  VS Code integration tests under
+  `src\Razor\src\Razor\test\Microsoft.VisualStudioCode.Razor.IntegrationTests`. They require
+  VS Code and waste significant time. Target a specific test project with
+  `dotnet test path\to\Project.csproj` instead.
+
+## File Types
+
+- `.razor` -- Blazor components.
+- `.cshtml` -- Razor views/pages (referred to as "Legacy" in the codebase).
+
+## Code Patterns
+
+- **Collections**: Use `ListPool<T>.GetPooledObject(out var list)` and `PooledArrayBuilder<T>`
+  instead of allocating new collections. Prefer immutable collection types.
+- **Positions**: Use `GetRequiredAbsoluteIndex` for converting positions to absolute indexes.
+- **LSP conversions**: `sourceText.GetTextChange(textEdit)` converts LSP `TextEdit` to
+  Roslyn `TextChange`. Reverse: `sourceText.GetTextEdit(change)`. Both live in
+  `src\Razor\src\Razor\src\Microsoft.CodeAnalysis.Razor.Workspaces\Extensions\LspExtensions_SourceText.cs`.
+- **RazorCodeDocument**: Immutable -- every `With*` method creates a new instance passing ALL
+  fields through the constructor. When adding a new field, thread it through every existing
+  `With*` method. Prefer computing derived data via extension methods (e.g.,
+  `GetUnusedDirectives()`) rather than storing computed results as fields.
+- **Razor documents in Roslyn**: Stored as additional documents. Resolve via
+  `solution.GetDocumentIdsWithFilePath(filePath)` then `solution.GetAdditionalDocument(documentId)`.
+- **Remote services**: Place the public stub method (calling `RunServiceAsync`) directly
+  above its private implementation method.
+
+## Testing
+
+- Place `[WorkItem("url")]` on tests that track a specific issue (GitHub or DevOps URL).
+- Use `TestCode` with `[|...|]` span markers for before/after test scenarios. Access
+  `input.Text` (cleaned) and `input.Span` (marked range).
+- Prefer raw string literals (`"""..."""`) over verbatim strings (`@"..."`).
+- Test end-user scenarios, not implementation details.
+- Verify/helper methods go at the bottom of test files. New test methods go above them.
+- New tooling tests go in
+  `src\Razor\src\Razor\test\Microsoft.VisualStudioCode.RazorExtension.UnitTests`
+  (Cohosting architecture).
+- Integration tests using `AdditionalSyntaxTrees` for tag helper discovery must set
+  `UseTwoPhaseCompilation => true` (see `ComponentDiscoveryIntegrationTest`).
+
+## Adding OOP Remote Services
+
+When adding a new `IRemote*Service` and `Remote*Service`:
+
+1. Interface: `src\Razor\src\Razor\src\Microsoft.CodeAnalysis.Razor.Workspaces\Remote\`
+2. Implementation: `src\Razor\src\Razor\src\Microsoft.CodeAnalysis.Remote.Razor\`
+3. Register in
+   `src\Razor\src\Razor\src\Microsoft.CodeAnalysis.Razor.Workspaces\Remote\RazorServices.cs`
+   (add to `MessagePackServices` or `JsonServices`).
+4. **Add an entry to `eng\targets\RazorServices.props`** (at the Roslyn repo root, not under
+   `src\Razor`):
+   `Include="Microsoft.VisualStudio.Razor.{ShortName}"` with
+   `ClassName="{FullTypeName}+Factory"`. The `ShortName` is your interface name with
+   `IRemote` and `Service` stripped (e.g., `IRemoteFrobulatorService` becomes `Frobulator`).
+5. Validate: `dotnet test src\Razor\src\Razor\test\Microsoft.CodeAnalysis.Remote.Razor.UnitTests --filter "FullyQualifiedName~RazorServicesTest"`
+
+## VS Code Validation
+
+Run Playwright E2E tests (the one place where `dotnet test` over a whole project tree is fine):
+
+```powershell
+cd src\Razor\src\Razor\test\Microsoft.VisualStudioCode.Razor.IntegrationTests
+dotnet test
+```


### PR DESCRIPTION
Recovers the `copilot-instructions.md` content from `dotnet/razor` (last commit before archive: [`2084a36`](https://github.com/dotnet/razor/blob/2084a36f86d094c4939ccb5d2d67453924c1f50b/.github/copilot-instructions.md)) and adapts it to roslyn's merged sub-tree layout.

### Changes

- **New `.github/instructions/Razor.instructions.md`** scoped to `src/Razor/**/*.{cs,vb}`, alongside the existing `IDE.instructions.md` and `Compiler.instructions.md`.
- Paths updated for the `src/Razor/src/Razor/...` layout (the razor sub-tree kept its internal `src/` directory, so the actual source is two levels deep).
- Test project names corrected to `*.UnitTests` to match what's actually in the repo.
- OOP service registration step now points at `eng/targets/RazorServices.props` at the roslyn root (renamed from the old `src/Razor/eng/targets/Services.props` to avoid colliding with roslyn's existing `Services.props`).
- **Repository-level `copilot-instructions.md`** gains a single line in the Core Components list announcing Razor's presence and pointing at the new scoped file.

### Notes

The two razor-specific skills (`formatting-log` and `run-toolset-tests`) were already migrated as part of the merge. The only razor skill not migrated was `update-roslyn-version`, which is moot now that the repos share a tree.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83461)