### PR TITLE
Flesh out handling of `isExplicitNotNullTest` for union matching

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -4909,8 +4909,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (unionMatchingInputType is not null)
             {
                 bool hasErrors = CheckValidPatternType(node.Right, unionType, inputType, targetType, diagnostics: diagnostics);
-                // https://github.com/dotnet/roslyn/issues/82636: Add test coverage for isExplicitNotNullTest
-                var pattern = new BoundTypePattern(node, typeExpression, isExplicitNotNullTest: false, isUnionMatching: true, inputType: unionMatchingInputType, targetType, hasErrors);
+                var pattern = new BoundTypePattern(node, typeExpression, isExplicitNotNullTest: targetType.SpecialType == SpecialType.System_Object, isUnionMatching: true, inputType: unionMatchingInputType, targetType, hasErrors);
                 return MakeIsPatternExpression(node, operand, pattern.MakeCompilerGenerated(), hasUnionMatching: true, resultType, operandHasErrors, diagnostics);
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -921,7 +921,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     CheckFeatureAvailability(innerExpression, MessageID.IDS_FeatureTypePattern, diagnostics);
 
                 var boundType = (BoundTypeExpression)convertedExpression;
-                bool isExplicitNotNullTest = !hasUnionMatching && boundType.Type.SpecialType == SpecialType.System_Object; // https://github.com/dotnet/roslyn/issues/82636: Add test coverage
+                bool isExplicitNotNullTest = boundType.Type.SpecialType == SpecialType.System_Object;
                 return new BoundTypePattern(node, boundType, isExplicitNotNullTest, isUnionMatching: hasUnionMatching, inputType: unionMatchingInputType ?? inputType, boundType.Type, hasErrors);
             }
         }

--- a/src/Compilers/CSharp/Portable/Binder/UnionMatchingRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UnionMatchingRewriter.cs
@@ -470,7 +470,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             new BoundTypePattern(
                                 result.Syntax,
                                 declaredType: new BoundTypeExpression(result.Syntax, aliasOpt: null, unionType).MakeCompilerGenerated(),
-                                isExplicitNotNullTest: false, // https://github.com/dotnet/roslyn/issues/82636: Is passing 'true' going to make a difference?
+                                isExplicitNotNullTest: false,
                                 isUnionMatching: false,
                                 inputType: unionMatchingInputType,
                                 narrowedType: unionType).MakeCompilerGenerated(),

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
@@ -23,10 +23,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private void LearnFromAnyNullPatterns(
             BoundExpression expression,
+            bool hasUnionMatching,
             BoundPattern pattern)
         {
             int slot = MakeSlot(expression);
-            LearnFromAnyNullPatterns(slot, expression.Type, pattern);
+            LearnFromAnyNullPatterns(slot, expression.Type, hasUnionMatching, pattern);
         }
 
         private void VisitForRewriting(BoundNode node)
@@ -152,14 +153,16 @@ namespace Microsoft.CodeAnalysis.CSharp
         private void LearnFromAnyNullPatterns(
             int inputSlot,
             TypeSymbol inputType,
+            bool hasUnionMatching,
             BoundPattern pattern)
         {
             if (inputSlot <= 0)
                 return;
 
-            // https://github.com/dotnet/roslyn/issues/35041 We only need to do this when we're rewriting, so we
-            // can get information for any nodes in the pattern.
-            VisitForRewriting(pattern);
+            if (hasUnionMatching)
+            {
+                pattern = UnionMatchingRewriter.Rewrite(compilation, pattern);
+            }
 
             switch (pattern)
             {
@@ -200,7 +203,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             {
                                 BoundSubpattern item = rp.Deconstruction[i];
                                 FieldSymbol element = elements[i];
-                                LearnFromAnyNullPatterns(GetOrCreateSlot(element, inputSlot), element.Type, item.Pattern);
+                                LearnFromAnyNullPatterns(GetOrCreateSlot(element, inputSlot), element.Type, hasUnionMatching: false, item.Pattern);
                             }
                         }
 
@@ -211,14 +214,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                             {
                                 if (subpattern.Member is BoundPropertySubpatternMember member)
                                 {
-                                    LearnFromAnyNullPatterns(getExtendedPropertySlot(member, inputSlot), member.Type, subpattern.Pattern);
+                                    LearnFromAnyNullPatterns(getExtendedPropertySlot(member, inputSlot), member.Type, hasUnionMatching: false, subpattern.Pattern);
                                 }
                             }
                         }
                     }
                     break;
                 case BoundNegatedPattern p:
-                    LearnFromAnyNullPatterns(inputSlot, inputType, p.Negated);
+                    LearnFromAnyNullPatterns(inputSlot, inputType, hasUnionMatching: false, p.Negated);
                     break;
                 case BoundBinaryPattern p:
                     // Do not use left recursion because we can have many nested binary patterns.
@@ -227,15 +230,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         // We don't need to visit in order here because we're only moving analysis in one direction:
                         // towards MaybeNull. Visiting the right or left first has no impact on the final state.
-                        LearnFromAnyNullPatterns(inputSlot, inputType, current.Right);
+                        LearnFromAnyNullPatterns(inputSlot, inputType, hasUnionMatching: false, current.Right);
                         if (current.Left is BoundBinaryPattern left)
                         {
                             current = left;
-                            VisitForRewriting(current);
                         }
                         else
                         {
-                            LearnFromAnyNullPatterns(inputSlot, inputType, current.Left);
+                            LearnFromAnyNullPatterns(inputSlot, inputType, hasUnionMatching: false, current.Left);
                             break;
                         }
                     }
@@ -281,7 +283,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     foreach (var label in section.SwitchLabels)
                     {
-                        LearnFromAnyNullPatterns(slot, originalInputType, label.Pattern);
+                        LearnFromAnyNullPatterns(slot, originalInputType, label.HasUnionMatching, label.Pattern);
                     }
                 }
             }
@@ -983,7 +985,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var originalInputType = node.Expression.Type;
                 foreach (var arm in node.SwitchArms)
                 {
-                    LearnFromAnyNullPatterns(slot, originalInputType, arm.Pattern);
+                    LearnFromAnyNullPatterns(slot, originalInputType, arm.HasUnionMatching, arm.Pattern);
                 }
             }
 
@@ -1153,7 +1155,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitIsPatternExpression(BoundIsPatternExpression node)
         {
             Debug.Assert(!IsConditionalState);
-            LearnFromAnyNullPatterns(node.Expression, node.Pattern);
+            LearnFromAnyNullPatterns(node.Expression, node.HasUnionMatching, node.Pattern);
             VisitForRewriting(node.Pattern);
             var hasStateWhenNotNull = VisitPossibleConditionalAccess(node.Expression, out var conditionalStateWhenNotNull);
             var expressionState = ResultType;

--- a/src/Compilers/CSharp/Test/CSharp15/UnionsTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/UnionsTests.cs
@@ -15822,14 +15822,10 @@ class Program
 ";
             var comp = CreateCompilation([src, UnionAttributeSource]);
 
-            // https://github.com/dotnet/roslyn/issues/82636: This is another case of behavior consistent with explicit property patterns. See below
             comp.VerifyDiagnostics(
                 // (100,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
                 //             _ = s switch { int => 1, bool => 3 };
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(100, 19),
-                // (200,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
-                //             _ = s switch { int => 1, bool => 3 };
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(200, 19)
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(100, 19)
                 );
 
             var src2 = @"
@@ -15844,7 +15840,7 @@ class Program
     static void Test2(S1 s)
     {
         _ = s.Value;
-        if (s is  { Value: not int })
+        if (s is not { Value: int })
         {
 #line 1000
             _ = s switch { { Value: {} } => 1 };
@@ -16047,14 +16043,10 @@ class Program
 ";
             var comp = CreateCompilation([src, UnionAttributeSource]);
 
-            // https://github.com/dotnet/roslyn/issues/82636: This is another case of behavior consistent with explicit property patterns. See below
             comp.VerifyDiagnostics(
                 // (100,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
                 //             _ = s switch { int => 1, bool => 3 };
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(100, 19),
-                // (200,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
-                //             _ = s switch { int => 1, bool => 3 };
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(200, 19)
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(100, 19)
                 );
 
             var src2 = @"
@@ -16069,7 +16061,7 @@ class Program
     static void Test2(S1 s)
     {
         _ = s.Value;
-        if (s is  { Value: not 1 })
+        if (s is not { Value: 1 })
         {
 #line 1000
             _ = s switch { { Value: {} } => 1 };
@@ -17130,6 +17122,602 @@ class Program
                 // (400,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.Value.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.Value").WithLocation(400, 13)
+                );
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void NullableAnalysis_46_State_From_isExplicitNotNullTest([CombinatorialValues("int", "System.Int32")] string typeNameSyntax)
+        {
+            var src = @"
+#nullable enable
+
+[System.Runtime.CompilerServices.Union]
+struct S2
+{
+    public S2(int x) => throw null!;
+    public S2(bool x) => throw null!;
+    public object? Value => throw null!;
+}
+
+struct S3
+{
+    public object Value => throw null!;
+}
+
+class Program
+{
+    static void Test1(S2 s)
+    {
+        if (s is " + typeNameSyntax + @") return;
+
+#line 100
+        s.Value.ToString();
+    } 
+
+    static void Test2(S3 s)
+    {
+        if (s is { Value: " + typeNameSyntax + @" }) return;
+
+#line 200
+        s.Value.ToString();
+    } 
+}
+";
+            var comp = CreateCompilation([src, UnionAttributeSource]);
+            comp.VerifyDiagnostics();
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void NullableAnalysis_47_State_From_isExplicitNotNullTest([CombinatorialValues("object", "System.Object")] string typeNameSyntax)
+        {
+            var src = @"
+#nullable enable
+
+[System.Runtime.CompilerServices.Union]
+struct S2
+{
+    public S2(int x) => throw null!;
+    public S2(bool x) => throw null!;
+    public object Value => throw null!;
+}
+
+struct S3
+{
+    public object Value => throw null!;
+}
+
+class Program
+{
+    static void Test1(S2 s)
+    {
+        if (s is " + typeNameSyntax + @") return;
+
+#line 100
+        s.Value.ToString();
+    } 
+
+    static void Test2(S3 s)
+    {
+        if (s is { Value: " + typeNameSyntax + @" }) return;
+
+#line 200
+        s.Value.ToString();
+    } 
+}
+";
+            var comp = CreateCompilation([src, UnionAttributeSource]);
+            comp.VerifyDiagnostics(
+                // (100,9): warning CS8602: Dereference of a possibly null reference.
+                //         s.Value.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.Value").WithLocation(100, 9),
+                // (200,9): warning CS8602: Dereference of a possibly null reference.
+                //         s.Value.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.Value").WithLocation(200, 9)
+                );
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void NullableAnalysis_48_State_From_isExplicitNotNullTest([CombinatorialValues("int", "System.Int32")] string typeNameSyntax)
+        {
+            var src = @"
+#nullable enable
+
+struct S0<T>
+{
+    public T S => default(T)!;
+}
+
+[System.Runtime.CompilerServices.Union]
+struct S2
+{
+    public S2(int x) => throw null!;
+    public S2(bool x) => throw null!;
+    public object? Value => throw null!;
+}
+
+struct S3
+{
+    public object Value => throw null!;
+}
+
+class Program
+{
+    static void Test1(S0<S2> s)
+    {
+        if (s is { S: " + typeNameSyntax + @" }) return;
+
+#line 100
+        s.S.Value.ToString();
+    } 
+
+    static void Test2(S0<S3> s)
+    {
+        if (s is { S.Value: " + typeNameSyntax + @" }) return;
+
+#line 200
+        s.S.Value.ToString();
+    } 
+}
+";
+            var comp = CreateCompilation([src, UnionAttributeSource]);
+            comp.VerifyDiagnostics();
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void NullableAnalysis_49_State_From_isExplicitNotNullTest([CombinatorialValues("object", "System.Object")] string typeNameSyntax)
+        {
+            var src = @"
+#nullable enable
+
+struct S0<T>
+{
+    public T S => default(T)!;
+}
+
+[System.Runtime.CompilerServices.Union]
+struct S2
+{
+    public S2(int x) => throw null!;
+    public S2(bool x) => throw null!;
+    public object Value => throw null!;
+}
+
+struct S3
+{
+    public object Value => throw null!;
+}
+
+class Program
+{
+    static void Test1(S0<S2> s)
+    {
+        if (s is { S: " + typeNameSyntax + @" }) return;
+
+#line 100
+        s.S.Value.ToString();
+    } 
+
+    static void Test2(S0<S3> s)
+    {
+        if (s is { S.Value: " + typeNameSyntax + @" }) return;
+
+#line 200
+        s.S.Value.ToString();
+    } 
+}
+";
+            var comp = CreateCompilation([src, UnionAttributeSource]);
+            comp.VerifyDiagnostics(
+                // (100,9): warning CS8602: Dereference of a possibly null reference.
+                //         s.S.Value.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.S.Value").WithLocation(100, 9),
+                // (200,9): warning CS8602: Dereference of a possibly null reference.
+                //         s.S.Value.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.S.Value").WithLocation(200, 9)
+                );
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void NullableAnalysis_50_State_From_isExplicitNotNullTest([CombinatorialValues("int", "System.Int32")] string typeNameSyntax)
+        {
+            var src = @"
+#nullable enable
+
+[System.Runtime.CompilerServices.Union]
+class S2
+{
+    public S2(int x) => throw null!;
+    public S2(bool x) => throw null!;
+    public object? Value => throw null!;
+}
+
+class S3
+{
+    public object Value => throw null!;
+}
+
+class Program
+{
+    static void Test1(S2 s)
+    {
+        if (s is " + typeNameSyntax + @") return;
+
+#line 100
+        s.Value.ToString();
+    } 
+
+    static void Test2(S3 s)
+    {
+        if (s is { Value: " + typeNameSyntax + @" }) return;
+
+#line 200
+        s.Value.ToString();
+    } 
+}
+";
+            var comp = CreateCompilation([src, UnionAttributeSource]);
+            comp.VerifyDiagnostics();
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void NullableAnalysis_51_State_From_isExplicitNotNullTest([CombinatorialValues("object", "System.Object")] string typeNameSyntax)
+        {
+            var src = @"
+#nullable enable
+
+[System.Runtime.CompilerServices.Union]
+class S2
+{
+    public S2(int x) => throw null!;
+    public S2(bool x) => throw null!;
+    public object Value => throw null!;
+}
+
+class S3
+{
+    public object Value => throw null!;
+}
+
+class Program
+{
+    static void Test1(S2 s)
+    {
+        if (s is " + typeNameSyntax + @") return;
+
+#line 100
+        s.Value.ToString();
+    } 
+
+    static void Test2(S3 s)
+    {
+        if (s is { Value: " + typeNameSyntax + @" }) return;
+
+#line 200
+        s.Value.ToString();
+    } 
+}
+";
+            var comp = CreateCompilation([src, UnionAttributeSource]);
+            comp.VerifyDiagnostics(
+                // (100,9): warning CS8602: Dereference of a possibly null reference.
+                //         s.Value.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.Value").WithLocation(100, 9),
+                // (200,9): warning CS8602: Dereference of a possibly null reference.
+                //         s.Value.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.Value").WithLocation(200, 9)
+                );
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void NullableAnalysis_52_State_From_isExplicitNotNullTest([CombinatorialValues("int", "System.Int32")] string typeNameSyntax)
+        {
+            var src = @"
+#nullable enable
+
+struct S0<T> where T : class
+{
+    public T S => default(T)!;
+}
+
+[System.Runtime.CompilerServices.Union]
+class S2
+{
+    public S2(int x) => throw null!;
+    public S2(bool x) => throw null!;
+    public object? Value => throw null!;
+}
+
+class S3
+{
+    public object Value => throw null!;
+}
+
+class Program
+{
+    static void Test1(S0<S2> s)
+    {
+        if (s is { S: " + typeNameSyntax + @" }) return;
+
+#line 100
+        s.S.Value.ToString();
+    } 
+
+    static void Test2(S0<S3> s)
+    {
+        if (s is { S.Value: " + typeNameSyntax + @" }) return;
+
+#line 200
+        s.S.Value.ToString();
+    } 
+}
+";
+            var comp = CreateCompilation([src, UnionAttributeSource]);
+            comp.VerifyDiagnostics();
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void NullableAnalysis_53_State_From_isExplicitNotNullTest([CombinatorialValues("object", "System.Object")] string typeNameSyntax)
+        {
+            var src = @"
+#nullable enable
+
+struct S0<T> where T : class
+{
+    public T S => default(T)!;
+}
+
+[System.Runtime.CompilerServices.Union]
+class S2
+{
+    public S2(int x) => throw null!;
+    public S2(bool x) => throw null!;
+    public object Value => throw null!;
+}
+
+class S3
+{
+    public object Value => throw null!;
+}
+
+class Program
+{
+    static void Test1(S0<S2> s)
+    {
+        if (s is { S: " + typeNameSyntax + @" }) return;
+
+#line 100
+        s.S.Value.ToString();
+    } 
+
+    static void Test2(S0<S3> s)
+    {
+        if (s is { S.Value: " + typeNameSyntax + @" }) return;
+
+#line 200
+        s.S.Value.ToString();
+    } 
+}
+";
+            var comp = CreateCompilation([src, UnionAttributeSource]);
+            comp.VerifyDiagnostics(
+                // (100,9): warning CS8602: Dereference of a possibly null reference.
+                //         s.S.Value.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.S.Value").WithLocation(100, 9),
+                // (200,9): warning CS8602: Dereference of a possibly null reference.
+                //         s.S.Value.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.S.Value").WithLocation(200, 9)
+                );
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void NullableAnalysis_54_State_From_isExplicitNotNullTest([CombinatorialValues("int", "System.Int32")] string typeNameSyntax)
+        {
+            var src = @"
+#nullable enable
+
+[System.Runtime.CompilerServices.Union]
+struct S2
+{
+    public S2(int x) => throw null!;
+    public S2(bool x) => throw null!;
+    public object? Value => throw null!;
+}
+
+struct S3
+{
+    public object Value => throw null!;
+}
+
+class Program
+{
+    static void Test1(S2? s)
+    {
+        if (s is null) return;
+        if (s is " + typeNameSyntax + @") return;
+
+#line 100
+        s.Value.Value.ToString();
+    } 
+
+    static void Test2(S3? s)
+    {
+        if (s is null) return;
+        if (s is { Value: " + typeNameSyntax + @" }) return;
+
+#line 200
+        s.Value.Value.ToString();
+    } 
+}
+";
+            var comp = CreateCompilation([src, UnionAttributeSource]);
+            comp.VerifyDiagnostics();
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void NullableAnalysis_55_State_From_isExplicitNotNullTest([CombinatorialValues("object", "System.Object")] string typeNameSyntax)
+        {
+            var src = @"
+#nullable enable
+
+[System.Runtime.CompilerServices.Union]
+struct S2
+{
+    public S2(int x) => throw null!;
+    public S2(bool x) => throw null!;
+    public object Value => throw null!;
+}
+
+struct S3
+{
+    public object Value => throw null!;
+}
+
+class Program
+{
+    static void Test1(S2? s)
+    {
+        if (s is null) return;
+        if (s is " + typeNameSyntax + @") return;
+
+#line 100
+        s.Value.Value.ToString();
+    } 
+
+    static void Test2(S3? s)
+    {
+        if (s is null) return;
+        if (s is { Value: " + typeNameSyntax + @" }) return;
+
+#line 200
+        s.Value.Value.ToString();
+    } 
+}
+";
+            var comp = CreateCompilation([src, UnionAttributeSource]);
+            comp.VerifyDiagnostics(
+                // (100,9): warning CS8602: Dereference of a possibly null reference.
+                //         s.Value.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.Value.Value").WithLocation(100, 9),
+                // (200,9): warning CS8602: Dereference of a possibly null reference.
+                //         s.Value.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.Value.Value").WithLocation(200, 9)
+                );
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void NullableAnalysis_56_State_From_isExplicitNotNullTest([CombinatorialValues("int", "System.Int32")] string typeNameSyntax)
+        {
+            var src = @"
+#nullable enable
+
+struct S0<T> where  T : struct
+{
+    public T? S => default(T)!;
+}
+
+[System.Runtime.CompilerServices.Union]
+struct S2
+{
+    public S2(int x) => throw null!;
+    public S2(bool x) => throw null!;
+    public object? Value => throw null!;
+}
+
+struct S3
+{
+    public object Value => throw null!;
+}
+
+class Program
+{
+    static void Test1(S0<S2> s)
+    {
+        if (s.S is null) return;
+        if (s is { S: " + typeNameSyntax + @" }) return;
+
+#line 100
+        s.S.Value.Value.ToString();
+    } 
+
+    static void Test2(S0<S3> s)
+    {
+        if (s.S is null) return;
+        if (s is { S.Value: " + typeNameSyntax + @" }) return;
+
+#line 200
+        s.S.Value.Value.ToString();
+    } 
+}
+";
+            var comp = CreateCompilation([src, UnionAttributeSource]);
+            comp.VerifyDiagnostics();
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void NullableAnalysis_57_State_From_isExplicitNotNullTest([CombinatorialValues("object", "System.Object")] string typeNameSyntax)
+        {
+            var src = @"
+#nullable enable
+
+struct S0<T> where T : struct
+{
+    public T? S => default(T)!;
+}
+
+[System.Runtime.CompilerServices.Union]
+struct S2
+{
+    public S2(int x) => throw null!;
+    public S2(bool x) => throw null!;
+    public object Value => throw null!;
+}
+
+struct S3
+{
+    public object Value => throw null!;
+}
+
+class Program
+{
+    static void Test1(S0<S2> s)
+    {
+        if (s.S is null) return;
+        if (s is { S: " + typeNameSyntax + @" }) return;
+
+#line 100
+        s.S.Value.Value.ToString();
+    } 
+
+    static void Test2(S0<S3> s)
+    {
+        if (s.S is null) return;
+        if (s is { S.Value: " + typeNameSyntax + @" }) return;
+
+#line 200
+        s.S.Value.Value.ToString();
+    } 
+}
+";
+            var comp = CreateCompilation([src, UnionAttributeSource]);
+            comp.VerifyDiagnostics(
+                // (100,9): warning CS8602: Dereference of a possibly null reference.
+                //         s.S.Value.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.S.Value.Value").WithLocation(100, 9),
+                // (200,9): warning CS8602: Dereference of a possibly null reference.
+                //         s.S.Value.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.S.Value.Value").WithLocation(200, 9)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/CSharp15/UnionsTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/UnionsTests.cs
@@ -17606,10 +17606,10 @@ class Program
             var comp = CreateCompilation([src, UnionAttributeSource]);
             comp.VerifyDiagnostics(
                 // (100,9): warning CS8602: Dereference of a possibly null reference.
-                //         s.Value.ToString();
+                //         s.Value.Value.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.Value.Value").WithLocation(100, 9),
                 // (200,9): warning CS8602: Dereference of a possibly null reference.
-                //         s.Value.ToString();
+                //         s.Value.Value.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.Value.Value").WithLocation(200, 9)
                 );
         }
@@ -17713,11 +17713,225 @@ class Program
             var comp = CreateCompilation([src, UnionAttributeSource]);
             comp.VerifyDiagnostics(
                 // (100,9): warning CS8602: Dereference of a possibly null reference.
-                //         s.S.Value.ToString();
+                //         s.S.Value.Value.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.S.Value.Value").WithLocation(100, 9),
                 // (200,9): warning CS8602: Dereference of a possibly null reference.
-                //         s.S.Value.ToString();
+                //         s.S.Value.Value.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.S.Value.Value").WithLocation(200, 9)
+                );
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void NullableAnalysis_58_State_From_isExplicitNotNullTest([CombinatorialValues("int", "System.Int32")] string typeNameSyntax)
+        {
+            var src = @"
+#nullable enable
+
+[System.Runtime.CompilerServices.Union]
+struct S2
+{
+    public S2(int x) => throw null!;
+    public S2(bool x) => throw null!;
+    public object? Value => throw null!;
+}
+
+struct S3
+{
+    public object Value => throw null!;
+}
+
+class Program
+{
+    static void Test1(S2 s)
+    {
+        switch (s)
+        {
+            case " + typeNameSyntax + @": return;
+            default:
+#line 100
+                s.Value.ToString();
+                break;
+        }
+    } 
+
+    static void Test2(S3 s)
+    {
+        switch (s)
+        {
+            case { Value: " + typeNameSyntax + @" }: return;
+            default:
+#line 200
+                s.Value.ToString();
+                break;
+        }
+    } 
+}
+";
+            var comp = CreateCompilation([src, UnionAttributeSource]);
+            comp.VerifyDiagnostics();
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void NullableAnalysis_59_State_From_isExplicitNotNullTest([CombinatorialValues("object", "System.Object")] string typeNameSyntax)
+        {
+            var src = @"
+#nullable enable
+
+[System.Runtime.CompilerServices.Union]
+struct S2
+{
+    public S2(int x) => throw null!;
+    public S2(bool x) => throw null!;
+    public object Value => throw null!;
+}
+
+struct S3
+{
+    public object Value => throw null!;
+}
+
+class Program
+{
+    static void Test1(S2 s)
+    {
+        switch (s)
+        {
+            case " + typeNameSyntax + @": return;
+            default:
+#line 100
+                s.Value.ToString();
+                break;
+        }
+    } 
+
+    static void Test2(S3 s)
+    {
+        switch (s)
+        {
+            case { Value: " + typeNameSyntax + @" }: return;
+            default:
+#line 200
+                s.Value.ToString();
+                break;
+        }
+    } 
+}
+";
+            var comp = CreateCompilation([src, UnionAttributeSource]);
+            comp.VerifyDiagnostics(
+                // (100,17): warning CS8602: Dereference of a possibly null reference.
+                //                 s.Value.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.Value").WithLocation(100, 17),
+                // (200,17): warning CS8602: Dereference of a possibly null reference.
+                //                 s.Value.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.Value").WithLocation(200, 17)
+                );
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void NullableAnalysis_61_State_From_isExplicitNotNullTest([CombinatorialValues("int", "System.Int32")] string typeNameSyntax)
+        {
+            var src = @"
+#nullable enable
+
+[System.Runtime.CompilerServices.Union]
+struct S2
+{
+    public S2(int x) => throw null!;
+    public S2(bool x) => throw null!;
+    public object? Value => throw null!;
+}
+
+struct S3
+{
+    public object Value => throw null!;
+}
+
+class Program
+{
+    static string? Test1(S2 s)
+    {
+        return s switch
+        {
+            " + typeNameSyntax + @" => null,
+            _ =>
+#line 100
+                s.Value.ToString()
+        };
+    } 
+
+    static string? Test2(S3 s)
+    {
+        return s switch
+        {
+            { Value: " + typeNameSyntax + @" } => null,
+            _ =>
+#line 200
+                s.Value.ToString()
+        };
+    } 
+}
+";
+            var comp = CreateCompilation([src, UnionAttributeSource]);
+            comp.VerifyDiagnostics();
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void NullableAnalysis_62_State_From_isExplicitNotNullTest([CombinatorialValues("object", "System.Object")] string typeNameSyntax)
+        {
+            var src = @"
+#nullable enable
+
+[System.Runtime.CompilerServices.Union]
+struct S2
+{
+    public S2(int x) => throw null!;
+    public S2(bool x) => throw null!;
+    public object Value => throw null!;
+}
+
+struct S3
+{
+    public object Value => throw null!;
+}
+
+class Program
+{
+    static string? Test1(S2 s)
+    {
+        return s switch
+        {
+            " + typeNameSyntax + @" => null,
+            _ =>
+#line 100
+                s.Value.ToString()
+        };
+    } 
+
+    static string? Test2(S3 s)
+    {
+        return s switch
+        {
+            { Value: " + typeNameSyntax + @" } => null,
+            _ =>
+#line 200
+                s.Value.ToString()
+        };
+    } 
+}
+";
+            var comp = CreateCompilation([src, UnionAttributeSource]);
+            comp.VerifyDiagnostics(
+                // (100,17): warning CS8602: Dereference of a possibly null reference.
+                //                 s.Value.ToString()
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.Value").WithLocation(100, 17),
+                // (200,17): warning CS8602: Dereference of a possibly null reference.
+                //                 s.Value.ToString()
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.Value").WithLocation(200, 17)
                 );
         }
 


### PR DESCRIPTION

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83556)