### PR TITLE
Select the signed vsixs, not the first vsixes found

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -289,9 +289,9 @@ extends:
                 condition: succeeded()
 
               - task: CopyFiles@2
-                displayName: 'Collect "vsix" from $(Build.SourcesDirectory)\Binaries\$(BuildConfiguration)\DevDivPackages'
+                displayName: 'Collect "vsix" from $(Build.SourcesDirectory)\Binaries\$(BuildConfiguration)\Vsix'
                 inputs:
-                  SourceFolder: '$(Build.SourcesDirectory)\Binaries\$(BuildConfiguration)\DevDivPackages'
+                  SourceFolder: '$(Build.SourcesDirectory)\Binaries\$(BuildConfiguration)\Vsix'
                   Contents: '**\*.?(vsix)'
                   TargetFolder: '$(Build.ArtifactStagingDirectory)\insertion'
                   FlattenFolders: true

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -280,10 +280,19 @@ extends:
                 condition: succeeded()
 
               - task: CopyFiles@2
-                displayName: 'Collect "vsman" and "vsix" from $(Build.SourcesDirectory)\Binaries\$(BuildConfiguration)'
+                displayName: 'Collect "vsman" from $(Build.SourcesDirectory)\Binaries\$(BuildConfiguration)'
                 inputs:
                   SourceFolder: '$(Build.SourcesDirectory)\Binaries\$(BuildConfiguration)'
-                  Contents: '**\*.?(vsman|vsix)'
+                  Contents: '**\*.?(vsman)'
+                  TargetFolder: '$(Build.ArtifactStagingDirectory)\insertion'
+                  FlattenFolders: true
+                condition: succeeded()
+
+              - task: CopyFiles@2
+                displayName: 'Collect "vsix" from $(Build.SourcesDirectory)\Binaries\$(BuildConfiguration)\DevDivPackages'
+                inputs:
+                  SourceFolder: '$(Build.SourcesDirectory)\Binaries\$(BuildConfiguration)\DevDivPackages'
+                  Contents: '**\*.?(vsix)'
                   TargetFolder: '$(Build.ArtifactStagingDirectory)\insertion'
                   FlattenFolders: true
                 condition: succeeded()


### PR DESCRIPTION
Collecting all vsixes means only the first ones encountered are eventually added to insertions; make sure to get the signed vsix files.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83497)