### PR TITLE
Port CodeStyle CSharp UnitTests to multi-target net10.0 and net472

### DIFF
--- a/docs/infrastructure/port-tests-to-unix.md
+++ b/docs/infrastructure/port-tests-to-unix.md
@@ -1,0 +1,121 @@
+## Goal
+
+Remove unnecessary .NET Framework / Windows restrictions from test methods so they run on .NET Core (net9.0) and non-Windows platforms.
+
+## Condition Types
+
+These test attributes are used to restrict tests to .NET Framework + Windows:
+
+| Attribute | Meaning |
+|-----------|---------|
+| `[ConditionalFact(typeof(DesktopOnly))]` | Skips on .NET Core |
+| `[ConditionalTheory(typeof(DesktopOnly))]` | Skips on .NET Core (parameterized) |
+| `[ConditionalFact(typeof(WindowsOnly))]` | Skips on non-Windows |
+| `[ConditionalTheory(typeof(WindowsOnly))]` | Skips on non-Windows (parameterized) |
+| `[ConditionalFact(typeof(WindowsDesktopOnly))]` | Skips on non-Windows AND non-Desktop |
+| `[ConditionalTheory(typeof(WindowsDesktopOnly))]` | Skips on non-Windows AND non-Desktop (parameterized) |
+
+The name of the type passed into these attributes describes the behavior of the condition. For example, `DesktopOnly` means the test will only run on .NET Framework, and `WindowsOnly` means the test will only run on Windows.
+
+When adding a `Conditional*` attribute to a test, include a concise reason for the restriction in the attribute's Reason message:
+
+```csharp
+[ConditionalFact(typeof(WindowsOnly), Reason = "Mixed line endings cause failures on Unix")]
+```
+
+## Key Types and Patterns
+
+```csharp
+// Mark a test as Windows-only
+[ConditionalFact(typeof(WindowsOnly))]
+public void SomeWindowsSpecificTest() { ... }
+
+[ConditionalTheory(typeof(WindowsOnly))]
+[InlineData(...)]
+public void SomeWindowsSpecificTheory(...) { ... }
+
+// Cross-platform path handling
+var tempPath = Path.GetTempPath();
+var path = Path.Combine(tempPath, "subdir", "file.txt");
+var rootedPath = TestPathUtil.GetRootedPath("temp", "subdir", "file.txt");
+
+// Platform checks
+if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+{
+    // Windows-specific logic
+}
+else
+{
+    // Unix logic  
+}
+
+// Existing utility
+ExecutionConditionUtil.IsWindows
+```
+
+## Porting Strategies
+
+### NativePdbRequiresDesktop
+
+Many tests are marked `WindowsOnly` with reason `NativePdbRequiresDesktop`. These tests use native PDB writing which only works on Windows with the native SymWriter COM component.
+
+**How to port:** Check if the test actually *requires* native PDB format. If the test:
+- Uses `EmitOptions` with `DebugInformationFormat.Pdb` → Try changing to `DebugInformationFormat.PortablePdb`
+- Explicitly tests native PDB writer behavior (SymWriter errors, WinMdExp data) → **Cannot port, leave as-is**
+- Tests general PDB content (sequence points, scopes, etc.) → Likely portable-PDB compatible
+
+### NoPiaNeedsDesktop
+
+Tests marked with `NoPiaNeedsDesktop` use COM interop / NoPIA embedding features.
+
+**How to port:** These typically **cannot be ported**. NoPIA is a desktop-only feature. Mark these as "skipped - genuine restriction" in the actions log.
+
+### Simple Desktop restriction with no specific reason
+
+Tests with just `ConditionalFact(typeof(DesktopOnly))` or `ConditionalFact(typeof(WindowsOnly))` without a specific skip reason may have been conservatively restricted.
+
+**How to port:** 
+1. Read the test carefully
+2. Check if it uses any desktop-specific APIs (AppDomain, COM, Registry, etc.)
+3. If not, simply change the attribute to `[Fact]` or `[Theory]`
+4. If it uses Windows paths, check if those are test-input strings vs actual filesystem access
+
+### TestExecutionNeedsDesktopTypes
+
+Tests that depend on types only available in .NET Framework.
+
+**How to port:** Usually **cannot be ported**. Check what specific types are needed.
+
+### Hardcoded Windows paths
+
+Tests that use hardcoded Windows paths (e.g., `C:\temp\file.txt`) may fail on non-Windows platforms.
+
+**How to port:** 
+1. Get a cross-platform path:
+   - For full paths use `TestPathUtil.GetRootedPath("temp", "file.txt")`
+   - For relative paths, use `Path.Combine("temp", "file.txt")`
+2. Update all paths in the test to use cross-platform patterns
+
+### Mixed Unix (\r) and Windows (\r\n) line endings
+
+Tests that fail because the content in `Assert` statements has different line endings on Windows vs Unix.
+
+**How to port:**
+1. Use the extension methods in `StringExtensions` (`src/Compilers/Test/Core/FX/StringExtensions.cs`) to normalize line endings 
+  - NormalizeLineEndings() to convert all line endings to `\r\n`
+  - ReplaceLineEndings to replace all line endings with a specific one. If explicit is omitted it will use the current OS line ending.
+
+## Testing
+
+After modifying tests, run them on .NET Core:
+
+```bash
+dotnet test src/Compilers/CSharp/Test/Emit2/Microsoft.CodeAnalysis.CSharp.Emit2.UnitTests.csproj -f net10.0 --filter "FullyQualifiedName~ClassName.MethodName" --nologo -v minimal --blame-hang --blame-hang-timeout 5min
+```
+
+## Rules
+
+1. **Never remove a restriction that is genuinely needed** — if a test truly requires native PDB or NoPIA, leave it
+2. **Minimal changes only** — change the attribute, fix the test if needed, nothing more
+3. **One class at a time** — port all methods in a class, test, commit
+4. **If unsure, leave it** — mark as skipped with a note explaining why

--- a/src/Analyzers/CSharp/Tests/MakeFieldReadonly/MakeFieldReadonlyTests.cs
+++ b/src/Analyzers/CSharp/Tests/MakeFieldReadonly/MakeFieldReadonlyTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.MakeFieldReadonly;
 public sealed class MakeFieldReadonlyTests(ITestOutputHelper logger)
     : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest_NoEditor(logger)
 {
-    private static readonly ParseOptions s_strictFeatureFlag = CSharpParseOptions.Default.WithFeatures([KeyValuePair.Create("strict", "true")]);
+    private static readonly ParseOptions s_strictFeatureFlag = CSharpParseOptions.Default.WithFeatures([new KeyValuePair<string, string>("strict", "true")]);
 
     private const string s_inlineArrayAttribute = """
         namespace System.Runtime.CompilerServices

--- a/src/CodeStyle/CSharp/Tests/Microsoft.CodeAnalysis.CSharp.CodeStyle.UnitTests.csproj
+++ b/src/CodeStyle/CSharp/Tests/Microsoft.CodeAnalysis.CSharp.CodeStyle.UnitTests.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.CodeAnalysis.CSharp</RootNamespace>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>$(NetRoslyn);net472</TargetFrameworks>
     <DefineConstants>$(DefineConstants),CODE_STYLE</DefineConstants>
 
     <!-- https://github.com/dotnet/roslyn/issues/31412 -->

--- a/src/CodeStyle/Core/Tests/LegacyTestFramework/Microsoft.CodeAnalysis.CodeStyle.LegacyTestFramework.UnitTestUtilities.csproj
+++ b/src/CodeStyle/Core/Tests/LegacyTestFramework/Microsoft.CodeAnalysis.CodeStyle.LegacyTestFramework.UnitTestUtilities.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.CodeAnalysis</RootNamespace>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>$(NetRoslyn);net472</TargetFrameworks>
     <DefineConstants>$(DefineConstants),CODE_STYLE</DefineConstants>
     <IsShipping>false</IsShipping>
     <IsTestUtilityProject>true</IsTestUtilityProject>
@@ -27,8 +27,9 @@
   </ItemGroup>
   <ItemGroup Label="Project References">
     <!-- TODO: Remove the below project references to test utility projects once all analyzer/code fix tests are switched to Microsoft.CodeAnalysis.Testing -->
-    <ProjectReference Include="..\..\..\..\EditorFeatures\TestUtilities\Microsoft.CodeAnalysis.EditorFeatures.Test.Utilities.csproj" />
+    <ProjectReference Include="..\..\..\..\EditorFeatures\TestUtilities\Microsoft.CodeAnalysis.EditorFeatures.Test.Utilities.csproj" Condition="'$(TargetFramework)' == 'net472'" />
     <ProjectReference Include="..\..\..\..\Features\TestUtilities\Microsoft.CodeAnalysis.Features.Test.Utilities.csproj"/>
+    <ProjectReference Include="..\..\..\..\LanguageServer\Protocol.TestUtilities\Microsoft.CodeAnalysis.LanguageServer.Protocol.Test.Utilities.csproj" />
     <ProjectReference Include="..\..\..\..\Compilers\Test\Core\Microsoft.CodeAnalysis.Test.Utilities.csproj" />
     <ProjectReference Include="..\UnitTestUtilities\Microsoft.CodeAnalysis.CodeStyle.UnitTestUtilities.csproj">
       <Aliases>global,CODESTYLE_UTILITIES</Aliases>

--- a/src/CodeStyle/Core/Tests/UnitTestUtilities/Microsoft.CodeAnalysis.CodeStyle.UnitTestUtilities.csproj
+++ b/src/CodeStyle/Core/Tests/UnitTestUtilities/Microsoft.CodeAnalysis.CodeStyle.UnitTestUtilities.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.CodeAnalysis</RootNamespace>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>$(NetRoslyn);net472</TargetFrameworks>
     <DefineConstants>$(DefineConstants),CODE_STYLE</DefineConstants>
     <IsShipping>false</IsShipping>
     <IsTestUtilityProject>true</IsTestUtilityProject>


### PR DESCRIPTION
Multi-target three projects to enable running on .NET Core / Linux:
- Microsoft.CodeAnalysis.CSharp.CodeStyle.UnitTests
- Microsoft.CodeAnalysis.CodeStyle.UnitTestUtilities
- Microsoft.CodeAnalysis.CodeStyle.LegacyTestFramework.UnitTestUtilities

The LegacyTestFramework's reference to EditorFeatures.Test.Utilities (which requires WPF) is conditioned on net472 only. The missing TestDiagnosticAnalyzerDriver dependency is provided by adding a reference to LanguageServer.Protocol.Test.Utilities.

Fixed a KeyValuePair type ambiguity in MakeFieldReadonlyTests caused by the CodeStyle polyfill conflicting with the net10.0 runtime type.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83528)