### PR TITLE
Remove unnecessary ProjectReference

### DIFF
--- a/src/CodeStyle/Core/Tests/LegacyTestFramework/Microsoft.CodeAnalysis.CodeStyle.LegacyTestFramework.UnitTestUtilities.csproj
+++ b/src/CodeStyle/Core/Tests/LegacyTestFramework/Microsoft.CodeAnalysis.CodeStyle.LegacyTestFramework.UnitTestUtilities.csproj
@@ -27,7 +27,6 @@
   </ItemGroup>
   <ItemGroup Label="Project References">
     <!-- TODO: Remove the below project references to test utility projects once all analyzer/code fix tests are switched to Microsoft.CodeAnalysis.Testing -->
-    <ProjectReference Include="..\..\..\..\EditorFeatures\TestUtilities\Microsoft.CodeAnalysis.EditorFeatures.Test.Utilities.csproj" Condition="'$(TargetFramework)' == 'net472'" />
     <ProjectReference Include="..\..\..\..\Features\TestUtilities\Microsoft.CodeAnalysis.Features.Test.Utilities.csproj"/>
     <ProjectReference Include="..\..\..\..\LanguageServer\Protocol.TestUtilities\Microsoft.CodeAnalysis.LanguageServer.Protocol.Test.Utilities.csproj" />
     <ProjectReference Include="..\..\..\..\Compilers\Test\Core\Microsoft.CodeAnalysis.Test.Utilities.csproj" />


### PR DESCRIPTION
A follow up to #83528 -- I found it strange that we could make a ProjectReference conditional since I'd assume it'd fail on the side where the reference was missing. It builds locally.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83596)