### PR TITLE
Shorten ServiceBroker test pipe names

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ServiceBrokerFactoryTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ServiceBrokerFactoryTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -27,6 +27,8 @@ public sealed class ServiceBrokerFactoryTests(ITestOutputHelper testOutputHelper
 {
     private const string ServiceBrokerConnectMethodName = "serviceBroker/connect";
     private const string ServiceBrokerChannelName = "serviceBroker";
+    private const int MacOSUnixDomainSocketMaxPathLength = 104;
+    private const string HelixUnixPipePathPrefix = "/tmp/helix/working/94B7081D/t/CoreFxPipe_";
     private static readonly TimeSpan s_timeout = TimeSpan.FromSeconds(30);
 
     [Fact]
@@ -96,6 +98,14 @@ public sealed class ServiceBrokerFactoryTests(ITestOutputHelper testOutputHelper
         Assert.NotNull(languageService);
     }
 
+    [Fact]
+    public void TestBrokeredServicePipeNameFitsWithinMacOSSocketPathLimit()
+    {
+        var pipeName = NamedPipeTestUtilities.CreateShortPipeName("rsb-");
+
+        Assert.InRange((HelixUnixPipePathPrefix + pipeName).Length, 1, MacOSUnixDomainSocketMaxPathLength);
+    }
+
     private static async Task<IReadOnlyCollection<ServiceMoniker>> GetAvailableServerServicesAsync(IServiceBroker serviceBroker, CancellationToken cancellationToken)
     {
         var manifest = await GetRequiredServiceAsync<IBrokeredServiceBridgeManifest>(serviceBroker, BrokeredServiceBridgeManifest.ServiceDescriptor, cancellationToken);
@@ -127,7 +137,7 @@ public sealed class ServiceBrokerFactoryTests(ITestOutputHelper testOutputHelper
 
         public TestBrokeredServiceClient()
         {
-            _pipeName = "roslyn-service-broker-test-" + Guid.NewGuid();
+            _pipeName = NamedPipeTestUtilities.CreateShortPipeName("rsb-");
             _pipeStream = new NamedPipeServerStream(
                 _pipeName,
                 PipeDirection.InOut,

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/AbstractLanguageServerClientTests.TestLspClient.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/AbstractLanguageServerClientTests.TestLspClient.cs
@@ -74,10 +74,7 @@ public partial class AbstractLanguageServerClientTests
 
             static string CreateNewPipeName()
             {
-                // The pipe name constructed by some systems is very long (due to temp path).
-                // Shorten the unique id for the pipe.
-                var newGuid = Guid.NewGuid().ToString();
-                return newGuid.Split('-')[0];
+                return NamedPipeTestUtilities.CreateShortPipeName();
             }
 
             static string GetFullPipePath(string pipeName)

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/NamedPipeTestUtilities.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/NamedPipeTestUtilities.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests;
+
+internal static class NamedPipeTestUtilities
+{
+    private const int UniquePipeSuffixLength = 12;
+
+    internal static string CreateShortPipeName(string prefix = "")
+    {
+        ArgumentNullException.ThrowIfNull(prefix);
+
+        // Keep the name comfortably below Unix domain socket path limits when Helix temp paths are prefixed.
+        return prefix + Guid.NewGuid().ToString("N")[..UniquePipeSuffixLength];
+    }
+}


### PR DESCRIPTION
## Summary
Macos tests fail sometimes with
```
System.ArgumentOutOfRangeException : The path '/tmp/helix/working/AC040945/t/CoreFxPipe_roslyn-service-broker-test-861f3230-afc5-402c-9b7f-12f8d9770180' is of an invalid length for use with domain sockets on this platform.  The length must be between 1 and 104 characters, inclusive. (Parameter 'path')
Actual value was /tmp/helix/working/AC040945/t/CoreFxPipe_roslyn-service-broker-test-861f3230-afc5-402c-9b7f-12f8d9770180.
```

e.g https://dnceng-public.visualstudio.com/public/_build/results?buildId=1413323&view=ms.vss-test-web.build-test-results-tab&runId=39324030&resultId=157983&paneView=debug

- shorten the brokered-service test pipe names so the Unix-domain-socket path stays below the macOS limit under Helix
- reuse the same short pipe-name helper from LanguageServer unit tests
- add a regression test that guards the macOS socket-path scenario

## Testing
- dotnet test src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Microsoft.CodeAnalysis.LanguageServer.UnitTests.csproj --filter FullyQualifiedName~ServiceBrokerFactoryTests --no-restore -tl:off -v minimal
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83630)