### PR TITLE
Throw content modified for stale code action resolve request

### DIFF
--- a/src/LanguageServer/Protocol/Handler/CodeActions/CodeActionHelpers.cs
+++ b/src/LanguageServer/Protocol/Handler/CodeActions/CodeActionHelpers.cs
@@ -14,10 +14,12 @@ using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.ExtractClass;
 using Microsoft.CodeAnalysis.ExtractInterface;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Suggestions;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CommonLanguageServerProtocol.Framework;
 using Roslyn.LanguageServer.Protocol;
 using Roslyn.Utilities;
+using StreamJsonRpc;
 using CodeAction = Microsoft.CodeAnalysis.CodeActions.CodeAction;
 using LSP = Roslyn.LanguageServer.Protocol;
 
@@ -435,12 +437,19 @@ internal static class CodeActionHelpers
         for (var i = 0; i < codeActionPath.Length; i++)
         {
             var title = codeActionPath[i];
-            var matchingActions = currentActions.Where(action => action.Title == title);
+            var matchingActions = currentActions.Where(action => action.Title == title).ToArray();
+
+            // If the project changed between the original request and resolve, we may not have the action to resolve anymore.
+            if (matchingActions.Length == 0)
+                throw new LocalRpcException($"Code action '{string.Join("|", codeActionPath)}' is no longer available.")
+                {
+                    ErrorCode = LspErrorCodes.ContentModified
+                };
 
             // If we only have one matching action then just need to retrieve it from the list.
-            if (matchingActions.Count() == 1)
+            if (matchingActions.Length == 1)
             {
-                matchingAction = matchingActions.First();
+                matchingAction = matchingActions[0];
             }
             else
             {

--- a/src/LanguageServer/ProtocolUnitTests/CodeActions/CodeActionResolveTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/CodeActions/CodeActionResolveTests.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CommonLanguageServerProtocol.Framework;
 using Roslyn.LanguageServer.Protocol;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -74,6 +75,55 @@ public sealed class CodeActionResolveTests : AbstractLanguageServerProtocolTests
 
         var actualResolvedAction = await RunGetCodeActionResolveAsync(testLspServer, unresolvedCodeAction);
         AssertJsonEquals(expectedResolvedAction, actualResolvedAction);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestCodeActionResolveHandlerAsync_StaleAction(bool mutatingLspWorkspace)
+    {
+        var initialMarkup =
+            """
+            class A
+            {
+                void M()
+                {
+                    {|caret:|}int i = 1;
+                }
+            }
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(initialMarkup, mutatingLspWorkspace);
+        var titlePath = new string[] { CSharpAnalyzersResources.Use_implicit_type };
+        var caretLocation = testLspServer.GetLocations("caret").Single();
+        var unresolvedCodeAction = CodeActionsTests.CreateCodeAction(
+            title: CSharpAnalyzersResources.Use_implicit_type,
+            kind: CodeActionKind.Refactor,
+            children: [],
+            data: CreateCodeActionResolveData(CSharpAnalyzersResources.Use_implicit_type, caretLocation, titlePath),
+            priority: VSInternalPriorityLevel.Low,
+            groupName: "Roslyn1",
+            applicableRange: new LSP.Range { Start = new Position { Line = 4, Character = 8 }, End = new Position { Line = 4, Character = 11 } },
+            diagnostics: null);
+
+        await testLspServer.OpenDocumentAsync(caretLocation.DocumentUri);
+
+        var typeRange = new LSP.Range { Start = new Position(4, 8), End = new Position(4, 11) };
+        var textEdit = new LSP.TextEdit { Range = typeRange, NewText = "var" };
+        await testLspServer.ReplaceTextAsync(caretLocation.DocumentUri, (textEdit.Range, textEdit.NewText));
+
+        if (!mutatingLspWorkspace)
+        {
+            var document = await testLspServer.GetDocumentAsync(caretLocation.DocumentUri);
+            var sourceText = await document.GetTextAsync(CancellationToken.None);
+            var textChange = ProtocolConversions.TextEditToTextChange(textEdit, sourceText);
+            await testLspServer.TestWorkspace.ChangeDocumentAsync(document.Id, sourceText.WithChanges(textChange));
+        }
+
+        await WaitForWorkspaceOperationsAsync(testLspServer.TestWorkspace);
+
+        var exception = await Assert.ThrowsAsync<StreamJsonRpc.RemoteInvocationException>(async () =>
+            await testLspServer.ExecuteRequestAsync<LSP.CodeAction, LSP.CodeAction>(
+                LSP.Methods.CodeActionResolveName, unresolvedCodeAction, CancellationToken.None));
+        Assert.Equal(LspErrorCodes.ContentModified, exception.ErrorCode);
+        Assert.False(testLspServer.GetServerAccessor().HasShutdownStarted());
     }
 
     [Theory, CombinatorialData]


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-csharp/issues/9236

If the project changes in between a code action request and the resolve, we may not be able to retrieve the matching action in resolve.  In such cases we can throw a content modified exception letting the client know it should retry.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83612)