### PR TITLE
Avoid stack overflow in blank-line analyzers on deep trees

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/NewLines/ArrowExpressionClausePlacement/ArrowExpressionClausePlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/NewLines/ArrowExpressionClausePlacement/ArrowExpressionClausePlacementDiagnosticAnalyzer.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.NewLines.ArrowExpressionClausePlacement;
@@ -38,23 +39,27 @@ internal sealed class ArrowExpressionClausePlacementDiagnosticAnalyzer : Abstrac
         if (option.Value || ShouldSkipAnalysis(context, compilationOptions, option.Notification))
             return;
 
-        Recurse(context, option.Notification, context.GetAnalysisRoot(findInTrivia: false));
-    }
+        var cancellationToken = context.CancellationToken;
 
-    private void Recurse(SyntaxTreeAnalysisContext context, NotificationOption2 notificationOption, SyntaxNode node)
-    {
-        context.CancellationToken.ThrowIfCancellationRequested();
+        // Use an explicit stack to avoid stack overflows on deeply nested trees.
+        using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var stack);
+        stack.Push(context.GetAnalysisRoot(findInTrivia: false));
 
-        if (node is ArrowExpressionClauseSyntax arrowExpressionClause)
-            ProcessArrowExpressionClause(context, notificationOption, arrowExpressionClause);
-
-        foreach (var child in node.ChildNodesAndTokens())
+        while (stack.TryPop(out var node))
         {
-            if (!context.ShouldAnalyzeSpan(child.Span))
-                continue;
+            cancellationToken.ThrowIfCancellationRequested();
 
-            if (child.AsNode(out var childNode))
-                Recurse(context, notificationOption, childNode);
+            if (node is ArrowExpressionClauseSyntax arrowExpressionClause)
+                ProcessArrowExpressionClause(context, option.Notification, arrowExpressionClause);
+
+            foreach (var child in node.ChildNodesAndTokens())
+            {
+                if (!context.ShouldAnalyzeSpan(child.Span))
+                    continue;
+
+                if (child.AsNode(out var childNode))
+                    stack.Push(childNode);
+            }
         }
     }
 

--- a/src/Analyzers/CSharp/Analyzers/NewLines/ConstructorInitializerPlacement/ConstructorInitializerPlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/NewLines/ConstructorInitializerPlacement/ConstructorInitializerPlacementDiagnosticAnalyzer.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.NewLines.ConstructorInitializerPlacement;
@@ -38,27 +39,31 @@ internal sealed class ConstructorInitializerPlacementDiagnosticAnalyzer : Abstra
         if (option.Value || ShouldSkipAnalysis(context, compilationOptions, option.Notification))
             return;
 
-        Recurse(context, option.Notification, context.GetAnalysisRoot(findInTrivia: false));
-    }
+        var cancellationToken = context.CancellationToken;
 
-    private void Recurse(SyntaxTreeAnalysisContext context, NotificationOption2 notificationOption, SyntaxNode node)
-    {
-        context.CancellationToken.ThrowIfCancellationRequested();
+        // Use an explicit stack to avoid stack overflows on deeply nested trees.
+        using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var stack);
+        stack.Push(context.GetAnalysisRoot(findInTrivia: false));
 
-        // Don't bother analyzing nodes that have syntax errors in them.
-        if (node.ContainsDiagnostics)
-            return;
-
-        if (node is ConstructorInitializerSyntax initializer)
-            ProcessConstructorInitializer(context, notificationOption, initializer);
-
-        foreach (var child in node.ChildNodesAndTokens())
+        while (stack.TryPop(out var node))
         {
-            if (!context.ShouldAnalyzeSpan(child.Span))
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Don't bother analyzing nodes that have syntax errors in them.
+            if (node.ContainsDiagnostics)
                 continue;
 
-            if (child.AsNode(out var childNode))
-                Recurse(context, notificationOption, childNode);
+            if (node is ConstructorInitializerSyntax initializer)
+                ProcessConstructorInitializer(context, option.Notification, initializer);
+
+            foreach (var child in node.ChildNodesAndTokens())
+            {
+                if (!context.ShouldAnalyzeSpan(child.Span))
+                    continue;
+
+                if (child.AsNode(out var childNode))
+                    stack.Push(childNode);
+            }
         }
     }
 

--- a/src/Analyzers/CSharp/Analyzers/NewLines/EmbeddedStatementPlacement/EmbeddedStatementPlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/NewLines/EmbeddedStatementPlacement/EmbeddedStatementPlacementDiagnosticAnalyzer.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.NewLines.EmbeddedStatementPlacement;
@@ -35,33 +36,37 @@ internal sealed class EmbeddedStatementPlacementDiagnosticAnalyzer()
         if (option.Value || ShouldSkipAnalysis(context, compilationOptions, option.Notification))
             return;
 
-        Recurse(context, option.Notification, context.GetAnalysisRoot(findInTrivia: false));
-    }
+        var cancellationToken = context.CancellationToken;
 
-    private void Recurse(SyntaxTreeAnalysisContext context, NotificationOption2 notificationOption, SyntaxNode node)
-    {
-        context.CancellationToken.ThrowIfCancellationRequested();
+        // Use an explicit stack to avoid stack overflows on deeply nested trees.
+        using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var stack);
+        stack.Push(context.GetAnalysisRoot(findInTrivia: false));
 
-        // Don't bother analyzing nodes that have syntax errors in them.
-        if (node.ContainsDiagnostics)
-            return;
-
-        // Report on the topmost statement that has an issue.  No need to recurse further at that point. Note: the
-        // fixer will fix up all statements, but we don't want to clutter things with lots of diagnostics on the
-        // same line.
-        if (node is StatementSyntax statement &&
-            CheckStatementSyntax(context, notificationOption, statement))
+        while (stack.TryPop(out var node))
         {
-            return;
-        }
+            cancellationToken.ThrowIfCancellationRequested();
 
-        foreach (var child in node.ChildNodesAndTokens())
-        {
-            if (!context.ShouldAnalyzeSpan(child.Span))
+            // Don't bother analyzing nodes that have syntax errors in them.
+            if (node.ContainsDiagnostics)
                 continue;
 
-            if (child.AsNode(out var childNode))
-                Recurse(context, notificationOption, childNode);
+            // Report on the topmost statement that has an issue.  No need to recurse further at that point. Note: the
+            // fixer will fix up all statements, but we don't want to clutter things with lots of diagnostics on the
+            // same line.
+            if (node is StatementSyntax statement &&
+                CheckStatementSyntax(context, option.Notification, statement))
+            {
+                continue;
+            }
+
+            foreach (var child in node.ChildNodesAndTokens())
+            {
+                if (!context.ShouldAnalyzeSpan(child.Span))
+                    continue;
+
+                if (child.AsNode(out var childNode))
+                    stack.Push(childNode);
+            }
         }
     }
 

--- a/src/Analyzers/Core/Analyzers/NewLines/ConsecutiveStatementPlacement/AbstractConsecutiveStatementPlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/NewLines/ConsecutiveStatementPlacement/AbstractConsecutiveStatementPlacementDiagnosticAnalyzer.cs
@@ -3,10 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;
-using System.Threading;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.LanguageService;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.NewLines.ConsecutiveStatementPlacement;
@@ -43,24 +43,30 @@ internal abstract class AbstractConsecutiveStatementPlacementDiagnosticAnalyzer<
         if (option.Value || ShouldSkipAnalysis(context, compilationOptions, option.Notification))
             return;
 
-        Recurse(context, option.Notification, context.GetAnalysisRoot(findInTrivia: false), context.CancellationToken);
-    }
+        var cancellationToken = context.CancellationToken;
 
-    private void Recurse(SyntaxTreeAnalysisContext context, NotificationOption2 notificationOption, SyntaxNode node, CancellationToken cancellationToken)
-    {
-        if (node.ContainsDiagnostics && node.GetDiagnostics().Any(d => d.Severity == DiagnosticSeverity.Error))
-            return;
+        // Use an explicit stack to avoid stack overflows on deeply nested trees.
+        using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var stack);
+        stack.Push(context.GetAnalysisRoot(findInTrivia: false));
 
-        if (IsBlockLikeStatement(node))
-            ProcessBlockLikeStatement(context, notificationOption, node);
-
-        foreach (var child in node.ChildNodesAndTokens())
+        while (stack.TryPop(out var node))
         {
-            if (!context.ShouldAnalyzeSpan(child.FullSpan))
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (node.ContainsDiagnostics && node.GetDiagnostics().Any(d => d.Severity == DiagnosticSeverity.Error))
                 continue;
 
-            if (child.AsNode(out var childNode))
-                Recurse(context, notificationOption, childNode, cancellationToken);
+            if (IsBlockLikeStatement(node))
+                ProcessBlockLikeStatement(context, option.Notification, node);
+
+            foreach (var child in node.ChildNodesAndTokens())
+            {
+                if (!context.ShouldAnalyzeSpan(child.FullSpan))
+                    continue;
+
+                if (child.AsNode(out var childNode))
+                    stack.Push(childNode);
+            }
         }
     }
 

--- a/src/Analyzers/Core/Analyzers/NewLines/MultipleBlankLines/AbstractMultipleBlankLinesDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/NewLines/MultipleBlankLines/AbstractMultipleBlankLinesDiagnosticAnalyzer.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Threading;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.LanguageService;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 
@@ -38,30 +38,31 @@ internal abstract class AbstractMultipleBlankLinesDiagnosticAnalyzer : AbstractB
         if (option.Value || ShouldSkipAnalysis(context, compilationOptions, option.Notification))
             return;
 
-        Recurse(context, option.Notification, context.GetAnalysisRoot(findInTrivia: false), context.CancellationToken);
-    }
+        var cancellationToken = context.CancellationToken;
 
-    private void Recurse(
-        SyntaxTreeAnalysisContext context,
-        NotificationOption2 notificationOption,
-        SyntaxNode node,
-        CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
+        // Use an explicit stack to avoid stack overflows on deeply nested trees (e.g. very long switch statements
+        // with deeply chained binary expressions like in ErrorFacts.cs).
+        using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var stack);
+        stack.Push(context.GetAnalysisRoot(findInTrivia: false));
 
-        // Don't bother analyzing nodes that have syntax errors in them.
-        if (node.ContainsDiagnostics)
-            return;
-
-        foreach (var child in node.ChildNodesAndTokens())
+        while (stack.TryPop(out var node))
         {
-            if (!context.ShouldAnalyzeSpan(child.FullSpan))
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Don't bother analyzing nodes that have syntax errors in them.
+            if (node.ContainsDiagnostics)
                 continue;
 
-            if (child.AsNode(out var childNode))
-                Recurse(context, notificationOption, childNode, cancellationToken);
-            else if (child.IsToken)
-                CheckToken(context, notificationOption, child.AsToken());
+            foreach (var child in node.ChildNodesAndTokens())
+            {
+                if (!context.ShouldAnalyzeSpan(child.FullSpan))
+                    continue;
+
+                if (child.AsNode(out var childNode))
+                    stack.Push(childNode);
+                else if (child.IsToken)
+                    CheckToken(context, option.Notification, child.AsToken());
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #83481.

`AbstractMultipleBlankLinesDiagnosticAnalyzer` was walking the tree recursively, which stack-overflowed on `ErrorFacts.cs`. Moved it to an explicit `ArrayBuilder<SyntaxNode>` stack (Push/TryPop), matching the pattern already used by the sibling `ConsecutiveBracePlacementDiagnosticAnalyzer`.

Did the same to `AbstractConsecutiveStatementPlacementDiagnosticAnalyzer` while I was here, since it has the identical recursive walk.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83483)