### PR TITLE
Allow LSP character position to go beyond line length

### DIFF
--- a/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -326,6 +326,10 @@ internal static partial class ProtocolConversions
     {
         var linePositionSpan = RangeToLinePositionSpan(range);
 
+        linePositionSpan = new LinePositionSpan(
+            ClampPositionToLineEnd(linePositionSpan.Start, text),
+            ClampPositionToLineEnd(linePositionSpan.End, text));
+
         // Handle the specific case where the end position is exactly one line beyond the document bounds
         // and the end character is 0 (start of the non-existent next line).
         // This can happen when deleting the last line, where LSP clients are allowed (by the spec) to
@@ -363,6 +367,18 @@ internal static partial class ProtocolConversions
 
         static string PositionToString(LSP.Position position)
             => $"{{ Line={position.Line}, Character={position.Character} }}";
+
+        static LinePosition ClampPositionToLineEnd(LinePosition position, SourceText text)
+        {
+            if (position.Line < 0 || position.Line >= text.Lines.Count)
+                return position;
+
+            var line = text.Lines[position.Line];
+            var lineLength = line.End - line.Start;
+            return position.Character > lineLength
+                ? new LinePosition(position.Line, lineLength)
+                : position;
+        }
     }
 
     public static LSP.TextEdit TextChangeToTextEdit(TextChange textChange, SourceText oldText)

--- a/src/LanguageServer/ProtocolUnitTests/ProtocolConversionsTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/ProtocolConversionsTests.cs
@@ -236,6 +236,32 @@ public sealed class ProtocolConversionsTests : AbstractLanguageServerProtocolTes
     }
 
     [Fact]
+    public void RangeToTextSpanClampsCharacterPastLineEnd()
+    {
+        var markup = GetTestMarkup();
+        var sourceText = SourceText.From(markup);
+
+        var range = new Range() { Start = new Position(2, 8), End = new Position(2, int.MaxValue) };
+        var textSpan = ProtocolConversions.RangeToTextSpan(range, sourceText);
+
+        Assert.Equal(21, textSpan.Start);
+        Assert.Equal(27, textSpan.End);
+    }
+
+    [Fact]
+    public void RangeToTextSpanClampsStartCharacterPastLineEnd()
+    {
+        var markup = GetTestMarkup();
+        var sourceText = SourceText.From(markup);
+
+        var range = new Range() { Start = new Position(2, int.MaxValue), End = new Position(2, int.MaxValue) };
+        var textSpan = ProtocolConversions.RangeToTextSpan(range, sourceText);
+
+        Assert.Equal(27, textSpan.Start);
+        Assert.Equal(27, textSpan.End);
+    }
+
+    [Fact]
     public void RangeToTextSpanLineEndOfDocument()
     {
         var markup = GetTestMarkup();
@@ -321,8 +347,8 @@ public sealed class ProtocolConversionsTests : AbstractLanguageServerProtocolTes
         var markup = GetTestMarkup();
         var sourceText = SourceText.From(markup);
 
-        // This start position will be beyond the end position
-        var range = new Range() { Start = new Position(2, 20), End = new Position(3, 0) };
+        // This start position will still be beyond the end position after clamping.
+        var range = new Range() { Start = new Position(2, int.MaxValue), End = new Position(2, 0) };
         Assert.Throws<ArgumentException>(() => ProtocolConversions.RangeToTextSpan(range, sourceText));
     }
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/SourceTextExtensions.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/SourceTextExtensions.cs
@@ -235,9 +235,9 @@ internal static class SourceTextExtensions
 
         var textLine = text.Lines[line];
 
-        if (character > textLine.SpanIncludingLineBreak.Length)
+        if (character > textLine.Span.Length)
         {
-            return false;
+            character = textLine.Span.Length;
         }
 
         absoluteIndex = textLine.Start + character;

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Extensions/SourceTextExtensionsTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Extensions/SourceTextExtensionsTest.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis.Text;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Razor.Workspaces.Test.Extensions;
+
+public class SourceTextExtensionsTest
+{
+    [Fact]
+    public void TryGetAbsoluteIndex_ClampsCharacterPastLineEnd()
+    {
+        var sourceText = SourceText.From("hello\r\nworld");
+
+        var result = sourceText.TryGetAbsoluteIndex(line: 0, character: int.MaxValue, out var absoluteIndex);
+
+        Assert.True(result);
+        Assert.Equal(5, absoluteIndex);
+    }
+
+    [Fact]
+    public void TryGetAbsoluteIndex_ClampsCharacterInsideLineBreakToLineEnd()
+    {
+        var sourceText = SourceText.From("hello\r\nworld");
+
+        var result = sourceText.TryGetAbsoluteIndex(line: 0, character: 6, out var absoluteIndex);
+
+        Assert.True(result);
+        Assert.Equal(5, absoluteIndex);
+    }
+
+    [Fact]
+    public void GetTextSpan_ClampsCharactersPastLineEnd()
+    {
+        var sourceText = SourceText.From("hello\r\nworld");
+
+        var textSpan = sourceText.GetTextSpan(startLine: 0, startCharacter: 0, endLine: 0, endCharacter: int.MaxValue);
+
+        Assert.Equal(new TextSpan(0, 5), textSpan);
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-csharp/issues/9226

Per spec, it is allowed for the character to be longer than the line length
> /**
	 * Character offset on a line in a document (zero-based). The meaning of this
	 * offset is determined by the negotiated `PositionEncodingKind`.
	 *
	 * If the character value is greater than the line length it defaults back
	 * to the line length.
	 */
	character: [uinteger](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#uinteger);

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83595)