### PR TITLE
*** WIP *** -- Skip forking dependent compilation trackers for body-only edits

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.TranslationAction_Actions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.TranslationAction_Actions.cs
@@ -25,17 +25,21 @@ internal sealed partial class SolutionCompilationState
             ImmutableArray<DocumentState> oldStates,
             ImmutableArray<DocumentState> newStates) : TranslationAction(oldProjectState, newProjectState)
         {
-            private readonly ImmutableArray<DocumentState> _oldStates = oldStates;
-            private readonly ImmutableArray<DocumentState> _newStates = newStates;
+
+            /// <summary>The document states before the edit.</summary>
+            public ImmutableArray<DocumentState> OldStates { get; } = oldStates;
+
+            /// <summary>The document states after the edit.</summary>
+            public ImmutableArray<DocumentState> NewStates { get; } = newStates;
 
             public override async Task<Compilation> TransformCompilationAsync(Compilation oldCompilation, CancellationToken cancellationToken)
             {
                 var finalCompilation = oldCompilation;
-                for (var i = 0; i < _newStates.Length; i++)
+                for (var i = 0; i < NewStates.Length; i++)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
-                    var newState = _newStates[i];
-                    var oldState = _oldStates[i];
+                    var newState = NewStates[i];
+                    var oldState = OldStates[i];
                     finalCompilation = finalCompilation.ReplaceSyntaxTree(
                         await oldState.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false),
                         await newState.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false));
@@ -56,11 +60,11 @@ internal sealed partial class SolutionCompilationState
             public override TranslationAction? TryMergeWithPrior(TranslationAction priorAction)
             {
                 if (priorAction is TouchDocumentsAction priorTouchAction &&
-                    priorTouchAction._newStates.SequenceEqual(_oldStates))
+                    priorTouchAction.NewStates.SequenceEqual(OldStates))
                 {
                     // As we're merging ourselves with the prior touch action, we want to keep the old project state
                     // that we are translating from.
-                    return new TouchDocumentsAction(priorAction.OldProjectState, NewProjectState, priorTouchAction._oldStates, _newStates);
+                    return new TouchDocumentsAction(priorAction.OldProjectState, NewProjectState, priorTouchAction.OldStates, NewStates);
                 }
 
                 return null;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionCompilationState.cs
@@ -178,28 +178,83 @@ internal sealed partial class SolutionCompilationState
         var newProjectState = stateChange.NewProjectState;
         var projectId = newProjectState.Id;
 
-        var newDependencyGraph = newSolutionState.GetProjectDependencyGraph();
-        var newTrackerMap = CreateCompilationTrackerMap(
-            projectId,
-            newDependencyGraph,
-            static (trackerMap, arg) =>
+        // Optimization: For body-only edits (e.g., typing inside a method body), dependent projects'
+        // compilations are unaffected because the public API surface hasn't changed. In this case,
+        // we can skip forking all dependent trackers (which discards their compilations) and instead
+        // only update the edited project's tracker. This avoids the expensive ToBuilder()/ToImmutable()
+        // cycle on the tracker map and eliminates redundant compilation rebuilds in dependents.
+        var newTrackerMap = _projectIdToTrackerMap;
+        if (forkTracker
+            && translationAction is TranslationAction.TouchDocumentsAction touchAction
+            && IsBodyOnlyChange(touchAction))
+        {
+            if (newTrackerMap.TryGetValue(projectId, out var existingTracker))
             {
-                // If we have a tracker for this project, then fork it as well (along with the
-                // translation action and store it in the tracker map.
-                if (trackerMap.TryGetValue(arg.projectId, out var tracker))
+                newTrackerMap = newTrackerMap.SetItem(projectId, existingTracker.Fork(newProjectState, translationAction));
+            }
+        }
+        else
+        {
+            var newDependencyGraph = newSolutionState.GetProjectDependencyGraph();
+            newTrackerMap = CreateCompilationTrackerMap(
+                projectId,
+                newDependencyGraph,
+                static (trackerMap, arg) =>
                 {
-                    if (!arg.forkTracker)
-                        trackerMap.Remove(arg.projectId);
-                    else
-                        trackerMap[arg.projectId] = tracker.Fork(arg.newProjectState, arg.translationAction);
-                }
-            },
-            (translationAction, forkTracker, projectId, newProjectState),
-            skipEmptyCallback: true);
+                    // If we have a tracker for this project, then fork it as well (along with the
+                    // translation action and store it in the tracker map.
+                    if (trackerMap.TryGetValue(arg.projectId, out var tracker))
+                    {
+                        if (!arg.forkTracker)
+                            trackerMap.Remove(arg.projectId);
+                        else
+                            trackerMap[arg.projectId] = tracker.Fork(arg.newProjectState, arg.translationAction);
+                    }
+                },
+                (translationAction, forkTracker, projectId, newProjectState),
+                skipEmptyCallback: true);
+        }
 
         return this.Branch(
             newSolutionState,
             projectIdToTrackerMap: newTrackerMap);
+    }
+
+    /// <summary>
+    /// Determines whether a <see cref="TranslationAction.TouchDocumentsAction"/> represents a body-only
+    /// change (no change to the public/internal API surface). This forces synchronous tree computation
+    /// for the changed documents to perform the equivalence check.
+    /// </summary>
+    private static bool IsBodyOnlyChange(TranslationAction.TouchDocumentsAction touchAction)
+    {
+        // Access the old and new document states via the action's fields.
+        // We need to compare old vs new syntax trees at the top level.
+        var oldStates = touchAction.OldStates;
+        var newStates = touchAction.NewStates;
+
+        for (var i = 0; i < newStates.Length; i++)
+        {
+            var oldState = oldStates[i];
+            var newState = newStates[i];
+
+            // If either tree source is null (e.g., non-C#/VB document), we can't determine
+            // body-only status. Fall back to the conservative path.
+            if (oldState.TreeSource is null || newState.TreeSource is null)
+                return false;
+
+            if (!oldState.TryGetSyntaxTree(out var oldTree))
+                return false;
+
+            // Force synchronous tree computation. Pay the parse cost upfront to potentially avoid much larger costs downstream.
+            var newTree = newState.GetSyntaxTree(CancellationToken.None);
+
+            // If the trees are NOT equivalent at the top level, this is a top-level change
+            // (e.g., adding/removing/renaming a method). We must fork dependents.
+            if (!newTree.IsEquivalentTo(oldTree, topLevel: true))
+                return false;
+        }
+
+        return true;
     }
 
     /// <summary>


### PR DESCRIPTION
*** This is just an idea that I'm playing with, don't consider this real unless speedometer comes back glaringly happy (which it most definitely won't). ***

On every keystroke, SolutionCompilationState.ForkProject calls CreateCompilationTrackerMap, which converts the entire tracker map to a mutable builder, iterates all trackers, forks every dependent project's tracker (with translate: null), and converts back to immutable. For a solution with N projects, this is O(N) allocations per keystroke even when the edit only changes a method body and has no effect on the public API surface of the edited project.

This change detects body-only edits by comparing the old and new syntax trees at the top level (SyntaxTree.IsEquivalentTo with topLevel: true). When the edit is body-only, we skip CreateCompilationTrackerMap entirely and instead update only the edited project's tracker via ImmutableSegmentedDictionary.SetItem.

Gains:

 - Eliminates O(N) tracker fork allocations per keystroke for the common case (typing inside method bodies)
 - Avoids discarding finalized compilations in dependent projects, preventing wasteful recompilation
 - Avoids unnecessary source generator re-runs and diagnostic reanalysis in dependent projects

Costs:

 - Forces synchronous syntax tree computation for the new document state on the fork path
 - For the old tree, uses TryGetSyntaxTree (zero cost if already computed by IntelliSense; falls back to conservative path if not available)
 - IsEquivalentTo comparison cost (fast for incremental parsing: shared green nodes terminate comparison early)

Risks:

 - If IsEquivalentTo has a bug that reports a top-level change as body-only, dependent projects would retain stale compilations. Mitigated by IsEquivalentTo being a well-tested, long-standing Roslyn API used extensively by EnC and analyzers.
 - Cached _lazyDependentVersion on un-forked trackers becomes stale. This is semantically correct (body-only edits don't change dependent semantics) but any consumer that incorrectly uses DependentVersion as a proxy for "any change happened in the dependency graph" would miss the update.

Notes:

 - Promotes _oldStates/_newStates fields in TouchDocumentsAction to public properties so IsBodyOnlyChange can access them.
 - The conservative fallback (full CreateCompilationTrackerMap) is taken for: non-TouchDocumentsAction translations, documents without cached old trees, non-C#/VB documents, and any top-level structural change.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83542)