### PR TITLE
Extension indexers: receiver handling and tests for remaining complex assignments

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
@@ -251,8 +251,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     if (leftTarget.Kind != BoundKind.DiscardExpression)
                     {
+                        // Note: the receiver is known to be captured because of TransformCompoundAssignmentLHS in GetAssignmentTargetsAndSideEffects
                         effects.assignments.Add(MakeAssignmentOperator(resultPart.Syntax, leftTarget, resultPart,
-                            used: false, isChecked: false, AssignmentKind.Deconstruction, receiverIsKnownToBeCaptured: false)); // PROTOTYPE revisit for deconstruction assignment
+                            used: false, isChecked: false, AssignmentKind.Deconstruction, receiverIsKnownToBeCaptured: true));
                     }
                 }
                 Debug.Assert(builder is null || resultPart is { });

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingAssignmentOperator.cs
@@ -41,17 +41,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(TypeSymbol.Equals(transformedLHS.Type, node.LeftOperand.Type, TypeCompareKind.AllIgnoreOptions));
                 BoundExpression assignment;
 
+                // Note: the receiver is known to be captured because of TransformCompoundAssignmentLHS
                 if (IsExtensionBlockMemberAccessWithByValPossiblyStructReceiver(transformedLHS))
                 {
                     // We need to create a tree that ensures that receiver of 'set' is evaluated after the right hand side value
                     BoundLocal rightResult = _factory.StoreToTemp(loweredRight, out BoundAssignmentOperator assignmentToTemp, refKind: RefKind.None);
-                    assignment = MakeAssignmentOperator(syntax, transformedLHS, rightResult, used: true, isChecked: false, AssignmentKind.NullCoalescingAssignment, receiverIsKnownToBeCaptured: false); // PROTOTYPE revisit as part of null-coalescing assignment
+                    assignment = MakeAssignmentOperator(syntax, transformedLHS, rightResult, used: true, isChecked: false, AssignmentKind.NullCoalescingAssignment, receiverIsKnownToBeCaptured: true);
                     Debug.Assert(assignment.Type is { });
                     assignment = new BoundSequence(syntax, [rightResult.LocalSymbol], [assignmentToTemp], assignment, assignment.Type);
                 }
                 else
                 {
-                    assignment = MakeAssignmentOperator(syntax, transformedLHS, loweredRight, used: true, isChecked: false, AssignmentKind.NullCoalescingAssignment, receiverIsKnownToBeCaptured: false); // PROTOTYPE revisit as part of null-coalescing assignment
+                    assignment = MakeAssignmentOperator(syntax, transformedLHS, loweredRight, used: true, isChecked: false, AssignmentKind.NullCoalescingAssignment, receiverIsKnownToBeCaptured: true);
                 }
 
                 // lhsRead ?? (transformedLHS = loweredRight)
@@ -120,11 +121,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 temps.Add(tmp.LocalSymbol);
 
                 // tmp = loweredRight;
-                var tmpAssignment = MakeAssignmentOperator(node.Syntax, tmp, loweredRight, used: true, isChecked: false, AssignmentKind.SimpleAssignment, receiverIsKnownToBeCaptured: false); // PROTOTYPE revisit as part of null-coalescing assignment
+                // Note: tmp is a fresh local, so receiverIsKnownToBeCaptured is irrelevant here.
+                var tmpAssignment = MakeAssignmentOperator(node.Syntax, tmp, loweredRight, used: true, isChecked: false, AssignmentKind.SimpleAssignment, receiverIsKnownToBeCaptured: false);
 
                 Debug.Assert(transformedLHS.Type.GetNullableUnderlyingType().Equals(tmp.Type.StrippedType(), TypeCompareKind.AllIgnoreOptions));
 
                 // transformedLhs = tmp;
+                // Note: the receiver is known to be captured because of TransformCompoundAssignmentLHS
                 Debug.Assert(TypeSymbol.Equals(transformedLHS.Type, node.LeftOperand.Type, TypeCompareKind.AllIgnoreOptions));
                 var transformedLhsAssignment =
                     MakeAssignmentOperator(
@@ -134,7 +137,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         used: true,
                         isChecked: false,
                         AssignmentKind.NullCoalescingAssignment,
-                        receiverIsKnownToBeCaptured: false); // PROTOTYPE revisit as part of null-coalescing assignment
+                        receiverIsKnownToBeCaptured: true);
 
                 // lhsRead.HasValue
                 var lhsReadHasValue = BoundCall.Synthesized(leftOperand.Syntax, lhsRead, initialBindingReceiverIsSubjectToCloning: ThreeState.Unknown, hasValue);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UnaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UnaryOperator.cs
@@ -527,7 +527,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             BoundExpression makeAssignmentBack(SyntaxNode syntax, BoundExpression transformedLHS, BoundLocal boundTemp, bool isChecked, AssignmentKind assignmentKind)
             {
-                return MakeAssignmentOperator(syntax, transformedLHS, boundTemp, used: false, isChecked: isChecked, assignmentKind, receiverIsKnownToBeCaptured: false); // PROTOTYPE revisit as part of null-coalescing assignment
+                // Note: the receiver is known to be captured because of TransformCompoundAssignmentLHS
+                return MakeAssignmentOperator(syntax, transformedLHS, boundTemp, used: false, isChecked: isChecked, assignmentKind, receiverIsKnownToBeCaptured: true);
             }
         }
 
@@ -661,19 +662,20 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // prefix:  temp = (X)(T.Increment((T)operand)));  operand = temp; 
                 // postfix: temp = operand;                        operand = (X)(T.Increment((T)temp)));
-                tempInitializers.Add(MakeAssignmentOperator(syntax, boundTemp, isPrefix ? newValue : MakeRValue(transformedLHS), used: false, isChecked: isChecked, AssignmentKind.SimpleAssignment, receiverIsKnownToBeCaptured: false)); // PROTOTYPE revisit as part of null-coalescing assignment
+                tempInitializers.Add(MakeAssignmentOperator(syntax, boundTemp, isPrefix ? newValue : MakeRValue(transformedLHS), used: false, isChecked: isChecked, AssignmentKind.SimpleAssignment, receiverIsKnownToBeCaptured: true));
 
+                // Note: the receiver in transformedLHS is known to be captured because of TransformCompoundAssignmentLHS
                 if (!isPrefix && IsExtensionBlockMemberAccessWithByValPossiblyStructReceiver(transformedLHS))
                 {
                     // We need to create a tree that ensures that receiver of 'set' is evaluated after the increment operation
                     BoundLocal incrementResult = _factory.StoreToTemp(newValue, out BoundAssignmentOperator assignmentToTemp, refKind: RefKind.None);
                     tempSymbols.Add(incrementResult.LocalSymbol);
                     tempInitializers.Add(assignmentToTemp);
-                    tempInitializers.Add(MakeAssignmentOperator(syntax, transformedLHS, incrementResult, used: false, isChecked: isChecked, AssignmentKind.IncrementDecrement, receiverIsKnownToBeCaptured: false)); // PROTOTYPE revisit as part of null-coalescing assignment
+                    tempInitializers.Add(MakeAssignmentOperator(syntax, transformedLHS, incrementResult, used: false, isChecked: isChecked, AssignmentKind.IncrementDecrement, receiverIsKnownToBeCaptured: true));
                 }
                 else
                 {
-                    tempInitializers.Add(MakeAssignmentOperator(syntax, transformedLHS, isPrefix ? boundTemp : newValue, used: false, isChecked: isChecked, AssignmentKind.IncrementDecrement, receiverIsKnownToBeCaptured: false)); // PROTOTYPE revisit as part of null-coalescing assignment
+                    tempInitializers.Add(MakeAssignmentOperator(syntax, transformedLHS, isPrefix ? boundTemp : newValue, used: false, isChecked: isChecked, AssignmentKind.IncrementDecrement, receiverIsKnownToBeCaptured: true));
                 }
 
                 // prefix:  Seq( operand initializers; temp = (T)(operand + 1); operand = temp;          result: temp)
@@ -700,7 +702,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 var tempValue = isPrefix ? newValue : MakeRValue(operand);
                 Debug.Assert(tempValue.Type is { });
-                var tempAssignment = MakeAssignmentOperator(syntax, boundTemp, tempValue, used: false, isChecked: isChecked, AssignmentKind.SimpleAssignment, receiverIsKnownToBeCaptured: false); // PROTOTYPE revisit as part of null-coalescing assignment
+                var tempAssignment = MakeAssignmentOperator(syntax, boundTemp, tempValue, used: false, isChecked: isChecked, AssignmentKind.SimpleAssignment, receiverIsKnownToBeCaptured: true);
 
                 var operandValue = isPrefix ? boundTemp : newValue;
                 var tempAssignedAndOperandValue = new BoundSequence(
@@ -712,7 +714,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // prefix:  operand = Seq{temp = (T)(operand + 1);  temp;}
                 // postfix: operand = Seq{temp = operand;        ;  (T)(temp + 1);}
-                BoundExpression operandAssignment = MakeAssignmentOperator(syntax, operand, tempAssignedAndOperandValue, used: false, isChecked: isChecked, AssignmentKind.IncrementDecrement, receiverIsKnownToBeCaptured: false); // PROTOTYPE revisit as part of null-coalescing assignment
+                BoundExpression operandAssignment = MakeAssignmentOperator(syntax, operand, tempAssignedAndOperandValue, used: false, isChecked: isChecked, AssignmentKind.IncrementDecrement, receiverIsKnownToBeCaptured: true);
 
                 // prefix:  Seq{operand initializers; operand = Seq{temp = (T)(operand + 1);  temp;}          result: temp}
                 // postfix: Seq{operand initializers; operand = Seq{temp = operand;        ;  (T)(temp + 1);} result: temp}

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
@@ -41055,5 +41055,1075 @@ class Program
 }
 """);
     }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_PrefixIncrementAssignment_01()
+    {
+        // sibling to ExtensionTests.PropertyAccess_PrefixIncrementAssignment_01
+        // struct extension parameter
+        var src = """
+static class E
+{
+    extension(S1 x)
+    {
+        public int this[int i]
+        {
+            get { System.Console.Write($"get:{x.F1} "); Program.F.F1++; return 0; }
+            set { System.Console.Write($"set:{x.F1} "); }
+        }
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 3; } }
+    }
+}
+
+struct S1
+{
+    public int F1;
+
+    public void Test2()
+    {
+        ++this[Program.GetIndex()];
+    }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        F = new S1 { F1 = 3 };
+        F.Test2();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        ++F[GetIndex()];
+    }
+
+    public static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program.F.F1} "); Program.F.F1++; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:4 get:5 set:6 final:6, GetIndex:3 length:4 get:5 set:6 final:6"),
+            verify: Verification.FailsPEVerify).VerifyDiagnostics();
+    }
+
+    [Theory]
+    [InlineData("ref")]
+    [InlineData("ref readonly")]
+    [InlineData("in")]
+    public void ImplicitIndexIndexerAccess_PrefixIncrementAssignment_02(string refKind)
+    {
+        // refKind on extension parameter
+        var src = $$$"""
+static class E
+{
+    extension({{{refKind}}} S1 x)
+    {
+        public int this[int i]
+        {
+            get { System.Console.Write($"get:{x.F1} "); Program.F.F1++; return 0; }
+            set { System.Console.Write($"set:{x.F1} "); }
+        }
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 3; } }
+    }
+}
+
+struct S1
+{
+    public int F1;
+
+    public void Test2()
+    {
+        ++this[Program.GetIndex()];
+    }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        F = new S1 { F1 = 3 };
+        F.Test2();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        ++F[GetIndex()];
+    }
+
+    public static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program.F.F1} "); Program.F.F1++; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:4 get:5 set:6 final:6, GetIndex:3 length:4 get:5 set:6 final:6"),
+            verify: Verification.FailsPEVerify).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_PrefixIncrementAssignment_03()
+    {
+        // class receiver
+        var src = """
+static class E
+{
+    extension(C1 x)
+    {
+        public int this[int i]
+        {
+            get { System.Console.Write($"get:{x.F1} "); Program.F.F1++; return 0; }
+            set { System.Console.Write($"set:{x.F1} "); }
+        }
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 3; } }
+    }
+}
+
+class C1
+{
+    public int F1;
+}
+
+class Program
+{
+    public static C1 F;
+
+    static void Main()
+    {
+        F = new C1 { F1 = 3 };
+        Test();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test()
+    {
+        ++F[GetIndex()];
+    }
+
+    static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program.F.F1} "); Program.F = new C1 { F1 = Program.F.F1 + 1 }; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:3 get:3 set:3 final:6"),
+            verify: Verification.FailsPEVerify).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_PostfixIncrementAssignment_01()
+    {
+        // sibling to ExtensionTests.PropertyAccess_PostfixIncrementAssignment_01
+        // struct extension parameter
+        var src = """
+static class E
+{
+    extension(S1 x)
+    {
+        public int this[int i]
+        {
+            get { System.Console.Write($"get:{x.F1} "); Program.F.F1++; return 0; }
+            set { System.Console.Write($"set:{x.F1} "); }
+        }
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 3; } }
+    }
+}
+
+struct S1
+{
+    public int F1;
+
+    public void Test2()
+    {
+        this[Program.GetIndex()]++;
+    }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        F = new S1 { F1 = 3 };
+        F.Test2();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        F[GetIndex()]++;
+    }
+
+    public static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program.F.F1} "); Program.F.F1++; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:4 get:5 set:6 final:6, GetIndex:3 length:4 get:5 set:6 final:6"),
+            verify: Verification.FailsPEVerify).VerifyDiagnostics();
+    }
+
+    [Theory]
+    [InlineData("ref")]
+    [InlineData("ref readonly")]
+    [InlineData("in")]
+    public void ImplicitIndexIndexerAccess_PostfixIncrementAssignment_02(string refKind)
+    {
+        // refKind on extension parameter
+        var src = $$$"""
+static class E
+{
+    extension({{{refKind}}} S1 x)
+    {
+        public int this[int i]
+        {
+            get { System.Console.Write($"get:{x.F1} "); Program.F.F1++; return 0; }
+            set { System.Console.Write($"set:{x.F1} "); }
+        }
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 3; } }
+    }
+}
+
+struct S1
+{
+    public int F1;
+
+    public void Test2()
+    {
+        this[Program.GetIndex()]++;
+    }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        F = new S1 { F1 = 3 };
+        F.Test2();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        F[GetIndex()]++;
+    }
+
+    public static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program.F.F1} "); Program.F.F1++; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:4 get:5 set:6 final:6, GetIndex:3 length:4 get:5 set:6 final:6"),
+            verify: Verification.FailsPEVerify).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_PostfixIncrementAssignment_03()
+    {
+        // class receiver
+        var src = """
+static class E
+{
+    extension(C1 x)
+    {
+        public int this[int i]
+        {
+            get { System.Console.Write($"get:{x.F1} "); Program.F.F1++; return 0; }
+            set { System.Console.Write($"set:{x.F1} "); }
+        }
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 3; } }
+    }
+}
+
+class C1
+{
+    public int F1;
+}
+
+class Program
+{
+    public static C1 F;
+
+    static void Main()
+    {
+        F = new C1 { F1 = 3 };
+        Test();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test()
+    {
+        F[GetIndex()]++;
+    }
+
+    static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program.F.F1} "); Program.F = new C1 { F1 = Program.F.F1 + 1 }; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:3 get:3 set:3 final:6"),
+            verify: Verification.FailsPEVerify).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_ConditionalAssignment_01()
+    {
+        // sibling to ExtensionTests.PropertyAccess_ConditionalAssignment_01 (??=)
+        // struct extension parameter, nullable result
+        var src = """
+#nullable enable
+static class E
+{
+    extension(S1 x)
+    {
+        public string? this[int i]
+        {
+            get { System.Console.Write($"get:{x.F1} "); Program.F.F1++; return null; }
+            set { System.Console.Write($"set:{x.F1} "); }
+        }
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 3; } }
+    }
+}
+
+struct S1
+{
+    public int F1;
+
+    public void Test2()
+    {
+        this[Program.GetIndex()] ??= Program.GetValue();
+    }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        F = new S1 { F1 = 3 };
+        F.Test2();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        F[GetIndex()] ??= GetValue();
+    }
+
+    public static string GetValue() { System.Console.Write($"GetValue:{Program.F.F1} "); Program.F.F1++; return "v"; }
+
+    public static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program.F.F1} "); Program.F.F1++; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:4 get:5 GetValue:6 set:7 final:7, GetIndex:3 length:4 get:5 GetValue:6 set:7 final:7"),
+            verify: Verification.FailsPEVerify).VerifyDiagnostics();
+    }
+
+    [Theory]
+    [InlineData("ref")]
+    [InlineData("ref readonly")]
+    [InlineData("in")]
+    public void ImplicitIndexIndexerAccess_ConditionalAssignment_02(string refKind)
+    {
+        // refKind on extension parameter
+        var src = $$$"""
+#nullable enable
+static class E
+{
+    extension({{{refKind}}} S1 x)
+    {
+        public string? this[int i]
+        {
+            get { System.Console.Write($"get:{x.F1} "); Program.F.F1++; return null; }
+            set { System.Console.Write($"set:{x.F1} "); }
+        }
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 3; } }
+    }
+}
+
+struct S1
+{
+    public int F1;
+
+    public void Test2()
+    {
+        this[Program.GetIndex()] ??= Program.GetValue();
+    }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        F = new S1 { F1 = 3 };
+        F.Test2();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        F[GetIndex()] ??= GetValue();
+    }
+
+    public static string GetValue() { System.Console.Write($"GetValue:{Program.F.F1} "); Program.F.F1++; return "v"; }
+
+    public static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program.F.F1} "); Program.F.F1++; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:4 get:5 GetValue:6 set:7 final:7, GetIndex:3 length:4 get:5 GetValue:6 set:7 final:7"),
+            verify: Verification.FailsPEVerify).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_ConditionalAssignment_03()
+    {
+        // class receiver
+        var src = """
+#nullable enable
+static class E
+{
+    extension(C1 x)
+    {
+        public string? this[int i]
+        {
+            get { System.Console.Write($"get:{x.F1} "); Program.F.F1++; return null; }
+            set { System.Console.Write($"set:{x.F1} "); }
+        }
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 3; } }
+    }
+}
+
+class C1
+{
+    public int F1;
+}
+
+class Program
+{
+    public static C1 F = null!;
+
+    static void Main()
+    {
+        F = new C1 { F1 = 3 };
+        Test();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test()
+    {
+        F[GetIndex()] ??= GetValue();
+    }
+
+    static string GetValue() { System.Console.Write($"GetValue:{Program.F.F1} "); Program.F = new C1 { F1 = Program.F.F1 + 1 }; return "v"; }
+
+    static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program.F.F1} "); Program.F = new C1 { F1 = Program.F.F1 + 1 }; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:3 get:3 GetValue:6 set:3 final:7"),
+            verify: Verification.FailsPEVerify).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_DeconstructAssignment_01()
+    {
+        // sibling to ExtensionTests.PropertyAccess_DeconstructAssignment_01
+        // struct extension parameter, indexer assigned via tuple deconstruction
+        var src = """
+static class E
+{
+    extension(S1 x)
+    {
+        public int this[int i]
+        {
+            set { System.Console.Write($"set:{x.F1} "); }
+        }
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 3; } }
+    }
+}
+
+struct S1
+{
+    public int F1;
+
+    public void Test2()
+    {
+        (this[Program.GetIndex()], int y) = Program.GetTuple();
+        System.Console.Write($"y:{y} ");
+    }
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        F = new S1 { F1 = 3 };
+        F.Test2();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        (F[GetIndex()], int y) = GetTuple();
+        System.Console.Write($"y:{y} ");
+    }
+
+    public static (int, int) GetTuple() { System.Console.Write($"GetTuple:{Program.F.F1} "); Program.F.F1++; return (1, 2); }
+
+    public static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program.F.F1} "); Program.F.F1++; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:4 GetTuple:5 set:6 y:2 final:6, GetIndex:3 length:4 GetTuple:5 set:6 y:2 final:6"),
+            verify: Verification.FailsPEVerify).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_DeconstructAssignment_02()
+    {
+        // by-ref struct value (deconstruction needs an assignable receiver, so 'in'/'ref readonly' are not valid)
+        var src = """
+static class E
+{
+    extension(S1 x)
+    {
+        public int this[int i]
+        {
+            set { System.Console.Write($"set:{x.F1} "); }
+        }
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 3; } }
+    }
+}
+
+struct S1
+{
+    public int F1;
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Main()
+    {
+        F = new S1 { F1 = 3 };
+        Test1(ref F);
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test1(ref S1 f)
+    {
+        (f[GetIndex()], int y) = GetTuple();
+        System.Console.Write($"y:{y} ");
+    }
+
+    static (int, int) GetTuple() { System.Console.Write($"GetTuple:{Program.F.F1} "); Program.F.F1++; return (1, 2); }
+
+    static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program.F.F1} "); Program.F.F1++; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:4 GetTuple:5 set:6 y:2 final:6"),
+            verify: Verification.FailsPEVerify).VerifyDiagnostics();
+
+        // 'in' and 'ref readonly' are rejected: deconstruction requires an assignable receiver
+        var src2 = """
+static class E
+{
+    extension(S1 x)
+    {
+        public int this[int i] { set {} }
+        public int Length => 3;
+    }
+}
+
+struct S1
+{
+}
+
+class Program
+{
+    public static S1 F;
+
+    static void Test1(in S1 f)
+    {
+        (f[^1], int _) = (1, 2);
+    }
+
+    static void Test2(ref readonly S1 f)
+    {
+        (f[^1], int _) = (1, 2);
+    }
+}
+""";
+
+        CreateCompilation(src2, targetFramework: TargetFramework.Net100).VerifyEmitDiagnostics(
+            // (16,22): warning CS0649: Field 'Program.F' is never assigned to, and will always have its default value
+            //     public static S1 F;
+            Diagnostic(ErrorCode.WRN_UnassignedInternalField, "F").WithArguments("Program.F", "").WithLocation(16, 22),
+            // (20,10): error CS8332: Cannot assign to a member of variable 'f' or use it as the right hand side of a ref assignment because it is a readonly variable
+            //         (f[^1], int _) = (1, 2);
+            Diagnostic(ErrorCode.ERR_AssignReadonlyNotField2, "f[^1]").WithArguments("variable", "f").WithLocation(20, 10),
+            // (25,10): error CS8332: Cannot assign to a member of variable 'f' or use it as the right hand side of a ref assignment because it is a readonly variable
+            //         (f[^1], int _) = (1, 2);
+            Diagnostic(ErrorCode.ERR_AssignReadonlyNotField2, "f[^1]").WithArguments("variable", "f").WithLocation(25, 10));
+    }
+
+    [Fact]
+    public void ImplicitIndexIndexerAccess_DeconstructAssignment_03()
+    {
+        // class receiver
+        var src = """
+static class E
+{
+    extension(C1 x)
+    {
+        public int this[int i]
+        {
+            set { System.Console.Write($"set:{x.F1} "); }
+        }
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 3; } }
+    }
+}
+
+class C1
+{
+    public int F1;
+}
+
+class Program
+{
+    public static C1 F;
+
+    static void Main()
+    {
+        F = new C1 { F1 = 3 };
+        Test();
+        System.Console.Write($"final:{F.F1}");
+    }
+
+    static void Test()
+    {
+        (F[GetIndex()], int y) = GetTuple();
+        System.Console.Write($"y:{y} ");
+    }
+
+    static (int, int) GetTuple() { System.Console.Write($"GetTuple:{Program.F.F1} "); Program.F = new C1 { F1 = Program.F.F1 + 1 }; return (1, 2); }
+
+    static System.Index GetIndex() { System.Console.Write($"GetIndex:{Program.F.F1} "); Program.F = new C1 { F1 = Program.F.F1 + 1 }; return ^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 length:3 GetTuple:5 set:3 y:2 final:6"),
+            verify: Verification.FailsPEVerify).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_PrefixIncrementAssignment_01()
+    {
+        // Range pattern with ref-returning extension Slice
+        var src = """
+static class E
+{
+    extension(S1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 5; } }
+        public ref int Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); Program.F.F1++; return ref Program.Result; }
+    }
+}
+
+struct S1
+{
+    public int F1;
+
+    public void Test2()
+    {
+        ++this[Program.GetRange()];
+    }
+}
+
+class Program
+{
+    public static S1 F;
+    public static int Result;
+
+    static void Main()
+    {
+        Result = 10;
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"result:{Result} final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        Result = 10;
+        F = new S1 { F1 = 3 };
+        F.Test2();
+        System.Console.Write($"result:{Result} final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        ++F[GetRange()];
+    }
+
+    public static System.Range GetRange() { System.Console.Write($"GetRange:{Program.F.F1} "); Program.F.F1++; return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:4 Slice:5 result:11 final:6, GetRange:3 length:4 Slice:5 result:11 final:6"),
+            verify: Verification.FailsPEVerify).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_PostfixIncrementAssignment_01()
+    {
+        // Range pattern with ref-returning extension Slice
+        var src = """
+static class E
+{
+    extension(S1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 5; } }
+        public ref int Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); Program.F.F1++; return ref Program.Result; }
+    }
+}
+
+struct S1
+{
+    public int F1;
+
+    public void Test2()
+    {
+        this[Program.GetRange()]++;
+    }
+}
+
+class Program
+{
+    public static S1 F;
+    public static int Result;
+
+    static void Main()
+    {
+        Result = 10;
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"result:{Result} final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        Result = 10;
+        F = new S1 { F1 = 3 };
+        F.Test2();
+        System.Console.Write($"result:{Result} final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        F[GetRange()]++;
+    }
+
+    public static System.Range GetRange() { System.Console.Write($"GetRange:{Program.F.F1} "); Program.F.F1++; return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:4 Slice:5 result:11 final:6, GetRange:3 length:4 Slice:5 result:11 final:6"),
+            verify: Verification.FailsPEVerify).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_ConditionalAssignment_01()
+    {
+        // Range pattern with ref-returning extension Slice (string?)
+        var src = """
+#nullable enable
+static class E
+{
+    extension(S1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 5; } }
+        public ref string? Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); Program.F.F1++; return ref Program.Result; }
+    }
+}
+
+struct S1
+{
+    public int F1;
+
+    public void Test2()
+    {
+        this[Program.GetRange()] ??= Program.GetValue();
+    }
+}
+
+class Program
+{
+    public static S1 F;
+    public static string? Result;
+
+    static void Main()
+    {
+        Result = null;
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"result:{Result} final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        Result = null;
+        F = new S1 { F1 = 3 };
+        F.Test2();
+        System.Console.Write($"result:{Result} final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        F[GetRange()] ??= GetValue();
+    }
+
+    public static string GetValue() { System.Console.Write($"GetValue:{Program.F.F1} "); Program.F.F1++; return "v"; }
+
+    public static System.Range GetRange() { System.Console.Write($"GetRange:{Program.F.F1} "); Program.F.F1++; return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:4 Slice:5 GetValue:6 result:v final:7, GetRange:3 length:4 Slice:5 GetValue:6 result:v final:7"),
+            verify: Verification.FailsPEVerify).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void ImplicitRangeIndexerAccess_DeconstructAssignment_01()
+    {
+        // Range pattern with ref-returning extension Slice (deconstruction target uses ref slice)
+        var src = """
+static class E
+{
+    extension(S1 x)
+    {
+        public int Length { get { System.Console.Write($"length:{x.F1} "); Program.F.F1++; return 5; } }
+        public ref int Slice(int start, int length) { System.Console.Write($"Slice:{x.F1} "); Program.F.F1++; return ref Program.Result; }
+    }
+}
+
+struct S1
+{
+    public int F1;
+
+    public void Test2()
+    {
+        (this[Program.GetRange()], int y) = Program.GetTuple();
+        System.Console.Write($"y:{y} ");
+    }
+}
+
+class Program
+{
+    public static S1 F;
+    public static int Result;
+
+    static void Main()
+    {
+        Result = 10;
+        F = new S1 { F1 = 3 };
+        Test1();
+        System.Console.Write($"result:{Result} final:{F.F1}");
+
+        System.Console.Write(", ");
+
+        Result = 10;
+        F = new S1 { F1 = 3 };
+        F.Test2();
+        System.Console.Write($"result:{Result} final:{F.F1}");
+    }
+
+    static void Test1()
+    {
+        (F[GetRange()], int y) = GetTuple();
+        System.Console.Write($"y:{y} ");
+    }
+
+    public static (int, int) GetTuple() { System.Console.Write($"GetTuple:{Program.F.F1} "); Program.F.F1++; return (1, 2); }
+
+    public static System.Range GetRange() { System.Console.Write($"GetRange:{Program.F.F1} "); Program.F.F1++; return 1..^1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetRange:3 length:4 Slice:5 GetTuple:6 y:2 result:1 final:7, GetRange:3 length:4 Slice:5 GetTuple:6 y:2 result:1 final:7"),
+            verify: Verification.FailsPEVerify).VerifyDiagnostics();
+    }
+
+    [Theory]
+    [InlineData("ref")]
+    [InlineData("ref readonly")]
+    [InlineData("in")]
+    public void ImplicitIndexIndexerAccess_PrefixIncrementAssignment_ReadonlyReceiver_041(string refKind)
+    {
+        // sibling to ExtensionTests.PropertyAccess_PrefixIncrementAssignment_ReadonlyReceiver_041
+        // unconstrained extension parameter, ref/ref readonly/in struct value
+        var src = $$$"""
+static class E
+{
+    extension<T>(T x)
+    {
+        public int this[int i]
+        {
+            get { System.Console.Write($"get:{((S1)(object)x).F1} "); Program<S1>.F.F1++; return 0; }
+            set { System.Console.Write($"set:{((S1)(object)x).F1} "); }
+        }
+    }
+}
+
+struct S1
+{
+    public int F1;
+}
+
+class Program<T>
+{
+    public static T F;
+}
+
+class Program
+{
+    static void Main()
+    {
+        Program<S1>.F = new S1 { F1 = 3 };
+        Test1({{{(refKind == "ref" ? "ref" : "in")}}} Program<S1>.F);
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+    }
+
+    static void Test1<T>({{{refKind}}} T f)
+    {
+        ++f[GetIndex()];
+    }
+
+    static int GetIndex() { System.Console.Write($"GetIndex:{Program<S1>.F.F1} "); Program<S1>.F.F1++; return 1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 get:4 set:5 final:5"),
+            verify: Verification.FailsPEVerify).VerifyDiagnostics();
+    }
+
+    [Theory]
+    [InlineData("ref")]
+    [InlineData("ref readonly")]
+    [InlineData("in")]
+    public void ImplicitIndexIndexerAccess_PostfixIncrementAssignment_ReadonlyReceiver_041(string refKind)
+    {
+        // unconstrained extension parameter, ref/ref readonly/in struct value
+        var src = $$$"""
+static class E
+{
+    extension<T>(T x)
+    {
+        public int this[int i]
+        {
+            get { System.Console.Write($"get:{((S1)(object)x).F1} "); Program<S1>.F.F1++; return 0; }
+            set { System.Console.Write($"set:{((S1)(object)x).F1} "); }
+        }
+    }
+}
+
+struct S1
+{
+    public int F1;
+}
+
+class Program<T>
+{
+    public static T F;
+}
+
+class Program
+{
+    static void Main()
+    {
+        Program<S1>.F = new S1 { F1 = 3 };
+        Test1({{{(refKind == "ref" ? "ref" : "in")}}} Program<S1>.F);
+        System.Console.Write($"final:{Program<S1>.F.F1}");
+    }
+
+    static void Test1<T>({{{refKind}}} T f)
+    {
+        f[GetIndex()]++;
+    }
+
+    static int GetIndex() { System.Console.Write($"GetIndex:{Program<S1>.F.F1} "); Program<S1>.F.F1++; return 1; }
+}
+""";
+
+        var comp = CreateCompilation(src, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net100);
+        CompileAndVerify(comp, expectedOutput: ExpectedOutput("GetIndex:3 get:4 set:5 final:5"),
+            verify: Verification.FailsPEVerify).VerifyDiagnostics();
+    }
 }
 


### PR DESCRIPTION
Like in the previous PR (for compound assignment), the code changes are for correctness but are not observable.
`receiverIsKnownToBeCaptured` in `MakeStaticAssignmentOperator`/`MakePropertyAssignment` only matters when `needSpecialExtensionPropertyReceiverReadOrder` is set in but that is not possible for complex assignments (`assignmentKind is not (AssignmentKind.CompoundAssignment or AssignmentKind.NullCoalescingAssignment or AssignmentKind.Deconstruction or AssignmentKind.IncrementDecrement)` condition in `MakePropertyAssignment`).

Relates to test plan https://github.com/dotnet/roslyn/issues/81505
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83587)