### PR TITLE
Rename constant to make it clear which is which

### DIFF
--- a/src/VisualStudio/Core/Def/Diagnostics/VisualStudioDiagnosticAnalyzerService.cs
+++ b/src/VisualStudio/Core/Def/Diagnostics/VisualStudioDiagnosticAnalyzerService.cs
@@ -39,8 +39,7 @@ internal sealed partial class VisualStudioDiagnosticAnalyzerService(
     [Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider) : IVisualStudioDiagnosticAnalyzerService
 {
     // "Run Code Analysis on <%ProjectName%>" command for Top level "Build" and "Analyze" menus.
-    // The below ID is actually defined as "ECMD_RUNFXCOPSEL" in stdidcmd.h, we're just referencing it here.
-    internal const int RunCodeAnalysisForSelectedProjectCommandId = 1647;
+    internal const int ECMD_RUNFXCOPSEL = 1647;
 
     private readonly VisualStudioWorkspace _workspace = workspace;
     private readonly IVsService<IVsStatusbar> _statusbar = statusbar;
@@ -126,7 +125,7 @@ internal sealed partial class VisualStudioDiagnosticAnalyzerService(
 
         if (visible)
         {
-            if (command.CommandID.ID == RunCodeAnalysisForSelectedProjectCommandId &&
+            if (command.CommandID.ID == ECMD_RUNFXCOPSEL &&
                 hierarchy!.TryGetProject(out var project))
             {
                 // Change to show the name of the project as part of the menu item display text.

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -89,7 +89,7 @@ internal sealed class RoslynPackage : AbstractPackage
                 (s, e) => ComponentModel.GetService<SyncNamespacesCommandHandler>().OnSyncNamespacesForSelectedProject(s, e),
                 (s, e) => ComponentModel.GetService<SyncNamespacesCommandHandler>().OnSyncNamespacesForSelectedProjectStatus(s, e));
 
-            _menuCommandService.AddCommand(VSConstants.VSStd2K, VisualStudioDiagnosticAnalyzerService.RunCodeAnalysisForSelectedProjectCommandId,
+            _menuCommandService.AddCommand(VSConstants.VSStd2K, VisualStudioDiagnosticAnalyzerService.ECMD_RUNFXCOPSEL,
                 (s, e) => ComponentModel.GetService<VisualStudioDiagnosticAnalyzerService>().OnRunCodeAnalysisForSelectedProject(s, e),
                 (s, e) => ComponentModel.GetService<VisualStudioDiagnosticAnalyzerService>().OnRunCodeAnalysisForSelectedProjectStatus(s, e));
             _menuCommandService.AddCommand(Guids.RoslynGroupId, ID.RoslynCommands.RunCodeAnalysisForProject,


### PR DESCRIPTION
This was very confusing otherwise since we have a similarly named ID elsewhere and also we still use this name in our VSCT.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83662)