### PR TITLE
Closed class: Do not suggest invalid types in inexhaustive switches

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/PatternExplainer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/PatternExplainer.cs
@@ -217,6 +217,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <param name="nullPaths">Permit the use of "null" paths on tests which check for null.</param>
         /// <returns></returns>
         internal static string SamplePatternForPathToDagNode(
+            Binder binder,
             BoundDagTemp rootIdentifier,
             ImmutableArray<BoundDecisionDagNode> nodes,
             BoundDecisionDagNode targetNode,
@@ -238,16 +239,16 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             try
             {
-                return SamplePatternForTemp(rootIdentifier, constraints, evaluations, requireExactType: false, ref unnamedEnumValue);
+                return SamplePatternForTemp(binder, rootIdentifier, constraints, evaluations, requireExactType: false, ref unnamedEnumValue);
             }
             catch (NoRemainingValuesException)
             {
             }
 
             // In rare cases, the shortest path isn't the one that yields a sample
-            return samplePatternFromOtherPaths(rootIdentifier, nodes[0], targetNode, nullPaths, out requiresFalseWhenClause, out unnamedEnumValue);
+            return samplePatternFromOtherPaths(binder, rootIdentifier, nodes[0], targetNode, nullPaths, out requiresFalseWhenClause, out unnamedEnumValue);
 
-            static string samplePatternFromOtherPaths(BoundDagTemp rootIdentifier, BoundDecisionDagNode rootNode,
+            static string samplePatternFromOtherPaths(Binder binder, BoundDagTemp rootIdentifier, BoundDecisionDagNode rootNode,
                 BoundDecisionDagNode targetNode, bool nullPaths, out bool requiresFalseWhenClause, out bool unnamedEnumValue)
             {
                 string altSamplePatternForTemp = null;
@@ -262,7 +263,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     try
                     {
                         altUnnamedEnumValue = false;
-                        altSamplePatternForTemp = SamplePatternForTemp(rootIdentifier, constraints, evaluations, requireExactType: false, ref altUnnamedEnumValue);
+                        altSamplePatternForTemp = SamplePatternForTemp(binder, rootIdentifier, constraints, evaluations, requireExactType: false, ref altUnnamedEnumValue);
                         return false; // we've successfully produced a sample, so stop exploring paths
                     }
                     catch (NoRemainingValuesException)
@@ -329,6 +330,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         private static string SamplePatternForTemp(
+            Binder binder,
             BoundDagTemp input,
             Dictionary<BoundDagTemp, ArrayBuilder<(BoundDagTest test, bool sense)>> constraintMap,
             Dictionary<BoundDagTemp, ArrayBuilder<BoundDagEvaluation>> evaluationMap,
@@ -397,7 +399,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         constraintType.Equals(evaluationType, TypeCompareKind.AllIgnoreOptions) == sense)
                     {
                         var typedTemp = te.MakeResultTemp();
-                        return SamplePatternForTemp(typedTemp, constraintMap, evaluationMap, requireExactType: true, ref unnamedEnumValue);
+                        return SamplePatternForTemp(binder, typedTemp, constraintMap, evaluationMap, requireExactType: true, ref unnamedEnumValue);
                     }
                 }
 
@@ -413,7 +415,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     input.Type.IsNullableType() && input.Type.GetNullableUnderlyingType().Equals(evaluationType, TypeCompareKind.AllIgnoreOptions))
                 {
                     var typedTemp = te.MakeResultTemp();
-                    var result = SamplePatternForTemp(typedTemp, constraintMap, evaluationMap, requireExactType: false, ref unnamedEnumValue);
+                    var result = SamplePatternForTemp(binder, typedTemp, constraintMap, evaluationMap, requireExactType: false, ref unnamedEnumValue);
                     // We need a null check. If not included in the result, add it.
                     return (result == "_") ? "not null" : result;
                 }
@@ -490,7 +492,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 if (effectiveIndex < 0 || effectiveIndex >= lengthValue)
                                     return null;
                                 var oldPattern = subpatterns[effectiveIndex];
-                                var newPattern = SamplePatternForTemp(indexerTemp, constraintMap, evaluationMap, requireExactType: false, ref unnamedEnumValue);
+                                var newPattern = SamplePatternForTemp(binder, indexerTemp, constraintMap, evaluationMap, requireExactType: false, ref unnamedEnumValue);
                                 subpatterns[effectiveIndex] = makeConjunct(oldPattern, newPattern);
                                 continue;
                             case BoundDagSliceEvaluation e:
@@ -504,7 +506,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (slice != null)
                     {
                         var sliceTemp = slice.MakeResultTemp();
-                        var slicePattern = SamplePatternForTemp(sliceTemp, constraintMap, evaluationMap, requireExactType: false, ref unnamedEnumValue);
+                        var slicePattern = SamplePatternForTemp(binder, sliceTemp, constraintMap, evaluationMap, requireExactType: false, ref unnamedEnumValue);
                         if (slicePattern != "_")
                         {
                             // If the slice is not matched against any pattern, the slice pattern would
@@ -538,7 +540,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             return null;
 
                         var oldPattern = subpatterns[index];
-                        var newPattern = SamplePatternForTemp(elementTemp, constraintMap, evaluationMap, requireExactType: false, ref unnamedEnumValue);
+                        var newPattern = SamplePatternForTemp(binder, elementTemp, constraintMap, evaluationMap, requireExactType: false, ref unnamedEnumValue);
                         subpatterns[index] = makeConjunct(oldPattern, newPattern);
                     }
 
@@ -619,7 +621,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (remainingValues.IsEmpty(ref discardedInfo))
                         return null;
 
-                    if (remainingValues.SampleType(ref discardedInfo) is { } type)
+                    if (remainingValues.SampleType(binder, ref discardedInfo) is { } type)
                     {
                         return type.ToDisplayString();
                     }
@@ -660,7 +662,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             bool first = true;
                             foreach (var elementTemp in outParamTemps)
                             {
-                                var newPattern = SamplePatternForTemp(elementTemp, constraintMap, evaluationMap, requireExactType: false, ref unnamedEnumValue);
+                                var newPattern = SamplePatternForTemp(binder, elementTemp, constraintMap, evaluationMap, requireExactType: false, ref unnamedEnumValue);
                                 if (first)
                                 {
                                     first = false;
@@ -687,14 +689,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                         case BoundDagFieldEvaluation e:
                             {
                                 var subInput = e.MakeResultTemp();
-                                var subPattern = SamplePatternForTemp(subInput, constraintMap, evaluationMap, false, ref unnamedEnumValue);
+                                var subPattern = SamplePatternForTemp(binder, subInput, constraintMap, evaluationMap, false, ref unnamedEnumValue);
                                 properties.Add(e.Field, subPattern);
                             }
                             break;
                         case BoundDagPropertyEvaluation e:
                             {
                                 var subInput = e.MakeResultTemp();
-                                var subPattern = SamplePatternForTemp(subInput, constraintMap, evaluationMap, false, ref unnamedEnumValue);
+                                var subPattern = SamplePatternForTemp(binder, subInput, constraintMap, evaluationMap, false, ref unnamedEnumValue);
 
                                 if (evaluations.Length == 1 && e.Property is { Name: WellKnownMemberNames.ValuePropertyName } property &&
                                     e.Input.Type is NamedTypeSymbol { IsUnionType: true } unionType &&

--- a/src/Compilers/CSharp/Portable/Binder/PatternExplainer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/PatternExplainer.cs
@@ -621,7 +621,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (remainingValues.IsEmpty(ref discardedInfo))
                         return null;
 
-                    if (remainingValues.SampleType(input.Type, binder, ref discardedInfo) is { } type)
+                    if (remainingValues.SampleType(binder, ref discardedInfo) is { } type)
                     {
                         return type.ToDisplayString();
                     }

--- a/src/Compilers/CSharp/Portable/Binder/PatternExplainer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/PatternExplainer.cs
@@ -621,7 +621,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (remainingValues.IsEmpty(ref discardedInfo))
                         return null;
 
-                    if (remainingValues.SampleType(binder, ref discardedInfo) is { } type)
+                    if (remainingValues.SampleType(input.Type, binder, ref discardedInfo) is { } type)
                     {
                         return type.ToDisplayString();
                     }

--- a/src/Compilers/CSharp/Portable/Binder/SwitchExpressionBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchExpressionBinder.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (n is BoundLeafDecisionDagNode leaf && leaf.Label == defaultLabel)
                 {
                     var samplePattern = PatternExplainer.SamplePatternForPathToDagNode(
-                        BoundDagTemp.ForOriginalInput(boundInputExpression), nodes, n, nullPaths: false, out bool requiresFalseWhenClause, out bool unnamedEnumValue);
+                        this, BoundDagTemp.ForOriginalInput(boundInputExpression), nodes, n, nullPaths: false, out bool requiresFalseWhenClause, out bool unnamedEnumValue);
                     ErrorCode warningCode =
                         requiresFalseWhenClause ? ErrorCode.WRN_SwitchExpressionNotExhaustiveWithWhen :
                         unnamedEnumValue ? ErrorCode.WRN_SwitchExpressionNotExhaustiveWithUnnamedEnumValue :

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
@@ -1000,7 +1000,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var nodes = node.ReachabilityDecisionDag.TopologicallySortedNodes;
                 var leaf = nodes.Where(n => n is BoundLeafDecisionDagNode leaf && leaf.Label == node.DefaultLabel).First();
                 var samplePattern = PatternExplainer.SamplePatternForPathToDagNode(
-                    BoundDagTemp.ForOriginalInput(node.Expression), nodes, leaf, nullPaths: true, out bool requiresFalseWhenClause, out _);
+                    _binder, BoundDagTemp.ForOriginalInput(node.Expression), nodes, leaf, nullPaths: true, out bool requiresFalseWhenClause, out _);
                 ErrorCode warningCode = requiresFalseWhenClause ? ErrorCode.WRN_SwitchExpressionNotExhaustiveForNullWithWhen : ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull;
                 ReportDiagnostic(
                     warningCode,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/DelegateCacheRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/DelegateCacheRewriter.cs
@@ -171,13 +171,13 @@ internal sealed class DelegateCacheRewriter
         {
             if ((targetMethod.IsAbstract || targetMethod.IsVirtual) && boundDelegateCreation.Argument is BoundTypeExpression typeExpression)
             {
-                FindTypeParameters(typeExpression.Type, usedTypeParameters);
+                typeExpression.Type.FindTypeParameters(usedTypeParameters);
             }
 
             var delegateType = boundDelegateCreation.Type;
 
-            FindTypeParameters(delegateType, usedTypeParameters);
-            FindTypeParameters(targetMethod, usedTypeParameters);
+            delegateType.FindTypeParameters(usedTypeParameters);
+            targetMethod.FindTypeParameters(usedTypeParameters);
 
             Symbol? enclosingSymbol = currentFunction;
             for (; enclosingSymbol is MethodSymbol enclosingMethod; enclosingSymbol = enclosingSymbol.ContainingSymbol)
@@ -217,27 +217,4 @@ internal sealed class DelegateCacheRewriter
             return false;
         }
     }
-
-    private static void FindTypeParameters(TypeSymbol type, HashSet<TypeParameterSymbol> result)
-        => type.VisitType(s_typeParameterSymbolCollector, result, visitCustomModifiers: true);
-
-    private static void FindTypeParameters(MethodSymbol method, HashSet<TypeParameterSymbol> result)
-    {
-        FindTypeParameters(method.ContainingType, result);
-
-        foreach (var typeArgument in method.TypeArgumentsWithAnnotations)
-        {
-            typeArgument.VisitType(type: null, typeWithAnnotationsPredicate: null, s_typeParameterSymbolCollector, result, visitCustomModifiers: true);
-        }
-    }
-
-    private static readonly Func<TypeSymbol, HashSet<TypeParameterSymbol>, bool, bool> s_typeParameterSymbolCollector = (typeSymbol, result, _) =>
-    {
-        if (typeSymbol is TypeParameterSymbol typeParameter)
-        {
-            result.Add(typeParameter);
-        }
-
-        return false;
-    };
 }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
@@ -347,19 +347,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var referenced = PooledHashSet<TypeParameterSymbol>.GetInstance();
             foreach (var field in typeDescr.Fields)
             {
-                field.TypeWithAnnotations.VisitType(
-                    type: null,
-                    typeWithAnnotationsPredicate: null,
-                    typePredicate: static (type, referenced, _) =>
-                    {
-                        if (type is TypeParameterSymbol typeParameter)
-                        {
-                            referenced.Add(typeParameter);
-                        }
-                        return false;
-                    },
-                    arg: referenced,
-                    visitCustomModifiers: true);
+                field.TypeWithAnnotations.FindTypeParameters(referenced);
             }
 
             ImmutableArray<TypeParameterSymbol> typeParameters;

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
@@ -347,7 +347,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var referenced = PooledHashSet<TypeParameterSymbol>.GetInstance();
             foreach (var field in typeDescr.Fields)
             {
-                field.Type.FindTypeParameters(referenced);
+                field.TypeWithAnnotations.VisitType(
+                    type: null,
+                    typeWithAnnotationsPredicate: null,
+                    typePredicate: static (type, referenced, _) =>
+                    {
+                        if (type is TypeParameterSymbol typeParameter)
+                        {
+                            referenced.Add(typeParameter);
+                        }
+                        return false;
+                    },
+                    arg: referenced,
+                    visitCustomModifiers: true);
             }
 
             ImmutableArray<TypeParameterSymbol> typeParameters;

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
@@ -347,19 +347,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var referenced = PooledHashSet<TypeParameterSymbol>.GetInstance();
             foreach (var field in typeDescr.Fields)
             {
-                field.TypeWithAnnotations.VisitType(
-                    type: null,
-                    typeWithAnnotationsPredicate: null,
-                    typePredicate: static (type, referenced, _) =>
-                    {
-                        if (type is TypeParameterSymbol typeParameter)
-                        {
-                            referenced.Add(typeParameter);
-                        }
-                        return false;
-                    },
-                    arg: referenced,
-                    visitCustomModifiers: true);
+                field.Type.FindTypeParameters(referenced);
             }
 
             ImmutableArray<TypeParameterSymbol> typeParameters;

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -747,8 +747,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     {
                         if (unifiedSubtype.IsGenericType && unifiedSubtype.ContainsAdditionalTypeParameter(allowedTypeParameters: baseTypeTypeParameters))
                         {
-                            // If 'closedSubtype' contains type parameters which are not present in '@this',
-                            // it implies 'closedSubtype' was able to unify but is not speakable at the use site.
+                            // If 'unifiedSubtype' contains type parameters which are not present in '@this',
+                            // it implies 'unifiedSubtype' was able to unify but is not speakable at the use site.
                             return false;
                         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -700,46 +700,83 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>Returns true if the type is 'closed', i.e. an abstract class where subtyping is only permitted in the current module.</summary>
         internal abstract bool IsClosed { get; }
 
-        /// <summary>
-        /// Returns the set of possible subtypes of a closed type.
-        /// </summary>
-        /// <remarks>
-        /// This set will be the same size or smaller than <see cref="CandidateClosedSubtypeDefinitions"/>.
-        /// The difference is that <see cref="ClosedSubtypes"/> will perform substitution
-        /// and rule out subtypes whose base types can't unify with 'this'.
-        /// </remarks>
         internal ImmutableArray<NamedTypeSymbol> ClosedSubtypes
         {
             get
             {
-                if (!IsClosed)
-                    return [];
+                // TODO2: update use sites?
+                TryGetClosedSubtypes(out var subtypes);
+                return subtypes;
+            }
+        }
 
-                // https://github.com/dotnet/csharplang/blob/3e15888c804dc632479c94589dcd02c341fd0a4f/proposals/closed-hierarchies.md#type-parameter-restriction
-                // If a closed type lacks type parameters, then, any valid subtype of it also lacks type parameters.
-                var candidateSubtypes = CandidateClosedSubtypeDefinitions;
-                if (!IsGenericType)
-                    return candidateSubtypes;
+        /// <summary>
+        /// Tries to get the set of possible subtypes of a closed type.
+        /// </summary>
+        /// <remarks>
+        /// When a closed class contains type parameters, it's possible that some subtype may or
+        /// may not apply, depending on what type substitution is ultimately performed at a later stage.
+        /// This call will return <see langword="false"/> and an empty subtype list in that situation.
+        /// </remarks>
+        internal bool TryGetClosedSubtypes(out ImmutableArray<NamedTypeSymbol> subtypes)
+        {
+            if (!IsClosed)
+            {
+                subtypes = [];
+                return false;
+            }
 
-                return unifyAndCheckSubtypes(this, candidateSubtypes);
+            // https://github.com/dotnet/csharplang/blob/3e15888c804dc632479c94589dcd02c341fd0a4f/proposals/closed-hierarchies.md#type-parameter-restriction
+            // If a closed type lacks type parameters, then, any valid subtype of it also lacks type parameters.
+            var candidateSubtypes = CandidateClosedSubtypeDefinitions;
+            if (!IsGenericType)
+            {
+                subtypes = candidateSubtypes;
+                return true;
+            }
 
-                static ImmutableArray<NamedTypeSymbol> unifyAndCheckSubtypes(NamedTypeSymbol @this, ImmutableArray<NamedTypeSymbol> candidateSubtypes)
+            var resultBuilder = ArrayBuilder<NamedTypeSymbol>.GetInstance(candidateSubtypes.Length);
+            if (!tryGetSpeakableSubtypes(this, candidateSubtypes, resultBuilder))
+            {
+                resultBuilder.Free();
+                subtypes = [];
+                return false;
+            }
+
+            subtypes = resultBuilder.ToImmutableAndFree();
+            return true;
+
+            static bool tryGetSpeakableSubtypes(NamedTypeSymbol @this, ImmutableArray<NamedTypeSymbol> candidateSubtypes, ArrayBuilder<NamedTypeSymbol> resultBuilder)
+            {
+                foreach (var candidateSubtype in candidateSubtypes)
                 {
-                    var resultBuilder = ArrayBuilder<NamedTypeSymbol>.GetInstance(candidateSubtypes.Length);
-                    foreach (var candidateSubtype in candidateSubtypes)
+                    if (TypeUnification.TryUnifyClosedSubtype(candidateSubtype, closedType: @this) is { } unifiedSubtype)
                     {
-                        if (TypeUnification.TryUnifyClosedSubtype(candidateSubtype, closedType: @this) is { } unifiedSubtype)
+                        // Check if 'closedSubtype' contains type parameters which are not present in '@this'.
+                        // This implies 'closedSubtype' was able to unify but is not speakable at the use site.
+                        var baseTypeTypeParameters = PooledHashSet<TypeParameterSymbol>.GetInstance();
+                        _ = @this.VisitType(static (type, inputTypeTypeParameters, isNested) =>
                         {
-                            // PROTOTYPE(cc): We should probably check the constraints of the 'unifiedSubtype'.
-                            // However, when considering the validity of the 'unifiedSubtype' containing type parameters,
-                            // we don't want to know the typical answer of: are the constraints "always" satisfied.
-                            // Instead we want to know: could any possible type argument satisfy the constraints of both 'this' and 'unifiedSubtype'.
-                            resultBuilder.Add(unifiedSubtype);
-                        }
-                    }
+                            if (type is TypeParameterSymbol typeParameter)
+                                inputTypeTypeParameters.Add(typeParameter);
 
-                    return resultBuilder.ToImmutableAndFree();
+                            return false;
+                        }, baseTypeTypeParameters);
+
+                        var unspeakableTypeParameter = unifiedSubtype.VisitType(
+                            (type, inputTypeTypeParameters, isNested) => type is TypeParameterSymbol typeParameter && !inputTypeTypeParameters.Contains(typeParameter),
+                            baseTypeTypeParameters);
+                        baseTypeTypeParameters.Free();
+                        if (unspeakableTypeParameter is not null)
+                        {
+                            return false;
+                        }
+
+                        resultBuilder.Add(unifiedSubtype);
+                    }
                 }
+
+                return true;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -762,6 +762,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             return false;
                         }
 
+                        // PROTOTYPE(cc): We should probably check the constraints of the 'unifiedSubtype'.
+                        // However, when considering the validity of the 'unifiedSubtype' containing type parameters,
+                        // we don't want to know the typical answer of: are the constraints "always" satisfied.
+                        // Instead we want to know: could any possible type argument satisfy the constraints of both 'this' and 'unifiedSubtype'.
                         resultBuilder.Add(unifiedSubtype);
                     }
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -700,16 +700,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>Returns true if the type is 'closed', i.e. an abstract class where subtyping is only permitted in the current module.</summary>
         internal abstract bool IsClosed { get; }
 
-        internal ImmutableArray<NamedTypeSymbol> ClosedSubtypes
-        {
-            get
-            {
-                // TODO2: update use sites?
-                TryGetClosedSubtypes(out var subtypes);
-                return subtypes;
-            }
-        }
-
         /// <summary>
         /// Tries to get the set of possible subtypes of a closed type.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -716,17 +716,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return false;
             }
 
-            // https://github.com/dotnet/csharplang/blob/3e15888c804dc632479c94589dcd02c341fd0a4f/proposals/closed-hierarchies.md#type-parameter-restriction
-            // If a closed type lacks type parameters, then, any valid subtype of it also lacks type parameters.
             var candidateSubtypes = CandidateClosedSubtypeDefinitions;
-            if (!IsGenericType)
+            if (candidateSubtypes.All(subtype => !subtype.IsGenericType))
             {
                 subtypes = candidateSubtypes;
                 return true;
             }
 
             var resultBuilder = ArrayBuilder<NamedTypeSymbol>.GetInstance(candidateSubtypes.Length);
-            if (!tryGetSpeakableSubtypes(this, candidateSubtypes, resultBuilder))
+            var baseTypeTypeParameters = PooledHashSet<TypeParameterSymbol>.GetInstance();
+            this.FindTypeParameters(baseTypeTypeParameters);
+
+            var success = tryGetSpeakableSubtypes(this, candidateSubtypes, resultBuilder, baseTypeTypeParameters);
+            baseTypeTypeParameters.Free();
+            if (!success)
             {
                 resultBuilder.Free();
                 subtypes = [];
@@ -736,29 +739,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             subtypes = resultBuilder.ToImmutableAndFree();
             return true;
 
-            static bool tryGetSpeakableSubtypes(NamedTypeSymbol @this, ImmutableArray<NamedTypeSymbol> candidateSubtypes, ArrayBuilder<NamedTypeSymbol> resultBuilder)
+            static bool tryGetSpeakableSubtypes(NamedTypeSymbol @this, ImmutableArray<NamedTypeSymbol> candidateSubtypes, ArrayBuilder<NamedTypeSymbol> resultBuilder, HashSet<TypeParameterSymbol> baseTypeTypeParameters)
             {
                 foreach (var candidateSubtype in candidateSubtypes)
                 {
                     if (TypeUnification.TryUnifyClosedSubtype(candidateSubtype, closedType: @this) is { } unifiedSubtype)
                     {
-                        // Check if 'closedSubtype' contains type parameters which are not present in '@this'.
-                        // This implies 'closedSubtype' was able to unify but is not speakable at the use site.
-                        var baseTypeTypeParameters = PooledHashSet<TypeParameterSymbol>.GetInstance();
-                        _ = @this.VisitType(static (type, inputTypeTypeParameters, isNested) =>
+                        if (unifiedSubtype.IsGenericType && unifiedSubtype.ContainsAdditionalTypeParameter(allowedTypeParameters: baseTypeTypeParameters))
                         {
-                            if (type is TypeParameterSymbol typeParameter)
-                                inputTypeTypeParameters.Add(typeParameter);
-
-                            return false;
-                        }, baseTypeTypeParameters);
-
-                        var unspeakableTypeParameter = unifiedSubtype.VisitType(
-                            (type, inputTypeTypeParameters, isNested) => type is TypeParameterSymbol typeParameter && !inputTypeTypeParameters.Contains(typeParameter),
-                            baseTypeTypeParameters);
-                        baseTypeTypeParameters.Free();
-                        if (unspeakableTypeParameter is not null)
-                        {
+                            // If 'closedSubtype' contains type parameters which are not present in '@this',
+                            // it implies 'closedSubtype' was able to unify but is not speakable at the use site.
                             return false;
                         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -717,7 +717,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             var candidateSubtypes = CandidateClosedSubtypeDefinitions;
-            if (candidateSubtypes.All(subtype => !subtype.IsGenericType))
+            if (!IsGenericType && candidateSubtypes.All(subtype => !subtype.IsGenericType))
             {
                 subtypes = candidateSubtypes;
                 return true;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -555,7 +555,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 int extensionMemberArity = extensionMember.GetMemberArity();
                 Debug.Assert(extensionMemberArity == 0); // we currently only apply the check for members which may not be generic
 
-                extensionParameter.Type.VisitType(collectTypeParameters, arg: usedTypeParameters);
+                extensionParameter.Type.FindTypeParameters(usedTypeParameters);
 
                 if (usedTypeParameters.Count == extensionArity && extensionMemberArity == 0)
                 {
@@ -564,7 +564,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 foreach (var parameter in parameters)
                 {
-                    parameter.Type.VisitType(collectTypeParameters, arg: usedTypeParameters);
+                    parameter.Type.FindTypeParameters(usedTypeParameters);
 
                     if (usedTypeParameters.Count == extensionArity && extensionMemberArity == 0)
                     {
@@ -579,16 +579,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         diagnostics.Add(ErrorCode.ERR_UnderspecifiedExtension, extensionMember.GetFirstLocation(), typeParameter);
                     }
                 }
-            }
-
-            static bool collectTypeParameters(TypeSymbol type, PooledHashSet<TypeParameterSymbol> typeParameters, bool ignored)
-            {
-                if (type is TypeParameterSymbol typeParameter)
-                {
-                    typeParameters.Add(typeParameter);
-                }
-
-                return false;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
@@ -427,14 +427,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     if (IsGenericType)
                     {
                         var usedTypeParameters = PooledHashSet<TypeParameterSymbol>.GetInstance();
-                        baseType.VisitType(static (type, arg, _) =>
-                        {
-                            var (usedTypeParameters, @this) = arg;
-                            if (type is TypeParameterSymbol typeParameter)
-                                usedTypeParameters.Add(typeParameter);
-
-                            return false;
-                        }, arg: (usedTypeParameters, this));
+                        baseType.FindTypeParameters(usedTypeParameters);
 
                         for (NamedTypeSymbol type = this; type is not null; type = type.ContainingType)
                         {

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1280,6 +1280,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public static void FindTypeParameters(this TypeSymbol type, HashSet<TypeParameterSymbol> result)
             => type.VisitType(s_typeParameterSymbolCollector, result, visitCustomModifiers: true);
 
+        public static void FindTypeParameters(this TypeWithAnnotations type, HashSet<TypeParameterSymbol> result)
+            => type.VisitType(
+                    type: null,
+                    typeWithAnnotationsPredicate: null,
+                    typePredicate: s_typeParameterSymbolCollector,
+                    arg: result,
+                    visitCustomModifiers: true);
+
         public static void FindTypeParameters(this MethodSymbol method, HashSet<TypeParameterSymbol> result)
         {
             FindTypeParameters(method.ContainingType, result);

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1273,7 +1273,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public static bool ContainsAdditionalTypeParameter(this TypeSymbol type, HashSet<TypeParameterSymbol> allowedTypeParameters)
         {
             var result = type.VisitType(
-                (type, allowedTypeParameters, isNested) => type is TypeParameterSymbol typeParameter && !allowedTypeParameters.Contains(typeParameter), allowedTypeParameters);
+                static (type, allowedTypeParameters, isNested) => type is TypeParameterSymbol typeParameter && !allowedTypeParameters.Contains(typeParameter), allowedTypeParameters);
             return result is object;
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1270,6 +1270,36 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private static readonly Func<TypeSymbol, HashSet<TypeParameterSymbol>, bool, bool> s_containsTypeParametersPredicate =
             (type, parameters, unused) => type.TypeKind == TypeKind.TypeParameter && parameters.Contains((TypeParameterSymbol)type);
 
+        public static bool ContainsAdditionalTypeParameter(this TypeSymbol type, HashSet<TypeParameterSymbol> allowedTypeParameters)
+        {
+            var result = type.VisitType(
+                (type, allowedTypeParameters, isNested) => type is TypeParameterSymbol typeParameter && !allowedTypeParameters.Contains(typeParameter), allowedTypeParameters);
+            return result is object;
+        }
+
+        public static void FindTypeParameters(this TypeSymbol type, HashSet<TypeParameterSymbol> result)
+            => type.VisitType(s_typeParameterSymbolCollector, result, visitCustomModifiers: true);
+
+        public static void FindTypeParameters(this MethodSymbol method, HashSet<TypeParameterSymbol> result)
+        {
+            FindTypeParameters(method.ContainingType, result);
+
+            foreach (var typeArgument in method.TypeArgumentsWithAnnotations)
+            {
+                typeArgument.VisitType(type: null, typeWithAnnotationsPredicate: null, s_typeParameterSymbolCollector, result, visitCustomModifiers: true);
+            }
+        }
+
+        private static readonly Func<TypeSymbol, HashSet<TypeParameterSymbol>, bool, bool> s_typeParameterSymbolCollector = (typeSymbol, result, _) =>
+        {
+            if (typeSymbol is TypeParameterSymbol typeParameter)
+            {
+                result.Add(typeParameter);
+            }
+
+            return false;
+        };
+
         public static bool ContainsMethodTypeParameter(this TypeSymbol type)
         {
             var result = type.VisitType(s_containsMethodTypeParameterPredicate, null);

--- a/src/Compilers/CSharp/Portable/Symbols/TypeUnification.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeUnification.cs
@@ -25,6 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public static NamedTypeSymbol? TryUnifyClosedSubtype(NamedTypeSymbol candidateSubtype, NamedTypeSymbol closedType)
         {
             Debug.Assert(candidateSubtype.IsDefinition);
+            Debug.Assert(closedType.IsClosed);
 
             var candidateBaseType = candidateSubtype.BaseTypeNoUseSiteDiagnostics;
             Debug.Assert(TypeSymbol.Equals(candidateBaseType.OriginalDefinition, closedType.OriginalDefinition, TypeCompareKind.CLRSignatureCompareOptions));

--- a/src/Compilers/CSharp/Portable/Utilities/TypeUnionValueSet.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/TypeUnionValueSet.cs
@@ -249,7 +249,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        public TypeSymbol? SampleType(Binder binder, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        public TypeSymbol? SampleType(TypeSymbol inputType, Binder binder, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
             if (IsEmpty(ref useSiteInfo))
                 throw new ArgumentException();
@@ -257,38 +257,40 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (_lazyMightIncludeNonNull != false)
             {
                 var sampleType = TryGetSampleType(_root, ref useSiteInfo);
-                return walkUpInvalidClosedSubtypesIfNeeded(binder, sampleType);
+                return walkUpInvalidClosedSubtypesIfNeeded(inputType, binder, sampleType, ref useSiteInfo);
             }
 
             return null;
 
-            static TypeSymbol? walkUpInvalidClosedSubtypesIfNeeded(Binder binder, TypeSymbol? sampleType)
+            static TypeSymbol? walkUpInvalidClosedSubtypesIfNeeded(TypeSymbol inputType, Binder binder, TypeSymbol? sampleType, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
             {
                 if (sampleType is null || sampleType is not NamedTypeSymbol namedType)
                 {
                     return sampleType;
                 }
 
-                while (isInvalidClosedSubtype(binder, namedType))
+                while (isInvalidClosedSubtype(inputType, binder, namedType, ref useSiteInfo))
                     namedType = namedType.BaseTypeNoUseSiteDiagnostics;
 
                 return namedType;
 
-                static bool isInvalidClosedSubtype(Binder binder, NamedTypeSymbol namedType)
+                static bool isInvalidClosedSubtype(TypeSymbol inputType, Binder binder, NamedTypeSymbol possibleClosedSubtype, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
                 {
-                    if (!namedType.BaseTypeNoUseSiteDiagnostics.IsClosed)
+                    if (!possibleClosedSubtype.BaseTypeNoUseSiteDiagnostics.IsClosed)
                         return false;
 
-                    if (!namedType.CheckAllConstraints(binder.Compilation, binder.Conversions))
-                    {
-                        return true;
-                    }
+                    // Do not suggest matching a type which is "more base" than the pattern's input type.
+                    // TODO2: it seems like the pattern input type itself isn't what we want to compare against when matching a union.
+                    // It seems like in order to provide the "most desirable" type suggestion in all scenarios, we might need to remember which original closed type is associated with each expanded type.
+                    // Since a union could contain multiple closed types, or even multiple constructions of the same closed type or types within the same hierarchy, there could be some fairly subtle conditions to handle here.
+                    if (inputType.OriginalDefinition.Equals(possibleClosedSubtype.OriginalDefinition, TypeCompareKind.AllIgnoreOptions))
+                        return false;
 
-                    var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
-                    if (!binder.IsAccessible(namedType, useSiteInfo: ref discardedUseSiteInfo))
-                    {
+                    if (!possibleClosedSubtype.CheckAllConstraints(binder.Compilation, binder.Conversions))
                         return true;
-                    }
+
+                    if (!binder.IsAccessible(possibleClosedSubtype, ref useSiteInfo))
+                        return true;
 
                     return false;
                 }

--- a/src/Compilers/CSharp/Portable/Utilities/TypeUnionValueSet.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/TypeUnionValueSet.cs
@@ -28,10 +28,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
         internal readonly struct CaseInfo(TypeSymbol caseType, TypeSymbol? originalClosedBase)
         {
-            internal TypeSymbol CaseType { get; } = caseType;
+            internal readonly TypeSymbol CaseType = caseType;
 
             /// <summary>If <see cref="CaseType"/> was included in the set due to being a subtype of a closed type, this is the original closed type it was expanded from.</summary>
-            internal TypeSymbol? OriginalClosedBase { get; } = originalClosedBase;
+            internal readonly TypeSymbol? OriginalClosedBase = originalClosedBase;
 
             private string GetDebuggerDisplay()
             {
@@ -283,6 +283,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return sampleType;
                 }
 
+                Debug.Assert(originalClosedBase is NamedTypeSymbol { IsClosed: true });
                 while (isInvalidClosedSubtype(namedType, originalClosedBase, binder, ref useSiteInfo))
                     namedType = namedType.BaseTypeNoUseSiteDiagnostics;
 
@@ -290,9 +291,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 static bool isInvalidClosedSubtype(NamedTypeSymbol possibleClosedSubtype, TypeSymbol originalClosedBase, Binder binder, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
                 {
-                    if (possibleClosedSubtype.BaseTypeNoUseSiteDiagnostics?.IsClosed is null or false)
-                        return false;
-
                     // Do not suggest matching a type which is "more base" than original base type it was expanded from.
                     if (originalClosedBase.OriginalDefinition.Equals(possibleClosedSubtype.OriginalDefinition, TypeCompareKind.AllIgnoreOptions))
                         return false;

--- a/src/Compilers/CSharp/Portable/Utilities/TypeUnionValueSet.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/TypeUnionValueSet.cs
@@ -249,17 +249,50 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        public TypeSymbol? SampleType(ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        public TypeSymbol? SampleType(Binder binder, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
             if (IsEmpty(ref useSiteInfo))
                 throw new ArgumentException();
 
             if (_lazyMightIncludeNonNull != false)
             {
-                return TryGetSampleType(_root, ref useSiteInfo);
+                var sampleType = TryGetSampleType(_root, ref useSiteInfo);
+                return walkUpInvalidClosedSubtypesIfNeeded(binder, sampleType);
             }
 
             return null;
+
+            static TypeSymbol? walkUpInvalidClosedSubtypesIfNeeded(Binder binder, TypeSymbol? sampleType)
+            {
+                if (sampleType is null || sampleType is not NamedTypeSymbol namedType)
+                {
+                    return sampleType;
+                }
+
+                while (isInvalidClosedSubtype(binder, namedType))
+                    namedType = namedType.BaseTypeNoUseSiteDiagnostics;
+
+                return namedType;
+
+                static bool isInvalidClosedSubtype(Binder binder, NamedTypeSymbol namedType)
+                {
+                    if (!namedType.BaseTypeNoUseSiteDiagnostics.IsClosed)
+                        return false;
+
+                    if (!namedType.CheckAllConstraints(binder.Compilation, binder.Conversions))
+                    {
+                        return true;
+                    }
+
+                    var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
+                    if (!binder.IsAccessible(namedType, useSiteInfo: ref discardedUseSiteInfo))
+                    {
+                        return true;
+                    }
+
+                    return false;
+                }
+            }
         }
 
         private TypeSymbol? TryGetSampleType(Node root, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)

--- a/src/Compilers/CSharp/Portable/Utilities/TypeUnionValueSet.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/TypeUnionValueSet.cs
@@ -23,7 +23,21 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// The set of types defining a union of types, instances of which could be in the value set.
         /// </summary>
-        private readonly ImmutableArray<TypeSymbol> _typesInUnion;
+        private readonly ImmutableArray<CaseInfo> _typesInUnion;
+
+        [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
+        internal readonly struct CaseInfo(TypeSymbol caseType, TypeSymbol? originalClosedBase)
+        {
+            internal TypeSymbol CaseType { get; } = caseType;
+
+            /// <summary>If <see cref="CaseType"/> was included in the set due to being a subtype of a closed type, this is the original closed type it was expanded from.</summary>
+            internal TypeSymbol? OriginalClosedBase { get; } = originalClosedBase;
+
+            private string GetDebuggerDisplay()
+            {
+                return $"(CaseType: {CaseType}, OriginalClosedBase: {OriginalClosedBase})";
+            }
+        }
 
         /// <summary>
         /// Root of a logical tree defining values contained in this value set.
@@ -45,24 +59,24 @@ namespace Microsoft.CodeAnalysis.CSharp
         private bool? _lazyIncludesNull;
 
         private TypeUnionValueSet(
-            ImmutableArray<TypeSymbol> typesInUnion,
+            ImmutableArray<CaseInfo> typesInUnion,
             Node root,
             ConversionsBase conversions)
         {
             Debug.Assert(!typesInUnion.IsEmpty);
-            Debug.Assert(!typesInUnion.Any(t => t.IsNullableType()));
-            Debug.Assert(typesInUnion.Distinct().Length == typesInUnion.Length);
+            Debug.Assert(!typesInUnion.Any(t => t.CaseType.IsNullableType()));
+            Debug.Assert(typesInUnion.Select(t => t.CaseType).Distinct().Count() == typesInUnion.Length);
             _typesInUnion = typesInUnion;
             _root = root;
             _conversions = conversions;
         }
 
-        internal static TypeUnionValueSet AllValues(ImmutableArray<TypeSymbol> typesInUnion, ConversionsBase conversions)
+        internal static TypeUnionValueSet AllValues(ImmutableArray<CaseInfo> typesInUnion, ConversionsBase conversions)
         {
             return new TypeUnionValueSet(typesInUnion, IsTrueNode.Instance, conversions);
         }
 
-        internal static TypeUnionValueSet FromTypeMatch(ImmutableArray<TypeSymbol> typesInUnion, TypeSymbol type, ConversionsBase conversions, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        internal static TypeUnionValueSet FromTypeMatch(ImmutableArray<CaseInfo> typesInUnion, TypeSymbol type, ConversionsBase conversions, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
             if (AnyTypeFromUnionMightMatch(typesInUnion, type, conversions, ref useSiteInfo))
             {
@@ -73,15 +87,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new TypeUnionValueSet(typesInUnion, IsFalseNode.Instance, conversions);
         }
 
-        private static bool AnyTypeFromUnionMightMatch(ImmutableArray<TypeSymbol> typesInUnion, TypeSymbol type, ConversionsBase conversions, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        private static bool AnyTypeFromUnionMightMatch(ImmutableArray<CaseInfo> typesInUnion, TypeSymbol type, ConversionsBase conversions, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
             Debug.Assert(!typesInUnion.IsEmpty);
-            Debug.Assert(!typesInUnion.Any(TypeSymbolExtensions.IsNullableType));
-            Debug.Assert(typesInUnion.Distinct().Length == typesInUnion.Length);
+            Debug.Assert(!typesInUnion.Any(t => TypeSymbolExtensions.IsNullableType(t.CaseType)));
+            Debug.Assert(typesInUnion.Select(t => t.CaseType).Distinct().Count() == typesInUnion.Length);
 
             foreach (var t in typesInUnion)
             {
-                ConstantValue? matches = DecisionDagBuilder.ExpressionOfTypeMatchesPatternTypeForLearningFromSuccessfulTypeTest(conversions, type, t, ref useSiteInfo);
+                ConstantValue? matches = DecisionDagBuilder.ExpressionOfTypeMatchesPatternTypeForLearningFromSuccessfulTypeTest(conversions, type, t.CaseType, ref useSiteInfo);
                 if (matches == ConstantValue.False)
                 {
                     // If 'type' could never be 't'
@@ -95,12 +109,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             return false;
         }
 
-        internal static TypeUnionValueSet FromNullMatch(ImmutableArray<TypeSymbol> typesInUnion, ConversionsBase conversions)
+        internal static TypeUnionValueSet FromNullMatch(ImmutableArray<CaseInfo> typesInUnion, ConversionsBase conversions)
         {
             return new TypeUnionValueSet(typesInUnion, IsNullNode.Instance, conversions);
         }
 
-        internal static TypeUnionValueSet FromNonNullMatch(ImmutableArray<TypeSymbol> typesInUnion, ConversionsBase conversions)
+        internal static TypeUnionValueSet FromNonNullMatch(ImmutableArray<CaseInfo> typesInUnion, ConversionsBase conversions)
         {
             return new TypeUnionValueSet(typesInUnion, new NotNode(IsNullNode.Instance), conversions);
         }
@@ -249,41 +263,38 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        public TypeSymbol? SampleType(TypeSymbol inputType, Binder binder, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        public TypeSymbol? SampleType(Binder binder, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
             if (IsEmpty(ref useSiteInfo))
                 throw new ArgumentException();
 
             if (_lazyMightIncludeNonNull != false)
             {
-                var sampleType = TryGetSampleType(_root, ref useSiteInfo);
-                return walkUpInvalidClosedSubtypesIfNeeded(inputType, binder, sampleType, ref useSiteInfo);
+                var sample = TryGetSampleType(_root, ref useSiteInfo);
+                return walkUpInvalidClosedSubtypesIfNeeded(sample?.CaseType, sample?.OriginalClosedBase, binder, ref useSiteInfo);
             }
 
             return null;
 
-            static TypeSymbol? walkUpInvalidClosedSubtypesIfNeeded(TypeSymbol inputType, Binder binder, TypeSymbol? sampleType, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+            static TypeSymbol? walkUpInvalidClosedSubtypesIfNeeded(TypeSymbol? sampleType, TypeSymbol? originalClosedBase, Binder binder, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
             {
-                if (sampleType is null || sampleType is not NamedTypeSymbol namedType)
+                if (originalClosedBase is null || sampleType is not NamedTypeSymbol namedType)
                 {
                     return sampleType;
                 }
 
-                while (isInvalidClosedSubtype(inputType, binder, namedType, ref useSiteInfo))
+                while (isInvalidClosedSubtype(namedType, originalClosedBase, binder, ref useSiteInfo))
                     namedType = namedType.BaseTypeNoUseSiteDiagnostics;
 
                 return namedType;
 
-                static bool isInvalidClosedSubtype(TypeSymbol inputType, Binder binder, NamedTypeSymbol possibleClosedSubtype, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+                static bool isInvalidClosedSubtype(NamedTypeSymbol possibleClosedSubtype, TypeSymbol originalClosedBase, Binder binder, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
                 {
-                    if (!possibleClosedSubtype.BaseTypeNoUseSiteDiagnostics.IsClosed)
+                    if (possibleClosedSubtype.BaseTypeNoUseSiteDiagnostics?.IsClosed is null or false)
                         return false;
 
-                    // Do not suggest matching a type which is "more base" than the pattern's input type.
-                    // TODO2: it seems like the pattern input type itself isn't what we want to compare against when matching a union.
-                    // It seems like in order to provide the "most desirable" type suggestion in all scenarios, we might need to remember which original closed type is associated with each expanded type.
-                    // Since a union could contain multiple closed types, or even multiple constructions of the same closed type or types within the same hierarchy, there could be some fairly subtle conditions to handle here.
-                    if (inputType.OriginalDefinition.Equals(possibleClosedSubtype.OriginalDefinition, TypeCompareKind.AllIgnoreOptions))
+                    // Do not suggest matching a type which is "more base" than original base type it was expanded from.
+                    if (originalClosedBase.OriginalDefinition.Equals(possibleClosedSubtype.OriginalDefinition, TypeCompareKind.AllIgnoreOptions))
                         return false;
 
                     if (!possibleClosedSubtype.CheckAllConstraints(binder.Compilation, binder.Conversions))
@@ -297,11 +308,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private TypeSymbol? TryGetSampleType(Node root, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        private CaseInfo? TryGetSampleType(Node root, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
             foreach (var t in _typesInUnion)
             {
-                if (EvaluateNodeForInputValue(root, t, ref useSiteInfo) != false)
+                if (EvaluateNodeForInputValue(root, t.CaseType, ref useSiteInfo) != false)
                     return t;
             }
 

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.ClosedClassTypeUnionValueSetFactory.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.ClosedClassTypeUnionValueSetFactory.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // PROTOTYPE(cc): A closed class with no subtypes, should probably expand into an empty type set.
                 // However, if we produce an empty type set as a result, we fail the non-empty assertion at 'TypeUnionValueSet..ctor' via 'SamplePatternForTemp().tryHandleTypeUnionLimits()'.
-                if (possibleClosedClass is not NamedTypeSymbol { IsClosed: true, ClosedSubtypes: [_, ..] subtypes })
+                if (possibleClosedClass is not NamedTypeSymbol namedType || !namedType.TryGetClosedSubtypes(out var subtypes) || subtypes.IsEmpty)
                 {
                     builder.Add(possibleClosedClass);
                     return;

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.ClosedClassTypeUnionValueSetFactory.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.ClosedClassTypeUnionValueSetFactory.cs
@@ -27,7 +27,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // However, if we produce an empty type set as a result, we fail the non-empty assertion at 'TypeUnionValueSet..ctor' via 'SamplePatternForTemp().tryHandleTypeUnionLimits()'.
                 if (possibleClosedClass is not NamedTypeSymbol namedType || !namedType.TryGetClosedSubtypes(out var subtypes) || subtypes.IsEmpty)
                 {
-                    builder.Add(possibleClosedClass);
+                    if (!builder.Contains(possibleClosedClass))
+                        builder.Add(possibleClosedClass);
+
                     return;
                 }
 

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.ClosedClassTypeUnionValueSetFactory.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.ClosedClassTypeUnionValueSetFactory.cs
@@ -52,23 +52,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             private static void AddCaseInfo(ArrayBuilder<TypeUnionValueSet.CaseInfo> builder, TypeSymbol caseType, NamedTypeSymbol? originalClosedBase)
             {
-                var index = builder.FindIndex((existingCaseInfo, caseType) => existingCaseInfo.CaseType.Equals(caseType, TypeCompareKind.AllIgnoreOptions), caseType);
-                if (index != -1)
-                {
-                    // Subtype is already present, possibly with a different 'originalClosedBase'.
-                    // One scenario where this can occur is when a union contains multiple closed types in the same hierarchy.
-                    // In this case, apply the following rule:
-                    // - If one case is missing an 'originalClosedBase', pick the other 'originalClosedBase'.
-                    // - If both cases have an originalBase, pick the more base of the two.
-                    // This is thought to keep a similarity in behavior, between a union which includes both a base and derived type, and a union which includes only the base type.
-                    var existingCaseInfo = builder[index];
-                    var discardedInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
-                    if (originalClosedBase is not null && (existingCaseInfo.OriginalClosedBase is null || existingCaseInfo.OriginalClosedBase.IsDerivedFrom(originalClosedBase, TypeCompareKind.AllIgnoreOptions, ref discardedInfo)))
-                    {
-                        builder[index] = new TypeUnionValueSet.CaseInfo(caseType, originalClosedBase);
-                    }
-                }
-                else
+                // PROTOTYPE(cc): There may be a need to report diagnostics when "runtime-equivalent" yet distinct caseTypes flow in.
+                // For example, when the caseTypes have nullability differences.
+                if (!builder.Any((existing, caseType) => existing.CaseType.Equals(caseType, TypeCompareKind.AllIgnoreOptions), caseType))
                 {
                     builder.Add(new TypeUnionValueSet.CaseInfo(caseType, originalClosedBase));
                 }

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.ClosedClassTypeUnionValueSetFactory.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.ClosedClassTypeUnionValueSetFactory.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // PROTOTYPE(cc): There may be a need to report diagnostics when "runtime-equivalent" yet distinct caseTypes flow in.
                 // For example, when the caseTypes have nullability differences.
-                if (!builder.Any((existing, caseType) => existing.CaseType.Equals(caseType, TypeCompareKind.AllIgnoreOptions), caseType))
+                if (!builder.Any(static (existing, caseType) => existing.CaseType.Equals(caseType, TypeCompareKind.AllIgnoreOptions), caseType))
                 {
                     builder.Add(new TypeUnionValueSet.CaseInfo(caseType, originalClosedBase));
                 }

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.ClosedClassTypeUnionValueSetFactory.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.ClosedClassTypeUnionValueSetFactory.cs
@@ -21,27 +21,62 @@ namespace Microsoft.CodeAnalysis.CSharp
                 _closedClass = closedClass;
             }
 
-            internal static void ExpandClosedSubtypes(TypeSymbol possibleClosedClass, ArrayBuilder<TypeSymbol> builder)
+            internal static void ExpandClosedSubtypes(TypeSymbol possibleClosedClass, ArrayBuilder<TypeUnionValueSet.CaseInfo> builder)
             {
                 // PROTOTYPE(cc): A closed class with no subtypes, should probably expand into an empty type set.
                 // However, if we produce an empty type set as a result, we fail the non-empty assertion at 'TypeUnionValueSet..ctor' via 'SamplePatternForTemp().tryHandleTypeUnionLimits()'.
                 if (possibleClosedClass is not NamedTypeSymbol namedType || !namedType.TryGetClosedSubtypes(out var subtypes) || subtypes.IsEmpty)
                 {
-                    if (!builder.Contains(possibleClosedClass))
-                        builder.Add(possibleClosedClass);
-
+                    AddCaseInfo(builder, possibleClosedClass, originalClosedBase: null);
                     return;
                 }
 
+                ExpandClosedSubtypesCore(subtypes, originalBase: namedType, builder);
+            }
+
+            private static void ExpandClosedSubtypesCore(ImmutableArray<NamedTypeSymbol> subtypes, NamedTypeSymbol originalBase, ArrayBuilder<TypeUnionValueSet.CaseInfo> builder)
+            {
+                Debug.Assert(!subtypes.IsDefaultOrEmpty);
                 foreach (var subtype in subtypes)
                 {
-                    ExpandClosedSubtypes(subtype, builder);
+                    if (!subtype.TryGetClosedSubtypes(out var innerSubtypes) || innerSubtypes.IsEmpty)
+                    {
+                        AddCaseInfo(builder, subtype, originalBase);
+                    }
+                    else
+                    {
+                        ExpandClosedSubtypesCore(innerSubtypes, originalBase, builder);
+                    }
                 }
             }
 
-            private ImmutableArray<TypeSymbol> ClosedSubtypes()
+            private static void AddCaseInfo(ArrayBuilder<TypeUnionValueSet.CaseInfo> builder, TypeSymbol caseType, NamedTypeSymbol? originalClosedBase)
             {
-                var builder = ArrayBuilder<TypeSymbol>.GetInstance();
+                var index = builder.FindIndex((existingCaseInfo, caseType) => existingCaseInfo.CaseType.Equals(caseType, TypeCompareKind.AllIgnoreOptions), caseType);
+                if (index != -1)
+                {
+                    // Subtype is already present, possibly with a different 'originalClosedBase'.
+                    // One scenario where this can occur is when a union contains multiple closed types in the same hierarchy.
+                    // In this case, apply the following rule:
+                    // - If one case is missing an 'originalClosedBase', pick the other 'originalClosedBase'.
+                    // - If both cases have an originalBase, pick the more base of the two.
+                    // This is thought to keep a similarity in behavior, between a union which includes both a base and derived type, and a union which includes only the base type.
+                    var existingCaseInfo = builder[index];
+                    var discardedInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
+                    if (originalClosedBase is not null && (existingCaseInfo.OriginalClosedBase is null || existingCaseInfo.OriginalClosedBase.IsDerivedFrom(originalClosedBase, TypeCompareKind.AllIgnoreOptions, ref discardedInfo)))
+                    {
+                        builder[index] = new TypeUnionValueSet.CaseInfo(caseType, originalClosedBase);
+                    }
+                }
+                else
+                {
+                    builder.Add(new TypeUnionValueSet.CaseInfo(caseType, originalClosedBase));
+                }
+            }
+
+            private ImmutableArray<TypeUnionValueSet.CaseInfo> ClosedSubtypes()
+            {
+                var builder = ArrayBuilder<TypeUnionValueSet.CaseInfo>.GetInstance();
                 ExpandClosedSubtypes(_closedClass, builder);
                 return builder.ToImmutableAndFree();
             }

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.UnionTypeTypeUnionValueSetFactory.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.UnionTypeTypeUnionValueSetFactory.cs
@@ -22,11 +22,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 _unionType = unionType;
             }
 
-            private ImmutableArray<TypeSymbol> AdjustedTypesInUnion()
+            private ImmutableArray<TypeUnionValueSet.CaseInfo> AdjustedTypesInUnion()
             {
                 Debug.Assert(!_unionType.UnionCaseTypes.Any(t => t.IsNullableType()));
 
-                var builder = ArrayBuilder<TypeSymbol>.GetInstance();
+                var builder = ArrayBuilder<TypeUnionValueSet.CaseInfo>.GetInstance();
                 foreach (var caseType in _unionType.UnionCaseTypes)
                 {
                     ClosedClassTypeUnionValueSetFactory.ExpandClosedSubtypes(caseType, builder);

--- a/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
@@ -3110,7 +3110,6 @@ public sealed class ClosedClassesTests : CSharpTestBase
     public void Exhaustiveness_Constraints_08()
     {
         // A union case type is a subtype of a closed type which violates constraints.
-        // TODO2: The suggestion to use 'C<int>' is undesired
         var source1 = """
             public closed class C<U1>;
             public closed class D1<V1> : C<V1> where V1 : class;
@@ -3118,6 +3117,78 @@ public sealed class ClosedClassesTests : CSharpTestBase
             public class D3<X1> : D1<X1> where X1 : class;
 
             public union U<T1>(D1<T1>) where T1 : class;
+            """;
+
+        var source2 = """
+            class Program
+            {
+            #line 100
+                public U<int> u = null!;
+
+                int M1()
+                {
+            #line 200
+                    return u switch
+                    {
+                    };
+                }
+
+                int M2()
+                {
+            #line 400
+                    return u switch
+                    {
+            #line 500
+                        D2<int> => 1,
+                    };
+                }
+
+                int M3()
+                {
+                    return u switch
+                    {
+            #line 600
+                        D1<int> => 1,
+                    };
+                }
+            }
+            """;
+
+        var comp = CreateCompilation([source1, source2, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
+        comp.VerifyEmitDiagnostics(
+            // (100,19): error CS0452: The type 'int' must be a reference type in order to use it as parameter 'T1' in the generic type or method 'U<T1>'
+            //     public U<int> u = null!;
+            Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "u").WithArguments("U<T1>", "T1", "int").WithLocation(100, 19),
+            // (200,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '_' is not covered.
+            //         return u switch
+            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("_").WithLocation(200, 18),
+            // (400,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'D1<int>' is not covered.
+            //         return u switch
+            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D1<int>").WithLocation(400, 18),
+            // (500,16): error CS0452: The type 'int' must be a reference type in order to use it as parameter 'W1' in the generic type or method 'D2<W1>'
+            //             D2<int> => 1,
+            Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "int").WithArguments("D2<W1>", "W1", "int").WithLocation(500, 16),
+            // (600,16): error CS0452: The type 'int' must be a reference type in order to use it as parameter 'V1' in the generic type or method 'D1<V1>'
+            //             D1<int> => 1,
+            Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "int").WithArguments("D1<V1>", "V1", "int").WithLocation(600, 16));
+    }
+
+    [Theory]
+    [InlineData("C<T1>, D1<T1>")]
+    [InlineData("D1<T1>, C<T1>")]
+    [InlineData("C<T1>")]
+    public void Exhaustiveness_Constraints_09(string caseTypes)
+    {
+        // A union case type is a subtype of a closed type which violates constraints.
+        // Note that when a union has multiple case types in the same hierarchy, we try to keep the example pattern
+        // similar to the case where only the most base type out of the aforementioned case types is included.
+        var source1 = $$"""
+            public closed class C<U1>;
+            public closed class D1<V1> : C<V1> where V1 : class;
+            public class D2<W1> : D1<W1> where W1 : class;
+            public class D3<X1> : D1<X1> where X1 : class;
+
+            public union U<T1>({{caseTypes}}) where T1 : class;
             """;
 
         var source2 = """

--- a/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
@@ -3246,6 +3246,73 @@ public sealed class ClosedClassesTests : CSharpTestBase
     }
 
     [Fact]
+    public void Exhaustiveness_Constraints_10()
+    {
+        // Union of leaf types of a closed hierarchy which violate constraints
+        var source1 = """
+            public closed class C<U1>;
+            public closed class D1<V1> : C<V1> where V1 : class;
+            public class D2<W1> : D1<W1> where W1 : class;
+            public class D3<X1> : D1<X1> where X1 : class;
+
+            public union U<T1>(D2<T1>, D3<T1>) where T1 : class;
+            """;
+
+        var source2 = """
+            class Program
+            {
+            #line 100
+                public U<int> u = null!;
+
+                int M1()
+                {
+            #line 200
+                    return u switch
+                    {
+                    };
+                }
+
+                int M2()
+                {
+            #line 400
+                    return u switch
+                    {
+            #line 500
+                        D2<int> => 1,
+                    };
+                }
+
+                int M3()
+                {
+                    return u switch
+                    {
+            #line 600
+                        D1<int> => 1,
+                    };
+                }
+            }
+            """;
+
+        var comp = CreateCompilation([source1, source2, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
+        comp.VerifyEmitDiagnostics(
+            // (100,19): error CS0452: The type 'int' must be a reference type in order to use it as parameter 'T1' in the generic type or method 'U<T1>'
+            //     public U<int> u = null!;
+            Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "u").WithArguments("U<T1>", "T1", "int").WithLocation(100, 19),
+            // (200,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '_' is not covered.
+            //         return u switch
+            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("_").WithLocation(200, 18),
+            // (400,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'D3<int>' is not covered.
+            //         return u switch
+            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D3<int>").WithLocation(400, 18),
+            // (500,16): error CS0452: The type 'int' must be a reference type in order to use it as parameter 'W1' in the generic type or method 'D2<W1>'
+            //             D2<int> => 1,
+            Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "int").WithArguments("D2<W1>", "W1", "int").WithLocation(500, 16),
+            // (600,16): error CS0452: The type 'int' must be a reference type in order to use it as parameter 'V1' in the generic type or method 'D1<V1>'
+            //             D1<int> => 1,
+            Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "int").WithArguments("D1<V1>", "V1", "int").WithLocation(600, 16));
+    }
+
+    [Fact]
     public void Exhaustiveness_InterfaceConstraints_01()
     {
         // Subtype has interface constraint

--- a/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
@@ -1502,6 +1502,48 @@ public sealed class ClosedClassesTests : CSharpTestBase
     }
 
     [Fact]
+    public void Exhaustiveness_UnionOfClosedClasses_02()
+    {
+        // Union including both base and derived of a hierarchy
+        var source = """
+            class Program
+            {
+                int M1(U u)
+                {
+            #line 100
+                    return u switch
+                    {
+                        E1 => 1,
+                    };
+                }
+
+                int M2(U u)
+                {
+                    return u switch
+                    {
+                        E1 => 1,
+                        F1 => 2,
+                    };
+                }
+            }
+
+            union U(D1, C);
+
+            closed class C { }
+
+            closed class D1 : C { }
+            class E1 : D1 { }
+            class F1 : D1 { }
+            """;
+
+        var comp = CreateCompilation([source, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
+        comp.VerifyDiagnostics(
+            // (100,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'F1' is not covered.
+            //         return u switch
+            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("F1").WithLocation(100, 18));
+    }
+
+    [Fact]
     public void Exhaustiveness_ClosedClassCustomUnion_01()
     {
         // Test a class which is both closed and a union.

--- a/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
@@ -590,8 +590,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
             Diagnostic(ErrorCode.ERR_UnderspecifiedClosedSubtype, "D").WithArguments("D<T>", "T", "C").WithLocation(2, 14));
 
         var classC = comp1.GetMember<NamedTypeSymbol>("C");
-        Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
-        Assert.Equal(["D<T>"], subtypes.ToTestDisplayStrings());
+        Assert.False(classC.TryGetClosedSubtypes(out _));
     }
 
     [Fact]
@@ -633,8 +632,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
             Diagnostic(ErrorCode.ERR_UnderspecifiedClosedSubtype, "D").WithArguments("Outer<T>.D", "T", "C").WithLocation(5, 18));
 
         var classC = comp1.GetMember<NamedTypeSymbol>("C");
-        Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
-        Assert.Equal(["Outer<T>.D"], subtypes.ToTestDisplayStrings());
+        Assert.False(classC.TryGetClosedSubtypes(out _));
     }
 
     [Fact]
@@ -700,8 +698,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
         Assert.Empty(subtypes);
 
         var classE = comp1.GetMember<NamedTypeSymbol>("E");
-        Assert.True(classE.TryGetClosedSubtypes(out subtypes));
-        Assert.Equal(["F<T>"], subtypes.ToTestDisplayStrings());
+        Assert.False(classE.TryGetClosedSubtypes(out _));
 
         Assert.True(comp1.GetMember<NamedTypeSymbol>("F").TryGetClosedSubtypes(out subtypes));
         Assert.Empty(subtypes);

--- a/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
@@ -3673,6 +3673,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
     {
         // Attempt to exhaust a type parameter constrained to closed type.
         // This scenario isn't supported by the exhaustiveness check.
+        // PROTOTYPE(cc): Confirm whether we want to allow exhausting such type parameters via subtypes.
         var source1 = """
             public closed class E;
             public sealed class F1 : E;

--- a/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
@@ -2740,6 +2740,313 @@ public sealed class ClosedClassesTests : CSharpTestBase
     }
 
     [Fact]
+    public void Exhaustiveness_Constraints_05()
+    {
+        // Pattern input type itself violates constraints. Do not suggest a more base type than the input type.
+        var source1 = """
+            public closed class C<T>;
+            public closed class D1<U1> : C<U1> where U1 : class;
+            public class D2<U2> : D1<U2> where U2 : class;
+            public class D3<U3> : D1<U3> where U3 : class;
+            """;
+
+        var source2 = """
+            class Program
+            {
+            #line 100
+                public D1<int> d1 = null!;
+
+                int M1()
+                {
+            #line 200
+                    return d1 switch
+                    {
+                    };
+                }
+
+                int M2()
+                {
+            #line 300
+                    return d1 switch
+                    {
+            #line 400
+                        D2<int> => 1,
+                    };
+                }
+
+                int M3()
+                {
+                    return d1 switch
+                    {
+            #line 500
+                        D1<int> => 1,
+                    };
+                }
+            }
+            """;
+
+        var comp = CreateCompilation([source1, source2, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
+        verify(comp);
+
+        var comp0 = CreateCompilation([source1, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
+        comp = CreateCompilation([source2], references: [comp0.ToMetadataReference()], targetFramework: TargetFramework.Net100);
+        verify(comp);
+
+        comp = CreateCompilation([source2], references: [comp0.EmitToImageReference()], targetFramework: TargetFramework.Net100);
+        verify(comp);
+
+        static void verify(CSharpCompilation comp)
+        {
+            comp.VerifyEmitDiagnostics(
+                // (100,20): error CS0452: The type 'int' must be a reference type in order to use it as parameter 'U1' in the generic type or method 'D1<U1>'
+                //     public D1<int> d1 = null!;
+                Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "d1").WithArguments("D1<U1>", "U1", "int").WithLocation(100, 20),
+                // (200,19): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'D1<int>' is not covered.
+                //         return d1 switch
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D1<int>").WithLocation(200, 19),
+                // (300,19): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'D1<int>' is not covered.
+                //         return d1 switch
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D1<int>").WithLocation(300, 19),
+                // (400,16): error CS0452: The type 'int' must be a reference type in order to use it as parameter 'U2' in the generic type or method 'D2<U2>'
+                //             D2<int> => 1,
+                Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "int").WithArguments("D2<U2>", "U2", "int").WithLocation(400, 16),
+                // (500,16): error CS0452: The type 'int' must be a reference type in order to use it as parameter 'U1' in the generic type or method 'D1<U1>'
+                //             D1<int> => 1,
+                Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "int").WithArguments("D1<U1>", "U1", "int").WithLocation(500, 16));
+        }
+    }
+
+    [Fact]
+    public void Exhaustiveness_Constraints_06()
+    {
+        // A nested pattern input type itself violates constraints. Do not suggest a more base type than the input type.
+        var source1 = """
+            public closed class C<T>;
+            public closed class D1<U1> : C<U1> where U1 : class;
+            public class D2<U2> : D1<U2> where U2 : class;
+            public class D3<U3> : D1<U3> where U3 : class;
+
+            public class Container<X1> where X1 : class
+            {
+                public D1<X1> Value;
+            }
+            """;
+
+        var source2 = """
+            class Program
+            {
+            #line 100
+                public Container<int> c = null!;
+
+                int M1()
+                {
+            #line 200
+                    return c switch
+                    {
+                    };
+                }
+
+                int M2()
+                {
+            #line 300
+                    return c switch
+                    {
+            #line 400
+                        { Value: D2<int> } => 1,
+                    };
+                }
+
+                int M3()
+                {
+                    return c switch
+                    {
+            #line 500
+                        { Value: D1<int> } => 1,
+                    };
+                }
+            }
+            """;
+
+        var comp = CreateCompilation([source1, source2, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
+        verify(comp);
+
+        var comp0 = CreateCompilation([source1, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
+        comp = CreateCompilation([source2], references: [comp0.ToMetadataReference()], targetFramework: TargetFramework.Net100);
+        verify(comp);
+
+        comp = CreateCompilation([source2], references: [comp0.EmitToImageReference()], targetFramework: TargetFramework.Net100);
+        verify(comp);
+
+        static void verify(CSharpCompilation comp)
+        {
+            comp.VerifyEmitDiagnostics(
+                // (100,27): error CS0452: The type 'int' must be a reference type in order to use it as parameter 'X1' in the generic type or method 'Container<X1>'
+                //     public Container<int> c = null!;
+                Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "c").WithArguments("Container<X1>", "X1", "int").WithLocation(100, 27),
+                // (200,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '_' is not covered.
+                //         return c switch
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("_").WithLocation(200, 18),
+                // (300,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '{ Value: D1<int> }' is not covered.
+                //         return c switch
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("{ Value: D1<int> }").WithLocation(300, 18),
+                // (400,25): error CS0452: The type 'int' must be a reference type in order to use it as parameter 'U2' in the generic type or method 'D2<U2>'
+                //             { Value: D2<int> } => 1,
+                Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "int").WithArguments("D2<U2>", "U2", "int").WithLocation(400, 25),
+                // (500,25): error CS0452: The type 'int' must be a reference type in order to use it as parameter 'U1' in the generic type or method 'D1<U1>'
+                //             { Value: D1<int> } => 1,
+                Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "int").WithArguments("D1<U1>", "U1", "int").WithLocation(500, 25)
+
+            );
+        }
+    }
+
+    [Fact]
+    public void Exhaustiveness_Constraints_07()
+    {
+        // A nested pattern input type violates constraints.
+        // The subtype has a different construction of the base type than the pattern input type.
+        var source1 = """
+            public closed class C<T1, T2>;
+            public closed class D1<U1, U2> : C<U1, U2> where U1 : class where U2 : class;
+
+            #line 100
+            public class D2<V1> : D1<int, V1> where V1 : class;
+
+            public class D3<V2, V3> : D1<V2, V3> where V2 : class where V3 : class;
+            """;
+
+        var source2 = """
+            class Program<X1, X2>
+            {
+            #line 200
+                public D1<X1, X2> d1 = null!;
+
+                int M1()
+                {
+            #line 300
+                    return d1 switch
+                    {
+                    };
+                }
+
+                int M2()
+                {
+            #line 400
+                    return d1 switch
+                    {
+            #line 500
+                        D2<X2> => 1,
+                    };
+                }
+
+                int M3()
+                {
+                    return d1 switch
+                    {
+            #line 600
+                        D1<X1, X2> => 1,
+                    };
+                }
+            }
+            """;
+
+        var comp = CreateCompilation([source1, source2, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
+        comp.VerifyEmitDiagnostics(
+            // (100,14): error CS0452: The type 'int' must be a reference type in order to use it as parameter 'U1' in the generic type or method 'D1<U1, U2>'
+            // public class D2<V1> : D1<int, V1> where V1 : class;
+            Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "D2").WithArguments("D1<U1, U2>", "U1", "int").WithLocation(100, 14),
+            // (200,23): error CS0452: The type 'X1' must be a reference type in order to use it as parameter 'U1' in the generic type or method 'D1<U1, U2>'
+            //     public D1<X1, X2> d1 = null!;
+            Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "d1").WithArguments("D1<U1, U2>", "U1", "X1").WithLocation(200, 23),
+            // (200,23): error CS0452: The type 'X2' must be a reference type in order to use it as parameter 'U2' in the generic type or method 'D1<U1, U2>'
+            //     public D1<X1, X2> d1 = null!;
+            Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "d1").WithArguments("D1<U1, U2>", "U2", "X2").WithLocation(200, 23),
+            // (300,19): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'D1<int, X2>' is not covered.
+            //         return d1 switch
+            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D1<int, X2>").WithLocation(300, 19),
+            // (400,19): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'D1<X1, X2>' is not covered.
+            //         return d1 switch
+            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D1<X1, X2>").WithLocation(400, 19),
+            // (500,16): error CS0452: The type 'X2' must be a reference type in order to use it as parameter 'V1' in the generic type or method 'D2<V1>'
+            //             D2<X2> => 1,
+            Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "X2").WithArguments("D2<V1>", "V1", "X2").WithLocation(500, 16),
+            // (600,16): error CS0452: The type 'X1' must be a reference type in order to use it as parameter 'U1' in the generic type or method 'D1<U1, U2>'
+            //             D1<X1, X2> => 1,
+            Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "X1").WithArguments("D1<U1, U2>", "U1", "X1").WithLocation(600, 16),
+            // (600,20): error CS0452: The type 'X2' must be a reference type in order to use it as parameter 'U2' in the generic type or method 'D1<U1, U2>'
+            //             D1<X1, X2> => 1,
+            Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "X2").WithArguments("D1<U1, U2>", "U2", "X2").WithLocation(600, 20));
+    }
+
+    [Fact]
+    public void Exhaustiveness_Constraints_08()
+    {
+        // A union case type is a subtype of a closed type which violates constraints.
+        // TODO2: The suggestion to use 'C<int>' is undesired
+        var source1 = """
+            public closed class C<U1>;
+            public closed class D1<V1> : C<V1> where V1 : class;
+            public class D2<W1> : D1<W1> where W1 : class;
+            public class D3<X1> : D1<X1> where X1 : class;
+
+            public union U<T1>(D1<T1>) where T1 : class;
+            """;
+
+        var source2 = """
+            class Program
+            {
+            #line 100
+                public U<int> u = null!;
+
+                int M1()
+                {
+            #line 200
+                    return u switch
+                    {
+                    };
+                }
+
+                int M2()
+                {
+            #line 400
+                    return u switch
+                    {
+            #line 500
+                        D2<int> => 1,
+                    };
+                }
+
+                int M3()
+                {
+                    return u switch
+                    {
+            #line 600
+                        D1<int> => 1,
+                    };
+                }
+            }
+            """;
+
+        var comp = CreateCompilation([source1, source2, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
+        comp.VerifyEmitDiagnostics(
+            // (100,19): error CS0452: The type 'int' must be a reference type in order to use it as parameter 'T1' in the generic type or method 'U<T1>'
+            //     public U<int> u = null!;
+            Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "u").WithArguments("U<T1>", "T1", "int").WithLocation(100, 19),
+            // (200,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '_' is not covered.
+            //         return u switch
+            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("_").WithLocation(200, 18),
+            // (400,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'C<int>' is not covered.
+            //         return u switch
+            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C<int>").WithLocation(400, 18),
+            // (500,16): error CS0452: The type 'int' must be a reference type in order to use it as parameter 'W1' in the generic type or method 'D2<W1>'
+            //             D2<int> => 1,
+            Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "int").WithArguments("D2<W1>", "W1", "int").WithLocation(500, 16),
+            // (600,16): error CS0452: The type 'int' must be a reference type in order to use it as parameter 'V1' in the generic type or method 'D1<V1>'
+            //             D1<int> => 1,
+            Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "int").WithArguments("D1<V1>", "V1", "int").WithLocation(600, 16));
+    }
+
+    [Fact]
     public void Exhaustiveness_InterfaceConstraints_01()
     {
         // Subtype has interface constraint

--- a/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
@@ -3175,13 +3175,10 @@ public sealed class ClosedClassesTests : CSharpTestBase
 
     [Theory]
     [InlineData("C<T1>, D1<T1>")]
-    [InlineData("D1<T1>, C<T1>")]
     [InlineData("C<T1>")]
     public void Exhaustiveness_Constraints_09(string caseTypes)
     {
         // A union case type is a subtype of a closed type which violates constraints.
-        // Note that when a union has multiple case types in the same hierarchy, we try to keep the example pattern
-        // similar to the case where only the most base type out of the aforementioned case types is included.
         var source1 = $$"""
             public closed class C<U1>;
             public closed class D1<V1> : C<V1> where V1 : class;
@@ -3237,6 +3234,73 @@ public sealed class ClosedClassesTests : CSharpTestBase
             // (400,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'C<int>' is not covered.
             //         return u switch
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C<int>").WithLocation(400, 18),
+            // (500,16): error CS0452: The type 'int' must be a reference type in order to use it as parameter 'W1' in the generic type or method 'D2<W1>'
+            //             D2<int> => 1,
+            Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "int").WithArguments("D2<W1>", "W1", "int").WithLocation(500, 16),
+            // (600,16): error CS0452: The type 'int' must be a reference type in order to use it as parameter 'V1' in the generic type or method 'D1<V1>'
+            //             D1<int> => 1,
+            Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "int").WithArguments("D1<V1>", "V1", "int").WithLocation(600, 16));
+    }
+
+    [Fact]
+    public void Exhaustiveness_Constraints_09_SubtypeFirst()
+    {
+        // A union case type is a subtype of a closed type which violates constraints.
+        var source1 = $$"""
+            public closed class C<U1>;
+            public closed class D1<V1> : C<V1> where V1 : class;
+            public class D2<W1> : D1<W1> where W1 : class;
+            public class D3<X1> : D1<X1> where X1 : class;
+
+            public union U<T1>(D1<T1>, C<T1>) where T1 : class;
+            """;
+
+        var source2 = """
+            class Program
+            {
+            #line 100
+                public U<int> u = null!;
+
+                int M1()
+                {
+            #line 200
+                    return u switch
+                    {
+                    };
+                }
+
+                int M2()
+                {
+            #line 400
+                    return u switch
+                    {
+            #line 500
+                        D2<int> => 1,
+                    };
+                }
+
+                int M3()
+                {
+                    return u switch
+                    {
+            #line 600
+                        D1<int> => 1,
+                    };
+                }
+            }
+            """;
+
+        var comp = CreateCompilation([source1, source2, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
+        comp.VerifyEmitDiagnostics(
+            // (100,19): error CS0452: The type 'int' must be a reference type in order to use it as parameter 'T1' in the generic type or method 'U<T1>'
+            //     public U<int> u = null!;
+            Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "u").WithArguments("U<T1>", "T1", "int").WithLocation(100, 19),
+            // (200,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '_' is not covered.
+            //         return u switch
+            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("_").WithLocation(200, 18),
+            // (400,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'D1<int>' is not covered.
+            //         return u switch
+            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D1<int>").WithLocation(400, 18),
             // (500,16): error CS0452: The type 'int' must be a reference type in order to use it as parameter 'W1' in the generic type or method 'D2<W1>'
             //             D2<int> => 1,
             Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "int").WithArguments("D2<W1>", "W1", "int").WithLocation(500, 16),

--- a/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
@@ -572,7 +572,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
         comp1.VerifyEmitDiagnostics();
 
         var classC = comp1.GetMember<NamedTypeSymbol>("C");
-        Assert.Equal(["D1<T>", "D2<T>", "D3<T>"], classC.ClosedSubtypes.ToTestDisplayStrings());
+        Assert.False(classC.TryGetClosedSubtypes(out _));
     }
 
     [Fact]
@@ -671,7 +671,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
             Diagnostic(ErrorCode.ERR_UnderspecifiedClosedSubtype, "D").WithArguments("Outer<U1, U2, U3>.D<U4, U5, U6>", "U3", "C<U1, U2, U4, U6>").WithLocation(4, 11));
 
         var classC = comp1.GetMember<NamedTypeSymbol>("C");
-        Assert.Equal(["Outer<T1, T2, U3>.D<T3, U5, T4>"], classC.ClosedSubtypes.ToTestDisplayStrings());
+        Assert.False(classC.TryGetClosedSubtypes(out _));
     }
 
     [Fact]
@@ -1108,11 +1108,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
         {
             var classC = comp.GetMember<NamedTypeSymbol>("C");
             Assert.Equal("C<T>", classC.ToTestDisplayString());
-            // PROTOTYPE(cc): This 'ClosedSubtypes' result reflects a unification which is possible, but not in terms of types available at the use site.
-            // It's unclear what representation of such types we want this API to use.
-            // For example, perhaps we only want to identify the fact that the situation is occurring, and introduce some 'bool IsExhaustibleViaSubtypes' API
-            // to check when creating a TypeUnionValueSet, so that we can advise user to match the base type.
-            Assert.Equal(["D1<T>", "D2<U>"], classC.ClosedSubtypes.ToTestDisplayStrings());
+            Assert.False(classC.TryGetClosedSubtypes(out _));
 
             var immutableArrayOfInt = comp
                 .GetWellKnownType(WellKnownType.System_Collections_Immutable_ImmutableArray_T)
@@ -1798,11 +1794,101 @@ public sealed class ClosedClassesTests : CSharpTestBase
             """;
 
         var comp = CreateCompilation([source, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
-        // PROTOTYPE(cc): We should not propose invalid subtype patterns (using type parameters not in scope, or which violate accessibility, constraints, etc.)
         comp.VerifyDiagnostics(
-            // (7,21): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'D2<U>' is not covered.
+            // (7,21): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'C<T>' is not covered.
             //         return item switch
-            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D2<U>").WithLocation(7, 21));
+            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C<T>").WithLocation(7, 21));
+    }
+
+    [Fact]
+    public void Exhaustiveness_Generic_03()
+    {
+        // Indirect subtype is unspeakable
+        var source = """
+            using System.Collections.Immutable;
+
+            closed class C<T>
+            {
+                public static int Use1(C<T> item)
+                {
+                    return item switch
+                    {
+                        D1<T> => 1,
+                    };
+                }
+
+                public static int Use2(C<T> item)
+                {
+                    return item switch
+                    {
+                        D1<T> => 1,
+                        C<T> => 2
+                    };
+                }
+
+                public static int Use3(C<T> item)
+                {
+                    return item switch
+                    {
+                        D1<T> => 1,
+                        D2<T> => 2
+                    };
+                }
+            }
+
+            class D1<U> : C<U> { }
+
+            closed class D2<U> : C<U> { }
+            class E2<V> : D2<ImmutableArray<V>> { }
+            """;
+
+        var comp = CreateCompilation([source, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
+        comp.VerifyDiagnostics(
+            // (7,21): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'D2<T>' is not covered.
+            //         return item switch
+            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D2<T>").WithLocation(7, 21));
+    }
+
+    [Fact]
+    public void Exhaustiveness_Generic_04()
+    {
+        // Unspeakable subtypes along two indirections
+        var source = """
+            using System.Collections.Immutable;
+
+            closed class C<T>
+            {
+                public static int Use1(C<T> item)
+                {
+                    return item switch
+                    {
+                        D1<T> => 1,
+                        // We know some 'D2<...>' may be possible here (i.e. 'C<T>' allows 'C<ImmutableArray<...>>' by substitution.)
+                        // But, we have no way of speaking that D2 in this context.
+                    };
+                }
+
+                public static int Use2(C<T> item)
+                {
+                    return item switch
+                    {
+                        D1<T> => 1,
+                        C<T> => 2
+                    };
+                }
+            }
+
+            class D1<U> : C<U> { }
+
+            closed class D2<U> : C<ImmutableArray<U>> { }
+            class E2<V> : D2<ImmutableArray<V>> { }
+            """;
+
+        var comp = CreateCompilation([source, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
+        comp.VerifyDiagnostics(
+            // (7,21): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'C<T>' is not covered.
+            //         return item switch
+            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C<T>").WithLocation(7, 21));
     }
 
     [Fact]
@@ -1867,6 +1953,38 @@ public sealed class ClosedClassesTests : CSharpTestBase
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C").WithLocation(5, 18));
         classC = comp2.GetMember<NamedTypeSymbol>("C");
         Assert.Empty(classC.ClosedSubtypes);
+    }
+
+    [Fact]
+    public void Exhaustiveness_BaseTypeSubsumedBySubtypes()
+    {
+        var source = """
+            class Program
+            {
+                int M(C c)
+                {
+                    return c switch
+                    {
+                        D1 => 1,
+                        D2 => 2,
+                        C => 3,
+                    };
+                }
+            }
+
+            closed class C
+            {
+            }
+
+            class D1 : C { }
+            class D2 : C { }
+            """;
+
+        var comp = CreateCompilation([source, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
+        comp.VerifyDiagnostics(
+            // (9,13): error CS8510: The pattern is unreachable. It has already been handled by a previous arm of the switch expression or it is impossible to match.
+            //             C => 3,
+            Diagnostic(ErrorCode.ERR_SwitchArmSubsumed, "C").WithLocation(9, 13));
     }
 
     [Fact]
@@ -1997,9 +2115,9 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 // (100,23): error CS0122: 'Container.D2' is inaccessible due to its protection level
                 //             Container.D2 => 2,
                 Diagnostic(ErrorCode.ERR_BadAccess, "D2").WithArguments("Container.D2").WithLocation(100, 23),
-                // (200,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'Container.D2' is not covered.
+                // (200,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'C' is not covered.
                 //         return c switch
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("Container.D2").WithLocation(200, 18));
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C").WithLocation(200, 18));
 
             var classC = comp.GetMember<NamedTypeSymbol>("C");
             Assert.Equal(["D1", "Container.D2"], classC.ClosedSubtypes.ToTestDisplayStrings());
@@ -2055,9 +2173,9 @@ public sealed class ClosedClassesTests : CSharpTestBase
             // (100,13): error CS0122: 'D2' is inaccessible due to its protection level
             //             D2 => 2,
             Diagnostic(ErrorCode.ERR_BadAccess, "D2").WithArguments("D2").WithLocation(100, 13),
-            // (200,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'D2' is not covered.
+            // (200,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'C' is not covered.
             //         return c switch
-            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D2").WithLocation(200, 18));
+            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C").WithLocation(200, 18));
 
         classC = comp.GetMember<NamedTypeSymbol>("C");
         Assert.Equal(["D1", "D2"], classC.ClosedSubtypes.ToTestDisplayStrings());
@@ -2067,9 +2185,9 @@ public sealed class ClosedClassesTests : CSharpTestBase
             // (100,13): error CS0122: 'D2' is inaccessible due to its protection level
             //             D2 => 2,
             Diagnostic(ErrorCode.ERR_BadAccess, "D2").WithArguments("D2").WithLocation(100, 13),
-            // (200,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'D2' is not covered.
+            // (200,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'C' is not covered.
             //         return c switch
-            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D2").WithLocation(200, 18));
+            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C").WithLocation(200, 18));
 
         classC = comp.GetMember<NamedTypeSymbol>("C");
         Assert.Equal(["D1", "D2"], classC.ClosedSubtypes.ToTestDisplayStrings());
@@ -2129,12 +2247,220 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 // (100,23): error CS0122: 'Container.D' is inaccessible due to its protection level
                 //             Container.D => 1,
                 Diagnostic(ErrorCode.ERR_BadAccess, "D").WithArguments("Container.D").WithLocation(100, 23),
-                // (200,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'Container.D' is not covered.
+                // (200,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'Container.C' is not covered.
                 //         return c switch
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("Container.D").WithLocation(200, 18));
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("Container.C").WithLocation(200, 18));
 
             var classC = comp.GetMember<NamedTypeSymbol>("Container.C");
             Assert.Equal(["Container.D"], classC.ClosedSubtypes.ToTestDisplayStrings());
+        }
+    }
+
+    [Fact]
+    public void Exhaustiveness_LessAccessibleSubtype_04()
+    {
+        // Less accessible indirect subtype
+        var source1 = """
+            public closed class C;
+            public class D1 : C;
+            public closed class D2 : C;
+
+            public class Container
+            {
+                protected class E2 : D2;
+            }
+            """;
+
+        var source2 = """
+            class Program
+            {
+                int M1(C c)
+                {
+                    return c switch
+                    {
+                        D1 => 1,
+            #line 100
+                        Container.E2 => 2,
+                    };
+                }
+
+                int M2(C c)
+                {
+            #line 200
+                    return c switch
+                    {
+                        D1 => 1,
+                    };
+                }
+
+                int M3(C c)
+                {
+                    return c switch
+                    {
+                        D1 => 1,
+                        D2 => 2,
+                    };
+                }
+            }
+            """;
+
+        var comp = CreateCompilation([source1, source2, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
+        verify(comp);
+
+        var comp1 = CreateCompilation([source1, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
+        var comp2 = CreateCompilation([source2], references: [comp1.ToMetadataReference()], targetFramework: TargetFramework.Net100);
+        verify(comp2);
+
+        comp2 = CreateCompilation([source2], references: [comp1.EmitToImageReference()], targetFramework: TargetFramework.Net100);
+        verify(comp2);
+
+        static void verify(CSharpCompilation comp)
+        {
+            comp.VerifyEmitDiagnostics(
+                // (100,23): error CS0122: 'Container.E2' is inaccessible due to its protection level
+                //             Container.E2 => 2,
+                Diagnostic(ErrorCode.ERR_BadAccess, "E2").WithArguments("Container.E2").WithLocation(100, 23),
+                // (200,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'D2' is not covered.
+                //         return c switch
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D2").WithLocation(200, 18));
+
+            var classC = comp.GetMember<NamedTypeSymbol>("C");
+            Assert.Equal(["D1", "D2"], classC.ClosedSubtypes.ToTestDisplayStrings());
+        }
+    }
+
+    [Fact]
+    public void Exhaustiveness_LessAccessibleSubtype_05()
+    {
+        // Less accessible subtypes across two indirections
+        var source1 = """
+            public closed class C;
+            public class D1 : C;
+
+            public class Container
+            {
+                protected closed class D2 : C;
+                protected class E2 : D2;
+            }
+            """;
+
+        var source2 = """
+            class Program
+            {
+                int M1(C c)
+                {
+                    return c switch
+                    {
+                        D1 => 1,
+            #line 100
+                        Container.E2 => 2,
+                    };
+                }
+
+                int M2(C c)
+                {
+            #line 200
+                    return c switch
+                    {
+                        D1 => 1,
+                    };
+                }
+            }
+            """;
+
+        var comp = CreateCompilation([source1, source2, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
+        verify(comp);
+
+        var comp1 = CreateCompilation([source1, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
+        var comp2 = CreateCompilation([source2], references: [comp1.ToMetadataReference()], targetFramework: TargetFramework.Net100);
+        verify(comp2);
+
+        comp2 = CreateCompilation([source2], references: [comp1.EmitToImageReference()], targetFramework: TargetFramework.Net100);
+        verify(comp2);
+
+        static void verify(CSharpCompilation comp)
+        {
+            comp.VerifyEmitDiagnostics(
+                // (100,23): error CS0122: 'Container.E2' is inaccessible due to its protection level
+                //             Container.E2 => 2,
+                Diagnostic(ErrorCode.ERR_BadAccess, "E2").WithArguments("Container.E2").WithLocation(100, 23),
+                // (200,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'C' is not covered.
+                //         return c switch
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C").WithLocation(200, 18));
+
+            var classC = comp.GetMember<NamedTypeSymbol>("C");
+            Assert.Equal(["D1", "Container.D2"], classC.ClosedSubtypes.ToTestDisplayStrings());
+        }
+    }
+
+    [Fact]
+    public void Exhaustiveness_LessAccessibleSubtype_06()
+    {
+        // Entire hierarchy is inaccessible
+        var source1 = """
+            public class Container
+            {
+                protected closed class C;
+                protected class D1 : C;
+
+                protected closed class D2 : C;
+                protected class E2 : D2;
+            }
+            """;
+
+        var source2 = """
+            class Program
+            {
+            #line 100
+                int M1(Container.C c)
+                {
+            #line 200
+                    return c switch
+                    {
+                    };
+                }
+
+            #line 300
+                int M2(Container.C c)
+                {
+                    return c switch
+                    {
+            #line 400
+                        Container.D1 => 1
+                    };
+                }
+            }
+            """;
+
+        var comp = CreateCompilation([source1, source2, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
+        verify(comp);
+
+        var comp1 = CreateCompilation([source1, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
+        var comp2 = CreateCompilation([source2], references: [comp1.ToMetadataReference()], targetFramework: TargetFramework.Net100);
+        verify(comp2);
+
+        comp2 = CreateCompilation([source2], references: [comp1.EmitToImageReference()], targetFramework: TargetFramework.Net100);
+        verify(comp2);
+
+        static void verify(CSharpCompilation comp)
+        {
+            comp.VerifyEmitDiagnostics(
+                // (100,22): error CS0122: 'Container.C' is inaccessible due to its protection level
+                //     int M1(Container.C c)
+                Diagnostic(ErrorCode.ERR_BadAccess, "C").WithArguments("Container.C").WithLocation(100, 22),
+                // (200,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '_' is not covered.
+                //         return c switch
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("_").WithLocation(200, 18),
+                // (300,22): error CS0122: 'Container.C' is inaccessible due to its protection level
+                //     int M2(Container.C c)
+                Diagnostic(ErrorCode.ERR_BadAccess, "C").WithArguments("Container.C").WithLocation(300, 22),
+                // (400,23): error CS0122: 'Container.D1' is inaccessible due to its protection level
+                //             Container.D1 => 1
+                Diagnostic(ErrorCode.ERR_BadAccess, "D1").WithArguments("Container.D1").WithLocation(400, 23));
+
+            var classC = comp.GetMember<NamedTypeSymbol>("Container.C");
+            Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
+            Assert.Equal(["Container.D1", "Container.D2"], subtypes.ToTestDisplayStrings());
         }
     }
 
@@ -2188,9 +2514,9 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 // (100,16): error CS0453: The type 'X' must be a non-nullable value type in order to use it as parameter 'U2' in the generic type or method 'D2<U2>'
                 //             D2<X> => 2,
                 Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "X").WithArguments("D2<U2>", "U2", "X").WithLocation(100, 16),
-                // (200,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'D2<X>' is not covered.
+                // (200,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'C<X>' is not covered.
                 //         return c switch
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D2<X>").WithLocation(200, 18));
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C<X>").WithLocation(200, 18));
 
             var classC = comp.GetMember<NamedTypeSymbol>("C");
             Assert.Equal(["D1<T>", "D2<T>"], classC.ClosedSubtypes.ToTestDisplayStrings());
@@ -2248,9 +2574,9 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 // (100,16): error CS0453: The type 'X' must be a non-nullable value type in order to use it as parameter 'U2' in the generic type or method 'D2<U2>'
                 //             D2<X> => 2,
                 Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "X").WithArguments("D2<U2>", "U2", "X").WithLocation(100, 16),
-                // (200,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'D2<X>' is not covered.
+                // (200,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'C<X>' is not covered.
                 //         return c switch
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D2<X>").WithLocation(200, 18));
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C<X>").WithLocation(200, 18));
 
             var classC = comp.GetMember<NamedTypeSymbol>("C");
             Assert.Equal(["D1<T>", "D2<T>"], classC.ClosedSubtypes.ToTestDisplayStrings());
@@ -2307,9 +2633,9 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 // (100,16): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'U2' in the generic type or method 'D2<U2>'
                 //             D2<string> => 2,
                 Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "string").WithArguments("D2<U2>", "U2", "string").WithLocation(100, 16),
-                // (200,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'D2<string>' is not covered.
+                // (200,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'C<string>' is not covered.
                 //         return c switch
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D2<string>").WithLocation(200, 18));
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C<string>").WithLocation(200, 18));
 
             var classC = comp.GetMember<NamedTypeSymbol>("C");
             Assert.Equal(["D1<T>", "D2<T>"], classC.ClosedSubtypes.ToTestDisplayStrings());
@@ -2359,9 +2685,9 @@ public sealed class ClosedClassesTests : CSharpTestBase
             // (200,16): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'U2' in the generic type or method 'D2<U2>'
             //             D2<string> => 2,
             Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "string").WithArguments("D2<U2>", "U2", "string").WithLocation(200, 16),
-            // (300,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'D2<string>' is not covered.
+            // (300,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'C<string>' is not covered.
             //         return c switch
-            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D2<string>").WithLocation(300, 18));
+            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C<string>").WithLocation(300, 18));
 
         var classC = comp.GetMember<NamedTypeSymbol>("C");
         Assert.Equal(["D1<T>", "D2<T>"], classC.ClosedSubtypes.ToTestDisplayStrings());
@@ -2372,12 +2698,211 @@ public sealed class ClosedClassesTests : CSharpTestBase
             // (200,16): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'U2' in the generic type or method 'D2<U2>'
             //             D2<string> => 2,
             Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "string").WithArguments("D2<U2>", "U2", "string").WithLocation(200, 16),
-            // (300,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'D2<string>' is not covered.
+            // (300,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'C<string>' is not covered.
             //         return c switch
-            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D2<string>").WithLocation(300, 18));
+            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C<string>").WithLocation(300, 18));
 
         classC = comp.GetMember<NamedTypeSymbol>("C");
         Assert.Equal(["D1<T>", "D2<T>"], classC.ClosedSubtypes.ToTestDisplayStrings());
+    }
+
+    [Fact]
+    public void Exhaustiveness_InterfaceConstraints_01()
+    {
+        // Subtype has interface constraint
+        var source1 = """
+            public closed class C<T>;
+            public class D1<U1> : C<U1> where U1 : I1;
+
+            public interface I1;
+            public interface I2;
+
+            public class E1 : I1;
+            public class E2 : E1, I2;
+            """;
+
+        var source2 = $$"""
+            class Program
+            {
+                int Match1<X>(C<X> c)
+            #line 100
+                    => c switch
+                    {
+                    };
+
+                int Match2<X>(C<X> c)
+                    => c switch
+                    {
+            #line 200
+                        D1<X> => 1
+                    };
+
+                int Match3<X>(C<X> c)
+                    => c switch
+                    {
+                        C<X> => 1
+                    };
+
+                void Use()
+                {
+            #line 300
+                    Match1(new D1<E1>());
+                    Match1(new D1<E2>());
+                }
+            }
+            """;
+
+        var comp = CreateCompilation([source1, source2, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
+        verify(comp);
+
+        var comp0 = CreateCompilation([source1, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
+        comp = CreateCompilation([source2], references: [comp0.ToMetadataReference()], targetFramework: TargetFramework.Net100);
+        verify(comp);
+
+        static void verify(CSharpCompilation comp)
+        {
+            comp.VerifyEmitDiagnostics(
+                // (100,14): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'C<X>' is not covered.
+                //         => c switch
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C<X>").WithLocation(100, 14),
+                // (200,16): error CS0314: The type 'X' cannot be used as type parameter 'U1' in the generic type or method 'D1<U1>'. There is no boxing conversion or type parameter conversion from 'X' to 'I1'.
+                //             D1<X> => 1
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedTyVar, "X").WithArguments("D1<U1>", "I1", "U1", "X").WithLocation(200, 16));
+
+            var classC = comp.GetMember<NamedTypeSymbol>("C");
+            Assert.Equal(["D1<T>"], classC.ClosedSubtypes.ToTestDisplayStrings());
+            Assert.Equal(["D1<E1>"], classC.Construct(comp.GetMember<NamedTypeSymbol>("E1")).ClosedSubtypes.ToTestDisplayStrings());
+            Assert.Equal(["D1<E2>"], classC.Construct(comp.GetMember<NamedTypeSymbol>("E2")).ClosedSubtypes.ToTestDisplayStrings());
+        }
+    }
+
+    [Fact]
+    public void Exhaustiveness_InterfaceConstraints_02()
+    {
+        // Subtype interface constraints "overlap" with use site interface constraints
+        var source1 = """
+            public closed class C<T>;
+            public class D1<U1> : C<U1> where U1 : I1;
+
+            public interface I1;
+            public interface I2;
+
+            public class E1 : I1;
+            public class E2 : E1, I2;
+            """;
+
+        var source2 = $$"""
+            class Program
+            {
+                int Match1<X>(C<X> c) where X : I2
+            #line 100
+                    => c switch
+                    {
+                    };
+
+                int Match2<X>(C<X> c) where X : I2
+                    => c switch
+                    {
+            #line 200
+                        D1<X> => 1
+                    };
+
+                int Match3<X>(C<X> c) where X : I2
+                    => c switch
+                    {
+                        C<X> => 1
+                    };
+
+                void Use()
+                {
+            #line 300
+                    Match1(new D1<E1>());
+                    Match1(new D1<E2>());
+                }
+            }
+            """;
+
+        var comp = CreateCompilation([source1, source2, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
+        verify(comp);
+
+        var comp0 = CreateCompilation([source1, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
+        comp = CreateCompilation([source2], references: [comp0.ToMetadataReference()], targetFramework: TargetFramework.Net100);
+        verify(comp);
+
+        static void verify(CSharpCompilation comp)
+        {
+            comp.VerifyEmitDiagnostics(
+                // (100,14): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'C<X>' is not covered.
+                //         => c switch
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C<X>").WithLocation(100, 14),
+                // (200,16): error CS0314: The type 'X' cannot be used as type parameter 'U1' in the generic type or method 'D1<U1>'. There is no boxing conversion or type parameter conversion from 'X' to 'I1'.
+                //             D1<X> => 1
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedTyVar, "X").WithArguments("D1<U1>", "I1", "U1", "X").WithLocation(200, 16),
+                // (300,9): error CS0311: The type 'E1' cannot be used as type parameter 'X' in the generic type or method 'Program.Match1<X>(C<X>)'. There is no implicit reference conversion from 'E1' to 'I2'.
+                //         Match1(new D1<E1>());
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "Match1").WithArguments("Program.Match1<X>(C<X>)", "I2", "X", "E1").WithLocation(300, 9));
+
+            var classC = comp.GetMember<NamedTypeSymbol>("C");
+            Assert.Equal(["D1<T>"], classC.ClosedSubtypes.ToTestDisplayStrings());
+            Assert.Equal(["D1<E1>"], classC.Construct(comp.GetMember<NamedTypeSymbol>("E1")).ClosedSubtypes.ToTestDisplayStrings());
+            Assert.Equal(["D1<E2>"], classC.Construct(comp.GetMember<NamedTypeSymbol>("E2")).ClosedSubtypes.ToTestDisplayStrings());
+        }
+    }
+
+    [Fact]
+    public void Exhaustiveness_InterfaceConstraints_03()
+    {
+        // Subtype interface constraints match use site interface constraints
+        var source1 = """
+            public closed class C<T>;
+            public class D1<U1> : C<U1> where U1 : I1;
+
+            public interface I1;
+
+            public class E1 : I1;
+            """;
+
+        var source2 = $$"""
+            class Program
+            {
+                int Match1<X>(C<X> c) where X : I1
+            #line 100
+                    => c switch
+                    {
+                    };
+
+                int Match2<X>(C<X> c) where X : I1
+                    => c switch
+                    {
+                        D1<X> => 1
+                    };
+
+                int Match3<X>(C<X> c) where X : I1
+                    => c switch
+                    {
+                        C<X> => 1
+                    };
+            }
+            """;
+
+        var comp = CreateCompilation([source1, source2, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
+        comp.VerifyEmitDiagnostics(
+            // (100,14): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'D1<X>' is not covered.
+            //         => c switch
+            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D1<X>").WithLocation(100, 14));
+
+        var classC = comp.GetMember<NamedTypeSymbol>("C");
+        Assert.Equal(["D1<T>"], classC.ClosedSubtypes.ToTestDisplayStrings());
+
+        var comp0 = CreateCompilation([source1, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
+        comp = CreateCompilation([source2], references: [comp0.ToMetadataReference()], targetFramework: TargetFramework.Net100);
+        comp.VerifyEmitDiagnostics(
+            // (100,14): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'D1<X>' is not covered.
+            //         => c switch
+            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D1<X>").WithLocation(100, 14));
+
+        classC = comp.GetMember<NamedTypeSymbol>("C");
+        Assert.Equal(["D1<T>"], classC.ClosedSubtypes.ToTestDisplayStrings());
     }
 
     [Fact]
@@ -2526,6 +3051,76 @@ public sealed class ClosedClassesTests : CSharpTestBase
     }
 
     [Fact]
+    public void Exhaustiveness_ConstrainedToClosedType_02()
+    {
+        // Attempt to exhaust a type parameter constrained to closed type.
+        // This scenario isn't supported by the exhaustiveness check.
+        var source1 = """
+            public closed class E;
+            public sealed class F1 : E;
+            public sealed class F2 : E;
+            """;
+
+        var source2 = """
+            class Program
+            {
+                int M1<X>(X x) where X : E
+                {
+            #line 100
+                    return x switch
+                    {
+                        F1 => 1,
+                        F2 => 2,
+                    };
+                }
+
+                int M2<X>(X x) where X : E
+                {
+            #line 200
+                    return x switch
+                    {
+                        F1 => 1,
+                    };
+                }
+
+                int M3<X>(X x) where X : E
+                {
+                    return x switch
+                    {
+                        F1 => 1,
+                        F2 => 2,
+                        E => 3,
+                    };
+                }
+            }
+            """;
+
+        var comp = CreateCompilation([source1, source2, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
+        verify(comp);
+
+        var comp0 = CreateCompilation([source1, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
+        comp = CreateCompilation([source2], references: [comp0.ToMetadataReference()], targetFramework: TargetFramework.Net100);
+        verify(comp);
+
+        comp = CreateCompilation([source2], references: [comp0.EmitToImageReference()], targetFramework: TargetFramework.Net100);
+        verify(comp);
+
+        static void verify(CSharpCompilation comp)
+        {
+            comp.VerifyEmitDiagnostics(
+                // (100,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '_' is not covered.
+                //         return x switch
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("_").WithLocation(100, 18),
+                // (200,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '_' is not covered.
+                //         return x switch
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("_").WithLocation(200, 18));
+
+            var classC = comp.GetMember<NamedTypeSymbol>("C");
+            Assert.Equal(["D1<T>"], classC.ClosedSubtypes.ToTestDisplayStrings());
+        }
+    }
+
+    [Fact]
     public void Exhaustiveness_BaseTypeArguments_Array_01()
     {
         var source1 = """
@@ -2606,15 +3201,15 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 // (200,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'D1<X>' is not covered.
                 //         return c switch
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D1<X>").WithLocation(200, 18),
-                // (300,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'D1<U1>' is not covered.
+                // (300,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'C<X>' is not covered.
                 //         return c switch
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D1<U1>").WithLocation(300, 18),
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C<X>").WithLocation(300, 18),
                 // (400,13): error CS8121: An expression of type 'C<string[]>' cannot be handled by a pattern of type 'D1<object>'.
                 //             D1<object> => 1
                 Diagnostic(ErrorCode.ERR_PatternWrongType, "D1<object>").WithArguments("C<string[]>", "D1<object>").WithLocation(400, 13));
 
             var classC = comp.GetMember<NamedTypeSymbol>("C");
-            Assert.Equal(["D1<U1>"], classC.ClosedSubtypes.ToTestDisplayStrings());
+            Assert.False(classC.TryGetClosedSubtypes(out _));
 
             var cOfStringArray = classC.Construct(
                 comp.CreateArrayTypeSymbol(comp.GetSpecialType(SpecialType.System_String)));
@@ -2700,7 +3295,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C<X[]>").WithLocation(300, 18));
 
             var classC = comp.GetMember<NamedTypeSymbol>("C");
-            Assert.Equal(["D1<U1>"], classC.ClosedSubtypes.ToTestDisplayStrings());
+            Assert.False(classC.TryGetClosedSubtypes(out _));
 
             var cOfStringArray = classC.Construct(
                 comp.CreateArrayTypeSymbol(
@@ -2820,18 +3415,18 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 // (300,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'D1<X1>' is not covered.
                 //         return c switch
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D1<X1>").WithLocation(300, 18),
-                // (400,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'D1<U1>' is not covered.
+                // (400,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'C<X>' is not covered.
                 //         return c switch
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D1<U1>").WithLocation(400, 18),
-                // (500,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'D1<U1>' is not covered.
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C<X>").WithLocation(400, 18),
+                // (500,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'C<X>' is not covered.
                 //         return c switch
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D1<U1>").WithLocation(500, 18),
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C<X>").WithLocation(500, 18),
                 // (600,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'C<string>' is not covered.
                 //         return c switch
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C<string>").WithLocation(600, 18));
 
             var classC = comp.GetMember<NamedTypeSymbol>("C");
-            Assert.Equal(["D1<U1>"], classC.ClosedSubtypes.ToTestDisplayStrings());
+            Assert.False(classC.TryGetClosedSubtypes(out _));
 
             var tupleOfStringInt = comp.GetWellKnownType(WellKnownType.System_ValueTuple_T2).Construct(
                     comp.GetSpecialType(SpecialType.System_String),

--- a/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
@@ -1906,6 +1906,95 @@ public sealed class ClosedClassesTests : CSharpTestBase
     }
 
     [Fact]
+    public void Exhaustiveness_Generic_NonGenericSubtypes_01()
+    {
+        // Base type is generic and subtypes are non-generic
+        var source = """
+            closed class C<T>;
+            class D1 : C<string>;
+            class D2 : C<int>;
+            
+            class Program
+            {
+                int Match1(C<int> c) =>
+            #line 100
+                    c switch
+                    {
+                    };
+
+                int Match2(C<int> c) =>
+                    c switch
+                    {
+                        D2 => 2,
+                    };
+
+                int Match3(C<int> c) =>
+                    c switch
+                    {
+            #line 200
+                        D1 => 2,
+                    };
+
+                int Match4(C<string> c) =>
+                    c switch
+                    {
+                        D1 => 2,
+                    };
+
+                int Match5(C<string> c) =>
+                    c switch
+                    {
+            #line 300
+                        D2 => 2,
+                    };
+
+                int Match6(C<object> c) =>
+            #line 400
+                    c switch
+                    {
+                    };
+
+                int Match7(C<object> c) =>
+                    c switch
+                    {
+                        C<object> => 1,
+                    };
+            }
+            """;
+
+        var comp = CreateCompilation([source, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
+        comp.VerifyDiagnostics(
+            // (100,11): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'D2' is not covered.
+            //         c switch
+            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D2").WithLocation(100, 11),
+            // (200,13): error CS8121: An expression of type 'C<int>' cannot be handled by a pattern of type 'D1'.
+            //             D1 => 2,
+            Diagnostic(ErrorCode.ERR_PatternWrongType, "D1").WithArguments("C<int>", "D1").WithLocation(200, 13),
+            // (300,13): error CS8121: An expression of type 'C<string>' cannot be handled by a pattern of type 'D2'.
+            //             D2 => 2,
+            Diagnostic(ErrorCode.ERR_PatternWrongType, "D2").WithArguments("C<string>", "D2").WithLocation(300, 13),
+            // (400,11): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'C<object>' is not covered.
+            //         c switch
+            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C<object>").WithLocation(400, 11));
+
+        var classC = comp.GetMember<NamedTypeSymbol>("C");
+        Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
+        Assert.Equal(["D1", "D2"], subtypes.ToTestDisplayStrings());
+
+        var cOfInt = classC.Construct(comp.GetSpecialType(SpecialType.System_Int32));
+        Assert.True(cOfInt.TryGetClosedSubtypes(out subtypes));
+        Assert.Equal(["D2"], subtypes.ToTestDisplayStrings());
+
+        var cOfString = classC.Construct(comp.GetSpecialType(SpecialType.System_String));
+        Assert.True(cOfString.TryGetClosedSubtypes(out subtypes));
+        Assert.Equal(["D1"], subtypes.ToTestDisplayStrings());
+
+        var cOfObject = classC.Construct(comp.GetSpecialType(SpecialType.System_Object));
+        Assert.True(cOfObject.TryGetClosedSubtypes(out subtypes));
+        Assert.Empty(subtypes);
+    }
+
+    [Fact]
     public void Exhaustiveness_NoSubtypes()
     {
         // Closed with no subtypes

--- a/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
@@ -590,7 +590,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
             Diagnostic(ErrorCode.ERR_UnderspecifiedClosedSubtype, "D").WithArguments("D<T>", "T", "C").WithLocation(2, 14));
 
         var classC = comp1.GetMember<NamedTypeSymbol>("C");
-        Assert.Equal(["D<T>"], classC.ClosedSubtypes.ToTestDisplayStrings());
+        Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
+        Assert.Equal(["D<T>"], subtypes.ToTestDisplayStrings());
     }
 
     [Fact]
@@ -609,7 +610,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
         comp1.VerifyEmitDiagnostics();
 
         var classC = comp1.GetMember<NamedTypeSymbol>("C");
-        Assert.Equal(["Outer<T>.D"], classC.ClosedSubtypes.ToTestDisplayStrings());
+        Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
+        Assert.Equal(["Outer<T>.D"], subtypes.ToTestDisplayStrings());
     }
 
     [Fact]
@@ -631,7 +633,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
             Diagnostic(ErrorCode.ERR_UnderspecifiedClosedSubtype, "D").WithArguments("Outer<T>.D", "T", "C").WithLocation(5, 18));
 
         var classC = comp1.GetMember<NamedTypeSymbol>("C");
-        Assert.Equal(["Outer<T>.D"], classC.ClosedSubtypes.ToTestDisplayStrings());
+        Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
+        Assert.Equal(["Outer<T>.D"], subtypes.ToTestDisplayStrings());
     }
 
     [Fact]
@@ -647,7 +650,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
         comp1.VerifyEmitDiagnostics();
 
         var classC = comp1.GetMember<NamedTypeSymbol>("C");
-        Assert.Equal(["D"], classC.ClosedSubtypes.ToTestDisplayStrings());
+        Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
+        Assert.Equal(["D"], subtypes.ToTestDisplayStrings());
     }
 
     [Fact]
@@ -691,13 +695,16 @@ public sealed class ClosedClassesTests : CSharpTestBase
             // closed class F<T> : E { }
             Diagnostic(ErrorCode.ERR_UnderspecifiedClosedSubtype, "F").WithArguments("F<T>", "T", "E").WithLocation(5, 14));
 
-        Assert.Empty(comp1.GetMember<NamedTypeSymbol>("C").ClosedSubtypes);
-        Assert.Empty(comp1.GetMember<NamedTypeSymbol>("D").ClosedSubtypes);
+        Assert.False(comp1.GetMember<NamedTypeSymbol>("C").TryGetClosedSubtypes(out _));
+        Assert.True(comp1.GetMember<NamedTypeSymbol>("D").TryGetClosedSubtypes(out var subtypes));
+        Assert.Empty(subtypes);
 
         var classE = comp1.GetMember<NamedTypeSymbol>("E");
-        Assert.Equal(["F<T>"], classE.ClosedSubtypes.ToTestDisplayStrings());
+        Assert.True(classE.TryGetClosedSubtypes(out subtypes));
+        Assert.Equal(["F<T>"], subtypes.ToTestDisplayStrings());
 
-        Assert.Empty(comp1.GetMember<NamedTypeSymbol>("F").ClosedSubtypes);
+        Assert.True(comp1.GetMember<NamedTypeSymbol>("F").TryGetClosedSubtypes(out subtypes));
+        Assert.Empty(subtypes);
     }
 
     [Fact]
@@ -1040,7 +1047,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
         {
             var classC = module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
             Assert.Equal("C", classC.ToTestDisplayString());
-            Assert.Equal(["D1", "D2"], classC.ClosedSubtypes.ToTestDisplayStrings());
+            Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
+            Assert.Equal(["D1", "D2"], subtypes.ToTestDisplayStrings());
         }
     }
 
@@ -1070,15 +1078,18 @@ public sealed class ClosedClassesTests : CSharpTestBase
             // Note: 'D2' is included in the set, because its base type 'C<int>' can unify with 'C<T>'.
             // For example, if we encounter a value of type 'C<U>' where U is some unconstrained generic,
             // then it's possible the value is also a 'D2'. i.e. 'U' could be substituted with 'int' at runtime.
-            Assert.Equal(["D1<T>", "D2"], classC.ClosedSubtypes.ToTestDisplayStrings());
+            Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
+            Assert.Equal(["D1<T>", "D2"], subtypes.ToTestDisplayStrings());
 
             var cOfInt = classC.Construct(comp.GetSpecialType(SpecialType.System_Int32));
             Assert.Equal("C<System.Int32>", cOfInt.ToTestDisplayString());
-            Assert.Equal(["D1<System.Int32>", "D2"], cOfInt.ClosedSubtypes.ToTestDisplayStrings());
+            Assert.True(cOfInt.TryGetClosedSubtypes(out subtypes));
+            Assert.Equal(["D1<System.Int32>", "D2"], subtypes.ToTestDisplayStrings());
 
             var cOfString = classC.Construct(comp.GetSpecialType(SpecialType.System_String));
             Assert.Equal("C<System.String>", cOfString.ToTestDisplayString());
-            Assert.Equal(["D1<System.String>"], cOfString.ClosedSubtypes.ToTestDisplayStrings());
+            Assert.True(cOfString.TryGetClosedSubtypes(out subtypes));
+            Assert.Equal(["D1<System.String>"], subtypes.ToTestDisplayStrings());
         }
     }
 
@@ -1116,18 +1127,20 @@ public sealed class ClosedClassesTests : CSharpTestBase
 
             var cOfImmutableArray = classC.Construct(immutableArrayOfInt);
             Assert.Equal("C<System.Collections.Immutable.ImmutableArray<System.Int32>>", cOfImmutableArray.ToTestDisplayString());
-            Assert.Equal(["D1<System.Collections.Immutable.ImmutableArray<System.Int32>>", "D2<System.Int32>"], cOfImmutableArray.ClosedSubtypes.ToTestDisplayStrings());
+            Assert.True(cOfImmutableArray.TryGetClosedSubtypes(out var subtypes));
+            Assert.Equal(["D1<System.Collections.Immutable.ImmutableArray<System.Int32>>", "D2<System.Int32>"], subtypes.ToTestDisplayStrings());
 
             var cOfInt = classC.Construct(comp.GetSpecialType(SpecialType.System_Int32));
             Assert.Equal("C<System.Int32>", cOfInt.ToTestDisplayString());
-            Assert.Equal(["D1<System.Int32>"], cOfInt.ClosedSubtypes.ToTestDisplayStrings());
+            Assert.True(cOfInt.TryGetClosedSubtypes(out subtypes));
+            Assert.Equal(["D1<System.Int32>"], subtypes.ToTestDisplayStrings());
         }
     }
 
     [Fact]
     public void Subtypes_04()
     {
-        // Verify that ClosedSubtypes API behaves reasonably in base type cycle scenario.
+        // Verify that TryGetClosedSubtypes API behaves reasonably in base type cycle scenario.
         var source = """
             using System.Collections.Immutable;
 
@@ -1151,7 +1164,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
 
         var classC = comp.GetMember<NamedTypeSymbol>("C");
         Assert.Equal("C<T>", classC.ToTestDisplayString());
-        Assert.Empty(classC.ClosedSubtypes);
+        Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
+        Assert.Empty(subtypes);
     }
 
     [Fact]
@@ -1176,15 +1190,18 @@ public sealed class ClosedClassesTests : CSharpTestBase
         {
             var classC = comp.GetMember<NamedTypeSymbol>("C");
             Assert.Equal("C<T1, T2>", classC.ToTestDisplayString());
-            Assert.Equal(["D1<T1>"], classC.ClosedSubtypes.ToTestDisplayStrings());
+            Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
+            Assert.Equal(["D1<T1>"], subtypes.ToTestDisplayStrings());
 
             var cOfStringInt = classC.Construct(comp.GetSpecialType(SpecialType.System_String), comp.GetSpecialType(SpecialType.System_Int32));
             Assert.Equal("C<System.String, System.Int32>", cOfStringInt.ToTestDisplayString());
-            Assert.Equal(["D1<System.String>"], cOfStringInt.ClosedSubtypes.ToTestDisplayStrings());
+            Assert.True(cOfStringInt.TryGetClosedSubtypes(out subtypes));
+            Assert.Equal(["D1<System.String>"], subtypes.ToTestDisplayStrings());
 
             var cOfIntString = classC.Construct(comp.GetSpecialType(SpecialType.System_Int32), comp.GetSpecialType(SpecialType.System_String));
             Assert.Equal("C<System.Int32, System.String>", cOfIntString.ToTestDisplayString());
-            Assert.Empty(cOfIntString.ClosedSubtypes);
+            Assert.True(cOfIntString.TryGetClosedSubtypes(out subtypes));
+            Assert.Empty(subtypes);
         }
     }
 
@@ -1935,7 +1952,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C").WithLocation(5, 18));
 
         var classC = comp.GetMember<NamedTypeSymbol>("C");
-        Assert.Empty(classC.ClosedSubtypes);
+        Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
+        Assert.Empty(subtypes);
 
         var comp1 = CreateCompilation([source1, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
         var comp2 = CreateCompilation([source2], references: [comp1.ToMetadataReference()], targetFramework: TargetFramework.Net100);
@@ -1944,7 +1962,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
             //         return c switch
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C").WithLocation(5, 18));
         classC = comp2.GetMember<NamedTypeSymbol>("C");
-        Assert.Empty(classC.ClosedSubtypes);
+        Assert.True(classC.TryGetClosedSubtypes(out subtypes));
+        Assert.Empty(subtypes);
 
         comp2 = CreateCompilation([source2], references: [comp1.EmitToImageReference()], targetFramework: TargetFramework.Net100);
         comp2.VerifyEmitDiagnostics(
@@ -1952,7 +1971,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
             //         return c switch
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C").WithLocation(5, 18));
         classC = comp2.GetMember<NamedTypeSymbol>("C");
-        Assert.Empty(classC.ClosedSubtypes);
+        Assert.True(classC.TryGetClosedSubtypes(out subtypes));
+        Assert.Empty(subtypes);
     }
 
     [Fact]
@@ -2057,7 +2077,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("E").WithLocation(200, 18));
 
             var classC = comp.GetMember<NamedTypeSymbol>("C");
-            Assert.Equal(["D", "F"], classC.ClosedSubtypes.ToTestDisplayStrings());
+            Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
+            Assert.Equal(["D", "F"], subtypes.ToTestDisplayStrings());
         }
     }
 
@@ -2120,7 +2141,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C").WithLocation(200, 18));
 
             var classC = comp.GetMember<NamedTypeSymbol>("C");
-            Assert.Equal(["D1", "Container.D2"], classC.ClosedSubtypes.ToTestDisplayStrings());
+            Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
+            Assert.Equal(["D1", "Container.D2"], subtypes.ToTestDisplayStrings());
         }
     }
 
@@ -2165,7 +2187,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D2").WithLocation(200, 18));
 
         var classC = comp.GetMember<NamedTypeSymbol>("C");
-        Assert.Equal(["D1", "D2"], classC.ClosedSubtypes.ToTestDisplayStrings());
+        Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
+        Assert.Equal(["D1", "D2"], subtypes.ToTestDisplayStrings());
 
         var comp0 = CreateCompilation([source1, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
         comp = CreateCompilation([source2], references: [comp0.ToMetadataReference()], targetFramework: TargetFramework.Net100);
@@ -2178,7 +2201,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C").WithLocation(200, 18));
 
         classC = comp.GetMember<NamedTypeSymbol>("C");
-        Assert.Equal(["D1", "D2"], classC.ClosedSubtypes.ToTestDisplayStrings());
+        Assert.True(classC.TryGetClosedSubtypes(out subtypes));
+        Assert.Equal(["D1", "D2"], subtypes.ToTestDisplayStrings());
 
         comp = CreateCompilation([source2], references: [comp0.EmitToImageReference()], targetFramework: TargetFramework.Net100);
         comp.VerifyEmitDiagnostics(
@@ -2190,7 +2214,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C").WithLocation(200, 18));
 
         classC = comp.GetMember<NamedTypeSymbol>("C");
-        Assert.Equal(["D1", "D2"], classC.ClosedSubtypes.ToTestDisplayStrings());
+        Assert.True(classC.TryGetClosedSubtypes(out subtypes));
+        Assert.Equal(["D1", "D2"], subtypes.ToTestDisplayStrings());
     }
 
     [Fact]
@@ -2252,7 +2277,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("Container.C").WithLocation(200, 18));
 
             var classC = comp.GetMember<NamedTypeSymbol>("Container.C");
-            Assert.Equal(["Container.D"], classC.ClosedSubtypes.ToTestDisplayStrings());
+            Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
+            Assert.Equal(["Container.D"], subtypes.ToTestDisplayStrings());
         }
     }
 
@@ -2325,7 +2351,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D2").WithLocation(200, 18));
 
             var classC = comp.GetMember<NamedTypeSymbol>("C");
-            Assert.Equal(["D1", "D2"], classC.ClosedSubtypes.ToTestDisplayStrings());
+            Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
+            Assert.Equal(["D1", "D2"], subtypes.ToTestDisplayStrings());
         }
     }
 
@@ -2389,7 +2416,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C").WithLocation(200, 18));
 
             var classC = comp.GetMember<NamedTypeSymbol>("C");
-            Assert.Equal(["D1", "Container.D2"], classC.ClosedSubtypes.ToTestDisplayStrings());
+            Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
+            Assert.Equal(["D1", "Container.D2"], subtypes.ToTestDisplayStrings());
         }
     }
 
@@ -2519,7 +2547,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C<X>").WithLocation(200, 18));
 
             var classC = comp.GetMember<NamedTypeSymbol>("C");
-            Assert.Equal(["D1<T>", "D2<T>"], classC.ClosedSubtypes.ToTestDisplayStrings());
+            Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
+            Assert.Equal(["D1<T>", "D2<T>"], subtypes.ToTestDisplayStrings());
         }
     }
 
@@ -2579,7 +2608,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C<X>").WithLocation(200, 18));
 
             var classC = comp.GetMember<NamedTypeSymbol>("C");
-            Assert.Equal(["D1<T>", "D2<T>"], classC.ClosedSubtypes.ToTestDisplayStrings());
+            Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
+            Assert.Equal(["D1<T>", "D2<T>"], subtypes.ToTestDisplayStrings());
         }
     }
 
@@ -2638,7 +2668,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C<string>").WithLocation(200, 18));
 
             var classC = comp.GetMember<NamedTypeSymbol>("C");
-            Assert.Equal(["D1<T>", "D2<T>"], classC.ClosedSubtypes.ToTestDisplayStrings());
+            Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
+            Assert.Equal(["D1<T>", "D2<T>"], subtypes.ToTestDisplayStrings());
         }
     }
 
@@ -2690,7 +2721,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C<string>").WithLocation(300, 18));
 
         var classC = comp.GetMember<NamedTypeSymbol>("C");
-        Assert.Equal(["D1<T>", "D2<T>"], classC.ClosedSubtypes.ToTestDisplayStrings());
+        Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
+        Assert.Equal(["D1<T>", "D2<T>"], subtypes.ToTestDisplayStrings());
 
         var comp0 = CreateCompilation([source1, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
         comp = CreateCompilation([source2], references: [comp0.ToMetadataReference()], targetFramework: TargetFramework.Net100);
@@ -2703,7 +2735,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C<string>").WithLocation(300, 18));
 
         classC = comp.GetMember<NamedTypeSymbol>("C");
-        Assert.Equal(["D1<T>", "D2<T>"], classC.ClosedSubtypes.ToTestDisplayStrings());
+        Assert.True(classC.TryGetClosedSubtypes(out subtypes));
+        Assert.Equal(["D1<T>", "D2<T>"], subtypes.ToTestDisplayStrings());
     }
 
     [Fact]
@@ -2770,9 +2803,12 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedTyVar, "X").WithArguments("D1<U1>", "I1", "U1", "X").WithLocation(200, 16));
 
             var classC = comp.GetMember<NamedTypeSymbol>("C");
-            Assert.Equal(["D1<T>"], classC.ClosedSubtypes.ToTestDisplayStrings());
-            Assert.Equal(["D1<E1>"], classC.Construct(comp.GetMember<NamedTypeSymbol>("E1")).ClosedSubtypes.ToTestDisplayStrings());
-            Assert.Equal(["D1<E2>"], classC.Construct(comp.GetMember<NamedTypeSymbol>("E2")).ClosedSubtypes.ToTestDisplayStrings());
+            Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
+            Assert.Equal(["D1<T>"], subtypes.ToTestDisplayStrings());
+            Assert.True(classC.Construct(comp.GetMember<NamedTypeSymbol>("E1")).TryGetClosedSubtypes(out subtypes));
+            Assert.Equal(["D1<E1>"], subtypes.ToTestDisplayStrings());
+            Assert.True(classC.Construct(comp.GetMember<NamedTypeSymbol>("E2")).TryGetClosedSubtypes(out subtypes));
+            Assert.Equal(["D1<E2>"], subtypes.ToTestDisplayStrings());
         }
     }
 
@@ -2843,9 +2879,12 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "Match1").WithArguments("Program.Match1<X>(C<X>)", "I2", "X", "E1").WithLocation(300, 9));
 
             var classC = comp.GetMember<NamedTypeSymbol>("C");
-            Assert.Equal(["D1<T>"], classC.ClosedSubtypes.ToTestDisplayStrings());
-            Assert.Equal(["D1<E1>"], classC.Construct(comp.GetMember<NamedTypeSymbol>("E1")).ClosedSubtypes.ToTestDisplayStrings());
-            Assert.Equal(["D1<E2>"], classC.Construct(comp.GetMember<NamedTypeSymbol>("E2")).ClosedSubtypes.ToTestDisplayStrings());
+            Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
+            Assert.Equal(["D1<T>"], subtypes.ToTestDisplayStrings());
+            Assert.True(classC.Construct(comp.GetMember<NamedTypeSymbol>("E1")).TryGetClosedSubtypes(out subtypes));
+            Assert.Equal(["D1<E1>"], subtypes.ToTestDisplayStrings());
+            Assert.True(classC.Construct(comp.GetMember<NamedTypeSymbol>("E2")).TryGetClosedSubtypes(out subtypes));
+            Assert.Equal(["D1<E2>"], subtypes.ToTestDisplayStrings());
         }
     }
 
@@ -2892,7 +2931,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D1<X>").WithLocation(100, 14));
 
         var classC = comp.GetMember<NamedTypeSymbol>("C");
-        Assert.Equal(["D1<T>"], classC.ClosedSubtypes.ToTestDisplayStrings());
+        Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
+        Assert.Equal(["D1<T>"], subtypes.ToTestDisplayStrings());
 
         var comp0 = CreateCompilation([source1, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
         comp = CreateCompilation([source2], references: [comp0.ToMetadataReference()], targetFramework: TargetFramework.Net100);
@@ -2902,7 +2942,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("D1<X>").WithLocation(100, 14));
 
         classC = comp.GetMember<NamedTypeSymbol>("C");
-        Assert.Equal(["D1<T>"], classC.ClosedSubtypes.ToTestDisplayStrings());
+        Assert.True(classC.TryGetClosedSubtypes(out subtypes));
+        Assert.Equal(["D1<T>"], subtypes.ToTestDisplayStrings());
     }
 
     [Fact]
@@ -2960,20 +3001,23 @@ public sealed class ClosedClassesTests : CSharpTestBase
         comp.VerifyEmitDiagnostics();
 
         var classC = comp.GetMember<NamedTypeSymbol>("Container.C");
-        Assert.Equal(["Container<T>.D1", "D2<T>", "D3", "D4"], classC.ClosedSubtypes.ToTestDisplayStrings());
+        Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
+        Assert.Equal(["Container<T>.D1", "D2<T>", "D3", "D4"], subtypes.ToTestDisplayStrings());
 
         var comp0 = CreateCompilation([source1, UnionAttributeSource, IUnionSource, ClosedAttributeDefinition], targetFramework: TargetFramework.Net100);
         comp = CreateCompilation([source2], references: [comp0.ToMetadataReference()], targetFramework: TargetFramework.Net100);
         comp.VerifyEmitDiagnostics();
 
         classC = comp.GetMember<NamedTypeSymbol>("Container.C");
-        Assert.Equal(["Container<T>.D1", "D2<T>", "D3", "D4"], classC.ClosedSubtypes.ToTestDisplayStrings());
+        Assert.True(classC.TryGetClosedSubtypes(out subtypes));
+        Assert.Equal(["Container<T>.D1", "D2<T>", "D3", "D4"], subtypes.ToTestDisplayStrings());
 
         comp = CreateCompilation([source2], references: [comp0.EmitToImageReference()], targetFramework: TargetFramework.Net100);
         comp.VerifyEmitDiagnostics();
 
         classC = comp.GetMember<NamedTypeSymbol>("Container.C");
-        Assert.Equal(["D2<T>", "D3", "D4", "Container<T>.D1"], classC.ClosedSubtypes.ToTestDisplayStrings());
+        Assert.True(classC.TryGetClosedSubtypes(out subtypes));
+        Assert.Equal(["D2<T>", "D3", "D4", "Container<T>.D1"], subtypes.ToTestDisplayStrings());
     }
 
     [Fact]
@@ -3046,7 +3090,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("_").WithLocation(200, 18));
 
             var classC = comp.GetMember<NamedTypeSymbol>("C");
-            Assert.Equal(["D1<T>"], classC.ClosedSubtypes.ToTestDisplayStrings());
+            Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
+            Assert.Equal(["D1<T>"], subtypes.ToTestDisplayStrings());
         }
     }
 
@@ -3115,8 +3160,9 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 //         return x switch
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("_").WithLocation(200, 18));
 
-            var classC = comp.GetMember<NamedTypeSymbol>("C");
-            Assert.Equal(["D1<T>"], classC.ClosedSubtypes.ToTestDisplayStrings());
+            var classE = comp.GetMember<NamedTypeSymbol>("E");
+            Assert.True(classE.TryGetClosedSubtypes(out var subtypes));
+            Assert.Equal(["F1", "F2"], subtypes.ToTestDisplayStrings());
         }
     }
 
@@ -3213,7 +3259,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
 
             var cOfStringArray = classC.Construct(
                 comp.CreateArrayTypeSymbol(comp.GetSpecialType(SpecialType.System_String)));
-            Assert.Equal(["D1<System.String>"], cOfStringArray.ClosedSubtypes.ToTestDisplayStrings());
+            Assert.True(cOfStringArray.TryGetClosedSubtypes(out var subtypes));
+            Assert.Equal(["D1<System.String>"], subtypes.ToTestDisplayStrings());
         }
     }
 
@@ -3301,7 +3348,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 comp.CreateArrayTypeSymbol(
                     comp.CreatePointerTypeSymbol(
                         comp.GetSpecialType(SpecialType.System_Int32))));
-            Assert.Equal(["D1<System.Int32>"], cOfStringArray.ClosedSubtypes.ToTestDisplayStrings());
+            Assert.True(cOfStringArray.TryGetClosedSubtypes(out var subtypes));
+            Assert.Equal(["D1<System.Int32>"], subtypes.ToTestDisplayStrings());
         }
     }
 
@@ -3433,11 +3481,13 @@ public sealed class ClosedClassesTests : CSharpTestBase
                     comp.GetSpecialType(SpecialType.System_Int32));
 
             var cOfStringArray = classC.Construct(tupleOfStringInt);
-            Assert.Equal(["D1<System.String>"], cOfStringArray.ClosedSubtypes.ToTestDisplayStrings());
+            Assert.True(cOfStringArray.TryGetClosedSubtypes(out var subtypes));
+            Assert.Equal(["D1<System.String>"], subtypes.ToTestDisplayStrings());
 
             tupleOfStringInt = NamedTypeSymbol.CreateTuple(tupleOfStringInt);
             cOfStringArray = classC.Construct(tupleOfStringInt);
-            Assert.Equal(["D1<System.String>"], cOfStringArray.ClosedSubtypes.ToTestDisplayStrings());
+            Assert.True(cOfStringArray.TryGetClosedSubtypes(out subtypes));
+            Assert.Equal(["D1<System.String>"], subtypes.ToTestDisplayStrings());
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolExtensionTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolExtensionTests.cs
@@ -256,16 +256,7 @@ class Test
             var typeParameters = PooledHashSet<TypeParameterSymbol>.GetInstance();
             try
             {
-                method.ContainingType.VisitType(static (typeSymbol, typeParameters, _) =>
-                {
-                    if (typeSymbol is TypeParameterSymbol typeParameter)
-                    {
-                        typeParameters.Add(typeParameter);
-                    }
-
-                    return false;
-                },
-                typeParameters, visitCustomModifiers: true);
+                method.ContainingType.FindTypeParameters(typeParameters);
 
                 var typeParameter = typeParameters.Single();
                 Assert.Equal("G", typeParameter.Name);


### PR DESCRIPTION
Test plan: #81039

- Replaces `ClosedSubtypes` API with `TryGetClosedSubtypes`. The idea is that we don't want subtype expansion to be performed, if it would result in including subtypes with invalid type parameters for the use site. I found that "letting such types in", and trying to work backwards to a valid type suggestion in PatternExplainer, didn't work well.
- Adjust `SampleType` API used by PatternExplainer so that it will "walk up" closed subtypes, so that we avoid suggesting types which are invalid at the use site.
    - Note that the constraint check performed here is different in nature/purpose than the constraint check suggested to be added to `TryGetClosedSubtypes`. The purpose in `PatternExplainer` is just to avoid suggesting a type which is invalid to use (but might still exist via type substitution), while, the purpose in `TryGetClosedSubtypes` would be to exclude a type which could never exist.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83493)