### PR TITLE
Implement `textDocument/selectionRange` for Razor and forward to Roslyn

### DIFF
--- a/.github/skills/run-vscode-local-testing/SKILL.md
+++ b/.github/skills/run-vscode-local-testing/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: run-vscode-local-testing
+description: Build the local Roslyn language server and Razor VS Code extension outputs, write a VS Code workspace that points at them, and launch VS Code for manual testing.
+argument-hint: Ask which project folder VS Code should open for local testing.
+---
+
+# Run VS Code for Local Testing
+
+Use this skill when:
+- manually testing Roslyn or Razor changes in VS Code against locally built bits
+- asked to launch VS Code with `dotnet.server.path` pointing at the repo's `Microsoft.CodeAnalysis.LanguageServer.dll`
+- asked to point the C# extension's Razor component at the locally built `Microsoft.VisualStudioCode.RazorExtension` output
+
+This workflow is currently **Windows-only**. It assumes:
+- `code` is available on `PATH`
+- the target project folder already exists on disk
+
+## First step
+
+If the user has not already given you a project folder, ask them which folder VS Code should open and wait for an absolute path before running the helper script.
+
+## Goal
+
+1. Build the local Roslyn language server and Razor VS Code extension outputs.
+2. Write a `.code-workspace` file under `artifacts\`.
+3. Point that workspace at the requested project folder.
+4. Set:
+   - `dotnet.server.path`
+   - `dotnet.server.componentPaths.razorExtension`
+5. Launch VS Code with that workspace.
+
+## Helper script
+
+Use the helper script in this skill:
+
+```powershell
+.\.github\skills\run-vscode-local-testing\scripts\Start-LocalVsCode.ps1 `
+  -ProjectPath C:\path\to\project
+```
+
+### Parameters
+
+- `-ProjectPath` (required): absolute path to the folder VS Code should open.
+- `-Configuration`: build configuration. Defaults to `Debug`.
+- `-WorkspacePath`: optional path for the generated workspace file. Defaults to `artifacts\<folder-name>-local-test.code-workspace`.
+- `-SkipBuild`: skip `dotnet build` if the outputs are already up to date.
+- `-NoLaunch`: write the workspace file without launching VS Code.
+- `-NewWindow`: open VS Code in a new window instead of reusing the current one.
+
+## What the script builds
+
+Unless `-SkipBuild` is passed, the script builds:
+
+```powershell
+dotnet build src\LanguageServer\Microsoft.CodeAnalysis.LanguageServer\Microsoft.CodeAnalysis.LanguageServer.csproj -c Debug
+dotnet build src\Razor\src\Razor\src\Microsoft.VisualStudioCode.RazorExtension\Microsoft.VisualStudioCode.RazorExtension.csproj -c Debug
+```
+
+The generated workspace points at:
+
+```text
+artifacts\bin\Microsoft.CodeAnalysis.LanguageServer\<Configuration>\net10.0\Microsoft.CodeAnalysis.LanguageServer.dll
+artifacts\bin\Microsoft.VisualStudioCode.RazorExtension\<Configuration>\net10.0
+```
+
+The Razor extension project has a local-only post-build target that copies its companion assemblies into that output folder for manual testing. That target is gated off in CI.
+
+## Generated workspace shape
+
+The script writes a workspace like this:
+
+```json
+{
+  "folders": [
+    {
+      "path": "C:\\path\\to\\project"
+    }
+  ],
+  "settings": {
+    "dotnet.server.path": "D:\\repo\\artifacts\\bin\\Microsoft.CodeAnalysis.LanguageServer\\Debug\\net10.0\\Microsoft.CodeAnalysis.LanguageServer.dll",
+    "dotnet.server.componentPaths": {
+      "razorExtension": "D:\\repo\\artifacts\\bin\\Microsoft.VisualStudioCode.RazorExtension\\Debug\\net10.0"
+    }
+  }
+}
+```
+
+## Troubleshooting
+
+If VS Code starts but Razor does not behave correctly, inspect the latest C# LSP trace log:
+
+```text
+C:\Users\<user>\AppData\Roaming\Code\logs\<latest>\window*\exthost\ms-dotnettools.csharp\C# LSP Trace Logs.log
+```
+
+Useful checks:
+- Success markers:
+  - `Razor extension startup finished.`
+  - `textDocument/selectionRange`
+  - other `razor/log` activity for the opened `.razor` file
+- Failure markers:
+  - `FileNotFoundException`
+  - `Could not load file or assembly`
+  - `No method by the name 'razor/documentClosed' is found`
+
+## Example follow-up
+
+If the user asks to re-open the same local-test workspace after rebuilding, rerun:
+
+```powershell
+.\.github\skills\run-vscode-local-testing\scripts\Start-LocalVsCode.ps1 `
+  -ProjectPath C:\path\to\project `
+  -SkipBuild
+```

--- a/.github/skills/run-vscode-local-testing/scripts/Start-LocalVsCode.ps1
+++ b/.github/skills/run-vscode-local-testing/scripts/Start-LocalVsCode.ps1
@@ -1,0 +1,173 @@
+<#
+.SYNOPSIS
+Creates a VS Code workspace for local Roslyn and Razor manual testing and optionally launches VS Code.
+
+.DESCRIPTION
+Builds the local language server and Razor extension outputs, writes a .code-workspace file that points
+the C# extension at those local bits, and launches VS Code against a chosen project folder.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ProjectPath,
+
+    [ValidateSet('Debug', 'Release')]
+    [string]$Configuration = 'Debug',
+
+    [string]$WorkspacePath,
+
+    [switch]$SkipBuild,
+
+    [switch]$NoLaunch,
+
+    [switch]$NewWindow
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-RepositoryRoot {
+    return (Resolve-Path (Join-Path $PSScriptRoot '..\..\..\..')).Path
+}
+
+function Get-AbsolutePath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string]$BasePath
+    )
+
+    if ([System.IO.Path]::IsPathRooted($Path))
+    {
+        return [System.IO.Path]::GetFullPath($Path)
+    }
+
+    return [System.IO.Path]::GetFullPath((Join-Path $BasePath $Path))
+}
+
+function Invoke-DotNetBuild {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ProjectFile,
+
+        [Parameter(Mandatory = $true)]
+        [string]$BuildConfiguration
+    )
+
+    & dotnet build $ProjectFile -c $BuildConfiguration --nologo
+    if ($LASTEXITCODE -ne 0)
+    {
+        throw "Build failed for '$ProjectFile'."
+    }
+}
+
+function Assert-PathExists {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Description
+    )
+
+    if (-not (Test-Path -LiteralPath $Path))
+    {
+        throw "$Description was not found at '$Path'."
+    }
+}
+
+function Get-DefaultWorkspacePath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RepoRoot,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ResolvedProjectPath
+    )
+
+    $projectName = Split-Path -Leaf ($ResolvedProjectPath.TrimEnd('\', '/'))
+    if ([string]::IsNullOrWhiteSpace($projectName))
+    {
+        $projectName = 'local'
+    }
+
+    return Join-Path $RepoRoot "artifacts\$projectName-local-test.code-workspace"
+}
+
+$repoRoot = Get-RepositoryRoot
+$resolvedProjectPath = (Resolve-Path -LiteralPath $ProjectPath).Path
+$resolvedWorkspacePath = if ($WorkspacePath)
+{
+    Get-AbsolutePath -Path $WorkspacePath -BasePath $repoRoot
+}
+else
+{
+    Get-DefaultWorkspacePath -RepoRoot $repoRoot -ResolvedProjectPath $resolvedProjectPath
+}
+
+$languageServerProject = Join-Path $repoRoot 'src\LanguageServer\Microsoft.CodeAnalysis.LanguageServer\Microsoft.CodeAnalysis.LanguageServer.csproj'
+$razorExtensionProject = Join-Path $repoRoot 'src\Razor\src\Razor\src\Microsoft.VisualStudioCode.RazorExtension\Microsoft.VisualStudioCode.RazorExtension.csproj'
+
+if (-not $SkipBuild)
+{
+    Invoke-DotNetBuild -ProjectFile $languageServerProject -BuildConfiguration $Configuration
+    Invoke-DotNetBuild -ProjectFile $razorExtensionProject -BuildConfiguration $Configuration
+}
+
+$languageServerPath = Join-Path $repoRoot "artifacts\bin\Microsoft.CodeAnalysis.LanguageServer\$Configuration\net10.0\Microsoft.CodeAnalysis.LanguageServer.dll"
+$razorExtensionPath = Join-Path $repoRoot "artifacts\bin\Microsoft.VisualStudioCode.RazorExtension\$Configuration\net10.0"
+
+Assert-PathExists -Path $languageServerPath -Description 'Local Roslyn language server'
+Assert-PathExists -Path $razorExtensionPath -Description 'Local Razor VS Code extension output'
+
+$workspaceDirectory = Split-Path -Parent $resolvedWorkspacePath
+if (-not [string]::IsNullOrWhiteSpace($workspaceDirectory))
+{
+    New-Item -ItemType Directory -Path $workspaceDirectory -Force | Out-Null
+}
+
+$workspace = [ordered]@{
+    folders  = @(
+        [ordered]@{
+            path = $resolvedProjectPath
+        }
+    )
+    settings = [ordered]@{
+        'dotnet.server.path' = $languageServerPath
+        'dotnet.server.componentPaths' = [ordered]@{
+            razorExtension = $razorExtensionPath
+        }
+    }
+}
+
+$workspaceJson = $workspace | ConvertTo-Json -Depth 10
+[System.IO.File]::WriteAllText($resolvedWorkspacePath, $workspaceJson + [Environment]::NewLine)
+
+Write-Host "Workspace: $resolvedWorkspacePath"
+Write-Host "Project folder: $resolvedProjectPath"
+Write-Host "Roslyn language server: $languageServerPath"
+Write-Host "Razor extension: $razorExtensionPath"
+
+if ($NoLaunch)
+{
+    return
+}
+
+if (-not (Get-Command code -ErrorAction SilentlyContinue))
+{
+    throw "VS Code command line launcher 'code' was not found on PATH."
+}
+
+$arguments = if ($NewWindow)
+{
+    @($resolvedWorkspacePath)
+}
+else
+{
+    @('--reuse-window', $resolvedWorkspacePath)
+}
+
+Start-Process code -ArgumentList $arguments | Out-Null

--- a/eng/targets/RazorServices.props
+++ b/eng/targets/RazorServices.props
@@ -25,6 +25,7 @@
     <ServiceHubService Include="Microsoft.VisualStudio.Razor.FoldingRange" ClassName="Microsoft.CodeAnalysis.Remote.Razor.RemoteFoldingRangeService+Factory" />
     <ServiceHubService Include="Microsoft.VisualStudio.Razor.SignatureHelp" ClassName="Microsoft.CodeAnalysis.Remote.Razor.RemoteSignatureHelpService+Factory" />
     <ServiceHubService Include="Microsoft.VisualStudio.Razor.DocumentHighlight" ClassName="Microsoft.CodeAnalysis.Remote.Razor.RemoteDocumentHighlightService+Factory" />
+    <ServiceHubService Include="Microsoft.VisualStudio.Razor.SelectionRange" ClassName="Microsoft.CodeAnalysis.Remote.Razor.RemoteSelectionRangeService+Factory" />
     <ServiceHubService Include="Microsoft.VisualStudio.Razor.InlayHint" ClassName="Microsoft.CodeAnalysis.Remote.Razor.RemoteInlayHintService+Factory" />
     <ServiceHubService Include="Microsoft.VisualStudio.Razor.DocumentSymbol" ClassName="Microsoft.CodeAnalysis.Remote.Razor.RemoteDocumentSymbolService+Factory" />
     <ServiceHubService Include="Microsoft.VisualStudio.Razor.GoToDefinition" ClassName="Microsoft.CodeAnalysis.Remote.Razor.RemoteGoToDefinitionService+Factory" />

--- a/src/LanguageServer/Protocol/Handler/SelectionRanges/SelectionRangeHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/SelectionRanges/SelectionRangeHandler.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
@@ -31,14 +32,24 @@ internal sealed class SelectionRangeHandler() : ILspServiceDocumentRequestHandle
         if (document is null)
             return null;
 
+        using var _ = ArrayBuilder<LinePosition>.GetInstance(out var linePositions);
+        foreach (var position in request.Positions)
+        {
+            linePositions.Add(ProtocolConversions.PositionToLinePosition(position));
+        }
+
+        return await GetSelectionRangesAsync(document, linePositions.ToImmutableAndClear(), cancellationToken).ConfigureAwait(false);
+    }
+
+    internal static async Task<SelectionRange[]?> GetSelectionRangesAsync(Document document, ImmutableArray<LinePosition> positions, CancellationToken cancellationToken)
+    {
         var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
         var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
 
         using var _ = ArrayBuilder<SelectionRange>.GetInstance(out var results);
-        foreach (var position in request.Positions)
+        foreach (var position in positions)
         {
-            var linePosition = ProtocolConversions.PositionToLinePosition(position);
-            var absolutePosition = text.Lines.GetPosition(linePosition);
+            var absolutePosition = text.Lines.GetPosition(position);
 
             results.Add(GetSelectionRange(root, text, absolutePosition));
         }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Microsoft.CodeAnalysis.Razor.CohostingShared.projitems
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Microsoft.CodeAnalysis.Razor.CohostingShared.projitems
@@ -40,6 +40,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)RazorSourceGeneratorLocator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rename\CohostRenameEndpoint.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rename\WorkspaceWillRenameEndpoint.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SelectionRanges\CohostSelectionRangeEndpoint.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SignatureHelp\CohostSignatureHelpEndpoint.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FoldingRange\CohostFoldingRangeEndpoint.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Hover\CohostHoverEndpoint.cs" />

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/SelectionRanges/CohostSelectionRangeEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/SelectionRanges/CohostSelectionRangeEndpoint.cs
@@ -1,0 +1,67 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
+using Microsoft.CodeAnalysis.Razor.Cohost;
+using Microsoft.CodeAnalysis.Razor.Remote;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+#pragma warning disable RS0030 // Do not use banned APIs
+[Shared]
+[CohostEndpoint(Methods.TextDocumentSelectionRangeName)]
+[Export(typeof(IDynamicRegistrationProvider))]
+[ExportRazorStatelessLspService(typeof(CohostSelectionRangeEndpoint))]
+[method: ImportingConstructor]
+#pragma warning restore RS0030 // Do not use banned APIs
+internal sealed class CohostSelectionRangeEndpoint(
+    IIncompatibleProjectService incompatibleProjectService,
+    IRemoteServiceInvoker remoteServiceInvoker)
+    : AbstractCohostDocumentEndpoint<SelectionRangeParams, SelectionRange[]?>(incompatibleProjectService), IDynamicRegistrationProvider
+{
+    private readonly IRemoteServiceInvoker _remoteServiceInvoker = remoteServiceInvoker;
+
+    protected override bool MutatesSolutionState => false;
+
+    protected override bool RequiresLSPSolution => true;
+
+    public ImmutableArray<Registration> GetRegistrations(VSInternalClientCapabilities clientCapabilities, RazorCohostRequestContext requestContext)
+    {
+        if (clientCapabilities.TextDocument?.SelectionRange?.DynamicRegistration == true)
+        {
+            return [new Registration
+            {
+                Method = Methods.TextDocumentSelectionRangeName,
+                RegisterOptions = new SelectionRangeRegistrationOptions()
+            }];
+        }
+
+        return [];
+    }
+
+    protected override RazorTextDocumentIdentifier? GetRazorTextDocumentIdentifier(SelectionRangeParams request)
+        => request.TextDocument.ToRazorTextDocumentIdentifier();
+
+    protected override Task<SelectionRange[]?> HandleRequestAsync(SelectionRangeParams request, TextDocument razorDocument, CancellationToken cancellationToken)
+        => HandleRequestAsync(razorDocument, request.Positions, cancellationToken);
+
+    private Task<SelectionRange[]?> HandleRequestAsync(TextDocument razorDocument, Position[] positions, CancellationToken cancellationToken)
+        => _remoteServiceInvoker.TryInvokeAsync<IRemoteSelectionRangeService, SelectionRange[]?>(
+            razorDocument.Project.Solution,
+            (service, solutionInfo, cancellationToken) => service.GetSelectionRangesAsync(solutionInfo, razorDocument.Id, positions, cancellationToken),
+            cancellationToken).AsTask();
+
+    internal TestAccessor GetTestAccessor() => new(this);
+
+    internal readonly struct TestAccessor(CohostSelectionRangeEndpoint instance)
+    {
+        public Task<SelectionRange[]?> HandleRequestAsync(TextDocument razorDocument, Position[] positions, CancellationToken cancellationToken)
+            => instance.HandleRequestAsync(razorDocument, positions, cancellationToken);
+    }
+}

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/IRemoteSelectionRangeService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/IRemoteSelectionRangeService.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+
+namespace Microsoft.CodeAnalysis.Razor.Remote;
+
+internal interface IRemoteSelectionRangeService : IRemoteJsonService
+{
+    ValueTask<SelectionRange[]?> GetSelectionRangesAsync(
+        JsonSerializableRazorPinnedSolutionInfoWrapper solutionInfo,
+        JsonSerializableDocumentId razorDocumentId,
+        Position[] positions,
+        CancellationToken cancellationToken);
+}

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RazorServices.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RazorServices.cs
@@ -42,6 +42,7 @@ internal static class RazorServices
             (typeof(IRemoteSignatureHelpService), null),
             (typeof(IRemoteInlayHintService), null),
             (typeof(IRemoteDocumentSymbolService), null),
+            (typeof(IRemoteSelectionRangeService), null),
             (typeof(IRemoteRenameService), null),
             (typeof(IRemoteGoToImplementationService), null),
             (typeof(IRemoteDiagnosticsService), null),

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SelectionRanges/RemoteSelectionRangeService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SelectionRanges/RemoteSelectionRangeService.cs
@@ -1,0 +1,115 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.PooledObjects;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.Razor.DocumentMapping;
+using Microsoft.CodeAnalysis.Razor.Protocol;
+using Microsoft.CodeAnalysis.Razor.Remote;
+using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Text;
+using ExternalHandlers = Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost.Handlers;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor;
+
+internal sealed class RemoteSelectionRangeService(in ServiceArgs args) : RazorDocumentServiceBase(in args), IRemoteSelectionRangeService
+{
+    internal sealed class Factory : FactoryBase<IRemoteSelectionRangeService>
+    {
+        protected override IRemoteSelectionRangeService CreateService(in ServiceArgs args)
+            => new RemoteSelectionRangeService(in args);
+    }
+
+    public ValueTask<SelectionRange[]?> GetSelectionRangesAsync(
+        JsonSerializableRazorPinnedSolutionInfoWrapper solutionInfo,
+        JsonSerializableDocumentId documentId,
+        Position[] positions,
+        CancellationToken cancellationToken)
+        => RunServiceAsync(
+            solutionInfo,
+            documentId,
+            context => GetSelectionRangesAsync(context, positions, cancellationToken),
+            cancellationToken);
+
+    private async ValueTask<SelectionRange[]?> GetSelectionRangesAsync(
+        RemoteDocumentContext context,
+        Position[] positions,
+        CancellationToken cancellationToken)
+    {
+        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+
+        using var mappedPositions = new PooledArrayBuilder<LinePosition>();
+        foreach (var position in positions)
+        {
+            if (!codeDocument.Source.Text.TryGetAbsoluteIndex(position, out var hostDocumentIndex))
+            {
+                return null;
+            }
+
+            var positionInfo = GetPositionInfo(codeDocument, hostDocumentIndex, preferCSharpOverHtml: true);
+            if (positionInfo.LanguageKind is not RazorLanguageKind.CSharp)
+            {
+                return null;
+            }
+
+            mappedPositions.Add(positionInfo.Position.ToLinePosition());
+        }
+
+        var generatedDocument = await context.Snapshot
+            .GetGeneratedDocumentAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var linePositions = mappedPositions.ToImmutable();
+        var csharpSelectionRanges = await ExternalHandlers.SelectionRanges
+            .GetSelectionRangesAsync(generatedDocument, linePositions, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (csharpSelectionRanges is null)
+        {
+            return null;
+        }
+
+        var csharpDocument = codeDocument.GetRequiredCSharpDocument();
+        using var selectionRanges = new PooledArrayBuilder<SelectionRange>(csharpSelectionRanges.Length);
+        for (var i = 0; i < csharpSelectionRanges.Length; i++)
+        {
+            selectionRanges.Add(MapSelectionRange(csharpDocument, csharpSelectionRanges[i], positions[i], isRoot: true)!);
+        }
+
+        return selectionRanges.ToArray();
+    }
+
+    private SelectionRange? MapSelectionRange(RazorCSharpDocument csharpDocument, SelectionRange? csharpSelectionRange, Position originalPosition, bool isRoot)
+    {
+        if (csharpSelectionRange is null)
+        {
+            return isRoot ? CreateEmptySelectionRange(originalPosition) : null;
+        }
+
+        var mappedParent = MapSelectionRange(csharpDocument, csharpSelectionRange.Parent, originalPosition, isRoot: false);
+        if (!DocumentMappingService.TryMapToRazorDocumentRange(csharpDocument, csharpSelectionRange.Range, out var mappedRange))
+        {
+            return mappedParent;
+        }
+
+        if (mappedParent is not null && mappedParent.Range == mappedRange)
+        {
+            return mappedParent;
+        }
+
+        return new SelectionRange
+        {
+            Range = mappedRange,
+            Parent = mappedParent
+        };
+    }
+
+    private static SelectionRange CreateEmptySelectionRange(Position originalPosition)
+        => new()
+        {
+            Range = LspFactory.CreateRange(originalPosition, originalPosition)
+        };
+}

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SelectionRanges/RemoteSelectionRangeService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SelectionRanges/RemoteSelectionRangeService.cs
@@ -73,13 +73,13 @@ internal sealed class RemoteSelectionRangeService(in ServiceArgs args) : RazorDo
         }
 
         var csharpDocument = codeDocument.GetRequiredCSharpDocument();
-        using var selectionRanges = new PooledArrayBuilder<SelectionRange>(csharpSelectionRanges.Length);
+        var selectionRanges = new SelectionRange[csharpSelectionRanges.Length];
         for (var i = 0; i < csharpSelectionRanges.Length; i++)
         {
-            selectionRanges.Add(MapSelectionRange(csharpDocument, csharpSelectionRanges[i], positions[i], isRoot: true)!);
+            selectionRanges[i] = MapSelectionRange(csharpDocument, csharpSelectionRanges[i], positions[i], isRoot: true)!;
         }
 
-        return selectionRanges.ToArray();
+        return selectionRanges;
     }
 
     private SelectionRange? MapSelectionRange(RazorCSharpDocument csharpDocument, SelectionRange? csharpSelectionRange, Position originalPosition, bool isRoot)

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Microsoft.VisualStudioCode.RazorExtension.csproj
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Microsoft.VisualStudioCode.RazorExtension.csproj
@@ -88,5 +88,29 @@
     </ItemGroup>
   </Target>
 
+  <!-- Copy the Razor companion assemblies into the local build output for manual VS Code testing without affecting CI packaging. -->
+  <Target Name="PopulateLocalDevelopmentOutput" AfterTargets="Build" Condition="'$(ContinuousIntegrationBuild)' != 'true'">
+    <ItemGroup>
+      <_LocalRootOutput Include="
+          $(ArtifactsDir)bin\Microsoft.AspNetCore.Razor.Utilities.Shared\$(Configuration)\$(TargetFramework)\Microsoft.AspNetCore.Razor.Utilities.Shared.dll;
+          $(ArtifactsDir)bin\Microsoft.AspNetCore.Razor.Utilities.Shared\$(Configuration)\$(TargetFramework)\Microsoft.AspNetCore.Razor.Utilities.Shared.xml;
+          $(ArtifactsDir)bin\Microsoft.CodeAnalysis.Razor.Compiler\$(Configuration)\$(TargetFramework)\Microsoft.CodeAnalysis.Razor.Compiler.dll;
+          $(ArtifactsDir)bin\Microsoft.CodeAnalysis.Razor.Compiler\$(Configuration)\$(TargetFramework)\Microsoft.CodeAnalysis.Razor.Compiler.pdb;
+          $(ArtifactsDir)bin\Microsoft.CodeAnalysis.Razor.Workspaces\$(Configuration)\$(TargetFramework)\Microsoft.CodeAnalysis.Razor.Workspaces.dll;
+          $(ArtifactsDir)bin\Microsoft.CodeAnalysis.Razor.Workspaces\$(Configuration)\$(TargetFramework)\Microsoft.CodeAnalysis.Razor.Workspaces.xml;
+          $(ArtifactsDir)bin\Microsoft.CodeAnalysis.Remote.Razor\$(Configuration)\$(TargetFramework)\Microsoft.CodeAnalysis.Remote.Razor.dll;
+          $(ArtifactsDir)bin\Microsoft.CodeAnalysis.Remote.Razor\$(Configuration)\$(TargetFramework)\Microsoft.CodeAnalysis.Remote.Razor.xml" />
+
+    </ItemGroup>
+
+    <Copy
+      SourceFiles="@(_LocalRootOutput)"
+      DestinationFiles="@(_LocalRootOutput->'$(TargetDir)%(Filename)%(Extension)')"
+      SkipUnchangedFiles="true"
+      UseHardlinksIfPossible="$(CreateHardLinksForCopyFilesToOutputDirectoryIfPossible)" />
+
+    <RemoveDir Directories="$(TargetDir)win-arm64;$(TargetDir)win-x64" />
+  </Target>
+
   <Import Project="..\Microsoft.CodeAnalysis.Razor.CohostingShared\Microsoft.CodeAnalysis.Razor.CohostingShared.projitems" Label="Shared" />
 </Project>

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostSelectionRangeEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostSelectionRangeEndpointTest.cs
@@ -1,0 +1,116 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+public sealed class CohostSelectionRangeEndpointTest(ITestOutputHelper testOutputHelper) : CohostEndpointTestBase(testOutputHelper)
+{
+    [Fact]
+    public Task SelectionRanges_CSharpMethodBody()
+        => VerifySelectionRangesAsync(
+            """
+            @code {
+                [|void M()
+                [|{
+                    [|[|var [|x [|= [|[|{|caret:|}1|] + 2|]|]|]|];|]
+                }|]|]
+            }
+            """);
+
+    [Fact]
+    public async Task SelectionRanges_MultiplePositions()
+    {
+        TestCode input =
+            """
+            @code {
+                void M()
+                {
+                    var x = {|caret:|}1;
+                    var y = {|caret:|}2;
+                }
+            }
+            """;
+
+        var results = await GetSelectionRangesAsync(input);
+
+        Assert.NotNull(results);
+        Assert.Equal(2, results!.Length);
+        AssertRangeChainIsNestedCorrectly(results[0]);
+        AssertRangeChainIsNestedCorrectly(results[1]);
+    }
+
+    [Fact]
+    public async Task SelectionRanges_HtmlReturnsNull()
+    {
+        TestCode input =
+            """
+            <div>He{|caret:|}llo</div>
+            """;
+
+        var results = await GetSelectionRangesAsync(input);
+
+        Assert.Null(results);
+    }
+
+    private async Task VerifySelectionRangesAsync(TestCode input)
+    {
+        var results = await GetSelectionRangesAsync(input);
+        Assert.NotNull(results);
+        var result = Assert.Single(results!);
+
+        var chain = new List<LspRange>();
+        for (var current = result; current is not null; current = current.Parent)
+        {
+            chain.Add(current.Range);
+        }
+
+        var sourceText = SourceText.From(input.Text);
+        var expected = input.Spans
+            .Select(sourceText.GetRange)
+            .ToList();
+
+        Assert.Equal(expected, chain);
+    }
+
+    private async Task<SelectionRange[]?> GetSelectionRangesAsync(TestCode input)
+    {
+        var document = CreateProjectAndRazorDocument(input.Text);
+        var sourceText = await document.GetTextAsync(DisposalToken);
+        var positions = input.NamedSpans["caret"].Select(c => sourceText.GetPosition(c.Start)).ToArray();
+
+        var endpoint = new CohostSelectionRangeEndpoint(IncompatibleProjectService, RemoteServiceInvoker);
+
+        return await endpoint.GetTestAccessor().HandleRequestAsync(document, positions, DisposalToken);
+    }
+
+    private static void AssertRangeChainIsNestedCorrectly(SelectionRange selectionRange)
+    {
+        var current = selectionRange;
+        while (current.Parent is not null)
+        {
+            Assert.True(
+                ContainsOrEquals(current.Parent.Range, current.Range),
+                $"Parent range {current.Parent.Range} should contain child range {current.Range}");
+            current = current.Parent;
+        }
+    }
+
+    private static bool ContainsOrEquals(LspRange outer, LspRange inner)
+    {
+        var outerStart = (outer.Start.Line, outer.Start.Character);
+        var outerEnd = (outer.End.Line, outer.End.Character);
+        var innerStart = (inner.Start.Line, inner.Start.Character);
+        var innerEnd = (inner.End.Line, inner.End.Character);
+
+        return outerStart.CompareTo(innerStart) <= 0 && outerEnd.CompareTo(innerEnd) >= 0;
+    }
+}

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests.projitems
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests.projitems
@@ -56,6 +56,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Endpoints\CohostLinkedEditingRangeEndpointTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Endpoints\CohostOnAutoInsertEndpointTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Endpoints\CohostRenameEndpointTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Endpoints\CohostSelectionRangeEndpointTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Endpoints\CohostSemanticTokensRangeEndpointTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Endpoints\CohostSignatureHelpEndpointTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Endpoints\CohostWillRenameEndpointTest.cs" />

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostEndpointTest.cs
@@ -97,6 +97,7 @@ public class CohostEndpointTest(ITestOutputHelper testOutputHelper) : ToolingTes
                 RangeFormatting = new() { DynamicRegistration = true },
                 References = new() { DynamicRegistration = true },
                 Rename = new() { DynamicRegistration = true },
+                SelectionRange = new() { DynamicRegistration = true },
                 SemanticTokens = new() { DynamicRegistration = true },
                 SignatureHelp = new() { DynamicRegistration = true },
                 Synchronization = new() { DynamicRegistration = true },

--- a/src/Tools/ExternalAccess/Razor/Features/Cohost/Handlers/SelectionRanges.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/Cohost/Handlers/SelectionRanges.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost.Handlers;
+
+internal static class SelectionRanges
+{
+    public static Task<SelectionRange[]?> GetSelectionRangesAsync(Document document, ImmutableArray<LinePosition> linePositions, CancellationToken cancellationToken)
+        => SelectionRangeHandler.GetSelectionRangesAsync(document, linePositions, cancellationToken);
+}


### PR DESCRIPTION
Port https://github.com/dotnet/vscode-csharp/issues/7067 to Razor

Also includes some tweaks to fix local use of Razor in VS Code (because all of Roslyn went from package references to project references) and a skill for it too, because we have to deploy both locally built parts now.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83514)