### PR TITLE
Fix Razor directive attribute completion issues

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
@@ -150,7 +150,8 @@ internal sealed class CohostDocumentCompletionEndpoint(
             cancellationToken).AsTask();
 
         RazorVSInternalCompletionList? htmlCompletionList = null;
-        if (documentPositionInfo.LanguageKind == RazorLanguageKind.Html &&
+        if (completionPositionInfo.ShouldIncludeHtmlCompletions &&
+            documentPositionInfo.LanguageKind == RazorLanguageKind.Html &&
             _triggerAndCommitCharacters.IsValidHtmlTrigger(completionContext))
         {
             // Fire HTML request concurrently with the OOP request already in flight.

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/AbstractRazorCompletionFactsService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/AbstractRazorCompletionFactsService.cs
@@ -112,6 +112,15 @@ internal abstract class AbstractRazorCompletionFactsService(ImmutableArray<IRazo
             return markupAttribute.Name;
         }
 
+        // Same as above but for directive attributes with structured colon/parameter, e.g.
+        // <InputText @bind-Value:format|=""> or <InputText @bind-Value|="">
+        // When cursor is at the EqualsToken, walk back to ParameterName (or Name if no parameter).
+        if (originalNode is MarkupTagHelperDirectiveAttributeSyntax directiveAttribute
+            && directiveAttribute.EqualsToken.SpanStart == requestIndex)
+        {
+            return directiveAttribute.ParameterName ?? directiveAttribute.Name;
+        }
+
         return originalNode;
     }
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionListOptimizer.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionListOptimizer.cs
@@ -9,11 +9,11 @@ namespace Microsoft.CodeAnalysis.Razor.Completion;
 
 internal static class CompletionListOptimizer
 {
-    public static RazorVSInternalCompletionList Optimize(RazorVSInternalCompletionList completionList, VSInternalCompletionSetting? completionCapability)
+    public static RazorVSInternalCompletionList Optimize(RazorVSInternalCompletionList completionList, CompletionSetting? completionCapability)
     {
-        if (completionCapability is not null)
+        if (completionCapability is VSInternalCompletionSetting vsCompletionCapability)
         {
-            completionList = OptimizeCommitCharacters(completionList, completionCapability);
+            completionList = OptimizeCommitCharacters(completionList, vsCompletionCapability);
         }
 
         completionList = PromoteEditRangeToListDefaults(completionList, completionCapability);
@@ -84,7 +84,7 @@ internal static class CompletionListOptimizer
         return completionList;
     }
 
-    private static RazorVSInternalCompletionList PromoteEditRangeToListDefaults(RazorVSInternalCompletionList completionList, VSInternalCompletionSetting? completionCapability)
+    private static RazorVSInternalCompletionList PromoteEditRangeToListDefaults(RazorVSInternalCompletionList completionList, CompletionSetting? completionCapability)
     {
         // Check if client supports editRange in ItemDefaults
         var itemDefaults = completionCapability?.CompletionListSetting?.ItemDefaults;

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionListOptimizer.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionListOptimizer.cs
@@ -16,6 +16,8 @@ internal static class CompletionListOptimizer
             completionList = OptimizeCommitCharacters(completionList, completionCapability);
         }
 
+        completionList = PromoteEditRangeToListDefaults(completionList, completionCapability);
+
         return completionList;
     }
 
@@ -79,6 +81,56 @@ internal static class CompletionListOptimizer
         }
 
         completionList.CommitCharacters = mostUsedCommitCharacterToItems.Value.VsCommitCharacters;
+        return completionList;
+    }
+
+    private static RazorVSInternalCompletionList PromoteEditRangeToListDefaults(RazorVSInternalCompletionList completionList, VSInternalCompletionSetting? completionCapability)
+    {
+        // Check if client supports editRange in ItemDefaults
+        var itemDefaults = completionCapability?.CompletionListSetting?.ItemDefaults;
+        if (itemDefaults is null || !itemDefaults.Contains("editRange"))
+        {
+            return completionList;
+        }
+
+        var items = completionList.Items;
+
+        // Find the common TextEdit range across all items.
+        // If any item lacks a TextEdit or has a different range, bail out.
+        LspRange? commonRange = null;
+        foreach (var item in items)
+        {
+            if (item.TextEdit?.Value is not TextEdit textEdit)
+            {
+                return completionList;
+            }
+
+            if (commonRange is null)
+            {
+                commonRange = textEdit.Range;
+            }
+            else if (!commonRange.Equals(textEdit.Range))
+            {
+                return completionList;
+            }
+        }
+
+        if (commonRange is null)
+        {
+            return completionList;
+        }
+
+        // Promote the common range to ItemDefaults.EditRange and replace per-item TextEdits with TextEditText
+        completionList.ItemDefaults ??= new CompletionListItemDefaults();
+        completionList.ItemDefaults.EditRange = commonRange;
+
+        foreach (var item in items)
+        {
+            var textEdit = (TextEdit)item.TextEdit!.Value;
+            item.TextEditText = textEdit.NewText;
+            item.TextEdit = null;
+        }
+
         return completionList;
     }
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/DelegatedCompletionHelper.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/DelegatedCompletionHelper.cs
@@ -18,6 +18,7 @@ using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Protocol.Completion;
+using Microsoft.VisualStudio.Editor.Razor;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion.Delegation;
 
@@ -261,6 +262,60 @@ internal static class DelegatedCompletionHelper
             }
 
             return false;
+        }
+    }
+
+    /// <summary>
+    /// Returns true if the position is inside the parameter portion of a directive attribute
+    /// (e.g., the "format" in <c>@bind-Value:format</c>). In this context, only directive
+    /// attribute parameter completions are valid — HTML attribute completions should be excluded.
+    /// </summary>
+    public static bool IsInDirectiveAttributeParameterContext(RazorCodeDocument razorCodeDocument, int absoluteIndex)
+    {
+        // Use the tag-helper-rewritten tree so that directive attributes are represented as
+        // structured nodes (e.g. MarkupTagHelperDirectiveAttributeSyntax) with explicit Colon
+        // and ParameterName children, matching what the Razor completion providers see.
+        var syntaxTree = razorCodeDocument.GetRequiredTagHelperRewrittenSyntaxTree();
+        var owner = syntaxTree.Root.FindInnermostNode(absoluteIndex, includeWhitespace: true, walkMarkersBack: true);
+        if (owner is null)
+        {
+            return false;
+        }
+
+        // FindInnermostNode returns token.Parent, which can be:
+        // 1. The attribute node itself (when the token is a direct child like EqualsToken)
+        // 2. A child node like MarkupTextLiteralSyntax (when cursor is inside the Name)
+        // 3. The start tag (boundary case: cursor at exclusive end of last attribute)
+        if (HtmlFacts.TryGetAttributeName(owner, out _, out var name, out var nameLocation)
+            || (owner is MarkupTextLiteralSyntax && HtmlFacts.TryGetAttributeName(owner.Parent, out _, out name, out nameLocation)))
+        {
+            return IsAfterColon(name, nameLocation.Start, absoluteIndex);
+        }
+
+        // Boundary case: cursor is at the exclusive end of an attribute's span, so
+        // FindInnermostNode returns the containing start tag instead. Check the last
+        // attribute, which is the one adjacent to the cursor position.
+        if (owner is BaseMarkupStartTagSyntax startTag && startTag.Attributes.Count > 0)
+        {
+            var lastAttribute = startTag.Attributes[^1];
+            if (lastAttribute.Span.End == absoluteIndex
+                && HtmlFacts.TryGetAttributeName(lastAttribute, out _, out name, out nameLocation))
+            {
+                return IsAfterColon(name, nameLocation.Start, absoluteIndex);
+            }
+        }
+
+        return false;
+
+        static bool IsAfterColon(string? attributeName, int nameSpanStart, int absoluteIndex)
+        {
+            if (attributeName is null || attributeName.Length < 2 || attributeName[0] != '@')
+            {
+                return false;
+            }
+
+            var count = Math.Min(absoluteIndex - nameSpanStart, attributeName.Length);
+            return count > 0 && attributeName.IndexOf(':', 0, count) != -1;
         }
     }
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionContext.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionContext.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Immutable;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion;
 
@@ -15,6 +16,14 @@ internal sealed record DirectiveAttributeCompletionContext
     public bool InAttributeName { get; init; } = true;
     public bool InParameterName { get; init; }
     public RazorCompletionOptions Options { get; init; }
+
+    /// <summary>
+    /// The range in the source document (excluding the leading '@') that should be replaced
+    /// when a directive attribute completion is committed. Used for items that include a colon
+    /// and parameter name (e.g., "bind-Value:after") to prevent duplication when the editor's
+    /// word-boundary heuristic doesn't extend past the ':'.
+    /// </summary>
+    public LinePositionSpan? ReplacementRange { get; init; }
 
     public bool AlreadySatisfiesParameter(BoundAttributeParameterDescriptor parameter, BoundAttributeDescriptor attribute)
         => ExistingAttributes.Any(

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.Razor.Tooltip;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Editor.Razor;
 using RazorSyntaxNode = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxNode;
 
@@ -67,6 +68,21 @@ internal partial class DirectiveAttributeCompletionItemProvider : DirectiveAttri
 
         var inSnippetContext = InSnippetContext(owner, context.Options);
 
+        // Compute the replacement range for directive attribute items. This covers from after the '@'
+        // through the end of the parameter name (if present) or the attribute name. This is needed
+        // because InsertText includes the colon and parameter (e.g., "bind-Value:after") but the
+        // editor's word-boundary heuristic stops at ':' causing duplication.
+        LinePositionSpan? replacementRange = null;
+        if (isAttributeRequest && attributeNameLocation.Length > 0)
+        {
+            var sourceText = context.CodeDocument.Source.Text;
+            var spanStart = attributeNameLocation.Start + 1; // skip '@'
+            var spanEnd = parameterNameLocation.Length > 0
+                ? parameterNameLocation.End
+                : attributeNameLocation.End;
+            replacementRange = sourceText.GetLinePositionSpan(TextSpan.FromBounds(spanStart, spanEnd));
+        }
+
         var completionContext = new DirectiveAttributeCompletionContext()
         {
             SelectedAttributeName = attributeName,
@@ -75,7 +91,8 @@ internal partial class DirectiveAttributeCompletionItemProvider : DirectiveAttri
             UseSnippets = inSnippetContext,
             InAttributeName = isAttributeRequest,
             InParameterName = isParameterRequest,
-            Options = context.Options
+            Options = context.Options,
+            ReplacementRange = replacementRange,
         };
 
         return GetAttributeCompletions(containingTagName, completionContext, context.TagHelperDocumentContext);
@@ -282,8 +299,8 @@ internal partial class DirectiveAttributeCompletionItemProvider : DirectiveAttri
             Debug.Assert(kind is RazorCompletionItemKind.DirectiveAttribute or RazorCompletionItemKind.DirectiveAttributeParameter);
 
             var razorCompletionItem = kind == RazorCompletionItemKind.DirectiveAttribute
-                ? RazorCompletionItem.CreateDirectiveAttribute(displayText, insertText, descriptionInfo: new(descriptions), commitCharacters, isSnippet)
-                : RazorCompletionItem.CreateDirectiveAttributeParameter(displayText, insertText, descriptionInfo: new(descriptions), commitCharacters, isSnippet);
+                ? RazorCompletionItem.CreateDirectiveAttribute(displayText, insertText, descriptionInfo: new(descriptions), commitCharacters, isSnippet, completionContext.ReplacementRange)
+                : RazorCompletionItem.CreateDirectiveAttributeParameter(displayText, insertText, descriptionInfo: new(descriptions), commitCharacters, isSnippet, completionContext.ReplacementRange);
 
             completionItems.Add(razorCompletionItem);
         }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItem.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItem.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.AspNetCore.Razor;
 using Microsoft.CodeAnalysis.Razor.Tooltip;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion;
 
@@ -25,6 +26,13 @@ internal sealed class RazorCompletionItem
     public ImmutableArray<RazorCommitCharacter> CommitCharacters { get; }
     public bool IsSnippet { get; }
     public TextEdit[]? AdditionalTextEdits { get; }
+
+    /// <summary>
+    /// An optional range in the source document that should be replaced by <see cref="InsertText"/>
+    /// when the item is committed. When set, a <c>TextEdit</c> is used instead of relying on the
+    /// editor's word-boundary heuristic for the applicable span.
+    /// </summary>
+    public LinePositionSpan? ReplacementRange { get; }
 
     private string GetDebuggerDisplay()
         => $"{Kind}: {DisplayText}";
@@ -49,7 +57,8 @@ internal sealed class RazorCompletionItem
         object descriptionInfo,
         ImmutableArray<RazorCommitCharacter> commitCharacters,
         bool isSnippet,
-        TextEdit[]? additionalTextEdits = null)
+        TextEdit[]? additionalTextEdits = null,
+        LinePositionSpan? replacementRange = null)
     {
         ArgHelper.ThrowIfNull(displayText);
         ArgHelper.ThrowIfNull(insertText);
@@ -62,6 +71,7 @@ internal sealed class RazorCompletionItem
         CommitCharacters = commitCharacters.NullToEmpty();
         IsSnippet = isSnippet;
         AdditionalTextEdits = additionalTextEdits;
+        ReplacementRange = replacementRange;
     }
 
     public static RazorCompletionItem CreateDirective(
@@ -74,15 +84,17 @@ internal sealed class RazorCompletionItem
         string displayText, string insertText,
         AggregateBoundAttributeDescription descriptionInfo,
         ImmutableArray<RazorCommitCharacter> commitCharacters,
-        bool isSnippet)
-        => new(RazorCompletionItemKind.DirectiveAttribute, displayText, insertText, sortText: null, descriptionInfo, commitCharacters, isSnippet);
+        bool isSnippet,
+        LinePositionSpan? replacementRange = null)
+        => new(RazorCompletionItemKind.DirectiveAttribute, displayText, insertText, sortText: null, descriptionInfo, commitCharacters, isSnippet, replacementRange: replacementRange);
 
     public static RazorCompletionItem CreateDirectiveAttributeParameter(
         string displayText, string insertText,
         AggregateBoundAttributeDescription descriptionInfo,
         ImmutableArray<RazorCommitCharacter> commitCharacters,
-        bool isSnippet)
-        => new(RazorCompletionItemKind.DirectiveAttributeParameter, displayText, insertText, sortText: null, descriptionInfo, commitCharacters, isSnippet);
+        bool isSnippet,
+        LinePositionSpan? replacementRange = null)
+        => new(RazorCompletionItemKind.DirectiveAttributeParameter, displayText, insertText, sortText: null, descriptionInfo, commitCharacters, isSnippet, replacementRange: replacementRange);
 
     public static RazorCompletionItem CreateMarkupTransition(
         string displayText, string insertText,

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionListProvider.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionListProvider.cs
@@ -191,39 +191,10 @@ internal class RazorCompletionListProvider(
                     return true;
                 }
             case RazorCompletionItemKind.DirectiveAttribute:
-                {
-                    var directiveAttributeCompletionItem = new VSInternalCompletionItem()
-                    {
-                        Label = razorCompletionItem.DisplayText,
-                        InsertText = razorCompletionItem.InsertText,
-                        FilterText = razorCompletionItem.InsertText,
-                        SortText = razorCompletionItem.SortText,
-                        InsertTextFormat = insertTextFormat,
-                        Kind = tagHelperCompletionItemKind,
-                        AdditionalTextEdits = razorCompletionItem.AdditionalTextEdits,
-                    };
-
-                    directiveAttributeCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
-
-                    completionItem = directiveAttributeCompletionItem;
-                    return true;
-                }
             case RazorCompletionItemKind.DirectiveAttributeParameter:
                 {
-                    var parameterCompletionItem = new VSInternalCompletionItem()
-                    {
-                        Label = razorCompletionItem.DisplayText,
-                        InsertText = razorCompletionItem.InsertText,
-                        FilterText = razorCompletionItem.InsertText,
-                        SortText = razorCompletionItem.SortText,
-                        InsertTextFormat = insertTextFormat,
-                        Kind = tagHelperCompletionItemKind,
-                        AdditionalTextEdits = razorCompletionItem.AdditionalTextEdits,
-                    };
-
-                    parameterCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
-
-                    completionItem = parameterCompletionItem;
+                    completionItem = CreateDirectiveAttributeCompletionItem(
+                        razorCompletionItem, clientCapabilities, insertTextFormat, tagHelperCompletionItemKind);
                     return true;
                 }
             case RazorCompletionItemKind.DirectiveAttributeParameterEventValue:
@@ -336,5 +307,44 @@ internal class RazorCompletionListProvider(
 
         completionItem = null;
         return false;
+    }
+
+    /// <summary>
+    /// Creates a completion item for directive attribute and directive attribute parameter kinds.
+    /// When a <see cref="RazorCompletionItem.ReplacementRange"/> is set, uses an explicit TextEdit
+    /// to define the replaced range. This prevents duplication when the InsertText contains a ':'
+    /// (e.g., "bind-Value:after") because the editor's word-boundary heuristic would stop at ':'
+    /// and only replace part of the existing text.
+    /// </summary>
+    private static VSInternalCompletionItem CreateDirectiveAttributeCompletionItem(
+        RazorCompletionItem razorCompletionItem,
+        VSInternalClientCapabilities clientCapabilities,
+        InsertTextFormat insertTextFormat,
+        CompletionItemKind kind)
+    {
+        var completionItem = new VSInternalCompletionItem()
+        {
+            Label = razorCompletionItem.DisplayText,
+            InsertText = razorCompletionItem.InsertText,
+            FilterText = razorCompletionItem.InsertText,
+            SortText = razorCompletionItem.SortText,
+            InsertTextFormat = insertTextFormat,
+            Kind = kind,
+            AdditionalTextEdits = razorCompletionItem.AdditionalTextEdits,
+        };
+
+        if (razorCompletionItem.ReplacementRange is { } replacementRange)
+        {
+            completionItem.TextEdit = new TextEdit()
+            {
+                Range = replacementRange.ToRange(),
+                NewText = razorCompletionItem.InsertText,
+            };
+            completionItem.InsertText = null;
+        }
+
+        completionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
+
+        return completionItem;
     }
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionListProvider.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionListProvider.cs
@@ -142,7 +142,7 @@ internal class RazorCompletionListProvider(
             IsIncomplete = false,
         };
 
-        var completionCapability = clientCapabilities.TextDocument?.Completion as VSInternalCompletionSetting;
+        var completionCapability = clientCapabilities.TextDocument?.Completion;
 
         return CompletionListOptimizer.Optimize(completionList, completionCapability);
     }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/HtmlFacts.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/HtmlFacts.cs
@@ -207,6 +207,52 @@ internal static class HtmlFacts
         }
     }
 
+    public static bool TryGetAttributeName(
+        SyntaxNode attribute,
+        out TextSpan? prefixLocation,
+        out string? name,
+        out TextSpan nameLocation)
+    {
+        switch (attribute)
+        {
+            case MarkupMinimizedAttributeBlockSyntax minimizedAttributeBlock:
+                prefixLocation = minimizedAttributeBlock.NamePrefix?.Span;
+                name = minimizedAttributeBlock.Name.GetContent();
+                nameLocation = minimizedAttributeBlock.Name.Span;
+                return true;
+            case MarkupAttributeBlockSyntax attributeBlock:
+                prefixLocation = attributeBlock.NamePrefix?.Span;
+                name = attributeBlock.Name.GetContent();
+                nameLocation = attributeBlock.Name.Span;
+                return true;
+            case MarkupTagHelperAttributeSyntax tagHelperAttribute:
+                prefixLocation = tagHelperAttribute.NamePrefix?.Span;
+                name = tagHelperAttribute.Name.GetContent();
+                nameLocation = tagHelperAttribute.Name.Span;
+                return true;
+            case MarkupMinimizedTagHelperAttributeSyntax minimizedAttribute:
+                prefixLocation = minimizedAttribute.NamePrefix?.Span;
+                name = minimizedAttribute.Name.GetContent();
+                nameLocation = minimizedAttribute.Name.Span;
+                return true;
+            case MarkupTagHelperDirectiveAttributeSyntax tagHelperDirectiveAttribute:
+                prefixLocation = tagHelperDirectiveAttribute.NamePrefix?.Span;
+                name = tagHelperDirectiveAttribute.FullName;
+                nameLocation = TextSpan.FromBounds(tagHelperDirectiveAttribute.Transition.Span.Start, tagHelperDirectiveAttribute.Name.Span.End);
+                return true;
+            case MarkupMinimizedTagHelperDirectiveAttributeSyntax minimizedTagHelperDirectiveAttribute:
+                prefixLocation = minimizedTagHelperDirectiveAttribute.NamePrefix?.Span;
+                name = minimizedTagHelperDirectiveAttribute.FullName;
+                nameLocation = TextSpan.FromBounds(minimizedTagHelperDirectiveAttribute.Transition.Span.Start, minimizedTagHelperDirectiveAttribute.Name.Span.End);
+                return true;
+        }
+
+        prefixLocation = null;
+        name = null;
+        nameLocation = default;
+        return false;
+    }
+
     public static bool TryGetAttributeInfo(
         SyntaxNode attribute,
         out SyntaxToken containingTagNameToken,
@@ -225,49 +271,18 @@ internal static class HtmlFacts
             return false;
         }
 
-        switch (attribute)
+        if (TryGetAttributeName(attribute, out prefixLocation, out selectedAttributeName, out var nameLocation))
         {
-            case MarkupMinimizedAttributeBlockSyntax minimizedAttributeBlock:
-                prefixLocation = minimizedAttributeBlock.NamePrefix?.Span;
-                selectedAttributeName = minimizedAttributeBlock.Name.GetContent();
-                selectedAttributeNameLocation = minimizedAttributeBlock.Name.Span;
-                return true;
-            case MarkupAttributeBlockSyntax attributeBlock:
-                prefixLocation = attributeBlock.NamePrefix?.Span;
-                selectedAttributeName = attributeBlock.Name.GetContent();
-                selectedAttributeNameLocation = attributeBlock.Name.Span;
-                return true;
-            case MarkupTagHelperAttributeSyntax tagHelperAttribute:
-                prefixLocation = tagHelperAttribute.NamePrefix?.Span;
-                selectedAttributeName = tagHelperAttribute.Name.GetContent();
-                selectedAttributeNameLocation = tagHelperAttribute.Name.Span;
-                return true;
-            case MarkupMinimizedTagHelperAttributeSyntax minimizedAttribute:
-                prefixLocation = minimizedAttribute.NamePrefix?.Span;
-                selectedAttributeName = minimizedAttribute.Name.GetContent();
-                selectedAttributeNameLocation = minimizedAttribute.Name.Span;
-                return true;
-            case MarkupTagHelperDirectiveAttributeSyntax tagHelperDirectiveAttribute:
-                {
-                    prefixLocation = tagHelperDirectiveAttribute.NamePrefix?.Span;
-                    selectedAttributeName = tagHelperDirectiveAttribute.FullName;
-                    var fullNameSpan = TextSpan.FromBounds(tagHelperDirectiveAttribute.Transition.Span.Start, tagHelperDirectiveAttribute.Name.Span.End);
-                    selectedAttributeNameLocation = fullNameSpan;
-                    return true;
-                }
-            case MarkupMinimizedTagHelperDirectiveAttributeSyntax minimizedTagHelperDirectiveAttribute:
-                {
-                    prefixLocation = minimizedTagHelperDirectiveAttribute.NamePrefix?.Span;
-                    selectedAttributeName = minimizedTagHelperDirectiveAttribute.FullName;
-                    var fullNameSpan = TextSpan.FromBounds(minimizedTagHelperDirectiveAttribute.Transition.Span.Start, minimizedTagHelperDirectiveAttribute.Name.Span.End);
-                    selectedAttributeNameLocation = fullNameSpan;
-                    return true;
-                }
-            case MarkupMiscAttributeContentSyntax:
-                prefixLocation = null;
-                selectedAttributeName = null;
-                selectedAttributeNameLocation = null;
-                return true;
+            selectedAttributeNameLocation = nameLocation;
+            return true;
+        }
+
+        if (attribute is MarkupMiscAttributeContentSyntax)
+        {
+            prefixLocation = null;
+            selectedAttributeName = null;
+            selectedAttributeNameLocation = null;
+            return true;
         }
 
         // Not an attribute type that we know of

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/Completion/CompletionPositionInfo.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/Completion/CompletionPositionInfo.cs
@@ -18,7 +18,10 @@ namespace Microsoft.CodeAnalysis.Razor.Protocol.Completion;
 /// </remarks>
 /// <param name="DocumentPositionInfo">Document position mapping data for language mappings</param>
 /// <param name="ShouldIncludeDelegationSnippets">Indicates that snippets should be added to delegated completion list (currently for HTML only)</param>
+/// <param name="ShouldIncludeHtmlCompletions">When false, HTML completions should not be fetched or merged. This is set
+/// when the position is in a context where only Razor-specific completions are valid (e.g., directive attribute parameters).</param>
 internal record struct CompletionPositionInfo(
     [property: JsonPropertyName("provisionalTextEdit")] TextEdit? ProvisionalTextEdit,
     [property: JsonPropertyName("documentPositionInfo")] DocumentPositionInfo DocumentPositionInfo,
-    [property: JsonPropertyName("shouldIncludeDelegationSnippets")] bool ShouldIncludeDelegationSnippets);
+    [property: JsonPropertyName("shouldIncludeDelegationSnippets")] bool ShouldIncludeDelegationSnippets,
+    [property: JsonPropertyName("shouldIncludeHtmlCompletions")] bool ShouldIncludeHtmlCompletions = true);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
@@ -83,7 +83,9 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
         var shouldIncludeSnippets = positionInfo.LanguageKind == RazorLanguageKind.Html
             && DelegatedCompletionHelper.ShouldIncludeSnippets(codeDocument, index);
 
-        return new CompletionPositionInfo(ProvisionalTextEdit: null, positionInfo, shouldIncludeSnippets);
+        var shouldIncludeHtmlCompletions = !DelegatedCompletionHelper.IsInDirectiveAttributeParameterContext(codeDocument, index);
+
+        return new CompletionPositionInfo(ProvisionalTextEdit: null, positionInfo, shouldIncludeSnippets, shouldIncludeHtmlCompletions);
     }
 
     public ValueTask<CompletionResponse> GetCompletionAsync(

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
@@ -83,7 +83,8 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
         var shouldIncludeSnippets = positionInfo.LanguageKind == RazorLanguageKind.Html
             && DelegatedCompletionHelper.ShouldIncludeSnippets(codeDocument, index);
 
-        var shouldIncludeHtmlCompletions = !DelegatedCompletionHelper.IsInDirectiveAttributeParameterContext(codeDocument, index);
+        var shouldIncludeHtmlCompletions = positionInfo.LanguageKind == RazorLanguageKind.Html
+            && !DelegatedCompletionHelper.IsInDirectiveAttributeParameterContext(codeDocument, index);
 
         return new CompletionPositionInfo(ProvisionalTextEdit: null, positionInfo, shouldIncludeSnippets, shouldIncludeHtmlCompletions);
     }

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
@@ -946,6 +946,43 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
             expectedItemLabels: ["culture", "event", "format", "get", "set", "after"]);
     }
 
+    // Tests that committing a directive attribute parameter completion with an existing parameter
+    // does not duplicate the parameter portion (e.g., @bind-:after="" -> @bind-Value:after="", not @bind-Value:after:after="")
+    [Fact]
+    public async Task DirectiveAttributeParameterCompletion_WithExistingParameter_HasTextEditReplacingFullSpan()
+    {
+        var result = await VerifyCompletionListAsync(
+            input: """
+                This is a Razor document.
+
+                <input @bind-$$:after=""></div>
+
+                The end.
+                """,
+            completionContext: new VSInternalCompletionContext()
+            {
+                InvokeKind = VSInternalCompletionInvokeKind.Typing,
+                TriggerCharacter = null,
+                TriggerKind = CompletionTriggerKind.Invoked
+            },
+            expectedItemLabels: ["bind-Value:after"]);
+
+        Assert.NotNull(result);
+
+        var item = Assert.Single(result.Items, i => i.Label == "bind-Value:after");
+
+        // The item should have a TextEdit that replaces the full "bind-:after" span (not just "bind-")
+        // This prevents the editor's word-boundary heuristic from stopping at the colon and duplicating ":after"
+        Assert.True(item.TextEdit.HasValue, "Expected a TextEdit on the completion item to prevent duplication");
+        var textEdit = Assert.IsType<TextEdit>(item.TextEdit!.Value.Value);
+        Assert.Equal("bind-Value:after", textEdit.NewText);
+
+        // The range should cover "bind-:after" (everything after '@' through end of parameter name)
+        Assert.Equal(textEdit.Range.Start.Line, textEdit.Range.End.Line);
+        var replacedLength = textEdit.Range.End.Character - textEdit.Range.Start.Character;
+        Assert.Equal("bind-:after".Length, replacedLength);
+    }
+
     [Fact]
     public async Task HtmlAndDirectiveAttributeEventParameterEmptyNoSuffixHtmlEventNamesCompletion()
     {

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
@@ -923,7 +923,8 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerKind = CompletionTriggerKind.Invoked
             },
             expectedItemLabels: ["culture", "event", "format", "get", "set", "after"],
-            unexpectedItemLabels: ["dir", "lang", "@bind-Value"]);
+            unexpectedItemLabels: ["dir", "lang", "@bind-Value"],
+            htmlItemLabels: ["dir", "lang"]);
     }
 
     // Tests that cursor immediately after colon (no parameter text yet) shows bind modifiers
@@ -945,7 +946,8 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerKind = CompletionTriggerKind.Invoked
             },
             expectedItemLabels: ["culture", "event", "format", "get", "set", "after"],
-            unexpectedItemLabels: ["dir", "lang", "@bind-Value"]);
+            unexpectedItemLabels: ["dir", "lang", "@bind-Value"],
+            htmlItemLabels: ["dir", "lang"]);
     }
 
     // Tests that committing a directive attribute parameter completion with an existing parameter
@@ -968,7 +970,8 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerKind = CompletionTriggerKind.Invoked
             },
             expectedItemLabels: ["@bind-value", "@bind-value:format"],
-            unexpectedItemLabels: ["dir", "lang"]);
+            unexpectedItemLabels: ["dir", "lang"],
+            htmlItemLabels: ["dir", "lang"]);
 
         Assert.NotNull(result);
 

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
@@ -982,8 +982,8 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
 
         // The range should cover "bind-Value:after" (everything after '@' through end of parameter name)
         Assert.Equal(textEditRange.Start.Line, textEditRange.End.Line);
-        var replacedLength = (textEditRange.End.Character - textEditRange.Start.Character) + 1;
-        Assert.Equal("bind-value:format".Length, replacedLength);
+        var replacedLength = textEditRange.End.Character - textEditRange.Start.Character;
+        Assert.Equal("bind-Value:after".Length, replacedLength);
     }
 
     [Fact]

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
@@ -883,7 +883,7 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
 #endif
     }
 
-    // Tests HTML attributes and DirectiveAttributeParameterCompletionItemProvider
+    // Tests that directive attribute parameter positions only show bind modifiers, not HTML attributes
     [Fact]
     public async Task HtmlAndDirectiveAttributeParameterNamesCompletion()
     {
@@ -901,8 +901,49 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerCharacter = null,
                 TriggerKind = CompletionTriggerKind.Invoked
             },
-            expectedItemLabels: ["style", "dir", "culture", "event", "format", "get", "set", "after"],
-            htmlItemLabels: ["style", "dir"]);
+            expectedItemLabels: ["culture", "event", "format", "get", "set", "after"]);
+    }
+
+    // Tests that cursor at end of parameter name before equals still shows bind modifiers
+    [Fact]
+    public async Task HtmlAndDirectiveAttributeParameterNamesBeforeEqualsCompletion()
+    {
+        await VerifyCompletionListAsync(
+            input: """
+                This is a Razor document.
+
+                <input @bind:fo$$=""></div>
+
+                The end.
+                """,
+            completionContext: new VSInternalCompletionContext()
+            {
+                InvokeKind = VSInternalCompletionInvokeKind.Typing,
+                TriggerCharacter = null,
+                TriggerKind = CompletionTriggerKind.Invoked
+            },
+            expectedItemLabels: ["culture", "event", "format", "get", "set", "after"]);
+    }
+
+    // Tests that cursor immediately after colon (no parameter text yet) shows bind modifiers
+    [Fact]
+    public async Task HtmlAndDirectiveAttributeParameterNamesAfterColonCompletion()
+    {
+        await VerifyCompletionListAsync(
+            input: """
+                This is a Razor document.
+
+                <input @bind:$$></div>
+
+                The end.
+                """,
+            completionContext: new VSInternalCompletionContext()
+            {
+                InvokeKind = VSInternalCompletionInvokeKind.Typing,
+                TriggerCharacter = null,
+                TriggerKind = CompletionTriggerKind.Invoked
+            },
+            expectedItemLabels: ["culture", "event", "format", "get", "set", "after"]);
     }
 
     [Fact]

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
@@ -979,7 +979,7 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
 
         // The list should have a TextEdit that replaces the full "bind-Value:after" span (not just "bind-")
         // This prevents the editor's word-boundary heuristic from stopping at the colon and duplicating ":after"
-        Assert.True(result.ItemDefaults!.EditRange.HasValue, "Expected a TextEdit on the completion list to prevent duplication");
+        Assert.True(result.ItemDefaults!.EditRange.HasValue, "Expected ItemDefaults.EditRange on the completion list to prevent duplication");
         Assert.Equal("bind-value:format", item.TextEditText);
         var textEditRange = Assert.IsType<LspRange>(result.ItemDefaults!.EditRange.Value.Value);
 

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
@@ -912,7 +912,7 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
             input: """
                 This is a Razor document.
 
-                <input @bind:fo$$=""></div>
+                <input @bind-Value:fo$$=""></div>
 
                 The end.
                 """,
@@ -922,7 +922,8 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerCharacter = null,
                 TriggerKind = CompletionTriggerKind.Invoked
             },
-            expectedItemLabels: ["culture", "event", "format", "get", "set", "after"]);
+            expectedItemLabels: ["culture", "event", "format", "get", "set", "after"],
+            unexpectedItemLabels: ["dir", "lang", "@bind-Value"]);
     }
 
     // Tests that cursor immediately after colon (no parameter text yet) shows bind modifiers
@@ -933,7 +934,7 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
             input: """
                 This is a Razor document.
 
-                <input @bind:$$></div>
+                <input @bind-Value:$$></div>
 
                 The end.
                 """,
@@ -943,7 +944,8 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerCharacter = null,
                 TriggerKind = CompletionTriggerKind.Invoked
             },
-            expectedItemLabels: ["culture", "event", "format", "get", "set", "after"]);
+            expectedItemLabels: ["culture", "event", "format", "get", "set", "after"],
+            unexpectedItemLabels: ["dir", "lang", "@bind-Value"]);
     }
 
     // Tests that committing a directive attribute parameter completion with an existing parameter
@@ -955,7 +957,7 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
             input: """
                 This is a Razor document.
 
-                <input @bind-$$:after=""></div>
+                <input @bind-Value$$:after=""></div>
 
                 The end.
                 """,
@@ -965,22 +967,23 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerCharacter = null,
                 TriggerKind = CompletionTriggerKind.Invoked
             },
-            expectedItemLabels: ["bind-Value:after"]);
+            expectedItemLabels: ["@bind-value", "@bind-value:format"],
+            unexpectedItemLabels: ["dir", "lang"]);
 
         Assert.NotNull(result);
 
-        var item = Assert.Single(result.Items, i => i.Label == "bind-Value:after");
+        var item = Assert.Single(result.Items, i => i.Label == "@bind-value:format");
 
-        // The item should have a TextEdit that replaces the full "bind-:after" span (not just "bind-")
+        // The list should have a TextEdit that replaces the full "bind-Value:after" span (not just "bind-")
         // This prevents the editor's word-boundary heuristic from stopping at the colon and duplicating ":after"
-        Assert.True(item.TextEdit.HasValue, "Expected a TextEdit on the completion item to prevent duplication");
-        var textEdit = Assert.IsType<TextEdit>(item.TextEdit!.Value.Value);
-        Assert.Equal("bind-Value:after", textEdit.NewText);
+        Assert.True(result.ItemDefaults!.EditRange.HasValue, "Expected a TextEdit on the completion list to prevent duplication");
+        Assert.Equal("bind-value:format", item.TextEditText);
+        var textEditRange = Assert.IsType<LspRange>(result.ItemDefaults!.EditRange.Value.Value);
 
-        // The range should cover "bind-:after" (everything after '@' through end of parameter name)
-        Assert.Equal(textEdit.Range.Start.Line, textEdit.Range.End.Line);
-        var replacedLength = textEdit.Range.End.Character - textEdit.Range.Start.Character;
-        Assert.Equal("bind-:after".Length, replacedLength);
+        // The range should cover "bind-Value:after" (everything after '@' through end of parameter name)
+        Assert.Equal(textEditRange.Start.Line, textEditRange.End.Line);
+        var replacedLength = (textEditRange.End.Character - textEditRange.Start.Character) + 1;
+        Assert.Equal("bind-value:format".Length, replacedLength);
     }
 
     [Fact]

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/CompletionListOptimizerTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/CompletionListOptimizerTest.cs
@@ -76,4 +76,171 @@ public class CompletionListOptimizerTest(ITestOutputHelper testOutput) : Tooling
         Assert.Equal(commitCharacters, ((VSInternalCompletionItem)item).VsCommitCharacters);
         Assert.Null(vsCompletionList.CommitCharacters);
     }
+
+    [Fact]
+    public void PromoteEditRange_AllItemsShareSameRange_PromotesToItemDefaults()
+    {
+        // Arrange
+        var sharedRange = new LspRange
+        {
+            Start = new Position { Line = 0, Character = 5 },
+            End = new Position { Line = 0, Character = 15 }
+        };
+        var completionList = new RazorVSInternalCompletionList()
+        {
+            Items = [
+                new VSInternalCompletionItem()
+                {
+                    Label = "Item1",
+                    TextEdit = new TextEdit { Range = sharedRange, NewText = "NewItem1" }
+                },
+                new VSInternalCompletionItem()
+                {
+                    Label = "Item2",
+                    TextEdit = new TextEdit { Range = sharedRange, NewText = "NewItem2" }
+                }
+            ]
+        };
+        var capabilities = new VSInternalCompletionSetting()
+        {
+            CompletionListSetting = new CompletionListSetting()
+            {
+                ItemDefaults = ["editRange"]
+            }
+        };
+
+        // Act
+        var result = CompletionListOptimizer.Optimize(completionList, capabilities);
+
+        // Assert
+        Assert.NotNull(result.ItemDefaults);
+        Assert.True(result.ItemDefaults.EditRange!.Value.TryGetFirst(out var promotedRange));
+        Assert.Equal(sharedRange, promotedRange);
+
+        Assert.All(result.Items, item =>
+        {
+            Assert.Null(item.TextEdit);
+            Assert.NotNull(item.TextEditText);
+        });
+        Assert.Equal("NewItem1", result.Items[0].TextEditText);
+        Assert.Equal("NewItem2", result.Items[1].TextEditText);
+    }
+
+    [Fact]
+    public void PromoteEditRange_ItemsHaveDifferentRanges_DoesNotPromote()
+    {
+        // Arrange
+        var range1 = new LspRange
+        {
+            Start = new Position { Line = 0, Character = 5 },
+            End = new Position { Line = 0, Character = 10 }
+        };
+        var range2 = new LspRange
+        {
+            Start = new Position { Line = 0, Character = 5 },
+            End = new Position { Line = 0, Character = 15 }
+        };
+        var completionList = new RazorVSInternalCompletionList()
+        {
+            Items = [
+                new VSInternalCompletionItem()
+                {
+                    Label = "Item1",
+                    TextEdit = new TextEdit { Range = range1, NewText = "NewItem1" }
+                },
+                new VSInternalCompletionItem()
+                {
+                    Label = "Item2",
+                    TextEdit = new TextEdit { Range = range2, NewText = "NewItem2" }
+                }
+            ]
+        };
+        var capabilities = new VSInternalCompletionSetting()
+        {
+            CompletionListSetting = new CompletionListSetting()
+            {
+                ItemDefaults = ["editRange"]
+            }
+        };
+
+        // Act
+        var result = CompletionListOptimizer.Optimize(completionList, capabilities);
+
+        // Assert
+        Assert.Null(result.ItemDefaults);
+        Assert.All(result.Items, item => Assert.NotNull(item.TextEdit));
+    }
+
+    [Fact]
+    public void PromoteEditRange_SomeItemsLackTextEdit_DoesNotPromote()
+    {
+        // Arrange
+        var sharedRange = new LspRange
+        {
+            Start = new Position { Line = 0, Character = 5 },
+            End = new Position { Line = 0, Character = 15 }
+        };
+        var completionList = new RazorVSInternalCompletionList()
+        {
+            Items = [
+                new VSInternalCompletionItem()
+                {
+                    Label = "Item1",
+                    TextEdit = new TextEdit { Range = sharedRange, NewText = "NewItem1" }
+                },
+                new VSInternalCompletionItem()
+                {
+                    Label = "Item2"
+                }
+            ]
+        };
+        var capabilities = new VSInternalCompletionSetting()
+        {
+            CompletionListSetting = new CompletionListSetting()
+            {
+                ItemDefaults = ["editRange"]
+            }
+        };
+
+        // Act
+        var result = CompletionListOptimizer.Optimize(completionList, capabilities);
+
+        // Assert
+        Assert.Null(result.ItemDefaults);
+    }
+
+    [Fact]
+    public void PromoteEditRange_ClientDoesNotSupportEditRange_DoesNotPromote()
+    {
+        // Arrange
+        var sharedRange = new LspRange
+        {
+            Start = new Position { Line = 0, Character = 5 },
+            End = new Position { Line = 0, Character = 15 }
+        };
+        var completionList = new RazorVSInternalCompletionList()
+        {
+            Items = [
+                new VSInternalCompletionItem()
+                {
+                    Label = "Item1",
+                    TextEdit = new TextEdit { Range = sharedRange, NewText = "NewItem1" }
+                }
+            ]
+        };
+        var capabilities = new VSInternalCompletionSetting()
+        {
+            CompletionListSetting = new CompletionListSetting()
+            {
+                ItemDefaults = ["commitCharacters"]
+            }
+        };
+
+        // Act
+        var result = CompletionListOptimizer.Optimize(completionList, capabilities);
+
+        // Assert
+        Assert.Null(result.ItemDefaults);
+        Assert.NotNull(result.Items[0].TextEdit);
+    }
 }

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/DirectiveAttributeCompletionItemProviderTest.ParameterNames.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/DirectiveAttributeCompletionItemProviderTest.ParameterNames.cs
@@ -32,6 +32,44 @@ public partial class DirectiveAttributeCompletionItemProviderTest
     }
 
     [Fact]
+    public void GetCompletionItems_OnDirectiveAttributeParameterEndBeforeEquals_ReturnsCompletions()
+    {
+        // Arrange - cursor at end of parameter name, right before the equals sign
+        var context = CreateRazorCompletionContext("""<input @bind:fo$$="" />""");
+
+        // Act
+        var completions = _provider.GetCompletionItems(context);
+
+        // Assert
+        Assert.Equal(6, completions.Length);
+        AssertContains(completions, "culture");
+        AssertContains(completions, "event");
+        AssertContains(completions, "format");
+        AssertContains(completions, "get");
+        AssertContains(completions, "set");
+        AssertContains(completions, "after");
+    }
+
+    [Fact]
+    public void GetCompletionItems_OnDirectiveAttributeParameterImmediatelyAfterColon_ReturnsCompletions()
+    {
+        // Arrange - cursor right after the colon with no parameter text yet
+        var context = CreateRazorCompletionContext("<input @bind:$$  />");
+
+        // Act
+        var completions = _provider.GetCompletionItems(context);
+
+        // Assert
+        Assert.Equal(6, completions.Length);
+        AssertContains(completions, "culture");
+        AssertContains(completions, "event");
+        AssertContains(completions, "format");
+        AssertContains(completions, "get");
+        AssertContains(completions, "set");
+        AssertContains(completions, "after");
+    }
+
+    [Fact]
     public void GetAttributeParameterCompletions_NoDescriptorsForTag_ReturnsEmptyCollection()
     {
         // Arrange

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/DirectiveAttributeCompletionItemProviderTest.ParameterNames.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/DirectiveAttributeCompletionItemProviderTest.ParameterNames.cs
@@ -168,6 +168,33 @@ public partial class DirectiveAttributeCompletionItemProviderTest
     }
 
     [Fact]
+    public void GetCompletionItems_OnDirectiveAttributeName_WithExistingParameter_SetsReplacementRange()
+    {
+        // Arrange - user has "@bind-|:after" and triggers completion.
+        // The ReplacementRange should cover "bind-:after" (everything after '@' through end of parameter).
+        var context = CreateRazorCompletionContext("""<input @bind-$$:after=""  />""");
+
+        // Act
+        var completions = _provider.GetCompletionItems(context);
+
+        // Assert - items that include a colon (attribute + parameter) should have ReplacementRange set
+        var itemWithParameter = completions.FirstOrDefault(c => c.InsertText.Contains(':'));
+        Assert.NotNull(itemWithParameter);
+
+        // The source is: <input @bind-:after=""  />
+        //                       ^     ^    ^
+        //                       |     |    `-- parameterLocation.End (index 19)
+        //                       |     `-- colon (index 13)
+        //                       `-- @ is at index 7, so replacement starts at index 8 (skipping '@')
+        // "bind-:after" starts at character 8 and ends at character 19, all on line 0
+        Assert.NotNull(itemWithParameter.ReplacementRange);
+        Assert.Equal(0, itemWithParameter.ReplacementRange.Value.Start.Line);
+        Assert.Equal(8, itemWithParameter.ReplacementRange.Value.Start.Character);
+        Assert.Equal(0, itemWithParameter.ReplacementRange.Value.End.Line);
+        Assert.Equal(19, itemWithParameter.ReplacementRange.Value.End.Character);
+    }
+
+    [Fact]
     public void GetAttributeParameterCompletions_BaseDirectiveAttributeAndParameterVariationsExist_ExcludesCompletion()
     {
         // Arrange


### PR DESCRIPTION
This PR fixes two related bugs in Razor directive attribute completion:

Bug 1: HTML attributes shown at directive attribute parameter positions

When typing at a directive attribute parameter context (e.g., @bind:|, @bind:f|, @bind-Value:format|), HTML attributes like "style" and "dir" were incorrectly shown instead of the expected directive modifiers ("culture", "event", "format", "get", "set", "after").

Fix: Detect directive attribute parameter contexts and suppress HTML completion delegation when in those positions.

Bug 2: Committing a completion item duplicates existing parameter text

When completing @bind-Value:after at @bind-|:after="", the editor's word-boundary heuristic stopped at :, only replacing the prefix and producing @bind-Value:after:after="".

Fix: Add an explicit replacement range to RazorCompletionItem so the TextEdit covers the full span from after @ through the existing parameter name, bypassing the editor's word-boundary behavior.

Fixes https://github.com/dotnet/razor/issues/11494

Bonus: EditRange promotion optimization

Added PromoteEditRangeToListDefaults to CompletionListOptimizer — when all completion items share the same TextEdit.Range, it is promoted to ItemDefaults.EditRange and per-item TextEdits are replaced with TextEditText, reducing serialized payload size.

Best reviewed by commit.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83559)