### PR TITLE
Add prepareRename support to Razor

### DIFF
--- a/.github/instructions/Razor.instructions.md
+++ b/.github/instructions/Razor.instructions.md
@@ -26,6 +26,14 @@ all Razor sources under `src/Razor/`. Razor was merged into the Roslyn repo from
   `src\Razor\src\Razor\test\Microsoft.VisualStudioCode.Razor.IntegrationTests`. They require
   VS Code and waste significant time. Target a specific test project with
   `dotnet test path\to\Project.csproj` instead.
+- **Shared projects need `.projitems` entries**: Files under
+  `src\Razor\src\Razor\src\Microsoft.CodeAnalysis.Razor.CohostingShared\` and
+  `src\Razor\src\Razor\test\Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests\`
+  are compiled through their `.projitems` files. Adding a new `.cs` file in either shared
+  tree is not enough by itself — you must also add a matching `<Compile Include="...">`
+  entry to `Microsoft.CodeAnalysis.Razor.CohostingShared.projitems` or
+  `Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests.projitems`, or the file will not
+  be built or tested by the importing projects.
 
 ## File Types
 

--- a/.github/instructions/Razor.instructions.md
+++ b/.github/instructions/Razor.instructions.md
@@ -30,7 +30,7 @@ all Razor sources under `src/Razor/`. Razor was merged into the Roslyn repo from
   `src\Razor\src\Razor\src\Microsoft.CodeAnalysis.Razor.CohostingShared\` and
   `src\Razor\src\Razor\test\Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests\`
   are compiled through their `.projitems` files. Adding a new `.cs` file in either shared
-  tree is not enough by itself — you must also add a matching `<Compile Include="...">`
+  tree is not enough by itself. You must also add a matching `<Compile Include="...">`
   entry to `Microsoft.CodeAnalysis.Razor.CohostingShared.projitems` or
   `Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests.projitems`, or the file will not
   be built or tested by the importing projects.

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Microsoft.CodeAnalysis.Razor.CohostingShared.projitems
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Microsoft.CodeAnalysis.Razor.CohostingShared.projitems
@@ -38,6 +38,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)RazorSourceGeneratedDocumentExcerptService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RazorSourceGeneratedDocumentSpanMappingService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RazorSourceGeneratorLocator.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rename\CohostPrepareRenameEndpoint.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rename\CohostRenameEndpoint.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rename\WorkspaceWillRenameEndpoint.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SelectionRanges\CohostSelectionRangeEndpoint.cs" />

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Rename/CohostPrepareRenameEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Rename/CohostPrepareRenameEndpoint.cs
@@ -1,0 +1,82 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
+using Microsoft.CodeAnalysis.Razor.Cohost;
+using Microsoft.CodeAnalysis.Razor.Remote;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+#pragma warning disable RS0030 // Do not use banned APIs
+[Shared]
+[CohostEndpoint(Methods.TextDocumentPrepareRenameName)]
+[ExportRazorStatelessLspService(typeof(CohostPrepareRenameEndpoint))]
+[method: ImportingConstructor]
+#pragma warning restore RS0030 // Do not use banned APIs
+internal sealed class CohostPrepareRenameEndpoint(
+    IIncompatibleProjectService incompatibleProjectService,
+    IRemoteServiceInvoker remoteServiceInvoker,
+    IHtmlRequestInvoker requestInvoker)
+    : AbstractCohostDocumentEndpoint<PrepareRenameParams, LspRange?>(incompatibleProjectService)
+{
+    private readonly IRemoteServiceInvoker _remoteServiceInvoker = remoteServiceInvoker;
+    private readonly IHtmlRequestInvoker _requestInvoker = requestInvoker;
+
+    protected override bool MutatesSolutionState => false;
+
+    protected override bool RequiresLSPSolution => true;
+
+    protected override RazorTextDocumentIdentifier? GetRazorTextDocumentIdentifier(PrepareRenameParams request)
+        => request.TextDocument.ToRazorTextDocumentIdentifier();
+
+    protected override async Task<LspRange?> HandleRequestAsync(PrepareRenameParams request, TextDocument razorDocument, CancellationToken cancellationToken)
+        => await HandleRequestAsync(razorDocument, request, cancellationToken).ConfigureAwait(false);
+
+    private async Task<LspRange?> HandleRequestAsync(TextDocument razorDocument, Position position, CancellationToken cancellationToken)
+        => await HandleRequestAsync(
+            razorDocument,
+            new PrepareRenameParams
+            {
+                TextDocument = new TextDocumentIdentifier { DocumentUri = razorDocument.CreateDocumentUri() },
+                Position = position
+            },
+            cancellationToken).ConfigureAwait(false);
+
+    private async Task<LspRange?> HandleRequestAsync(TextDocument razorDocument, PrepareRenameParams request, CancellationToken cancellationToken)
+    {
+        var result = await _remoteServiceInvoker.TryInvokeAsync<IRemoteRenameService, RemoteResponse<LspRange?>>(
+            razorDocument.Project.Solution,
+            (service, solutionInfo, cancellationToken) => service.GetPrepareRenameRangeAsync(solutionInfo, razorDocument.Id, request.Position, cancellationToken),
+            cancellationToken).ConfigureAwait(false);
+
+        if (result.Result is { } range)
+        {
+            return range;
+        }
+
+        if (result.StopHandling)
+        {
+            return null;
+        }
+
+        return await _requestInvoker.MakeHtmlLspRequestAsync<PrepareRenameParams, LspRange>(
+            razorDocument,
+            Methods.TextDocumentPrepareRenameName,
+            request,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    internal TestAccessor GetTestAccessor() => new(this);
+
+    internal readonly struct TestAccessor(CohostPrepareRenameEndpoint instance)
+    {
+        public Task<LspRange?> HandleRequestAsync(TextDocument razorDocument, Position position, CancellationToken cancellationToken)
+            => instance.HandleRequestAsync(razorDocument, position, cancellationToken);
+    }
+}

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Rename/CohostRenameEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Rename/CohostRenameEndpoint.cs
@@ -42,7 +42,10 @@ internal sealed class CohostRenameEndpoint(
                 Method = Methods.TextDocumentRenameName,
                 RegisterOptions = new RenameRegistrationOptions()
                 {
-                    PrepareProvider = false
+#if VSCODE
+                    // VS Code only until https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1914930 is fixed
+                    PrepareProvider = true
+#endif
                 }
             }];
         }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/IRemoteRenameService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/IRemoteRenameService.cs
@@ -9,6 +9,7 @@ namespace Microsoft.CodeAnalysis.Razor.Remote;
 
 internal interface IRemoteRenameService : IRemoteJsonService
 {
+    ValueTask<RemoteResponse<LspRange?>> GetPrepareRenameRangeAsync(JsonSerializableRazorPinnedSolutionInfoWrapper solutionInfo, JsonSerializableDocumentId documentId, Position position, CancellationToken cancellationToken);
     ValueTask<RemoteResponse<WorkspaceEdit?>> GetRenameEditAsync(JsonSerializableRazorPinnedSolutionInfoWrapper solutionInfo, JsonSerializableDocumentId documentId, Position position, string newName, CancellationToken cancellationToken);
     ValueTask<WorkspaceEdit?> GetFileRenameEditAsync(JsonSerializableRazorPinnedSolutionInfoWrapper solutionInfo, RenameFilesParams fileRenameRequest, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Rename/RemoteRenameService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Rename/RemoteRenameService.cs
@@ -38,6 +38,8 @@ internal sealed class RemoteRenameService(in ServiceArgs args) : RazorDocumentSe
     private readonly IRenameService _renameService = args.ExportProvider.GetExportedValue<IRenameService>();
     private readonly IRazorEditService _razorEditService = args.ExportProvider.GetExportedValue<IRazorEditService>();
 
+    protected override IDocumentPositionInfoStrategy DocumentPositionInfoStrategy => PreferAttributeNameDocumentPositionInfoStrategy.Instance;
+
     public ValueTask<RemoteResponse<WorkspaceEdit?>> GetRenameEditAsync(
         JsonSerializableRazorPinnedSolutionInfoWrapper solutionInfo,
         JsonSerializableDocumentId documentId,
@@ -93,6 +95,74 @@ internal sealed class RemoteRenameService(in ServiceArgs args) : RazorDocumentSe
         await _razorEditService.MapWorkspaceEditAsync(context.Snapshot, csharpEdit, cancellationToken).ConfigureAwait(false);
 
         return Results(csharpEdit.Concat(razorEdit.Edit));
+    }
+
+    public ValueTask<RemoteResponse<LspRange?>> GetPrepareRenameRangeAsync(
+        JsonSerializableRazorPinnedSolutionInfoWrapper solutionInfo,
+        JsonSerializableDocumentId documentId,
+        Position position,
+        CancellationToken cancellationToken)
+        => RunServiceAsync(
+            solutionInfo,
+            documentId,
+            context => GetPrepareRenameRangeAsync(context, position, cancellationToken),
+            cancellationToken);
+
+    private async ValueTask<RemoteResponse<LspRange?>> GetPrepareRenameRangeAsync(
+        RemoteDocumentContext context,
+        Position position,
+        CancellationToken cancellationToken)
+    {
+        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var sourceText = codeDocument.Source.Text;
+
+        if (!sourceText.TryGetAbsoluteIndex(position, out var hostDocumentIndex))
+        {
+            return RemoteResponse<LspRange?>.NoFurtherHandling;
+        }
+
+        var originalHostDocumentIndex = hostDocumentIndex;
+        hostDocumentIndex = codeDocument.AdjustPositionForComponentEndTag(hostDocumentIndex);
+
+        var positionInfo = GetPositionInfo(codeDocument, hostDocumentIndex, preferCSharpOverHtml: true);
+
+        // We have various logic in rename to check for tag helpers and component tags etc. but ultimately none of that is necessary here.
+        // If the range isn't C#, we don't support rename, so we can just ask Roslyn. The extra gubbins in the actual rename path is because
+        // if we let Roslyn rename a component class name, for example, it won't know that it needs to actually rename the .razor file or
+        // nothing will actually happen.
+        if (positionInfo.LanguageKind is not CodeAnalysis.Razor.Protocol.RazorLanguageKind.CSharp)
+        {
+            return RemoteResponse<LspRange?>.CallHtml;
+        }
+
+        var generatedDocument = await context.Snapshot.GetGeneratedDocumentAsync(cancellationToken).ConfigureAwait(false);
+
+        var csharpRange = await ExternalHandlers.Rename.GetRenameRangeAsync(generatedDocument, positionInfo.Position.ToLinePosition(), cancellationToken).ConfigureAwait(false);
+
+        if (csharpRange is null)
+        {
+            return RemoteResponse<LspRange?>.NoFurtherHandling;
+        }
+
+        if (!DocumentMappingService.TryMapToRazorDocumentRange(codeDocument.GetRequiredCSharpDocument(), csharpRange, out var mappedRange))
+        {
+            return RemoteResponse<LspRange?>.NoFurtherHandling;
+        }
+
+        // Component end tags are looked up via their matching start tag so Roslyn can find the symbol.
+        // If the request started on an end tag, shift the mapped range back so prepare-rename highlights that end tag text.
+        if (originalHostDocumentIndex != hostDocumentIndex)
+        {
+            var offset = originalHostDocumentIndex - hostDocumentIndex;
+            if (offset != 0 &&
+                sourceText.TryGetAbsoluteIndex(mappedRange.Start, out var start) &&
+                sourceText.TryGetAbsoluteIndex(mappedRange.End, out var end))
+            {
+                mappedRange = sourceText.GetRange(start + offset, end + offset);
+            }
+        }
+
+        return RemoteResponse<LspRange?>.Results(mappedRange);
     }
 
     public ValueTask<WorkspaceEdit?> GetFileRenameEditAsync(

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Rename/RemoteRenameService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Rename/RemoteRenameService.cs
@@ -154,8 +154,7 @@ internal sealed class RemoteRenameService(in ServiceArgs args) : RazorDocumentSe
         if (originalHostDocumentIndex != hostDocumentIndex)
         {
             var offset = originalHostDocumentIndex - hostDocumentIndex;
-            if (offset != 0 &&
-                sourceText.TryGetAbsoluteIndex(mappedRange.Start, out var start) &&
+            if (sourceText.TryGetAbsoluteIndex(mappedRange.Start, out var start) &&
                 sourceText.TryGetAbsoluteIndex(mappedRange.End, out var end))
             {
                 mappedRange = sourceText.GetRange(start + offset, end + offset);

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostPrepareRenameEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostPrepareRenameEndpointTest.cs
@@ -106,10 +106,10 @@ public class CohostPrepareRenameEndpointTest(ITestOutputHelper testOutputHelper)
 
     [Fact]
     public Task Component_StartTag_FromMetadata()
-    => VerifyPrepareRenameAsync(
-        input: """
-            <Inp$$utText></InputText>
-            """);
+        => VerifyPrepareRenameAsync(
+            input: """
+                <Inp$$utText></InputText>
+                """);
 
     [Fact]
     public Task Component_Attribute_FromMetadata()

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostPrepareRenameEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostPrepareRenameEndpointTest.cs
@@ -1,0 +1,352 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+public class CohostPrepareRenameEndpointTest(ITestOutputHelper testOutputHelper) : CohostEndpointTestBase(testOutputHelper)
+{
+    [Fact]
+    public Task CSharp_Method()
+        => VerifyPrepareRenameAsync(
+            input: """
+                @code
+                {
+                    void [|M$$ethod|]()
+                    {
+                    }
+                }
+                """);
+
+    [Fact]
+    public Task CSharp_StringLiteral_ReturnsNull()
+        => VerifyPrepareRenameAsync(
+            input: """
+                @code
+                {
+                    void M()
+                    {
+                        var x = "he$$llo";
+                    }
+                }
+                """);
+
+    [Fact]
+    public Task CSharp_ExplicitStatement_Local()
+        => VerifyPrepareRenameAsync(
+            input: """
+                @{
+                    var hello = 1;
+                    [|he$$llo|]++;
+                }
+                """);
+
+    [Fact]
+    public Task CSharp_ImplicitExpression_Field()
+        => VerifyPrepareRenameAsync(
+            input: """
+                <div>@[|Tit$$le|]</div>
+
+                @code
+                {
+                    private string Title = "hello";
+                }
+                """);
+
+    [Fact]
+    public Task Component_SelfClosingTag()
+        => VerifyPrepareRenameAsync(
+            input: """
+                <[|Com$$ponent|] />
+                """,
+            additionalFiles:
+            [
+                (FilePath("Component.razor"), "")
+            ]);
+
+    [Fact]
+    public Task Component_StartTag()
+        => VerifyPrepareRenameAsync(
+            input: """
+                <[|Com$$ponent|]></Component>
+                """,
+            additionalFiles:
+            [
+                (FilePath("Component.razor"), "")
+            ]);
+
+    [Fact]
+    public Task Component_Attribute()
+        => VerifyPrepareRenameAsync(
+            input: """
+                <Component [|Tit$$le|]="Hello" />
+                """,
+            additionalFiles: GetComponentFiles());
+
+    [Fact]
+    public Task Component_Attribute_Bind()
+        => VerifyPrepareRenameAsync(
+            input: """
+                <Component @bind-[|Tit$$le|]="Hello" />
+                """,
+            additionalFiles: GetComponentFiles());
+
+    [Fact]
+    public Task Component_Attribute_BindWithParameter()
+        => VerifyPrepareRenameAsync(
+            input: """
+                <Component @bind-[|Tit$$le|]:get="Hello" />
+                """,
+            additionalFiles: GetComponentFiles());
+
+    [Fact]
+    public Task Component_StartTag_FromMetadata()
+    => VerifyPrepareRenameAsync(
+        input: """
+            <Inp$$utText></InputText>
+            """);
+
+    [Fact]
+    public Task Component_Attribute_FromMetadata()
+        => VerifyPrepareRenameAsync(
+            input: """
+            <InputText V$$alue="Hello" />
+            """);
+
+    [Fact]
+    public Task Component_AttributeValue_ImplicitExpression()
+        => VerifyPrepareRenameAsync(
+            input: """
+                <Component Title="@[|Inp$$utValue|]" />
+
+                @code
+                {
+                    private string InputValue = "hello";
+                }
+                """,
+            additionalFiles: GetComponentFiles());
+
+    [Fact]
+    public Task Component_AttributeValue_StringLiteral_ReturnsNull()
+        => VerifyPrepareRenameAsync(
+            input: """
+                <Component Title="he$$llo" />
+                """,
+            additionalFiles: GetComponentFiles());
+
+    [Fact]
+    public Task Component_EndTag()
+        => VerifyPrepareRenameAsync(
+            input: """
+                <Component></[|Com$$ponent|]>
+                """,
+            additionalFiles:
+            [
+                (FilePath("Component.razor"), "")
+            ]);
+
+    [Fact]
+    public Task Component_FullyQualified_Name()
+        => VerifyPrepareRenameAsync(
+            input: """
+                <My.Foo.[|Com$$ponent|] />
+                """,
+            additionalFiles: GetComponentFiles("My.Foo"));
+
+    [Fact]
+    public Task Component_FullyQualified_Namespace_UsesRoslyn()
+        => VerifyPrepareRenameAsync(
+            input: """
+                <My.[|Fo$$o|].Component />
+                """,
+            additionalFiles: GetComponentFiles("My.Foo"));
+
+    [Fact]
+    public Task Component_FullyQualified_EndTagNamespace_UsesRoslyn()
+        => VerifyPrepareRenameAsync(
+            input: """
+                <My.Foo.Component></My.[|Fo$$o|].Component>
+                """,
+            additionalFiles: GetComponentFiles("My.Foo"));
+
+    [Fact]
+    public Task Html_ReturnsNull()
+        => VerifyPrepareRenameAsync(
+            input: """
+                <di$$v></div>
+                """);
+
+    [Fact]
+    public Task Html_UsesHtmlLanguageServer()
+        => VerifyPrepareRenameAsync(
+            input: """
+                <{|html:di$$v|}></div>
+                """);
+
+    [Fact]
+    public Task Html_Attribute_ReturnsNull()
+        => VerifyPrepareRenameAsync(
+            input: """
+                <div cla$$ss="hello"></div>
+                """);
+
+    [Fact]
+    public Task Html_AttributeValue_ReturnsNull()
+        => VerifyPrepareRenameAsync(
+            input: """
+                <div class="he$$llo"></div>
+                """);
+
+    [Fact]
+    public Task Html_AttributeValue_ImplicitExpression()
+        => VerifyPrepareRenameAsync(
+            input: """
+                <div class="@[|Cla$$ssName|]"></div>
+
+                @code
+                {
+                    private string ClassName = "hello";
+                }
+                """);
+
+    [Fact]
+    public Task Legacy_CSharp_ExplicitStatement_Local()
+        => VerifyPrepareRenameAsync(
+            input: """
+                @{
+                    var hello = 1;
+                    [|he$$llo|]++;
+                }
+                """,
+                fileKind: RazorFileKind.Legacy);
+
+    [Fact]
+    public Task Legacy_CSharp_ImplicitExpression_Field()
+        => VerifyPrepareRenameAsync(
+            input: """
+                <div>@[|Tit$$le|]</div>
+
+                @functions
+                {
+                    private string Title = "hello";
+                }
+                """,
+                fileKind: RazorFileKind.Legacy);
+
+    [Fact]
+    public Task Legacy_TagHelper_Element_UsesHtmlLanguageServer()
+        => VerifyPrepareRenameAsync(
+            input: """
+                @addTagHelper *, SomeProject
+
+                <{|html:dw:abou$$t-box|} />
+                """,
+            fileKind: RazorFileKind.Legacy,
+            additionalFiles: GetTagHelperFiles());
+
+    [Fact]
+    public Task Legacy_TagHelper_Attribute_UsesHtmlLanguageServer()
+        => VerifyPrepareRenameAsync(
+            input: """
+                @addTagHelper *, SomeProject
+
+                <dw:about-box {|html:tit$$le|}="Dave" />
+                """,
+            fileKind: RazorFileKind.Legacy,
+            additionalFiles: GetTagHelperFiles());
+
+    [Fact]
+    public Task Legacy_Html_Attribute_ReturnsNull()
+        => VerifyPrepareRenameAsync(
+            input: """
+                <div cla$$ss="hello"></div>
+                """,
+                fileKind: RazorFileKind.Legacy);
+
+    [Fact]
+    public Task Legacy_Html_AttributeValue_ReturnsNull()
+        => VerifyPrepareRenameAsync(
+            input: """
+                <div class="he$$llo"></div>
+                """,
+                fileKind: RazorFileKind.Legacy);
+
+    [Fact]
+    public Task Legacy_Html_AttributeValue_ImplicitExpression()
+        => VerifyPrepareRenameAsync(
+            input: """
+                <div class="@[|Cla$$ssName|]"></div>
+
+                @functions
+                {
+                    private string ClassName = "hello";
+                }
+                """,
+                fileKind: RazorFileKind.Legacy);
+
+    private static (string fileName, string contents)[] GetComponentFiles(string? @namespace = "SomeProject") =>
+        [
+            (FilePath("Component.razor"), $$"""
+                @namespace {{@namespace}}
+
+                <div></div>
+
+                @code
+                {
+                    [Parameter]
+                    public string Title { get; set; }
+                }
+                """)
+        ];
+
+    private static (string fileName, string contents)[] GetTagHelperFiles() =>
+        [
+            (FilePath("AboutBoxTagHelper.cs"), """
+                using Microsoft.AspNetCore.Razor.TagHelpers;
+
+                [HtmlTargetElement("dw:about-box")]
+                public class AboutBoxTagHelper : TagHelper
+                {
+                    public string Title { get; set; }
+
+                    public override void Process(TagHelperContext context, TagHelperOutput output)
+                    {
+                        output.TagName = "div";
+                    }
+                }
+                """)
+        ];
+
+    private async Task VerifyPrepareRenameAsync(
+        TestCode input,
+        RazorFileKind? fileKind = null,
+        (string fileName, string contents)[]? additionalFiles = null)
+    {
+        var document = CreateProjectAndRazorDocument(input.Text, fileKind, additionalFiles: additionalFiles);
+        var sourceText = await document.GetTextAsync(DisposalToken);
+        var htmlResponse = input.TryGetNamedSpans("html", out var htmlSpans)
+            ? (object?)sourceText.GetRange(Assert.Single(htmlSpans))
+            : null;
+        var requestInvoker = new TestHtmlRequestInvoker([(Methods.TextDocumentPrepareRenameName, htmlResponse)]);
+
+        var endpoint = new CohostPrepareRenameEndpoint(IncompatibleProjectService, RemoteServiceInvoker, requestInvoker);
+        var result = await endpoint.GetTestAccessor().HandleRequestAsync(document, sourceText.GetPosition(input.Position), DisposalToken);
+
+        if (!input.HasSpans && htmlResponse is null)
+        {
+            Assert.Null(result);
+            return;
+        }
+
+        Assert.NotNull(result);
+        var expectedRange = input.HasSpans
+            ? sourceText.GetRange(input.Span)
+            : sourceText.GetRange(Assert.Single(htmlSpans));
+        Assert.Equal(expectedRange, result);
+    }
+}

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests.projitems
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests.projitems
@@ -56,6 +56,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Endpoints\CohostInlayHintEndpointTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Endpoints\CohostLinkedEditingRangeEndpointTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Endpoints\CohostOnAutoInsertEndpointTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Endpoints\CohostPrepareRenameEndpointTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Endpoints\CohostRenameEndpointTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Endpoints\CohostSelectionRangeEndpointTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Endpoints\CohostSemanticTokensRangeEndpointTest.cs" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/4285

Copilot CLI won't rename anything if we don't do this (or rather, it will fallback to Roslyn's handler, and that errors because it doesn't know about razor files, obviously)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83599)