### PR TITLE
Remove IncludeRoslynDeps from Razor

### DIFF
--- a/src/Razor/docs/contributing/BuildFromSource.md
+++ b/src/Razor/docs/contributing/BuildFromSource.md
@@ -61,15 +61,11 @@ Before opening the `Razor.slnx` file in Visual Studio or VS Code, you need to pe
    .\startvs.cmd
    ```
    script to open Visual Studio with the Razor solution. This script first sets the required
-   environment variables. In addition, the following switches can be specified:
+   environment variables. In addition, the following switch can be specified:
 
    - `-chooseVS`: When specified, displays a list of the installed Visual Studio instances and prompts to
      pick an instance to launch. By default, the newest recently installed instance of Visual Studio is
      launched.
-   - `-includeRoslynDeps`: When specified, sets an environment variable that causes the Roslyn dependences
-     of Razor to be deployed. This can be useful if the latest Razor bits depend on a breaking change in
-     Roslyn that isn't available in the version of Visual Studio being targeted. If you encounter errors
-     when debugging the Razor bits that you've built and deployed, setting this switch _might_ fix them.
 
 3. Set `Microsoft.VisualStudio.RazorExtension` as the startup project.
 

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension.Dependencies/AssemblyCodeBases.cs
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension.Dependencies/AssemblyCodeBases.cs
@@ -6,26 +6,3 @@ using Microsoft.VisualStudio.Shell;
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.VisualStudio.LanguageServer.Protocol.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.VisualStudio.LanguageServer.Protocol.Internal.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.VisualStudio.LanguageServer.Protocol.Extensions.dll")]
-
-#if INCLUDE_ROSLYN_DEPS
-[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
-[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.CSharp", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
-[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.CSharp.Features", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
-[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.CSharp.Workspaces", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
-[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.EditorFeatures", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
-[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.EditorFeatures.Text", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
-[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.ExternalAccess.Razor.Features", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
-[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.InteractiveHost", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
-[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.Features", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
-[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.LanguageServer.Protocol", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
-[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.Remote.Workspaces", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
-[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.VisualBasic", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
-[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.VisualBasic.Features", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
-[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.VisualBasic.Workspaces", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
-[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.Workspaces", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
-[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.VisualStudio.LanguageServices", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
-[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.VisualStudio.LanguageServices.Implementation", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
-[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.VisualStudio.LanguageServices.CSharp", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
-
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.CodeAnalysis.Workspaces.dll")]
-#endif

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension.Dependencies/Microsoft.VisualStudio.RazorExtension.Dependencies.csproj
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension.Dependencies/Microsoft.VisualStudio.RazorExtension.Dependencies.csproj
@@ -3,10 +3,11 @@
   <PropertyGroup>
     <!--
       This project deploys extra dependencies that may not be included in the host VS.
-      Used by integration tests to deploy dependencies not available on public preview.
+      Used by integration tests and local development to deploy assemblies that the
+      main Razor VSIX does not carry.
 
       In general this project should not be deployed (F5'd) by itself as it only includes
-      extra dependencies + codebases that may not be present in public VS installs.
+      extra dependencies + codebases that may not be present in the target VS install.
     -->
 
     <TargetFramework>$(NetFxVS)</TargetFramework>
@@ -26,7 +27,6 @@
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
-    <DefineConstants Condition="'$(IncludeRoslynDeps)' == 'true'">$(DefineConstants);INCLUDE_ROSLYN_DEPS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -58,37 +58,5 @@
     <VSIXSourceItem Include="$(OutputPath)Microsoft.VisualStudio.LanguageServer.Protocol.dll" />
     <VSIXSourceItem Include="$(OutputPath)Microsoft.VisualStudio.LanguageServer.Protocol.Extensions.dll" />
     <VSIXSourceItem Include="$(OutputPath)Microsoft.VisualStudio.LanguageServer.Protocol.Internal.dll" />
-  </ItemGroup>
-
-  <!-- Reference the Roslyn dependencies so that Preview builds work -->
-  <ItemGroup Condition="'$(IncludeRoslynDeps)' == 'true'">
-    <ProjectReference Include="..\..\..\..\..\Features\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.Features.csproj" />
-    <ProjectReference Include="..\..\..\..\..\EditorFeatures\Core\Microsoft.CodeAnalysis.EditorFeatures.csproj" />
-    <ProjectReference Include="..\..\..\..\..\Tools\ExternalAccess\Razor\Features\Microsoft.CodeAnalysis.ExternalAccess.Razor.Features.csproj" />
-    <ProjectReference Include="..\..\..\..\..\VisualStudio\ExternalAccess\FSharp\Microsoft.CodeAnalysis.ExternalAccess.FSharp.csproj" />
-    <ProjectReference Include="..\..\..\..\..\VisualStudio\Core\Def\Microsoft.VisualStudio.LanguageServices.csproj" />
-    <PackageReference Include="Microsoft.VisualStudio.LanguageServices.CSharp.Symbols" />
-    <PackageReference Include="Microsoft.VisualStudio.LanguageServices.Implementation.Symbols" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(IncludeRoslynDeps)' == 'true'">
-    <VSIXSourceItem Include="$(OutputPath)Microsoft.CodeAnalysis.dll" />
-    <VSIXSourceItem Include="$(OutputPath)Microsoft.CodeAnalysis.CSharp.dll" />
-    <VSIXSourceItem Include="$(OutputPath)Microsoft.CodeAnalysis.CSharp.Features.dll" />
-    <VSIXSourceItem Include="$(OutputPath)Microsoft.CodeAnalysis.CSharp.Workspaces.dll" />
-    <VSIXSourceItem Include="$(OutputPath)Microsoft.CodeAnalysis.EditorFeatures.dll" />
-    <VSIXSourceItem Include="$(OutputPath)Microsoft.CodeAnalysis.EditorFeatures.Text.dll" />
-    <VSIXSourceItem Include="$(OutputPath)Microsoft.CodeAnalysis.ExternalAccess.Razor.Features.dll" />
-    <VSIXSourceItem Include="$(OutputPath)Microsoft.CodeAnalysis.InteractiveHost.dll" />
-    <VSIXSourceItem Include="$(OutputPath)Microsoft.CodeAnalysis.Features.dll" />
-    <VSIXSourceItem Include="$(OutputPath)Microsoft.CodeAnalysis.LanguageServer.Protocol.dll" />
-    <VSIXSourceItem Include="$(OutputPath)Microsoft.CodeAnalysis.Remote.Workspaces.dll" />
-    <VSIXSourceItem Include="$(OutputPath)Microsoft.CodeAnalysis.Workspaces.dll" />
-    <VSIXSourceItem Include="$(OutputPath)Microsoft.VisualStudio.LanguageServices.dll" />
-    <VSIXSourceItem Include="$(OutputPath)Microsoft.VisualStudio.LanguageServices.CSharp.dll" />
-    <VSIXSourceItem Include="$(OutputPath)Microsoft.VisualStudio.LanguageServices.Implementation.dll" />
-    <VSIXSourceItem Include="$(OutputPath)Microsoft.CodeAnalysis.VisualBasic.dll" />
-    <VSIXSourceItem Include="$(OutputPath)Microsoft.CodeAnalysis.VisualBasic.Features.dll" />
-    <VSIXSourceItem Include="$(OutputPath)Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll" />
   </ItemGroup>
 </Project>

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/README.md
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/README.md
@@ -25,7 +25,7 @@ The general strategy for an individual test is:
 ## Troubleshooting
 
 - When adding a new test it's absolutely vital that you run it multiple times (5-10+) before even sending the PR since the most frequent issue in our Integration tests is flakyness. If you see any "random" failures while testing check `artifacts\log\Debug\Screenshots` for relevant logs and diagnostics.
-- Ensure you have deployed `Microsoft.VisualStudio.RazorExtension.Dependencies` if you're using a Preview version of VS, or have not deployed it if you're running VS IntPreview or main. If you've any doubt I recommend just checking the hive folder under `Extensions\Microsoft\Razor Extension Dependencies`.
+- If you're seeing packaging issues, check whether `Microsoft.VisualStudio.RazorExtension.Dependencies` was deployed to the hive folder under `Extensions\Microsoft\Razor Extension Dependencies`.
 - If you're suddenly seeing strange packaging issues it's likely your "Hive" is corrupted somehow. I recommend deleting all the folders containing `RoslynDev` from `AppData\Local\Microsoft\VisualStudio`
 - If the test did not produce enough logs/diagnostics to know why it failed it's time to [add/capture some more](https://github.com/dotnet/razor/blob/main/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/VisualStudioLogging.cs).
 - When in doubt, ask for help!
@@ -40,7 +40,7 @@ The real trick usually lies in identifying the specific VS APIs and Services to 
 
 ## Limitations
 
-Generally development in Razor targets the VS main branch but we can't build against VS main for public repos due to policy. We must therefore be able to run the Integration tests against both VS preview and VS main at any given time, which can lead to to package versioning issues. We try to work around them with the `Microsoft.VisualStudio.RazorExtension.Dependencies` package, by forcibly deploying specific dependencies to the VS experimental hive that we will use for testing. That can be finicky and can break when there is a new VS preview released or one of our dependencies makes a breaking change in a DLL we are not redirecting.
+Generally development in Razor targets the VS main branch but we can't build against VS main for public repos due to policy. The `Microsoft.VisualStudio.RazorExtension.Dependencies` package helps local development and integration tests by deploying extra dependencies into the VS experimental hive. That can still be finicky when a new VS preview changes which assemblies are already present in the target instance.
 
 ## Running
 


### PR DESCRIPTION
This was used almost never, and its purpose was to try to workaround issues when Roslyn dependencies would be higher than Razor's and that would cause integration tests to fail. Now that we're in the same repo, its unnecessary.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83659)