### PR TITLE
Delete warning about a bug we fixed long ago

### DIFF
--- a/src/Razor/Directory.Build.targets
+++ b/src/Razor/Directory.Build.targets
@@ -89,16 +89,6 @@
     <None Include="**\*_NetCore\**\*.*" />
   </ItemGroup>
 
-  <!--
-    Warn consumers until the underlying issue is fixed
-    https://github.com/dotnet/roslyn/issues/72657
-  -->
-  <Target Name="CheckNuPkgEnvEndsWithSlash"
-          AfterTargets="AfterCompile">
-    <Warning Condition="'$(NUGET_PACKAGES)' != '' AND !$(NUGET_PACKAGES.EndsWith($([System.String]::new($([System.IO.Path]::DirectorySeparatorChar)))))"
-             Text="NUGET_PACKAGES should end with a slash or it will lead to editorconfig issues: $(NUGET_PACKAGES)" />
-  </Target>
-
   <Target Name="GetCustomAssemblyAttributes"
           BeforeTargets="GetAssemblyAttributes"
           Condition=" '$(MSBuildProjectExtension)' == '.csproj' "


### PR DESCRIPTION
The bug is about to celebrate it's second anniversary of being fixed, so we can probably remove the warning now.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83490)