### PR TITLE
Fix inline rename in VS for Razor

### DIFF
--- a/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostRoslynRenameTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostRoslynRenameTest.cs
@@ -89,6 +89,60 @@ public class CohostRoslynRenameTest(ITestOutputHelper testOutputHelper) : Cohost
 
     [Theory]
     [CombinatorialData]
+    public Task CSharp_Property(bool useLsp, bool fromRazor)
+        => VerifyRenamesAsync(
+            csharpFile: """
+                public class MyClass
+                {
+                    public string MyPr$$operty { get; } = nameof(MyProperty);
+                }
+                """,
+            razorFile: """
+                This is a Razor document.
+
+                <h1>@_myClass.MyPr$$operty</h1>
+
+                @code
+                {
+                    private MyClass _myClass = new MyClass();
+
+                    public string M()
+                    {
+                        return _myClass.MyProperty;
+                    }
+                }
+
+                The end.
+                """,
+            newName: "CallThisProperty",
+            expectedCSharpFile: """
+                public class MyClass
+                {
+                    public string CallThisProperty { get; } = nameof(CallThisProperty);
+                }
+                """,
+            expectedRazorFile: """
+                This is a Razor document.
+
+                <h1>@_myClass.CallThisProperty</h1>
+
+                @code
+                {
+                    private MyClass _myClass = new MyClass();
+
+                    public string M()
+                    {
+                        return _myClass.CallThisProperty;
+                    }
+                }
+
+                The end.
+                """,
+            useLsp,
+            fromRazor);
+
+    [Theory]
+    [CombinatorialData]
     public Task Component(bool useLsp, bool fromRazor)
         => VerifyRenamesAsync(
             csharpFile: """

--- a/src/Workspaces/Core/Portable/Rename/Renamer.cs
+++ b/src/Workspaces/Core/Portable/Rename/Renamer.cs
@@ -137,7 +137,10 @@ public static partial class Renamer
 
     /// <inheritdoc cref="LightweightRenameLocations.FindRenameLocationsAsync(ISymbol, Solution, SymbolRenameOptions, CancellationToken)"/>
     internal static Task<LightweightRenameLocations> FindRenameLocationsAsync(Solution solution, ISymbol symbol, SymbolRenameOptions options, CancellationToken cancellationToken)
-        => FindRenameLocationsAsync(solution, symbol, options, allowRenamesInRazorSourceGeneratedDocuments: false, cancellationToken);
+        => FindRenameLocationsAsync(
+            solution, symbol, options,
+            allowRenamesInRazorSourceGeneratedDocuments: solution.Services.GetService<ISourceGeneratedDocumentSpanMappingService>() is not null,
+            cancellationToken);
 
     internal static Task<LightweightRenameLocations> FindRenameLocationsAsync(
         Solution solution,


### PR DESCRIPTION
The previous attempt at fixing this failed to address when a rename is initiated from a C# file, not a Razor file. This does that.

Probably could have just hardcoded the parameter to `true`, but just in case anything in editor features ships with cli stuff, I figured this was safer.