### PR TITLE
Suppress snippets and tag helper completions in end-tag contexts

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/DelegatedCompletionHelper.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/DelegatedCompletionHelper.cs
@@ -210,11 +210,12 @@ internal static class DelegatedCompletionHelper
         var token = root.FindToken(absoluteIndex, includeWhitespace: false);
         if (token.Kind == SyntaxKind.EndOfFile &&
             token.GetPreviousToken().Parent is { } parent &&
-            parent.FirstAncestorOrSelf<RazorSyntaxNode>(RazorSyntaxFacts.IsAnyStartTag) is not null)
+            parent.FirstAncestorOrSelf<RazorSyntaxNode>(n => RazorSyntaxFacts.IsAnyStartTag(n) || RazorSyntaxFacts.IsAnyEndTag(n)) is { } eofTag &&
+            IsIncompleteTag(eofTag))
         {
-            // If we're at the end of the file, we check if the previous token is part of a start tag, because the parser
-            // treats whitespace at the end different. eg with "<$$[EOF]" or "<div $$", the EndOfFile won't be seen as being
-            // in the tag, so without this special casing snippets would be shown.
+            // If we're at the end of the file, we check if the previous token is part of an incomplete start or end tag,
+            // because the parser treats whitespace at the end different. eg with "<$$[EOF]" or "<div $$" or "</$$[EOF]",
+            // the EndOfFile won't be seen as being in the tag, so without this special casing snippets would be shown.
             return false;
         }
 
@@ -236,10 +237,20 @@ internal static class DelegatedCompletionHelper
         {
             // We're at the start of the tag, we should include snippets. This is the case for things like $$<div></div> or <div>$$</div>, since the
             // index is right associative to the token when using FindToken.
+            // However, if the user just typed "</" (e.g., <div></|</div>), suppress snippets because the previous
+            // token is part of an (incomplete) end tag that precedes this position.
+            if (absoluteIndex > 0 &&
+                root.FindToken(absoluteIndex - 1, includeWhitespace: false).Parent is RazorSyntaxNode previousTokenParent &&
+                RazorSyntaxFacts.IsAnyEndTag(previousTokenParent) &&
+                IsIncompleteTag(previousTokenParent))
+            {
+                return false;
+            }
+
             return true;
         }
 
-        return !startOrEndTag.Span.Contains(absoluteIndex);
+        return !startOrEndTag.Span.IntersectsWith(absoluteIndex);
 
         static bool IsInScriptOrStyleOrHtmlComment(AspNetCore.Razor.Language.Syntax.SyntaxNode? initialNode)
         {
@@ -262,6 +273,16 @@ internal static class DelegatedCompletionHelper
             }
 
             return false;
+        }
+
+        static bool IsIncompleteTag(RazorSyntaxNode tag)
+        {
+            return tag switch
+            {
+                BaseMarkupStartTagSyntax startTag => startTag.CloseAngle.IsMissing,
+                BaseMarkupEndTagSyntax endTag => endTag.CloseAngle.IsMissing,
+                _ => false
+            };
         }
     }
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/TagHelperCompletionProvider.cs
@@ -42,6 +42,7 @@ internal class TagHelperCompletionProvider(ITagHelperCompletionService tagHelper
         // surface. The attribute path does not depend on HTML labels at all.
         var owner = CompletionContextHelper.AdjustSyntaxNodeForCompletion(context.Owner);
         if (owner is not null
+            && owner is not BaseMarkupEndTagSyntax
             && HtmlFacts.TryGetElementInfo(owner, out var containingTagNameToken, out _, out _)
             && containingTagNameToken.Span.IntersectsWith(context.AbsoluteIndex))
         {
@@ -103,7 +104,8 @@ internal class TagHelperCompletionProvider(ITagHelperCompletionService tagHelper
             return [];
         }
 
-        if (HtmlFacts.TryGetElementInfo(owner, out var containingTagNameToken, out var elementAttributes, out _) &&
+        if (owner is not BaseMarkupEndTagSyntax &&
+            HtmlFacts.TryGetElementInfo(owner, out var containingTagNameToken, out var elementAttributes, out _) &&
             containingTagNameToken.Span.IntersectsWith(context.AbsoluteIndex))
         {
             // When NeedsHtmlCompletions returned false (pure Blazor/component scenario),

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/TagHelperCompletionProviderTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/TagHelperCompletionProviderTest.cs
@@ -94,4 +94,37 @@ public class TagHelperCompletionProviderTest(ITestOutputHelper testOutput) : Too
 
         return projectEngine.Process(sourceDocument, RazorFileKind.Legacy, importSources: default, tagHelpers);
     }
+
+    [Fact]
+    public void GetCompletionItems_EndTag_NoElementCompletions()
+    {
+        // Arrange - cursor is on the tag name inside an end tag (e.g., </te$$st1>).
+        // Tag helper element completions should not be offered in end-tag context.
+        var tagHelpers = SimpleTagHelpers.Default;
+
+        var testCode = new TestCode("@addTagHelper *, TestAssembly\n<test1></te$$st1>");
+        var codeDocument = CreateCodeDocument(testCode.Text, tagHelpers);
+        var syntaxTree = codeDocument.GetRequiredTagHelperRewrittenSyntaxTree();
+        var tagHelperContext = codeDocument.GetRequiredTagHelperContext();
+
+        var owner = syntaxTree.Root.FindInnermostNode(testCode.Position, includeWhitespace: true, walkMarkersBack: true);
+        owner = AbstractRazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, testCode.Position);
+
+        var context = new RazorCompletionContext(
+            codeDocument,
+            testCode.Position,
+            owner,
+            syntaxTree,
+            tagHelperContext,
+            CompletionReason.Invoked,
+            new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true, UseVsCodeCompletionCommitCharacters: false));
+
+        var provider = new TagHelperCompletionProvider(new TagHelperCompletionService());
+
+        // Act
+        var completions = provider.GetCompletionItems(context);
+
+        // Assert - No element completions should be returned for end tags
+        Assert.Empty(completions);
+    }
 }

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostDocumentCompletionEndpointTest_VS.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostDocumentCompletionEndpointTest_VS.cs
@@ -267,4 +267,78 @@ public partial class CohostDocumentCompletionEndpointTest
             htmlItemLabels: ["style", "dir"],
             snippetLabels: ["snippet1", "snippet2"]);
     }
+
+    [Fact]
+    public async Task HtmlSnippetsCompletion_NotInEndTag()
+    {
+        await VerifyCompletionListAsync(
+            input: """
+                <div></$$
+                """,
+            completionContext: new VSInternalCompletionContext()
+            {
+                InvokeKind = VSInternalCompletionInvokeKind.Typing,
+                TriggerCharacter = "/",
+                TriggerKind = CompletionTriggerKind.TriggerCharacter
+            },
+            expectedItemLabels: ["</div>"],
+            unexpectedItemLabels: ["snippet1", "snippet2"],
+            htmlItemLabels: ["</div>"],
+            snippetLabels: ["snippet1", "snippet2"]);
+    }
+
+    [Fact]
+    public async Task HtmlSnippetsCompletion_NotInEndTag_FollowedByContent()
+    {
+        await VerifyCompletionListAsync(
+            input: """
+                <div></$$</div>
+                """,
+            completionContext: new VSInternalCompletionContext()
+            {
+                InvokeKind = VSInternalCompletionInvokeKind.Typing,
+                TriggerCharacter = "/",
+                TriggerKind = CompletionTriggerKind.TriggerCharacter
+            },
+            expectedItemLabels: ["</div>"],
+            unexpectedItemLabels: ["snippet1", "snippet2"],
+            htmlItemLabels: ["</div>"],
+            snippetLabels: ["snippet1", "snippet2"]);
+    }
+
+    [Fact]
+    public async Task TagHelperElementCompletion_NotInEndTag()
+    {
+        await VerifyCompletionListAsync(
+            input: """
+                <div></d$$iv>
+                """,
+            completionContext: new VSInternalCompletionContext()
+            {
+                InvokeKind = VSInternalCompletionInvokeKind.Explicit,
+                TriggerKind = CompletionTriggerKind.Invoked
+            },
+            expectedItemLabels: [],
+            unexpectedItemLabels: ["EditForm"],
+            htmlItemLabels: []);
+    }
+
+    [Fact]
+    public async Task HtmlSnippetsCompletion_AfterCompleteEndTag()
+    {
+        // Snippets should still be offered when the cursor is immediately after a complete end tag.
+        // This guards against incorrectly suppressing snippets due to the previous token being part of an end tag.
+        await VerifyCompletionListAsync(
+            input: """
+                <div></div>$$
+                """,
+            completionContext: new VSInternalCompletionContext()
+            {
+                InvokeKind = VSInternalCompletionInvokeKind.Explicit,
+                TriggerKind = CompletionTriggerKind.Invoked
+            },
+            expectedItemLabels: ["snippet1", "snippet2"],
+            htmlItemLabels: [],
+            snippetLabels: ["snippet1", "snippet2"]);
+    }
 }


### PR DESCRIPTION
 Fixes https://github.com/dotnet/razor/issues/10030

 When typing `</` in Razor, HTML snippets and tag helper/component element completions were incorrectly offered alongside the expected end-tag completion items.

 Changes:
 - Change Span.Contains to Span.IntersectsWith in ShouldIncludeSnippets so the cursor at the end of an incomplete `</` tag (at Span.End) is recognized as inside the tag
 - Extend the EOF check to cover end tags and only suppress snippets when the tag is incomplete (CloseAngle.IsMissing), so that `<div>[EOF]` still offers snippets while `</[EOF]` does not
 - Add an incomplete-end-tag check when the cursor is right-associated to the next tag (e.g., `<div></|</div>`)
 - Add BaseMarkupEndTagSyntax guards in TagHelperCompletionProvider to skip element completions and phase-2 HTML label fetching for end-tag contexts
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83573)