### PR TITLE
Fix compiler crash for badly formed attributes

### DIFF
--- a/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentBindIntegrationTest.cs
+++ b/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentBindIntegrationTest.cs
@@ -97,7 +97,7 @@ namespace Test
     }
 
     [Fact]
-    public void BindToComponent_IncompleteDirectiveAttribute_DoesNotThrow()
+    public void BindToComponent_IncompleteDirectiveAttribute_ReportsDiagnostics()
     {
         AdditionalSyntaxTrees.Add(Parse("""
             using System;
@@ -121,6 +121,17 @@ namespace Test
             <InputText @bind-F
             """);
 
-        Assert.NotEmpty(generated.RazorDiagnostics);
+        Assert.Collection(
+            generated.RazorDiagnostics,
+            diagnostic =>
+            {
+                Assert.Equal("RZ1035", diagnostic.Id);
+                Assert.Equal("Missing close angle for tag helper 'InputText'.", diagnostic.GetMessage(CultureInfo.CurrentCulture));
+            },
+            diagnostic =>
+            {
+                Assert.Equal("RZ1034", diagnostic.Id);
+                Assert.Equal("Found a malformed 'InputText' tag helper. Tag helpers must have a start and end tag or be self closing.", diagnostic.GetMessage(CultureInfo.CurrentCulture));
+            });
     }
 }

--- a/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentBindIntegrationTest.cs
+++ b/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentBindIntegrationTest.cs
@@ -95,4 +95,32 @@ namespace Test
             d => Assert.Equal("RZ2005", d.Id),
             d => Assert.Equal("RZ1011", d.Id));
     }
+
+    [Fact]
+    public void BindToComponent_IncompleteDirectiveAttribute_DoesNotThrow()
+    {
+        AdditionalSyntaxTrees.Add(Parse("""
+            using System;
+            using Microsoft.AspNetCore.Components;
+
+            namespace Test
+            {
+                public class InputText : ComponentBase
+                {
+                    [Parameter]
+                    public string Value { get; set; }
+
+                    [Parameter]
+                    public Action<string> ValueChanged { get; set; }
+                }
+            }
+            """));
+
+        var generated = CompileToCSharp("""
+            @using Test
+            <InputText @bind-F
+            """);
+
+        Assert.NotEmpty(generated.RazorDiagnostics);
+    }
 }

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentBindLoweringPass.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentBindLoweringPass.cs
@@ -1022,6 +1022,11 @@ internal partial class ComponentBindLoweringPass : ComponentIntermediateNodePass
             return IntermediateNodeFactory.CSharpToken(string.Empty);
         }
 
+        if (node.Children.Count == 0)
+        {
+            return IntermediateNodeFactory.CSharpToken(string.Empty);
+        }
+
         return node.Children[0] switch
         {
             // This case can be hit for a 'string' attribute. We want to turn it into an expression.


### PR DESCRIPTION
Fix for https://github.com/microsoft/vscode-dotnettools/issues/3027 and https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2853453
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83516)