### PR TITLE
Honor `SymbolDisplayMiscellaneousOptions.UseSpecialTypes` for native integer display on supported platforms

### DIFF
--- a/docs/Breaking API Changes.md
+++ b/docs/Breaking API Changes.md
@@ -118,3 +118,11 @@ A new required parameter `Compilation` has been added. Existing overloads withou
 ### Changes in `Microsoft.CodeAnalysis.Emit.SemanticEdit` constructors
 
 The value of `preserveLocalVariables` passed to the constructors is no longer used.
+
+# Version 5.4.0
+
+### Symbol display now honors `SymbolDisplayMiscellaneousOptions.UseSpecialTypes` option for native integers on supported platforms
+
+On platforms with `NumericIntPtr` capability (.NET 7 and beyond) `n[u]int` and `System.[U]IntPtr` represent the same types. Now on such platforms `SymbolDisplayMiscellaneousOptions.UseSpecialTypes` controls whether they are represented as keywords or respective type names in symbol display routines (`ToDisplayString`, `ToDisplayParts` etc.). On platforms without `NumericIntPtr` capability they are different types thus behavior is unchanged: native integers are represented as `n[u]int` keywords and `System.[U]IntPtr` as type names regardless of `SymbolDisplayMiscellaneousOptions.UseSpecialTypes` option.
+
+PR: TODO

--- a/docs/Breaking API Changes.md
+++ b/docs/Breaking API Changes.md
@@ -125,4 +125,4 @@ The value of `preserveLocalVariables` passed to the constructors is no longer us
 
 On platforms with `NumericIntPtr` capability (.NET 7 and beyond) `n[u]int` and `System.[U]IntPtr` represent the same types. Now on such platforms `SymbolDisplayMiscellaneousOptions.UseSpecialTypes` controls whether they are represented as keywords or respective type names in symbol display routines (`ToDisplayString`, `ToDisplayParts` etc.). On platforms without `NumericIntPtr` capability they are different types thus behavior is unchanged: native integers are represented as `n[u]int` keywords and `System.[U]IntPtr` as type names regardless of `SymbolDisplayMiscellaneousOptions.UseSpecialTypes` option.
 
-PR: TODO
+PR: https://github.com/dotnet/roslyn/pull/83583

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -205,12 +205,19 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (symbol.IsNativeIntegerType)
             {
-                if (!Format.CompilerInternalOptions.IncludesOption(SymbolDisplayCompilerInternalOptions.UseNativeIntegerUnderlyingType) &&
+                // If the runtime has the NumeriIntPtr capability then `nint` and
+                // `System.IntPtr` are the same type thus we follow user choice
+                // of `UseSpecialTypes` flag. Otherwise they are truly different types
+                // and we represent `nint` with a keyword regardless of user preferences
+                if ((Format.MiscellaneousOptions.IncludesOption(SymbolDisplayMiscellaneousOptions.UseSpecialTypes) || !hasNumericIntPtrCapability(symbol)) &&
                     AddSpecialTypeKeyword(symbol))
                 {
                     //if we're using special type keywords and this is a special type, then no other work is required
                     return;
                 }
+
+                static bool hasNumericIntPtrCapability(INamedTypeSymbol type)
+                    => type is Symbols.PublicModel.NamedTypeSymbol { UnderlyingNamedTypeSymbol.ContainingAssembly.RuntimeSupportsNumericIntPtr: true };
             }
             else if (Format.MiscellaneousOptions.IncludesOption(SymbolDisplayMiscellaneousOptions.UseSpecialTypes))
             {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
@@ -4290,7 +4290,7 @@ class TestCase
                   IL_0012:  pop
                   IL_0013:  ldsfld     "TestCase.<>c TestCase.<>c.<>9"
                   IL_0018:  ldftn      "int TestCase.<>c.<Run>b__1_0()"
-                  IL_001e:  newobj     "System.Func<int>..ctor(object, System.IntPtr)"
+                  IL_001e:  newobj     "System.Func<int>..ctor(object, nint)"
                   IL_0023:  dup
                   IL_0024:  stsfld     "System.Func<int> TestCase.<>c.<>9__1_0"
                   IL_0029:  callvirt   "System.Threading.Tasks.Task<int> System.Threading.Tasks.TaskFactory.StartNew<int>(System.Func<int>)"
@@ -4665,7 +4665,7 @@ class Driver
                   IL_0025:  pop
                   IL_0026:  ldsfld     "Driver.<>c Driver.<>c.<>9"
                   IL_002b:  ldftn      "int Driver.<>c.<Run>b__1_0()"
-                  IL_0031:  newobj     "System.Func<int>..ctor(object, System.IntPtr)"
+                  IL_0031:  newobj     "System.Func<int>..ctor(object, nint)"
                   IL_0036:  dup
                   IL_0037:  stsfld     "System.Func<int> Driver.<>c.<>9__1_0"
                   IL_003c:  callvirt   "System.Threading.Tasks.Task<int> System.Threading.Tasks.TaskFactory.StartNew<int>(System.Func<int>)"
@@ -4738,7 +4738,7 @@ class Driver
                   IL_001d:  pop
                   IL_001e:  ldsfld     "Driver.<>c Driver.<>c.<>9"
                   IL_0023:  ldftn      "int Driver.<>c.<Run>b__1_0()"
-                  IL_0029:  newobj     "System.Func<int>..ctor(object, System.IntPtr)"
+                  IL_0029:  newobj     "System.Func<int>..ctor(object, nint)"
                   IL_002e:  dup
                   IL_002f:  stsfld     "System.Func<int> Driver.<>c.<>9__1_0"
                   IL_0034:  callvirt   "System.Threading.Tasks.Task<int> System.Threading.Tasks.TaskFactory.StartNew<int>(System.Func<int>)"
@@ -4761,7 +4761,7 @@ class Driver
                   IL_0056:  pop
                   IL_0057:  ldsfld     "Driver.<>c Driver.<>c.<>9"
                   IL_005c:  ldftn      "int Driver.<>c.<Run>b__1_1()"
-                  IL_0062:  newobj     "System.Func<int>..ctor(object, System.IntPtr)"
+                  IL_0062:  newobj     "System.Func<int>..ctor(object, nint)"
                   IL_0067:  dup
                   IL_0068:  stsfld     "System.Func<int> Driver.<>c.<>9__1_1"
                   IL_006d:  callvirt   "System.Threading.Tasks.Task<int> System.Threading.Tasks.TaskFactory.StartNew<int>(System.Func<int>)"
@@ -4844,7 +4844,7 @@ class Driver
                   IL_0014:  pop
                   IL_0015:  ldsfld     "Driver.<>c Driver.<>c.<>9"
                   IL_001a:  ldftn      "int Driver.<>c.<Run>b__0_0()"
-                  IL_0020:  newobj     "System.Func<int>..ctor(object, System.IntPtr)"
+                  IL_0020:  newobj     "System.Func<int>..ctor(object, nint)"
                   IL_0025:  dup
                   IL_0026:  stsfld     "System.Func<int> Driver.<>c.<>9__0_0"
                   IL_002b:  callvirt   "System.Threading.Tasks.Task<int> System.Threading.Tasks.TaskFactory.StartNew<int>(System.Func<int>)"
@@ -4875,7 +4875,7 @@ class Driver
                   IL_0069:  pop
                   IL_006a:  ldsfld     "Driver.<>c Driver.<>c.<>9"
                   IL_006f:  ldftn      "int Driver.<>c.<Run>b__0_1()"
-                  IL_0075:  newobj     "System.Func<int>..ctor(object, System.IntPtr)"
+                  IL_0075:  newobj     "System.Func<int>..ctor(object, nint)"
                   IL_007a:  dup
                   IL_007b:  stsfld     "System.Func<int> Driver.<>c.<>9__0_1"
                   IL_0080:  callvirt   "System.Threading.Tasks.Task<int> System.Threading.Tasks.TaskFactory.StartNew<int>(System.Func<int>)"
@@ -4896,7 +4896,7 @@ class Driver
                   IL_00ae:  pop
                   IL_00af:  ldsfld     "Driver.<>c Driver.<>c.<>9"
                   IL_00b4:  ldftn      "int Driver.<>c.<Run>b__0_2()"
-                  IL_00ba:  newobj     "System.Func<int>..ctor(object, System.IntPtr)"
+                  IL_00ba:  newobj     "System.Func<int>..ctor(object, nint)"
                   IL_00bf:  dup
                   IL_00c0:  stsfld     "System.Func<int> Driver.<>c.<>9__0_2"
                   IL_00c5:  callvirt   "System.Threading.Tasks.Task<int> System.Threading.Tasks.TaskFactory.StartNew<int>(System.Func<int>)"
@@ -4985,7 +4985,7 @@ class Driver
                   IL_0014:  pop
                   IL_0015:  ldsfld     "Driver.<>c Driver.<>c.<>9"
                   IL_001a:  ldftn      "int Driver.<>c.<Run>b__0_0()"
-                  IL_0020:  newobj     "System.Func<int>..ctor(object, System.IntPtr)"
+                  IL_0020:  newobj     "System.Func<int>..ctor(object, nint)"
                   IL_0025:  dup
                   IL_0026:  stsfld     "System.Func<int> Driver.<>c.<>9__0_0"
                   IL_002b:  callvirt   "System.Threading.Tasks.Task<int> System.Threading.Tasks.TaskFactory.StartNew<int>(System.Func<int>)"
@@ -5018,7 +5018,7 @@ class Driver
                   IL_006e:  pop
                   IL_006f:  ldsfld     "Driver.<>c Driver.<>c.<>9"
                   IL_0074:  ldftn      "int Driver.<>c.<Run>b__0_1()"
-                  IL_007a:  newobj     "System.Func<int>..ctor(object, System.IntPtr)"
+                  IL_007a:  newobj     "System.Func<int>..ctor(object, nint)"
                   IL_007f:  dup
                   IL_0080:  stsfld     "System.Func<int> Driver.<>c.<>9__0_1"
                   IL_0085:  callvirt   "System.Threading.Tasks.Task<int> System.Threading.Tasks.TaskFactory.StartNew<int>(System.Func<int>)"
@@ -5050,7 +5050,7 @@ class Driver
                   IL_00cd:  pop
                   IL_00ce:  ldsfld     "Driver.<>c Driver.<>c.<>9"
                   IL_00d3:  ldftn      "int Driver.<>c.<Run>b__0_2()"
-                  IL_00d9:  newobj     "System.Func<int>..ctor(object, System.IntPtr)"
+                  IL_00d9:  newobj     "System.Func<int>..ctor(object, nint)"
                   IL_00de:  dup
                   IL_00df:  stsfld     "System.Func<int> Driver.<>c.<>9__0_2"
                   IL_00e4:  callvirt   "System.Threading.Tasks.Task<int> System.Threading.Tasks.TaskFactory.StartNew<int>(System.Func<int>)"
@@ -5085,7 +5085,7 @@ class Driver
                   IL_0134:  pop
                   IL_0135:  ldsfld     "Driver.<>c Driver.<>c.<>9"
                   IL_013a:  ldftn      "int Driver.<>c.<Run>b__0_3()"
-                  IL_0140:  newobj     "System.Func<int>..ctor(object, System.IntPtr)"
+                  IL_0140:  newobj     "System.Func<int>..ctor(object, nint)"
                   IL_0145:  dup
                   IL_0146:  stsfld     "System.Func<int> Driver.<>c.<>9__0_3"
                   IL_014b:  callvirt   "System.Threading.Tasks.Task<int> System.Threading.Tasks.TaskFactory.StartNew<int>(System.Func<int>)"
@@ -6113,7 +6113,7 @@ class Test
                   IL_000d:  pop
                   IL_000e:  ldsfld     "Test.<>c Test.<>c.<>9"
                   IL_0013:  ldftn      "int Test.<>c.<Run>b__0_0()"
-                  IL_0019:  newobj     "System.Func<int>..ctor(object, System.IntPtr)"
+                  IL_0019:  newobj     "System.Func<int>..ctor(object, nint)"
                   IL_001e:  dup
                   IL_001f:  stsfld     "System.Func<int> Test.<>c.<>9__0_0"
                   IL_0024:  callvirt   "System.Threading.Tasks.Task<int> System.Threading.Tasks.TaskFactory.StartNew<int>(System.Func<int>)"
@@ -6360,7 +6360,7 @@ class Driver
                   IL_0017:  pop
                   IL_0018:  ldsfld     "Test.<>c Test.<>c.<>9"
                   IL_001d:  ldftn      "int Test.<>c.<Run>b__2_0()"
-                  IL_0023:  newobj     "System.Func<int>..ctor(object, System.IntPtr)"
+                  IL_0023:  newobj     "System.Func<int>..ctor(object, nint)"
                   IL_0028:  dup
                   IL_0029:  stsfld     "System.Func<int> Test.<>c.<>9__2_0"
                   IL_002e:  callvirt   "System.Threading.Tasks.Task<int> System.Threading.Tasks.TaskFactory.StartNew<int>(System.Func<int>)"
@@ -7758,7 +7758,7 @@ static class Driver
                   IL_001a:  pop
                   IL_001b:  ldsfld     "TestCase.<>c TestCase.<>c.<>9"
                   IL_0020:  ldftn      "int TestCase.<>c.<Run>b__1_0()"
-                  IL_0026:  newobj     "System.Func<int>..ctor(object, System.IntPtr)"
+                  IL_0026:  newobj     "System.Func<int>..ctor(object, nint)"
                   IL_002b:  dup
                   IL_002c:  stsfld     "System.Func<int> TestCase.<>c.<>9__1_0"
                   IL_0031:  callvirt   "System.Threading.Tasks.Task<int> System.Threading.Tasks.TaskFactory.StartNew<int>(System.Func<int>)"
@@ -9762,7 +9762,7 @@ class C
                   IL_0036:  pop
                   IL_0037:  ldsfld     "C.<>c C.<>c.<>9"
                   IL_003c:  ldftn      "int C.<>c.<F2>b__2_1()"
-                  IL_0042:  newobj     "System.Func<int>..ctor(object, System.IntPtr)"
+                  IL_0042:  newobj     "System.Func<int>..ctor(object, nint)"
                   IL_0047:  dup
                   IL_0048:  stsfld     "System.Func<int> C.<>c.<>9__2_1"
                   IL_004d:  callvirt   "System.Threading.Tasks.Task<int> System.Threading.Tasks.TaskFactory.StartNew<int>(System.Func<int>)"
@@ -10134,7 +10134,7 @@ public class AsyncBug {
                   IL_0006:  call       "int System.Runtime.CompilerServices.AsyncHelpers.Await<int>(System.Threading.Tasks.Task<int>)"
                   IL_000b:  box        "int"
                   IL_0010:  ldftn      "System.Type object.GetType()"
-                  IL_0016:  newobj     "System.Func<System.Type>..ctor(object, System.IntPtr)"
+                  IL_0016:  newobj     "System.Func<System.Type>..ctor(object, nint)"
                   IL_001b:  callvirt   "System.Type System.Func<System.Type>.Invoke()"
                   IL_0020:  call       "void System.Console.WriteLine(object)"
                   IL_0025:  ret
@@ -10212,7 +10212,7 @@ namespace AsyncBug
                   IL_001c:  stloc.0
                   IL_001d:  ldloc.0
                   IL_001e:  ldftn      "bool AsyncBug.Program.SomeClass.Method(int)"
-                  IL_0024:  newobj     "System.Func<int, bool>..ctor(object, System.IntPtr)"
+                  IL_0024:  newobj     "System.Func<int, bool>..ctor(object, nint)"
                   IL_0029:  call       "System.Collections.Generic.IEnumerable<bool> System.Linq.Enumerable.Select<int, bool>(System.Collections.Generic.IEnumerable<int>, System.Func<int, bool>)"
                   IL_002e:  ret
                 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -12,7 +12,6 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
-using Roslyn.Utilities;
 using Xunit;
 
 // https://github.com/dotnet/runtime/issues/118042: ILVerify for runtime async?
@@ -181,7 +180,7 @@ class Test
                       IL_001a:  pop
                       IL_001b:  ldsfld     "Test.<>c Test.<>c.<>9"
                       IL_0020:  ldftn      "void Test.<>c.<F>b__1_0()"
-                      IL_0026:  newobj     "System.Action..ctor(object, System.IntPtr)"
+                      IL_0026:  newobj     "System.Action..ctor(object, nint)"
                       IL_002b:  dup
                       IL_002c:  stsfld     "System.Action Test.<>c.<>9__1_0"
                       IL_0031:  callvirt   "System.Threading.Tasks.Task System.Threading.Tasks.TaskFactory.StartNew(System.Action)"
@@ -305,7 +304,7 @@ class Test
                   IL_000d:  pop
                   IL_000e:  ldsfld     "Test.<>c Test.<>c.<>9"
                   IL_0013:  ldftn      "void Test.<>c.<F>b__1_0()"
-                  IL_0019:  newobj     "System.Action..ctor(object, System.IntPtr)"
+                  IL_0019:  newobj     "System.Action..ctor(object, nint)"
                   IL_001e:  dup
                   IL_001f:  stsfld     "System.Action Test.<>c.<>9__1_0"
                   IL_0024:  callvirt   "System.Threading.Tasks.Task System.Threading.Tasks.TaskFactory.StartNew(System.Action)"
@@ -433,7 +432,7 @@ O brave new world...
                   IL_000d:  pop
                   IL_000e:  ldsfld     "Test.<>c Test.<>c.<>9"
                   IL_0013:  ldftn      "string Test.<>c.<F>b__0_0()"
-                  IL_0019:  newobj     "System.Func<string>..ctor(object, System.IntPtr)"
+                  IL_0019:  newobj     "System.Func<string>..ctor(object, nint)"
                   IL_001e:  dup
                   IL_001f:  stsfld     "System.Func<string> Test.<>c.<>9__0_0"
                   IL_0024:  callvirt   "System.Threading.Tasks.Task<string> System.Threading.Tasks.TaskFactory.StartNew<string>(System.Func<string>)"
@@ -592,7 +591,7 @@ class Test
                       IL_0008:  pop
                       IL_0009:  ldsfld     "Test.<>c Test.<>c.<>9"
                       IL_000e:  ldftn      "string Test.<>c.<F>b__0_0()"
-                      IL_0014:  newobj     "System.Func<string>..ctor(object, System.IntPtr)"
+                      IL_0014:  newobj     "System.Func<string>..ctor(object, nint)"
                       IL_0019:  dup
                       IL_001a:  stsfld     "System.Func<string> Test.<>c.<>9__0_0"
                       IL_001f:  newobj     "System.Threading.Tasks.Task<string>..ctor(System.Func<string>)"
@@ -9190,7 +9189,7 @@ static class Test1
                   IL_000f:  brtrue.s   IL_0026
                   IL_0011:  ldsfld     "Program.<>c Program.<>c.<>9"
                   IL_0016:  ldftn      "System.Threading.Tasks.Task Program.<>c.<Main>b__0_0()"
-                  IL_001c:  newobj     "System.Func<System.Threading.Tasks.Task>..ctor(object, System.IntPtr)"
+                  IL_001c:  newobj     "System.Func<System.Threading.Tasks.Task>..ctor(object, nint)"
                   IL_0021:  stsfld     "System.Func<System.Threading.Tasks.Task> Program.<>c.<>9__0_0"
                   IL_0026:  ret
                 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
@@ -1465,7 +1465,7 @@ public class C
                     IL_006a:  brtrue.s   IL_007a
                     IL_006c:  ldloc.s    V_4
                     IL_006e:  ldftn      "void C.<>c__DisplayClass0_0.<Main>b__0()"
-                    IL_0074:  newobj     "System.Action..ctor(object, System.IntPtr)"
+                    IL_0074:  newobj     "System.Action..ctor(object, nint)"
                     IL_0079:  stloc.0
                     IL_007a:  ldloc.1
                     IL_007b:  callvirt   "System.Threading.Tasks.Task<bool> C.AsyncEnumerator.MoveNextAsync()"
@@ -11166,7 +11166,7 @@ public static class Extensions
                   IL_0008:  pop
                   IL_0009:  ldsfld     "C.<>c C.<>c.<>9"
                   IL_000e:  ldftn      "int C.<>c.<Main>b__0_0()"
-                  IL_0014:  newobj     "System.Func<int>..ctor(object, System.IntPtr)"
+                  IL_0014:  newobj     "System.Func<int>..ctor(object, nint)"
                   IL_0019:  dup
                   IL_001a:  stsfld     "System.Func<int> C.<>c.<>9__0_0"
                   IL_001f:  call       "C.Enumerator Extensions.GetAsyncEnumerator(System.Func<int>)"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOptimizedNullableOperators.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOptimizedNullableOperators.cs
@@ -4,11 +4,7 @@
 
 #nullable disable
 
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.CSharp.UnitTests.Emit;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -4764,7 +4760,7 @@ class Program
                 {
                   // Code size       24 (0x18)
                   .maxstack  2
-                  .locals init (System.IntPtr? V_0,
+                  .locals init (nint? V_0,
                                 System.IntPtr V_1)
                   IL_0000:  ldarg.0
                   IL_0001:  stloc.0
@@ -4772,11 +4768,11 @@ class Program
                   IL_0003:  conv.i
                   IL_0004:  stloc.1
                   IL_0005:  ldloca.s   V_0
-                  IL_0007:  call       "System.IntPtr System.IntPtr?.GetValueOrDefault()"
+                  IL_0007:  call       "nint nint?.GetValueOrDefault()"
                   IL_000c:  ldloc.1
                   IL_000d:  ceq
                   IL_000f:  ldloca.s   V_0
-                  IL_0011:  call       "bool System.IntPtr?.HasValue.get"
+                  IL_0011:  call       "bool nint?.HasValue.get"
                   IL_0016:  and
                   IL_0017:  ret
                 }
@@ -4813,7 +4809,7 @@ class Program
                   // Code size       12 (0xc)
                   .maxstack  2
                   IL_0000:  ldarga.s   V_0
-                  IL_0002:  call       "System.IntPtr System.IntPtr?.GetValueOrDefault()"
+                  IL_0002:  call       "nint nint?.GetValueOrDefault()"
                   IL_0007:  ldc.i4.1
                   IL_0008:  conv.i
                   IL_0009:  ceq
@@ -4851,7 +4847,7 @@ class Program
                 {
                   // Code size       24 (0x18)
                   .maxstack  2
-                  .locals init (System.UIntPtr? V_0,
+                  .locals init (nuint? V_0,
                                 System.UIntPtr V_1)
                   IL_0000:  ldarg.0
                   IL_0001:  stloc.0
@@ -4859,11 +4855,11 @@ class Program
                   IL_0003:  conv.i
                   IL_0004:  stloc.1
                   IL_0005:  ldloca.s   V_0
-                  IL_0007:  call       "System.UIntPtr System.UIntPtr?.GetValueOrDefault()"
+                  IL_0007:  call       "nuint nuint?.GetValueOrDefault()"
                   IL_000c:  ldloc.1
                   IL_000d:  ceq
                   IL_000f:  ldloca.s   V_0
-                  IL_0011:  call       "bool System.UIntPtr?.HasValue.get"
+                  IL_0011:  call       "bool nuint?.HasValue.get"
                   IL_0016:  and
                   IL_0017:  ret
                 }
@@ -4900,7 +4896,7 @@ class Program
                   // Code size       12 (0xc)
                   .maxstack  2
                   IL_0000:  ldarga.s   V_0
-                  IL_0002:  call       "System.UIntPtr System.UIntPtr?.GetValueOrDefault()"
+                  IL_0002:  call       "nuint nuint?.GetValueOrDefault()"
                   IL_0007:  ldc.i4.1
                   IL_0008:  conv.i
                   IL_0009:  ceq

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadOnlySpanConstructionTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadOnlySpanConstructionTest.cs
@@ -2932,7 +2932,7 @@ public class C
   IL_0013:  stelem.i
   IL_0014:  dup
   IL_0015:  stsfld     "nint[] <PrivateImplementationDetails>.67ABDD721024F0FF4E0B3F4C2FC13BC5BAD42D0B7851D456D88D203D15AAA450_B8"
-  IL_001a:  newobj     "System.ReadOnlySpan<System.IntPtr>..ctor(System.IntPtr[])"
+  IL_001a:  newobj     "System.ReadOnlySpan<nint>..ctor(nint[])"
   IL_001f:  ret
 }
 """;
@@ -2975,7 +2975,7 @@ public class C
   IL_0017:  stelem.i
   IL_0018:  dup
   IL_0019:  stsfld     "nint[] <PrivateImplementationDetails>.A2C70538651A7E9296B097E8C3DFC1B195A945802FFE45AA471868FBA6F1042E_B8"
-  IL_001e:  newobj     "System.ReadOnlySpan<System.IntPtr>..ctor(System.IntPtr[])"
+  IL_001e:  newobj     "System.ReadOnlySpan<nint>..ctor(nint[])"
   IL_0023:  ret
 }
 """;
@@ -3025,7 +3025,7 @@ public class C
   IL_0013:  stelem.i
   IL_0014:  dup
   IL_0015:  stsfld     "nuint[] <PrivateImplementationDetails>.67ABDD721024F0FF4E0B3F4C2FC13BC5BAD42D0B7851D456D88D203D15AAA450_B16"
-  IL_001a:  newobj     "System.ReadOnlySpan<System.UIntPtr>..ctor(System.UIntPtr[])"
+  IL_001a:  newobj     "System.ReadOnlySpan<nuint>..ctor(nuint[])"
   IL_001f:  ret
 }
 """;
@@ -3068,7 +3068,7 @@ public class C
   IL_0013:  stelem.i
   IL_0014:  dup
   IL_0015:  stsfld     "nuint[] <PrivateImplementationDetails>.AD95131BC0B799C0B1AF477FB14FCF26A6A9F76079E48BF090ACB7E8367BFD0E_B16"
-  IL_001a:  newobj     "System.ReadOnlySpan<System.UIntPtr>..ctor(System.UIntPtr[])"
+  IL_001a:  newobj     "System.ReadOnlySpan<nuint>..ctor(nuint[])"
   IL_001f:  ret
 }
 """;
@@ -3115,7 +3115,7 @@ public class C
   IL_0013:  stelem.i
   IL_0014:  dup
   IL_0015:  stsfld     "nuint[] <PrivateImplementationDetails>.67ABDD721024F0FF4E0B3F4C2FC13BC5BAD42D0B7851D456D88D203D15AAA450_B16"
-  IL_001a:  newobj     "System.ReadOnlySpan<System.UIntPtr>..ctor(System.UIntPtr[])"
+  IL_001a:  newobj     "System.ReadOnlySpan<nuint>..ctor(nuint[])"
   IL_001f:  ret
 }
 """);
@@ -3136,7 +3136,7 @@ public class C
   IL_0013:  stelem.i
   IL_0014:  dup
   IL_0015:  stsfld     "nint[] <PrivateImplementationDetails>.67ABDD721024F0FF4E0B3F4C2FC13BC5BAD42D0B7851D456D88D203D15AAA450_B8"
-  IL_001a:  newobj     "System.ReadOnlySpan<System.IntPtr>..ctor(System.IntPtr[])"
+  IL_001a:  newobj     "System.ReadOnlySpan<nint>..ctor(nint[])"
   IL_001f:  ret
 }
 """);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadOnlySpanConstructionTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadOnlySpanConstructionTest.cs
@@ -3425,7 +3425,7 @@ class Test
   IL_003f:  call       "void System.Console.Write(bool)"
   IL_0044:  ret
 }
-""", ilFormat: SymbolDisplayFormat.ILVisualizationFormat.RemoveCompilerInternalOptions(SymbolDisplayCompilerInternalOptions.UseNativeIntegerUnderlyingType));
+""");
         }
 
         [Theory]

--- a/src/Compilers/CSharp/Test/Emit2/Emit/LocalStateTracing/LocalStateTracingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Emit/LocalStateTracing/LocalStateTracingTests.cs
@@ -1425,7 +1425,7 @@ F: Returned
       // sequence point: }}
       IL_0055:  ret
     }}
-", ilFormat: SymbolDisplayFormat.ILVisualizationFormat.RemoveCompilerInternalOptions(SymbolDisplayCompilerInternalOptions.UseNativeIntegerUnderlyingType));
+");
         }
 
         [Theory]

--- a/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
@@ -20,7 +20,6 @@ using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
-using Roslyn.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
@@ -51,10 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
         internal static readonly ConversionKind[] ExplicitNullableIdentity = new[] { ConversionKind.ExplicitNullable, ConversionKind.Identity };
 
         internal static readonly SymbolDisplayFormat TestFormat = SymbolDisplayFormat.TestFormat
-            .RemoveCompilerInternalOptions(SymbolDisplayCompilerInternalOptions.UseNativeIntegerUnderlyingType);
-
-        internal static readonly SymbolDisplayFormat ILFormat = SymbolDisplayFormat.ILVisualizationFormat
-            .RemoveCompilerInternalOptions(SymbolDisplayCompilerInternalOptions.UseNativeIntegerUnderlyingType);
+            .AddMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
 
         internal static bool IsNoConversion(ConversionKind[] conversionKinds)
         {
@@ -575,9 +571,9 @@ class Program
                 var actualMembers = members.SelectAsArray(m => m.ToDisplayString(TestFormat));
                 var expectedMembers = new[]
                 {
-                    $"System.Boolean {type}.Equals(System.Object obj)",
-                    $"System.Int32 {type}.GetHashCode()",
-                    $"System.String {type}.ToString()",
+                    $"bool {type}.Equals(object obj)",
+                    $"int {type}.GetHashCode()",
+                    $"string {type}.ToString()",
                     $"{type}..ctor()",
                 };
                 AssertEx.Equal(expectedMembers, actualMembers);
@@ -1347,7 +1343,7 @@ class Program
   IL_0021:  sizeof     ""nuint""
   IL_0027:  call       ""void System.Console.Write(int)""
   IL_002c:  ret
-}", ilFormat: ILFormat);
+}");
         }
 
         [Fact]
@@ -1474,7 +1470,7 @@ class Program
   IL_0009:  ldsfld     ""nuint Program.F2""
   IL_000e:  add
   IL_000f:  ret
-}", ilFormat: ILFormat);
+}");
         }
 
         [Fact]
@@ -1508,7 +1504,7 @@ class Program
   IL_0000:  ldarga.s   V_0
   IL_0002:  call       ""string nint.ToString()""
   IL_0007:  ret
-}", ilFormat: ILFormat);
+}");
             verifier.VerifyIL("Program.F2",
 @"{
   // Code size        7 (0x7)
@@ -1516,7 +1512,7 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  box        ""nint""
   IL_0006:  ret
-}", ilFormat: ILFormat);
+}");
         }
 
         /// <summary>
@@ -1682,7 +1678,7 @@ public class A
   IL_0034:  call       ""readonly nuint nuint?.GetValueOrDefault()""
   IL_0039:  pop
   IL_003a:  ret
-}", ilFormat: ILFormat);
+}");
             verifier.VerifyIL("B.M2",
 @"{
   // Code size       95 (0x5f)
@@ -1726,7 +1722,7 @@ public class A
   IL_0054:  newobj     ""nuint?..ctor(nuint)""
   IL_0059:  stsfld     ""nuint? A.F4""
   IL_005e:  ret
-}", ilFormat: ILFormat);
+}");
         }
 
         [Theory, CombinatorialData]
@@ -1851,7 +1847,7 @@ public class A
   IL_00ec:  newobj     ""nuint?..ctor(nuint)""
   IL_00f1:  stsfld     ""nuint? A.F4""
   IL_00f6:  ret
-}", ilFormat: ILFormat);
+}");
         }
 
         [Fact, WorkItem(63860, "https://github.com/dotnet/roslyn/issues/63860")]
@@ -1985,17 +1981,17 @@ $@"class Program
                 $"{nativeType} {nativeType}.op_Multiply({nativeType} left, {nativeType} right)",
                 $"{nativeType} {nativeType}.op_Division({nativeType} left, {nativeType} right)",
                 $"{nativeType} {nativeType}.op_Modulus({nativeType} left, {nativeType} right)",
-                $"System.Boolean {nativeType}.op_LessThan({nativeType} left, {nativeType} right)",
-                $"System.Boolean {nativeType}.op_LessThanOrEqual({nativeType} left, {nativeType} right)",
-                $"System.Boolean {nativeType}.op_GreaterThan({nativeType} left, {nativeType} right)",
-                $"System.Boolean {nativeType}.op_GreaterThanOrEqual({nativeType} left, {nativeType} right)",
-                $"System.Boolean {nativeType}.op_Equality({nativeType} left, {nativeType} right)",
-                $"System.Boolean {nativeType}.op_Inequality({nativeType} left, {nativeType} right)",
+                $"bool {nativeType}.op_LessThan({nativeType} left, {nativeType} right)",
+                $"bool {nativeType}.op_LessThanOrEqual({nativeType} left, {nativeType} right)",
+                $"bool {nativeType}.op_GreaterThan({nativeType} left, {nativeType} right)",
+                $"bool {nativeType}.op_GreaterThanOrEqual({nativeType} left, {nativeType} right)",
+                $"bool {nativeType}.op_Equality({nativeType} left, {nativeType} right)",
+                $"bool {nativeType}.op_Inequality({nativeType} left, {nativeType} right)",
                 $"{nativeType} {nativeType}.op_BitwiseAnd({nativeType} left, {nativeType} right)",
                 $"{nativeType} {nativeType}.op_BitwiseOr({nativeType} left, {nativeType} right)",
                 $"{nativeType} {nativeType}.op_ExclusiveOr({nativeType} left, {nativeType} right)",
-                $"{nativeType} {nativeType}.op_LeftShift({nativeType} left, System.Int32 right)",
-                $"{nativeType} {nativeType}.op_RightShift({nativeType} left, System.Int32 right)",
+                $"{nativeType} {nativeType}.op_LeftShift({nativeType} left, int right)",
+                $"{nativeType} {nativeType}.op_RightShift({nativeType} left, int right)",
             };
             AssertEx.Equal(expectedOperators, actualOperators);
         }
@@ -2568,7 +2564,7 @@ $@"class Program
   IL_00cb:  call       ""void Program.F(nint)""
   IL_00d0:  ret
 }";
-            verifier.VerifyIL("Program.Main", expectedIL, ilFormat: ILFormat);
+            verifier.VerifyIL("Program.Main", expectedIL);
         }
 
         [Theory]
@@ -2681,7 +2677,7 @@ $@"class Program
   IL_0087:  call       ""void Program.F(nuint)""
   IL_008c:  ret
 }";
-            verifier.VerifyIL("Program.Main", expectedIL, ilFormat: ILFormat);
+            verifier.VerifyIL("Program.Main", expectedIL);
         }
 
         [Fact]
@@ -3243,7 +3239,7 @@ default: 0
       IL_00c7:  ldarg.0
       IL_00c8:  ret
     }
-    ", ilFormat: ILFormat);
+    ");
         }
 
         [Fact]
@@ -3405,7 +3401,7 @@ default: 0
       IL_00b6:  ldarg.0
       IL_00b7:  ret
     }
-", ilFormat: ILFormat);
+");
         }
 
         [Fact]
@@ -6029,7 +6025,7 @@ enum E {{ }}
                 if (expectedIL != null)
                 {
                     var verifier = CompileAndVerify(comp, verify: useUnsafeContext ? Verification.Skipped : Verification.FailsPEVerify);
-                    verifier.VerifyIL("Program.Convert", expectedIL, ilFormat: ILFormat);
+                    verifier.VerifyIL("Program.Convert", expectedIL);
                 }
 
                 static bool useUnsafe(string type) => type == "void*" || type == "delegate*<void>";
@@ -6258,7 +6254,7 @@ $@"class Program
                 if (expectedDiagnostics.Length == 0)
                 {
                     var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(expectedResult));
-                    verifier.VerifyIL("Program.Evaluate", expectedIL, ilFormat: ILFormat);
+                    verifier.VerifyIL("Program.Evaluate", expectedIL);
                 }
             }
         }
@@ -6634,7 +6630,7 @@ class Program
                 if (expectedDiagnostics.Length == 0)
                 {
                     var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(expectedResult));
-                    verifier.VerifyIL("Program.Evaluate", expectedIL, ilFormat: ILFormat);
+                    verifier.VerifyIL("Program.Evaluate", expectedIL);
                 }
             }
         }
@@ -6866,7 +6862,7 @@ class Program
                 if (expectedDiagnostics.Length == 0)
                 {
                     var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(expectedResult));
-                    verifier.VerifyIL("Program.Evaluate", expectedIL, ilFormat: ILFormat);
+                    verifier.VerifyIL("Program.Evaluate", expectedIL);
                 }
             }
         }
@@ -8215,7 +8211,7 @@ False
   IL_0001:  ldarg.1
   IL_0002:  add
   IL_0003:  ret
-}", ilFormat: ILFormat);
+}");
             verifier.VerifyIL("Program.Subtract",
 @"{
   // Code size        4 (0x4)
@@ -8224,7 +8220,7 @@ False
   IL_0001:  ldarg.1
   IL_0002:  sub
   IL_0003:  ret
-}", ilFormat: ILFormat);
+}");
             verifier.VerifyIL("Program.Multiply",
 @"{
   // Code size        4 (0x4)
@@ -8233,7 +8229,7 @@ False
   IL_0001:  ldarg.1
   IL_0002:  mul
   IL_0003:  ret
-}", ilFormat: ILFormat);
+}");
             verifier.VerifyIL("Program.Divide",
 @"{
   // Code size        4 (0x4)
@@ -8242,7 +8238,7 @@ False
   IL_0001:  ldarg.1
   IL_0002:  div
   IL_0003:  ret
-}", ilFormat: ILFormat);
+}");
             verifier.VerifyIL("Program.Mod",
 @"{
   // Code size        4 (0x4)
@@ -8251,7 +8247,7 @@ False
   IL_0001:  ldarg.1
   IL_0002:  rem
   IL_0003:  ret
-}", ilFormat: ILFormat);
+}");
             verifier.VerifyIL("Program.Equals",
 @"{
   // Code size        5 (0x5)
@@ -8260,7 +8256,7 @@ False
   IL_0001:  ldarg.1
   IL_0002:  ceq
   IL_0004:  ret
-}", ilFormat: ILFormat);
+}");
             verifier.VerifyIL("Program.NotEquals",
 @"{
   // Code size        8 (0x8)
@@ -8271,7 +8267,7 @@ False
   IL_0004:  ldc.i4.0
   IL_0005:  ceq
   IL_0007:  ret
-}", ilFormat: ILFormat);
+}");
             verifier.VerifyIL("Program.LessThan",
 @"{
   // Code size        5 (0x5)
@@ -8280,7 +8276,7 @@ False
   IL_0001:  ldarg.1
   IL_0002:  clt
   IL_0004:  ret
-}", ilFormat: ILFormat);
+}");
             verifier.VerifyIL("Program.LessThanOrEqual",
 @"{
   // Code size        8 (0x8)
@@ -8291,7 +8287,7 @@ False
   IL_0004:  ldc.i4.0
   IL_0005:  ceq
   IL_0007:  ret
-}", ilFormat: ILFormat);
+}");
             verifier.VerifyIL("Program.GreaterThan",
 @"{
   // Code size        5 (0x5)
@@ -8300,7 +8296,7 @@ False
   IL_0001:  ldarg.1
   IL_0002:  cgt
   IL_0004:  ret
-}", ilFormat: ILFormat);
+}");
             verifier.VerifyIL("Program.GreaterThanOrEqual",
 @"{
   // Code size        8 (0x8)
@@ -8311,7 +8307,7 @@ False
   IL_0004:  ldc.i4.0
   IL_0005:  ceq
   IL_0007:  ret
-}", ilFormat: ILFormat);
+}");
             verifier.VerifyIL("Program.And",
 @"{
   // Code size        4 (0x4)
@@ -8320,7 +8316,7 @@ False
   IL_0001:  ldarg.1
   IL_0002:  and
   IL_0003:  ret
-}", ilFormat: ILFormat);
+}");
             verifier.VerifyIL("Program.Or",
 @"{
   // Code size        4 (0x4)
@@ -8329,7 +8325,7 @@ False
   IL_0001:  ldarg.1
   IL_0002:  or
   IL_0003:  ret
-}", ilFormat: ILFormat);
+}");
             verifier.VerifyIL("Program.Xor",
 @"{
   // Code size        4 (0x4)
@@ -8338,7 +8334,7 @@ False
   IL_0001:  ldarg.1
   IL_0002:  xor
   IL_0003:  ret
-}", ilFormat: ILFormat);
+}");
             verifier.VerifyIL("Program.ShiftLeft",
 @"{
   // Code size       15 (0xf)
@@ -8353,7 +8349,7 @@ False
   IL_000c:  and
   IL_000d:  shl
   IL_000e:  ret
-}", ilFormat: ILFormat);
+}");
             verifier.VerifyIL("Program.ShiftRight",
 @"{
   // Code size       15 (0xf)
@@ -8368,7 +8364,7 @@ False
   IL_000c:  and
   IL_000d:  shr
   IL_000e:  ret
-}", ilFormat: ILFormat);
+}");
         }
 
         [Fact]
@@ -8579,7 +8575,7 @@ False
   IL_000c:  and
   IL_000d:  shl
   IL_000e:  ret
-}", ilFormat: ILFormat);
+}");
             verifier.VerifyIL("Program.ShiftRight",
 @"{
   // Code size       15 (0xf)
@@ -8594,7 +8590,7 @@ False
   IL_000c:  and
   IL_000d:  shr.un
   IL_000e:  ret
-}", ilFormat: ILFormat);
+}");
         }
 
         [Fact]
@@ -10387,18 +10383,14 @@ interface I
             {
                 Assert.Equal(SpecialType.System_IntPtr, type.SpecialType);
                 Assert.Equal("nint", type.ToDisplayString(TestFormat));
-                Assert.Equal("nint", type.ToDisplayString(TestFormat));
-                Assert.Equal("System.IntPtr", type.ToDisplayString(TestFormat.WithCompilerInternalOptions(SymbolDisplayCompilerInternalOptions.UseNativeIntegerUnderlyingType)));
-                Assert.Equal("nint", type.ToDisplayString(TestFormat.WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes)));
+                Assert.Equal("System.IntPtr", type.ToDisplayString(TestFormat.RemoveMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes)));
             }
 
             static void verifyUIntPtr(TypeSymbol type)
             {
                 Assert.Equal(SpecialType.System_UIntPtr, type.SpecialType);
                 Assert.Equal("nuint", type.ToDisplayString(TestFormat));
-                Assert.Equal("nuint", type.ToDisplayString(TestFormat));
-                Assert.Equal("System.UIntPtr", type.ToDisplayString(TestFormat.WithCompilerInternalOptions(SymbolDisplayCompilerInternalOptions.UseNativeIntegerUnderlyingType)));
-                Assert.Equal("nuint", type.ToDisplayString(TestFormat.WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes)));
+                Assert.Equal("System.UIntPtr", type.ToDisplayString(TestFormat.RemoveMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes)));
             }
 
             static void verifyCommon(TypeSymbol type)
@@ -10554,8 +10546,8 @@ class C
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
             var returnStatements = tree.GetRoot().DescendantNodes().OfType<ReturnStatementSyntax>().ToArray();
-            Assert.Equal("nint nint.op_Implicit(System.String s)", model.GetConversion(returnStatements[0].Expression).Method.ToDisplayString(TestFormat));
-            Assert.Equal("nuint nuint.op_Implicit(System.String s)", model.GetConversion(returnStatements[1].Expression).Method.ToDisplayString(TestFormat));
+            Assert.Equal("nint nint.op_Implicit(string s)", model.GetConversion(returnStatements[0].Expression).Method.ToDisplayString(TestFormat));
+            Assert.Equal("nuint nuint.op_Implicit(string s)", model.GetConversion(returnStatements[1].Expression).Method.ToDisplayString(TestFormat));
         }
 
         [Fact]
@@ -10994,12 +10986,12 @@ public class C
             var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
             var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify);
-            verifier.VerifyIL("C.M1", shiftRight("nint"), ilFormat: ILFormat);
-            verifier.VerifyIL("C.M2", shiftRight("nuint"), ilFormat: ILFormat);
-            verifier.VerifyIL("C.M3", shiftRight("nint"), ilFormat: ILFormat);
-            verifier.VerifyIL("C.M4", shiftRight("nuint"), ilFormat: ILFormat);
-            verifier.VerifyIL("C.M5", shiftRight("nint"), ilFormat: ILFormat);
-            verifier.VerifyIL("C.M6", shiftRight("nuint"), ilFormat: ILFormat);
+            verifier.VerifyIL("C.M1", shiftRight("nint"));
+            verifier.VerifyIL("C.M2", shiftRight("nuint"));
+            verifier.VerifyIL("C.M3", shiftRight("nint"));
+            verifier.VerifyIL("C.M4", shiftRight("nuint"));
+            verifier.VerifyIL("C.M5", shiftRight("nint"));
+            verifier.VerifyIL("C.M6", shiftRight("nuint"));
 
             return;
 
@@ -11433,7 +11425,7 @@ class C
   IL_002b:  newobj     ""nint?..ctor(nint)""
   IL_0030:  ret
 }
-", ilFormat: ILFormat);
+");
 
             // lifted value and lifted count
             compileAndVerify("""
@@ -11477,7 +11469,7 @@ class C
   IL_0039:  newobj     ""nint?..ctor(nint)""
   IL_003e:  ret
 }
-", ilFormat: ILFormat);
+");
             return;
 
             static string nint_shr(int count) => shift(count, "nint", "shr");
@@ -11695,7 +11687,7 @@ class C
 """;
                 var comp = CreateCompilation(source, options: TestOptions.UnsafeReleaseExe, targetFramework: TargetFramework.Net70);
                 var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput("RAN"));
-                verifier.VerifyIL("C.M", expectedIL, ilFormat: ILFormat);
+                verifier.VerifyIL("C.M", expectedIL);
             }
         }
 
@@ -11728,7 +11720,7 @@ static class C
   IL_000e:  shr
   IL_000f:  ret
 }
-", ilFormat: ILFormat);
+");
         }
 
         [WorkItem(63348, "https://github.com/dotnet/roslyn/issues/63348")]

--- a/src/Compilers/CSharp/Test/Emit3/Attributes/AttributeTests_NativeInteger.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Attributes/AttributeTests_NativeInteger.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection.Metadata;
-using System.Reflection.PortableExecutable;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
@@ -21,8 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     public class AttributeTests_NativeInteger : CSharpTestBase
     {
         private static readonly SymbolDisplayFormat FormatWithSpecialTypes = SymbolDisplayFormat.TestFormat
-            .WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes)
-            .RemoveCompilerInternalOptions(SymbolDisplayCompilerInternalOptions.UseNativeIntegerUnderlyingType);
+            .WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
 
         [Fact]
         public void EmptyProject()
@@ -46,8 +44,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var comp = CreateCompilation(new[] { NativeIntegerAttributeDefinition, source });
             var expected =
 @"Program
-    [NativeInteger] System.IntPtr F1
-    [NativeInteger] System.UIntPtr[] F2
+    [NativeInteger] nint F1
+    [NativeInteger] nuint[] F2
 ";
             CompileAndVerify(comp, symbolValidator: module =>
             {
@@ -73,8 +71,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             comp = CreateCompilation(source, references: new[] { ref0 }, parseOptions: TestOptions.Regular9);
             var expected =
 @"Program
-    [NativeInteger] System.IntPtr F1
-    [NativeInteger] System.UIntPtr[] F2
+    [NativeInteger] nint F1
+    [NativeInteger] nuint[] F2
 ";
             CompileAndVerify(comp, symbolValidator: module =>
             {
@@ -441,13 +439,13 @@ using System.Runtime.CompilerServices;
 
                 var expected =
     @"B
-    void F0(System.IntPtr x, System.UIntPtr y)
-        [NativeInteger({ True })] System.IntPtr x
-        [NativeInteger({ True })] System.UIntPtr y
-    void F1(A<System.Int32, System.UIntPtr> a)
-        [NativeInteger({ True })] A<System.Int32, System.UIntPtr> a
-    void F2(A<System.IntPtr, System.UInt32> a)
-        [NativeInteger({ True })] A<System.IntPtr, System.UInt32> a
+    void F0(nint x, nuint y)
+        [NativeInteger({ True })] nint x
+        [NativeInteger({ True })] nuint y
+    void F1(A<System.Int32, nuint> a)
+        [NativeInteger({ True })] A<System.Int32, nuint> a
+    void F2(A<nint, System.UInt32> a)
+        [NativeInteger({ True })] A<nint, System.UInt32> a
 ";
                 AssertNativeIntegerAttributes(type.ContainingModule, expected);
             }
@@ -644,8 +642,8 @@ using System.Runtime.CompilerServices;
         [NativeInteger({  })] ? a
     void F1(? a)
         [NativeInteger({ True })] ? a
-    void F2(A<System.IntPtr, System.UIntPtr> a)
-        [NativeInteger({ False, True })] A<System.IntPtr, System.UIntPtr> a
+    void F2(A<System.IntPtr, nuint> a)
+        [NativeInteger({ False, True })] A<System.IntPtr, nuint> a
     void F3(? a)
         [NativeInteger({ False, True, True })] ? a
 ";
@@ -817,12 +815,12 @@ public class C<T>
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
             var expected =
 @"C<T>
-    [NativeInteger] C<T>.S<System.IntPtr> F1
-    [NativeInteger] C<System.UIntPtr>.I<T> F2
-    [NativeInteger] C<E>.D<System.IntPtr> F3
-    [NativeInteger] C<System.UIntPtr>.D<dynamic> F4
-    [NativeInteger({ True, False })] C<C<System.UIntPtr>.D<System.IntPtr>>.F F5
-    [NativeInteger({ False, True })] C<C<System.UIntPtr>.F>.D<System.IntPtr> F6
+    [NativeInteger] C<T>.S<nint> F1
+    [NativeInteger] C<nuint>.I<T> F2
+    [NativeInteger] C<E>.D<nint> F3
+    [NativeInteger] C<nuint>.D<dynamic> F4
+    [NativeInteger({ True, False })] C<C<nuint>.D<System.IntPtr>>.F F5
+    [NativeInteger({ False, True })] C<C<System.UIntPtr>.F>.D<nint> F6
 ";
             AssertNativeIntegerAttributes(comp, expected);
         }
@@ -878,8 +876,8 @@ public class D
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
             var expected =
 @"Program
-    [NativeInteger] System.IntPtr F1
-    [NativeInteger({ False, True })] (System.IntPtr, System.UIntPtr[]) F2
+    [NativeInteger] nint F1
+    [NativeInteger({ False, True })] (System.IntPtr, nuint[]) F2
 ";
             AssertNativeIntegerAttributes(comp, expected);
         }
@@ -895,7 +893,7 @@ public class D
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
             var expected =
 @"Program
-    [NativeInteger({ False, True })] (System.IntPtr, System.UIntPtr[]) F()
+    [NativeInteger({ False, True })] (System.IntPtr, nuint[]) F()
 ";
             AssertNativeIntegerAttributes(comp, expected);
         }
@@ -911,9 +909,9 @@ public class D
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
             var expected =
 @"Program
-    void F(System.IntPtr x, System.UIntPtr y)
-        [NativeInteger] System.IntPtr x
-        [NativeInteger] System.UIntPtr y
+    void F(nint x, nuint y)
+        [NativeInteger] nint x
+        [NativeInteger] nuint y
 ";
             AssertNativeIntegerAttributes(comp, expected);
         }
@@ -929,8 +927,8 @@ public class D
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
             var expected =
 @"Program
-    [NativeInteger({ False, True })] (System.IntPtr, System.UIntPtr[]) P { get; }
-        [NativeInteger({ False, True })] (System.IntPtr, System.UIntPtr[]) P.get
+    [NativeInteger({ False, True })] (System.IntPtr, nuint[]) P { get; }
+        [NativeInteger({ False, True })] (System.IntPtr, nuint[]) P.get
 ";
             AssertNativeIntegerAttributes(comp, expected);
         }
@@ -946,12 +944,12 @@ public class D
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
             var expected =
 @"Program
-    System.Object this[System.IntPtr x, (System.UIntPtr[], System.IntPtr) y] { get; }
-        [NativeInteger] System.IntPtr x
-        [NativeInteger({ True, False })] (System.UIntPtr[], System.IntPtr) y
-        System.Object this[System.IntPtr x, (System.UIntPtr[], System.IntPtr) y].get
-            [NativeInteger] System.IntPtr x
-            [NativeInteger({ True, False })] (System.UIntPtr[], System.IntPtr) y
+    System.Object this[nint x, (nuint[], System.IntPtr) y] { get; }
+        [NativeInteger] nint x
+        [NativeInteger({ True, False })] (nuint[], System.IntPtr) y
+        System.Object this[nint x, (nuint[], System.IntPtr) y].get
+            [NativeInteger] nint x
+            [NativeInteger({ True, False })] (nuint[], System.IntPtr) y
 ";
             AssertNativeIntegerAttributes(comp, expected);
         }
@@ -968,11 +966,11 @@ public class Program
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
             var expected =
 @"Program
-    [NativeInteger] event System.EventHandler<System.UIntPtr[]> E
+    [NativeInteger] event System.EventHandler<nuint[]> E
         void E.add
-            [NativeInteger] System.EventHandler<System.UIntPtr[]> value
+            [NativeInteger] System.EventHandler<nuint[]> value
         void E.remove
-            [NativeInteger] System.EventHandler<System.UIntPtr[]> value
+            [NativeInteger] System.EventHandler<nuint[]> value
 ";
             AssertNativeIntegerAttributes(comp, expected);
         }
@@ -988,7 +986,7 @@ public class Program
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
             var expected =
 @"C
-    [NativeInteger] System.IntPtr operator +(C a, C b)
+    [NativeInteger] nint operator +(C a, C b)
 ";
             AssertNativeIntegerAttributes(comp, expected);
         }
@@ -1004,8 +1002,8 @@ public class Program
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
             var expected =
 @"C
-    C operator +(C a, System.UIntPtr[] b)
-        [NativeInteger] System.UIntPtr[] b
+    C operator +(C a, nuint[] b)
+        [NativeInteger] nuint[] b
 ";
             AssertNativeIntegerAttributes(comp, expected);
         }
@@ -1018,8 +1016,8 @@ public class Program
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
             var expected =
 @"D
-    [NativeInteger] System.IntPtr Invoke()
-    [NativeInteger] System.IntPtr EndInvoke(System.IAsyncResult result)
+    [NativeInteger] nint Invoke()
+    [NativeInteger] nint EndInvoke(System.IAsyncResult result)
 ";
             AssertNativeIntegerAttributes(comp, expected);
         }
@@ -1032,12 +1030,12 @@ public class Program
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
             var expected =
 @"D
-    void Invoke(System.IntPtr x, System.UIntPtr[] y)
-        [NativeInteger] System.IntPtr x
-        [NativeInteger] System.UIntPtr[] y
-    System.IAsyncResult BeginInvoke(System.IntPtr x, System.UIntPtr[] y, System.AsyncCallback callback, System.Object @object)
-        [NativeInteger] System.IntPtr x
-        [NativeInteger] System.UIntPtr[] y
+    void Invoke(nint x, nuint[] y)
+        [NativeInteger] nint x
+        [NativeInteger] nuint[] y
+    System.IAsyncResult BeginInvoke(nint x, nuint[] y, System.AsyncCallback callback, System.Object @object)
+        [NativeInteger] nint x
+        [NativeInteger] nuint[] y
 ";
             AssertNativeIntegerAttributes(comp, expected);
         }
@@ -1311,7 +1309,7 @@ class Program
             var expected =
 @"Program
     Program.<>c
-        [NativeInteger] <>A{00000003}<System.IntPtr> <>9__0_0
+        [NativeInteger] <>A{00000003}<nint> <>9__0_0
 ";
             AssertNativeIntegerAttributes(comp, expected);
         }
@@ -1335,11 +1333,11 @@ unsafe public class Program
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9, options: TestOptions.UnsafeReleaseDll);
             var expected =
 @"Program
-    [NativeInteger] System.IntPtr F1
-    [NativeInteger] System.UIntPtr[] F2
-    [NativeInteger] System.IntPtr* F3
-    [NativeInteger({ True, True })] A<System.IntPtr>.B<System.UIntPtr> F4
-    [NativeInteger({ True, True })] (System.IntPtr, System.UIntPtr) F5
+    [NativeInteger] nint F1
+    [NativeInteger] nuint[] F2
+    [NativeInteger] nint* F3
+    [NativeInteger({ True, True })] A<nint>.B<nuint> F4
+    [NativeInteger({ True, True })] (nint, nuint) F5
 ";
             AssertNativeIntegerAttributes(comp, expected);
         }
@@ -1359,8 +1357,8 @@ unsafe public class B
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9, options: TestOptions.UnsafeReleaseDll);
             var expected =
 @"B
-    [NativeInteger({ True, True, True, True, True, True, True, False })] A<(System.Object, (System.IntPtr, System.UIntPtr, System.IntPtr[], System.UIntPtr, System.IntPtr, System.UIntPtr*[], System.IntPtr, System.UIntPtr))> F1
-    [NativeInteger({ True, True, True, False, True, True })] A<(System.IntPtr, System.Object, System.UIntPtr[], System.Object, System.IntPtr, System.Object, (System.IntPtr, System.UIntPtr), System.Object, System.UIntPtr)> F2
+    [NativeInteger({ True, True, True, True, True, True, True, False })] A<(System.Object, (nint, nuint, nint[], nuint, nint, nuint*[], nint, System.UIntPtr))> F1
+    [NativeInteger({ True, True, True, False, True, True })] A<(nint, System.Object, nuint[], System.Object, nint, System.Object, (System.IntPtr, nuint), System.Object, nuint)> F2
 ";
             AssertNativeIntegerAttributes(comp, expected);
         }
@@ -1415,8 +1413,8 @@ public class C : IA, IB<(nint, object, nuint[], object, nint, object, (System.In
             var comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All), parseOptions: TestOptions.Regular9);
             var expected =
 @"Program
-    void F2(System.UIntPtr x)
-        [NativeInteger] System.UIntPtr x
+    void F2(nuint x)
+        [NativeInteger] nuint x
 ";
             AssertNativeIntegerAttributes(comp, expected);
 
@@ -1518,21 +1516,21 @@ class C<T, U, V>
             {
                 var expectedAttributes = @"
 C<T, U, V>
-    [NativeInteger] C<dynamic, T, System.IntPtr> F0
-    [NativeInteger({ True, False })] C<dynamic, System.IntPtr, System.IntPtr> F1
-    [NativeInteger({ True, False })] C<dynamic, System.UIntPtr, System.UIntPtr> F2
-    [NativeInteger({ True, False })] C<T, System.IntPtr, System.IntPtr> F3
-    [NativeInteger({ True, False })] C<T, System.UIntPtr, System.UIntPtr> F4
+    [NativeInteger] C<dynamic, T, nint> F0
+    [NativeInteger({ True, False })] C<dynamic, nint, System.IntPtr> F1
+    [NativeInteger({ True, False })] C<dynamic, nuint, System.UIntPtr> F2
+    [NativeInteger({ True, False })] C<T, nint, System.IntPtr> F3
+    [NativeInteger({ True, False })] C<T, nuint, System.UIntPtr> F4
 ";
 
                 AssertNativeIntegerAttributes(module, expectedAttributes);
                 var c = module.GlobalNamespace.GetTypeMember("C");
 
-                assert("C<dynamic, T, System.IntPtr>", "F0");
-                assert("C<dynamic, System.IntPtr, System.IntPtr>", "F1");
-                assert("C<dynamic, System.UIntPtr, System.UIntPtr>", "F2");
-                assert("C<T, System.IntPtr, System.IntPtr>", "F3");
-                assert("C<T, System.UIntPtr, System.UIntPtr>", "F4");
+                assert("C<dynamic, T, nint>", "F0");
+                assert("C<dynamic, nint, System.IntPtr>", "F1");
+                assert("C<dynamic, nuint, System.UIntPtr>", "F2");
+                assert("C<T, nint, System.IntPtr>", "F3");
+                assert("C<T, nuint, System.UIntPtr>", "F4");
 
                 void assert(string expectedType, string fieldName)
                 {
@@ -1563,29 +1561,29 @@ unsafe class C
             {
                 var expectedAttributes = @"
 C
-    [NativeInteger] delegate*<System.IntPtr, System.Object, System.Object> F0
-    [NativeInteger({ True, True, True })] delegate*<System.IntPtr, System.IntPtr, System.IntPtr> F1
-    [NativeInteger({ True, False, False })] delegate*<System.IntPtr, System.IntPtr, System.IntPtr> F2
-    [NativeInteger({ False, True, False })] delegate*<System.IntPtr, System.IntPtr, System.IntPtr> F3
-    [NativeInteger({ False, False, True })] delegate*<System.IntPtr, System.IntPtr, System.IntPtr> F4
-    [NativeInteger({ True, False, False, False })] delegate*<delegate*<System.IntPtr, System.IntPtr, System.IntPtr>, System.IntPtr> F5
-    [NativeInteger({ False, False, False, True })] delegate*<System.IntPtr, delegate*<System.IntPtr, System.IntPtr, System.IntPtr>> F6
-    [NativeInteger({ False, True, False, False })] delegate*<delegate*<System.IntPtr, System.IntPtr, System.IntPtr>, System.IntPtr> F7
-    [NativeInteger({ False, False, True, False })] delegate*<System.IntPtr, delegate*<System.IntPtr, System.IntPtr, System.IntPtr>> F8
+    [NativeInteger] delegate*<nint, System.Object, System.Object> F0
+    [NativeInteger({ True, True, True })] delegate*<nint, nint, nint> F1
+    [NativeInteger({ True, False, False })] delegate*<System.IntPtr, System.IntPtr, nint> F2
+    [NativeInteger({ False, True, False })] delegate*<nint, System.IntPtr, System.IntPtr> F3
+    [NativeInteger({ False, False, True })] delegate*<System.IntPtr, nint, System.IntPtr> F4
+    [NativeInteger({ True, False, False, False })] delegate*<delegate*<System.IntPtr, System.IntPtr, System.IntPtr>, nint> F5
+    [NativeInteger({ False, False, False, True })] delegate*<nint, delegate*<System.IntPtr, System.IntPtr, System.IntPtr>> F6
+    [NativeInteger({ False, True, False, False })] delegate*<delegate*<System.IntPtr, System.IntPtr, nint>, System.IntPtr> F7
+    [NativeInteger({ False, False, True, False })] delegate*<System.IntPtr, delegate*<System.IntPtr, nint, System.IntPtr>> F8
 ";
 
                 AssertNativeIntegerAttributes(module, expectedAttributes);
                 var c = module.GlobalNamespace.GetTypeMember("C");
 
-                assert("delegate*<System.IntPtr, System.Object, System.Object>", "F0");
-                assert("delegate*<System.IntPtr, System.IntPtr, System.IntPtr>", "F1");
-                assert("delegate*<System.IntPtr, System.IntPtr, System.IntPtr>", "F2");
-                assert("delegate*<System.IntPtr, System.IntPtr, System.IntPtr>", "F3");
-                assert("delegate*<System.IntPtr, System.IntPtr, System.IntPtr>", "F4");
-                assert("delegate*<delegate*<System.IntPtr, System.IntPtr, System.IntPtr>, System.IntPtr>", "F5");
-                assert("delegate*<System.IntPtr, delegate*<System.IntPtr, System.IntPtr, System.IntPtr>>", "F6");
-                assert("delegate*<delegate*<System.IntPtr, System.IntPtr, System.IntPtr>, System.IntPtr>", "F7");
-                assert("delegate*<System.IntPtr, delegate*<System.IntPtr, System.IntPtr, System.IntPtr>>", "F8");
+                assert("delegate*<nint, System.Object, System.Object>", "F0");
+                assert("delegate*<nint, nint, nint>", "F1");
+                assert("delegate*<System.IntPtr, System.IntPtr, nint>", "F2");
+                assert("delegate*<nint, System.IntPtr, System.IntPtr>", "F3");
+                assert("delegate*<System.IntPtr, nint, System.IntPtr>", "F4");
+                assert("delegate*<delegate*<System.IntPtr, System.IntPtr, System.IntPtr>, nint>", "F5");
+                assert("delegate*<nint, delegate*<System.IntPtr, System.IntPtr, System.IntPtr>>", "F6");
+                assert("delegate*<delegate*<System.IntPtr, System.IntPtr, nint>, System.IntPtr>", "F7");
+                assert("delegate*<System.IntPtr, delegate*<System.IntPtr, nint, System.IntPtr>>", "F8");
 
                 void assert(string expectedType, string fieldName)
                 {

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
@@ -26682,7 +26682,7 @@ partial class Program
                   IL_0008:  pop
                   IL_0009:  ldsfld     "C<T>.<>c C<T>.<>c.<>9"
                   IL_000e:  ldftn      "void C<T>.<>c.<.ctor>b__1_1(T)"
-                  IL_0014:  newobj     "System.Action<T>..ctor(object, System.IntPtr)"
+                  IL_0014:  newobj     "System.Action<T>..ctor(object, nint)"
                   IL_0019:  dup
                   IL_001a:  stsfld     "System.Action<T> C<T>.<>c.<>9__1_1"
                   IL_001f:  ldarg.2
@@ -27299,8 +27299,8 @@ partial class Program
                   .maxstack  1
                   .locals init (object V_0,
                                 string V_1,
-                                System.IntPtr V_2,
-                                System.UIntPtr V_3)
+                                nint V_2,
+                                nuint V_3)
                   IL_0000:  ldstr      "1"
                   IL_0005:  stloc.0
                   IL_0006:  ldloca.s   V_0
@@ -27315,14 +27315,14 @@ partial class Program
                   IL_0025:  conv.i
                   IL_0026:  stloc.2
                   IL_0027:  ldloca.s   V_2
-                  IL_0029:  newobj     "System.ReadOnlySpan<System.IntPtr>..ctor(ref readonly System.IntPtr)"
-                  IL_002e:  call       "void Program.Report<System.IntPtr>(System.ReadOnlySpan<System.IntPtr>)"
+                  IL_0029:  newobj     "System.ReadOnlySpan<nint>..ctor(ref readonly nint)"
+                  IL_002e:  call       "void Program.Report<nint>(System.ReadOnlySpan<nint>)"
                   IL_0033:  ldc.i4.4
                   IL_0034:  conv.i
                   IL_0035:  stloc.3
                   IL_0036:  ldloca.s   V_3
-                  IL_0038:  newobj     "System.ReadOnlySpan<System.UIntPtr>..ctor(ref readonly System.UIntPtr)"
-                  IL_003d:  call       "void Program.Report<System.UIntPtr>(System.ReadOnlySpan<System.UIntPtr>)"
+                  IL_0038:  newobj     "System.ReadOnlySpan<nuint>..ctor(ref readonly nuint)"
+                  IL_003d:  call       "void Program.Report<nuint>(System.ReadOnlySpan<nuint>)"
                   IL_0042:  ret
                 }
                 """);

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/RecordTests.cs
@@ -10605,7 +10605,7 @@ record C(dynamic P1, object[] P2, object P3, object?[] P4, (int, int) P5, (int X
                 "System.Object[] C.P4 { get; }",
                 "(System.Int32 X, System.Int32 Y) C.P5 { get; }",
                 "(System.Int32, System.Int32)[] C.P6 { get; }",
-                "System.IntPtr C.P7 { get; }",
+                "nint C.P7 { get; }",
                 "System.UIntPtr[] C.P8 { get; }"
             };
             AssertEx.Equal(expectedMembers, actualMembers);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
@@ -15,7 +15,6 @@ using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
-using Roslyn.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
@@ -41,12 +40,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
         internal static readonly ConversionKind[] ExplicitNullableNumeric = new[] { ConversionKind.ExplicitNullable, ConversionKind.ExplicitNumeric };
         internal static readonly ConversionKind[] ExplicitNullablePointerToInteger = new[] { ConversionKind.ExplicitNullable, ConversionKind.ExplicitPointerToInteger };
         internal static readonly ConversionKind[] ExplicitNullableIdentity = new[] { ConversionKind.ExplicitNullable, ConversionKind.Identity };
-
-        internal static readonly SymbolDisplayFormat TestFormat = SymbolDisplayFormat.TestFormat
-            .RemoveCompilerInternalOptions(SymbolDisplayCompilerInternalOptions.UseNativeIntegerUnderlyingType);
-
-        internal static readonly SymbolDisplayFormat ILFormat = SymbolDisplayFormat.ILVisualizationFormat
-            .RemoveCompilerInternalOptions(SymbolDisplayCompilerInternalOptions.UseNativeIntegerUnderlyingType);
 
         internal static bool IsNoConversion(ConversionKind[] conversionKinds)
         {
@@ -117,12 +110,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             VerifyType(type.GetPublicSymbol(), signed: false, isNativeInt: false);
 
             var method = comp.GetMember<MethodSymbol>("I.F1");
-            Assert.Equal("void I.F1(System.IntPtr x, nint y)", method.ToDisplayString(TestFormat));
+            Assert.Equal("void I.F1(System.IntPtr x, nint y)", method.ToTestDisplayString());
             Assert.Equal("Sub I.F1(x As System.IntPtr, y As System.IntPtr)", VisualBasic.SymbolDisplay.ToDisplayString(method.GetPublicSymbol(), SymbolDisplayFormat.TestFormat));
             VerifyTypes((NamedTypeSymbol)method.Parameters[0].Type, (NamedTypeSymbol)method.Parameters[1].Type, signed: true);
 
             method = comp.GetMember<MethodSymbol>("I.F2");
-            Assert.Equal("void I.F2(System.UIntPtr x, nuint y)", method.ToDisplayString(TestFormat));
+            Assert.Equal("void I.F2(System.UIntPtr x, nuint y)", method.ToTestDisplayString());
             Assert.Equal("Sub I.F2(x As System.UIntPtr, y As System.UIntPtr)", VisualBasic.SymbolDisplay.ToDisplayString(method.GetPublicSymbol(), SymbolDisplayFormat.TestFormat));
             VerifyTypes((NamedTypeSymbol)method.Parameters[0].Type, (NamedTypeSymbol)method.Parameters[1].Type, signed: false);
         }
@@ -213,11 +206,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                 VerifyType(type.GetPublicSymbol(), signed: false, isNativeInt: false);
 
                 var method = comp.GetMember<MethodSymbol>("I.F1");
-                Assert.Equal("void I.F1(System.IntPtr x, nint y)", method.ToDisplayString(TestFormat));
+                Assert.Equal("void I.F1(System.IntPtr x, nint y)", method.ToTestDisplayString());
                 VerifyTypes((NamedTypeSymbol)method.Parameters[0].Type, (NamedTypeSymbol)method.Parameters[1].Type, signed: true);
 
                 method = comp.GetMember<MethodSymbol>("I.F2");
-                Assert.Equal("void I.F2(System.UIntPtr x, nuint y)", method.ToDisplayString(TestFormat));
+                Assert.Equal("void I.F2(System.UIntPtr x, nuint y)", method.ToTestDisplayString());
                 VerifyTypes((NamedTypeSymbol)method.Parameters[0].Type, (NamedTypeSymbol)method.Parameters[1].Type, signed: false);
             }
         }
@@ -717,11 +710,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             static void verify(CSharpCompilation comp)
             {
                 var method = comp.GetMember<MethodSymbol>("I.F1");
-                Assert.Equal("void I.F1(System.IntPtr x, nint y)", method.ToDisplayString(TestFormat));
+                Assert.Equal("void I.F1(System.IntPtr x, nint y)", method.ToTestDisplayString());
                 VerifyErrorTypes((NamedTypeSymbol)method.Parameters[0].Type, (NamedTypeSymbol)method.Parameters[1].Type, signed: true);
 
                 method = comp.GetMember<MethodSymbol>("I.F2");
-                Assert.Equal("void I.F2(System.UIntPtr x, nuint y)", method.ToDisplayString(TestFormat));
+                Assert.Equal("void I.F2(System.UIntPtr x, nuint y)", method.ToTestDisplayString());
                 VerifyErrorTypes((NamedTypeSymbol)method.Parameters[0].Type, (NamedTypeSymbol)method.Parameters[1].Type, signed: false);
             }
         }
@@ -814,7 +807,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             static void verifyField(FieldSymbol field, string expectedSymbol, AssemblySymbol expectedAssembly)
             {
                 Assert.IsType<Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting.RetargetingFieldSymbol>(field);
-                Assert.Equal(expectedSymbol, field.ToDisplayString(TestFormat));
+                Assert.Equal(expectedSymbol, field.ToTestDisplayString());
                 var type = (NamedTypeSymbol)field.Type;
                 Assert.True(type.IsNativeIntegerWrapperType);
                 Assert.IsType<NativeIntegerTypeSymbol>(type);
@@ -927,7 +920,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             static void verifyField(FieldSymbol field, string expectedSymbol, AssemblySymbol expectedAssembly)
             {
                 Assert.IsType<Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting.RetargetingFieldSymbol>(field);
-                Assert.Equal(expectedSymbol, field.ToDisplayString(TestFormat));
+                Assert.Equal(expectedSymbol, field.ToTestDisplayString());
                 var type = (NamedTypeSymbol)field.Type;
                 Assert.True(type.IsNativeIntegerWrapperType);
                 Assert.IsType<MissingMetadataTypeSymbol.TopLevel>(type);
@@ -1034,7 +1027,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             static void verifyField(FieldSymbol field, string expectedSymbol, AssemblySymbol expectedAssembly)
             {
                 Assert.IsType<Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting.RetargetingFieldSymbol>(field);
-                Assert.Equal(expectedSymbol, field.ToDisplayString(TestFormat));
+                Assert.Equal(expectedSymbol, field.ToTestDisplayString());
                 var type = (NamedTypeSymbol)field.Type;
                 Assert.True(type.IsNativeIntegerWrapperType);
                 Assert.IsType<MissingMetadataTypeSymbol.TopLevel>(type);
@@ -1106,7 +1099,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             static void verifyField(FieldSymbol field, string expectedSymbol)
             {
                 Assert.IsType<Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting.RetargetingFieldSymbol>(field);
-                Assert.Equal(expectedSymbol, field.ToDisplayString(TestFormat));
+                Assert.Equal(expectedSymbol, field.ToTestDisplayString());
                 var type = (NamedTypeSymbol)field.Type;
                 Assert.True(type.IsNativeIntegerWrapperType);
                 Assert.IsType<NativeIntegerTypeSymbol>(type);
@@ -1791,7 +1784,7 @@ namespace System
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
-            var actualLocals = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Select(d => model.GetDeclaredSymbol(d).ToDisplayString(TestFormat));
+            var actualLocals = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Select(d => model.GetDeclaredSymbol(d).ToTestDisplayString());
             var expectedLocals = new[]
             {
                 "nint x1",
@@ -1811,7 +1804,7 @@ namespace System
                 VerifyType(type.GetPublicSymbol(), signed: signed, isNativeInt: true);
 
                 var members = type.GetMembers().Sort(SymbolComparison);
-                var actualMembers = members.SelectAsArray(m => m.ToDisplayString(TestFormat));
+                var actualMembers = members.SelectAsArray(m => m.ToTestDisplayString());
                 var expectedMembers = new[]
                 {
                     $"System.Boolean {type}.TryParse(System.String s, out {type} value)",
@@ -1976,7 +1969,7 @@ class Program
                 VerifyType(type.GetPublicSymbol(), signed: signed, isNativeInt: true);
 
                 var members = type.GetMembers().Sort(SymbolComparison);
-                var actualMembers = members.SelectAsArray(m => m.ToDisplayString(TestFormat));
+                var actualMembers = members.SelectAsArray(m => m.ToTestDisplayString());
                 var expectedMembers = new[]
                 {
                     $"System.Boolean {type}.Equals({type} other)",
@@ -2146,7 +2139,7 @@ class Program
                 VerifyType(type.GetPublicSymbol(), signed: signed, isNativeInt: true);
 
                 var members = type.GetMembers().Sort(SymbolComparison);
-                var actualMembers = members.SelectAsArray(m => m.ToDisplayString(TestFormat));
+                var actualMembers = members.SelectAsArray(m => m.ToTestDisplayString());
                 var expectedMembers = new[]
                 {
                     $"{type}..ctor()",
@@ -2242,7 +2235,7 @@ class Program
                 VerifyType(type.GetPublicSymbol(), signed: signed, isNativeInt: true);
 
                 var members = type.GetMembers().Sort(SymbolComparison);
-                var actualMembers = members.SelectAsArray(m => m.ToDisplayString(TestFormat));
+                var actualMembers = members.SelectAsArray(m => m.ToTestDisplayString());
                 var expectedMembers = new[]
                 {
                     $"System.Boolean {type}.Equals(System.Object obj)",
@@ -2348,7 +2341,7 @@ class Program
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
-            var actualLocals = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Select(d => model.GetDeclaredSymbol(d).ToDisplayString(TestFormat));
+            var actualLocals = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Select(d => model.GetDeclaredSymbol(d).ToTestDisplayString());
             var expectedLocals = new[]
             {
                 "nint x1",
@@ -2370,7 +2363,7 @@ class Program
 
                 var underlyingType = type.NativeIntegerUnderlyingType;
                 var members = type.GetMembers().Sort(SymbolComparison);
-                var actualMembers = members.SelectAsArray(m => m.ToDisplayString(TestFormat));
+                var actualMembers = members.SelectAsArray(m => m.ToTestDisplayString());
                 var expectedMembers = new[]
                 {
                     $"{type}..ctor()",
@@ -2468,7 +2461,7 @@ class Program
 
             var tree = compB.SyntaxTrees[0];
             var model = compB.GetSemanticModel(tree);
-            var actualLocals = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Select(d => model.GetDeclaredSymbol(d).ToDisplayString(TestFormat));
+            var actualLocals = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Select(d => model.GetDeclaredSymbol(d).ToTestDisplayString());
             var expectedLocals = new[]
             {
                 "nint x1",
@@ -2495,7 +2488,7 @@ class Program
                     Assert.True(member.GetExplicitInterfaceImplementations().IsEmpty);
                 }
 
-                var actualMembers = members.SelectAsArray(m => m.ToDisplayString(TestFormat));
+                var actualMembers = members.SelectAsArray(m => m.ToTestDisplayString());
                 var expectedMembers = new[]
                 {
                     $"{type} {type}.F()",
@@ -2646,7 +2639,7 @@ class Program
 
                 var underlyingType = type.NativeIntegerUnderlyingType;
                 var members = type.GetMembers().Sort(SymbolComparison);
-                var actualMembers = members.SelectAsArray(m => m.ToDisplayString(TestFormat));
+                var actualMembers = members.SelectAsArray(m => m.ToTestDisplayString());
                 var expectedMembers = new[]
                 {
                     $"{type} {type}.F3()",
@@ -2748,7 +2741,7 @@ namespace System.Reflection
 
                 var underlyingType = type.NativeIntegerUnderlyingType;
                 var members = type.GetMembers().Sort(SymbolComparison);
-                var actualMembers = members.SelectAsArray(m => m.ToDisplayString(TestFormat));
+                var actualMembers = members.SelectAsArray(m => m.ToTestDisplayString());
                 var expectedMembers = new[]
                 {
                     $"{type}..ctor()",
@@ -2888,7 +2881,7 @@ namespace System.Reflection
 
                 var underlyingType = type.NativeIntegerUnderlyingType;
                 var members = type.GetMembers().Sort(SymbolComparison);
-                var actualMembers = members.SelectAsArray(m => m.ToDisplayString(TestFormat));
+                var actualMembers = members.SelectAsArray(m => m.ToTestDisplayString());
                 var expectedMembers = new[]
                 {
                     $"System.IComparable<{type} modopt({underlyingType})> {type}.F5()",
@@ -2996,7 +2989,7 @@ namespace System.Reflection
   IL_0000:  call       ""void Program.F<nint>()""
   IL_0005:  call       ""void Program.F<nuint>()""
   IL_000a:  ret
-}", ilFormat: ILFormat);
+}");
         }
 
         [Fact]
@@ -3079,7 +3072,7 @@ System.UIntPtr: 4294967295");
   IL_0044:  stelem.i
   IL_0045:  call       ""void Program.Report<nuint>(nuint[])""
   IL_004a:  ret
-}", ilFormat: ILFormat);
+}");
         }
 
         [Fact]
@@ -3642,7 +3635,7 @@ interface I
                 Assert.Equal("nint", underlyingType.ToDisplayString());
                 Assert.Equal(SpecialType.None, underlyingType.SpecialType);
                 var method = model.GetDeclaredSymbol(nodes.OfType<MethodDeclarationSyntax>().Single());
-                Assert.Equal("nint I.Add(nint x, nuint y)", method.ToDisplayString(TestFormat));
+                Assert.Equal("nint I.Add(nint x, nuint y)", method.ToTestDisplayString());
                 var underlyingType0 = method.Parameters[0].Type.GetSymbol<NamedTypeSymbol>();
                 var underlyingType1 = method.Parameters[1].Type.GetSymbol<NamedTypeSymbol>();
                 Assert.Equal(SpecialType.None, underlyingType0.SpecialType);
@@ -3684,7 +3677,7 @@ class Program
 @"System.Int16
 System.Object");
                 var method = comp.GetMember<MethodSymbol>("Program.F");
-                Assert.Equal("System.Int16 Program.F(System.Int16 x, System.Object y)", method.ToDisplayString(TestFormat));
+                Assert.Equal("System.Int16 Program.F(System.Int16 x, System.Object y)", method.ToTestDisplayString());
                 var underlyingType0 = (NamedTypeSymbol)method.Parameters[0].Type;
                 var underlyingType1 = (NamedTypeSymbol)method.Parameters[1].Type;
                 Assert.Equal(SpecialType.System_Int16, underlyingType0.SpecialType);
@@ -3718,7 +3711,7 @@ class Program
             static void verify(CSharpCompilation comp)
             {
                 var method = comp.GetMember<MethodSymbol>("Program.F");
-                Assert.Equal("System.Int16 Program.F(System.Int16 x, nuint y)", method.ToDisplayString(TestFormat));
+                Assert.Equal("System.Int16 Program.F(System.Int16 x, nuint y)", method.ToTestDisplayString());
                 var underlyingType0 = (NamedTypeSymbol)method.Parameters[0].Type;
                 var underlyingType1 = (NamedTypeSymbol)method.Parameters[1].Type;
                 Assert.Equal(SpecialType.System_Int16, underlyingType0.SpecialType);
@@ -3752,7 +3745,7 @@ class Program
             static void verify(CSharpCompilation comp)
             {
                 var method = comp.GetMember<MethodSymbol>("Program.F");
-                Assert.Equal("System.Int16 Program.F(System.Int16 x, nuint y)", method.ToDisplayString(TestFormat));
+                Assert.Equal("System.Int16 Program.F(System.Int16 x, nuint y)", method.ToTestDisplayString());
                 var underlyingType0 = (NamedTypeSymbol)method.Parameters[0].Type;
                 var underlyingType1 = (NamedTypeSymbol)method.Parameters[1].Type;
                 Assert.Equal(SpecialType.System_Int16, underlyingType0.SpecialType);
@@ -4524,7 +4517,7 @@ class Program
   IL_0009:  ldsfld     ""nuint Program.F2""
   IL_000e:  add
   IL_000f:  ret
-}", ilFormat: ILFormat);
+}");
         }
 
         // PEVerify should succeed. Previously, PEVerify reported duplicate
@@ -4713,7 +4706,7 @@ False
   IL_0007:  ldloca.s   V_0
   IL_0009:  call       ""string System.IntPtr.ToString()""
   IL_000e:  ret
-}", ilFormat: ILFormat);
+}");
             verifier.VerifyIL("MyInt.GetHashCode",
 @"{
   // Code size       29 (0x1d)
@@ -4726,7 +4719,7 @@ False
   IL_0012:  newobj     ""System.Func<int>..ctor(object, System.IntPtr)""
   IL_0017:  callvirt   ""int System.Func<int>.Invoke()""
   IL_001c:  ret
-}", ilFormat: ILFormat);
+}");
             verifier.VerifyIL("MyInt.Equals",
 @"{
   // Code size       51 (0x33)
@@ -4751,7 +4744,7 @@ False
   IL_0028:  box        ""nint?""
   IL_002d:  call       ""bool System.IntPtr.Equals(object)""
   IL_0032:  ret
-}", ilFormat: ILFormat);
+}");
         }
 
         /// <summary>
@@ -4925,7 +4918,7 @@ False
   IL_0034:  call       ""nuint nuint?.GetValueOrDefault()""
   IL_0039:  pop
   IL_003a:  ret
-}", ilFormat: ILFormat);
+}");
             verifier.VerifyIL("B.M2",
 @"{
   // Code size       95 (0x5f)
@@ -4969,7 +4962,7 @@ False
   IL_0054:  newobj     ""nuint?..ctor(nuint)""
   IL_0059:  stsfld     ""nuint? A.F4""
   IL_005e:  ret
-}", ilFormat: ILFormat);
+}");
         }
 
         [WorkItem(3259, "https://github.com/dotnet/csharplang/issues/3259")]
@@ -5066,7 +5059,7 @@ False
   IL_008c:  div.un
   IL_008d:  pop
   IL_008e:  ret
-}", ilFormat: ILFormat);
+}");
 
             comp = CreateCompilation(sourceB, references: new[] { refA }, parseOptions: TestOptions.Regular8);
             comp.VerifyEmitDiagnostics(
@@ -5282,7 +5275,7 @@ class A
   IL_0034:  call       ""nuint nuint?.GetValueOrDefault()""
   IL_0039:  pop
   IL_003a:  ret
-}", ilFormat: ILFormat);
+}");
             verifier.VerifyIL("B.M2",
 @"{
   // Code size       95 (0x5f)
@@ -5326,7 +5319,7 @@ class A
   IL_0054:  newobj     ""nuint?..ctor(nuint)""
   IL_0059:  stsfld     ""nuint? A.F4""
   IL_005e:  ret
-}", ilFormat: ILFormat);
+}");
         }
 
         [WorkItem(3259, "https://github.com/dotnet/csharplang/issues/3259")]
@@ -5450,7 +5443,7 @@ class A
   IL_00ec:  newobj     ""nuint?..ctor(nuint)""
   IL_00f1:  stsfld     ""nuint? A.F4""
   IL_00f6:  ret
-}", ilFormat: ILFormat);
+}");
 
             comp = CreateCompilation(sourceB, references: new[] { refA }, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
@@ -6067,7 +6060,7 @@ $@"class Program
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
             var nodes = tree.GetRoot().DescendantNodes().OfType<PrefixUnaryExpressionSyntax>();
-            var actualOperators = nodes.Select(n => model.GetSymbolInfo(n).Symbol.ToDisplayString(TestFormat)).ToArray();
+            var actualOperators = nodes.Select(n => model.GetSymbolInfo(n).Symbol.ToTestDisplayString()).ToArray();
             var expectedOperators = new[]
             {
                 "nint nint.op_UnaryPlus(nint value)",
@@ -6115,7 +6108,7 @@ $@"class Program
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
             var nodes = tree.GetRoot().DescendantNodes().OfType<BinaryExpressionSyntax>();
-            var actualOperators = nodes.Select(n => model.GetSymbolInfo(n).Symbol.ToDisplayString(TestFormat)).ToArray();
+            var actualOperators = nodes.Select(n => model.GetSymbolInfo(n).Symbol.ToTestDisplayString()).ToArray();
             var expectedOperators = new[]
             {
                 $"{type} {type}.op_Addition({type} left, {type} right)",
@@ -6702,7 +6695,7 @@ $@"class Program
   IL_00cb:  call       ""void Program.F(nint)""
   IL_00d0:  ret
 }";
-            verifier.VerifyIL("Program.Main", expectedIL, ilFormat: ILFormat);
+            verifier.VerifyIL("Program.Main", expectedIL);
         }
 
         [Fact]
@@ -6813,7 +6806,7 @@ $@"class Program
   IL_0087:  call       ""void Program.F(nuint)""
   IL_008c:  ret
 }";
-            verifier.VerifyIL("Program.Main", expectedIL, ilFormat: ILFormat);
+            verifier.VerifyIL("Program.Main", expectedIL);
         }
 
         [Fact]
@@ -7403,7 +7396,7 @@ default: 0
       IL_00c7:  ldarg.0
       IL_00c8:  ret
     }
-", ilFormat: ILFormat);
+");
         }
 
         [Fact]
@@ -7564,7 +7557,7 @@ default: 0
       IL_00b6:  ldarg.0
       IL_00b7:  ret
     }
-", ilFormat: ILFormat);
+");
         }
 
         [Fact]
@@ -9518,7 +9511,7 @@ enum E {{ }}
                 if (expectedIL != null)
                 {
                     var verifier = CompileAndVerify(comp, verify: useUnsafeContext || !verify ? Verification.Skipped : Verification.Passes);
-                    verifier.VerifyIL("Program.Convert", expectedIL, ilFormat: ILFormat);
+                    verifier.VerifyIL("Program.Convert", expectedIL);
                 }
 
                 static bool useUnsafe(string type) => type == "void*" || type == "delegate*<void>";
@@ -9737,12 +9730,12 @@ $@"class Program
                 var model = comp.GetSemanticModel(tree);
                 var expr = tree.GetRoot().DescendantNodes().OfType<PrefixUnaryExpressionSyntax>().Single();
                 var symbolInfo = model.GetSymbolInfo(expr);
-                Assert.Equal(expectedSymbol, symbolInfo.Symbol?.ToDisplayString(TestFormat.WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes)));
+                Assert.Equal(expectedSymbol, symbolInfo.Symbol?.ToDisplayString(SymbolDisplayFormat.TestFormat.WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes)));
 
                 if (expectedDiagnostics.Length == 0)
                 {
                     var verifier = CompileAndVerify(comp, expectedOutput: expectedResult);
-                    verifier.VerifyIL("Program.Evaluate", expectedIL, ilFormat: ILFormat);
+                    verifier.VerifyIL("Program.Evaluate", expectedIL);
                 }
             }
         }
@@ -10114,12 +10107,12 @@ class Program
                     isPrefix ? SyntaxKind.PreDecrementExpression : SyntaxKind.PostDecrementExpression;
                 var expr = tree.GetRoot().DescendantNodes().Single(n => n.Kind() == kind);
                 var symbolInfo = model.GetSymbolInfo(expr);
-                Assert.Equal(expectedSymbol, symbolInfo.Symbol?.ToDisplayString(TestFormat.WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes)));
+                Assert.Equal(expectedSymbol, symbolInfo.Symbol?.ToDisplayString(SymbolDisplayFormat.TestFormat.WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes)));
 
                 if (expectedDiagnostics.Length == 0)
                 {
                     var verifier = CompileAndVerify(comp, expectedOutput: expectedResult);
-                    verifier.VerifyIL("Program.Evaluate", expectedIL, ilFormat: ILFormat);
+                    verifier.VerifyIL("Program.Evaluate", expectedIL);
                 }
             }
         }
@@ -10339,12 +10332,12 @@ class Program
                 var kind = (op == "++") ? SyntaxKind.PreIncrementExpression : SyntaxKind.PreDecrementExpression;
                 var expr = tree.GetRoot().DescendantNodes().Single(n => n.Kind() == kind);
                 var symbolInfo = model.GetSymbolInfo(expr);
-                Assert.Equal(expectedSymbol, symbolInfo.Symbol?.ToDisplayString(TestFormat.WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes)));
+                Assert.Equal(expectedSymbol, symbolInfo.Symbol?.ToDisplayString(SymbolDisplayFormat.TestFormat.WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes)));
 
                 if (expectedDiagnostics.Length == 0)
                 {
                     var verifier = CompileAndVerify(comp, expectedOutput: expectedResult);
-                    verifier.VerifyIL("Program.Evaluate", expectedIL, ilFormat: ILFormat);
+                    verifier.VerifyIL("Program.Evaluate", expectedIL);
                 }
             }
         }
@@ -12388,7 +12381,7 @@ $@"class Program
                 var model = comp.GetSemanticModel(tree);
                 var expr = tree.GetRoot().DescendantNodes().OfType<BinaryExpressionSyntax>().Single();
                 var symbolInfo = model.GetSymbolInfo(expr);
-                Assert.Equal(expectedSymbol, symbolInfo.Symbol?.ToDisplayString(TestFormat.WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes)));
+                Assert.Equal(expectedSymbol, symbolInfo.Symbol?.ToDisplayString(SymbolDisplayFormat.TestFormat.WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes)));
 
                 if (expectedDiagnostics.Length == 0)
                 {
@@ -13578,16 +13571,16 @@ class C : I
             comp.VerifyEmitDiagnostics();
 
             var type = comp.GetTypeByMetadataName("I");
-            Assert.Equal("S<nint> I.F1()", type.GetMember("F1").ToDisplayString(TestFormat));
-            Assert.Equal("S<System.IntPtr> I.F2()", type.GetMember("F2").ToDisplayString(TestFormat));
-            Assert.Equal("S<nint> I.F3()", type.GetMember("F3").ToDisplayString(TestFormat));
-            Assert.Equal("S<System.IntPtr> I.F4()", type.GetMember("F4").ToDisplayString(TestFormat));
+            Assert.Equal("S<nint> I.F1()", type.GetMember("F1").ToTestDisplayString());
+            Assert.Equal("S<System.IntPtr> I.F2()", type.GetMember("F2").ToTestDisplayString());
+            Assert.Equal("S<nint> I.F3()", type.GetMember("F3").ToTestDisplayString());
+            Assert.Equal("S<System.IntPtr> I.F4()", type.GetMember("F4").ToTestDisplayString());
 
             type = comp.GetTypeByMetadataName("C");
-            Assert.Equal("S<System.IntPtr> C.I.F1()", type.GetMember("I.F1").ToDisplayString(TestFormat));
-            Assert.Equal("S<nint> C.I.F2()", type.GetMember("I.F2").ToDisplayString(TestFormat));
-            Assert.Equal("S<nint> C.I.F3()", type.GetMember("I.F3").ToDisplayString(TestFormat));
-            Assert.Equal("S<System.IntPtr> C.I.F4()", type.GetMember("I.F4").ToDisplayString(TestFormat));
+            Assert.Equal("S<System.IntPtr> C.I.F1()", type.GetMember("I.F1").ToTestDisplayString());
+            Assert.Equal("S<nint> C.I.F2()", type.GetMember("I.F2").ToTestDisplayString());
+            Assert.Equal("S<nint> C.I.F3()", type.GetMember("I.F3").ToTestDisplayString());
+            Assert.Equal("S<System.IntPtr> C.I.F4()", type.GetMember("I.F4").ToTestDisplayString());
         }
 
         [WorkItem(42500, "https://github.com/dotnet/roslyn/issues/42500")]
@@ -13614,16 +13607,16 @@ class B : A
             comp.VerifyEmitDiagnostics();
 
             var type = comp.GetTypeByMetadataName("A");
-            Assert.Equal("nint[] A.F1()", type.GetMember("F1").ToDisplayString(TestFormat));
-            Assert.Equal("System.IntPtr[] A.F2()", type.GetMember("F2").ToDisplayString(TestFormat));
-            Assert.Equal("nint[] A.F3()", type.GetMember("F3").ToDisplayString(TestFormat));
-            Assert.Equal("System.IntPtr[] A.F4()", type.GetMember("F4").ToDisplayString(TestFormat));
+            Assert.Equal("nint[] A.F1()", type.GetMember("F1").ToTestDisplayString());
+            Assert.Equal("System.IntPtr[] A.F2()", type.GetMember("F2").ToTestDisplayString());
+            Assert.Equal("nint[] A.F3()", type.GetMember("F3").ToTestDisplayString());
+            Assert.Equal("System.IntPtr[] A.F4()", type.GetMember("F4").ToTestDisplayString());
 
             type = comp.GetTypeByMetadataName("B");
-            Assert.Equal("System.IntPtr[] B.F1()", type.GetMember("F1").ToDisplayString(TestFormat));
-            Assert.Equal("nint[] B.F2()", type.GetMember("F2").ToDisplayString(TestFormat));
-            Assert.Equal("nint[] B.F3()", type.GetMember("F3").ToDisplayString(TestFormat));
-            Assert.Equal("System.IntPtr[] B.F4()", type.GetMember("F4").ToDisplayString(TestFormat));
+            Assert.Equal("System.IntPtr[] B.F1()", type.GetMember("F1").ToTestDisplayString());
+            Assert.Equal("nint[] B.F2()", type.GetMember("F2").ToTestDisplayString());
+            Assert.Equal("nint[] B.F3()", type.GetMember("F3").ToTestDisplayString());
+            Assert.Equal("System.IntPtr[] B.F4()", type.GetMember("F4").ToTestDisplayString());
         }
 
         [WorkItem(42500, "https://github.com/dotnet/roslyn/issues/42500")]
@@ -13673,16 +13666,16 @@ class B : A
             comp.VerifyEmitDiagnostics();
 
             var type = comp.GetTypeByMetadataName("A");
-            Assert.Equal("void A.F1(nint modopt(System.Int32) i)", type.GetMember("F1").ToDisplayString(TestFormat));
-            Assert.Equal("void A.F2(System.IntPtr modopt(System.Int32) i)", type.GetMember("F2").ToDisplayString(TestFormat));
-            Assert.Equal("void A.F3(nint modopt(System.Int32) i)", type.GetMember("F3").ToDisplayString(TestFormat));
-            Assert.Equal("void A.F4(System.IntPtr modopt(System.Int32) i)", type.GetMember("F4").ToDisplayString(TestFormat));
+            Assert.Equal("void A.F1(nint modopt(System.Int32) i)", type.GetMember("F1").ToTestDisplayString());
+            Assert.Equal("void A.F2(System.IntPtr modopt(System.Int32) i)", type.GetMember("F2").ToTestDisplayString());
+            Assert.Equal("void A.F3(nint modopt(System.Int32) i)", type.GetMember("F3").ToTestDisplayString());
+            Assert.Equal("void A.F4(System.IntPtr modopt(System.Int32) i)", type.GetMember("F4").ToTestDisplayString());
 
             type = comp.GetTypeByMetadataName("B");
-            Assert.Equal("void B.F1(System.IntPtr modopt(System.Int32) i)", type.GetMember("F1").ToDisplayString(TestFormat));
-            Assert.Equal("void B.F2(nint modopt(System.Int32) i)", type.GetMember("F2").ToDisplayString(TestFormat));
-            Assert.Equal("void B.F3(nint modopt(System.Int32) i)", type.GetMember("F3").ToDisplayString(TestFormat));
-            Assert.Equal("void B.F4(System.IntPtr modopt(System.Int32) i)", type.GetMember("F4").ToDisplayString(TestFormat));
+            Assert.Equal("void B.F1(System.IntPtr modopt(System.Int32) i)", type.GetMember("F1").ToTestDisplayString());
+            Assert.Equal("void B.F2(nint modopt(System.Int32) i)", type.GetMember("F2").ToTestDisplayString());
+            Assert.Equal("void B.F3(nint modopt(System.Int32) i)", type.GetMember("F3").ToTestDisplayString());
+            Assert.Equal("void B.F4(System.IntPtr modopt(System.Int32) i)", type.GetMember("F4").ToTestDisplayString());
         }
 
         [WorkItem(42500, "https://github.com/dotnet/roslyn/issues/42500")]
@@ -13736,16 +13729,16 @@ class B : A
             comp.VerifyEmitDiagnostics();
 
             var type = comp.GetTypeByMetadataName("A");
-            Assert.Equal("nint[] modopt(System.Int32) A.F1()", type.GetMember("F1").ToDisplayString(TestFormat));
-            Assert.Equal("System.IntPtr[] modopt(System.Int32) A.F2()", type.GetMember("F2").ToDisplayString(TestFormat));
-            Assert.Equal("nint[] modopt(System.Int32) A.F3()", type.GetMember("F3").ToDisplayString(TestFormat));
-            Assert.Equal("System.IntPtr[] modopt(System.Int32) A.F4()", type.GetMember("F4").ToDisplayString(TestFormat));
+            Assert.Equal("nint[] modopt(System.Int32) A.F1()", type.GetMember("F1").ToTestDisplayString());
+            Assert.Equal("System.IntPtr[] modopt(System.Int32) A.F2()", type.GetMember("F2").ToTestDisplayString());
+            Assert.Equal("nint[] modopt(System.Int32) A.F3()", type.GetMember("F3").ToTestDisplayString());
+            Assert.Equal("System.IntPtr[] modopt(System.Int32) A.F4()", type.GetMember("F4").ToTestDisplayString());
 
             type = comp.GetTypeByMetadataName("B");
-            Assert.Equal("System.IntPtr[] modopt(System.Int32) B.F1()", type.GetMember("F1").ToDisplayString(TestFormat));
-            Assert.Equal("nint[] modopt(System.Int32) B.F2()", type.GetMember("F2").ToDisplayString(TestFormat));
-            Assert.Equal("nint[] modopt(System.Int32) B.F3()", type.GetMember("F3").ToDisplayString(TestFormat));
-            Assert.Equal("System.IntPtr[] modopt(System.Int32) B.F4()", type.GetMember("F4").ToDisplayString(TestFormat));
+            Assert.Equal("System.IntPtr[] modopt(System.Int32) B.F1()", type.GetMember("F1").ToTestDisplayString());
+            Assert.Equal("nint[] modopt(System.Int32) B.F2()", type.GetMember("F2").ToTestDisplayString());
+            Assert.Equal("nint[] modopt(System.Int32) B.F3()", type.GetMember("F3").ToTestDisplayString());
+            Assert.Equal("System.IntPtr[] modopt(System.Int32) B.F4()", type.GetMember("F4").ToTestDisplayString());
         }
 
         [WorkItem(42457, "https://github.com/dotnet/roslyn/issues/42457")]
@@ -15582,7 +15575,7 @@ class C
   IL_002b:  newobj     ""nint?..ctor(nint)""
   IL_0030:  ret
 }
-", ilFormat: ILFormat);
+");
 
             // lifted value and lifted count
             CompileAndVerify("""
@@ -15626,7 +15619,7 @@ class C
   IL_0039:  newobj     ""nint?..ctor(nint)""
   IL_003e:  ret
 }
-", ilFormat: ILFormat);
+");
             return;
 
             static string nint_shr(int count) => shift(count, "System.IntPtr", "shr");
@@ -15839,7 +15832,7 @@ class C
 """;
                 var comp = CreateCompilation(source, options: TestOptions.UnsafeReleaseExe);
                 var verifier = CompileAndVerify(comp, expectedOutput: "RAN");
-                verifier.VerifyIL("C.M", expectedIL, ilFormat: ILFormat);
+                verifier.VerifyIL("C.M", expectedIL);
             }
         }
 
@@ -15892,7 +15885,7 @@ class C
   IL_0000:  ldarg.0
   IL_0001:  ret
 }
-", ilFormat: ILFormat);
+");
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TopLevelStatementsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TopLevelStatementsTests.cs
@@ -7953,7 +7953,7 @@ return 11;
                   IL_0017:  pop
                   IL_0018:  ldsfld     "Program.<>c Program.<>c.<>9"
                   IL_001d:  ldftn      "int Program.<>c.<<Main>$>b__0_0()"
-                  IL_0023:  newobj     "System.Func<int>..ctor(object, System.IntPtr)"
+                  IL_0023:  newobj     "System.Func<int>..ctor(object, nint)"
                   IL_0028:  dup
                   IL_0029:  stsfld     "System.Func<int> Program.<>c.<>9__0_0"
                   IL_002e:  callvirt   "System.Threading.Tasks.Task<int> System.Threading.Tasks.TaskFactory.StartNew<int>(System.Func<int>)"

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
+using Basic.Reference.Assemblies;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
@@ -15,7 +16,6 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
-using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
@@ -8225,7 +8225,7 @@ class C
                 SymbolDisplayPartKind.RangeVariableName);
         }
 
-        [Fact]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76895")]
         public void NativeInt()
         {
             var source =
@@ -8240,34 +8240,21 @@ class B
     static void F3(nint? x, UIntPtr? y) { }
     static void F4(nint[] x, A<nuint> y) { }
 }";
-            var comp = CreateCompilation(new[] { source }, parseOptions: TestOptions.Regular9);
-            var formatWithoutOptions = new SymbolDisplayFormat(
+            var compWithoutNumericIntPtrCapability = CreateCompilation([source], parseOptions: TestOptions.Regular9);
+            Assert.False(compWithoutNumericIntPtrCapability.SupportsRuntimeCapability(RuntimeCapability.NumericIntPtr));
+
+            var compWithNumericIntPtrCapability = CreateCompilation([source], targetFramework: TargetFramework.Net100);
+            Assert.True(compWithNumericIntPtrCapability.SupportsRuntimeCapability(RuntimeCapability.NumericIntPtr));
+
+            var formatWithoutSpecialTypes = new SymbolDisplayFormat(
                 memberOptions: SymbolDisplayMemberOptions.IncludeParameters | SymbolDisplayMemberOptions.IncludeType | SymbolDisplayMemberOptions.IncludeModifiers,
                 parameterOptions: SymbolDisplayParameterOptions.IncludeType | SymbolDisplayParameterOptions.IncludeName,
                 genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters);
-            var formatWithUnderlyingTypes = formatWithoutOptions.WithCompilerInternalOptions(SymbolDisplayCompilerInternalOptions.UseNativeIntegerUnderlyingType);
+            var formatWithSpecialTypes = formatWithoutSpecialTypes.AddMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
 
-            var method = comp.GetMember<MethodSymbol>("B.F1");
+            var methodNoNumericIntPtr = compWithoutNumericIntPtrCapability.GetMember<MethodSymbol>("B.F1");
             Verify(
-                method.ToDisplayParts(formatWithUnderlyingTypes),
-                "static void F1(IntPtr x, UIntPtr y)",
-                SymbolDisplayPartKind.Keyword,
-                SymbolDisplayPartKind.Space,
-                SymbolDisplayPartKind.Keyword,
-                SymbolDisplayPartKind.Space,
-                SymbolDisplayPartKind.MethodName,
-                SymbolDisplayPartKind.Punctuation,
-                SymbolDisplayPartKind.StructName,
-                SymbolDisplayPartKind.Space,
-                SymbolDisplayPartKind.ParameterName,
-                SymbolDisplayPartKind.Punctuation,
-                SymbolDisplayPartKind.Space,
-                SymbolDisplayPartKind.StructName,
-                SymbolDisplayPartKind.Space,
-                SymbolDisplayPartKind.ParameterName,
-                SymbolDisplayPartKind.Punctuation);
-            Verify(
-                method.ToDisplayParts(formatWithoutOptions),
+                methodNoNumericIntPtr.ToDisplayParts(formatWithoutSpecialTypes),
                 "static void F1(nint x, nuint y)",
                 SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Space,
@@ -8285,31 +8272,61 @@ class B
                 SymbolDisplayPartKind.ParameterName,
                 SymbolDisplayPartKind.Punctuation);
             Verify(
-                method.ToDisplayParts(formatWithoutOptions.AddMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes)),
+                methodNoNumericIntPtr.ToDisplayParts(formatWithSpecialTypes),
                 "static void F1(nint x, nuint y)");
 
-            method = comp.GetMember<MethodSymbol>("B.F2");
+            var methodNumericIntPtr = compWithNumericIntPtrCapability.GetMember<MethodSymbol>("B.F1");
+            Verify(methodNumericIntPtr.ToDisplayParts(formatWithoutSpecialTypes),
+                "static void F1(IntPtr x, UIntPtr y)");
+            Verify(methodNumericIntPtr.ToDisplayParts(formatWithSpecialTypes),
+                "static void F1(nint x, nuint y)");
+
+            methodNoNumericIntPtr = compWithoutNumericIntPtrCapability.GetMember<MethodSymbol>("B.F2");
             Verify(
-                method.ToDisplayParts(formatWithUnderlyingTypes),
-                "static void F2(IntPtr x, IntPtr y)");
+                methodNoNumericIntPtr.ToDisplayParts(formatWithoutSpecialTypes),
+                "static void F2(nint x, IntPtr y)");
             Verify(
-                method.ToDisplayParts(formatWithoutOptions),
+                methodNoNumericIntPtr.ToDisplayParts(formatWithSpecialTypes),
                 "static void F2(nint x, IntPtr y)");
 
-            method = comp.GetMember<MethodSymbol>("B.F3");
+            methodNumericIntPtr = compWithNumericIntPtrCapability.GetMember<MethodSymbol>("B.F2");
             Verify(
-                method.ToDisplayParts(formatWithUnderlyingTypes),
-                "static void F3(IntPtr? x, UIntPtr? y)");
+                methodNumericIntPtr.ToDisplayParts(formatWithoutSpecialTypes),
+                "static void F2(IntPtr x, IntPtr y)");
             Verify(
-                method.ToDisplayParts(formatWithoutOptions),
+                methodNumericIntPtr.ToDisplayParts(formatWithSpecialTypes),
+                "static void F2(nint x, nint y)");
+
+            methodNoNumericIntPtr = compWithoutNumericIntPtrCapability.GetMember<MethodSymbol>("B.F3");
+            Verify(
+                methodNoNumericIntPtr.ToDisplayParts(formatWithoutSpecialTypes),
+                "static void F3(nint? x, UIntPtr? y)");
+            Verify(
+                methodNoNumericIntPtr.ToDisplayParts(formatWithSpecialTypes),
                 "static void F3(nint? x, UIntPtr? y)");
 
-            method = comp.GetMember<MethodSymbol>("B.F4");
+            methodNumericIntPtr = compWithNumericIntPtrCapability.GetMember<MethodSymbol>("B.F3");
             Verify(
-                method.ToDisplayParts(formatWithUnderlyingTypes),
+                methodNumericIntPtr.ToDisplayParts(formatWithoutSpecialTypes),
+                "static void F3(IntPtr? x, UIntPtr? y)");
+            Verify(
+                methodNumericIntPtr.ToDisplayParts(formatWithSpecialTypes),
+                "static void F3(nint? x, nuint? y)");
+
+            methodNoNumericIntPtr = compWithoutNumericIntPtrCapability.GetMember<MethodSymbol>("B.F4");
+            Verify(
+                methodNoNumericIntPtr.ToDisplayParts(formatWithoutSpecialTypes),
+                "static void F4(nint[] x, A<nuint> y)");
+            Verify(
+                methodNoNumericIntPtr.ToDisplayParts(formatWithSpecialTypes),
+                "static void F4(nint[] x, A<nuint> y)");
+
+            methodNumericIntPtr = compWithNumericIntPtrCapability.GetMember<MethodSymbol>("B.F4");
+            Verify(
+                methodNumericIntPtr.ToDisplayParts(formatWithoutSpecialTypes),
                 "static void F4(IntPtr[] x, A<UIntPtr> y)");
             Verify(
-                method.ToDisplayParts(formatWithoutOptions),
+                methodNumericIntPtr.ToDisplayParts(formatWithSpecialTypes),
                 "static void F4(nint[] x, A<nuint> y)");
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/InterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/InterfaceImplementationTests.cs
@@ -2553,12 +2553,12 @@ class B<T> : A<T>, I where T : class
         [InlineData("object", "dynamic", "dynamic", "System.Object", false)]
         [InlineData("(int X, int Y)", "(int X, int Y)", "(System.Int32 X, System.Int32 Y)", "System.ValueTuple`2[System.Int32,System.Int32]", true)]
         [InlineData("(int X, int Y)", "(int X, int Y)", "(System.Int32 X, System.Int32 Y)", "System.ValueTuple`2[System.Int32,System.Int32]", false)]
-        [InlineData("nint", "nint", "System.IntPtr", "System.IntPtr", true)]
-        [InlineData("nint", "nint", "System.IntPtr", "System.IntPtr", false)]
+        [InlineData("nint", "nint", "nint", "System.IntPtr", true)]
+        [InlineData("nint", "nint", "nint", "System.IntPtr", false)]
         [InlineData("nint", "System.IntPtr", "System.IntPtr", "System.IntPtr", true)]
         [InlineData("nint", "System.IntPtr", "System.IntPtr", "System.IntPtr", false)]
-        [InlineData("System.IntPtr", "nint", "System.IntPtr", "System.IntPtr", true)]
-        [InlineData("System.IntPtr", "nint", "System.IntPtr", "System.IntPtr", false)]
+        [InlineData("System.IntPtr", "nint", "nint", "System.IntPtr", true)]
+        [InlineData("System.IntPtr", "nint", "nint", "System.IntPtr", false)]
         public void ExplicitImplementationInBaseType_02(string interfaceTypeArg, string baseTypeArg, string expectedTypeArg, string expectedOutput, bool useCompilationReference)
         {
             var source0 =
@@ -2645,12 +2645,12 @@ class B<T> : A<T>, I
         [InlineData("object", "dynamic", "dynamic", false)]
         [InlineData("(int X, int Y)", "(int X, int Y)", "(System.Int32 X, System.Int32 Y)", true)]
         [InlineData("(int X, int Y)", "(int X, int Y)", "(System.Int32 X, System.Int32 Y)", false)]
-        [InlineData("nint", "nint", "System.IntPtr", true)]
-        [InlineData("nint", "nint", "System.IntPtr", false)]
+        [InlineData("nint", "nint", "nint", true)]
+        [InlineData("nint", "nint", "nint", false)]
         [InlineData("nint", "System.IntPtr", "System.IntPtr", true)]
         [InlineData("nint", "System.IntPtr", "System.IntPtr", false)]
-        [InlineData("System.IntPtr", "nint", "System.IntPtr", true)]
-        [InlineData("System.IntPtr", "nint", "System.IntPtr", false)]
+        [InlineData("System.IntPtr", "nint", "nint", true)]
+        [InlineData("System.IntPtr", "nint", "nint", false)]
         public void ExplicitImplementationInBaseType_04(string interfaceTypeArg, string baseTypeArg, string expectedTypeArg, bool useCompilationReference)
         {
             var source0 =

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FileModifierTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FileModifierTests.cs
@@ -2865,15 +2865,15 @@ public partial class C
 
         var comp = CreateCompilation(new[] { (source1, "F1.cs") }, targetFramework: TargetFramework.Net70);
         comp.VerifyDiagnostics(
-            // F1.cs(8,16): error CS8646: 'FI<nint>.Prop' is explicitly implemented more than once.
-            // internal class C : FI<nint>, FI<IntPtr>
-            Diagnostic(ErrorCode.ERR_DuplicateExplicitImpl, "C").WithArguments("FI<nint>.Prop").WithLocation(8, 16),
-            // F1.cs(8,30): error CS0528: 'FI<nint>' is already listed in interface list
-            // internal class C : FI<nint>, FI<IntPtr>
-            Diagnostic(ErrorCode.ERR_DuplicateInterfaceInBaseList, "FI<IntPtr>").WithArguments("FI<nint>").WithLocation(8, 30),
-            // F1.cs(11,23): error CS0102: The type 'C' already contains a definition for '<F1>F2A62B10769F2595F65CAD631A41E2B54F5D1B3601B00884A41306FA9AD9BACDB__FI<nint>.Prop'
-            //     IntPtr FI<IntPtr>.Prop { get; }
-            Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "Prop").WithArguments("C", "<F1>F2A62B10769F2595F65CAD631A41E2B54F5D1B3601B00884A41306FA9AD9BACDB__FI<nint>.Prop").WithLocation(11, 23)
+                // F1.cs(8,16): error CS8646: 'FI<nint>.Prop' is explicitly implemented more than once.
+                // internal class C : FI<nint>, FI<IntPtr>
+                Diagnostic(ErrorCode.ERR_DuplicateExplicitImpl, "C").WithArguments("FI<nint>.Prop").WithLocation(8, 16),
+                // F1.cs(8,30): error CS0528: 'FI<nint>' is already listed in interface list
+                // internal class C : FI<nint>, FI<IntPtr>
+                Diagnostic(ErrorCode.ERR_DuplicateInterfaceInBaseList, "FI<IntPtr>").WithArguments("FI<nint>").WithLocation(8, 30),
+                // F1.cs(11,23): error CS0102: The type 'C' already contains a definition for '<F1>F2A62B10769F2595F65CAD631A41E2B54F5D1B3601B00884A41306FA9AD9BACDB__FI<System.IntPtr>.Prop'
+                //     IntPtr FI<IntPtr>.Prop { get; }
+                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "Prop").WithArguments("C", "<F1>F2A62B10769F2595F65CAD631A41E2B54F5D1B3601B00884A41306FA9AD9BACDB__FI<System.IntPtr>.Prop").WithLocation(11, 23)
             );
     }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/UsingAliasTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/UsingAliasTests.cs
@@ -4,7 +4,6 @@
 
 #nullable disable
 
-using System;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
@@ -253,8 +252,9 @@ partial class A : Object {}
         [InlineData("int*", "System.Int32*")]
         [InlineData("delegate*<int,int>", "delegate*<System.Int32, System.Int32>")]
         [InlineData("dynamic", "dynamic")]
-        [InlineData("nint", "System.IntPtr")]
-        public void GetAliasTypeInfo(string aliasType, string expected)
+        [InlineData("nint", "nint")]
+        [InlineData("nint", "System.IntPtr", TargetFramework.Net100)]
+        public void GetAliasTypeInfo(string aliasType, string expected, TargetFramework targetFramework = TargetFramework.Standard)
         {
             // Should get the same results in the semantic model regardless of whether the using has the 'unsafe'
             // keyword or not.
@@ -266,7 +266,7 @@ partial class A : Object {}
                 var text = $"using {unsafeString} O = {aliasType};";
                 var tree = Parse(text);
                 var root = tree.GetCompilationUnitRoot();
-                var comp = CreateCompilation(tree);
+                var comp = CreateCompilation(tree, targetFramework: targetFramework);
 
                 var usingAlias = root.Usings[0];
 

--- a/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayCompilerInternalOptions.cs
+++ b/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayCompilerInternalOptions.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 
 namespace Microsoft.CodeAnalysis
@@ -55,31 +53,26 @@ namespace Microsoft.CodeAnalysis
         ReverseArrayRankSpecifiers = 1 << 5,
 
         /// <summary>
-        /// Display `System.[U]IntPtr` instead of `n[u]int`.
-        /// </summary>
-        UseNativeIntegerUnderlyingType = 1 << 6,
-
-        /// <summary>
         /// Separate out nested types from containing types using <c>+</c> instead of <c>.</c> (dot).
         /// </summary>
-        UsePlusForNestedTypes = 1 << 7,
+        UsePlusForNestedTypes = 1 << 6,
 
         /// <summary>
         /// Display `MyType@File.cs` instead of `MyType`.
         /// </summary>
-        IncludeContainingFileForFileTypes = 1 << 8,
+        IncludeContainingFileForFileTypes = 1 << 7,
 
         /// <summary>
         /// Does not include parameter name if the parameter is displayed on its own
         /// (i.e., not as part of a method, delegate, or indexer).
         /// </summary>
-        ExcludeParameterNameIfStandalone = 1 << 9,
+        ExcludeParameterNameIfStandalone = 1 << 8,
 
         /// <summary>
         /// Display `&lt;File&gt;F&lt;sha256-hex-string&gt;_MyType` instead of `MyType`.
         /// Differs from <see cref="IncludeContainingFileForFileTypes"/> because it guarantees that
         /// the prefix will be unique for all files which are permitted to declare file-local types.
         /// </summary>
-        IncludeFileLocalTypesPrefix = 1 << 10,
+        IncludeFileLocalTypesPrefix = 1 << 9,
     }
 }

--- a/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayFormat.cs
+++ b/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayFormat.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
-
 namespace Microsoft.CodeAnalysis
 {
     /// <summary>
@@ -200,7 +198,6 @@ namespace Microsoft.CodeAnalysis
                 compilerInternalOptions:
                     SymbolDisplayCompilerInternalOptions.IncludeScriptType |
                     SymbolDisplayCompilerInternalOptions.UseMetadataMemberNames |
-                    SymbolDisplayCompilerInternalOptions.UseNativeIntegerUnderlyingType |
                     SymbolDisplayCompilerInternalOptions.FlagMissingMetadataTypes |
                     SymbolDisplayCompilerInternalOptions.IncludeCustomModifiers |
                     SymbolDisplayCompilerInternalOptions.IncludeContainingFileForFileTypes);
@@ -258,7 +255,7 @@ namespace Microsoft.CodeAnalysis
                 miscellaneousOptions:
                     SymbolDisplayMiscellaneousOptions.UseSpecialTypes |
                     SymbolDisplayMiscellaneousOptions.ExpandValueTuple,
-                compilerInternalOptions: SymbolDisplayCompilerInternalOptions.UseMetadataMemberNames | SymbolDisplayCompilerInternalOptions.UseNativeIntegerUnderlyingType);
+                compilerInternalOptions: SymbolDisplayCompilerInternalOptions.UseMetadataMemberNames);
 
         /// <summary>
         /// Used to normalize explicit interface implementation member names.

--- a/src/Compilers/Test/Utilities/CSharp/NativeIntegerAttributesVisitor.cs
+++ b/src/Compilers/Test/Utilities/CSharp/NativeIntegerAttributesVisitor.cs
@@ -31,8 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
                 SymbolDisplayMemberOptions.IncludeParameters |
                 SymbolDisplayMemberOptions.IncludeType |
                 SymbolDisplayMemberOptions.IncludeRef |
-                SymbolDisplayMemberOptions.IncludeExplicitInterface).
-            WithCompilerInternalOptions(SymbolDisplayCompilerInternalOptions.UseNativeIntegerUnderlyingType);
+                SymbolDisplayMemberOptions.IncludeExplicitInterface);
 
         protected override bool TypeRequiresAttribute(TypeSymbol? type) => type?.ContainsNativeIntegerWrapperType() == true;
 


### PR DESCRIPTION
Closes: https://github.com/dotnet/roslyn/issues/76895

Also retired compiler-internal option that forced `System.[U]IntPtr` instead of keywords. Having both public and internal option, one of which is also conditional, just adds confusion without much benifit
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83583)