### PR TITLE
Add Microsoft.AspNetCore.Razor.Utilities.Shared.dll to the Razor toolset

### DIFF
--- a/src/Razor/src/Compiler/Microsoft.Net.Compilers.Razor.Toolset/Microsoft.Net.Compilers.Razor.Toolset.csproj
+++ b/src/Razor/src/Compiler/Microsoft.Net.Compilers.Razor.Toolset/Microsoft.Net.Compilers.Razor.Toolset.csproj
@@ -35,6 +35,7 @@
   <Target Name="PackLayout" BeforeTargets="$(GenerateNuspecDependsOn)">
     <ItemGroup>
       <Content Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.Razor.Compiler\$(Configuration)\$(TargetFramework)\*.dll" PackagePath="\source-generators" />
+      <Content Include="$(ArtifactsBinDir)Microsoft.AspNetCore.Razor.Utilities.Shared\$(Configuration)\$(TargetFramework)\Microsoft.AspNetCore.Razor.Utilities.Shared.dll" PackagePath="\source-generators" />
       <Content Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.Razor.Tooling.Internal\$(Configuration)\$(TargetFramework)\Microsoft.Extensions.ObjectPool.dll" PackagePath="\source-generators" />
     </ItemGroup>
   </Target>


### PR DESCRIPTION
Getting the Razor toolset CI up and running exposed this missing DLL post-merge.

https://github.com/dotnet/razor/issues/13110

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83488)