### PR TITLE
[17.11] Change default value of SkipApplyOptimizationData to true

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -31,7 +31,7 @@ parameters:
 
 - name: SkipApplyOptimizationData
   type: boolean
-  default: false
+  default: true
 
 - name: SkipTests
   type: boolean


### PR DESCRIPTION
VS 17.11 is no longer being serviced and the OptProf data is only useful for .NET Framework assemblies.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83465)