### PR TITLE
Set source map for VSCode debugger

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,6 +38,9 @@
     "dotnet.testWindow.disableAutoDiscovery": true,
     "dotnet.testWindow.disableBuildOnRefresh": true,
 	"dotnet.enableWorkspaceBasedDevelopment": false,
+    "csharp.debug.sourceFileMap": {
+        "/_/": "${workspaceFolder}/"
+    },
     "cSpell.words": [
         "darc",
         "Nerdbank",

--- a/docs/compilers/Design/compiler-output-cache-experiment.md
+++ b/docs/compilers/Design/compiler-output-cache-experiment.md
@@ -57,6 +57,31 @@ There are currently two ways to get the feature onto the request:
 
 If both are supplied, the explicit feature flag wins over `ROSLYN_CACHE_PATH`.
 
+## Path mapping for cache reuse and debugging
+
+Useful cache reuse across worktrees generally requires the build to normalize machine-specific source paths.
+Use `PathMap` to map the local checkout root to a stable path that will be identical in every worktree that should share cache entries.
+
+The simplest setup is to put this in a `Directory.Build.props` file at the source root:
+
+```xml
+<Project>
+  <PropertyGroup>
+    <PathMap>$(MSBuildThisFileDirectory)=/_/</PathMap>
+  </PropertyGroup>
+</Project>
+```
+
+Then for VS Code's C# debugger, add this setting to the workspace settings file:
+
+```json
+{
+  "csharp.debug.sourceFileMap": {
+    "/_/": "${workspaceFolder}/"
+  }
+}
+```
+
 ## Cache key
 
 The cache key is based on Roslyn's deterministic compilation key. For a given compilation request, the server computes a deterministic key from inputs such as:


### PR DESCRIPTION
Fixes debugging in VSCode when using the caching compiler.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83550)