### PR TITLE
Allow C# code actions in Razor to affect more than one file

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/CSharp/CSharpCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/CSharp/CSharpCodeActionResolver.cs
@@ -1,21 +1,23 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Razor.Formatting;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Settings;
 
 namespace Microsoft.CodeAnalysis.Razor.CodeActions;
 
-internal class CSharpCodeActionResolver(IRazorFormattingService razorFormattingService, IClientSettingsManager clientSettingsManager) : ICSharpCodeActionResolver
+internal abstract class CSharpCodeActionResolver(IRazorFormattingService razorFormattingService, IClientSettingsManager clientSettingsManager, IFilePathService filePathService) : ICSharpCodeActionResolver
 {
     private readonly IRazorFormattingService _razorFormattingService = razorFormattingService;
     private readonly IClientSettingsManager _clientSettingsManager = clientSettingsManager;
+    private readonly IFilePathService _filePathService = filePathService;
 
     public string Action => LanguageServerConstants.CodeActions.Default;
 
@@ -30,52 +32,52 @@ internal class CSharpCodeActionResolver(IRazorFormattingService razorFormattingS
             return codeAction;
         }
 
-        if (codeAction.Edit.DocumentChanges.Value.Count() != 1)
+        var snapshot = documentContext.Snapshot;
+        var formattingOptions = _clientSettingsManager.GetClientSettings().ToRazorFormattingOptions();
+
+        foreach (var textDocumentEdit in codeAction.Edit.EnumerateTextDocumentEdits())
         {
-            // We don't yet support multi-document code actions, return original code action
-            return codeAction;
-        }
+            cancellationToken.ThrowIfCancellationRequested();
 
-        cancellationToken.ThrowIfCancellationRequested();
+            var generatedDocumentUri = textDocumentEdit.TextDocument.DocumentUri.GetRequiredParsedUri();
 
-        var documentChanged = codeAction.Edit.DocumentChanges.Value.First();
-        if (!documentChanged.TryGetFirst(out var textDocumentEdit))
-        {
-            // Only Text Document Edit changes are supported currently, return original code action
-            return codeAction;
-        }
-
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var csharpSourceText = await documentContext.GetCSharpSourceTextAsync(cancellationToken).ConfigureAwait(false);
-        var csharpTextChanges = textDocumentEdit.Edits.SelectAsArray(e => csharpSourceText.GetTextChange((TextEdit)e));
-
-        // Remaps the text edits from the generated C# to the razor file,
-        // as well as applying appropriate formatting.
-        var formattedChange = await _razorFormattingService.TryGetCSharpCodeActionEditAsync(
-            documentContext,
-            csharpTextChanges,
-            _clientSettingsManager.GetClientSettings().ToRazorFormattingOptions(),
-            cancellationToken).ConfigureAwait(false);
-
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var sourceText = await documentContext.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
-        var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier()
-        {
-            DocumentUri = new(documentContext.Uri)
-        };
-        codeAction.Edit = new WorkspaceEdit()
-        {
-            DocumentChanges = new TextDocumentEdit[] {
-                new TextDocumentEdit()
-                {
-                    TextDocument = codeDocumentIdentifier,
-                    Edits = formattedChange is { } change ? [sourceText.GetTextEdit(change)] : [],
-                }
+            // If Roslyn wants to edit a random .cs file, then who are we to interfere
+            if (!_filePathService.IsVirtualCSharpFile(generatedDocumentUri))
+            {
+                continue;
             }
-        };
+
+            var editDocumentContext = await CreateDocumentContextAsync(snapshot, generatedDocumentUri, cancellationToken).ConfigureAwait(false);
+            if (editDocumentContext is null)
+            {
+                continue;
+            }
+
+            var csharpSourceText = await editDocumentContext.GetCSharpSourceTextAsync(cancellationToken).ConfigureAwait(false);
+            var csharpTextChanges = textDocumentEdit.Edits.SelectAsArray(e => csharpSourceText.GetTextChange((TextEdit)e));
+
+            // Remaps the text edits from the generated C# to the razor file,
+            // as well as applying appropriate formatting.
+            var formattedChange = await _razorFormattingService.TryGetCSharpCodeActionEditAsync(
+                editDocumentContext,
+                csharpTextChanges,
+                formattingOptions,
+                cancellationToken).ConfigureAwait(false);
+
+            if (formattedChange is { } change)
+            {
+                var sourceText = await editDocumentContext.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
+                textDocumentEdit.TextDocument = new() { DocumentUri = new(editDocumentContext.Uri) };
+                textDocumentEdit.Edits = [sourceText.GetTextEdit(change)];
+            }
+            else
+            {
+                textDocumentEdit.Edits = [];
+            }
+        }
 
         return codeAction;
     }
+
+    protected abstract Task<DocumentContext?> CreateDocumentContextAsync(IDocumentSnapshot originDocumentSnapshot, Uri generatedDocumentUri, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/CSharp/CSharpCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/CSharp/CSharpCodeActionResolver.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Razor.Formatting;
+using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
@@ -13,11 +14,12 @@ using Microsoft.CodeAnalysis.Razor.Workspaces.Settings;
 
 namespace Microsoft.CodeAnalysis.Razor.CodeActions;
 
-internal abstract class CSharpCodeActionResolver(IRazorFormattingService razorFormattingService, IClientSettingsManager clientSettingsManager, IFilePathService filePathService) : ICSharpCodeActionResolver
+internal abstract class CSharpCodeActionResolver(IRazorFormattingService razorFormattingService, IClientSettingsManager clientSettingsManager, IFilePathService filePathService, ILoggerFactory loggerFactory) : ICSharpCodeActionResolver
 {
     private readonly IRazorFormattingService _razorFormattingService = razorFormattingService;
     private readonly IClientSettingsManager _clientSettingsManager = clientSettingsManager;
     private readonly IFilePathService _filePathService = filePathService;
+    private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<CSharpCodeActionResolver>();
 
     public string Action => LanguageServerConstants.CodeActions.Default;
 
@@ -50,6 +52,7 @@ internal abstract class CSharpCodeActionResolver(IRazorFormattingService razorFo
             var editDocumentContext = await CreateDocumentContextAsync(snapshot, generatedDocumentUri, cancellationToken).ConfigureAwait(false);
             if (editDocumentContext is null)
             {
+                _logger.LogWarning($"Could not create document context for {generatedDocumentUri} processing {codeAction.Title}, so leaving original edit in place.");
                 continue;
             }
 
@@ -72,6 +75,7 @@ internal abstract class CSharpCodeActionResolver(IRazorFormattingService razorFo
             }
             else
             {
+                _logger.LogWarning($"Formatting dropped all C# code edits for {codeAction.Title} in {editDocumentContext.Uri}");
                 textDocumentEdit.Edits = [];
             }
         }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/RemoteServices.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/RemoteServices.cs
@@ -1,15 +1,21 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.CodeAnalysis.Razor.CodeActions;
 using Microsoft.CodeAnalysis.Razor.CodeActions.Razor;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.Formatting;
 using Microsoft.CodeAnalysis.Razor.Logging;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Settings;
+using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor.CodeActions;
 
@@ -133,7 +139,35 @@ internal sealed class OOPSortAndConsolidateUsingsCodeActionResolver : SortAndCon
 
 [Export(typeof(ICSharpCodeActionResolver)), Shared]
 [method: ImportingConstructor]
-internal sealed class OOPCSharpCodeActionResolver(IRazorFormattingService razorFormattingService, IClientSettingsManager clientSettingsManager) : CSharpCodeActionResolver(razorFormattingService, clientSettingsManager);
+internal sealed class OOPCSharpCodeActionResolver(
+    IRazorFormattingService razorFormattingService,
+    IClientSettingsManager clientSettingsManager,
+    IFilePathService filePathService,
+    RemoteSnapshotManager snapshotManager)
+    : CSharpCodeActionResolver(razorFormattingService, clientSettingsManager, filePathService)
+{
+    private readonly RemoteSnapshotManager _snapshotManager = snapshotManager;
+
+    protected override async Task<DocumentContext?> CreateDocumentContextAsync(IDocumentSnapshot originDocumentSnapshot, Uri generatedDocumentUri, CancellationToken cancellationToken)
+    {
+        if (originDocumentSnapshot is not RemoteDocumentSnapshot remoteDocumentSnapshot)
+        {
+            throw new InvalidOperationException($"{nameof(OOPCSharpCodeActionResolver)} can only be used with {nameof(RemoteDocumentSnapshot)} instances.");
+        }
+
+        var razorDocument = await _snapshotManager.TryGetRazorDocumentAsync(
+            remoteDocumentSnapshot.TextDocument.Project.Solution,
+            generatedDocumentUri,
+            cancellationToken).ConfigureAwait(false);
+        if (razorDocument is null)
+        {
+            return null;
+        }
+
+        var razorDocumentSnapshot = _snapshotManager.GetSnapshot(razorDocument);
+        return new RemoteDocumentContext(razorDocument.CreateUri(), razorDocumentSnapshot);
+    }
+}
 
 [Export(typeof(ICSharpCodeActionResolver)), Shared]
 [method: ImportingConstructor]

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/RemoteServices.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/RemoteServices.cs
@@ -143,8 +143,9 @@ internal sealed class OOPCSharpCodeActionResolver(
     IRazorFormattingService razorFormattingService,
     IClientSettingsManager clientSettingsManager,
     IFilePathService filePathService,
-    RemoteSnapshotManager snapshotManager)
-    : CSharpCodeActionResolver(razorFormattingService, clientSettingsManager, filePathService)
+    RemoteSnapshotManager snapshotManager,
+    ILoggerFactory loggerFactory)
+    : CSharpCodeActionResolver(razorFormattingService, clientSettingsManager, filePathService, loggerFactory)
 {
     private readonly RemoteSnapshotManager _snapshotManager = snapshotManager;
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteSnapshotManager.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteSnapshotManager.cs
@@ -49,4 +49,16 @@ internal sealed class RemoteSnapshotManager(IFilePathService filePathService, IT
         var snapshot = GetSnapshot(project);
         return snapshot.TryGetCodeDocumentForGeneratedDocumentAsync(identity, cancellationToken);
     }
+
+    public Task<TextDocument?> TryGetRazorDocumentAsync(Solution solution, Uri generatedDocumentUri, CancellationToken cancellationToken)
+    {
+        if (!solution.TryGetSourceGeneratedDocumentIdentity(generatedDocumentUri, out var identity) ||
+            !solution.TryGetProject(identity.DocumentId.ProjectId, out var project))
+        {
+            return SpecializedTasks.Null<TextDocument>();
+        }
+
+        var snapshot = GetSnapshot(project);
+        return snapshot.TryGetRazorDocumentForGeneratedDocumentAsync(identity, cancellationToken);
+    }
 }

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/GenerateConstructorTests.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/GenerateConstructorTests.cs
@@ -11,6 +11,10 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost.CodeActions;
 
 public class GenerateConstructorTests(ITestOutputHelper testOutputHelper) : CohostCodeActionsEndpointTestBase(testOutputHelper)
 {
+    private const int FieldActionIndex = 0;
+    private const int PropertyActionIndex = 1;
+    private const int NoFieldActionIndex = 2;
+
     [Fact]
     public async Task GenerateConstructor_FromCodeBlock_ExistingCodeBlock()
     {
@@ -166,6 +170,288 @@ public class GenerateConstructorTests(ITestOutputHelper testOutputHelper) : Coho
     }
 
     [Fact]
+    public async Task GenerateConstructor_FromRazor_InOtherFile()
+    {
+        await VerifyCodeActionAsync(
+            input: """
+                @code {
+                    private Helper M(int value)
+                    {
+                        return new [||]Helper(value);
+                    }
+                }
+                """,
+            expected: """
+                @code {
+                    private Helper M(int value)
+                    {
+                        return new Helper(value);
+                    }
+                }
+                """,
+            additionalFiles:
+            [
+                (FilePath("Helper.cs"), """
+                    namespace SomeProject;
+
+                    public class Helper
+                    {
+                    }
+                    """)
+            ],
+            additionalExpectedFiles:
+            [
+                (FileUri("Helper.cs"), """
+                    namespace SomeProject;
+
+                    public class Helper
+                    {
+                        private int value;
+
+                        public Helper(int value)
+                        {
+                            this.value = value;
+                        }
+                    }
+                    """)
+            ],
+            codeActionName: RazorPredefinedCodeFixProviderNames.GenerateConstructor,
+            codeActionIndex: FieldActionIndex,
+            makeDiagnosticsRequest: true);
+    }
+
+    [Fact]
+    public async Task GenerateConstructor_FromRazor_InOtherFile_Property()
+    {
+        await VerifyCodeActionAsync(
+            input: """
+                @code {
+                    private Helper M(int value)
+                    {
+                        return new [||]Helper(value);
+                    }
+                }
+                """,
+            expected: """
+                @code {
+                    private Helper M(int value)
+                    {
+                        return new Helper(value);
+                    }
+                }
+                """,
+            additionalFiles:
+            [
+                (FilePath("Helper.cs"), """
+                    namespace SomeProject;
+
+                    public class Helper
+                    {
+                    }
+                    """)
+            ],
+            additionalExpectedFiles:
+            [
+                (FileUri("Helper.cs"), """
+                    namespace SomeProject;
+
+                    public class Helper
+                    {
+                        public Helper(int value)
+                        {
+                            Value = value;
+                        }
+
+                        public int Value { get; }
+                    }
+                    """)
+            ],
+            codeActionName: RazorPredefinedCodeFixProviderNames.GenerateConstructor,
+            codeActionIndex: PropertyActionIndex,
+            makeDiagnosticsRequest: true);
+    }
+
+    [Fact]
+    public async Task GenerateConstructor_FromRazor_InOtherFile_NoField()
+    {
+        await VerifyCodeActionAsync(
+            input: """
+                @code {
+                    private Helper M(int value)
+                    {
+                        return new [||]Helper(value);
+                    }
+                }
+                """,
+            expected: """
+                @code {
+                    private Helper M(int value)
+                    {
+                        return new Helper(value);
+                    }
+                }
+                """,
+            additionalFiles:
+            [
+                (FilePath("Helper.cs"), """
+                    namespace SomeProject;
+
+                    public class Helper
+                    {
+                    }
+                    """)
+            ],
+            additionalExpectedFiles:
+            [
+                (FileUri("Helper.cs"), """
+                    namespace SomeProject;
+
+                    public class Helper
+                    {
+                        public Helper(int value)
+                        {
+                        }
+                    }
+                    """)
+            ],
+            codeActionName: RazorPredefinedCodeFixProviderNames.GenerateConstructor,
+            codeActionIndex: NoFieldActionIndex,
+            makeDiagnosticsRequest: true);
+    }
+
+    [Fact]
+    public async Task GenerateConstructor_FromRazor_InOtherRazorFile()
+    {
+        await VerifyCodeActionAsync(
+            input: """
+                @code {
+                    private OtherComponent M(int value)
+                    {
+                        return new [||]OtherComponent(value);
+                    }
+                }
+                """,
+            expected: """
+                @code {
+                    private OtherComponent M(int value)
+                    {
+                        return new OtherComponent(value);
+                    }
+                }
+                """,
+            additionalFiles:
+            [
+                (FilePath("OtherComponent.razor"), """
+                    <div>Hi</div>
+                    """)
+            ],
+            additionalExpectedFiles:
+            [
+                (FileUri("OtherComponent.razor"), """
+                    <div>Hi</div>
+                    @code {
+                        private int value;
+
+                        public OtherComponent(int value)
+                        {
+                            this.value = value;
+                        }
+                    }
+                    """)
+            ],
+            codeActionName: RazorPredefinedCodeFixProviderNames.GenerateConstructor,
+            codeActionIndex: FieldActionIndex,
+            makeDiagnosticsRequest: true);
+    }
+
+    [Fact]
+    public async Task GenerateConstructor_FromRazor_InOtherRazorFile_Property()
+    {
+        await VerifyCodeActionAsync(
+            input: """
+                @code {
+                    private OtherComponent M(int value)
+                    {
+                        return new [||]OtherComponent(value);
+                    }
+                }
+                """,
+            expected: """
+                @code {
+                    private OtherComponent M(int value)
+                    {
+                        return new OtherComponent(value);
+                    }
+                }
+                """,
+            additionalFiles:
+            [
+                (FilePath("OtherComponent.razor"), """
+                    <div>Hi</div>
+                    """)
+            ],
+            additionalExpectedFiles:
+            [
+                (FileUri("OtherComponent.razor"), """
+                    <div>Hi</div>
+                    @code {
+                        public OtherComponent(int value)
+                        {
+                            this.Value = value;
+                        }
+
+                        public int Value { get; }
+                    }
+                    """)
+            ],
+            codeActionName: RazorPredefinedCodeFixProviderNames.GenerateConstructor,
+            codeActionIndex: PropertyActionIndex,
+            makeDiagnosticsRequest: true);
+    }
+
+    [Fact]
+    public async Task GenerateConstructor_FromRazor_InOtherRazorFile_NoField()
+    {
+        await VerifyCodeActionAsync(
+            input: """
+                @code {
+                    private OtherComponent M(int value)
+                    {
+                        return new [||]OtherComponent(value);
+                    }
+                }
+                """,
+            expected: """
+                @code {
+                    private OtherComponent M(int value)
+                    {
+                        return new OtherComponent(value);
+                    }
+                }
+                """,
+            additionalFiles:
+            [
+                (FilePath("OtherComponent.razor"), """
+                    <div>Hi</div>
+                    """)
+            ],
+            additionalExpectedFiles:
+            [
+                (FileUri("OtherComponent.razor"), """
+                    <div>Hi</div>
+                    @code {
+                        public OtherComponent(int value)
+                        {
+                        }
+                    }
+                    """)
+            ],
+            codeActionName: RazorPredefinedCodeFixProviderNames.GenerateConstructor,
+            codeActionIndex: NoFieldActionIndex,
+            makeDiagnosticsRequest: true);
+    }
+
+    [Fact]
     public async Task GenerateConstructor_ForClassInCodeBlock()
     {
         var input = """
@@ -206,7 +492,7 @@ public class GenerateConstructorTests(ITestOutputHelper testOutputHelper) : Coho
             input,
             expected,
             RazorPredefinedCodeFixProviderNames.GenerateConstructor,
-            codeActionIndex: 0,
+            codeActionIndex: FieldActionIndex,
             makeDiagnosticsRequest: true);
     }
 
@@ -239,7 +525,7 @@ public class GenerateConstructorTests(ITestOutputHelper testOutputHelper) : Coho
             input,
             expected,
             RazorPredefinedCodeFixProviderNames.GenerateConstructor,
-            codeActionIndex: 0,
+            codeActionIndex: FieldActionIndex,
             fileKind: RazorFileKind.Legacy,
             makeDiagnosticsRequest: true);
     }

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/GenerateConversionTests.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/GenerateConversionTests.cs
@@ -70,4 +70,56 @@ public class GenerateConversionTests(ITestOutputHelper testOutputHelper) : Cohos
             RazorPredefinedCodeFixProviderNames.GenerateConversion,
             makeDiagnosticsRequest: true);
     }
+
+    [Fact]
+    public async Task GenerateExplicitConversion_FromRazor_InOtherFile()
+    {
+        await VerifyCodeActionAsync(
+            input: """
+                @code {
+                    private int M()
+                    {
+                        var x = new Helper();
+                        return [||](int)x;
+                    }
+                }
+                """,
+            expected: """
+                @code {
+                    private int M()
+                    {
+                        var x = new Helper();
+                        return (int)x;
+                    }
+                }
+                """,
+            additionalFiles:
+            [
+                (FilePath("Helper.cs"), """
+                    namespace SomeProject;
+
+                    public class Helper
+                    {
+                    }
+                    """)
+            ],
+            additionalExpectedFiles:
+            [
+                (FileUri("Helper.cs"), """
+                    using System;
+
+                    namespace SomeProject;
+
+                    public class Helper
+                    {
+                        public static explicit operator int(Helper v)
+                        {
+                            throw new NotImplementedException();
+                        }
+                    }
+                    """)
+            ],
+            codeActionName: RazorPredefinedCodeFixProviderNames.GenerateConversion,
+            makeDiagnosticsRequest: true);
+    }
 }

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/GenerateDeconstructMethodTests.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/GenerateDeconstructMethodTests.cs
@@ -74,4 +74,56 @@ public class GenerateDeconstructMethodTests(ITestOutputHelper testOutputHelper) 
             RazorPredefinedCodeFixProviderNames.GenerateDeconstructMethod,
             makeDiagnosticsRequest: true);
     }
+
+    [Fact]
+    public async Task GenerateDeconstructMethod_FromRazor_InOtherFile()
+    {
+        await VerifyCodeActionAsync(
+            input: """
+                @code {
+                    private void M()
+                    {
+                        var helper = new Helper();
+                        (int x, int y) = [||]helper;
+                    }
+                }
+                """,
+            expected: """
+                @code {
+                    private void M()
+                    {
+                        var helper = new Helper();
+                        (int x, int y) = helper;
+                    }
+                }
+                """,
+            additionalFiles:
+            [
+                (FilePath("Helper.cs"), """
+                    namespace SomeProject;
+
+                    public class Helper
+                    {
+                    }
+                    """)
+            ],
+            additionalExpectedFiles:
+            [
+                (FileUri("Helper.cs"), """
+                    using System;
+
+                    namespace SomeProject;
+
+                    public class Helper
+                    {
+                        internal void Deconstruct(out int x, out int y)
+                        {
+                            throw new NotImplementedException();
+                        }
+                    }
+                    """)
+            ],
+            codeActionName: RazorPredefinedCodeFixProviderNames.GenerateDeconstructMethod,
+            makeDiagnosticsRequest: true);
+    }
 }

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/GenerateFieldTests.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/GenerateFieldTests.cs
@@ -103,6 +103,54 @@ public class GenerateFieldTests(ITestOutputHelper testOutputHelper) : CohostCode
     }
 
     [Fact]
+    public async Task GenerateField_FromRazor_InOtherFile()
+    {
+        await VerifyCodeActionAsync(
+            input: """
+                @code {
+                    private int M()
+                    {
+                        var x = new Helper();
+                        return x.[||]newField;
+                    }
+                }
+                """,
+            expected: """
+                @code {
+                    private int M()
+                    {
+                        var x = new Helper();
+                        return x.newField;
+                    }
+                }
+                """,
+            additionalFiles:
+            [
+                (FilePath("Helper.cs"), """
+                    namespace SomeProject;
+
+                    public class Helper
+                    {
+                    }
+                    """)
+            ],
+            additionalExpectedFiles:
+            [
+                (FileUri("Helper.cs"), """
+                    namespace SomeProject;
+
+                    public class Helper
+                    {
+                        internal int newField;
+                    }
+                    """)
+            ],
+            codeActionName: RazorPredefinedCodeFixProviderNames.GenerateVariable,
+            codeActionIndex: FieldActionIndex,
+            makeDiagnosticsRequest: true);
+    }
+
+    [Fact]
     public async Task GenerateConstField_FromCodeBlock_ExistingCodeBlock()
     {
         var input = """

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/GenerateMethodTests.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/GenerateMethodTests.cs
@@ -375,6 +375,156 @@ public class GenerateMethodTests(ITestOutputHelper testOutputHelper) : CohostCod
     }
 
     [Fact]
+    public async Task GenerateMethod_FromRazor_InOtherFile()
+    {
+        await VerifyCodeActionAsync(
+            input: """
+                @code {
+                    private void M()
+                    {
+                        var x= new Helper();
+                        x.[||]NewMethod();
+                    }
+                }
+                """,
+            expected: """
+                @code {
+                    private void M()
+                    {
+                        var x= new Helper();
+                        x.NewMethod();
+                    }
+                }
+                """,
+            additionalFiles:
+            [
+                (FilePath("Helper.cs"), """
+                    namespace SomeProject;
+
+                    public class Helper
+                    {
+                    }
+                    """)
+            ],
+            additionalExpectedFiles:
+            [
+                (FileUri("Helper.cs"), """
+                    using System;
+
+                    namespace SomeProject;
+
+                    public class Helper
+                    {
+                        internal void NewMethod()
+                        {
+                            throw new NotImplementedException();
+                        }
+                    }
+                    """)
+            ],
+            codeActionName: RazorPredefinedCodeFixProviderNames.GenerateMethod);
+    }
+
+    [Fact]
+    public async Task GenerateMethod_FromRazor_InOtherFile_WithUsing()
+    {
+        await VerifyCodeActionAsync(
+            input: """
+                @using MyOtherProject.Data
+
+                @code {
+                    private void M()
+                    {
+                        var x= new Helper();
+                        x.[||]NewMethod();
+                    }
+                }
+                """,
+            expected: """
+                @using MyOtherProject.Data
+
+                @code {
+                    private void M()
+                    {
+                        var x= new Helper();
+                        x.NewMethod();
+                    }
+                }
+                """,
+            additionalFiles:
+            [
+                (FilePath("Helper.cs"), """
+                    namespace SomeProject;
+
+                    public class Helper
+                    {
+                    }
+                    """)
+            ],
+            additionalExpectedFiles:
+            [
+                (FileUri("Helper.cs"), """
+                    using System;
+
+                    namespace SomeProject;
+
+                    public class Helper
+                    {
+                        internal void NewMethod()
+                        {
+                            throw new NotImplementedException();
+                        }
+                    }
+                    """)
+            ],
+            codeActionName: RazorPredefinedCodeFixProviderNames.GenerateMethod);
+    }
+
+    [Fact]
+    public async Task GenerateMethod_FromRazor_InOtherRazorFile()
+    {
+        await VerifyCodeActionAsync(
+            input: """
+                @code {
+                    private void M()
+                    {
+                        var x= new OtherComponent();
+                        x.[||]NewMethod();
+                    }
+                }
+                """,
+            expected: """
+                @code {
+                    private void M()
+                    {
+                        var x= new OtherComponent();
+                        x.NewMethod();
+                    }
+                }
+                """,
+            additionalFiles:
+            [
+                (FilePath("OtherComponent.razor"), """
+                    <div>Hi</div>
+                    """)
+            ],
+            additionalExpectedFiles:
+            [
+                (FileUri("OtherComponent.razor"), """
+                    @using System
+                    <div>Hi</div>
+                    @code {
+                        internal void NewMethod()
+                        {
+                            throw new NotImplementedException();
+                        }
+                    }
+                    """)
+            ],
+            codeActionName: RazorPredefinedCodeFixProviderNames.GenerateMethod);
+    }
+
+    [Fact]
     public async Task GenerateMethod_Legacy_WithoutFunctionsBlock_CodeBlockBraceOnNextLine()
     {
         ClientSettingsManager.Update(ClientSettingsManager.GetClientSettings().AdvancedSettings with { CodeBlockBraceOnNextLine = true });

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/GeneratePropertyTests.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/GeneratePropertyTests.cs
@@ -69,6 +69,54 @@ public class GeneratePropertyTests(ITestOutputHelper testOutputHelper) : CohostC
     }
 
     [Fact]
+    public async Task GenerateProperty_FromRazor_InOtherFile()
+    {
+        await VerifyCodeActionAsync(
+            input: """
+                @code {
+                    private int M()
+                    {
+                        var x = new Helper();
+                        return x.[||]NewProperty;
+                    }
+                }
+                """,
+            expected: """
+                @code {
+                    private int M()
+                    {
+                        var x = new Helper();
+                        return x.NewProperty;
+                    }
+                }
+                """,
+            additionalFiles:
+            [
+                (FilePath("Helper.cs"), """
+                    namespace SomeProject;
+
+                    public class Helper
+                    {
+                    }
+                    """)
+            ],
+            additionalExpectedFiles:
+            [
+                (FileUri("Helper.cs"), """
+                    namespace SomeProject;
+
+                    public class Helper
+                    {
+                        public int NewProperty { get; internal set; }
+                    }
+                    """)
+            ],
+            codeActionName: RazorPredefinedCodeFixProviderNames.GenerateVariable,
+            codeActionIndex: PropertyActionIndex,
+            makeDiagnosticsRequest: true);
+    }
+
+    [Fact]
     public async Task GenerateProperty_Legacy_WithoutFunctionsBlock()
     {
         var input = """

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/GenerateTypeTests.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/GenerateTypeTests.cs
@@ -137,6 +137,54 @@ public class GenerateTypeTests(ITestOutputHelper testOutputHelper) : CohostCodeA
             makeDiagnosticsRequest: true);
 
     [Fact]
+    public Task GenerateType_FromRazor_InOtherFile()
+        => VerifyCodeActionAsync(
+            input: """
+                @code {
+                    private object M()
+                    {
+                        return new Helper.[||]NestedType();
+                    }
+                }
+                """,
+            expected: """
+                @code {
+                    private object M()
+                    {
+                        return new Helper.NestedType();
+                    }
+                }
+                """,
+            additionalFiles:
+            [
+                (FilePath("Helper.cs"), """
+                    namespace SomeProject;
+
+                    public class Helper
+                    {
+                    }
+                    """)
+            ],
+            additionalExpectedFiles:
+            [
+                (FileUri("Helper.cs"), """
+                    namespace SomeProject;
+
+                    public class Helper
+                    {
+                        internal class NestedType
+                        {
+                            public NestedType()
+                            {
+                            }
+                        }
+                    }
+                    """)
+            ],
+            codeActionName: RazorPredefinedCodeFixProviderNames.GenerateType,
+            makeDiagnosticsRequest: true);
+
+    [Fact]
     public Task GenerateType_WithoutCodeBlock()
         => VerifyCodeActionAsync(
             input: """


### PR DESCRIPTION
While I was recording a demo for the showcase, I noticed a bug with Generate Method, and it turns out that our CSharpCodeActionResolver only ever supported changes to a single document, and just assumed that document was the Razor file it was being run for. With the new code actions, that isn't true.

This PR simply updates what the resolver did to being done in a loop, and otherwise let edits for documents we don't understand through to the IDE. Also adds a bunch of tests, mainly to prevent regressions.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83524)