### PR TITLE
Update xcopy-msbuild version to 17.8.5

### DIFF
--- a/global.json
+++ b/global.json
@@ -9,7 +9,7 @@
     "vs": {
       "version": "17.8.0"
     },
-    "xcopy-msbuild": "17.8.1-2"
+    "xcopy-msbuild": "17.8.5"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.26224.3",


### PR DESCRIPTION
Seeing the following official build error

> Version 8.0.420 of the .NET SDK requires at least version 17.8.3 of MSBuild. The current available version of MSBuild is 17.8.1.47607.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83679)