### PR TITLE
Remove working directory for roslyn-tools installation

### DIFF
--- a/eng/pipelines/insert.yml
+++ b/eng/pipelines/insert.yml
@@ -52,9 +52,6 @@ steps:
 
   - script: dotnet tool install Microsoft.RoslynTools --tool-path "$(Build.SourcesDirectory)\.tools" --prerelease --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json
     displayName: 'Install roslyn-tools'
-    # We use the eng/common/post-build directory because it contains a global.json pinning the .NET 8 SDK
-    # The roslyn-tools tool require .NET 8
-    workingDirectory: eng/common/post-build
 
   - powershell: |
       $authorization = if ("" -ne $Env:PublishDataAccessToken) { "Bearer $Env:PublishDataAccessToken" } else { "" }


### PR DESCRIPTION
The working directory is not needed because this job does not perform a checkout so
should be using a recent SDK because there is no global.json pinning it to an older version.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83683)