### PR TITLE
Implement type hierarchy LSP methods in Razor

### DIFF
--- a/eng/targets/RazorServices.props
+++ b/eng/targets/RazorServices.props
@@ -41,6 +41,7 @@
     <ServiceHubService Include="Microsoft.VisualStudio.Razor.AddNestedFile" ClassName="Microsoft.CodeAnalysis.Remote.Razor.RemoteAddNestedFileService+Factory" />
     <ServiceHubService Include="Microsoft.VisualStudio.Razor.CallHierarchy" ClassName="Microsoft.CodeAnalysis.Remote.Razor.RemoteCallHierarchyService+Factory" />
     <ServiceHubService Include="Microsoft.VisualStudio.Razor.FindAllReferences" ClassName="Microsoft.CodeAnalysis.Remote.Razor.RemoteFindAllReferencesService+Factory" />
+    <ServiceHubService Include="Microsoft.VisualStudio.Razor.TypeHierarchy" ClassName="Microsoft.CodeAnalysis.Remote.Razor.RemoteTypeHierarchyService+Factory" />
     <ServiceHubService Include="Microsoft.VisualStudio.Razor.InlineCompletion" ClassName="Microsoft.CodeAnalysis.Remote.Razor.RemoteInlineCompletionService+Factory" />
     <ServiceHubService Include="Microsoft.VisualStudio.Razor.DebugInfo" ClassName="Microsoft.CodeAnalysis.Remote.Razor.RemoteDebugInfoService+Factory" />
     <ServiceHubService Include="Microsoft.VisualStudio.Razor.WrapWithTag" ClassName="Microsoft.CodeAnalysis.Remote.Razor.RemoteWrapWithTagService+Factory" />

--- a/src/LanguageServer/Protocol/Handler/TypeHierarchy/PrepareTypeHierarchyHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/TypeHierarchy/PrepareTypeHierarchyHandler.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
 using Roslyn.LanguageServer.Protocol;
 using LSP = Roslyn.LanguageServer.Protocol;
 
@@ -28,10 +29,12 @@ internal sealed class PrepareTypeHierarchyHandler() : ILspServiceDocumentRequest
         => request.TextDocument;
 
     public async Task<LSP.TypeHierarchyItem[]?> HandleRequestAsync(LSP.TypeHierarchyPrepareParams request, RequestContext context, CancellationToken cancellationToken)
+        => await PrepareTypeHierarchyAsync(context.GetRequiredDocument(), ProtocolConversions.PositionToLinePosition(request.Position), cancellationToken).ConfigureAwait(false);
+
+    internal static async Task<LSP.TypeHierarchyItem[]?> PrepareTypeHierarchyAsync(Document document, LinePosition linePosition, CancellationToken cancellationToken)
     {
-        var document = context.GetRequiredDocument();
         var solution = document.Project.Solution;
-        var position = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(request.Position), cancellationToken).ConfigureAwait(false);
+        var position = await document.GetPositionFromLinePositionAsync(linePosition, cancellationToken).ConfigureAwait(false);
         var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
         var symbol = await SymbolFinder.FindSymbolAtPositionAsync(semanticModel, position, solution.Services, includeType: true, cancellationToken).ConfigureAwait(false);

--- a/src/LanguageServer/Protocol/Handler/TypeHierarchy/TypeHierarchySubtypesHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/TypeHierarchy/TypeHierarchySubtypesHandler.cs
@@ -29,10 +29,12 @@ internal sealed class TypeHierarchySubtypesHandler() : ILspServiceDocumentReques
         => TypeHierarchyHelpers.GetResolveData(request.Item).TextDocument;
 
     public async Task<LSP.TypeHierarchyItem[]?> HandleRequestAsync(LSP.TypeHierarchySubtypesParams request, RequestContext context, CancellationToken cancellationToken)
+        => await ResolveSubtypesAsync(context.GetRequiredDocument(), request.Item, cancellationToken).ConfigureAwait(false);
+
+    internal static async Task<LSP.TypeHierarchyItem[]?> ResolveSubtypesAsync(Document document, LSP.TypeHierarchyItem item, CancellationToken cancellationToken)
     {
-        var document = context.GetRequiredDocument();
         var solution = document.Project.Solution;
-        var typeSymbol = await TypeHierarchyHelpers.GetTypeSymbolAsync(request.Item, solution, cancellationToken).ConfigureAwait(false);
+        var typeSymbol = await TypeHierarchyHelpers.GetTypeSymbolAsync(item, solution, cancellationToken).ConfigureAwait(false);
         if (typeSymbol == null)
             return null;
 
@@ -42,9 +44,9 @@ internal sealed class TypeHierarchySubtypesHandler() : ILspServiceDocumentReques
         using var _ = ArrayBuilder<LSP.TypeHierarchyItem>.GetInstance(out var items);
         foreach (var derivedType in derivedTypes)
         {
-            var item = await TypeHierarchyHelpers.CreateItemAsync(derivedType, solution, cancellationToken).ConfigureAwait(false);
-            if (item != null)
-                items.Add(item);
+            var hierarchyItem = await TypeHierarchyHelpers.CreateItemAsync(derivedType, solution, cancellationToken).ConfigureAwait(false);
+            if (hierarchyItem != null)
+                items.Add(hierarchyItem);
         }
 
         return items.ToArray();

--- a/src/LanguageServer/Protocol/Handler/TypeHierarchy/TypeHierarchySupertypesHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/TypeHierarchy/TypeHierarchySupertypesHandler.cs
@@ -29,10 +29,12 @@ internal sealed class TypeHierarchySupertypesHandler() : ILspServiceDocumentRequ
         => TypeHierarchyHelpers.GetResolveData(request.Item).TextDocument;
 
     public async Task<LSP.TypeHierarchyItem[]?> HandleRequestAsync(LSP.TypeHierarchySupertypesParams request, RequestContext context, CancellationToken cancellationToken)
+        => await ResolveSupertypesAsync(context.GetRequiredDocument(), request.Item, cancellationToken).ConfigureAwait(false);
+
+    internal static async Task<LSP.TypeHierarchyItem[]?> ResolveSupertypesAsync(Document document, LSP.TypeHierarchyItem item, CancellationToken cancellationToken)
     {
-        var document = context.GetRequiredDocument();
         var solution = document.Project.Solution;
-        var typeSymbol = await TypeHierarchyHelpers.GetTypeSymbolAsync(request.Item, solution, cancellationToken).ConfigureAwait(false);
+        var typeSymbol = await TypeHierarchyHelpers.GetTypeSymbolAsync(item, solution, cancellationToken).ConfigureAwait(false);
         if (typeSymbol == null)
             return null;
 
@@ -42,9 +44,9 @@ internal sealed class TypeHierarchySupertypesHandler() : ILspServiceDocumentRequ
         using var _ = ArrayBuilder<LSP.TypeHierarchyItem>.GetInstance(out var items);
         foreach (var baseType in baseTypes)
         {
-            var item = await TypeHierarchyHelpers.CreateItemAsync(baseType, solution, cancellationToken).ConfigureAwait(false);
-            if (item != null)
-                items.Add(item);
+            var hierarchyItem = await TypeHierarchyHelpers.CreateItemAsync(baseType, solution, cancellationToken).ConfigureAwait(false);
+            if (hierarchyItem != null)
+                items.Add(hierarchyItem);
         }
 
         return items.ToArray();

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Microsoft.CodeAnalysis.Razor.CohostingShared.projitems
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Microsoft.CodeAnalysis.Razor.CohostingShared.projitems
@@ -59,6 +59,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)IRazorCohostStartupService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SemanticTokens\CohostSemanticTokensLegendService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SemanticTokens\CohostSemanticTokensRangeEndpoint.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TypeHierarchy\CohostPrepareTypeHierarchyEndpoint.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TypeHierarchy\CohostTypeHierarchySubtypesEndpoint.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TypeHierarchy\CohostTypeHierarchySupertypesEndpoint.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IDynamicRegistrationProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RazorCohostClientCapabilitiesService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RazorCohostDynamicRegistrationService.cs" />

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/TypeHierarchy/CohostPrepareTypeHierarchyEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/TypeHierarchy/CohostPrepareTypeHierarchyEndpoint.cs
@@ -1,0 +1,85 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.Cohost;
+using Microsoft.CodeAnalysis.Razor.Remote;
+using Microsoft.CodeAnalysis.Razor.TypeHierarchy;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+#pragma warning disable RS0030 // Do not use banned APIs
+[Shared]
+[CohostEndpoint(Methods.PrepareTypeHierarchyName)]
+[Export(typeof(IDynamicRegistrationProvider))]
+[ExportRazorStatelessLspService(typeof(CohostPrepareTypeHierarchyEndpoint))]
+[method: ImportingConstructor]
+#pragma warning restore RS0030 // Do not use banned APIs
+internal sealed class CohostPrepareTypeHierarchyEndpoint(
+    IIncompatibleProjectService incompatibleProjectService,
+    IRemoteServiceInvoker remoteServiceInvoker)
+    : AbstractCohostDocumentEndpoint<TypeHierarchyPrepareParams, TypeHierarchyItem[]?>(incompatibleProjectService), IDynamicRegistrationProvider
+{
+    private readonly IRemoteServiceInvoker _remoteServiceInvoker = remoteServiceInvoker;
+
+    protected override bool MutatesSolutionState => false;
+
+    protected override bool RequiresLSPSolution => true;
+
+    public ImmutableArray<Registration> GetRegistrations(VSInternalClientCapabilities clientCapabilities, RazorCohostRequestContext requestContext)
+    {
+        if (clientCapabilities.TextDocument?.TypeHierarchy?.DynamicRegistration == true)
+        {
+            return [new Registration
+            {
+                Method = Methods.PrepareTypeHierarchyName,
+                RegisterOptions = new TypeHierarchyRegistrationOptions()
+            }];
+        }
+
+        return [];
+    }
+
+    protected override RazorTextDocumentIdentifier? GetRazorTextDocumentIdentifier(TypeHierarchyPrepareParams request)
+        => request.TextDocument.ToRazorTextDocumentIdentifier();
+
+    protected override async Task<TypeHierarchyItem[]?> HandleRequestAsync(TypeHierarchyPrepareParams request, TextDocument razorDocument, CancellationToken cancellationToken)
+    {
+        var response = await _remoteServiceInvoker.TryInvokeAsync<IRemoteTypeHierarchyService, RemoteResponse<TypeHierarchyItem[]?>>(
+            razorDocument.Project.Solution,
+            (service, solutionInfo, cancellationToken) =>
+                service.PrepareTypeHierarchyAsync(solutionInfo, razorDocument.Id, request.Position, cancellationToken),
+            cancellationToken).ConfigureAwait(false);
+
+        if (response.Result is not TypeHierarchyItem[] items)
+        {
+            return null;
+        }
+
+        return Array.ConvertAll(items, item => WrapRazorItem(item, request.TextDocument));
+    }
+
+    private static TypeHierarchyItem WrapRazorItem(TypeHierarchyItem item, TextDocumentIdentifier textDocument)
+    {
+        var uri = item.Uri.GetRequiredParsedUri();
+        return uri.GetDocumentFilePathFromUri().IsRazorFilePath()
+            ? RazorTypeHierarchyResolveData.Wrap(item, textDocument.WithUri(uri))
+            : item;
+    }
+
+    internal TestAccessor GetTestAccessor() => new(this);
+
+    internal readonly struct TestAccessor(CohostPrepareTypeHierarchyEndpoint instance)
+    {
+        public Task<TypeHierarchyItem[]?> HandleRequestAsync(TypeHierarchyPrepareParams request, TextDocument razorDocument, CancellationToken cancellationToken)
+            => instance.HandleRequestAsync(request, razorDocument, cancellationToken);
+    }
+}

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/TypeHierarchy/CohostTypeHierarchySubtypesEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/TypeHierarchy/CohostTypeHierarchySubtypesEndpoint.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.Cohost;
+using Microsoft.CodeAnalysis.Razor.Remote;
+using Microsoft.CodeAnalysis.Razor.TypeHierarchy;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+#pragma warning disable RS0030 // Do not use banned APIs
+[Shared]
+[CohostEndpoint(Methods.TypeHierarchySubtypesName)]
+[ExportRazorStatelessLspService(typeof(CohostTypeHierarchySubtypesEndpoint))]
+[method: ImportingConstructor]
+#pragma warning restore RS0030 // Do not use banned APIs
+internal sealed class CohostTypeHierarchySubtypesEndpoint(
+    IIncompatibleProjectService incompatibleProjectService,
+    IRemoteServiceInvoker remoteServiceInvoker)
+    : AbstractCohostDocumentEndpoint<TypeHierarchySubtypesParams, TypeHierarchyItem[]?>(incompatibleProjectService)
+{
+    private readonly IRemoteServiceInvoker _remoteServiceInvoker = remoteServiceInvoker;
+
+    protected override bool MutatesSolutionState => false;
+
+    protected override bool RequiresLSPSolution => true;
+
+    protected override RazorTextDocumentIdentifier? GetRazorTextDocumentIdentifier(TypeHierarchySubtypesParams request)
+        => RazorTypeHierarchyResolveData.Unwrap(request.Item)?.TextDocument.ToRazorTextDocumentIdentifier();
+
+    protected override async Task<TypeHierarchyItem[]?> HandleRequestAsync(TypeHierarchySubtypesParams request, TextDocument razorDocument, CancellationToken cancellationToken)
+    {
+        var razorData = RazorTypeHierarchyResolveData.Unwrap(request.Item);
+        if (razorData is null)
+        {
+            return null;
+        }
+
+        var unwrappedItem = RazorTypeHierarchyResolveData.WithData(request.Item, razorData.OriginalData);
+
+        var response = await _remoteServiceInvoker.TryInvokeAsync<IRemoteTypeHierarchyService, RemoteResponse<TypeHierarchyItem[]?>>(
+            razorDocument.Project.Solution,
+            (service, solutionInfo, cancellationToken) =>
+                service.ResolveSubtypesAsync(solutionInfo, razorDocument.Id, unwrappedItem, cancellationToken),
+            cancellationToken).ConfigureAwait(false);
+
+        if (response.Result is not TypeHierarchyItem[] items)
+        {
+            return null;
+        }
+
+        return Array.ConvertAll(items, static item => WrapRazorItem(item));
+    }
+
+    private static TypeHierarchyItem WrapRazorItem(TypeHierarchyItem item)
+    {
+        var uri = item.Uri.GetRequiredParsedUri();
+        return uri.GetDocumentFilePathFromUri().IsRazorFilePath()
+            ? RazorTypeHierarchyResolveData.Wrap(item, new TextDocumentIdentifier { DocumentUri = item.Uri })
+            : item;
+    }
+
+    internal TestAccessor GetTestAccessor() => new(this);
+
+    internal readonly struct TestAccessor(CohostTypeHierarchySubtypesEndpoint instance)
+    {
+        public Task<TypeHierarchyItem[]?> HandleRequestAsync(TypeHierarchySubtypesParams request, TextDocument razorDocument, CancellationToken cancellationToken)
+            => instance.HandleRequestAsync(request, razorDocument, cancellationToken);
+    }
+}

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/TypeHierarchy/CohostTypeHierarchySupertypesEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/TypeHierarchy/CohostTypeHierarchySupertypesEndpoint.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.Cohost;
+using Microsoft.CodeAnalysis.Razor.Remote;
+using Microsoft.CodeAnalysis.Razor.TypeHierarchy;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+#pragma warning disable RS0030 // Do not use banned APIs
+[Shared]
+[CohostEndpoint(Methods.TypeHierarchySupertypesName)]
+[ExportRazorStatelessLspService(typeof(CohostTypeHierarchySupertypesEndpoint))]
+[method: ImportingConstructor]
+#pragma warning restore RS0030 // Do not use banned APIs
+internal sealed class CohostTypeHierarchySupertypesEndpoint(
+    IIncompatibleProjectService incompatibleProjectService,
+    IRemoteServiceInvoker remoteServiceInvoker)
+    : AbstractCohostDocumentEndpoint<TypeHierarchySupertypesParams, TypeHierarchyItem[]?>(incompatibleProjectService)
+{
+    private readonly IRemoteServiceInvoker _remoteServiceInvoker = remoteServiceInvoker;
+
+    protected override bool MutatesSolutionState => false;
+
+    protected override bool RequiresLSPSolution => true;
+
+    protected override RazorTextDocumentIdentifier? GetRazorTextDocumentIdentifier(TypeHierarchySupertypesParams request)
+        => RazorTypeHierarchyResolveData.Unwrap(request.Item)?.TextDocument.ToRazorTextDocumentIdentifier();
+
+    protected override async Task<TypeHierarchyItem[]?> HandleRequestAsync(TypeHierarchySupertypesParams request, TextDocument razorDocument, CancellationToken cancellationToken)
+    {
+        var razorData = RazorTypeHierarchyResolveData.Unwrap(request.Item);
+        if (razorData is null)
+        {
+            return null;
+        }
+
+        var unwrappedItem = RazorTypeHierarchyResolveData.WithData(request.Item, razorData.OriginalData);
+
+        var response = await _remoteServiceInvoker.TryInvokeAsync<IRemoteTypeHierarchyService, RemoteResponse<TypeHierarchyItem[]?>>(
+            razorDocument.Project.Solution,
+            (service, solutionInfo, cancellationToken) =>
+                service.ResolveSupertypesAsync(solutionInfo, razorDocument.Id, unwrappedItem, cancellationToken),
+            cancellationToken).ConfigureAwait(false);
+
+        if (response.Result is not TypeHierarchyItem[] items)
+        {
+            return null;
+        }
+
+        return Array.ConvertAll(items, static item => WrapRazorItem(item));
+    }
+
+    private static TypeHierarchyItem WrapRazorItem(TypeHierarchyItem item)
+    {
+        var uri = item.Uri.GetRequiredParsedUri();
+        return uri.GetDocumentFilePathFromUri().IsRazorFilePath()
+            ? RazorTypeHierarchyResolveData.Wrap(item, new TextDocumentIdentifier { DocumentUri = item.Uri })
+            : item;
+    }
+
+    internal TestAccessor GetTestAccessor() => new(this);
+
+    internal readonly struct TestAccessor(CohostTypeHierarchySupertypesEndpoint instance)
+    {
+        public Task<TypeHierarchyItem[]?> HandleRequestAsync(TypeHierarchySupertypesParams request, TextDocument razorDocument, CancellationToken cancellationToken)
+            => instance.HandleRequestAsync(request, razorDocument, cancellationToken);
+    }
+}

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/TypeHierarchy/RazorTypeHierarchyResolveData.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/TypeHierarchy/RazorTypeHierarchyResolveData.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
+
+namespace Microsoft.CodeAnalysis.Razor.TypeHierarchy;
+
+internal sealed record RazorTypeHierarchyResolveData(
+    TextDocumentIdentifier TextDocument,
+    [property: JsonPropertyName("data")] object? OriginalData,
+    [property: JsonPropertyName("razorTypeHierarchy")] bool IsRazorTypeHierarchy = true) : DocumentResolveData(TextDocument)
+{
+    public static RazorTypeHierarchyResolveData? Unwrap(TypeHierarchyItem item)
+    {
+        if (item.Data is RazorTypeHierarchyResolveData wrapper)
+        {
+            return wrapper is { IsRazorTypeHierarchy: true, OriginalData: not null } ? wrapper : null;
+        }
+
+        if (item.Data is not JsonElement paramsObj)
+        {
+            return null;
+        }
+
+        return paramsObj.Deserialize<RazorTypeHierarchyResolveData>() is { IsRazorTypeHierarchy: true, OriginalData: not null } parsedWrapper
+            ? parsedWrapper
+            : null;
+    }
+
+    public static TypeHierarchyItem Wrap(TypeHierarchyItem item, TextDocumentIdentifier textDocument)
+        => WithData(item, new RazorTypeHierarchyResolveData(textDocument, item.Data));
+
+    public static TypeHierarchyItem WithData(TypeHierarchyItem item, object? data)
+        => new()
+        {
+            Name = item.Name,
+            Kind = item.Kind,
+            Tags = item.Tags,
+            Detail = item.Detail,
+            Uri = item.Uri,
+            Range = item.Range,
+            SelectionRange = item.SelectionRange,
+            Data = data,
+        };
+}

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/IRemoteTypeHierarchyService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/IRemoteTypeHierarchyService.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+
+namespace Microsoft.CodeAnalysis.Razor.Remote;
+
+internal interface IRemoteTypeHierarchyService : IRemoteJsonService
+{
+    ValueTask<RemoteResponse<TypeHierarchyItem[]?>> PrepareTypeHierarchyAsync(
+        JsonSerializableRazorPinnedSolutionInfoWrapper solutionInfo,
+        JsonSerializableDocumentId razorDocumentId,
+        Position position,
+        CancellationToken cancellationToken);
+
+    ValueTask<RemoteResponse<TypeHierarchyItem[]?>> ResolveSupertypesAsync(
+        JsonSerializableRazorPinnedSolutionInfoWrapper solutionInfo,
+        JsonSerializableDocumentId razorDocumentId,
+        TypeHierarchyItem item,
+        CancellationToken cancellationToken);
+
+    ValueTask<RemoteResponse<TypeHierarchyItem[]?>> ResolveSubtypesAsync(
+        JsonSerializableRazorPinnedSolutionInfoWrapper solutionInfo,
+        JsonSerializableDocumentId razorDocumentId,
+        TypeHierarchyItem item,
+        CancellationToken cancellationToken);
+}

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RazorServices.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RazorServices.cs
@@ -51,6 +51,7 @@ internal static class RazorServices
             (typeof(IRemoteAddNestedFileService), null),
             (typeof(IRemoteCallHierarchyService), null),
             (typeof(IRemoteFindAllReferencesService), null),
+            (typeof(IRemoteTypeHierarchyService), null),
             (typeof(IRemoteMEFInitializationService), null),
             (typeof(IRemoteCodeLensService), null),
             (typeof(IRemoteDataTipRangeService), null),

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/TypeHierarchy/RemoteTypeHierarchyService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/TypeHierarchy/RemoteTypeHierarchyService.cs
@@ -1,0 +1,192 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.PooledObjects;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.DocumentMapping;
+using Microsoft.CodeAnalysis.Razor.Protocol;
+using Microsoft.CodeAnalysis.Razor.Remote;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.CodeAnalysis.Remote.Razor.DocumentMapping;
+using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Text;
+using static Microsoft.CodeAnalysis.Razor.Remote.RemoteResponse<Roslyn.LanguageServer.Protocol.TypeHierarchyItem[]?>;
+using ExternalTypeHierarchy = Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost.Handlers.TypeHierarchy;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor;
+
+internal sealed class RemoteTypeHierarchyService(in ServiceArgs args) : RazorDocumentServiceBase(in args), IRemoteTypeHierarchyService
+{
+    internal sealed class Factory : FactoryBase<IRemoteTypeHierarchyService>
+    {
+        protected override IRemoteTypeHierarchyService CreateService(in ServiceArgs args)
+            => new RemoteTypeHierarchyService(in args);
+    }
+
+    private readonly IFilePathService _filePathService = args.ExportProvider.GetExportedValue<IFilePathService>();
+
+    protected override IDocumentPositionInfoStrategy DocumentPositionInfoStrategy => PreferAttributeNameDocumentPositionInfoStrategy.Instance;
+
+    public ValueTask<RemoteResponse<TypeHierarchyItem[]?>> PrepareTypeHierarchyAsync(
+        JsonSerializableRazorPinnedSolutionInfoWrapper solutionInfo,
+        JsonSerializableDocumentId razorDocumentId,
+        Position position,
+        CancellationToken cancellationToken)
+        => RunServiceAsync(
+            solutionInfo,
+            razorDocumentId,
+            context => PrepareTypeHierarchyAsync(context, position, cancellationToken),
+            cancellationToken);
+
+    private async ValueTask<RemoteResponse<TypeHierarchyItem[]?>> PrepareTypeHierarchyAsync(
+        RemoteDocumentContext context,
+        Position position,
+        CancellationToken cancellationToken)
+    {
+        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!codeDocument.Source.Text.TryGetAbsoluteIndex(position, out var hostDocumentIndex))
+        {
+            return NoFurtherHandling;
+        }
+
+        hostDocumentIndex = codeDocument.AdjustPositionForComponentEndTag(hostDocumentIndex);
+
+        var positionInfo = GetPositionInfo(codeDocument, hostDocumentIndex, preferCSharpOverHtml: true);
+        if (positionInfo.LanguageKind is not RazorLanguageKind.CSharp)
+        {
+            return NoFurtherHandling;
+        }
+
+        var generatedDocument = await context.Snapshot.GetGeneratedDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var items = await ExternalTypeHierarchy
+            .PrepareTypeHierarchyAsync(generatedDocument, positionInfo.Position.ToLinePosition(), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (items is null)
+        {
+            return NoFurtherHandling;
+        }
+
+        var mappedItems = await MapItemsAsync(context, items, cancellationToken).ConfigureAwait(false);
+        return Results(mappedItems);
+    }
+
+    public ValueTask<RemoteResponse<TypeHierarchyItem[]?>> ResolveSupertypesAsync(
+        JsonSerializableRazorPinnedSolutionInfoWrapper solutionInfo,
+        JsonSerializableDocumentId razorDocumentId,
+        TypeHierarchyItem item,
+        CancellationToken cancellationToken)
+        => RunServiceAsync(
+            solutionInfo,
+            razorDocumentId,
+            context => ResolveSupertypesAsync(context, item, cancellationToken),
+            cancellationToken);
+
+    private async ValueTask<RemoteResponse<TypeHierarchyItem[]?>> ResolveSupertypesAsync(
+        RemoteDocumentContext context,
+        TypeHierarchyItem item,
+        CancellationToken cancellationToken)
+    {
+        var generatedDocument = await context.Snapshot.GetGeneratedDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var items = await ExternalTypeHierarchy
+            .ResolveSupertypesAsync(generatedDocument, item, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (items is null)
+        {
+            return NoFurtherHandling;
+        }
+
+        var mappedItems = await MapItemsAsync(context, items, cancellationToken).ConfigureAwait(false);
+        return Results(mappedItems);
+    }
+
+    public ValueTask<RemoteResponse<TypeHierarchyItem[]?>> ResolveSubtypesAsync(
+        JsonSerializableRazorPinnedSolutionInfoWrapper solutionInfo,
+        JsonSerializableDocumentId razorDocumentId,
+        TypeHierarchyItem item,
+        CancellationToken cancellationToken)
+        => RunServiceAsync(
+            solutionInfo,
+            razorDocumentId,
+            context => ResolveSubtypesAsync(context, item, cancellationToken),
+            cancellationToken);
+
+    private async ValueTask<RemoteResponse<TypeHierarchyItem[]?>> ResolveSubtypesAsync(
+        RemoteDocumentContext context,
+        TypeHierarchyItem item,
+        CancellationToken cancellationToken)
+    {
+        var generatedDocument = await context.Snapshot.GetGeneratedDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var items = await ExternalTypeHierarchy
+            .ResolveSubtypesAsync(generatedDocument, item, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (items is null)
+        {
+            return NoFurtherHandling;
+        }
+
+        var mappedItems = await MapItemsAsync(context, items, cancellationToken).ConfigureAwait(false);
+        return Results(mappedItems);
+    }
+
+    private async Task<TypeHierarchyItem[]?> MapItemsAsync(
+        RemoteDocumentContext context,
+        TypeHierarchyItem[] items,
+        CancellationToken cancellationToken)
+    {
+        using var mappedItems = new PooledArrayBuilder<TypeHierarchyItem>(items.Length);
+        foreach (var item in items)
+        {
+            var mappedItem = await MapItemAsync(context, item, cancellationToken).ConfigureAwait(false);
+            if (mappedItem is not null)
+            {
+                mappedItems.Add(mappedItem);
+            }
+        }
+
+        return mappedItems.ToArrayAndClear();
+    }
+
+    private async Task<TypeHierarchyItem?> MapItemAsync(
+        RemoteDocumentContext context,
+        TypeHierarchyItem item,
+        CancellationToken cancellationToken)
+    {
+        var uri = item.Uri.GetRequiredParsedUri();
+
+        var (mappedDocumentUri, mappedRange) = await DocumentMappingService
+            .MapToHostDocumentUriAndRangeAsync(context.Snapshot, uri, item.Range, cancellationToken)
+            .ConfigureAwait(false);
+        if (_filePathService.IsVirtualCSharpFile(mappedDocumentUri))
+        {
+            return null;
+        }
+
+        var (mappedSelectionUri, mappedSelectionRange) = await DocumentMappingService
+            .MapToHostDocumentUriAndRangeAsync(context.Snapshot, uri, item.SelectionRange, cancellationToken)
+            .ConfigureAwait(false);
+        if (_filePathService.IsVirtualCSharpFile(mappedSelectionUri))
+        {
+            return null;
+        }
+
+        return new TypeHierarchyItem
+        {
+            Name = item.Name,
+            Kind = item.Kind,
+            Tags = item.Tags,
+            Detail = item.Detail,
+            Uri = new(mappedDocumentUri),
+            Range = mappedRange,
+            SelectionRange = mappedSelectionRange,
+            Data = item.Data,
+        };
+    }
+}

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostTypeHierarchyEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostTypeHierarchyEndpointTest.cs
@@ -1,0 +1,257 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.Razor.Protocol;
+using Microsoft.CodeAnalysis.Razor.TypeHierarchy;
+using Microsoft.CodeAnalysis.Text;
+using Xunit;
+using Xunit.Abstractions;
+using TypeHierarchyRange = Roslyn.LanguageServer.Protocol.Range;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+public class CohostTypeHierarchyEndpointTest(ITestOutputHelper testOutputHelper) : CohostEndpointTestBase(testOutputHelper)
+{
+    [Fact]
+    public async Task PrepareTypeHierarchy_ComponentDefinedInCSharp()
+    {
+        TestCode input = """
+            <Sur$$veyPrompt />
+            """;
+
+        TestCode surveyPrompt = """
+            using Microsoft.AspNetCore.Components;
+
+            namespace SomeProject;
+
+            public class {|componentDef:SurveyPrompt|} : ComponentBase
+            {
+            }
+            """;
+
+        var items = await GetPreparedItemsAsync(input, (FilePath("SurveyPrompt.cs"), surveyPrompt.Text));
+        AssertItems(items, (FileUri("SurveyPrompt.cs"), surveyPrompt, names: null));
+    }
+
+    [Fact]
+    public async Task TypeHierarchySupertypes_RoundTripsMappedItems()
+    {
+        TestCode input = """
+            @code
+            {
+                interface {|topInterfaceDef:ITop|}
+                {
+                }
+
+                interface {|midInterfaceDef:IMid|} : ITop
+                {
+                }
+
+                class {|baseDef:Base|} : IMid
+                {
+                }
+
+                class {|midDef:Mid|} : Base
+                {
+                }
+
+                class {|derivedDef:Der$$ived|} : Mid
+                {
+                }
+            }
+            """;
+
+        var document = CreateProjectAndRazorDocument(input.Text);
+        var preparedItem = Assert.Single(await GetPreparedItemsAsync(document, input.Position));
+        AssertItems([preparedItem], (document.CreateUri(), input, ["derivedDef"]));
+
+        var supertypes = await GetSupertypesAsync(document, preparedItem);
+        AssertItems(supertypes, (document.CreateUri(), input, ["midDef"]));
+        var midItem = Assert.Single(supertypes);
+
+        var midSupertypes = await GetSupertypesAsync(document, midItem);
+        AssertItems(midSupertypes, (document.CreateUri(), input, ["baseDef"]));
+        var baseItem = Assert.Single(midSupertypes);
+
+        var baseSupertypes = await GetSupertypesAsync(document, baseItem);
+        AssertItems(baseSupertypes, (document.CreateUri(), input, ["midInterfaceDef"]));
+        var midInterfaceItem = Assert.Single(baseSupertypes);
+
+        var midInterfaceSupertypes = await GetSupertypesAsync(document, midInterfaceItem);
+        AssertItems(midInterfaceSupertypes, (document.CreateUri(), input, ["topInterfaceDef"]));
+    }
+
+    [Fact]
+    public async Task TypeHierarchySubtypes_RoundTripsMappedItems()
+    {
+        TestCode input = """
+            @code
+            {
+                interface {|rootDef:IRoot|}
+                {
+                }
+
+                interface {|childDef:IChild|} : IRoot
+                {
+                }
+
+                interface {|grandchildDef:IGrandChild|} : IChild
+                {
+                }
+
+                class {|directImplDef:DirectImplementation|} : IRoot
+                {
+                }
+
+                class {|indirectImplDef:IndirectImplementation|} : IGrandChild
+                {
+                }
+
+                void M(IR$$oot value)
+                {
+                }
+            }
+            """;
+
+        var document = CreateProjectAndRazorDocument(input.Text);
+        var preparedItem = Assert.Single(await GetPreparedItemsAsync(document, input.Position));
+        AssertItems([preparedItem], (document.CreateUri(), input, ["rootDef"]));
+
+        var subtypes = await GetSubtypesAsync(document, preparedItem);
+        AssertItems(subtypes, (document.CreateUri(), input, ["childDef", "directImplDef"]));
+
+        var childItem = Assert.Single(subtypes, item => item.Name == "IChild");
+        var childSubtypes = await GetSubtypesAsync(document, childItem);
+        AssertItems(childSubtypes, (document.CreateUri(), input, ["grandchildDef"]));
+        var grandchildItem = Assert.Single(childSubtypes);
+
+        var grandchildSubtypes = await GetSubtypesAsync(document, grandchildItem);
+        AssertItems(grandchildSubtypes, (document.CreateUri(), input, ["indirectImplDef"]));
+    }
+
+    private async Task<TypeHierarchyItem[]> GetPreparedItemsAsync(
+        TestCode input,
+        params (string fileName, string contents)[] additionalFiles)
+    {
+        var document = CreateProjectAndRazorDocument(input.Text, additionalFiles: additionalFiles);
+        return await GetPreparedItemsAsync(document, input.Position);
+    }
+
+    private async Task<TypeHierarchyItem[]> GetPreparedItemsAsync(TextDocument document, int absolutePosition)
+    {
+        var inputText = await document.GetTextAsync(DisposalToken);
+        var endpoint = new CohostPrepareTypeHierarchyEndpoint(IncompatibleProjectService, RemoteServiceInvoker);
+
+        var request = new TypeHierarchyPrepareParams
+        {
+            Position = inputText.GetPosition(absolutePosition),
+            TextDocument = new TextDocumentIdentifier { DocumentUri = document.CreateDocumentUri() },
+        };
+
+        return await endpoint.GetTestAccessor().HandleRequestAsync(request, document, DisposalToken) ?? [];
+    }
+
+    private async Task<TypeHierarchyItem[]> GetSupertypesAsync(TextDocument document, TypeHierarchyItem item)
+    {
+        var endpoint = new CohostTypeHierarchySupertypesEndpoint(IncompatibleProjectService, RemoteServiceInvoker);
+        var roundTrippedItem = RoundTripItemData(item);
+
+        var request = new TypeHierarchySupertypesParams
+        {
+            Item = roundTrippedItem,
+            Position = roundTrippedItem.SelectionRange.Start,
+            TextDocument = new TextDocumentIdentifier { DocumentUri = roundTrippedItem.Uri },
+        };
+
+        return await endpoint.GetTestAccessor().HandleRequestAsync(request, document, DisposalToken) ?? [];
+    }
+
+    private async Task<TypeHierarchyItem[]> GetSubtypesAsync(TextDocument document, TypeHierarchyItem item)
+    {
+        var endpoint = new CohostTypeHierarchySubtypesEndpoint(IncompatibleProjectService, RemoteServiceInvoker);
+        var roundTrippedItem = RoundTripItemData(item);
+
+        var request = new TypeHierarchySubtypesParams
+        {
+            Item = roundTrippedItem,
+            Position = roundTrippedItem.SelectionRange.Start,
+            TextDocument = new TextDocumentIdentifier { DocumentUri = roundTrippedItem.Uri },
+        };
+
+        return await endpoint.GetTestAccessor().HandleRequestAsync(request, document, DisposalToken) ?? [];
+    }
+
+    private static TypeHierarchyItem RoundTripItemData(TypeHierarchyItem item)
+        => RazorTypeHierarchyResolveData.WithData(item, JsonSerializer.SerializeToElement(item.Data, JsonHelpers.JsonSerializerOptions));
+
+    private static void AssertItems(TypeHierarchyItem[] items, params (Uri uri, TestCode code, string[]? names)[] expectedSources)
+    {
+        var expectedItems = GetExpectedItems(expectedSources);
+        Assert.Equal(expectedItems.Length, items.Length);
+
+        foreach (var expectedItem in expectedItems)
+        {
+            var item = Assert.Single(items, item => item.Name == expectedItem.Name);
+            AssertItem(item, expectedItem);
+        }
+    }
+
+    private static void AssertItem(TypeHierarchyItem item, ExpectedTypeHierarchyItem expectedItem)
+    {
+        Assert.Equal(expectedItem.Name, item.Name);
+        Assert.Equal(expectedItem.Uri, item.Uri.ParsedUri);
+        Assert.Equal(expectedItem.SelectionRange, item.SelectionRange);
+        Assert.Equal(expectedItem.Uri, GetResolveDataDocumentUri(item));
+    }
+
+    private static ExpectedTypeHierarchyItem[] GetExpectedItems((Uri uri, TestCode code, string[]? names)[] expectedSources)
+    {
+        return
+        [
+            .. expectedSources.SelectMany(source =>
+            {
+                var expectedNames = source.names ?? [.. source.code.NamedSpans.Keys];
+                return expectedNames.Select(name => GetExpectedItem(source.uri, source.code, name));
+            }),
+        ];
+    }
+
+    private static ExpectedTypeHierarchyItem GetExpectedItem(Uri uri, TestCode code, string name)
+    {
+        var span = Assert.Single(code.NamedSpans[name]);
+        var sourceText = SourceText.From(code.Text);
+        return new(
+            sourceText.ToString(span),
+            uri,
+            sourceText.GetRange(span));
+    }
+
+    private static Uri GetResolveDataDocumentUri(TypeHierarchyItem item)
+    {
+        var data = item.Data switch
+        {
+            JsonElement jsonElement => jsonElement,
+            { } value => JsonSerializer.SerializeToElement(value, value.GetType()),
+            _ => throw new Xunit.Sdk.XunitException("Expected type hierarchy item to have resolve data."),
+        };
+
+        var textDocument = data.TryGetProperty("textDocument", out var camelCaseTextDocument)
+            ? camelCaseTextDocument
+            : data.GetProperty("TextDocument");
+        var uriString = textDocument.TryGetProperty("uri", out var camelCaseUri)
+            ? camelCaseUri.GetString()
+            : textDocument.GetProperty("Uri").GetString();
+
+        Assert.NotNull(uriString);
+        return new Uri(uriString);
+    }
+
+    private sealed record ExpectedTypeHierarchyItem(string Name, Uri Uri, TypeHierarchyRange SelectionRange);
+}

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests.projitems
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests.projitems
@@ -62,6 +62,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Endpoints\CohostSelectionRangeEndpointTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Endpoints\CohostSemanticTokensRangeEndpointTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Endpoints\CohostSignatureHelpEndpointTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Endpoints\CohostTypeHierarchyEndpointTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Endpoints\CohostWillRenameEndpointTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NestedFiles\RemoteAddNestedFileServiceTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Formatting\CascadingTypeParameterFormattingTest.cs" />

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostEndpointTest.cs
@@ -102,6 +102,7 @@ public class CohostEndpointTest(ITestOutputHelper testOutputHelper) : ToolingTes
                 SemanticTokens = new() { DynamicRegistration = true },
                 SignatureHelp = new() { DynamicRegistration = true },
                 Synchronization = new() { DynamicRegistration = true },
+                TypeHierarchy = new() { DynamicRegistration = true },
                 TypeDefinition = new() { DynamicRegistration = true }
             },
         };

--- a/src/Tools/ExternalAccess/Razor/Features/Cohost/Handlers/TypeHierarchy.cs
+++ b/src/Tools/ExternalAccess/Razor/Features/Cohost/Handlers/TypeHierarchy.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Text;
+using LSP = Roslyn.LanguageServer.Protocol;
+using RoslynTypeHierarchy = Microsoft.CodeAnalysis.LanguageServer.Handler.TypeHierarchy;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost.Handlers;
+
+internal static class TypeHierarchy
+{
+    public static Task<LSP.TypeHierarchyItem[]?> PrepareTypeHierarchyAsync(
+        Document document, LinePosition linePosition, CancellationToken cancellationToken)
+        => RoslynTypeHierarchy.PrepareTypeHierarchyHandler.PrepareTypeHierarchyAsync(document, linePosition, cancellationToken);
+
+    public static Task<LSP.TypeHierarchyItem[]?> ResolveSupertypesAsync(
+        Document document, LSP.TypeHierarchyItem item, CancellationToken cancellationToken)
+        => RoslynTypeHierarchy.TypeHierarchySupertypesHandler.ResolveSupertypesAsync(document, item, cancellationToken);
+
+    public static Task<LSP.TypeHierarchyItem[]?> ResolveSubtypesAsync(
+        Document document, LSP.TypeHierarchyItem item, CancellationToken cancellationToken)
+        => RoslynTypeHierarchy.TypeHierarchySubtypesHandler.ResolveSubtypesAsync(document, item, cancellationToken);
+}


### PR DESCRIPTION
Last one of the three new LSP endpoints Roslyn added, but Razor didn't support yet.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83637)