### PR TITLE
Skip dot-prefixed directories in file-based app discovery

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/FileBasedProgramsEntryPointDiscoveryTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/FileBasedProgramsEntryPointDiscoveryTests.cs
@@ -167,6 +167,72 @@ public sealed class FileBasedProgramsEntryPointDiscoveryTests : AbstractLanguage
     }
 
     [Fact]
+    public async Task TestDiscovery_DotPrefixedFolders()
+    {
+        // Demonstrate that directories starting with '.' are ignored
+        // tempDir/
+        //   .git/App1.cs
+        //   .vs/App2.cs
+        //   .config/App3.cs
+        //   App4.cs
+
+        var tempDir = _tempRoot.CreateDirectory();
+        DeferDeleteCacheDirectory(tempDir.Path);
+
+        var appText = """
+            #!/usr/bin/env dotnet
+            #:sdk Microsoft.NET.Sdk
+            Console.WriteLine("Hello World");
+            """;
+
+        var gitDir = tempDir.CreateDirectory(".git");
+        var app1File = gitDir.CreateFile("App1.cs").WriteAllText(appText);
+
+        var vsDir = tempDir.CreateDirectory(".vs");
+        var app2File = vsDir.CreateFile("App2.cs").WriteAllText(appText);
+
+        var configDir = tempDir.CreateDirectory(".config");
+        var app3File = configDir.CreateFile("App3.cs").WriteAllText(appText);
+
+        var app4File = tempDir.CreateFile("App4.cs").WriteAllText(appText);
+
+        await using var testLspServer = await CreateDiscoveryTestServerAsync(tempDir.Path);
+
+        var discovery = testLspServer.GetRequiredLspService<FileBasedProgramsEntryPointDiscovery>();
+        AssertSequenceEqualAndStable([app4File.Path], () => discovery.FindEntryPoints(tempDir.Path));
+    }
+
+    [Fact]
+    public async Task TestDiscovery_NestedDotPrefixedFolders()
+    {
+        // Demonstrate that nested directories starting with '.' are also ignored
+        // tempDir/
+        //   subdir/
+        //     .hidden/App1.cs
+        //     App2.cs
+
+        var tempDir = _tempRoot.CreateDirectory();
+        DeferDeleteCacheDirectory(tempDir.Path);
+
+        var appText = """
+            #!/usr/bin/env dotnet
+            #:sdk Microsoft.NET.Sdk
+            Console.WriteLine("Hello World");
+            """;
+
+        var subDir = tempDir.CreateDirectory("subdir");
+        var hiddenDir = subDir.CreateDirectory(".hidden");
+        var app1File = hiddenDir.CreateFile("App1.cs").WriteAllText(appText);
+
+        var app2File = subDir.CreateFile("App2.cs").WriteAllText(appText);
+
+        await using var testLspServer = await CreateDiscoveryTestServerAsync(tempDir.Path);
+
+        var discovery = testLspServer.GetRequiredLspService<FileBasedProgramsEntryPointDiscovery>();
+        AssertSequenceEqualAndStable([app2File.Path], () => discovery.FindEntryPoints(tempDir.Path));
+    }
+
+    [Fact]
     public async Task TestDiscovery_CsprojInCone()
     {
         // Demonstrate csproj-in-cone behavior

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/FileBasedProgramsEntryPointDiscovery.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/FileBasedProgramsEntryPointDiscovery.cs
@@ -45,7 +45,7 @@ internal sealed partial class FileBasedProgramsEntryPointDiscovery(
     private static readonly StringComparer s_pathComparer = StringComparer.OrdinalIgnoreCase;
 
     /// <summary>Directories which are ignored per convention.</summary>
-    /// <remarks>Some conventional directories like '.git' and '.vs' are expected to be marked hidden and will be automatically ignored by discovery.</remarks>
+    /// <remarks>Directories whose name starts with '.' (e.g. '.git', '.vs') are also ignored.</remarks>
     private static readonly SearchValues<string> s_ignoredDirectories = SearchValues.Create([
         "artifacts",
         "bin",
@@ -283,7 +283,8 @@ internal sealed partial class FileBasedProgramsEntryPointDiscovery(
 
         private void VisitDirectory(string directory, DateTimeOffset createdOrModifiedTimeUtc)
         {
-            if (Path.GetFileName(directory.AsSpan()).ContainsAny(s_ignoredDirectories))
+            var directoryName = Path.GetFileName(directory.AsSpan());
+            if (directoryName.StartsWith('.') || directoryName.ContainsAny(s_ignoredDirectories))
                 return;
 
             if (createdOrModifiedTimeUtc < cache.LastWalkTimeUtc)


### PR DESCRIPTION
I missed that directories like `.git` are only marked hidden on Windows, so, on Linux we were doing unnecessary work to search them for entry points.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83547)