### PR TITLE
Fix doc comment autocomplete corrupting declarations with existing ///

### DIFF
--- a/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
+++ b/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
@@ -2074,6 +2074,60 @@ public sealed class DocumentationCommentTests : AbstractDocumentationCommentTest
             }
             """);
 
+    [WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/82174")]
+    public void TypingCharacter_ExistingDocCommentLines_DoesNotCorruptDeclaration()
+        => VerifyTypingCharacter("""
+            /// imagine existing content here
+            /// imagine existing content here
+            /// imagine even more existing content here
+            //$$
+            public abstract class Content(
+                string key,
+                int content)
+            {
+            }
+            """, """
+            /// imagine existing content here
+            /// imagine existing content here
+            /// imagine even more existing content here
+            /// <summary>
+            /// $$
+            /// </summary>
+            /// <param name="key"></param>
+            /// <param name="content"></param>
+            public abstract class Content(
+                string key,
+                int content)
+            {
+            }
+            """);
+
+    [WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/82174")]
+    public void TypingCharacter_ExistingDocCommentLines_Nested_DoesNotCorruptDeclaration()
+        => VerifyTypingCharacter("""
+            namespace N
+            {
+                /// existing doc line 1
+                /// existing doc line 2
+                //$$
+                class C
+                {
+                }
+            }
+            """, """
+            namespace N
+            {
+                /// existing doc line 1
+                /// existing doc line 2
+                /// <summary>
+                /// $$
+                /// </summary>
+                class C
+                {
+                }
+            }
+            """);
+
     [WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/10968")]
     public void TypingCharacter_Class_Collapsed()
     {

--- a/src/Features/CSharp/Portable/DocumentationComments/CSharpDocumentationCommentSnippetService.cs
+++ b/src/Features/CSharp/Portable/DocumentationComments/CSharpDocumentationCommentSnippetService.cs
@@ -296,9 +296,12 @@ internal sealed class CSharpDocumentationCommentSnippetService() : AbstractDocum
             return false;
         }
 
-        // If there are two text tokens it means there is an existing comment that we want to
-        // preserve.
-        existingCommentText = textTokens.Count == 1 ? "" : firstTextToken.ValueText;
+        // If there are exactly two text tokens it means there is an existing comment on a single
+        // line that we want to preserve. When there are more tokens the parser has merged multiple
+        // consecutive `///` lines into one DocumentationCommentTriviaSyntax; in that case the
+        // existing text belongs to earlier lines, not the line the user just typed, so we must not
+        // use it as the replacement-span length (doing so would overflow into the declaration).
+        existingCommentText = textTokens.Count == 2 ? firstTextToken.ValueText : "";
 
         return lastTextToken.Kind() == SyntaxKind.XmlTextLiteralNewLineToken
             && lastTextToken.TrailingTrivia.Count == 0


### PR DESCRIPTION
Fixes: #82174 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83648)