### PR TITLE
Use an AppDomain in the .NET Framework BuildHost to better isolate us from VS-installed MSBuilds

### DIFF
--- a/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
+++ b/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
@@ -895,10 +895,14 @@ namespace Roslyn.Utilities
                 {
                     resolvedParts.Add(part);
                 }
-                // /../../file is considered equal to /file, so we only process the parent relative directory info if there is actually a parent
-                else if (resolvedParts.Count > 0)
+                else
                 {
-                    resolvedParts.RemoveAt(resolvedParts.Count - 1);
+                    // /../../file is considered equal to /file, so we only process the parent relative directory info if there is actually a parent
+                    var partCount = resolvedParts.Count;
+                    if (partCount > 0)
+                    {
+                        resolvedParts.RemoveAt(partCount - 1);
+                    }
                 }
             }
 

--- a/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
+++ b/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
@@ -4,14 +4,17 @@
 
 using System;
 using System.Collections.Generic;
+#if !MSBUILDWORKSPACE_BUILDHOST
 using System.Collections.Immutable;
+#endif
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text;
-using Microsoft.CodeAnalysis;
+#if !MSBUILDWORKSPACE_BUILDHOST
 using Microsoft.CodeAnalysis.PooledObjects;
+#endif
 
 namespace Roslyn.Utilities
 {
@@ -721,6 +724,8 @@ namespace Roslyn.Utilities
             return hc;
         }
 
+#if !MSBUILDWORKSPACE_BUILDHOST // This uses ImmutableArray but isn't needed in the BuildHost.
+
         public static string NormalizePathPrefix(string filePath, ImmutableArray<KeyValuePair<string, string>> pathMap)
         {
             if (pathMap.IsDefaultOrEmpty)
@@ -756,6 +761,8 @@ namespace Roslyn.Utilities
 
             return filePath;
         }
+
+#endif
 
         public static string NormalizeDriveLetter(string filePath)
         {
@@ -876,22 +883,29 @@ namespace Roslyn.Utilities
             var toSkip = isDriveRooted ? 2 : 1;
             Debug.Assert(parts[toSkip - 1] == string.Empty);
 
+#if MSBUILDWORKSPACE_BUILDHOST
+            var resolvedParts = new List<string>();
+#else
             var resolvedParts = ArrayBuilder<string>.GetInstance();
+#endif
+
             foreach (var part in parts.Skip(toSkip))
             {
                 if (!part.Equals(ParentRelativeDirectory))
                 {
-                    resolvedParts.Push(part);
+                    resolvedParts.Add(part);
                 }
                 // /../../file is considered equal to /file, so we only process the parent relative directory info if there is actually a parent
                 else if (resolvedParts.Count > 0)
                 {
-                    resolvedParts.Pop();
+                    resolvedParts.RemoveAt(resolvedParts.Count - 1);
                 }
             }
 
             var expandedPath = volumeSpecifier + '/' + string.Join("/", resolvedParts);
+#if !MSBUILDWORKSPACE_BUILDHOST
             resolvedParts.Free();
+#endif
             return expandedPath;
         }
 

--- a/src/Compilers/Core/Portable/InternalUtilities/Hash.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/Hash.cs
@@ -6,7 +6,9 @@
 
 using System;
 using System.Collections.Generic;
+#if !MSBUILDWORKSPACE_BUILDHOST
 using System.Collections.Immutable;
+#endif
 using Microsoft.CodeAnalysis;
 
 namespace Roslyn.Utilities
@@ -20,6 +22,8 @@ namespace Roslyn.Utilities
         {
             return unchecked((currentKey * (int)0xA5555529) + newKey);
         }
+
+#if !MSBUILDWORKSPACE_BUILDHOST // The BuildHost only needs the method above, and since there's various uses of immutable collections we can just ignore all of these
 
         internal static int Combine(bool newKeyPart, int currentKey)
         {
@@ -403,5 +407,7 @@ namespace Roslyn.Utilities
 
             return hashCode;
         }
+
+#endif
     }
 }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/CanonicalMiscellaneousFilesProjectProvider.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/CanonicalMiscellaneousFilesProjectProvider.cs
@@ -37,7 +37,7 @@ internal sealed class CanonicalMiscellaneousFilesProjectProvider : IDisposable
 
         var forkedInfos = canonicalInfos.SelectAsArray(info => info with
         {
-            Documents = info.Documents.Add(miscDocFileInfo),
+            Documents = [.. info.Documents, miscDocFileInfo],
             FileGlobs = [],
         });
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
@@ -172,7 +172,7 @@ internal sealed class LoadedProject : IDisposable
             _targetFrameworkManager.UpdateIdentifierForProject(_projectSystemProject.Id, newProjectInfo.TargetFrameworkIdentifier);
         }
 
-        _optionsProcessor.SetCommandLine(newProjectInfo.CommandLineArgs);
+        _optionsProcessor.SetCommandLine([.. newProjectInfo.CommandLineArgs]);
         var commandLineArguments = _optionsProcessor.GetParsedCommandLineArguments();
 
         UpdateProjectSystemProjectCollection(
@@ -182,12 +182,12 @@ internal sealed class LoadedProject : IDisposable
             document =>
             {
                 if (PathUtilities.IsAbsolute(document.FilePath))
-                    _projectSystemProject.AddSourceFile(document.FilePath, folders: document.Folders);
+                    _projectSystemProject.AddSourceFile(document.FilePath, folders: [.. document.Folders]);
                 else
                     // When the file doesn't have an absolute path, then we think it doesn't exist on disk.
                     // e.g. it is a virtual document for an unsaved file or similar.
                     // In this case we just put a SourceTextContainer with empty text for it and rely on the LSP's solution forking to ensure it has up to date text.
-                    _projectSystemProject.AddSourceTextContainer(SourceText.From("").Container, document.FilePath, folders: document.Folders);
+                    _projectSystemProject.AddSourceTextContainer(SourceText.From("").Container, document.FilePath, folders: [.. document.Folders]);
             },
             document =>
             {
@@ -241,7 +241,7 @@ internal sealed class LoadedProject : IDisposable
             newProjectInfo.AdditionalDocuments,
             _mostRecentFileInfo?.AdditionalDocuments,
             DocumentFileInfoComparer.Instance,
-            document => _projectSystemProject.AddAdditionalFile(document.FilePath, folders: document.Folders),
+            document => _projectSystemProject.AddAdditionalFile(document.FilePath, folders: [.. document.Folders]),
             document => _projectSystemProject.RemoveAdditionalFile(document.FilePath),
             "Project {0} now has {1} additional file(s). ({2} added, {3} removed.)");
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectDependencyHelper.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectDependencyHelper.cs
@@ -55,7 +55,7 @@ internal static class ProjectDependencyHelper
             return true;
         }
 
-        if (projectFileInfo.PackageReferences.IsEmpty)
+        if (projectFileInfo.PackageReferences.Length == 0)
         {
             // If there are no package references then there are no unresolved dependencies.
             return false;

--- a/src/Workspaces/MSBuild/BuildHost/AbstractBuildHost.cs
+++ b/src/Workspaces/MSBuild/BuildHost/AbstractBuildHost.cs
@@ -6,20 +6,17 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Locator;
 using Microsoft.Build.Logging;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.MSBuild;
 
-internal sealed class BuildHost : IBuildHost
+internal abstract class AbstractBuildHost : IBuildHost
 {
-    private readonly BuildHostLogger _logger;
     private readonly RpcServer _server;
     private readonly object _gate = new();
     private ProjectBuildManager? _buildManager;
@@ -39,18 +36,23 @@ internal sealed class BuildHost : IBuildHost
     /// </summary>
     private string? _binaryLogPath;
 
-    public BuildHost(BuildHostLogger logger, RpcServer server)
+    public AbstractBuildHost(BuildHostLogger logger, RpcServer server)
     {
-        _logger = logger;
+        Logger = logger;
         _server = server;
     }
+
+    protected BuildHostLogger Logger { get; init; }
+
+    protected abstract MSBuildLocation? FindMSBuild(string projectOrSolutionFilePath, bool includeUnloadableInstances);
+    protected abstract bool IsMSBuildLoaded();
 
     private bool TryEnsureMSBuildLoaded(string projectOrSolutionFilePath)
     {
         lock (_gate)
         {
             // If we've already created our MSBuild types, then there's nothing further to do.
-            if (MSBuildLocator.IsRegistered)
+            if (IsMSBuildLoaded())
             {
                 return true;
             }
@@ -62,68 +64,9 @@ internal sealed class BuildHost : IBuildHost
             }
 
             MSBuildLocator.RegisterMSBuildPath(instance.Path);
-            _logger.LogInformation($"Registered MSBuild {instance.Version} instance at {instance.Path}");
+            Logger.LogInformation($"Registered MSBuild {instance.Version} instance at {instance.Path}");
             return true;
         }
-    }
-
-    private MSBuildLocation? FindMSBuild(string projectOrSolutionFilePath, bool includeUnloadableInstances)
-    {
-        if (!PlatformInformation.IsRunningOnMono)
-        {
-            VisualStudioInstance? instance;
-
-#if NETFRAMEWORK
-            // In this case, we're just going to pick the highest VS install on the machine, in case the projects are using some newer
-            // MSBuild features. Since we don't have something like a global.json we can't really know what the minimum version is.
-
-            // TODO: we should also check that the managed tools are actually installed
-            instance = MSBuildLocator.QueryVisualStudioInstances().OrderByDescending(vs => vs.Version).FirstOrDefault();
-#else
-            // Locate the right SDK for this particular project; MSBuildLocator ensures in this case the first one is the preferred one.
-            // The includeUnloadableInstance parameter additionally locates SDKs from all installations regardless of whether they are
-            // loadable by the BuildHost process.
-            var options = new VisualStudioInstanceQueryOptions
-            {
-                DiscoveryTypes = DiscoveryType.DotNetSdk,
-                WorkingDirectory = Path.GetDirectoryName(projectOrSolutionFilePath),
-                AllowAllDotnetLocations = includeUnloadableInstances,
-                AllowAllRuntimeVersions = includeUnloadableInstances,
-            };
-
-            instance = MSBuildLocator.QueryVisualStudioInstances(options).FirstOrDefault();
-#endif
-
-            if (instance != null)
-            {
-                return new(instance.MSBuildPath, instance.Version.ToString());
-            }
-
-            _logger.LogCritical("No compatible MSBuild instance could be found.");
-        }
-        else
-        {
-
-#if NETFRAMEWORK
-            // We're running on Mono, but not all Mono installations have a usable MSBuild installation, so let's see if we have one that we can use.
-            var monoMSBuildDirectory = MonoMSBuildDiscovery.GetMonoMSBuildDirectory();
-            if (monoMSBuildDirectory != null)
-            {
-                var monoMSBuildVersion = MonoMSBuildDiscovery.GetMonoMSBuildVersion();
-                if (monoMSBuildVersion != null)
-                {
-                    return new(monoMSBuildDirectory, monoMSBuildVersion);
-                }
-            }
-
-            _logger.LogCritical("No Mono MSBuild installation could be found; see https://www.mono-project.com/ for installation instructions.");
-#else
-            _logger.LogCritical("Trying to run the .NET Core BuildHost on Mono is unsupported.");
-#endif
-
-        }
-
-        return null;
     }
 
     [MemberNotNull(nameof(_buildManager))]
@@ -143,7 +86,7 @@ internal sealed class BuildHost : IBuildHost
             if (_binaryLogPath != null)
             {
                 logger = new BinaryLogger { Parameters = _binaryLogPath };
-                _logger.LogInformation($"Logging builds to {_binaryLogPath}");
+                Logger.LogInformation($"Logging builds to {_binaryLogPath}");
             }
 
             _buildManager = new ProjectBuildManager(_knownCommandLineParserLanguages, _globalMSBuildProperties, logger);
@@ -205,7 +148,7 @@ internal sealed class BuildHost : IBuildHost
     {
         CreateBuildManager();
 
-        _logger.LogInformation($"Loading {projectFilePath}");
+        Logger.LogInformation($"Loading {projectFilePath}");
 
         var (project, log) = await _buildManager.LoadProjectAsync(projectFilePath, cancellationToken).ConfigureAwait(false);
         return AddProjectFileTarget(project, languageName, log);
@@ -219,7 +162,7 @@ internal sealed class BuildHost : IBuildHost
     {
         CreateBuildManager();
 
-        _logger.LogInformation($"Loading an in-memory project with the path {projectFilePath}");
+        Logger.LogInformation($"Loading an in-memory project with the path {projectFilePath}");
 
         // We expect MSBuild to consume this stream with a utf-8 encoding.
         // This is because we expect the stream we create to not include a BOM nor an an encoding declaration a la `<?xml encoding="..."?>`.

--- a/src/Workspaces/MSBuild/BuildHost/AbstractBuildHost.cs
+++ b/src/Workspaces/MSBuild/BuildHost/AbstractBuildHost.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Immutable;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -28,12 +28,12 @@ internal abstract class AbstractBuildHost :
     /// <summary>
     /// The global properties to use for all builds; should not be changed once the <see cref="_buildManager"/> is initialized.
     /// </summary>
-    private ImmutableDictionary<string, string>? _globalMSBuildProperties;
+    private Dictionary<string, string>? _globalMSBuildProperties;
 
     /// <summary>
     /// Should not be changed once the <see cref="_buildManager"/> is initialized.
     /// </summary>
-    private ImmutableArray<string> _knownCommandLineParserLanguages;
+    private string[] _knownCommandLineParserLanguages = [];
 
     /// <summary>
     /// The binary log path to use for all builds; should not be changed once the <see cref="_buildManager"/> is initialized.
@@ -113,7 +113,7 @@ internal abstract class AbstractBuildHost :
         Contract.ThrowIfFalse(TryEnsureMSBuildLoaded(projectFilePath), $"We don't have an MSBuild to use; {nameof(HasUsableMSBuild)} should have been called first to check.");
     }
 
-    public void ConfigureGlobalState(ImmutableArray<string> knownCommandLineParserLanguages, ImmutableDictionary<string, string> globalProperties, string? binlogPath)
+    public void ConfigureGlobalState(string[] knownCommandLineParserLanguages, Dictionary<string, string> globalProperties, string? binlogPath)
     {
         lock (_gate)
         {

--- a/src/Workspaces/MSBuild/BuildHost/AbstractBuildHost.cs
+++ b/src/Workspaces/MSBuild/BuildHost/AbstractBuildHost.cs
@@ -15,7 +15,11 @@ using Microsoft.Build.Logging;
 
 namespace Microsoft.CodeAnalysis.MSBuild;
 
-internal abstract class AbstractBuildHost : IBuildHost
+internal abstract class AbstractBuildHost :
+#if NETFRAMEWORK
+    MarshalByRefObject, // We need this object to pass across the AppDomain boundary when on .NET Framework
+#endif
+    IBuildHost
 {
     private readonly RpcServer _server;
     private readonly object _gate = new();

--- a/src/Workspaces/MSBuild/BuildHost/Build/ProjectBuildManager.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Build/ProjectBuildManager.cs
@@ -4,10 +4,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
@@ -25,7 +25,7 @@ internal sealed class ProjectBuildManager
         XmlResolver = null
     };
 
-    private static readonly ImmutableDictionary<string, string> s_defaultGlobalProperties = new Dictionary<string, string>()
+    private static readonly Dictionary<string, string> s_defaultGlobalProperties = new()
     {
         // this will tell msbuild to not build the dependent projects
         { PropertyNames.DesignTimeBuild, bool.TrueString },
@@ -55,11 +55,11 @@ internal sealed class ProjectBuildManager
         // references to also be built with Configuration=Release. This is necessary for getting
         // a more-likely-to-be-correct output path from project references.
         { PropertyNames.ShouldUnsetParentConfigurationAndPlatform, bool.FalseString }
-    }.ToImmutableDictionary();
+    };
 
-    public ImmutableArray<string> KnownCommandLineParserLanguages { get; }
+    public string[] KnownCommandLineParserLanguages { get; }
 
-    private readonly ImmutableDictionary<string, string> _additionalGlobalProperties;
+    private readonly Dictionary<string, string> _additionalGlobalProperties;
     private readonly ILogger? _msbuildLogger;
     private MSB.Evaluation.ProjectCollection? _batchBuildProjectCollection;
     private MSBuildDiagnosticLogger? _batchBuildLogger;
@@ -72,15 +72,23 @@ internal sealed class ProjectBuildManager
         }
     }
 
-    public ProjectBuildManager(ImmutableArray<string> knownCommandLineParserLanguages, ImmutableDictionary<string, string> additionalGlobalProperties, ILogger? msbuildLogger = null)
+    public ProjectBuildManager(string[] knownCommandLineParserLanguages, Dictionary<string, string> additionalGlobalProperties, ILogger? msbuildLogger = null)
     {
         KnownCommandLineParserLanguages = knownCommandLineParserLanguages;
-        _additionalGlobalProperties = additionalGlobalProperties ?? ImmutableDictionary<string, string>.Empty;
+        _additionalGlobalProperties = additionalGlobalProperties ?? new Dictionary<string, string>();
         _msbuildLogger = msbuildLogger;
     }
 
-    private ImmutableDictionary<string, string> AllGlobalProperties
-        => s_defaultGlobalProperties.AddRange(_additionalGlobalProperties);
+    private Dictionary<string, string> AllGlobalProperties
+    {
+        get
+        {
+            var result = new Dictionary<string, string>(s_defaultGlobalProperties);
+            foreach (var kvp in _additionalGlobalProperties)
+                result[kvp.Key] = kvp.Value;
+            return result;
+        }
+    }
 
     private static async Task<(MSB.Evaluation.Project? project, DiagnosticLog log)> LoadProjectAsync(
         string path, MSB.Evaluation.ProjectCollection? projectCollection, CancellationToken cancellationToken)
@@ -98,7 +106,12 @@ internal sealed class ProjectBuildManager
             }
 
             using var stream = FileUtilities.OpenAsyncRead(path);
-            using var readStream = await SerializableBytes.CreateReadableStreamAsync(stream, cancellationToken).ConfigureAwait(false);
+            using var readStream = new MemoryStream();
+
+            // There is no overload that we can call that takes a cancellationToken but doesn't take a bufferSize; this bufferSize
+            // is the default if we call the overload with just a stream.
+            await stream.CopyToAsync(readStream, bufferSize: 81920, cancellationToken).ConfigureAwait(false);
+            readStream.Position = 0;
             return LoadProjectCore(path, readStream, projectCollection, log);
         }
         catch (Exception e)
@@ -224,8 +237,10 @@ internal sealed class ProjectBuildManager
             throw new InvalidOperationException();
         }
 
-        globalProperties ??= ImmutableDictionary<string, string>.Empty;
-        var allProperties = s_defaultGlobalProperties.RemoveRange(globalProperties.Keys).AddRange(globalProperties);
+        globalProperties ??= new Dictionary<string, string>();
+        var allProperties = new Dictionary<string, string>(s_defaultGlobalProperties);
+        foreach (var kvp in globalProperties)
+            allProperties[kvp.Key] = kvp.Value;
 
         _batchBuildLogger = new MSBuildDiagnosticLogger()
         {
@@ -237,8 +252,8 @@ internal sealed class ProjectBuildManager
         // We do not need to include the _batchBuildLogger in the ProjectCollection - it just collects the
         // DiagnosticLog from the build steps, but evaluation already separately reports the DiagnosticLog.
         var loggers = _msbuildLogger is not null
-            ? [_msbuildLogger]
-            : ImmutableArray<MSB.Framework.ILogger>.Empty;
+            ? new MSB.Framework.ILogger[] { _msbuildLogger }
+            : Array.Empty<MSB.Framework.ILogger>();
 
         // Pass empty loggers array to workaround LoggerException when passing binary logger to both evaluation and build. See https://github.com/dotnet/msbuild/issues/11867
         _batchBuildProjectCollection = new MSB.Evaluation.ProjectCollection(allProperties, loggers: [], MSB.Evaluation.ToolsetDefinitionLocations.Default);
@@ -247,7 +262,7 @@ internal sealed class ProjectBuildManager
         {
             // The loggers are not inherited from the project collection, so specify both the
             // binlog logger and the _batchBuildLogger for the build steps.
-            Loggers = loggers.Add(_batchBuildLogger),
+            Loggers = [.. loggers, _batchBuildLogger],
             // If we have an additional logger and it's diagnostic, then we need to opt into task inputs globally, or otherwise
             // it won't get any log events. This logic matches https://github.com/dotnet/msbuild/blob/fa6710d2720dcf1230a732a8858ffe71bcdbe110/src/Build/Instance/ProjectInstance.cs#L2365-L2371
             LogTaskInputs = _msbuildLogger is not null && _msbuildLogger.Verbosity == LoggerVerbosity.Diagnostic
@@ -274,7 +289,7 @@ internal sealed class ProjectBuildManager
         BatchBuildStarted = false;
     }
 
-    public async Task<ImmutableArray<MSB.Execution.ProjectInstance>> BuildProjectInstancesAsync(
+    public async Task<MSB.Execution.ProjectInstance[]> BuildProjectInstancesAsync(
         MSB.Evaluation.Project project, DiagnosticLog log, CancellationToken cancellationToken)
     {
         var targetFrameworkValue = project.GetPropertyValue(PropertyNames.TargetFramework);
@@ -294,7 +309,7 @@ internal sealed class ProjectBuildManager
         if (!project.GlobalProperties.TryGetValue(PropertyNames.TargetFramework, out var initialGlobalTargetFrameworkValue))
             initialGlobalTargetFrameworkValue = null;
 
-        var results = new FixedSizeArrayBuilder<MSB.Execution.ProjectInstance>(targetFrameworks.Length);
+        var results = new List<MSB.Execution.ProjectInstance>(targetFrameworks.Length);
         foreach (var targetFramework in targetFrameworks)
         {
             project.SetGlobalProperty(PropertyNames.TargetFramework, targetFramework);
@@ -315,7 +330,7 @@ internal sealed class ProjectBuildManager
 
         project.ReevaluateIfNecessary();
 
-        return results.MoveToImmutable();
+        return results.ToArray();
     }
 
     private Task<MSB.Execution.ProjectInstance> BuildProjectInstanceAsync(

--- a/src/Workspaces/MSBuild/BuildHost/BuildHostLogger.cs
+++ b/src/Workspaces/MSBuild/BuildHost/BuildHostLogger.cs
@@ -8,6 +8,9 @@ using System.IO;
 namespace Microsoft.CodeAnalysis.MSBuild;
 
 internal sealed class BuildHostLogger(TextWriter output)
+#if NETFRAMEWORK
+    : MarshalByRefObject
+#endif
 {
     private const string InformationLevel = "info";
     private const string WarningLevel = "warn";

--- a/src/Workspaces/MSBuild/BuildHost/MSBuild/CSharp/CSharpCommandLineArgumentReader.cs
+++ b/src/Workspaces/MSBuild/BuildHost/MSBuild/CSharp/CSharpCommandLineArgumentReader.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
 using MSB = Microsoft.Build;
 
 namespace Microsoft.CodeAnalysis.MSBuild;
@@ -14,7 +13,7 @@ internal sealed class CSharpCommandLineArgumentReader : CommandLineArgumentReade
     {
     }
 
-    public static ImmutableArray<string> Read(MSB.Execution.ProjectInstance project)
+    public static string[] Read(MSB.Execution.ProjectInstance project)
     {
         return new CSharpCommandLineArgumentReader(project).Read();
     }

--- a/src/Workspaces/MSBuild/BuildHost/MSBuild/CSharp/CSharpProjectCommandLineReader.cs
+++ b/src/Workspaces/MSBuild/BuildHost/MSBuild/CSharp/CSharpProjectCommandLineReader.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using MSB = Microsoft.Build;
 
 namespace Microsoft.CodeAnalysis.MSBuild;
@@ -18,7 +17,7 @@ internal sealed class CSharpProjectCommandLineProvider : ProjectCommandLineProvi
     public override IEnumerable<MSB.Framework.ITaskItem> GetCompilerCommandLineArgs(MSB.Execution.ProjectInstance executedProject)
         => executedProject.GetItems(ItemNames.CscCommandLineArgs);
 
-    public override ImmutableArray<string> ReadCommandLineArgs(MSB.Execution.ProjectInstance project)
+    public override string[] ReadCommandLineArgs(MSB.Execution.ProjectInstance project)
         => CSharpCommandLineArgumentReader.Read(project);
 }
 

--- a/src/Workspaces/MSBuild/BuildHost/MSBuild/Logging/MSBuildDiagnosticLogItem.cs
+++ b/src/Workspaces/MSBuild/BuildHost/MSBuild/Logging/MSBuildDiagnosticLogItem.cs
@@ -4,6 +4,9 @@
 
 namespace Microsoft.CodeAnalysis.MSBuild;
 
+#if NETFRAMEWORK
+[System.Serializable] // We need to this to be able to serialize across the AppDomain boundary
+#endif
 internal sealed class MSBuildDiagnosticLogItem(
     DiagnosticLogItemKind kind,
     string projectFilePath,

--- a/src/Workspaces/MSBuild/BuildHost/MSBuild/ProjectFile/CommandLineArgumentReader.cs
+++ b/src/Workspaces/MSBuild/BuildHost/MSBuild/ProjectFile/CommandLineArgumentReader.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using Roslyn.Utilities;
 using MSB = Microsoft.Build;
@@ -14,12 +13,12 @@ namespace Microsoft.CodeAnalysis.MSBuild;
 internal abstract class CommandLineArgumentReader
 {
     protected readonly MSB.Execution.ProjectInstance Project;
-    private readonly ImmutableArray<string>.Builder _builder;
+    private readonly List<string> _builder;
 
     protected CommandLineArgumentReader(MSB.Execution.ProjectInstance project)
     {
         Project = project;
-        _builder = ImmutableArray.CreateBuilder<string>();
+        _builder = new List<string>();
     }
 
     protected abstract void ReadCore();
@@ -142,14 +141,14 @@ internal abstract class CommandLineArgumentReader
         AddIfTrue("codepage", codePage.ToString(), codePage != 0);
     }
 
-    private static readonly ImmutableDictionary<string, string> s_debugTypeValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    private static readonly Dictionary<string, string> s_debugTypeValues = new(StringComparer.OrdinalIgnoreCase)
     {
         { "none", "none" },
         { "pdbonly", "pdbonly" },
         { "full", "full" },
         { "portable", "portable" },
         { "embedded", "embedded" }
-    }.ToImmutableDictionary();
+    };
 
     protected void ReadDebugInfo()
     {
@@ -228,7 +227,7 @@ internal abstract class CommandLineArgumentReader
     {
         foreach (var (filePath, aliases) in Project.GetMetadataReferences())
         {
-            if (aliases.IsEmpty)
+            if (aliases.Length == 0)
             {
                 Add("reference", filePath);
             }
@@ -268,9 +267,9 @@ internal abstract class CommandLineArgumentReader
         }
     }
 
-    protected ImmutableArray<string> Read()
+    protected string[] Read()
     {
         ReadCore();
-        return _builder.ToImmutable();
+        return _builder.ToArray();
     }
 }

--- a/src/Workspaces/MSBuild/BuildHost/MSBuild/ProjectFile/Extensions.cs
+++ b/src/Workspaces/MSBuild/BuildHost/MSBuild/ProjectFile/Extensions.cs
@@ -4,9 +4,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 using MSB = Microsoft.Build;
 
@@ -49,10 +47,10 @@ internal static class Extensions
             .GetItems(ItemNames.ProjectReference)
             .Select(CreateProjectFileReference);
 
-    public static ImmutableArray<PackageReferenceItem> GetPackageReferences(this MSB.Execution.ProjectInstance executedProject)
+    public static PackageReferenceItem[] GetPackageReferences(this MSB.Execution.ProjectInstance executedProject)
     {
         var packageReferenceItems = executedProject.GetItems(ItemNames.PackageReference);
-        using var _ = PooledHashSet<PackageReferenceItem>.GetInstance(out var references);
+        var references = new HashSet<PackageReferenceItem>(capacity: packageReferenceItems.Count);
 
         foreach (var item in packageReferenceItems)
         {
@@ -71,7 +69,7 @@ internal static class Extensions
     private static ProjectFileReference CreateProjectFileReference(MSB.Execution.ProjectItemInstance reference)
         => new(reference.EvaluatedInclude, reference.GetAliases(), reference.ReferenceOutputAssemblyIsTrue());
 
-    public static ImmutableArray<string> GetAliases(this MSB.Framework.ITaskItem item)
+    public static string[] GetAliases(this MSB.Framework.ITaskItem item)
     {
         var aliasesText = item.GetMetadata(MetadataNames.Aliases);
 
@@ -109,20 +107,15 @@ internal static class Extensions
 
     public static string ReadItemsAsString(this MSB.Execution.ProjectInstance executedProject, string itemType)
     {
-        var pooledBuilder = PooledStringBuilder.GetInstance();
-        var builder = pooledBuilder.Builder;
+        var items = executedProject.GetItems(itemType);
 
-        foreach (var item in executedProject.GetItems(itemType))
-        {
-            if (builder.Length > 0)
-            {
-                builder.Append(' ');
-            }
+        if (items.Count == 0)
+            return "";
 
-            builder.Append(item.EvaluatedInclude);
-        }
+        if (items.Count == 1)
+            return items.Single().EvaluatedInclude;
 
-        return pooledBuilder.ToStringAndFree();
+        return string.Join(" ", items.Select(static i => i.EvaluatedInclude));
     }
 
     public static IEnumerable<MSB.Framework.ITaskItem> GetTaskItems(this MSB.Execution.ProjectInstance executedProject, string itemType)

--- a/src/Workspaces/MSBuild/BuildHost/MSBuild/ProjectFile/ProjectCommandLineReader.cs
+++ b/src/Workspaces/MSBuild/BuildHost/MSBuild/ProjectFile/ProjectCommandLineReader.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
+using System.Linq;
 using MSB = Microsoft.Build;
 
 namespace Microsoft.CodeAnalysis.MSBuild;
@@ -15,9 +15,9 @@ internal abstract class ProjectCommandLineProvider
 {
     public abstract string Language { get; }
     public abstract IEnumerable<MSB.Framework.ITaskItem> GetCompilerCommandLineArgs(MSB.Execution.ProjectInstance executedProject);
-    public abstract ImmutableArray<string> ReadCommandLineArgs(MSB.Execution.ProjectInstance project);
+    public abstract string[] ReadCommandLineArgs(MSB.Execution.ProjectInstance project);
 
-    public static ProjectCommandLineProvider? TryCreate(string languageName, ImmutableArray<string> knownCommandLineParserLanguages)
+    public static ProjectCommandLineProvider? TryCreate(string languageName, string[] knownCommandLineParserLanguages)
     {
         if (!knownCommandLineParserLanguages.Contains(languageName))
         {

--- a/src/Workspaces/MSBuild/BuildHost/MSBuild/ProjectFile/ProjectFile.cs
+++ b/src/Workspaces/MSBuild/BuildHost/MSBuild/ProjectFile/ProjectFile.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -29,7 +28,7 @@ internal sealed class ProjectFile(
     public string FilePath
         => project?.FullPath ?? string.Empty;
 
-    public ImmutableArray<DiagnosticLogItem> GetDiagnosticLogItems()
+    public DiagnosticLogItem[] GetDiagnosticLogItems()
         => [.. log];
 
     /// <summary>
@@ -37,7 +36,7 @@ internal sealed class ProjectFile(
     /// instances of <see cref="ProjectFileInfo"/> if the project is multi-targeted: one for
     /// each target framework.
     /// </summary>
-    public async Task<ImmutableArray<ProjectFileInfo>> GetProjectFileInfosAsync(CancellationToken cancellationToken)
+    public async Task<ProjectFileInfo[]> GetProjectFileInfosAsync(CancellationToken cancellationToken)
     {
         if (project is null)
         {
@@ -46,8 +45,8 @@ internal sealed class ProjectFile(
 
         var projectInstances = await buildManager.BuildProjectInstancesAsync(project, log, cancellationToken).ConfigureAwait(false);
 
-        return projectInstances.SelectAsArray(
-            instance => new ProjectInstanceReader(language, _commandLineProvider, instance, project).CreateProjectFileInfo());
+        return projectInstances.Select(
+            instance => new ProjectInstanceReader(language, _commandLineProvider, instance, project).CreateProjectFileInfo()).ToArray();
     }
 
     public void AddDocument(string filePath, string? logicalPath = null)
@@ -91,7 +90,7 @@ internal sealed class ProjectFile(
         }
     }
 
-    public void AddMetadataReference(string metadataReferenceIdentity, ImmutableArray<string> aliases, string? hintPath)
+    public void AddMetadataReference(string metadataReferenceIdentity, string[] aliases, string? hintPath)
     {
         if (project is null)
         {
@@ -99,7 +98,7 @@ internal sealed class ProjectFile(
         }
 
         var metadata = new Dictionary<string, string>();
-        if (!aliases.IsEmpty)
+        if (aliases.Length > 0)
             metadata.Add(MetadataNames.Aliases, string.Join(",", aliases));
 
         if (hintPath is not null)
@@ -177,7 +176,7 @@ internal sealed class ProjectFile(
             { MetadataNames.Name, projectName }
         };
 
-        if (!reference.Aliases.IsEmpty)
+        if (reference.Aliases.Length > 0)
         {
             metadata.Add(MetadataNames.Aliases, string.Join(",", reference.Aliases));
         }

--- a/src/Workspaces/MSBuild/BuildHost/MSBuild/ProjectFile/ProjectFile.cs
+++ b/src/Workspaces/MSBuild/BuildHost/MSBuild/ProjectFile/ProjectFile.cs
@@ -18,7 +18,11 @@ internal sealed class ProjectFile(
     string language,
     MSB.Evaluation.Project? project,
     ProjectBuildManager buildManager,
-    DiagnosticLog log) : IProjectFile
+    DiagnosticLog log) :
+#if NETFRAMEWORK
+    MarshalByRefObject, // We need this object to pass across the AppDomain boundary when on .NET Framework
+#endif
+    IProjectFile
 {
     private readonly ProjectCommandLineProvider? _commandLineProvider = ProjectCommandLineProvider.TryCreate(language, buildManager.KnownCommandLineParserLanguages);
 

--- a/src/Workspaces/MSBuild/BuildHost/MSBuild/ProjectFile/ProjectInstanceReader.cs
+++ b/src/Workspaces/MSBuild/BuildHost/MSBuild/ProjectFile/ProjectInstanceReader.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using Roslyn.Utilities;
@@ -84,22 +83,25 @@ internal readonly struct ProjectInstanceReader
 
         var targetFrameworkVersion = _projectInstance.ReadPropertyString(PropertyNames.TargetFrameworkVersion);
 
-        var docs = _projectInstance.GetDocuments().SelectAsArray(
-            predicate: IsNotTemporaryGeneratedFile,
-            selector: MakeDocumentFileInfo);
+        var docs = _projectInstance.GetDocuments()
+            .Where(IsNotTemporaryGeneratedFile)
+            .Select(MakeDocumentFileInfo)
+            .ToArray();
 
         var additionalDocs = _projectInstance.GetAdditionalFiles()
-            .SelectAsArray(MakeNonSourceFileDocumentFileInfo);
+            .Select(MakeNonSourceFileDocumentFileInfo)
+            .ToArray();
 
         var analyzerConfigDocs = _projectInstance.GetEditorConfigFiles()
-            .SelectAsArray(MakeNonSourceFileDocumentFileInfo);
+            .Select(MakeNonSourceFileDocumentFileInfo)
+            .ToArray();
 
         var packageReferences = _projectInstance.GetPackageReferences();
 
         // Do not pass metadata references if we have command line args that already specify them.
-        var metadataReferences = commandLineArgs.IsEmpty ? _projectInstance.GetMetadataReferences().ToImmutableArray() : [];
+        var metadataReferences = commandLineArgs.Length == 0 ? _projectInstance.GetMetadataReferences().ToArray() : [];
 
-        var projectCapabilities = _projectInstance.GetItems(ItemNames.ProjectCapability).SelectAsArray(item => item.ToString());
+        var projectCapabilities = _projectInstance.GetItems(ItemNames.ProjectCapability).Select(item => item.ToString()).ToArray();
         var contentFileInfo = GetContentFiles(_projectInstance);
         var codePage = _projectInstance.ReadCodePage();
 
@@ -110,7 +112,7 @@ internal readonly struct ProjectInstanceReader
             checksumAlgorithm = _projectInstance.ReadPropertyString(PropertyNames.PdbChecksumAlgorithm);
         }
 
-        var fileGlobs = Project?.GetAllGlobs().SelectAsArray(GetFileGlobs) ?? [];
+        var fileGlobs = Project?.GetAllGlobs().Select(GetFileGlobs).ToArray() ?? [];
 
         return new ProjectFileInfo()
         {
@@ -148,15 +150,16 @@ internal readonly struct ProjectInstanceReader
         }
     }
 
-    private static ImmutableArray<string> GetContentFiles(MSB.Execution.ProjectInstance project)
+    private static string[] GetContentFiles(MSB.Execution.ProjectInstance project)
     {
         var contentFiles = project
             .GetItems(ItemNames.Content)
-            .SelectAsArray(item => item.GetMetadataValue(MetadataNames.FullPath));
+            .Select(item => item.GetMetadataValue(MetadataNames.FullPath))
+            .ToArray();
         return contentFiles;
     }
 
-    private ImmutableArray<string> TryGetCommandLineArgs(MSB.Execution.ProjectInstance project)
+    private string[] TryGetCommandLineArgs(MSB.Execution.ProjectInstance project)
     {
         if (_commandLineProvider == null)
         {
@@ -164,7 +167,8 @@ internal readonly struct ProjectInstanceReader
         }
 
         var commandLineArgs = _commandLineProvider.GetCompilerCommandLineArgs(project)
-            .SelectAsArray(item => item.ItemSpec);
+            .Select(item => item.ItemSpec)
+            .ToArray();
 
         if (commandLineArgs.Length == 0)
         {
@@ -201,18 +205,18 @@ internal readonly struct ProjectInstanceReader
         return new DocumentFileInfo(filePath, logicalPath, isLinked, isGenerated: false, folders);
     }
 
-    private ImmutableArray<string> GetRelativeFolders(MSB.Framework.ITaskItem documentItem)
+    private string[] GetRelativeFolders(MSB.Framework.ITaskItem documentItem)
     {
         var linkPath = documentItem.GetMetadata(MetadataNames.Link);
         if (!RoslynString.IsNullOrEmpty(linkPath))
         {
-            return [.. PathUtilities.GetDirectoryName(linkPath).Split(PathUtilities.DirectorySeparatorChar, PathUtilities.AltDirectorySeparatorChar)];
+            return PathUtilities.GetDirectoryName(linkPath).Split(PathUtilities.DirectorySeparatorChar, PathUtilities.AltDirectorySeparatorChar);
         }
         else
         {
             var filePath = documentItem.ItemSpec;
             var relativePath = PathUtilities.GetDirectoryName(PathUtilities.GetRelativePath(_projectDirectory, filePath));
-            var folders = relativePath == null ? [] : relativePath.Split([PathUtilities.DirectorySeparatorChar, PathUtilities.AltDirectorySeparatorChar], StringSplitOptions.RemoveEmptyEntries).ToImmutableArray();
+            var folders = relativePath == null ? [] : relativePath.Split([PathUtilities.DirectorySeparatorChar, PathUtilities.AltDirectorySeparatorChar], StringSplitOptions.RemoveEmptyEntries);
             return folders;
         }
     }

--- a/src/Workspaces/MSBuild/BuildHost/MSBuild/VisualBasic/VisualBasicCommandLineArgumentReader.cs
+++ b/src/Workspaces/MSBuild/BuildHost/MSBuild/VisualBasic/VisualBasicCommandLineArgumentReader.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Immutable;
 using Roslyn.Utilities;
 using MSB = Microsoft.Build;
 
@@ -16,7 +15,7 @@ internal sealed class VisualBasicCommandLineArgumentReader : CommandLineArgument
     {
     }
 
-    public static ImmutableArray<string> Read(MSB.Execution.ProjectInstance project)
+    public static string[] Read(MSB.Execution.ProjectInstance project)
     {
         return new VisualBasicCommandLineArgumentReader(project).Read();
     }

--- a/src/Workspaces/MSBuild/BuildHost/MSBuild/VisualBasic/VisualBasicProjectCommandLineReader.cs
+++ b/src/Workspaces/MSBuild/BuildHost/MSBuild/VisualBasic/VisualBasicProjectCommandLineReader.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using MSB = Microsoft.Build;
 
 namespace Microsoft.CodeAnalysis.MSBuild;
@@ -18,6 +17,6 @@ internal sealed class VisualBasicProjectCommandLineProvider : ProjectCommandLine
     public override IEnumerable<MSB.Framework.ITaskItem> GetCompilerCommandLineArgs(MSB.Execution.ProjectInstance executedProject)
         => executedProject.GetItems(ItemNames.VbcCommandLineArgs);
 
-    public override ImmutableArray<string> ReadCommandLineArgs(MSB.Execution.ProjectInstance project)
+    public override string[] ReadCommandLineArgs(MSB.Execution.ProjectInstance project)
         => VisualBasicCommandLineArgumentReader.Read(project);
 }

--- a/src/Workspaces/MSBuild/BuildHost/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj
+++ b/src/Workspaces/MSBuild/BuildHost/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Microsoft.CodeAnalysis</RootNamespace>
     <TargetFrameworks>$(NetRoslynBuildHostNetCoreVersion);net472</TargetFrameworks>
     <IsShipping>true</IsShipping>
+    <DefineConstants>$(DefineConstants);MSBUILDWORKSPACE_BUILDHOST</DefineConstants>
 
     <!-- NuGet -->
     <IsPackable>true</IsPackable>
@@ -49,29 +50,27 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Locator" PrivateAssets="All" />
-    <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="Microsoft.IO.Redist" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
     <PackageReference Include="System.Text.Json" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\*.cs" Link="InternalUtilities\%(FileName).cs" />
-
-    <!-- Exclude utilities that use System.Reflection.Metadata -->
-    <Compile Remove="..\..\..\Compilers\Core\Portable\InternalUtilities\BlobBuildingStream.cs" />
-    <Compile Remove="..\..\..\Compilers\Core\Portable\InternalUtilities\IncrementalHashExtensions.cs" />
-    <Compile Include="..\..\..\Compilers\Core\Portable\Collections\IOrderedReadOnlySet.cs" Link="Collections\IOrderedReadOnlySet.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\FileSystem\PathKind.cs" Link="FileSystem\PathKind.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\FileSystem\PathUtilities.cs" Link="FileSystem\PathUtilities.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\FileSystem\FileUtilities.cs" Link="FileSystem\FileUtilities.cs" />
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\CompilerOptionParseUtilities.cs" Link="Utilities\CompilerOptionParseUtilities.cs" />
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\ConcurrentSet.cs" Link="Utilities\ConcurrentSet.cs" />
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\Debug.cs" Link="Utilities\Debug.cs" />
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\Hash.cs" Link="Utilities\Hash.cs" />
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\FileNameUtilities.cs" Link="Utilities\FileNameUtilities.cs" />
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\PerformanceSensitiveAttribute.cs" Link="Utilities\PerformanceSensitiveAttribute.cs" />
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\PlatformInformation.cs" Link="Utilities\PlatformInformation.cs" />
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\RoslynString.cs" Link="Utilities\RoslynString.cs" />
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\NoMessagePumpSyncContext.cs" Link="Utilities\NoMessagePumpSyncContext.cs" />
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\SpecializedSyncContext.cs" Link="Utilities\SpecializedSyncContext.cs" />
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\SemaphoreSlimExtensions.cs" Link="Utilities\SemaphoreSlimExtensions.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\Symbols\LanguageNames.cs" Link="Compiler\LanguageNames.cs" />
-    <Compile Include="..\..\..\Compilers\Core\Portable\CaseInsensitiveComparison.cs" Link="Compiler\CaseInsensitiveComparison.cs" />
-    <Compile Include="..\..\..\Compilers\Shared\NamedPipeUtil.cs" Link="SharedUtilities\NamedPipeUtil.cs" />
-    <Compile Include="..\..\..\Workspaces\SharedUtilitiesAndExtensions\Compiler\Core\Extensions\ImmutableArrayExtensions.cs" Link="SharedUtilities\ImmutableArrayExtensions.cs" />
-    <Compile Include="..\..\..\Workspaces\SharedUtilitiesAndExtensions\Compiler\Core\ObjectPools\Extensions.cs" Link="SharedUtilities\Extensions.cs" />
-    <Compile Include="..\..\..\Workspaces\SharedUtilitiesAndExtensions\Compiler\Core\ObjectPools\PooledObject.cs" Link="SharedUtilities\PooledObject.cs" />
-    <Compile Include="..\..\..\Workspaces\SharedUtilitiesAndExtensions\Compiler\Core\ObjectPools\SharedPools.cs" Link="SharedUtilities\SharedPools.cs" />
-    <Compile Include="..\..\..\Workspaces\SharedUtilitiesAndExtensions\Compiler\Core\Utilities\SerializableBytes.cs" Link="SharedUtilities\SerializableBytes.cs" />
+    <Compile Include="..\..\..\Compilers\Shared\NamedPipeUtil.cs" Link="Utilities\NamedPipeUtil.cs" />
 
   </ItemGroup>
   <ItemGroup>
@@ -110,7 +109,5 @@
       </ProjectDepsJsonFile>
     </ItemGroup>
   </Target>
-  <Import Project="..\..\..\Dependencies\PooledObjects\Microsoft.CodeAnalysis.PooledObjects.projitems" Label="Shared" />
-  <Import Project="..\..\..\Dependencies\Collections\Microsoft.CodeAnalysis.Collections.projitems" Label="Shared" />
   <Import Project="$(RepositoryEngineeringDir)targets\PackageDownloadAndReference.targets" />
 </Project>

--- a/src/Workspaces/MSBuild/BuildHost/MonoBuildHost.cs
+++ b/src/Workspaces/MSBuild/BuildHost/MonoBuildHost.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if NETFRAMEWORK
+
+using System.Linq;
+using Microsoft.Build.Locator;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.MSBuild;
+
+internal sealed class MonoBuildHost : AbstractBuildHost
+{
+    public MonoBuildHost(BuildHostLogger logger, RpcServer server) : base(logger, server)
+    {
+    }
+
+    protected override MSBuildLocation? FindMSBuild(string projectOrSolutionFilePath, bool includeUnloadableInstances)
+    {
+        // We're running on Mono, but not all Mono installations have a usable MSBuild installation, so let's see if we have one that we can use.
+        var monoMSBuildDirectory = MonoMSBuildDiscovery.GetMonoMSBuildDirectory();
+        if (monoMSBuildDirectory != null)
+        {
+            var monoMSBuildVersion = MonoMSBuildDiscovery.GetMonoMSBuildVersion();
+            if (monoMSBuildVersion != null)
+            {
+                return new(monoMSBuildDirectory, monoMSBuildVersion);
+            }
+        }
+
+        Logger.LogCritical("No Mono MSBuild installation could be found; see https://www.mono-project.com/ for installation instructions.");
+        return null;
+    }
+
+    protected override bool IsMSBuildLoaded()
+    {
+        return MSBuildLocator.IsRegistered;
+    }
+}
+
+#endif

--- a/src/Workspaces/MSBuild/BuildHost/NetCoreBuildHost.cs
+++ b/src/Workspaces/MSBuild/BuildHost/NetCoreBuildHost.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if !NETFRAMEWORK
+
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Locator;
+
+namespace Microsoft.CodeAnalysis.MSBuild;
+
+internal sealed class NetCoreBuildHost : AbstractBuildHost
+{
+    public NetCoreBuildHost(BuildHostLogger logger, RpcServer server) : base(logger, server)
+    {
+    }
+
+    protected override MSBuildLocation? FindMSBuild(string projectOrSolutionFilePath, bool includeUnloadableInstances)
+    {
+        VisualStudioInstance? instance;
+
+        // Locate the right SDK for this particular project; MSBuildLocator ensures in this case the first one is the preferred one.
+        // The includeUnloadableInstance parameter additionally locates SDKs from all installations regardless of whether they are
+        // loadable by the BuildHost process.
+        var options = new VisualStudioInstanceQueryOptions
+        {
+            DiscoveryTypes = DiscoveryType.DotNetSdk,
+            WorkingDirectory = Path.GetDirectoryName(projectOrSolutionFilePath),
+            AllowAllDotnetLocations = includeUnloadableInstances,
+            AllowAllRuntimeVersions = includeUnloadableInstances,
+        };
+
+        instance = MSBuildLocator.QueryVisualStudioInstances(options).FirstOrDefault();
+
+        if (instance != null)
+        {
+            return new(instance.MSBuildPath, instance.Version.ToString());
+        }
+
+        Logger.LogCritical("No compatible MSBuild instance could be found.");
+
+        return null;
+    }
+
+    protected override bool IsMSBuildLoaded()
+    {
+        return MSBuildLocator.IsRegistered;
+    }
+}
+
+#endif

--- a/src/Workspaces/MSBuild/BuildHost/NetFrameworkBuildHost.cs
+++ b/src/Workspaces/MSBuild/BuildHost/NetFrameworkBuildHost.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Pipes;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Build.Locator;
@@ -15,7 +16,7 @@ namespace Microsoft.CodeAnalysis.MSBuild;
 
 internal sealed class NetFrameworkBuildHost : AbstractBuildHost
 {
-    public static AbstractBuildHost Create(BuildHostLogger logger, RpcServer server)
+    public static (AbstractBuildHost, RpcServer) Create(BuildHostLogger logger, PipeStream pipeStream)
     {
         // In this case, we're just going to pick the highest VS install on the machine, in case the projects are using some newer
         // MSBuild features. Since we don't have something like a global.json we can't really know what the minimum version is.
@@ -26,7 +27,8 @@ internal sealed class NetFrameworkBuildHost : AbstractBuildHost
         if (instance is null)
         {
             logger.LogCritical("No compatible MSBuild instance could be found.");
-            return new NoNetFrameworkFoundBuildHost(logger, server);
+            var server = new RpcServer(pipeStream);
+            return (new NoNetFrameworkFoundBuildHost(logger, server), server);
         }
 
         // We need to create a build host, but in the .NET Framework case we need to ensure we have the proper binding redirects for MSBuild assemblies.
@@ -56,7 +58,8 @@ internal sealed class NetFrameworkBuildHost : AbstractBuildHost
             culture: null,
             activationAttributes: null);
 
-        return factory.CreateBuildHost(logger, server);
+        var rpcServer = new RpcServer(pipeStream, factory.CreateMethodInvoker());
+        return (factory.CreateBuildHost(logger, rpcServer), rpcServer);
     }
 
     internal class Factory : MarshalByRefObject
@@ -85,6 +88,7 @@ internal sealed class NetFrameworkBuildHost : AbstractBuildHost
         }
 
 #pragma warning disable CA1822 // Mark members as static - this is being called across AppDomains, so must be instance
+        public RpcMethodInvoker CreateMethodInvoker() => new RpcMethodInvoker();
         public NetFrameworkBuildHost CreateBuildHost(BuildHostLogger logger, RpcServer server) => new NetFrameworkBuildHost(logger, server);
 #pragma warning restore CA1822 // Mark members as static
     }

--- a/src/Workspaces/MSBuild/BuildHost/NetFrameworkBuildHost.cs
+++ b/src/Workspaces/MSBuild/BuildHost/NetFrameworkBuildHost.cs
@@ -1,0 +1,65 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if NETFRAMEWORK
+
+using System.Linq;
+using Microsoft.Build.Locator;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.MSBuild;
+
+internal sealed class NetFrameworkBuildHost : AbstractBuildHost
+{
+    public NetFrameworkBuildHost(BuildHostLogger logger, RpcServer server) : base(logger, server)
+    {
+    }
+
+    protected override MSBuildLocation? FindMSBuild(string projectOrSolutionFilePath, bool includeUnloadableInstances)
+    {
+        if (!PlatformInformation.IsRunningOnMono)
+        {
+            VisualStudioInstance? instance;
+
+            // In this case, we're just going to pick the highest VS install on the machine, in case the projects are using some newer
+            // MSBuild features. Since we don't have something like a global.json we can't really know what the minimum version is.
+
+            // TODO: we should also check that the managed tools are actually installed
+            instance = MSBuildLocator.QueryVisualStudioInstances().OrderByDescending(vs => vs.Version).FirstOrDefault();
+
+            if (instance != null)
+            {
+                return new(instance.MSBuildPath, instance.Version.ToString());
+            }
+            else
+            {
+                Logger.LogCritical("No compatible MSBuild instance could be found.");
+                return null;
+            }
+        }
+        else
+        {
+            // We're running on Mono, but not all Mono installations have a usable MSBuild installation, so let's see if we have one that we can use.
+            var monoMSBuildDirectory = MonoMSBuildDiscovery.GetMonoMSBuildDirectory();
+            if (monoMSBuildDirectory != null)
+            {
+                var monoMSBuildVersion = MonoMSBuildDiscovery.GetMonoMSBuildVersion();
+                if (monoMSBuildVersion != null)
+                {
+                    return new(monoMSBuildDirectory, monoMSBuildVersion);
+                }
+            }
+
+            Logger.LogCritical("No Mono MSBuild installation could be found; see https://www.mono-project.com/ for installation instructions.");
+            return null;
+        }
+    }
+
+    protected override bool IsMSBuildLoaded()
+    {
+        return MSBuildLocator.IsRegistered;
+    }
+}
+
+#endif

--- a/src/Workspaces/MSBuild/BuildHost/NetFrameworkBuildHost.cs
+++ b/src/Workspaces/MSBuild/BuildHost/NetFrameworkBuildHost.cs
@@ -4,61 +4,118 @@
 
 #if NETFRAMEWORK
 
+using System;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using Microsoft.Build.Locator;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.MSBuild;
 
 internal sealed class NetFrameworkBuildHost : AbstractBuildHost
 {
-    public NetFrameworkBuildHost(BuildHostLogger logger, RpcServer server) : base(logger, server)
+    public static AbstractBuildHost Create(BuildHostLogger logger, RpcServer server)
+    {
+        // In this case, we're just going to pick the highest VS install on the machine, in case the projects are using some newer
+        // MSBuild features. Since we don't have something like a global.json we can't really know what the minimum version is.
+
+        // TODO: we should also check that the managed tools are actually installed
+        var instance = MSBuildLocator.QueryVisualStudioInstances().OrderByDescending(vs => vs.Version).FirstOrDefault();
+
+        if (instance is null)
+        {
+            logger.LogCritical("No compatible MSBuild instance could be found.");
+            return new NoNetFrameworkFoundBuildHost(logger, server);
+        }
+
+        // We need to create a build host, but in the .NET Framework case we need to ensure we have the proper binding redirects for MSBuild assemblies.
+        // We achieve this by creating the build host in a new AppDomain whose base path is the MSBuild directory. This ensures MSBuild assemblies
+        // are resolved from the correct location. We use CreateInstanceFromAndUnwrap to load our assembly by path, since it won't be in the
+        // new AppDomain's base directory.
+        var appDomainSetup = new AppDomainSetup
+        {
+            ApplicationBase = instance.MSBuildPath,
+            ConfigurationFile = Path.Combine(instance.MSBuildPath, "MSBuild.exe.config"),
+        };
+
+        var appDomain = AppDomain.CreateDomain(
+            friendlyName: nameof(NetFrameworkBuildHost),
+            securityInfo: null,
+            info: appDomainSetup);
+
+        // Use CreateInstanceFromAndUnwrap which takes a file path to the assembly, since our assembly
+        // won't be in the new AppDomain's ApplicationBase (which points to the MSBuild directory).
+        var factory = (Factory)appDomain.CreateInstanceFromAndUnwrap(
+            assemblyFile: (string?)typeof(Factory).Assembly.Location,
+            typeName: typeof(Factory).FullName,
+            ignoreCase: false,
+            bindingAttr: default,
+            binder: null,
+            args: [],
+            culture: null,
+            activationAttributes: null);
+
+        return factory.CreateBuildHost(logger, server);
+    }
+
+    internal class Factory : MarshalByRefObject
+    {
+        public Factory()
+        {
+            // Before we can actualy create an object or pass things along, we need to ensure our assembly loading is correct, so hook AssemblyResolve here.
+            AppDomain.CurrentDomain.AssemblyResolve += (s, e) =>
+            {
+                // Because we caled CreateInstanceFrom we would have been loaded in the LoadFrom context of our new AppDomain, but we still need to be present
+                // in the regular Load context too. This ensures we wil be loaded when the rest of the code runs.
+                if (e.Name == typeof(Factory).Assembly.FullName)
+                    return typeof(Factory).Assembly;
+
+                // Since our AppDomain's ApplicationBase is not our BuildHost directory, we need to direct our dependency to our folder
+                // explicitly.
+                var requestedAssemblyName = new AssemblyName(e.Name);
+                if (requestedAssemblyName.Name == "Microsoft.CodeAnalysis.Workspaces.MSBuild.Contracts")
+                {
+                    var buildHostFolder = Path.GetDirectoryName(typeof(Factory).Assembly.Location);
+                    return Assembly.LoadFrom(Path.Combine(buildHostFolder, $"{requestedAssemblyName.Name}.dll"));
+                }
+
+                return null;
+            };
+        }
+
+#pragma warning disable CA1822 // Mark members as static - this is being called across AppDomains, so must be instance
+        public NetFrameworkBuildHost CreateBuildHost(BuildHostLogger logger, RpcServer server) => new NetFrameworkBuildHost(logger, server);
+#pragma warning restore CA1822 // Mark members as static
+    }
+
+    private NetFrameworkBuildHost(BuildHostLogger logger, RpcServer server)
+        : base(logger, server)
     {
     }
 
     protected override MSBuildLocation? FindMSBuild(string projectOrSolutionFilePath, bool includeUnloadableInstances)
     {
-        if (!PlatformInformation.IsRunningOnMono)
-        {
-            VisualStudioInstance? instance;
-
-            // In this case, we're just going to pick the highest VS install on the machine, in case the projects are using some newer
-            // MSBuild features. Since we don't have something like a global.json we can't really know what the minimum version is.
-
-            // TODO: we should also check that the managed tools are actually installed
-            instance = MSBuildLocator.QueryVisualStudioInstances().OrderByDescending(vs => vs.Version).FirstOrDefault();
-
-            if (instance != null)
-            {
-                return new(instance.MSBuildPath, instance.Version.ToString());
-            }
-            else
-            {
-                Logger.LogCritical("No compatible MSBuild instance could be found.");
-                return null;
-            }
-        }
-        else
-        {
-            // We're running on Mono, but not all Mono installations have a usable MSBuild installation, so let's see if we have one that we can use.
-            var monoMSBuildDirectory = MonoMSBuildDiscovery.GetMonoMSBuildDirectory();
-            if (monoMSBuildDirectory != null)
-            {
-                var monoMSBuildVersion = MonoMSBuildDiscovery.GetMonoMSBuildVersion();
-                if (monoMSBuildVersion != null)
-                {
-                    return new(monoMSBuildDirectory, monoMSBuildVersion);
-                }
-            }
-
-            Logger.LogCritical("No Mono MSBuild installation could be found; see https://www.mono-project.com/ for installation instructions.");
-            return null;
-        }
+        throw new System.NotImplementedException();
     }
 
     protected override bool IsMSBuildLoaded()
     {
-        return MSBuildLocator.IsRegistered;
+        return true;
+    }
+
+    private class NoNetFrameworkFoundBuildHost(BuildHostLogger logger, RpcServer server) : AbstractBuildHost(logger, server)
+    {
+        protected override MSBuildLocation? FindMSBuild(string projectOrSolutionFilePath, bool includeUnloadableInstances)
+        {
+            // We couldn't find one, so just return null so the rest of the system can handle the failure.
+            return null;
+        }
+
+        protected override bool IsMSBuildLoaded()
+        {
+            return false;
+        }
     }
 }
 

--- a/src/Workspaces/MSBuild/BuildHost/Program.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Program.cs
@@ -40,16 +40,22 @@ internal static class Program
         var pipeServer = NamedPipeUtil.CreateServer(pipeName, PipeDirection.InOut);
         await pipeServer.WaitForConnectionAsync().ConfigureAwait(false);
 
-        var server = new RpcServer(pipeServer);
-
+        RpcServer server;
         AbstractBuildHost buildHost;
 
 #if NETFRAMEWORK
+
         if (PlatformInformation.IsRunningOnMono)
+        {
+            server = new RpcServer(pipeServer);
             buildHost = new MonoBuildHost(logger, server);
+        }
         else
-            buildHost = NetFrameworkBuildHost.Create(logger, server);
+        {
+            (buildHost, server) = NetFrameworkBuildHost.Create(logger, pipeServer);
+        }
 #else
+        server = new RpcServer(pipeServer);
         buildHost = new NetCoreBuildHost(logger, server);
 #endif
 

--- a/src/Workspaces/MSBuild/BuildHost/Program.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Program.cs
@@ -41,7 +41,15 @@ internal static class Program
 
         var server = new RpcServer(pipeServer);
 
-        var targetObject = server.AddTarget(new BuildHost(logger, server));
+        AbstractBuildHost buildHost;
+
+#if NETFRAMEWORK
+        buildHost = new NetFrameworkBuildHost(logger, server);
+#else
+        buildHost = new NetCoreBuildHost(logger, server);
+#endif
+
+        var targetObject = server.AddTarget(buildHost);
         Contract.ThrowIfFalse(targetObject == 0, "The first object registered should have target 0, which is assumed by the client.");
 
         await server.RunAsync().ConfigureAwait(false);

--- a/src/Workspaces/MSBuild/BuildHost/Program.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Program.cs
@@ -6,6 +6,7 @@ using System;
 using System.Globalization;
 using System.IO.Pipes;
 using System.Threading.Tasks;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.MSBuild;
 
@@ -44,7 +45,10 @@ internal static class Program
         AbstractBuildHost buildHost;
 
 #if NETFRAMEWORK
-        buildHost = new NetFrameworkBuildHost(logger, server);
+        if (PlatformInformation.IsRunningOnMono)
+            buildHost = new MonoBuildHost(logger, server);
+        else
+            buildHost = NetFrameworkBuildHost.Create(logger, server);
 #else
         buildHost = new NetCoreBuildHost(logger, server);
 #endif

--- a/src/Workspaces/MSBuild/BuildHost/Rpc/RpcMethodInvoker.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Rpc/RpcMethodInvoker.cs
@@ -1,0 +1,63 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis.MSBuild;
+
+/// <summary>
+/// A smaller helper that lets us invoke methods; but ensures they happen in the right AppDomain in the case of the .NET Framework build host,
+/// where we need to work around some marshalling issues. In the .NET Framework case this lives inside of the MSBuild AppDomain, and in .NET Core
+/// there is just no such thing so this is in the same AssemblyLoadContext as everything else.
+/// </summary>
+internal sealed class RpcMethodInvoker
+#if NETFRAMEWORK
+    : MarshalByRefObject // We need to let this live inside the AppDomain in the .NET Framework case
+#endif
+{
+#pragma warning disable CA1822 // Mark members as static - this is being called across AppDomains, so must be instance
+    public object? InvokeMethod(object rpcTarget, MethodInfo method, object?[] arguments, bool lastParameterIsCancellationToken)
+#pragma warning restore CA1822
+    {
+        // Fill in the CancellationToken if the last parameter needs one; this we have to do inside the AppDomain since we can't marshal a CancellationToken
+        // (even CancellationToken.None) across the AppDomain boundary.
+        if (lastParameterIsCancellationToken)
+            arguments[arguments.Length - 1] = CancellationToken.None;
+
+        var result = method.Invoke(rpcTarget, arguments);
+
+#if NETFRAMEWORK
+
+        // If we're inside the AppDomain we create in the .NET Framework case, we can't return a task since those can't be marshalled, so we'll get the underlying value now.
+        if (result is Task resultTask)
+        {
+            result = GetTaskResultAsync(resultTask, method).GetAwaiter().GetResult();
+        }
+
+#endif
+
+        return result;
+    }
+
+    public static async Task<object?> GetTaskResultAsync(Task task, MethodInfo calledMethod)
+    {
+        await task.ConfigureAwait(false);
+
+        // If it's actually a Task<T> then get the result; we're looking at the declared return type because in some cases a method might
+        // return a Task<T> under the covers as a workaround for the lack of TaskCompletionSource on .NET Framework but we don't want to see
+        // that workaround since the result isn't intended to be seen.
+        if (calledMethod.ReturnType.IsConstructedGenericType)
+        {
+            return task.GetType().GetProperty("Result")!.GetValue(task);
+        }
+        else
+        {
+            // It's just a simple Task so no result to return
+            return null;
+        }
+    }
+}

--- a/src/Workspaces/MSBuild/BuildHost/Rpc/RpcServer.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Rpc/RpcServer.cs
@@ -24,6 +24,9 @@ namespace Microsoft.CodeAnalysis.MSBuild;
 /// are out. If at some point there is a standard RPC mechanism exposed in .NET or Source Build, we should delete this and use that instead.
 /// </remarks>
 internal sealed class RpcServer
+#if NETFRAMEWORK
+    : MarshalByRefObject
+#endif
 {
     private readonly TextWriter _streamWriter;
     private readonly SemaphoreSlim _sendingStreamSemaphore = new(initialCount: 1);

--- a/src/Workspaces/MSBuild/BuildHost/Rpc/RpcServer.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Rpc/RpcServer.cs
@@ -165,7 +165,7 @@ internal sealed class RpcServer
             if (e is TargetInvocationException)
                 e = e.InnerException ?? e;
 
-            response = new Response { Id = request.Id, Exception = $"An exception of type {e.GetType()} was thrown: {e.Message}" };
+            response = new Response { Id = request.Id, ExceptionMessage = $"An exception of type {e.GetType()} was thrown: {e.Message}", ExceptionStackTrace = e.StackTrace };
         }
 
         var responseJson = JsonSerializer.Serialize(response, JsonSettings.SingleLineSerializerOptions);

--- a/src/Workspaces/MSBuild/BuildHost/Rpc/RpcServer.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Rpc/RpcServer.cs
@@ -31,16 +31,22 @@ internal sealed class RpcServer
     private readonly TextWriter _streamWriter;
     private readonly SemaphoreSlim _sendingStreamSemaphore = new(initialCount: 1);
     private readonly TextReader _streamReader;
+    private readonly RpcMethodInvoker _rpcMethodInvoker;
 
     private readonly ConcurrentDictionary<int, object> _rpcTargets = [];
     private volatile int _nextRpcTargetIndex = -1; // We'll start at -1 so the first value becomes zero
 
     private readonly CancellationTokenSource _shutdownTokenSource = new();
 
-    public RpcServer(PipeStream stream)
+    public RpcServer(PipeStream stream) : this(stream, new RpcMethodInvoker())
+    {
+    }
+
+    public RpcServer(PipeStream stream, RpcMethodInvoker methodInvoker)
     {
         _streamWriter = new StreamWriter(stream, JsonSettings.StreamEncoding);
         _streamReader = new StreamReader(stream, JsonSettings.StreamEncoding);
+        _rpcMethodInvoker = methodInvoker;
     }
 
     public int AddTarget(object rpcTarget)
@@ -130,32 +136,17 @@ internal sealed class RpcServer
 
             for (var i = 0; i < methodParameters.Length; i++)
             {
-                // If the method we're calling accepts a cancellation token, we wouldn't have passed that, so add in a CancellationToken.None here. Although we could
-                // remove the cancellation from the underlying method, this keeps that support around should we need it.
-                if (i == methodParameters.Length - 1 && lastParameterIsCancellationToken)
-                    arguments[i] = CancellationToken.None;
-                else
+                // If the method we're calling accepts a cancellation token, we want to fill in a CancellationToken. That filling in happens in the
+                // RpcMethodInvoker, so we just keep the array null here.
+                if (!(i == methodParameters.Length - 1 && lastParameterIsCancellationToken))
                     arguments[i] = request.Parameters[i].Deserialize(methodParameters[i].ParameterType, JsonSettings.SingleLineSerializerOptions);
             }
 
-            var result = method.Invoke(rpcTarget, arguments);
+            var result = _rpcMethodInvoker.InvokeMethod(rpcTarget, method, arguments, lastParameterIsCancellationToken);
 
-            if (result is Task task)
+            if (result is Task resultTask)
             {
-                await task.ConfigureAwait(false);
-
-                // If it's actually a Task<T> then get the result; we're looking at the declared return type because in some cases a method might
-                // return a Task<T> under the covers as a workaround for the lack of TaskCompletionSource on .NET Framework but we don't want to see
-                // that workaround since the result isn't intended to be seen.
-                if (method.ReturnType.IsConstructedGenericType)
-                {
-                    result = task.GetType().GetProperty("Result")!.GetValue(task);
-                }
-                else
-                {
-                    // It's just a simple Task so no result to return
-                    result = null;
-                }
+                result = await RpcMethodInvoker.GetTaskResultAsync(resultTask, calledMethod: method).ConfigureAwait(false);
             }
 
             response = new Response { Id = request.Id, Value = result is not null ? JsonSerializer.SerializeToElement(result, JsonSettings.SingleLineSerializerOptions) : null };

--- a/src/Workspaces/MSBuild/Contracts/DiagnosticLogItem.cs
+++ b/src/Workspaces/MSBuild/Contracts/DiagnosticLogItem.cs
@@ -13,6 +13,9 @@ internal enum DiagnosticLogItemKind
 }
 
 [DataContract]
+#if NETFRAMEWORK
+[System.Serializable] // We need to this to be able to serialize across the AppDomain boundary
+#endif
 internal class DiagnosticLogItem(DiagnosticLogItemKind kind, string message, string projectFilePath)
 {
     [DataMember(Order = 0)]

--- a/src/Workspaces/MSBuild/Contracts/DocumentFileInfo.cs
+++ b/src/Workspaces/MSBuild/Contracts/DocumentFileInfo.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
 using System.Runtime.Serialization;
 
 namespace Microsoft.CodeAnalysis.MSBuild;
@@ -14,7 +13,7 @@ namespace Microsoft.CodeAnalysis.MSBuild;
 #if NETFRAMEWORK
 [System.Serializable] // We need to this to be able to serialize across the AppDomain boundary
 #endif
-internal sealed class DocumentFileInfo(string filePath, string logicalPath, bool isLinked, bool isGenerated, ImmutableArray<string> folders)
+internal sealed class DocumentFileInfo(string filePath, string logicalPath, bool isLinked, bool isGenerated, string[] folders)
 {
     /// <summary>
     /// The absolute path to the document file on disk.
@@ -47,5 +46,5 @@ internal sealed class DocumentFileInfo(string filePath, string logicalPath, bool
     /// Containing folders of the document relative to the containing project root path.
     /// </summary>
     [DataMember(Order = 4)]
-    public ImmutableArray<string> Folders { get; } = folders;
+    public string[] Folders { get; } = folders;
 }

--- a/src/Workspaces/MSBuild/Contracts/DocumentFileInfo.cs
+++ b/src/Workspaces/MSBuild/Contracts/DocumentFileInfo.cs
@@ -11,6 +11,9 @@ namespace Microsoft.CodeAnalysis.MSBuild;
 /// Represents a source file that is part of a project file.
 /// </summary>
 [DataContract]
+#if NETFRAMEWORK
+[System.Serializable] // We need to this to be able to serialize across the AppDomain boundary
+#endif
 internal sealed class DocumentFileInfo(string filePath, string logicalPath, bool isLinked, bool isGenerated, ImmutableArray<string> folders)
 {
     /// <summary>

--- a/src/Workspaces/MSBuild/Contracts/FileGlobs.cs
+++ b/src/Workspaces/MSBuild/Contracts/FileGlobs.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
 using System.Runtime.Serialization;
 
 namespace Microsoft.CodeAnalysis.MSBuild;
@@ -12,7 +11,7 @@ namespace Microsoft.CodeAnalysis.MSBuild;
 [System.Serializable] // We need to this to be able to serialize across the AppDomain boundary
 #endif
 internal sealed record FileGlobs(
-    [property: DataMember(Order = 0)] ImmutableArray<string> Includes,
-    [property: DataMember(Order = 1)] ImmutableArray<string> Excludes,
-    [property: DataMember(Order = 2)] ImmutableArray<string> Removes
+    [property: DataMember(Order = 0)] string[] Includes,
+    [property: DataMember(Order = 1)] string[] Excludes,
+    [property: DataMember(Order = 2)] string[] Removes
 );

--- a/src/Workspaces/MSBuild/Contracts/FileGlobs.cs
+++ b/src/Workspaces/MSBuild/Contracts/FileGlobs.cs
@@ -8,6 +8,9 @@ using System.Runtime.Serialization;
 namespace Microsoft.CodeAnalysis.MSBuild;
 
 [DataContract]
+#if NETFRAMEWORK
+[System.Serializable] // We need to this to be able to serialize across the AppDomain boundary
+#endif
 internal sealed record FileGlobs(
     [property: DataMember(Order = 0)] ImmutableArray<string> Includes,
     [property: DataMember(Order = 1)] ImmutableArray<string> Excludes,

--- a/src/Workspaces/MSBuild/Contracts/IBuildHost.cs
+++ b/src/Workspaces/MSBuild/Contracts/IBuildHost.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -34,7 +34,7 @@ internal interface IBuildHost
     /// contain paths (which can have escaping issues) or could be quite large (which could run into length limits).
     /// </summary>
     /// <param name="knownCommandLineParserLanguages">Languages whose command line parser we understand (ICommandLineParserService).</param>
-    void ConfigureGlobalState(ImmutableArray<string> knownCommandLineParserLanguages, ImmutableDictionary<string, string> globalProperties, string? binlogPath);
+    void ConfigureGlobalState(string[] knownCommandLineParserLanguages, Dictionary<string, string> globalProperties, string? binlogPath);
 
     Task<int> LoadProjectFileAsync(string projectFilePath, string languageName, CancellationToken cancellationToken);
 

--- a/src/Workspaces/MSBuild/Contracts/IProjectFile.cs
+++ b/src/Workspaces/MSBuild/Contracts/IProjectFile.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,11 +12,11 @@ namespace Microsoft.CodeAnalysis.MSBuild;
 /// </summary>
 internal interface IProjectFile
 {
-    ImmutableArray<DiagnosticLogItem> GetDiagnosticLogItems();
-    Task<ImmutableArray<ProjectFileInfo>> GetProjectFileInfosAsync(CancellationToken cancellationToken);
+    DiagnosticLogItem[] GetDiagnosticLogItems();
+    Task<ProjectFileInfo[]> GetProjectFileInfosAsync(CancellationToken cancellationToken);
     void AddDocument(string filePath, string? logicalPath);
     void RemoveDocument(string filePath);
-    void AddMetadataReference(string metadataReferenceIdentity, ImmutableArray<string> aliases, string? hintPath);
+    void AddMetadataReference(string metadataReferenceIdentity, string[] aliases, string? hintPath);
     void RemoveMetadataReference(string shortAssemblyName, string fullAssemblyName, string filePath);
     void AddProjectReference(string projectName, ProjectFileReference reference);
     void RemoveProjectReference(string projectName, string projectFilePath);

--- a/src/Workspaces/MSBuild/Contracts/MSBuildLocation.cs
+++ b/src/Workspaces/MSBuild/Contracts/MSBuildLocation.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,6 +7,9 @@ using System.Runtime.Serialization;
 namespace Microsoft.CodeAnalysis.MSBuild;
 
 [DataContract]
+#if NETFRAMEWORK
+[System.Serializable] // We need to this to be able to serialize across the AppDomain boundary
+#endif
 internal sealed class MSBuildLocation(string path, string version)
 {
     /// <summary>

--- a/src/Workspaces/MSBuild/Contracts/MetadataReferenceItem.cs
+++ b/src/Workspaces/MSBuild/Contracts/MetadataReferenceItem.cs
@@ -8,6 +8,9 @@ using System.Runtime.Serialization;
 namespace Microsoft.CodeAnalysis.MSBuild;
 
 [DataContract]
+#if NETFRAMEWORK
+[System.Serializable] // We need to this to be able to serialize across the AppDomain boundary
+#endif
 internal readonly record struct MetadataReferenceItem(
     [property: DataMember(Order = 0)] string Path,
     [property: DataMember(Order = 1)] ImmutableArray<string> Aliases

--- a/src/Workspaces/MSBuild/Contracts/MetadataReferenceItem.cs
+++ b/src/Workspaces/MSBuild/Contracts/MetadataReferenceItem.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
 using System.Runtime.Serialization;
 
 namespace Microsoft.CodeAnalysis.MSBuild;
@@ -13,5 +12,5 @@ namespace Microsoft.CodeAnalysis.MSBuild;
 #endif
 internal readonly record struct MetadataReferenceItem(
     [property: DataMember(Order = 0)] string Path,
-    [property: DataMember(Order = 1)] ImmutableArray<string> Aliases
+    [property: DataMember(Order = 1)] string[] Aliases
 );

--- a/src/Workspaces/MSBuild/Contracts/Microsoft.CodeAnalysis.Workspaces.MSBuild.Contracts.csproj
+++ b/src/Workspaces/MSBuild/Contracts/Microsoft.CodeAnalysis.Workspaces.MSBuild.Contracts.csproj
@@ -12,7 +12,6 @@
     </PackageDescription>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
     <PackageReference Include="System.Text.Json" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
   </ItemGroup>

--- a/src/Workspaces/MSBuild/Contracts/PackageReferenceItem.cs
+++ b/src/Workspaces/MSBuild/Contracts/PackageReferenceItem.cs
@@ -7,6 +7,9 @@ using System.Runtime.Serialization;
 namespace Microsoft.CodeAnalysis.MSBuild;
 
 [DataContract]
+#if NETFRAMEWORK
+[System.Serializable] // We need to this to be able to serialize across the AppDomain boundary
+#endif
 internal sealed record PackageReferenceItem(
     [property: DataMember(Order = 0)] string Name,
     [property: DataMember(Order = 1)] string VersionRange

--- a/src/Workspaces/MSBuild/Contracts/ProjectFileInfo.cs
+++ b/src/Workspaces/MSBuild/Contracts/ProjectFileInfo.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
 using System.Runtime.Serialization;
 
 namespace Microsoft.CodeAnalysis.MSBuild;
@@ -86,43 +85,43 @@ internal sealed record ProjectFileInfo
     /// The command line args used to compile the project.
     /// </summary>
     [DataMember]
-    public ImmutableArray<string> CommandLineArgs { get; init; }
+    public required string[] CommandLineArgs { get; init; }
 
     /// <summary>
     /// The source documents.
     /// </summary>
     [DataMember]
-    public ImmutableArray<DocumentFileInfo> Documents { get; init; }
+    public required DocumentFileInfo[] Documents { get; init; }
 
     /// <summary>
     /// The additional documents.
     /// </summary>
     [DataMember]
-    public ImmutableArray<DocumentFileInfo> AdditionalDocuments { get; init; }
+    public required DocumentFileInfo[] AdditionalDocuments { get; init; }
 
     /// <summary>
     /// The analyzer config documents.
     /// </summary>
     [DataMember]
-    public ImmutableArray<DocumentFileInfo> AnalyzerConfigDocuments { get; init; }
+    public required DocumentFileInfo[] AnalyzerConfigDocuments { get; init; }
 
     /// <summary>
     /// References to other projects.
     /// </summary>
     [DataMember]
-    public ImmutableArray<ProjectFileReference> ProjectReferences { get; init; }
+    public required ProjectFileReference[] ProjectReferences { get; init; }
 
     /// <summary>
     /// The msbuild project capabilities.
     /// </summary>
     [DataMember]
-    public ImmutableArray<string> ProjectCapabilities { get; init; }
+    public required string[] ProjectCapabilities { get; init; }
 
     /// <summary>
     /// The paths to content files included in the project.
     /// </summary>
     [DataMember]
-    public ImmutableArray<string> ContentFilePaths { get; init; }
+    public required string[] ContentFilePaths { get; init; }
 
     /// <summary>
     /// The path to the project.assets.json path in obj/.
@@ -134,13 +133,13 @@ internal sealed record ProjectFileInfo
     /// Any package references defined on the project.
     /// </summary>
     [DataMember]
-    public ImmutableArray<PackageReferenceItem> PackageReferences { get; init; }
+    public required PackageReferenceItem[] PackageReferences { get; init; }
 
     /// <summary>
     /// Metadata references referenced by the project if not specified in <see cref="CommandLineArgs"/>.
     /// </summary>
     [DataMember]
-    public ImmutableArray<MetadataReferenceItem> MetadataReferences { get; init; }
+    public required MetadataReferenceItem[] MetadataReferences { get; init; }
 
     /// <summary>
     /// The value of `CodePage` property. Zero if not specified.
@@ -161,7 +160,7 @@ internal sealed record ProjectFileInfo
     public string? TargetFrameworkVersion { get; init; }
 
     [DataMember]
-    public ImmutableArray<FileGlobs> FileGlobs { get; init; }
+    public required FileGlobs[] FileGlobs { get; init; }
 
     public override string ToString()
         => string.IsNullOrWhiteSpace(TargetFramework)

--- a/src/Workspaces/MSBuild/Contracts/ProjectFileInfo.cs
+++ b/src/Workspaces/MSBuild/Contracts/ProjectFileInfo.cs
@@ -13,6 +13,9 @@ namespace Microsoft.CodeAnalysis.MSBuild;
 /// the information from a single target framework.
 /// </summary>
 [DataContract]
+#if NETFRAMEWORK
+[System.Serializable] // We need to this to be able to serialize across the AppDomain boundary
+#endif
 internal sealed record ProjectFileInfo
 {
     [DataMember]

--- a/src/Workspaces/MSBuild/Contracts/ProjectFileReference.cs
+++ b/src/Workspaces/MSBuild/Contracts/ProjectFileReference.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Runtime.Serialization;
 
@@ -28,7 +27,7 @@ internal sealed class ProjectFileReference
     /// The aliases assigned to this reference, if any.
     /// </summary>
     [DataMember(Order = 1)]
-    public ImmutableArray<string> Aliases { get; }
+    public string[] Aliases { get; }
 
     /// <summary>
     /// The value of "ReferenceOutputAssembly" metadata.
@@ -36,9 +35,9 @@ internal sealed class ProjectFileReference
     [DataMember(Order = 2)]
     public bool ReferenceOutputAssembly { get; }
 
-    public ProjectFileReference(string path, ImmutableArray<string> aliases, bool referenceOutputAssembly)
+    public ProjectFileReference(string path, string[] aliases, bool referenceOutputAssembly)
     {
-        Debug.Assert(!aliases.IsDefault);
+        Debug.Assert(aliases != null);
 
         Path = path;
         Aliases = aliases;

--- a/src/Workspaces/MSBuild/Contracts/ProjectFileReference.cs
+++ b/src/Workspaces/MSBuild/Contracts/ProjectFileReference.cs
@@ -12,6 +12,9 @@ namespace Microsoft.CodeAnalysis.MSBuild;
 /// Represents a reference to another project file.
 /// </summary>
 [DataContract]
+#if NETFRAMEWORK
+[System.Serializable] // We need to this to be able to serialize across the AppDomain boundary
+#endif
 internal sealed class ProjectFileReference
 {
     /// <summary>

--- a/src/Workspaces/MSBuild/Contracts/Request.cs
+++ b/src/Workspaces/MSBuild/Contracts/Request.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
 using System.Text.Json;
 
 namespace Microsoft.CodeAnalysis.MSBuild;
@@ -24,5 +23,5 @@ internal sealed class Request
     /// </summary>
     public required string Method { get; init; }
 
-    public required ImmutableArray<JsonElement> Parameters { get; init; }
+    public required JsonElement[] Parameters { get; init; }
 }

--- a/src/Workspaces/MSBuild/Contracts/Response.cs
+++ b/src/Workspaces/MSBuild/Contracts/Response.cs
@@ -10,6 +10,7 @@ internal sealed class Response
 {
     public int Id { get; init; }
     public JsonElement? Value { get; init; }
-    public string? Exception { get; init; }
+    public string? ExceptionMessage { get; init; }
+    public string? ExceptionStackTrace { get; init; }
 }
 

--- a/src/Workspaces/MSBuild/Core/MSBuild/MSBuildProjectLoader.Worker.cs
+++ b/src/Workspaces/MSBuild/Core/MSBuild/MSBuildProjectLoader.Worker.cs
@@ -261,7 +261,7 @@ public partial class MSBuildProjectLoader
                     ? algorithm : SourceHashAlgorithms.Default;
 
                 resolvedMetadataReferences = projectFileInfo.MetadataReferences
-                    .Select(r => metadataService.GetReference(r.Path, new MetadataReferenceProperties(aliases: r.Aliases)));
+                    .Select(r => metadataService.GetReference(r.Path, new MetadataReferenceProperties(aliases: [.. r.Aliases])));
             }
 
             var documents = CreateDocumentInfos(projectFileInfo.Documents, projectId, encoding);

--- a/src/Workspaces/MSBuild/Core/MSBuild/MSBuildProjectLoader.Worker_ResolveReferences.cs
+++ b/src/Workspaces/MSBuild/Core/MSBuild/MSBuildProjectLoader.Worker_ResolveReferences.cs
@@ -199,7 +199,7 @@ public partial class MSBuildProjectLoader
                 if (_pathResolver.TryGetAbsoluteProjectPath(projectFileReference.Path, baseDirectory: projectDirectory, _discoveredProjectOptions.OnPathFailure, out var projectReferencePath))
                 {
                     // The easiest case is to add a reference to a project we already know about.
-                    if (TryAddReferenceToKnownProject(id, projectReferencePath, aliases, builder))
+                    if (TryAddReferenceToKnownProject(id, projectReferencePath, aliases.ToImmutableArray(), builder))
                     {
                         continue;
                     }
@@ -222,7 +222,7 @@ public partial class MSBuildProjectLoader
                         }
 
                         // Finally, we'll try to load and reference the project.
-                        if (await TryLoadAndAddReferenceAsync(id, projectReferencePath, aliases, builder, cancellationToken).ConfigureAwait(false))
+                        if (await TryLoadAndAddReferenceAsync(id, projectReferencePath, [.. aliases], builder, cancellationToken).ConfigureAwait(false))
                         {
                             continue;
                         }
@@ -244,7 +244,7 @@ public partial class MSBuildProjectLoader
 
                 // We weren't able to handle this project reference, so add it without further processing.
                 var unknownProjectId = _projectMap.GetOrCreateProjectId(projectFileReference.Path);
-                var newProjectReference = CreateProjectReference(from: id, to: unknownProjectId, aliases);
+                var newProjectReference = CreateProjectReference(from: id, to: unknownProjectId, [.. aliases]);
                 builder.AddProjectReference(newProjectReference);
             }
 

--- a/src/Workspaces/MSBuild/Core/MSBuild/MSBuildWorkspace.cs
+++ b/src/Workspaces/MSBuild/Core/MSBuild/MSBuildWorkspace.cs
@@ -593,19 +593,19 @@ public sealed class MSBuildWorkspace : Workspace
             {
                 // Since the location of the reference is in GAC, need to use full identity name to find it again.
                 // This typically happens when you base the reference off of a reflection assembly location.
-                _applyChangesProjectFile.AddMetadataReferenceAsync(identity.GetDisplayName(), metadataReference.Properties.Aliases, hintPath: null, CancellationToken.None).Wait();
+                _applyChangesProjectFile.AddMetadataReferenceAsync(identity.GetDisplayName(), [.. metadataReference.Properties.Aliases], hintPath: null, CancellationToken.None).Wait();
             }
             else if (IsFrameworkReferenceAssembly(peRef.FilePath))
             {
                 // just use short name since this will be resolved by msbuild relative to the known framework reference assemblies.
                 var fileName = identity != null ? identity.Name : Path.GetFileNameWithoutExtension(peRef.FilePath);
-                _applyChangesProjectFile.AddMetadataReferenceAsync(fileName, metadataReference.Properties.Aliases, hintPath: null, CancellationToken.None).Wait();
+                _applyChangesProjectFile.AddMetadataReferenceAsync(fileName, [.. metadataReference.Properties.Aliases], hintPath: null, CancellationToken.None).Wait();
             }
             else // other location -- need hint to find correct assembly
             {
                 var relativePath = PathUtilities.GetRelativePath(Path.GetDirectoryName(CurrentSolution.GetRequiredProject(projectId).FilePath)!, peRef.FilePath);
                 var fileName = Path.GetFileNameWithoutExtension(peRef.FilePath);
-                _applyChangesProjectFile.AddMetadataReferenceAsync(fileName, metadataReference.Properties.Aliases, relativePath, CancellationToken.None).Wait();
+                _applyChangesProjectFile.AddMetadataReferenceAsync(fileName, [.. metadataReference.Properties.Aliases], relativePath, CancellationToken.None).Wait();
             }
         }
 
@@ -662,7 +662,7 @@ public sealed class MSBuildWorkspace : Workspace
         if (project?.FilePath is not null)
         {
             // Only "ReferenceOutputAssembly=true" project references are represented in the workspace:
-            var reference = new ProjectFileReference(project.FilePath, projectReference.Aliases, referenceOutputAssembly: true);
+            var reference = new ProjectFileReference(project.FilePath, [.. projectReference.Aliases], referenceOutputAssembly: true);
             _applyChangesProjectFile.AddProjectReferenceAsync(project.Name, reference, CancellationToken.None).Wait();
         }
 

--- a/src/Workspaces/MSBuild/Core/Rpc/RemoteBuildHost.cs
+++ b/src/Workspaces/MSBuild/Core/Rpc/RemoteBuildHost.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -39,9 +41,9 @@ internal sealed class RemoteBuildHost
     public Task<bool> HasUsableMSBuildAsync(string projectOrSolutionFilePath, CancellationToken cancellationToken)
         => _client.InvokeAsync<bool>(BuildHostTargetObject, nameof(IBuildHost.HasUsableMSBuild), parameters: [projectOrSolutionFilePath], cancellationToken);
 
-    /// <inheritdoc cref="IBuildHost.ConfigureGlobalState(ImmutableArray{string}, ImmutableDictionary{string, string}, string?)"/>
+    /// <inheritdoc cref="IBuildHost.ConfigureGlobalState"/>
     public Task ConfigureGlobalStateAsync(ImmutableArray<string> knownCommandLineParserLanguages, ImmutableDictionary<string, string> globalProperties, string? binlogPath, CancellationToken cancellationToken)
-        => _client.InvokeAsync(BuildHostTargetObject, nameof(IBuildHost.ConfigureGlobalState), parameters: [knownCommandLineParserLanguages, globalProperties, binlogPath], cancellationToken);
+        => _client.InvokeAsync(BuildHostTargetObject, nameof(IBuildHost.ConfigureGlobalState), parameters: [knownCommandLineParserLanguages.ToArray(), new Dictionary<string, string>(globalProperties), binlogPath], cancellationToken);
 
     public async Task<RemoteProjectFile> LoadProjectFileAsync(string projectFilePath, string languageName, CancellationToken cancellationToken)
     {

--- a/src/Workspaces/MSBuild/Core/Rpc/RemoteInvocationException.cs
+++ b/src/Workspaces/MSBuild/Core/Rpc/RemoteInvocationException.cs
@@ -6,9 +6,7 @@ using System;
 
 namespace Microsoft.CodeAnalysis.MSBuild;
 
-internal sealed class RemoteInvocationException : Exception
+internal sealed class RemoteInvocationException(string message, string? stackTrace) : Exception(message)
 {
-    public RemoteInvocationException(string? message) : base(message)
-    {
-    }
+    public override string? StackTrace => stackTrace;
 }

--- a/src/Workspaces/MSBuild/Core/Rpc/RemoteProjectFile.cs
+++ b/src/Workspaces/MSBuild/Core/Rpc/RemoteProjectFile.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -19,11 +20,17 @@ internal sealed class RemoteProjectFile
         _remoteProjectFileTargetObject = remoteProjectFileTargetObject;
     }
 
-    public Task<ImmutableArray<DiagnosticLogItem>> GetDiagnosticLogItemsAsync(CancellationToken cancellationToken)
-        => _client.InvokeAsync<ImmutableArray<DiagnosticLogItem>>(_remoteProjectFileTargetObject, nameof(IProjectFile.GetDiagnosticLogItems), parameters: [], cancellationToken);
+    public async Task<ImmutableArray<DiagnosticLogItem>> GetDiagnosticLogItemsAsync(CancellationToken cancellationToken)
+    {
+        var diagnostics = await _client.InvokeAsync<DiagnosticLogItem[]>(_remoteProjectFileTargetObject, nameof(IProjectFile.GetDiagnosticLogItems), parameters: [], cancellationToken).ConfigureAwait(false);
+        return diagnostics.ToImmutableArray();
+    }
 
-    public Task<ImmutableArray<ProjectFileInfo>> GetProjectFileInfosAsync(CancellationToken cancellationToken)
-        => _client.InvokeAsync<ImmutableArray<ProjectFileInfo>>(_remoteProjectFileTargetObject, nameof(IProjectFile.GetProjectFileInfosAsync), parameters: [], cancellationToken);
+    public async Task<ImmutableArray<ProjectFileInfo>> GetProjectFileInfosAsync(CancellationToken cancellationToken)
+    {
+        var projectFileInfos = await _client.InvokeAsync<ProjectFileInfo[]>(_remoteProjectFileTargetObject, nameof(IProjectFile.GetProjectFileInfosAsync), parameters: [], cancellationToken).ConfigureAwait(false);
+        return projectFileInfos.ToImmutableArray();
+    }
 
     public Task AddDocumentAsync(string filePath, string? logicalPath, CancellationToken cancellationToken)
         => _client.InvokeAsync(_remoteProjectFileTargetObject, nameof(IProjectFile.AddDocument), parameters: [filePath, logicalPath], cancellationToken);
@@ -32,7 +39,7 @@ internal sealed class RemoteProjectFile
         => _client.InvokeAsync(_remoteProjectFileTargetObject, nameof(IProjectFile.RemoveDocument), parameters: [filePath], cancellationToken);
 
     public Task AddMetadataReferenceAsync(string metadataReferenceIdentity, ImmutableArray<string> aliases, string? hintPath, CancellationToken cancellationToken)
-        => _client.InvokeAsync(_remoteProjectFileTargetObject, nameof(IProjectFile.AddMetadataReference), parameters: [metadataReferenceIdentity, aliases, hintPath], cancellationToken);
+        => _client.InvokeAsync(_remoteProjectFileTargetObject, nameof(IProjectFile.AddMetadataReference), parameters: [metadataReferenceIdentity, aliases.ToArray(), hintPath], cancellationToken);
 
     public Task RemoveMetadataReferenceAsync(string shortAssemblyName, string fullAssemblyName, string filePath, CancellationToken cancellationToken)
         => _client.InvokeAsync(_remoteProjectFileTargetObject, nameof(IProjectFile.RemoveMetadataReference), parameters: [shortAssemblyName, fullAssemblyName, filePath], cancellationToken);

--- a/src/Workspaces/MSBuild/Core/Rpc/RpcClient.cs
+++ b/src/Workspaces/MSBuild/Core/Rpc/RpcClient.cs
@@ -72,9 +72,9 @@ internal sealed class RpcClient
                     Contract.ThrowIfFalse(_outstandingRequests.TryRemove(response.Id, out var completionSourceAndExpectedType), $"We got a response for request ID {response.Id} but that was already completed.");
                     var (completionSource, expectedType) = completionSourceAndExpectedType;
 
-                    if (response.Exception != null)
+                    if (response.ExceptionMessage != null)
                     {
-                        completionSource.SetException(new RemoteInvocationException(response.Exception));
+                        completionSource.SetException(new RemoteInvocationException(response.ExceptionMessage, response.ExceptionStackTrace));
                     }
                     else
                     {

--- a/src/Workspaces/MSBuild/Core/Rpc/RpcClient.cs
+++ b/src/Workspaces/MSBuild/Core/Rpc/RpcClient.cs
@@ -7,6 +7,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Pipes;
+using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -154,7 +155,7 @@ internal sealed class RpcClient
             Id = requestId,
             TargetObject = targetObject,
             Method = methodName,
-            Parameters = parameters.SelectAsArray(static p => JsonSerializer.SerializeToElement(p, JsonSettings.SingleLineSerializerOptions))
+            Parameters = [.. parameters.Select(static p => JsonSerializer.SerializeToElement(p, JsonSettings.SingleLineSerializerOptions))]
         };
 
         var requestJson = JsonSerializer.Serialize(request, JsonSettings.SingleLineSerializerOptions) + Environment.NewLine;

--- a/src/Workspaces/MSBuild/Test/MSBuildWorkspaceTestBase.cs
+++ b/src/Workspaces/MSBuild/Test/MSBuildWorkspaceTestBase.cs
@@ -182,7 +182,21 @@ public abstract class MSBuildWorkspaceTestBase : WorkspaceTestBase
 
         if (throwOnWorkspaceFailed)
         {
-            _ = workspace.RegisterWorkspaceFailedHandler((e) => throw new Exception($"Workspace failure {e.Diagnostic.Kind}:{e.Diagnostic.Message}"));
+            _ = workspace.RegisterWorkspaceFailedHandler((e) =>
+            {
+                var message = $"MSBuildWorkspace raised WorkspaceFailed with kind {e.Diagnostic.Kind}: {e.Diagnostic.Message}";
+                var logger = LoggerFactory.CreateLogger(nameof(workspace.WorkspaceFailed));
+                if (e.Diagnostic.Kind == WorkspaceDiagnosticKind.Failure)
+                {
+                    logger.LogError(message);
+                }
+                else
+                {
+                    logger.LogWarning(message);
+                }
+
+                throw new Exception(message);
+            });
         }
 
         if (skipUnrecognizedProjects)

--- a/src/Workspaces/MSBuild/Test/Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests.csproj
+++ b/src/Workspaces/MSBuild/Test/Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests.csproj
@@ -22,6 +22,7 @@
     <EmbeddedResource Include="Resources\**\*.*" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\BuildHost\Rpc\RpcMethodInvoker.cs" Link="Rpc\RpcMethodInvoker.cs"/>
     <Compile Include="..\BuildHost\Rpc\RpcServer.cs" Link="Rpc\RpcServer.cs"/>
     <Compile Remove="Resources\**\*.*" />
   </ItemGroup>


### PR DESCRIPTION
We've recently ran into various issues around loading non-SDK projects with MSBuildWorkspace, or generally projects where we choose to use the .NET Framework BuildHost that loads a version of MSBuild from VS. The general problem has been that MSBuildLocator is difficult to use: it will redirect the MSBuild binaries, but you don't have a more generic guarantee that:

1. You are getting other assemblies matching MSBuild, for example, System.Collections.Immutable or other runtime-provided assemblies might have already been loaded by our BuildHost during startup, so now the MSBuild one may or may not load.
2. You are getting all the binding redirects that are expected, in the case of .NET Framework.

In .NET Framework, the way you get better isolation and ability to pick up dependencies is to use AppDomains, so this PR puts the MSBuild-using parts of the BuildHost inside of an AppDomain. For the most part, this is relatively clean, since we already had an RPC layer in place for talking outside the BuildHost, the surface area that needs to cross the AppDomain boundary is pretty amenable to that. The particular challenge is our use of System.Collections.Immutable, which are not marked [Serializable] and thus need to be removed. With the exception of one or two dictionaries, almost all our uses were simply ImmutableArrays, which here we just replace with a classic array.

On .NET Core, we are not doing something similar. Ideally, we'd use AssemblyLoadContexts to do a similar approach to this, ensuring that we are loading MSBuild assemblies in their own ALC to avoid mixing. Unfortunately, [MSBuild itself currently has various places it hardcodes AssemblyLoadContext.Default](https://github.com/dotnet/msbuild/issues/6794), so that's simply not something we can do.

The other approach here would be we stop loading MSBuild entirely and move the model where start to use the /getproperty /getitem flags to fetch what we need. Although that would work, it drops support for older versions of VS that predate those new flags, and would necessitate much of a rewrite of some of the backend here. I'm also not sure how TryApplyChanges would then work since we still use that for some MSBuild manipulation too. Since other than the ImmutableArray changes this is otherwise pretty sane, we just go this way for now.

Fixes https://github.com/dotnet/roslyn/issues/82931

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83477)