### PR TITLE
Fix stale completion span in await and doc comment providers

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AwaitCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AwaitCompletionProviderTests.cs
@@ -4,11 +4,16 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -832,5 +837,100 @@ public sealed class AwaitCompletionProviderTests : AbstractCSharpCompletionProvi
             await VerifyKeywordAsync(code);
         else
             await VerifyAbsenceAsync(code);
+    }
+
+    [Fact]
+    public async Task TestDotAwait_WithAdditionalTypedCharacters_DoesNotLeaveResidualText()
+    {
+        // Simulate the scenario where item.Span is stale: completion triggers at the dot,
+        // user types "aw" before committing. GetChangeAsync receives the current document
+        // (with "aw") but item.Span.End still points to the position right after the dot.
+        var code = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                async Task F()
+                {
+                    Task.Delay(100).$$
+                }
+            }
+            """;
+
+        using var workspace = EditorTestWorkspace.Create(LanguageNames.CSharp,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+            new CSharpParseOptions(LanguageVersion.Default),
+            [code],
+            composition: GetComposition());
+
+        var testDocument = workspace.Documents.Single();
+        var document = workspace.CurrentSolution.GetRequiredDocument(testDocument.Id);
+        var position = testDocument.CursorPosition!.Value;
+
+        var service = GetCompletionService(document.Project);
+        var completionList = await GetCompletionListAsync(service, document, position, CompletionTrigger.Invoke);
+        var awaitItem = completionList.ItemsList.First(i => i.DisplayText == "await");
+
+        // Now simulate the user typing "aw" after the dot by inserting text at the trigger position
+        var text = await document.GetTextAsync();
+        var newText = text.WithChanges(new TextChange(new TextSpan(position, 0), "aw"));
+        var modifiedDocument = document.WithText(newText);
+
+        // GetChangeAsync should produce a clean result even with stale item.Span
+        var change = await service.GetChangeAsync(modifiedDocument, awaitItem, commitCharacter: null, CancellationToken.None);
+
+        var finalText = newText.WithChanges(change.TextChange);
+        var finalCode = finalText.ToString();
+
+        // The result should contain "await Task.Delay(100)" without residual "aw"
+        Assert.Contains("await Task.Delay(100)", finalCode);
+        Assert.DoesNotContain("await Task.Delay(100)aw", finalCode);
+        Assert.DoesNotContain(".aw", finalCode);
+    }
+
+    [Fact]
+    public async Task TestAwaitKeyword_WithAdditionalTypedCharacters_DoesNotLeaveResidualText()
+    {
+        // Same scenario but for the "await at current position" path (non-dot context).
+        // The method is non-async so committing "await" makes it async (complex text edit).
+        var code = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                Task F()
+                {
+                    $$
+                }
+            }
+            """;
+
+        using var workspace = EditorTestWorkspace.Create(LanguageNames.CSharp,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+            new CSharpParseOptions(LanguageVersion.CSharp9),
+            [code],
+            composition: GetComposition());
+
+        var testDocument = workspace.Documents.Single();
+        var document = workspace.CurrentSolution.GetRequiredDocument(testDocument.Id);
+        var position = testDocument.CursorPosition!.Value;
+
+        var service = GetCompletionService(document.Project);
+        var completionList = await GetCompletionListAsync(service, document, position, CompletionTrigger.Invoke);
+        var awaitItem = completionList.ItemsList.First(i => i.DisplayText == "await");
+
+        // Simulate the user typing "aw" at the trigger position
+        var text = await document.GetTextAsync();
+        var newText = text.WithChanges(new TextChange(new TextSpan(position, 0), "aw"));
+        var modifiedDocument = document.WithText(newText);
+
+        var change = await service.GetChangeAsync(modifiedDocument, awaitItem, commitCharacter: null, CancellationToken.None);
+
+        var finalText = newText.WithChanges(change.TextChange);
+        var finalCode = finalText.ToString();
+
+        // Should produce clean "await" without leaving residual "aw"
+        Assert.Contains("await", finalCode);
+        Assert.DoesNotContain("awaitaw", finalCode);
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AwaitCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AwaitCompletionProviderTests.cs
@@ -839,7 +839,7 @@ public sealed class AwaitCompletionProviderTests : AbstractCSharpCompletionProvi
             await VerifyAbsenceAsync(code);
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/razor/issues/11569")]
     public async Task TestDotAwait_WithAdditionalTypedCharacters_DoesNotLeaveResidualText()
     {
         // Simulate the scenario where item.Span is stale: completion triggers at the dot,
@@ -888,7 +888,7 @@ public sealed class AwaitCompletionProviderTests : AbstractCSharpCompletionProvi
         Assert.DoesNotContain(".aw", finalCode);
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/razor/issues/11569")]
     public async Task TestAwaitKeyword_WithAdditionalTypedCharacters_DoesNotLeaveResidualText()
     {
         // Same scenario but for the "await at current position" path (non-dot context).

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/XmlDocumentationCommentCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/XmlDocumentationCommentCompletionProviderTests.cs
@@ -1182,7 +1182,7 @@ public sealed class XmlDocumentationCommentCompletionProviderTests : AbstractCSh
             typeparamref name="T"
             """);
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/razor/issues/11569")]
     public async Task TestDocCommentTag_WithAdditionalTypedCharacters_DoesNotLeaveResidualText()
     {
         // Simulate the scenario where item.Span is stale: completion triggers after "<" in a doc comment,

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/XmlDocumentationCommentCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/XmlDocumentationCommentCompletionProviderTests.cs
@@ -6,11 +6,15 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -1177,4 +1181,47 @@ public sealed class XmlDocumentationCommentCompletionProviderTests : AbstractCSh
             """, """
             typeparamref name="T"
             """);
+
+    [Fact]
+    public async Task TestDocCommentTag_WithAdditionalTypedCharacters_DoesNotLeaveResidualText()
+    {
+        // Simulate the scenario where item.Span is stale: completion triggers after "<" in a doc comment,
+        // user types "su" before committing "summary". GetChangeAsync receives the current document
+        // (with "su") but item.Span.End still points to the position right after "<".
+        var code = """
+            class C
+            {
+                /// <$$
+                void M(int x) { }
+            }
+            """;
+
+        using var workspace = EditorTestWorkspace.Create(LanguageNames.CSharp,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+            new CSharpParseOptions(LanguageVersion.Default),
+            [code],
+            composition: GetComposition());
+
+        var testDocument = workspace.Documents.Single();
+        var document = workspace.CurrentSolution.GetRequiredDocument(testDocument.Id);
+        var position = testDocument.CursorPosition!.Value;
+
+        var service = GetCompletionService(document.Project);
+        var completionList = await GetCompletionListAsync(service, document, position, Microsoft.CodeAnalysis.Completion.CompletionTrigger.Invoke);
+        var summaryItem = completionList.ItemsList.First(i => i.DisplayText == "summary");
+
+        // Simulate the user typing "su" after the "<"
+        var text = await document.GetTextAsync();
+        var newText = text.WithChanges(new TextChange(new TextSpan(position, 0), "su"));
+        var modifiedDocument = document.WithText(newText);
+
+        var change = await service.GetChangeAsync(modifiedDocument, summaryItem, commitCharacter: null, CancellationToken.None);
+
+        var finalText = newText.WithChanges(change.TextChange);
+        var finalCode = finalText.ToString();
+
+        // Should produce clean "summary" tag without residual "su"
+        Assert.Contains("/// <summary", finalCode);
+        Assert.DoesNotContain("summarysu", finalCode);
+    }
 }

--- a/src/Features/Core/Portable/Completion/Providers/AbstractAwaitCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractAwaitCompletionProvider.cs
@@ -174,6 +174,7 @@ internal abstract class AbstractAwaitCompletionProvider : LSPCompletionProvider
         var syntaxKinds = syntaxFacts.SyntaxKinds;
 
         var root = await syntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
+        var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
 
         if (item.TryGetProperty(MakeContainerAsync, out var _))
         {
@@ -206,9 +207,10 @@ internal abstract class AbstractAwaitCompletionProvider : LSPCompletionProvider
         }
 
         // item.Span was captured when the completion session started and does not advance as the
-        // user types. Compute the actual span of the typed text from the current syntax tree so we
-        // replace all characters the user has entered since the trigger point.
-        var currentSpanEnd = root.FindToken(item.Span.Start).Span.End;
+        // user types. Scan forward from the original span start to find the current end of any
+        // typed identifier characters so we replace all characters the user has entered since the
+        // trigger point.
+        var currentSpanEnd = CompletionUtilities.GetCurrentSpanEnd(item.Span.Start, text, syntaxFacts);
 
         if (item.TryGetProperty(AddAwaitAtCurrentPosition, out var _))
         {
@@ -234,7 +236,6 @@ internal abstract class AbstractAwaitCompletionProvider : LSPCompletionProvider
             builder.Add(new TextChange(TextSpan.FromBounds(dotToken.Value.SpanStart, currentSpanEnd), replacementText));
         }
 
-        var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
         var newText = text.WithChanges(builder);
         var allChanges = builder.ToImmutable();
 

--- a/src/Features/Core/Portable/Completion/Providers/AbstractAwaitCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractAwaitCompletionProvider.cs
@@ -100,6 +100,11 @@ internal abstract class AbstractAwaitCompletionProvider : LSPCompletionProvider
         builder.Add(KeyValuePair.Create(Position, position.ToString()));
         builder.Add(KeyValuePair.Create(LeftTokenPosition, leftToken.SpanStart.ToString()));
 
+        // Compute the identifier length at the trigger position so GetChangeAsync can
+        // distinguish pre-existing text from characters the user typed after the trigger.
+        var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        builder.Add(CompletionUtilities.GetOriginalIdentifierEndProperty(position, text, syntaxFacts));
+
         var makeContainerAsync = declaration is not null && !SyntaxGenerator.GetGenerator(document).GetModifiers(declaration).IsAsync;
         if (makeContainerAsync)
             builder.Add(KeyValuePair.Create(MakeContainerAsync, string.Empty));
@@ -173,11 +178,9 @@ internal abstract class AbstractAwaitCompletionProvider : LSPCompletionProvider
         var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
         var syntaxKinds = syntaxFacts.SyntaxKinds;
 
-        var root = await syntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
-        var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
-
         if (item.TryGetProperty(MakeContainerAsync, out var _))
         {
+            var root = await syntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
             var position = int.Parse(item.GetProperty(Position));
             var leftTokenPosition = int.Parse(item.GetProperty(LeftTokenPosition));
             var declaration = GetAsyncSupportingDeclaration(root.FindToken(leftTokenPosition), position);
@@ -206,11 +209,12 @@ internal abstract class AbstractAwaitCompletionProvider : LSPCompletionProvider
             builder.AddIfNotNull(returnTypeChange);
         }
 
+        var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
+
         // item.Span was captured when the completion session started and does not advance as the
-        // user types. Scan forward from the original span start to find the current end of any
-        // typed identifier characters so we replace all characters the user has entered since the
-        // trigger point.
-        var currentSpanEnd = CompletionUtilities.GetCurrentSpanEnd(item.Span.Start, text, syntaxFacts);
+        // user types. Use the original identifier length (stored at trigger time) to detect how
+        // many characters the user has typed since, so the replacement span covers them all.
+        var currentSpanEnd = CompletionUtilities.GetCurrentSpanEnd(item, text, syntaxFacts);
 
         if (item.TryGetProperty(AddAwaitAtCurrentPosition, out var _))
         {

--- a/src/Features/Core/Portable/Completion/Providers/AbstractAwaitCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractAwaitCompletionProvider.cs
@@ -173,9 +173,10 @@ internal abstract class AbstractAwaitCompletionProvider : LSPCompletionProvider
         var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
         var syntaxKinds = syntaxFacts.SyntaxKinds;
 
+        var root = await syntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
+
         if (item.TryGetProperty(MakeContainerAsync, out var _))
         {
-            var root = await syntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
             var position = int.Parse(item.GetProperty(Position));
             var leftTokenPosition = int.Parse(item.GetProperty(LeftTokenPosition));
             var declaration = GetAsyncSupportingDeclaration(root.FindToken(leftTokenPosition), position);
@@ -204,9 +205,14 @@ internal abstract class AbstractAwaitCompletionProvider : LSPCompletionProvider
             builder.AddIfNotNull(returnTypeChange);
         }
 
+        // item.Span was captured when the completion session started and does not advance as the
+        // user types. Compute the actual span of the typed text from the current syntax tree so we
+        // replace all characters the user has entered since the trigger point.
+        var currentSpanEnd = root.FindToken(item.Span.Start).Span.End;
+
         if (item.TryGetProperty(AddAwaitAtCurrentPosition, out var _))
         {
-            builder.Add(new TextChange(item.Span, _awaitKeyword));
+            builder.Add(new TextChange(TextSpan.FromBounds(item.Span.Start, currentSpanEnd), _awaitKeyword));
         }
         else
         {
@@ -225,7 +231,7 @@ internal abstract class AbstractAwaitCompletionProvider : LSPCompletionProvider
                 ? $".{nameof(Task.ConfigureAwait)}({_falseKeyword})"
                 : "";
 
-            builder.Add(new TextChange(TextSpan.FromBounds(dotToken.Value.SpanStart, item.Span.End), replacementText));
+            builder.Add(new TextChange(TextSpan.FromBounds(dotToken.Value.SpanStart, currentSpanEnd), replacementText));
         }
 
         var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/Completion/Providers/AbstractDocCommentCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractDocCommentCompletionProvider.cs
@@ -86,7 +86,12 @@ internal abstract class AbstractDocCommentCompletionProvider<TSyntax> : LSPCompl
 
         if (items != null)
         {
-            context.AddItems(items);
+            // Store the identifier length at trigger time so GetChangeAsync can distinguish
+            // pre-existing text from characters the user typed after the trigger.
+            var text = await context.Document.GetTextAsync(context.CancellationToken).ConfigureAwait(false);
+            var syntaxFacts = context.Document.GetRequiredLanguageService<ISyntaxFactsService>();
+
+            context.AddItems(items.Select(item => CompletionUtilities.SetOriginalIdentifierEnd(item, context.Position, text, syntaxFacts)));
         }
     }
 
@@ -285,15 +290,16 @@ internal abstract class AbstractDocCommentCompletionProvider<TSyntax> : LSPCompl
         var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
 
         // item.Span was captured when the completion session started and does not advance as the
-        // user types. Scan forward from the original span start to find the current end of any
-        // typed identifier characters. We cannot use the syntax tree here because doc comments are
-        // trivia in the C# tree, and FindToken would return the next code token instead.
-        // We also cannot use CompletionService.GetDefaultCompletionListSpan because its underlying
-        // GetWordSpan only extends forward when the position is in the *middle* of a word (i.e.
-        // there are word characters before it). Since item.Span.Start is at the beginning of
-        // any typed text, GetWordSpan returns a zero-length span and misses the typed characters.
+        // user types. Use the original identifier length (stored at trigger time) to detect how
+        // many characters the user has typed since, so the replacement span covers them all.
+        // We cannot use the syntax tree here because doc comments are trivia in the C# tree,
+        // and FindToken would return the next code token instead. We also cannot use
+        // CompletionService.GetDefaultCompletionListSpan because its underlying GetWordSpan only
+        // extends forward when the position is in the *middle* of a word (i.e. there are word
+        // characters before it). Since item.Span.Start is at the beginning of any typed text,
+        // GetWordSpan returns a zero-length span and misses the typed characters.
         var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
-        var spanEnd = CompletionUtilities.GetCurrentSpanEnd(item.Span.Start, text, syntaxFacts);
+        var spanEnd = CompletionUtilities.GetCurrentSpanEnd(item, text, syntaxFacts);
 
         var itemSpan = item.Span;
         var replacementSpan = TextSpan.FromBounds(text[itemSpan.Start - 1] == '<' && beforeCaretText[0] == '<' ? itemSpan.Start - 1 : itemSpan.Start, spanEnd);

--- a/src/Features/Core/Portable/Completion/Providers/AbstractDocCommentCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractDocCommentCompletionProvider.cs
@@ -283,8 +283,22 @@ internal abstract class AbstractDocCommentCompletionProvider<TSyntax> : LSPCompl
         var afterCaretText = XmlDocCommentCompletionItem.GetAfterCaretText(item);
         var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
 
+        // item.Span was captured when the completion session started and does not advance as the
+        // user types. Scan forward from the original span start to find the current end of any
+        // typed identifier characters. We cannot use the syntax tree here because doc comments are
+        // trivia in the C# tree, and FindToken would return the next code token instead.
+        // We also cannot use CompletionService.GetDefaultCompletionListSpan because its underlying
+        // GetWordSpan only extends forward when the position is in the *middle* of a word (i.e.
+        // there are word characters before it). Since item.Span.Start is at the beginning of
+        // any typed text, GetWordSpan returns a zero-length span and misses the typed characters.
+        var spanEnd = item.Span.Start;
+        while (spanEnd < text.Length && char.IsLetterOrDigit(text[spanEnd]))
+        {
+            spanEnd++;
+        }
+
         var itemSpan = item.Span;
-        var replacementSpan = TextSpan.FromBounds(text[itemSpan.Start - 1] == '<' && beforeCaretText[0] == '<' ? itemSpan.Start - 1 : itemSpan.Start, itemSpan.End);
+        var replacementSpan = TextSpan.FromBounds(text[itemSpan.Start - 1] == '<' && beforeCaretText[0] == '<' ? itemSpan.Start - 1 : itemSpan.Start, spanEnd);
 
         var replacementText = beforeCaretText;
         var newPosition = replacementSpan.Start + beforeCaretText.Length;

--- a/src/Features/Core/Portable/Completion/Providers/AbstractDocCommentCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractDocCommentCompletionProvider.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -291,11 +292,8 @@ internal abstract class AbstractDocCommentCompletionProvider<TSyntax> : LSPCompl
         // GetWordSpan only extends forward when the position is in the *middle* of a word (i.e.
         // there are word characters before it). Since item.Span.Start is at the beginning of
         // any typed text, GetWordSpan returns a zero-length span and misses the typed characters.
-        var spanEnd = item.Span.Start;
-        while (spanEnd < text.Length && char.IsLetterOrDigit(text[spanEnd]))
-        {
-            spanEnd++;
-        }
+        var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
+        var spanEnd = CompletionUtilities.GetCurrentSpanEnd(item.Span.Start, text, syntaxFacts);
 
         var itemSpan = item.Span;
         var replacementSpan = TextSpan.FromBounds(text[itemSpan.Start - 1] == '<' && beforeCaretText[0] == '<' ? itemSpan.Start - 1 : itemSpan.Start, spanEnd);

--- a/src/Features/Core/Portable/Completion/Providers/CompletionUtilities.cs
+++ b/src/Features/Core/Portable/Completion/Providers/CompletionUtilities.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -15,6 +16,12 @@ namespace Microsoft.CodeAnalysis.Completion.Providers;
 
 internal static class CompletionUtilities
 {
+    /// <summary>
+    /// Property key for the identifier end position at trigger time.
+    /// Used by <see cref="GetCurrentSpanEnd"/> to detect characters typed after the trigger.
+    /// </summary>
+    private const string OriginalIdentifierEnd = nameof(OriginalIdentifierEnd);
+
     public static bool IsTypeImplicitlyConvertible(Compilation compilation, ITypeSymbol sourceType, IEnumerable<ITypeSymbol> targetTypes)
     {
         foreach (var targetType in targetTypes)
@@ -61,12 +68,21 @@ internal static class CompletionUtilities
     }
 
     /// <summary>
-    /// Finds the end of any identifier characters that the user has typed starting at
-    /// <paramref name="start"/>. <see cref="CompletionItem.Span"/> is frozen at session start
-    /// and does not advance as the user types. This method scans forward to find the actual end
-    /// of the typed text so the replacement span covers all characters entered since the trigger.
+    /// Stores the identifier end position at <paramref name="position"/> as a property on <paramref name="item"/>.
     /// </summary>
-    public static int GetCurrentSpanEnd(int start, SourceText text, ISyntaxFactsService syntaxFacts)
+    public static CompletionItem SetOriginalIdentifierEnd(CompletionItem item, int position, SourceText text, ISyntaxFactsService syntaxFacts)
+    {
+        var property = GetOriginalIdentifierEndProperty(position, text, syntaxFacts);
+        return item.AddProperty(property.Key, property.Value);
+    }
+
+    /// <summary>
+    /// Returns a property key-value pair for the identifier end position at <paramref name="position"/>.
+    /// </summary>
+    public static KeyValuePair<string, string> GetOriginalIdentifierEndProperty(int position, SourceText text, ISyntaxFactsService syntaxFacts)
+        => KeyValuePair.Create(OriginalIdentifierEnd, ScanForwardThroughIdentifier(position, text, syntaxFacts).ToString());
+
+    private static int ScanForwardThroughIdentifier(int start, SourceText text, ISyntaxFactsService syntaxFacts)
     {
         var end = start;
         while (end < text.Length && syntaxFacts.IsIdentifierPartCharacter(text[end]))
@@ -75,5 +91,27 @@ internal static class CompletionUtilities
         }
 
         return end;
+    }
+
+    /// <summary>
+    /// Returns <c>item.Span.End</c> adjusted forward by the number of identifier characters
+    /// typed since the completion session started. When <c>GetChangeAsync</c> receives the
+    /// trigger-time document (CommitManager path), this returns <c>item.Span.End</c> unchanged.
+    /// When it receives the current document (LSP path), extra typed characters are detected.
+    /// </summary>
+    public static int GetCurrentSpanEnd(CompletionItem item, SourceText text, ISyntaxFactsService syntaxFacts)
+    {
+        var spanEnd = item.Span.End;
+
+        if (item.TryGetProperty(OriginalIdentifierEnd, out var endStr)
+            && int.TryParse(endStr, out var originalIdentifierEnd))
+        {
+            var currentIdentifierEnd = ScanForwardThroughIdentifier(item.Span.Start, text, syntaxFacts);
+            var typedChars = Math.Max(0, currentIdentifierEnd - originalIdentifierEnd);
+
+            spanEnd += typedChars;
+        }
+
+        return spanEnd;
     }
 }

--- a/src/Features/Core/Portable/Completion/Providers/CompletionUtilities.cs
+++ b/src/Features/Core/Portable/Completion/Providers/CompletionUtilities.cs
@@ -6,7 +6,9 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.Collections;
+using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Completion.Providers;
@@ -56,5 +58,22 @@ internal static class CompletionUtilities
 
         Contract.ThrowIfNull(solution);
         return [.. projectIds.Select(solution.GetProject).WhereNotNull()];
+    }
+
+    /// <summary>
+    /// Finds the end of any identifier characters that the user has typed starting at
+    /// <paramref name="start"/>. <see cref="CompletionItem.Span"/> is frozen at session start
+    /// and does not advance as the user types. This method scans forward to find the actual end
+    /// of the typed text so the replacement span covers all characters entered since the trigger.
+    /// </summary>
+    public static int GetCurrentSpanEnd(int start, SourceText text, ISyntaxFactsService syntaxFacts)
+    {
+        var end = start;
+        while (end < text.Length && syntaxFacts.IsIdentifierPartCharacter(text[end]))
+        {
+            end++;
+        }
+
+        return end;
     }
 }


### PR DESCRIPTION
Remaining partial fix for https://github.com/dotnet/razor/issues/11569

CompletionItem.Span is frozen when the completion session starts. When GetChangeAsync is called at resolve time, the document has advanced (user typed additional characters), but item.Span.End still points to the original trigger position. This leaves residual characters after commit — e.g., Task.Delay().aw committing "await" produces await Task.Delay()w

Before: item.Span.End used directly as replacement end
After: Replacement end computed from the current document