### PR TITLE
Increase SharedPools byte buffer from 4KB to 64KB

### DIFF
--- a/src/Workspaces/CoreTest/UtilityTest/SerializableBytesTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/SerializableBytesTests.cs
@@ -203,8 +203,8 @@ public sealed class SerializableBytesTests
     {
         using var expected = new MemoryStream();
         expected.WriteByte(1);
-        expected.SetLength(10000);
-        expected.Position = 10000 - 1;
+        expected.SetLength(SharedPools.ByteBufferSize * 3);
+        expected.Position = SharedPools.ByteBufferSize * 3 - 1;
         expected.WriteByte(2);
         expected.SetLength(SharedPools.ByteBufferSize);
         expected.WriteByte(3);
@@ -213,8 +213,8 @@ public sealed class SerializableBytesTests
 
         using var stream = SerializableBytes.CreateWritableStream();
         stream.WriteByte(1);
-        stream.SetLength(10000);
-        stream.Position = 10000 - 1;
+        stream.SetLength(SharedPools.ByteBufferSize * 3);
+        stream.Position = SharedPools.ByteBufferSize * 3 - 1;
         stream.WriteByte(2);
         stream.SetLength(SharedPools.ByteBufferSize);
         stream.WriteByte(3);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/SharedPools.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/SharedPools.cs
@@ -55,9 +55,9 @@ internal static class SharedPools
     /// </summary>
     public static readonly ObjectPool<byte[]> ByteArray = new(() => new byte[ByteBufferSize], ByteBufferCount);
 
-    // byte pooled memory : 4K * 512 = 2MB
-    public const int ByteBufferSize = 4 * 1024;
-    private const int ByteBufferCount = 512;
+    // byte pooled memory : 64K * 32 = 2MB
+    public const int ByteBufferSize = 64 * 1024;
+    private const int ByteBufferCount = 32;
 
     private static class DefaultBigPool<T> where T : class, new()
     {


### PR DESCRIPTION
The shared byte array pool (`SharedPools.ByteArray`) backs all `SerializableBytes` stream I/O -- `CreateReadableStreamAsync`, `ReadWriteStream`, `VisualStudioMetadataReferenceManager` stream copy, and `TemporaryStorageService` writes. All of these are file or memory-mapped I/O where the OS prefetches aggressively, so `ReadAsync` fills as much of the buffer as it can on every call.

At 4 KB, each `ReadAsync` completion in `CreateReadableStreamAsync` triggers a full async continuation chain including `ExecutionContext.Run` and a `HostExecutionContextSwitcher` allocation on .NET Framework. For a 1 MB file this means ~256 continuations.

Measured impact (file ReadAsync, 630 KB file):

| Buffer size | Completions | Avg bytes/read |
|-------------|-------------|----------------|
| 4 KB | 154 | 4,091 |
| 32 KB | 20 | 31,500 |
| 64 KB | 10 | 63,000 |

Increasing to 64 KB (16x) reduces the number of async completions proportionally while staying under the 85 KB large object heap threshold. The pool count is adjusted from 512 to 32 to maintain the same 2 MB total pool footprint.

Note: this optimization only helps because all consumers of `SharedPools.ByteArray` read from file or memory streams (fast producers). It would not help for pipe or PTY streams where data arrives in small interactive-sized chunks regardless of buffer size.

Other Roslyn I/O buffers already use 32 KB+ (`SourceText.CharBufferSize` = 32K chars, `BlobBuildingStream.ChunkSize` = 32 KB). The 4 KB byte pool was anomalously small.

Guideline: https://aka.ms/vsguideline?pageId=51866&%E2%9C%94-DO-use-appropriately-sized-IO-buffers