### PR TITLE
Clear false-positive SuggestionMode in Razor implicit expression completions

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/DelegatedCompletionHelper.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/DelegatedCompletionHelper.cs
@@ -32,7 +32,7 @@ internal static class DelegatedCompletionHelper
     // 2. Adds items
     // 3. Filters items
     private static readonly ImmutableArray<IDelegatedCSharpCompletionResponseRewriter> s_delegatedCSharpCompletionResponseRewriters =
-        [new SnippetResponseRewriter(), new TextEditResponseRewriter(), new DesignTimeHelperResponseRewriter()];
+        [new SnippetResponseRewriter(), new TextEditResponseRewriter(), new DesignTimeHelperResponseRewriter(), new ImplicitExpressionSuggestionModeRewriter()];
 
     // Currently we only have one HTML response re-writer. Should we ever need more, we can create a common base and a collection
     private static readonly HtmlCommitCharacterResponseRewriter s_delegatedHtmlCompletionResponseRewriter = new();

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/ImplicitExpressionSuggestionModeRewriter.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/ImplicitExpressionSuggestionModeRewriter.cs
@@ -1,0 +1,92 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Razor.Completion.Delegation;
+
+/// <summary>
+/// Clears <see cref="Roslyn.LanguageServer.Protocol.VSInternalCompletionList.SuggestionMode"/> for C# completions
+/// at the top level of implicit Razor expressions.
+/// </summary>
+/// <remarks>
+/// In implicit expressions (e.g., <c>@h</c>), the Razor compiler generates C# like
+/// <c>__builder.AddContent(seq, h)</c>. Because <c>RenderTreeBuilder.AddContent</c> has a
+/// <c>RenderFragment</c> (delegate) overload, Roslyn's suggestion-mode completion provider detects
+/// a potential lambda context and enables suggestion mode. This is a false positive at the top level
+/// of an implicit expression—users almost always intend to reference an identifier, not start a lambda.
+///
+/// However, implicit expressions can contain nested method calls with balanced parentheses
+/// (e.g., <c>@items.Where(x =&gt; x.Name)</c>), where suggestion mode from the inner method's
+/// delegate parameter is legitimate. This rewriter only clears suggestion mode when the cursor is
+/// at the top level of the implicit expression (not inside parentheses).
+/// </remarks>
+internal class ImplicitExpressionSuggestionModeRewriter : IDelegatedCSharpCompletionResponseRewriter
+{
+    public RazorVSInternalCompletionList Rewrite(
+        RazorVSInternalCompletionList completionList,
+        RazorCodeDocument codeDocument,
+        int hostDocumentIndex,
+        Position projectedPosition,
+        RazorCompletionOptions completionOptions)
+    {
+        if (!completionList.SuggestionMode)
+        {
+            return completionList;
+        }
+
+        // The cursor is positioned right after the last typed character.  For example, in @h|
+        // the host document index points at the character after 'h', which is typically the
+        // start of the next token (e.g., '<' in '</div>').  To find the token the user is
+        // actually typing, we look one position back.
+        if (hostDocumentIndex == 0)
+        {
+            return completionList;
+        }
+
+        var owner = codeDocument
+            .GetRequiredSyntaxRoot()
+            .FindInnermostNode(hostDocumentIndex - 1);
+
+        var implicitExpression = owner?.FirstAncestorOrSelf<CSharpImplicitExpressionSyntax>();
+        if (implicitExpression is not null
+            && !IsInsideParentheses(codeDocument.Source.Text, implicitExpression.SpanStart, hostDocumentIndex))
+        {
+            completionList.SuggestionMode = false;
+        }
+
+        return completionList;
+    }
+
+    /// <summary>
+    /// Checks whether the position at <paramref name="end"/> is inside unbalanced parentheses
+    /// relative to <paramref name="start"/>.
+    /// </summary>
+    /// <remarks>
+    /// We use character scanning rather than Razor syntax tree inspection because the Razor parser
+    /// treats all C# content in an implicit expression as a single flat <c>CSharpExpressionLiteralSyntax</c>
+    /// token. Both <c>@h</c> and <c>@items.Where(x)</c> produce identical ancestor chains, so tree
+    /// depth cannot distinguish top-level positions from those nested inside parentheses.
+    /// </remarks>
+    private static bool IsInsideParentheses(SourceText sourceText, int start, int end)
+    {
+        var depth = 0;
+
+        for (var i = start; i < end; i++)
+        {
+            var ch = sourceText[i];
+            if (ch is '(')
+            {
+                depth++;
+            }
+            else if (ch is ')' && depth > 0)
+            {
+                depth--;
+            }
+        }
+
+        return depth > 0;
+    }
+}

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/ImplicitExpressionSuggestionModeRewriter.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/ImplicitExpressionSuggestionModeRewriter.cs
@@ -50,7 +50,10 @@ internal class ImplicitExpressionSuggestionModeRewriter : IDelegatedCSharpComple
             .GetRequiredSyntaxRoot()
             .FindInnermostNode(hostDocumentIndex - 1);
 
-        var implicitExpression = owner?.FirstAncestorOrSelf<CSharpImplicitExpressionSyntax>();
+        var implicitExpression = owner is { Parent: CSharpCodeBlockSyntax { Parent: CSharpImplicitExpressionBodySyntax { Parent: CSharpImplicitExpressionSyntax expr } } }
+            ? expr
+            : null;
+
         if (implicitExpression is not null
             && !IsInsideParentheses(codeDocument.Source.Text, implicitExpression.SpanStart, hostDocumentIndex))
         {

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
@@ -104,6 +104,57 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
     }
 
     [Fact]
+    public async Task ImplicitExpression_SuggestionModeIsCleared()
+    {
+        // In implicit expressions, the generated C# wraps the expression in __builder.AddContent(seq, expr).
+        // AddContent has a RenderFragment (delegate) overload that causes Roslyn to set SuggestionMode.
+        // We clear it because lambdas are not a practical completion scenario at the top level of implicit expressions.
+        var result = await VerifyCompletionListAsync(
+            input: """
+                This is a Razor document.
+
+                <div>@h$$</div>
+
+                The end.
+                """,
+            completionContext: new VSInternalCompletionContext()
+            {
+                InvokeKind = VSInternalCompletionInvokeKind.Typing,
+                TriggerKind = CompletionTriggerKind.Invoked
+            },
+            expectedItemLabels: ["HashSet<>"]);
+
+        Assert.NotNull(result);
+        Assert.False(result.SuggestionMode);
+    }
+
+    [Fact]
+    public async Task ImplicitExpression_InsideParens_SuggestionModeIsPreserved()
+    {
+        // Inside parentheses of a method that takes a delegate parameter, SuggestionMode should be
+        // preserved because the user may legitimately be starting a lambda expression.
+        var result = await VerifyCompletionListAsync(
+            input: """
+                @using System.Linq
+
+                <div>@items.Where($$)</div>
+
+                @code {
+                    List<string> items = new();
+                }
+                """,
+            completionContext: new VSInternalCompletionContext()
+            {
+                InvokeKind = VSInternalCompletionInvokeKind.Typing,
+                TriggerKind = CompletionTriggerKind.Invoked
+            },
+            expectedItemLabels: ["items"]);
+
+        Assert.NotNull(result);
+        Assert.True(result.SuggestionMode);
+    }
+
+    [Fact]
     public async Task CSharpClassesBeforeTag()
     {
         await VerifyCompletionListAsync(

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/ImplicitExpressionSuggestionModeRewriterTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/ImplicitExpressionSuggestionModeRewriterTest.cs
@@ -1,0 +1,107 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Razor.Completion.Delegation;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Razor.Completion;
+
+public class ImplicitExpressionSuggestionModeRewriterTest
+{
+    private readonly ImplicitExpressionSuggestionModeRewriter _rewriter = new();
+
+    [Fact]
+    public void TopLevel_SimpleIdentifier_ClearsSuggestionMode()
+    {
+        // @h$$
+        Assert.False(GetRewrittenSuggestionMode("<div>@h$$</div>"));
+    }
+
+    [Fact]
+    public void TopLevel_BalancedParens_ClearsSuggestionMode()
+    {
+        // @items.Where(x => x.Name).First()$$
+        Assert.False(GetRewrittenSuggestionMode("<div>@items.Where(x => x.Name).First()$$</div>"));
+    }
+
+    [Fact]
+    public void TopLevel_Brackets_ClearsSuggestionMode()
+    {
+        // Brackets are not tracked — only parentheses affect nesting depth
+        // @items[0].N$$
+        Assert.False(GetRewrittenSuggestionMode("<div>@items[0].N$$</div>"));
+    }
+
+    [Fact]
+    public void Nested_InsideParens_PreservesSuggestionMode()
+    {
+        // @items.Where(x$$)
+        Assert.True(GetRewrittenSuggestionMode("<div>@items.Where(x$$)</div>"));
+    }
+
+    [Fact]
+    public void Nested_InsideNestedParens_PreservesSuggestionMode()
+    {
+        // @items.Where(x => x.Select(y$$))
+        Assert.True(GetRewrittenSuggestionMode("<div>@items.Where(x => x.Select(y$$))</div>"));
+    }
+
+    [Fact]
+    public void NotImplicitExpression_CodeBlock_PreservesSuggestionMode()
+    {
+        // @{ h$$ } — code block, not implicit expression; rewriter should not touch it
+        Assert.True(GetRewrittenSuggestionMode("<div>@{ h$$ }</div>"));
+    }
+
+    [Fact]
+    public void SuggestionModeAlreadyFalse_RemainsUnchanged()
+    {
+        // When SuggestionMode is already false, the rewriter should leave it alone
+        var (codeDocument, cursorIndex) = Parse("<div>@h$$</div>");
+
+        var completionList = CreateCompletionList(suggestionMode: false);
+        var result = _rewriter.Rewrite(completionList, codeDocument, cursorIndex, new Position(), new RazorCompletionOptions());
+
+        Assert.False(result.SuggestionMode);
+    }
+
+    /// <summary>
+    /// Parses the input, invokes the rewriter with SuggestionMode=true, and returns the resulting SuggestionMode value.
+    /// </summary>
+    private bool GetRewrittenSuggestionMode(string textWithMarker)
+    {
+        var (codeDocument, cursorIndex) = Parse(textWithMarker);
+
+        var completionList = CreateCompletionList(suggestionMode: true);
+        var result = _rewriter.Rewrite(completionList, codeDocument, cursorIndex, new Position(), new RazorCompletionOptions());
+
+        return result.SuggestionMode;
+    }
+
+    private static (RazorCodeDocument CodeDocument, int CursorIndex) Parse(string textWithMarker)
+    {
+        var cursorIndex = textWithMarker.IndexOf("$$");
+        Assert.True(cursorIndex >= 0, "Test input must contain $$ cursor marker");
+
+        var text = textWithMarker.Remove(cursorIndex, 2);
+
+        var sourceDocument = TestRazorSourceDocument.Create(text);
+        var options = new RazorParserOptions.Builder(RazorLanguageVersion.Latest, RazorFileKind.Component).ToOptions();
+        var syntaxTree = RazorSyntaxTree.Parse(sourceDocument, options);
+
+        var codeDocument = RazorCodeDocument.Create(sourceDocument);
+        codeDocument = codeDocument.WithTagHelperRewrittenSyntaxTree(syntaxTree);
+
+        return (codeDocument, cursorIndex);
+    }
+
+    private static RazorVSInternalCompletionList CreateCompletionList(bool suggestionMode)
+    {
+        return new RazorVSInternalCompletionList()
+        {
+            Items = [new VSInternalCompletionItem() { Label = "test" }],
+            SuggestionMode = suggestionMode
+        };
+    }
+}

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/ImplicitExpressionSuggestionModeRewriterTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/ImplicitExpressionSuggestionModeRewriterTest.cs
@@ -11,47 +11,22 @@ public class ImplicitExpressionSuggestionModeRewriterTest
 {
     private readonly ImplicitExpressionSuggestionModeRewriter _rewriter = new();
 
-    [Fact]
-    public void TopLevel_SimpleIdentifier_ClearsSuggestionMode()
+    [Theory]
+    [InlineData("<div>@h$$</div>")]                                        // Simple identifier
+    [InlineData("<div>@items.Where(x => x.Name).First()$$</div>")]         // Balanced parens after expression
+    [InlineData("<div>@items[0].N$$</div>")]                               // Brackets don't affect paren depth
+    public void TopLevel_ClearsSuggestionMode(string markup)
     {
-        // @h$$
-        Assert.False(GetRewrittenSuggestionMode("<div>@h$$</div>"));
+        Assert.False(GetRewrittenSuggestionMode(markup));
     }
 
-    [Fact]
-    public void TopLevel_BalancedParens_ClearsSuggestionMode()
+    [Theory]
+    [InlineData("<div>@items.Where(x$$)</div>")]                           // Inside parens
+    [InlineData("<div>@items.Where(x => x.Select(y$$))</div>")]            // Inside nested parens
+    [InlineData("<div>@{ h$$ }</div>")]                                    // Code block, not implicit expression
+    public void Nested_PreservesSuggestionMode(string markup)
     {
-        // @items.Where(x => x.Name).First()$$
-        Assert.False(GetRewrittenSuggestionMode("<div>@items.Where(x => x.Name).First()$$</div>"));
-    }
-
-    [Fact]
-    public void TopLevel_Brackets_ClearsSuggestionMode()
-    {
-        // Brackets are not tracked — only parentheses affect nesting depth
-        // @items[0].N$$
-        Assert.False(GetRewrittenSuggestionMode("<div>@items[0].N$$</div>"));
-    }
-
-    [Fact]
-    public void Nested_InsideParens_PreservesSuggestionMode()
-    {
-        // @items.Where(x$$)
-        Assert.True(GetRewrittenSuggestionMode("<div>@items.Where(x$$)</div>"));
-    }
-
-    [Fact]
-    public void Nested_InsideNestedParens_PreservesSuggestionMode()
-    {
-        // @items.Where(x => x.Select(y$$))
-        Assert.True(GetRewrittenSuggestionMode("<div>@items.Where(x => x.Select(y$$))</div>"));
-    }
-
-    [Fact]
-    public void NotImplicitExpression_CodeBlock_PreservesSuggestionMode()
-    {
-        // @{ h$$ } — code block, not implicit expression; rewriter should not touch it
-        Assert.True(GetRewrittenSuggestionMode("<div>@{ h$$ }</div>"));
+        Assert.True(GetRewrittenSuggestionMode(markup));
     }
 
     [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/11625

Problem

When typing in a Razor implicit expression (e.g., @h or @items.Se), IntelliSense shows in suggestion mode — displaying a header row and requiring Tab to commit instead of Enter. This doesn't happen in @code blocks.

This primarily affects non-Blazor Razor pages. CSHTML pages generate Write(h) which has no delegate overload and are unaffected.

Root Cause

The Razor compiler generates __builder.AddContent(seq, h) for implicit expressions. Because RenderTreeBuilder.AddContent has a RenderFragment (delegate) overload, Roslyn's CSharpSuggestionModeCompletionProvider infers a potential lambda context and enables suggestion mode. This is a false positive — users almost never intend to start a lambda at the top level of an implicit expression.

Fix

Add a new IDelegatedCSharpCompletionResponseRewriter — ImplicitExpressionSuggestionModeRewriter — that clears SuggestionMode when the cursor is at the top level of a CSharpImplicitExpressionSyntax. It preserves suggestion mode inside parentheses (e.g., @items.Where($$)) where lambda completions are legitimate.

The rewriter uses character scanning to determine parenthesis depth because the Razor parser treats all C# content in an implicit expression as a single flat CSharpExpressionLiteralSyntax token — tree depth cannot distinguish top-level from nested positions.

Testing

 - 2 integration tests (CohostDocumentCompletionEndpointTest): top-level clears, inside-parens preserves
 - 7 unit tests (ImplicitExpressionSuggestionModeRewriterTest): simple identifier, balanced parens, brackets, nested parens, inside parens, code block passthrough, already-false passthrough
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83463)