### PR TITLE
Fix leaked event handlers in AbstractRefreshQueue and ProjectSystemProject

### DIFF
--- a/src/LanguageServer/Protocol/Handler/AbstractRefreshQueue.cs
+++ b/src/LanguageServer/Protocol/Handler/AbstractRefreshQueue.cs
@@ -29,6 +29,7 @@ internal abstract class AbstractRefreshQueue :
     private readonly IAsynchronousOperationListener _asyncListener;
     private readonly CancellationTokenSource _disposalTokenSource;
     private readonly LspWorkspaceRegistrationService _lspWorkspaceRegistrationService;
+    private readonly FeatureProviderRefresher _providerRefresher;
 
     protected abstract string GetFeatureAttribute();
     protected abstract bool? GetRefreshSupport(ClientCapabilities clientCapabilities);
@@ -46,7 +47,8 @@ internal abstract class AbstractRefreshQueue :
         _disposalTokenSource = new();
         _lspWorkspaceManager = lspWorkspaceManager;
         _notificationManager = notificationManager;
-        providerRefresher.ProviderRefreshRequested += EnqueueRefreshNotification;
+        _providerRefresher = providerRefresher;
+        _providerRefresher.ProviderRefreshRequested += EnqueueRefreshNotification;
     }
 
     public async Task OnInitializedAsync(ClientCapabilities clientCapabilities, RequestContext context, CancellationToken cancellationToken)
@@ -132,6 +134,7 @@ internal abstract class AbstractRefreshQueue :
 
     public virtual void Dispose()
     {
+        _providerRefresher.ProviderRefreshRequested -= EnqueueRefreshNotification;
         _lspWorkspaceRegistrationService.LspSolutionChanged -= OnLspSolutionChanged;
         _disposalTokenSource.Cancel();
         _disposalTokenSource.Dispose();

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
@@ -1387,6 +1387,7 @@ internal sealed partial class ProjectSystemProject
             _dynamicFileInfoProvidersSubscribedTo.Clear();
         }
 
+        _documentFileChangeContext.FileChanged -= DocumentFileChangeContext_FileChanged;
         _documentFileChangeContext.Dispose();
 
         IReadOnlyList<MetadataReference>? remainingMetadataReferences = null;


### PR DESCRIPTION
Two leaked event handler fixes:

**1. AbstractRefreshQueue — FeatureProviderRefresher.ProviderRefreshRequested**

`AbstractRefreshQueue` subscribes to `FeatureProviderRefresher.ProviderRefreshRequested` in its constructor but never unsubscribes in `Dispose()`. `FeatureProviderRefresher` is a `[Shared]` MEF singleton (process-lifetime), so the delegate keeps every disposed subclass (`CodeLensRefreshQueue`, `DiagnosticsRefreshQueue`, `InlayHintRefreshQueue`, `ProjectContextRefreshQueue`, `SemanticTokensRefreshQueue`) alive when LSP servers recycle.

Fix: Store the `FeatureProviderRefresher` reference and unsubscribe in `Dispose()`.

**2. ProjectSystemProject — FileChangeWatcher.Context.FileChanged**

`ProjectSystemProject` subscribes to `_documentFileChangeContext.FileChanged` in its constructor but never unsubscribes in `RemoveFromWorkspace()`. The `Context` object can remain rooted by the static `FileChangeService._instance` singleton when async unwatch operations race with shutdown, keeping the `ProjectSystemProject` alive via the delegate.

Fix: Unsubscribe from `FileChanged` before disposing the context.