### PR TITLE
Compare DocumentUri instances in LSP tests instead of file path strings

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/LspFileChangeWatcherTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/LspFileChangeWatcherTests.cs
@@ -62,7 +62,7 @@ public sealed class LspFileChangeWatcherTests(ITestOutputHelper testOutputHelper
 
         var watcher = GetSingleFileWatcher(dynamicCapabilitiesRpcTarget);
 
-        Assert.Equal(tempDirectory.Path, watcher.GlobPattern.Second.BaseUri.Second.GetRequiredParsedUri().LocalPath);
+        Assert.Equal(ProtocolConversions.CreateAbsoluteDocumentUri(tempDirectory.Path), watcher.GlobPattern.Second.BaseUri.Second);
         Assert.Equal("**/*", watcher.GlobPattern.Second.Pattern);
 
         // Get rid of the registration and it should be gone again
@@ -94,7 +94,7 @@ public sealed class LspFileChangeWatcherTests(ITestOutputHelper testOutputHelper
 
         var watcher = GetSingleFileWatcher(dynamicCapabilitiesRpcTarget);
 
-        Assert.Equal(tempDirectory.Path, watcher.GlobPattern.Second.BaseUri.Second.GetRequiredParsedUri().LocalPath);
+        Assert.Equal(ProtocolConversions.CreateAbsoluteDocumentUri(tempDirectory.Path), watcher.GlobPattern.Second.BaseUri.Second);
         Assert.Equal("SingleFile.txt", watcher.GlobPattern.Second.Pattern);
 
         // Get rid of the registration and it should be gone again

--- a/src/LanguageServer/ProtocolUnitTests/Definitions/GoToDefinitionTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Definitions/GoToDefinitionTests.cs
@@ -335,7 +335,7 @@ public sealed class GoToDefinitionTests : AbstractLanguageServerProtocolTests
         await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
 
         var results = await RunGotoDefinitionAsync(testLspServer, testLspServer.GetLocations("caret").Single());
-        Assert.True(results.Single().DocumentUri.GetRequiredParsedUri().OriginalString.EndsWith("String.cs"));
+        Assert.True(results.Single().DocumentUri.UriString.EndsWith("String.cs"));
     }
 
     [Theory, CombinatorialData]
@@ -368,7 +368,7 @@ public sealed class GoToDefinitionTests : AbstractLanguageServerProtocolTests
         workspace.TryApplyChanges(project.Solution);
 
         var results = await RunGotoDefinitionAsync(testLspServer, testLspServer.GetLocations("caret").Single());
-        Assert.True(results.Single().DocumentUri.GetRequiredParsedUri().LocalPath.EndsWith("generated_file.cs"));
+        Assert.True(results.Single().DocumentUri.UriString.EndsWith("generated_file.cs"));
 
         var service = Assert.IsType<TestSourceGeneratedDocumentSpanMappingService>(workspace.Services.GetService<ISourceGeneratedDocumentSpanMappingService>());
         Assert.True(service.DidMapSpans);

--- a/src/LanguageServer/ProtocolUnitTests/Definitions/GoToDefinitionTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Definitions/GoToDefinitionTests.cs
@@ -368,7 +368,7 @@ public sealed class GoToDefinitionTests : AbstractLanguageServerProtocolTests
         workspace.TryApplyChanges(project.Solution);
 
         var results = await RunGotoDefinitionAsync(testLspServer, testLspServer.GetLocations("caret").Single());
-        Assert.True(results.Single().DocumentUri.UriString.EndsWith("generated_file.cs"));
+        Assert.Contains("/generated_file.cs", results.Single().DocumentUri.UriString);
 
         var service = Assert.IsType<TestSourceGeneratedDocumentSpanMappingService>(workspace.Services.GetService<ISourceGeneratedDocumentSpanMappingService>());
         Assert.True(service.DidMapSpans);

--- a/src/LanguageServer/ProtocolUnitTests/Diagnostics/AdditionalFileDiagnosticsTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Diagnostics/AdditionalFileDiagnosticsTests.cs
@@ -58,8 +58,8 @@ public sealed class AdditionalFileDiagnosticsTests : AbstractPullDiagnosticTests
         Assert.NotEmpty(results);
         AssertEx.Equal(
         [
-            @$"{xamlFilePath}: [{MockAdditionalFileDiagnosticAnalyzer.Id}]",
-        ], results.Select(r => $"{r.Uri.GetRequiredParsedUri().LocalPath}: [{string.Join(", ", r.Diagnostics!.Select(d => d.Code?.Value?.ToString()))}]"));
+            @$"{ProtocolConversions.CreateAbsoluteDocumentUri(xamlFilePath)}: [{MockAdditionalFileDiagnosticAnalyzer.Id}]",
+        ], results.Select(r => $"{r.Uri}: [{string.Join(", ", r.Diagnostics!.Select(d => d.Code?.Value?.ToString()))}]"));
     }
 
     [Theory, CombinatorialData]
@@ -85,10 +85,10 @@ public sealed class AdditionalFileDiagnosticsTests : AbstractPullDiagnosticTests
         var results = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics);
         AssertEx.Equal(
         [
-            @$"{csFilePath}: []",
-            @$"{txtFilePath}: [{MockAdditionalFileDiagnosticAnalyzer.Id}]",
-            @$"{projFilePath}: []"
-        ], results.Select(r => $"{r.Uri.GetRequiredParsedUri().LocalPath}: [{string.Join(", ", r.Diagnostics!.Select(d => d.Code?.Value?.ToString()))}]"));
+            @$"{ProtocolConversions.CreateAbsoluteDocumentUri(csFilePath)}: []",
+            @$"{ProtocolConversions.CreateAbsoluteDocumentUri(txtFilePath)}: [{MockAdditionalFileDiagnosticAnalyzer.Id}]",
+            @$"{ProtocolConversions.CreateAbsoluteDocumentUri(projFilePath)}: []"
+        ], results.Select(r => $"{r.Uri}: [{string.Join(", ", r.Diagnostics!.Select(d => d.Code?.Value?.ToString()))}]"));
 
         // Asking again should give us back an unchanged diagnostic.
         var results2 = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics, previousResults: CreateDiagnosticParamsFromPreviousReports(results));
@@ -120,7 +120,7 @@ public sealed class AdditionalFileDiagnosticsTests : AbstractPullDiagnosticTests
 
         AssertEx.Empty(results[0].Diagnostics);
         Assert.Equal(MockAdditionalFileDiagnosticAnalyzer.Id, results[1].Diagnostics!.Single().Code);
-        Assert.Equal(txtFilePath, results[1].Uri.GetRequiredParsedUri().LocalPath);
+        Assert.Equal(ProtocolConversions.CreateAbsoluteDocumentUri(txtFilePath), results[1].Uri);
         AssertEx.Empty(results[2].Diagnostics);
 
         var initialSolution = testLspServer.GetCurrentSolution();
@@ -164,10 +164,10 @@ public sealed class AdditionalFileDiagnosticsTests : AbstractPullDiagnosticTests
         Assert.Equal(6, results.Length);
 
         Assert.Equal(MockAdditionalFileDiagnosticAnalyzer.Id, results[1].Diagnostics!.Single().Code);
-        Assert.Equal(txtFilePath, results[1].Uri.GetRequiredParsedUri().LocalPath);
+        Assert.Equal(ProtocolConversions.CreateAbsoluteDocumentUri(txtFilePath), results[1].Uri);
         Assert.Equal("CSProj1", ((LSP.VSDiagnostic)results[1].Diagnostics!.Single()).Projects!.First().ProjectName);
         Assert.Equal(MockAdditionalFileDiagnosticAnalyzer.Id, results[4].Diagnostics!.Single().Code);
-        Assert.Equal(txtFilePath, results[4].Uri.GetRequiredParsedUri().LocalPath);
+        Assert.Equal(ProtocolConversions.CreateAbsoluteDocumentUri(txtFilePath), results[4].Uri);
         Assert.Equal("CSProj2", ((LSP.VSDiagnostic)results[4].Diagnostics!.Single()).Projects!.First().ProjectName);
 
         // Asking again should give us back an unchanged diagnostic.
@@ -209,10 +209,10 @@ public sealed class AdditionalFileDiagnosticsTests : AbstractPullDiagnosticTests
         var results = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics);
         AssertEx.Equal(
         [
-            @$"{csFilePath}: []",
-            @$"{additionaFilePath}: [{DiagnosticProducingGenerator.Descriptor.Id}, {MockAdditionalFileDiagnosticAnalyzer.Id}]",
-            @$"{projFilePath}: []"
-        ], results.Select(r => $"{r.Uri.GetRequiredParsedUri().LocalPath}: [{string.Join(", ", r.Diagnostics!.Select(d => d.Code?.Value?.ToString()))}]"));
+            @$"{ProtocolConversions.CreateAbsoluteDocumentUri(csFilePath)}: []",
+            @$"{ProtocolConversions.CreateAbsoluteDocumentUri(additionaFilePath)}: [{DiagnosticProducingGenerator.Descriptor.Id}, {MockAdditionalFileDiagnosticAnalyzer.Id}]",
+            @$"{ProtocolConversions.CreateAbsoluteDocumentUri(projFilePath)}: []"
+        ], results.Select(r => $"{r.Uri}: [{string.Join(", ", r.Diagnostics!.Select(d => d.Code?.Value?.ToString()))}]"));
     }
 
     protected override TestComposition Composition => base.Composition.AddParts(typeof(MockAdditionalFileDiagnosticAnalyzer), typeof(TestAdditionalFileDocumentSourceProvider));

--- a/src/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
@@ -1578,7 +1578,7 @@ public sealed class PullDiagnosticTests(ITestOutputHelper testOutputHelper) : Ab
 
         var results = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics);
 
-        Assert.False(results.Any(r => r.TextDocument!.DocumentUri.GetRequiredParsedUri().LocalPath.Contains(".ts")));
+        Assert.False(results.Any(r => r.TextDocument!.DocumentUri.UriString.Contains(".ts")));
     }
 
     [Theory, CombinatorialData]
@@ -2158,14 +2158,12 @@ public sealed class PullDiagnosticTests(ITestOutputHelper testOutputHelper) : Ab
 
         var results = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics);
 
-        var dir = TestWorkspace.RootDirectory.Replace("\\", "/");
-
         AssertEx.SequenceEqual(
         [
-            $"{dir}/C.cs",
-            $"{dir}/CSProj1.csproj",
-            $"{dir}/C2.cs"
-        ], results.Select(r => r.TextDocument.DocumentUri.GetRequiredParsedUri().AbsolutePath));
+            ProtocolConversions.CreateAbsoluteDocumentUri(Path.Combine(TestWorkspace.RootDirectory, "C.cs")),
+            ProtocolConversions.CreateAbsoluteDocumentUri(Path.Combine(TestWorkspace.RootDirectory, "CSProj1.csproj")),
+            ProtocolConversions.CreateAbsoluteDocumentUri(Path.Combine(TestWorkspace.RootDirectory, "C2.cs"))
+        ], results.Select(r => r.TextDocument.DocumentUri));
     }
 
     [Theory, CombinatorialData]

--- a/src/LanguageServer/ProtocolUnitTests/References/FindAllReferencesHandlerTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/References/FindAllReferencesHandlerTests.cs
@@ -379,7 +379,7 @@ public sealed class FindAllReferencesHandlerTests(ITestOutputHelper testOutputHe
 
         var results = await RunFindAllReferencesAsync(testLspServer, testLspServer.GetLocations("caret").First());
         Assert.Equal(2, results.Length);
-        Assert.True(results.Any(r => r.Location.DocumentUri.UriString.EndsWith("generated_file.cs")));
+        Assert.True(results.Any(r => r.Location.DocumentUri.UriString.Contains("/generated_file.cs")));
 
         var service = Assert.IsType<TestSourceGeneratedDocumentSpanMappingService>(workspace.Services.GetService<ISourceGeneratedDocumentSpanMappingService>());
         Assert.True(service.DidMapSpans);
@@ -417,7 +417,7 @@ public sealed class FindAllReferencesHandlerTests(ITestOutputHelper testOutputHe
 
         var results = await RunFindAllReferencesAsync(testLspServer, testLspServer.GetLocations("caret").First());
         Assert.Equal(2, results.Length);
-        Assert.True(results.Any(r => r.Location.DocumentUri.UriString.EndsWith("generated_file.cs")));
+        Assert.True(results.Any(r => r.Location.DocumentUri.UriString.Contains("/generated_file.cs")));
 
         var service = Assert.IsType<TestSourceGeneratedDocumentSpanMappingService>(workspace.Services.GetService<ISourceGeneratedDocumentSpanMappingService>());
         Assert.True(service.DidMapSpans);

--- a/src/LanguageServer/ProtocolUnitTests/References/FindAllReferencesHandlerTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/References/FindAllReferencesHandlerTests.cs
@@ -379,7 +379,7 @@ public sealed class FindAllReferencesHandlerTests(ITestOutputHelper testOutputHe
 
         var results = await RunFindAllReferencesAsync(testLspServer, testLspServer.GetLocations("caret").First());
         Assert.Equal(2, results.Length);
-        Assert.True(results.Any(r => r.Location.DocumentUri.GetRequiredParsedUri().LocalPath.EndsWith("generated_file.cs")));
+        Assert.True(results.Any(r => r.Location.DocumentUri.UriString.EndsWith("generated_file.cs")));
 
         var service = Assert.IsType<TestSourceGeneratedDocumentSpanMappingService>(workspace.Services.GetService<ISourceGeneratedDocumentSpanMappingService>());
         Assert.True(service.DidMapSpans);
@@ -417,7 +417,7 @@ public sealed class FindAllReferencesHandlerTests(ITestOutputHelper testOutputHe
 
         var results = await RunFindAllReferencesAsync(testLspServer, testLspServer.GetLocations("caret").First());
         Assert.Equal(2, results.Length);
-        Assert.True(results.Any(r => r.Location.DocumentUri.GetRequiredParsedUri().LocalPath.EndsWith("generated_file.cs")));
+        Assert.True(results.Any(r => r.Location.DocumentUri.UriString.EndsWith("generated_file.cs")));
 
         var service = Assert.IsType<TestSourceGeneratedDocumentSpanMappingService>(workspace.Services.GetService<ISourceGeneratedDocumentSpanMappingService>());
         Assert.True(service.DidMapSpans);

--- a/src/LanguageServer/ProtocolUnitTests/SpellCheck/SpellCheckTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/SpellCheck/SpellCheckTests.cs
@@ -377,7 +377,7 @@ class {|Identifier:A{{v}}|}
 
             var results = await RunGetWorkspaceSpellCheckSpansAsync(testLspServer);
 
-            Assert.True(results.All(r => r.TextDocument!.DocumentUri.GetRequiredParsedUri().LocalPath == csharpFilePath));
+            Assert.True(results.All(r => r.TextDocument!.DocumentUri == ProtocolConversions.CreateAbsoluteDocumentUri(csharpFilePath)));
         }
 
         //        [Fact]


### PR DESCRIPTION
Compare `DocumentUri` instances in LSP tests instead of file path strings extracted from `GetRequiredParsedUri().LocalPath` / `.AbsolutePath` / `.OriginalString`. This is in preparation for an upcoming refactoring of `System.Uri` usage in the LSP layer.
