### PR TITLE
Fix progress reporting to report done on dispose

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/AutoLoadProjectsInitializer.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/AutoLoadProjectsInitializer.cs
@@ -56,7 +56,10 @@ internal sealed class AutoLoadProjectsInitializer(
         else if (solutionPath is not null)
         {
             _logger.LogInformation("Using VS Code settings to auto load solution {SolutionFile}", solutionPath);
-            await StartAndReportProgressAsync(() => projectSystem.OpenSolutionAsync(solutionPath));
+            await StartAndReportProgressAsync(
+                () => projectSystem.OpenSolutionAsync(solutionPath),
+                string.Format(LanguageServerResources.Loading_0, solutionPath),
+                string.Format(LanguageServerResources.Loaded_0, solutionPath));
             return;
         }
 
@@ -73,7 +76,10 @@ internal sealed class AutoLoadProjectsInitializer(
                 if (solutionFiles.Length == 1)
                 {
                     _logger.LogInformation("Found single solution file {SolutionFile} to auto load", solutionFiles[0]);
-                    await StartAndReportProgressAsync(() => projectSystem.OpenSolutionAsync(solutionFiles[0]));
+                    await StartAndReportProgressAsync(
+                        () => projectSystem.OpenSolutionAsync(solutionFiles[0]),
+                        string.Format(LanguageServerResources.Loading_0, solutionFiles[0]),
+                        string.Format(LanguageServerResources.Loaded_0, solutionFiles[0]));
                     return;
                 }
             }
@@ -91,14 +97,22 @@ internal sealed class AutoLoadProjectsInitializer(
 
         _logger.LogInformation("Discovered {count} projects to auto load", projectFiles.Count);
 
-        await StartAndReportProgressAsync(() => projectSystem.OpenProjectsAsync(projectFiles.ToImmutable()));
+        await StartAndReportProgressAsync(
+            () => projectSystem.OpenProjectsAsync(projectFiles.ToImmutable()),
+            string.Format(LanguageServerResources.Loading_0_projects, projectFiles.Count),
+            string.Format(LanguageServerResources.Loaded_0_projects, projectFiles.Count));
 
-        async Task StartAndReportProgressAsync(Func<Task> loadOperation)
+        async Task StartAndReportProgressAsync(Func<Task> loadOperation, string startMessage, string endMessage)
         {
             var workDoneProgressManager = context.GetRequiredLspService<WorkDoneProgressManager>();
 
             // We will await for the client to know that we are starting work...
-            var progressReporter = await workDoneProgressManager.CreateWorkDoneProgressAsync(reportProgressToClient: true, cancellationToken);
+            var progressReporter = await workDoneProgressManager.CreateWorkDoneProgressAsync(reportProgressToClient: true,
+                title: startMessage,
+                startMessage: startMessage,
+                endMessage: endMessage,
+                clientCanCancel: false,
+                cancellationToken);
 
             // ...but we'll fire-and-forget for the actual loading. Pass CancellationToken.None since we want to ensure the progressReporter is always disposed.
             Task.Run(async () =>
@@ -112,7 +126,7 @@ internal sealed class AutoLoadProjectsInitializer(
                     }
                     finally
                     {
-                        progressReporter.Dispose();
+                        await progressReporter.DisposeAsync();
                     }
                 }, CancellationToken.None).Forget();
         }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/AutoLoadProjectsInitializer.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/AutoLoadProjectsInitializer.cs
@@ -58,8 +58,8 @@ internal sealed class AutoLoadProjectsInitializer(
             _logger.LogInformation("Using VS Code settings to auto load solution {SolutionFile}", solutionPath);
             await StartAndReportProgressAsync(
                 () => projectSystem.OpenSolutionAsync(solutionPath),
-                string.Format(LanguageServerResources.Loading_0, solutionPath),
-                string.Format(LanguageServerResources.Loaded_0, solutionPath));
+                startMessage: string.Format(LanguageServerResources.Loading_0, solutionPath),
+                endMessage: string.Format(LanguageServerResources.Loaded_0, solutionPath));
             return;
         }
 
@@ -78,8 +78,8 @@ internal sealed class AutoLoadProjectsInitializer(
                     _logger.LogInformation("Found single solution file {SolutionFile} to auto load", solutionFiles[0]);
                     await StartAndReportProgressAsync(
                         () => projectSystem.OpenSolutionAsync(solutionFiles[0]),
-                        string.Format(LanguageServerResources.Loading_0, solutionFiles[0]),
-                        string.Format(LanguageServerResources.Loaded_0, solutionFiles[0]));
+                        startMessage: string.Format(LanguageServerResources.Loading_0, solutionFiles[0]),
+                        endMessage: string.Format(LanguageServerResources.Loaded_0, solutionFiles[0]));
                     return;
                 }
             }
@@ -99,8 +99,8 @@ internal sealed class AutoLoadProjectsInitializer(
 
         await StartAndReportProgressAsync(
             () => projectSystem.OpenProjectsAsync(projectFiles.ToImmutable()),
-            string.Format(LanguageServerResources.Loading_0_projects, projectFiles.Count),
-            string.Format(LanguageServerResources.Loaded_0_projects, projectFiles.Count));
+            startMessage: string.Format(LanguageServerResources.Loading_0_projects, projectFiles.Count),
+            endMessage: string.Format(LanguageServerResources.Loaded_0_projects, projectFiles.Count));
 
         async Task StartAndReportProgressAsync(Func<Task> loadOperation, string startMessage, string endMessage)
         {

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/Handler/Restore/RestoreHandler.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/Handler/Restore/RestoreHandler.cs
@@ -68,7 +68,12 @@ internal sealed class RestoreHandler(DotnetCliHelper dotnetCliHelper, ILoggerFac
         bool enableProgressReporting,
         CancellationToken cancellationToken)
     {
-        using var progress = await workDoneProgressManager.CreateWorkDoneProgressAsync(reportProgressToClient: enableProgressReporting, cancellationToken);
+        await using var progress = await workDoneProgressManager.CreateWorkDoneProgressAsync(reportProgressToClient: enableProgressReporting,
+            title: LanguageServerResources.Restore,
+            startMessage: LanguageServerResources.Restore_started,
+            endMessage: LanguageServerResources.Restore_complete,
+            clientCanCancel: true,
+            cancellationToken);
         // Ensure we're observing cancellation token from the work done progress (to allow client cancellation).
         cancellationToken = progress.CancellationToken;
         return await RestoreCoreAsync(pathsToRestore, progress, dotnetCliHelper, logger, cancellationToken);
@@ -82,17 +87,6 @@ internal sealed class RestoreHandler(DotnetCliHelper dotnetCliHelper, ILoggerFac
         ILogger logger,
         CancellationToken cancellationToken)
     {
-        // Report the start of the work done progress to the client.
-        progress.Report(new WorkDoneProgressBegin()
-        {
-            Title = LanguageServerResources.Restore,
-            // Adds a cancel button to the client side progress UI.
-            // Cancellation here is fine, it just means the restore will be incomplete (same as a cntrl+C for a CLI restore).
-            Cancellable = true,
-            Message = LanguageServerResources.Restore_started,
-            Percentage = 0,
-        });
-
         var success = true;
         foreach (var path in pathsToRestore)
         {
@@ -121,13 +115,6 @@ internal sealed class RestoreHandler(DotnetCliHelper dotnetCliHelper, ILoggerFac
                 success = false;
             }
         }
-
-        // Report work done progress completion
-        progress.Report(
-            new WorkDoneProgressEnd()
-            {
-                Message = LanguageServerResources.Restore_complete
-            });
 
         logger.LogInformation(LanguageServerResources.Restore_complete);
         return success;

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServerResources.resx
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServerResources.resx
@@ -169,11 +169,11 @@
     <comment>The placeholder is a name of a file</comment>
   </data>
   <data name="Loading_0_projects" xml:space="preserve">
-    <value>Loading {0} projects...</value>
+    <value>Loading {0} project(s)...</value>
     <comment>The placeholder is the number of projects</comment>
   </data>
   <data name="Loaded_0_projects" xml:space="preserve">
-    <value>Loaded {0} projects</value>
+    <value>Loaded {0} project(s)</value>
     <comment>The placeholder is the number of projects</comment>
   </data>
   <data name="Message" xml:space="preserve">

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServerResources.resx
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServerResources.resx
@@ -164,6 +164,18 @@
     <value>Loading {0}...</value>
     <comment>The placeholder is a name of a file</comment>
   </data>
+  <data name="Loaded_0" xml:space="preserve">
+    <value>Loaded {0}</value>
+    <comment>The placeholder is a name of a file</comment>
+  </data>
+  <data name="Loading_0_projects" xml:space="preserve">
+    <value>Loading {0} projects...</value>
+    <comment>The placeholder is the number of projects</comment>
+  </data>
+  <data name="Loaded_0_projects" xml:space="preserve">
+    <value>Loaded {0} projects</value>
+    <comment>The placeholder is the number of projects</comment>
+  </data>
   <data name="Message" xml:space="preserve">
     <value>Message</value>
   </data>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.cs.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.cs.xlf
@@ -82,10 +82,25 @@
         <target state="translated">Nalezené testy: {0} v {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Loaded_0">
+        <source>Loaded {0}</source>
+        <target state="new">Loaded {0}</target>
+        <note>The placeholder is a name of a file</note>
+      </trans-unit>
+      <trans-unit id="Loaded_0_projects">
+        <source>Loaded {0} projects</source>
+        <target state="new">Loaded {0} projects</target>
+        <note>The placeholder is the number of projects</note>
+      </trans-unit>
       <trans-unit id="Loading_0">
         <source>Loading {0}...</source>
         <target state="translated">Načítá se {0}…</target>
         <note>The placeholder is a name of a file</note>
+      </trans-unit>
+      <trans-unit id="Loading_0_projects">
+        <source>Loading {0} projects...</source>
+        <target state="new">Loading {0} projects...</target>
+        <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.cs.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.cs.xlf
@@ -88,8 +88,8 @@
         <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Loaded_0_projects">
-        <source>Loaded {0} projects</source>
-        <target state="new">Loaded {0} projects</target>
+        <source>Loaded {0} project(s)</source>
+        <target state="new">Loaded {0} project(s)</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Loading_0">
@@ -98,8 +98,8 @@
         <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Loading_0_projects">
-        <source>Loading {0} projects...</source>
-        <target state="new">Loading {0} projects...</target>
+        <source>Loading {0} project(s)...</source>
+        <target state="new">Loading {0} project(s)...</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Message">

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.de.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.de.xlf
@@ -88,8 +88,8 @@
         <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Loaded_0_projects">
-        <source>Loaded {0} projects</source>
-        <target state="new">Loaded {0} projects</target>
+        <source>Loaded {0} project(s)</source>
+        <target state="new">Loaded {0} project(s)</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Loading_0">
@@ -98,8 +98,8 @@
         <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Loading_0_projects">
-        <source>Loading {0} projects...</source>
-        <target state="new">Loading {0} projects...</target>
+        <source>Loading {0} project(s)...</source>
+        <target state="new">Loading {0} project(s)...</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Message">

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.de.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.de.xlf
@@ -82,10 +82,25 @@
         <target state="translated">In {1} wurden {0} Tests gefunden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Loaded_0">
+        <source>Loaded {0}</source>
+        <target state="new">Loaded {0}</target>
+        <note>The placeholder is a name of a file</note>
+      </trans-unit>
+      <trans-unit id="Loaded_0_projects">
+        <source>Loaded {0} projects</source>
+        <target state="new">Loaded {0} projects</target>
+        <note>The placeholder is the number of projects</note>
+      </trans-unit>
       <trans-unit id="Loading_0">
         <source>Loading {0}...</source>
         <target state="translated">{0} wird geladen...</target>
         <note>The placeholder is a name of a file</note>
+      </trans-unit>
+      <trans-unit id="Loading_0_projects">
+        <source>Loading {0} projects...</source>
+        <target state="new">Loading {0} projects...</target>
+        <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.es.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.es.xlf
@@ -82,10 +82,25 @@
         <target state="translated">Se encontraron {0} pruebas en {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Loaded_0">
+        <source>Loaded {0}</source>
+        <target state="new">Loaded {0}</target>
+        <note>The placeholder is a name of a file</note>
+      </trans-unit>
+      <trans-unit id="Loaded_0_projects">
+        <source>Loaded {0} projects</source>
+        <target state="new">Loaded {0} projects</target>
+        <note>The placeholder is the number of projects</note>
+      </trans-unit>
       <trans-unit id="Loading_0">
         <source>Loading {0}...</source>
         <target state="translated">Cargando {0}...</target>
         <note>The placeholder is a name of a file</note>
+      </trans-unit>
+      <trans-unit id="Loading_0_projects">
+        <source>Loading {0} projects...</source>
+        <target state="new">Loading {0} projects...</target>
+        <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.es.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.es.xlf
@@ -88,8 +88,8 @@
         <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Loaded_0_projects">
-        <source>Loaded {0} projects</source>
-        <target state="new">Loaded {0} projects</target>
+        <source>Loaded {0} project(s)</source>
+        <target state="new">Loaded {0} project(s)</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Loading_0">
@@ -98,8 +98,8 @@
         <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Loading_0_projects">
-        <source>Loading {0} projects...</source>
-        <target state="new">Loading {0} projects...</target>
+        <source>Loading {0} project(s)...</source>
+        <target state="new">Loading {0} project(s)...</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Message">

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.fr.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.fr.xlf
@@ -82,10 +82,25 @@
         <target state="translated">{0} tests trouvés dans {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Loaded_0">
+        <source>Loaded {0}</source>
+        <target state="new">Loaded {0}</target>
+        <note>The placeholder is a name of a file</note>
+      </trans-unit>
+      <trans-unit id="Loaded_0_projects">
+        <source>Loaded {0} projects</source>
+        <target state="new">Loaded {0} projects</target>
+        <note>The placeholder is the number of projects</note>
+      </trans-unit>
       <trans-unit id="Loading_0">
         <source>Loading {0}...</source>
         <target state="translated">Chargement en cours de {0}...</target>
         <note>The placeholder is a name of a file</note>
+      </trans-unit>
+      <trans-unit id="Loading_0_projects">
+        <source>Loading {0} projects...</source>
+        <target state="new">Loading {0} projects...</target>
+        <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.fr.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.fr.xlf
@@ -88,8 +88,8 @@
         <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Loaded_0_projects">
-        <source>Loaded {0} projects</source>
-        <target state="new">Loaded {0} projects</target>
+        <source>Loaded {0} project(s)</source>
+        <target state="new">Loaded {0} project(s)</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Loading_0">
@@ -98,8 +98,8 @@
         <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Loading_0_projects">
-        <source>Loading {0} projects...</source>
-        <target state="new">Loading {0} projects...</target>
+        <source>Loading {0} project(s)...</source>
+        <target state="new">Loading {0} project(s)...</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Message">

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.it.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.it.xlf
@@ -82,10 +82,25 @@
         <target state="translated">Sono stati trovati {0} test in {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Loaded_0">
+        <source>Loaded {0}</source>
+        <target state="new">Loaded {0}</target>
+        <note>The placeholder is a name of a file</note>
+      </trans-unit>
+      <trans-unit id="Loaded_0_projects">
+        <source>Loaded {0} projects</source>
+        <target state="new">Loaded {0} projects</target>
+        <note>The placeholder is the number of projects</note>
+      </trans-unit>
       <trans-unit id="Loading_0">
         <source>Loading {0}...</source>
         <target state="translated">Caricamento di {0} in corso...</target>
         <note>The placeholder is a name of a file</note>
+      </trans-unit>
+      <trans-unit id="Loading_0_projects">
+        <source>Loading {0} projects...</source>
+        <target state="new">Loading {0} projects...</target>
+        <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.it.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.it.xlf
@@ -88,8 +88,8 @@
         <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Loaded_0_projects">
-        <source>Loaded {0} projects</source>
-        <target state="new">Loaded {0} projects</target>
+        <source>Loaded {0} project(s)</source>
+        <target state="new">Loaded {0} project(s)</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Loading_0">
@@ -98,8 +98,8 @@
         <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Loading_0_projects">
-        <source>Loading {0} projects...</source>
-        <target state="new">Loading {0} projects...</target>
+        <source>Loading {0} project(s)...</source>
+        <target state="new">Loading {0} project(s)...</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Message">

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ja.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ja.xlf
@@ -88,8 +88,8 @@
         <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Loaded_0_projects">
-        <source>Loaded {0} projects</source>
-        <target state="new">Loaded {0} projects</target>
+        <source>Loaded {0} project(s)</source>
+        <target state="new">Loaded {0} project(s)</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Loading_0">
@@ -98,8 +98,8 @@
         <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Loading_0_projects">
-        <source>Loading {0} projects...</source>
-        <target state="new">Loading {0} projects...</target>
+        <source>Loading {0} project(s)...</source>
+        <target state="new">Loading {0} project(s)...</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Message">

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ja.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ja.xlf
@@ -82,10 +82,25 @@
         <target state="translated">{1} で {0} 件のテストが見つかりました</target>
         <note />
       </trans-unit>
+      <trans-unit id="Loaded_0">
+        <source>Loaded {0}</source>
+        <target state="new">Loaded {0}</target>
+        <note>The placeholder is a name of a file</note>
+      </trans-unit>
+      <trans-unit id="Loaded_0_projects">
+        <source>Loaded {0} projects</source>
+        <target state="new">Loaded {0} projects</target>
+        <note>The placeholder is the number of projects</note>
+      </trans-unit>
       <trans-unit id="Loading_0">
         <source>Loading {0}...</source>
         <target state="translated">{0} を読み込んでいます...</target>
         <note>The placeholder is a name of a file</note>
+      </trans-unit>
+      <trans-unit id="Loading_0_projects">
+        <source>Loading {0} projects...</source>
+        <target state="new">Loading {0} projects...</target>
+        <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ko.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ko.xlf
@@ -88,8 +88,8 @@
         <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Loaded_0_projects">
-        <source>Loaded {0} projects</source>
-        <target state="new">Loaded {0} projects</target>
+        <source>Loaded {0} project(s)</source>
+        <target state="new">Loaded {0} project(s)</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Loading_0">
@@ -98,8 +98,8 @@
         <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Loading_0_projects">
-        <source>Loading {0} projects...</source>
-        <target state="new">Loading {0} projects...</target>
+        <source>Loading {0} project(s)...</source>
+        <target state="new">Loading {0} project(s)...</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Message">

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ko.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ko.xlf
@@ -82,10 +82,25 @@
         <target state="translated">{0} 테스트를 {1}에서 찾았습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Loaded_0">
+        <source>Loaded {0}</source>
+        <target state="new">Loaded {0}</target>
+        <note>The placeholder is a name of a file</note>
+      </trans-unit>
+      <trans-unit id="Loaded_0_projects">
+        <source>Loaded {0} projects</source>
+        <target state="new">Loaded {0} projects</target>
+        <note>The placeholder is the number of projects</note>
+      </trans-unit>
       <trans-unit id="Loading_0">
         <source>Loading {0}...</source>
         <target state="translated">{0} 로드 중...</target>
         <note>The placeholder is a name of a file</note>
+      </trans-unit>
+      <trans-unit id="Loading_0_projects">
+        <source>Loading {0} projects...</source>
+        <target state="new">Loading {0} projects...</target>
+        <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pl.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pl.xlf
@@ -88,8 +88,8 @@
         <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Loaded_0_projects">
-        <source>Loaded {0} projects</source>
-        <target state="new">Loaded {0} projects</target>
+        <source>Loaded {0} project(s)</source>
+        <target state="new">Loaded {0} project(s)</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Loading_0">
@@ -98,8 +98,8 @@
         <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Loading_0_projects">
-        <source>Loading {0} projects...</source>
-        <target state="new">Loading {0} projects...</target>
+        <source>Loading {0} project(s)...</source>
+        <target state="new">Loading {0} project(s)...</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Message">

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pl.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pl.xlf
@@ -82,10 +82,25 @@
         <target state="translated">Znalezione testy ({0}) w {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Loaded_0">
+        <source>Loaded {0}</source>
+        <target state="new">Loaded {0}</target>
+        <note>The placeholder is a name of a file</note>
+      </trans-unit>
+      <trans-unit id="Loaded_0_projects">
+        <source>Loaded {0} projects</source>
+        <target state="new">Loaded {0} projects</target>
+        <note>The placeholder is the number of projects</note>
+      </trans-unit>
       <trans-unit id="Loading_0">
         <source>Loading {0}...</source>
         <target state="translated">Trwa ładowanie {0}...</target>
         <note>The placeholder is a name of a file</note>
+      </trans-unit>
+      <trans-unit id="Loading_0_projects">
+        <source>Loading {0} projects...</source>
+        <target state="new">Loading {0} projects...</target>
+        <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pt-BR.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pt-BR.xlf
@@ -88,8 +88,8 @@
         <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Loaded_0_projects">
-        <source>Loaded {0} projects</source>
-        <target state="new">Loaded {0} projects</target>
+        <source>Loaded {0} project(s)</source>
+        <target state="new">Loaded {0} project(s)</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Loading_0">
@@ -98,8 +98,8 @@
         <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Loading_0_projects">
-        <source>Loading {0} projects...</source>
-        <target state="new">Loading {0} projects...</target>
+        <source>Loading {0} project(s)...</source>
+        <target state="new">Loading {0} project(s)...</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Message">

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pt-BR.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pt-BR.xlf
@@ -82,10 +82,25 @@
         <target state="translated">Foram encontrados {0} testes em {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Loaded_0">
+        <source>Loaded {0}</source>
+        <target state="new">Loaded {0}</target>
+        <note>The placeholder is a name of a file</note>
+      </trans-unit>
+      <trans-unit id="Loaded_0_projects">
+        <source>Loaded {0} projects</source>
+        <target state="new">Loaded {0} projects</target>
+        <note>The placeholder is the number of projects</note>
+      </trans-unit>
       <trans-unit id="Loading_0">
         <source>Loading {0}...</source>
         <target state="translated">Carregando {0}...</target>
         <note>The placeholder is a name of a file</note>
+      </trans-unit>
+      <trans-unit id="Loading_0_projects">
+        <source>Loading {0} projects...</source>
+        <target state="new">Loading {0} projects...</target>
+        <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ru.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ru.xlf
@@ -88,8 +88,8 @@
         <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Loaded_0_projects">
-        <source>Loaded {0} projects</source>
-        <target state="new">Loaded {0} projects</target>
+        <source>Loaded {0} project(s)</source>
+        <target state="new">Loaded {0} project(s)</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Loading_0">
@@ -98,8 +98,8 @@
         <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Loading_0_projects">
-        <source>Loading {0} projects...</source>
-        <target state="new">Loading {0} projects...</target>
+        <source>Loading {0} project(s)...</source>
+        <target state="new">Loading {0} project(s)...</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Message">

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ru.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ru.xlf
@@ -82,10 +82,25 @@
         <target state="translated">Обнаружены тесты ({0}) в {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Loaded_0">
+        <source>Loaded {0}</source>
+        <target state="new">Loaded {0}</target>
+        <note>The placeholder is a name of a file</note>
+      </trans-unit>
+      <trans-unit id="Loaded_0_projects">
+        <source>Loaded {0} projects</source>
+        <target state="new">Loaded {0} projects</target>
+        <note>The placeholder is the number of projects</note>
+      </trans-unit>
       <trans-unit id="Loading_0">
         <source>Loading {0}...</source>
         <target state="translated">Загрузка {0}...</target>
         <note>The placeholder is a name of a file</note>
+      </trans-unit>
+      <trans-unit id="Loading_0_projects">
+        <source>Loading {0} projects...</source>
+        <target state="new">Loading {0} projects...</target>
+        <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.tr.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.tr.xlf
@@ -82,10 +82,25 @@
         <target state="translated">{1} içinde {0} test bulundu</target>
         <note />
       </trans-unit>
+      <trans-unit id="Loaded_0">
+        <source>Loaded {0}</source>
+        <target state="new">Loaded {0}</target>
+        <note>The placeholder is a name of a file</note>
+      </trans-unit>
+      <trans-unit id="Loaded_0_projects">
+        <source>Loaded {0} projects</source>
+        <target state="new">Loaded {0} projects</target>
+        <note>The placeholder is the number of projects</note>
+      </trans-unit>
       <trans-unit id="Loading_0">
         <source>Loading {0}...</source>
         <target state="translated">{0} yükleniyor...</target>
         <note>The placeholder is a name of a file</note>
+      </trans-unit>
+      <trans-unit id="Loading_0_projects">
+        <source>Loading {0} projects...</source>
+        <target state="new">Loading {0} projects...</target>
+        <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.tr.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.tr.xlf
@@ -88,8 +88,8 @@
         <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Loaded_0_projects">
-        <source>Loaded {0} projects</source>
-        <target state="new">Loaded {0} projects</target>
+        <source>Loaded {0} project(s)</source>
+        <target state="new">Loaded {0} project(s)</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Loading_0">
@@ -98,8 +98,8 @@
         <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Loading_0_projects">
-        <source>Loading {0} projects...</source>
-        <target state="new">Loading {0} projects...</target>
+        <source>Loading {0} project(s)...</source>
+        <target state="new">Loading {0} project(s)...</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Message">

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hans.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hans.xlf
@@ -88,8 +88,8 @@
         <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Loaded_0_projects">
-        <source>Loaded {0} projects</source>
-        <target state="new">Loaded {0} projects</target>
+        <source>Loaded {0} project(s)</source>
+        <target state="new">Loaded {0} project(s)</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Loading_0">
@@ -98,8 +98,8 @@
         <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Loading_0_projects">
-        <source>Loading {0} projects...</source>
-        <target state="new">Loading {0} projects...</target>
+        <source>Loading {0} project(s)...</source>
+        <target state="new">Loading {0} project(s)...</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Message">

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hans.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hans.xlf
@@ -82,10 +82,25 @@
         <target state="translated">在 {1} 中找到了 {0} 个测试</target>
         <note />
       </trans-unit>
+      <trans-unit id="Loaded_0">
+        <source>Loaded {0}</source>
+        <target state="new">Loaded {0}</target>
+        <note>The placeholder is a name of a file</note>
+      </trans-unit>
+      <trans-unit id="Loaded_0_projects">
+        <source>Loaded {0} projects</source>
+        <target state="new">Loaded {0} projects</target>
+        <note>The placeholder is the number of projects</note>
+      </trans-unit>
       <trans-unit id="Loading_0">
         <source>Loading {0}...</source>
         <target state="translated">正在加载 {0}...</target>
         <note>The placeholder is a name of a file</note>
+      </trans-unit>
+      <trans-unit id="Loading_0_projects">
+        <source>Loading {0} projects...</source>
+        <target state="new">Loading {0} projects...</target>
+        <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hant.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hant.xlf
@@ -88,8 +88,8 @@
         <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Loaded_0_projects">
-        <source>Loaded {0} projects</source>
-        <target state="new">Loaded {0} projects</target>
+        <source>Loaded {0} project(s)</source>
+        <target state="new">Loaded {0} project(s)</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Loading_0">
@@ -98,8 +98,8 @@
         <note>The placeholder is a name of a file</note>
       </trans-unit>
       <trans-unit id="Loading_0_projects">
-        <source>Loading {0} projects...</source>
-        <target state="new">Loading {0} projects...</target>
+        <source>Loading {0} project(s)...</source>
+        <target state="new">Loading {0} project(s)...</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Message">

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hant.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hant.xlf
@@ -82,10 +82,25 @@
         <target state="translated">在 {1} 中找到 {0} 個測試</target>
         <note />
       </trans-unit>
+      <trans-unit id="Loaded_0">
+        <source>Loaded {0}</source>
+        <target state="new">Loaded {0}</target>
+        <note>The placeholder is a name of a file</note>
+      </trans-unit>
+      <trans-unit id="Loaded_0_projects">
+        <source>Loaded {0} projects</source>
+        <target state="new">Loaded {0} projects</target>
+        <note>The placeholder is the number of projects</note>
+      </trans-unit>
       <trans-unit id="Loading_0">
         <source>Loading {0}...</source>
         <target state="translated">正在載入 {0}...</target>
         <note>The placeholder is a name of a file</note>
+      </trans-unit>
+      <trans-unit id="Loading_0_projects">
+        <source>Loading {0} projects...</source>
+        <target state="new">Loading {0} projects...</target>
+        <note>The placeholder is the number of projects</note>
       </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>

--- a/src/LanguageServer/Protocol/Handler/WorkDoneProgress/IWorkDoneProgressReporter.cs
+++ b/src/LanguageServer/Protocol/Handler/WorkDoneProgress/IWorkDoneProgressReporter.cs
@@ -7,7 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Roslyn.LanguageServer.Protocol;
 
-interface IWorkDoneProgressReporter : IDisposable, IProgress<WorkDoneProgress>
+interface IWorkDoneProgressReporter : IAsyncDisposable, IProgress<WorkDoneProgress>
 {
     /// <summary>
     /// Cancellation token that can be monitored to know when work done progress has been cancelled,

--- a/src/LanguageServer/Protocol/Handler/WorkDoneProgress/WorkDoneProgressManager.cs
+++ b/src/LanguageServer/Protocol/Handler/WorkDoneProgress/WorkDoneProgressManager.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Roslyn.LanguageServer.Protocol;
+using StreamJsonRpc;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler;
 
@@ -43,9 +44,9 @@ class WorkDoneProgressManager(IClientLanguageServerManager clientLanguageServerM
 
     /// <summary>
     /// Initiates a new work done progress reporting session with the client.
-    /// This sends the initial `window/workDoneProgress/create` request, but callers are responsible for sending the
-    /// begin and end reports.
+    /// This sends the initial `window/workDoneProgress/create` request and begin report to the client.
     /// In the case of server side cancellation, an end report will be sent automatically with a "Cancelled" message.
+    /// On dispose of the <see cref="IWorkDoneProgressReporter"/>, an end report will be sent with the provided end message.
     /// </summary>
     /// <param name="serverCancellationToken">a cancellation token that signals when the server wants to cancel the operation</param>
     public async Task<IWorkDoneProgressReporter> CreateWorkDoneProgressAsync(
@@ -66,6 +67,14 @@ class WorkDoneProgressManager(IClientLanguageServerManager clientLanguageServerM
         {
             var clientReporter = new WorkDoneProgressReporter(token, endMessage, this, serverCancellationToken);
             await clientReporter.SendCreateRequestAsync().ConfigureAwait(false);
+
+            // Tell the client to end the work done progress if the server cancels the request.
+            // Note - no need to observe client cancellation - the client does not expect an end report when it cancels.
+            serverCancellationToken.Register(() =>
+            {
+                clientReporter.TryReportEndAsync("Cancelled").ReportNonFatalErrorAsync();
+            });
+
             lock (_progressLock)
             {
                 _progressReporters[token] = clientReporter;
@@ -130,13 +139,6 @@ class WorkDoneProgressManager(IClientLanguageServerManager clientLanguageServerM
             // Link the server cancellation token to the source handling client side cancellation.
             _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(serverCancellationToken);
             CancellationToken = _cancellationTokenSource.Token;
-
-            // Tell the client to end the work done progress if the server cancels the request.
-            // Note - no need to observe client cancellation - the client does not expect an end report when it cancels.
-            serverCancellationToken.Register(() =>
-            {
-                TryReportEndAsync("Cancelled").ReportNonFatalErrorAsync();
-            });
         }
 
         public async Task SendCreateRequestAsync()
@@ -196,10 +198,18 @@ class WorkDoneProgressManager(IClientLanguageServerManager clientLanguageServerM
             if (Interlocked.CompareExchange(ref _ended, 1, 0) != 0)
                 return;
 
-            await ReportProgressAsync(new WorkDoneProgressEnd()
+            try
             {
-                Message = message
-            }, CancellationToken.None /* do not observe cancellation as this may be a report triggered by cancellation. */).ConfigureAwait(false);
+                await ReportProgressAsync(new WorkDoneProgressEnd()
+                {
+                    Message = message
+                }, CancellationToken.None /* do not observe cancellation as this may be a report triggered by cancellation. */).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is ObjectDisposedException or ConnectionLostException)
+            {
+                // It is entirely possible that we're shutting down and the connection is lost while we're trying to send a notification.
+                // These are safely ignored as there is no client to recieve the notification.
+            }
         }
 
         private record struct ProgressReportType(

--- a/src/LanguageServer/Protocol/Handler/WorkDoneProgress/WorkDoneProgressManager.cs
+++ b/src/LanguageServer/Protocol/Handler/WorkDoneProgress/WorkDoneProgressManager.cs
@@ -72,7 +72,7 @@ class WorkDoneProgressManager(IClientLanguageServerManager clientLanguageServerM
             // Note - no need to observe client cancellation - the client does not expect an end report when it cancels.
             serverCancellationToken.Register(() =>
             {
-                clientReporter.TryReportEndAsync("Cancelled").ReportNonFatalErrorAsync();
+                clientReporter.TryReportEndAsync(LanguageServerProtocolResources.Cancelled).ReportNonFatalErrorAsync();
             });
 
             lock (_progressLock)
@@ -127,7 +127,7 @@ class WorkDoneProgressManager(IClientLanguageServerManager clientLanguageServerM
         /// </summary>
         private readonly string _endMessage;
 
-        private readonly CancellationTokenSource _cancellationTokenSource;
+        private readonly CancellationTokenSource _linkedCancellationSource;
 
         public CancellationToken CancellationToken { get; }
 
@@ -137,8 +137,8 @@ class WorkDoneProgressManager(IClientLanguageServerManager clientLanguageServerM
             _endMessage = endMessage;
             _manager = manager;
             // Link the server cancellation token to the source handling client side cancellation.
-            _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(serverCancellationToken);
-            CancellationToken = _cancellationTokenSource.Token;
+            _linkedCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(serverCancellationToken);
+            CancellationToken = _linkedCancellationSource.Token;
         }
 
         public async Task SendCreateRequestAsync()
@@ -168,7 +168,7 @@ class WorkDoneProgressManager(IClientLanguageServerManager clientLanguageServerM
         /// </summary>
         public void CancelSource_NoLock()
         {
-            _cancellationTokenSource.Cancel();
+            _linkedCancellationSource.Cancel();
         }
 
         public async ValueTask DisposeAsync()
@@ -177,9 +177,9 @@ class WorkDoneProgressManager(IClientLanguageServerManager clientLanguageServerM
             var isDisposedByCancellation = false;
             lock (_manager._progressLock)
             {
-                isDisposedByCancellation = _cancellationTokenSource.IsCancellationRequested;
+                isDisposedByCancellation = _linkedCancellationSource.IsCancellationRequested;
                 _manager._progressReporters.Remove(_token);
-                _cancellationTokenSource.Dispose();
+                _linkedCancellationSource.Dispose();
             }
 
             // Do not send an end report if the reporter was disposed due to cancellation.

--- a/src/LanguageServer/Protocol/Handler/WorkDoneProgress/WorkDoneProgressManager.cs
+++ b/src/LanguageServer/Protocol/Handler/WorkDoneProgress/WorkDoneProgressManager.cs
@@ -48,7 +48,13 @@ class WorkDoneProgressManager(IClientLanguageServerManager clientLanguageServerM
     /// In the case of server side cancellation, an end report will be sent automatically with a "Cancelled" message.
     /// </summary>
     /// <param name="serverCancellationToken">a cancellation token that signals when the server wants to cancel the operation</param>
-    public async Task<IWorkDoneProgressReporter> CreateWorkDoneProgressAsync(bool reportProgressToClient, CancellationToken serverCancellationToken)
+    public async Task<IWorkDoneProgressReporter> CreateWorkDoneProgressAsync(
+        bool reportProgressToClient,
+        string title,
+        string startMessage,
+        string endMessage,
+        bool clientCanCancel,
+        CancellationToken serverCancellationToken)
     {
         var token = Guid.NewGuid().ToString();
         IWorkDoneProgressReporter reporter;
@@ -58,12 +64,20 @@ class WorkDoneProgressManager(IClientLanguageServerManager clientLanguageServerM
 
         if (reportProgress)
         {
-            var clientReporter = new WorkDoneProgressReporter(token, this, serverCancellationToken);
+            var clientReporter = new WorkDoneProgressReporter(token, endMessage, this, serverCancellationToken);
             await clientReporter.SendCreateRequestAsync().ConfigureAwait(false);
             lock (_progressLock)
             {
                 _progressReporters[token] = clientReporter;
             }
+
+            clientReporter.Report(new WorkDoneProgressBegin()
+            {
+                Title = title,
+                Message = startMessage,
+                Cancellable = clientCanCancel,
+                Percentage = 0,
+            });
 
             return clientReporter;
         }
@@ -90,6 +104,8 @@ class WorkDoneProgressManager(IClientLanguageServerManager clientLanguageServerM
 
     private class WorkDoneProgressReporter : IWorkDoneProgressReporter
     {
+        private int _ended = 0;
+
         private readonly WorkDoneProgressManager _manager;
 
         /// <summary>
@@ -97,27 +113,29 @@ class WorkDoneProgressManager(IClientLanguageServerManager clientLanguageServerM
         /// </summary>
         private readonly string _token;
 
+        /// <summary>
+        /// The message to send to the client when the work done progress session ends.
+        /// </summary>
+        private readonly string _endMessage;
+
         private readonly CancellationTokenSource _cancellationTokenSource;
 
-        public CancellationToken CancellationToken => _cancellationTokenSource.Token;
+        public CancellationToken CancellationToken { get; }
 
-        public WorkDoneProgressReporter(string token, WorkDoneProgressManager manager, CancellationToken serverCancellationToken)
+        public WorkDoneProgressReporter(string token, string endMessage, WorkDoneProgressManager manager, CancellationToken serverCancellationToken)
         {
             _token = token;
+            _endMessage = endMessage;
             _manager = manager;
             // Link the server cancellation token to the source handling client side cancellation.
             _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(serverCancellationToken);
+            CancellationToken = _cancellationTokenSource.Token;
 
             // Tell the client to end the work done progress if the server cancels the request.
-            // This needs to not observe the linked cancellation token as it will already be cancelled.
+            // Note - no need to observe client cancellation - the client does not expect an end report when it cancels.
             serverCancellationToken.Register(() =>
             {
-                // the reporter is already cancelled (linked cancellation token) - but we need to ensure the client is notified of the server requested cancellation.
-                // this report should not be cancellable so report with no cancellation token.
-                ReportProgressAsync(new WorkDoneProgressEnd()
-                {
-                    Message = "Cancelled"
-                }, CancellationToken.None).ReportNonFatalErrorAsync();
+                TryReportEndAsync("Cancelled").ReportNonFatalErrorAsync();
             });
         }
 
@@ -151,14 +169,37 @@ class WorkDoneProgressManager(IClientLanguageServerManager clientLanguageServerM
             _cancellationTokenSource.Cancel();
         }
 
-        public void Dispose()
+        public async ValueTask DisposeAsync()
         {
             // Take the lock here to ensure we don't run this concurrently with Cancel.
+            var isDisposedByCancellation = false;
             lock (_manager._progressLock)
             {
+                isDisposedByCancellation = _cancellationTokenSource.IsCancellationRequested;
                 _manager._progressReporters.Remove(_token);
                 _cancellationTokenSource.Dispose();
             }
+
+            // Do not send an end report if the reporter was disposed due to cancellation.
+            // If the client cancelled, the client is not expecting an end report.
+            // If the server cancelled, we have/will send a report in the cancellation callback registered in the constructor.
+            if (!isDisposedByCancellation)
+            {
+                await TryReportEndAsync(_endMessage).ConfigureAwait(false);
+            }
+        }
+
+        public async Task TryReportEndAsync(string message)
+        {
+            // There is an inherent race in that the server can complete while we get a cancellation from another source.
+            // We'll just respond based on whatever we see first.
+            if (Interlocked.CompareExchange(ref _ended, 1, 0) != 0)
+                return;
+
+            await ReportProgressAsync(new WorkDoneProgressEnd()
+            {
+                Message = message
+            }, CancellationToken.None /* do not observe cancellation as this may be a report triggered by cancellation. */).ConfigureAwait(false);
         }
 
         private record struct ProgressReportType(
@@ -169,9 +210,7 @@ class WorkDoneProgressManager(IClientLanguageServerManager clientLanguageServerM
     private record struct NoOpProgressReporter(CancellationToken cancellationToken) : IWorkDoneProgressReporter
     {
         public readonly CancellationToken CancellationToken => cancellationToken;
-        public readonly void Dispose()
-        {
-        }
+        public readonly ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
         public readonly void Report(WorkDoneProgress value)
         {

--- a/src/LanguageServer/Protocol/Handler/WorkDoneProgress/WorkDoneProgressManager.cs
+++ b/src/LanguageServer/Protocol/Handler/WorkDoneProgress/WorkDoneProgressManager.cs
@@ -184,7 +184,7 @@ class WorkDoneProgressManager(IClientLanguageServerManager clientLanguageServerM
 
             // Do not send an end report if the reporter was disposed due to cancellation.
             // If the client cancelled, the client is not expecting an end report.
-            // If the server cancelled, we have/will send a report in the cancellation callback registered in the constructor.
+            // If the server cancelled, we have/will send a report in the cancellation callback registered in CreateWorkDoneProgressAsync.
             if (!isDisposedByCancellation)
             {
                 await TryReportEndAsync(_endMessage).ConfigureAwait(false);

--- a/src/LanguageServer/Protocol/LanguageServerProtocolResources.Designer.cs
+++ b/src/LanguageServer/Protocol/LanguageServerProtocolResources.Designer.cs
@@ -61,6 +61,15 @@ internal sealed class LanguageServerProtocolResources {
     }
     
     /// <summary>
+    ///   Looks up a localized string similar to Cancelled.
+    /// </summary>
+    internal static string Cancelled {
+        get {
+            return ResourceManager.GetString("Cancelled", resourceCulture);
+        }
+    }
+    
+    /// <summary>
     ///   Looks up a localized string similar to Unable to deserialize Uri. Unexpected value encountered: {0}.
     /// </summary>
     internal static string DocumentUriSerializationError {

--- a/src/LanguageServer/Protocol/LanguageServerProtocolResources.resx
+++ b/src/LanguageServer/Protocol/LanguageServerProtocolResources.resx
@@ -98,6 +98,9 @@
 	<resheader name="writer">
 		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
 	</resheader>
+	<data name="Cancelled" xml:space="preserve">
+		<value>Cancelled</value>
+	</data>
   <data name="DocumentUriSerializationError" xml:space="preserve">
     <value>Unable to deserialize Uri. Unexpected value encountered: {0}</value>
   </data>

--- a/src/LanguageServer/Protocol/xlf/LanguageServerProtocolResources.cs.xlf
+++ b/src/LanguageServer/Protocol/xlf/LanguageServerProtocolResources.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../LanguageServerProtocolResources.resx">
     <body>
+      <trans-unit id="Cancelled">
+        <source>Cancelled</source>
+        <target state="new">Cancelled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DocumentUriSerializationError">
         <source>Unable to deserialize Uri. Unexpected value encountered: {0}</source>
         <target state="translated">Nejde deserializovat identifikátor Uri. Zjistila se neočekávaná hodnota: {0}.</target>

--- a/src/LanguageServer/Protocol/xlf/LanguageServerProtocolResources.de.xlf
+++ b/src/LanguageServer/Protocol/xlf/LanguageServerProtocolResources.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../LanguageServerProtocolResources.resx">
     <body>
+      <trans-unit id="Cancelled">
+        <source>Cancelled</source>
+        <target state="new">Cancelled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DocumentUriSerializationError">
         <source>Unable to deserialize Uri. Unexpected value encountered: {0}</source>
         <target state="translated">URI kann nicht deserialisiert werden kann. Unerwarteter Wert erkannt: {0}</target>

--- a/src/LanguageServer/Protocol/xlf/LanguageServerProtocolResources.es.xlf
+++ b/src/LanguageServer/Protocol/xlf/LanguageServerProtocolResources.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../LanguageServerProtocolResources.resx">
     <body>
+      <trans-unit id="Cancelled">
+        <source>Cancelled</source>
+        <target state="new">Cancelled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DocumentUriSerializationError">
         <source>Unable to deserialize Uri. Unexpected value encountered: {0}</source>
         <target state="translated">No se puede deserializar el URI. Se encontró un valor inesperado: {0}</target>

--- a/src/LanguageServer/Protocol/xlf/LanguageServerProtocolResources.fr.xlf
+++ b/src/LanguageServer/Protocol/xlf/LanguageServerProtocolResources.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../LanguageServerProtocolResources.resx">
     <body>
+      <trans-unit id="Cancelled">
+        <source>Cancelled</source>
+        <target state="new">Cancelled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DocumentUriSerializationError">
         <source>Unable to deserialize Uri. Unexpected value encountered: {0}</source>
         <target state="translated">Impossible de désérialiser l'URI. Valeur inattendue rencontrée : {0}</target>

--- a/src/LanguageServer/Protocol/xlf/LanguageServerProtocolResources.it.xlf
+++ b/src/LanguageServer/Protocol/xlf/LanguageServerProtocolResources.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../LanguageServerProtocolResources.resx">
     <body>
+      <trans-unit id="Cancelled">
+        <source>Cancelled</source>
+        <target state="new">Cancelled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DocumentUriSerializationError">
         <source>Unable to deserialize Uri. Unexpected value encountered: {0}</source>
         <target state="translated">Non è possibile deserializzare Uri. È stato rilevato il valore imprevisto {0}</target>

--- a/src/LanguageServer/Protocol/xlf/LanguageServerProtocolResources.ja.xlf
+++ b/src/LanguageServer/Protocol/xlf/LanguageServerProtocolResources.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../LanguageServerProtocolResources.resx">
     <body>
+      <trans-unit id="Cancelled">
+        <source>Cancelled</source>
+        <target state="new">Cancelled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DocumentUriSerializationError">
         <source>Unable to deserialize Uri. Unexpected value encountered: {0}</source>
         <target state="translated">URI を逆シリアル化できません。予期しない値が発生しました: {0}</target>

--- a/src/LanguageServer/Protocol/xlf/LanguageServerProtocolResources.ko.xlf
+++ b/src/LanguageServer/Protocol/xlf/LanguageServerProtocolResources.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../LanguageServerProtocolResources.resx">
     <body>
+      <trans-unit id="Cancelled">
+        <source>Cancelled</source>
+        <target state="new">Cancelled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DocumentUriSerializationError">
         <source>Unable to deserialize Uri. Unexpected value encountered: {0}</source>
         <target state="translated">URI를 역직렬화할 수 없습니다. 예기치 않은 값 {0}이(가) 있습니다.</target>

--- a/src/LanguageServer/Protocol/xlf/LanguageServerProtocolResources.pl.xlf
+++ b/src/LanguageServer/Protocol/xlf/LanguageServerProtocolResources.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../LanguageServerProtocolResources.resx">
     <body>
+      <trans-unit id="Cancelled">
+        <source>Cancelled</source>
+        <target state="new">Cancelled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DocumentUriSerializationError">
         <source>Unable to deserialize Uri. Unexpected value encountered: {0}</source>
         <target state="translated">Nie można zdeserializować identyfikatora Uri. Napotkano nieoczekiwaną wartość: {0}</target>

--- a/src/LanguageServer/Protocol/xlf/LanguageServerProtocolResources.pt-BR.xlf
+++ b/src/LanguageServer/Protocol/xlf/LanguageServerProtocolResources.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../LanguageServerProtocolResources.resx">
     <body>
+      <trans-unit id="Cancelled">
+        <source>Cancelled</source>
+        <target state="new">Cancelled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DocumentUriSerializationError">
         <source>Unable to deserialize Uri. Unexpected value encountered: {0}</source>
         <target state="translated">Não é possível desserializar o Uri. Valor inesperado encontrado: {0}</target>

--- a/src/LanguageServer/Protocol/xlf/LanguageServerProtocolResources.ru.xlf
+++ b/src/LanguageServer/Protocol/xlf/LanguageServerProtocolResources.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../LanguageServerProtocolResources.resx">
     <body>
+      <trans-unit id="Cancelled">
+        <source>Cancelled</source>
+        <target state="new">Cancelled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DocumentUriSerializationError">
         <source>Unable to deserialize Uri. Unexpected value encountered: {0}</source>
         <target state="translated">Не удалось десериализовать URI. Возникло непредвиденное значение: {0}</target>

--- a/src/LanguageServer/Protocol/xlf/LanguageServerProtocolResources.tr.xlf
+++ b/src/LanguageServer/Protocol/xlf/LanguageServerProtocolResources.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../LanguageServerProtocolResources.resx">
     <body>
+      <trans-unit id="Cancelled">
+        <source>Cancelled</source>
+        <target state="new">Cancelled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DocumentUriSerializationError">
         <source>Unable to deserialize Uri. Unexpected value encountered: {0}</source>
         <target state="translated">URI seri durumdan çıkarılamıyor. Beklenmeyen değerle karşılaşıldı: {0}</target>

--- a/src/LanguageServer/Protocol/xlf/LanguageServerProtocolResources.zh-Hans.xlf
+++ b/src/LanguageServer/Protocol/xlf/LanguageServerProtocolResources.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../LanguageServerProtocolResources.resx">
     <body>
+      <trans-unit id="Cancelled">
+        <source>Cancelled</source>
+        <target state="new">Cancelled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DocumentUriSerializationError">
         <source>Unable to deserialize Uri. Unexpected value encountered: {0}</source>
         <target state="translated">无法反序列化 URI。出现意外值: {0}</target>

--- a/src/LanguageServer/Protocol/xlf/LanguageServerProtocolResources.zh-Hant.xlf
+++ b/src/LanguageServer/Protocol/xlf/LanguageServerProtocolResources.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../LanguageServerProtocolResources.resx">
     <body>
+      <trans-unit id="Cancelled">
+        <source>Cancelled</source>
+        <target state="new">Cancelled</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DocumentUriSerializationError">
         <source>Unable to deserialize Uri. Unexpected value encountered: {0}</source>
         <target state="translated">無法將 URI 還原序列化。發現非預期的值: {0}</target>

--- a/src/LanguageServer/ProtocolUnitTests/WorkDoneProgressTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/WorkDoneProgressTests.cs
@@ -1,0 +1,290 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CommonLanguageServerProtocol.Framework;
+using Roslyn.LanguageServer.Protocol;
+using Roslyn.Test.Utilities;
+using StreamJsonRpc;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests;
+
+[UseExportProvider]
+public sealed class WorkDoneProgressTests : AbstractLanguageServerProtocolTests
+{
+    private const string Title = "Test progress";
+    private const string StartMessage = "Starting";
+    private const string ReportMessage = "Working";
+    private const string EndMessage = "Finished";
+    private const string CancelledMessage = "Cancelled";
+
+    public WorkDoneProgressTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+    {
+    }
+
+    protected override TestComposition Composition => base.Composition.AddParts(typeof(TestWorkDoneProgressServiceFactory));
+
+    [Theory, CombinatorialData]
+    public async Task ProgressCanBeCreatedReportedAndCompleted(bool mutatingLspWorkspace)
+    {
+        var clientCallbackTarget = new ClientCallbackTarget();
+        await using var server = await CreateTestServerAsync(mutatingLspWorkspace, clientCallbackTarget);
+
+        var response = await GetTestService(server).RunCompleteWorkDoneProgress();
+
+        var end = await clientCallbackTarget.WaitForEndAsync();
+        var progressReports = clientCallbackTarget.GetProgressReports();
+        Assert.Collection(
+            progressReports,
+            progressReport => Assert.IsType<WorkDoneProgressBegin>(progressReport.Value),
+            progressReport => Assert.IsType<WorkDoneProgressReport>(progressReport.Value),
+            progressReport => Assert.IsType<WorkDoneProgressEnd>(progressReport.Value));
+
+        Assert.All(progressReports, progressReport => Assert.Equal(end.Token, progressReport.Token));
+    }
+
+    [Theory, CombinatorialData]
+    public async Task ThrowingDuringProgressCompletesProgress(bool mutatingLspWorkspace)
+    {
+        var clientCallbackTarget = new ClientCallbackTarget();
+        await using var server = await CreateTestServerAsync(mutatingLspWorkspace, clientCallbackTarget);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await GetTestService(server).RunThrowingWorkDoneProgress());
+
+        await clientCallbackTarget.WaitForEndAsync();
+
+        var progressReports = clientCallbackTarget.GetProgressReports();
+        Assert.Collection(
+            progressReports,
+            progressReport => Assert.IsType<WorkDoneProgressBegin>(progressReport.Value),
+            progressReport => Assert.IsType<WorkDoneProgressReport>(progressReport.Value),
+            progressReport => Assert.IsType<WorkDoneProgressEnd>(progressReport.Value));
+
+        Assert.Equal(EndMessage, ((WorkDoneProgressEnd)progressReports[2].Value).Message);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task ClientCancellingProgressDoesNotReceiveProgressEnd(bool mutatingLspWorkspace)
+    {
+        var clientCallbackTarget = new ClientCallbackTarget();
+        await using var server = await CreateTestServerAsync(mutatingLspWorkspace, clientCallbackTarget);
+
+        var requestTask = GetTestService(server).RunClientCancellationWorkDoneProgress();
+        var report = await clientCallbackTarget.WaitForReportAsync();
+
+        await server.ExecuteNotificationAsync(Methods.WindowWorkDoneProgressCancelName, new WorkDoneProgressCancelParams
+        {
+            Token = report.Token,
+        });
+
+        var response = await requestTask;
+
+        var progressReports = clientCallbackTarget.GetProgressReports();
+        Assert.Collection(
+            progressReports,
+            progressReport => Assert.IsType<WorkDoneProgressBegin>(progressReport.Value),
+            progressReport => Assert.IsType<WorkDoneProgressReport>(progressReport.Value));
+    }
+
+    [Theory, CombinatorialData]
+    public async Task ServerCancellationCancelsProgressOnClient(bool mutatingLspWorkspace)
+    {
+        var clientCallbackTarget = new ClientCallbackTarget();
+        await using var server = await CreateTestServerAsync(mutatingLspWorkspace, clientCallbackTarget);
+
+        var serverCancellationTokenSource = new CancellationTokenSource();
+        var requestTask = GetTestService(server).RunServerCancellationWorkDoneProgress(serverCancellationTokenSource.Token);
+        await clientCallbackTarget.WaitForReportAsync();
+
+        serverCancellationTokenSource.Cancel();
+
+        await clientCallbackTarget.WaitForServerCancelledAsync();
+        await requestTask;
+
+        var progressReports = clientCallbackTarget.GetProgressReports();
+        Assert.Collection(
+            progressReports,
+            progressReport => Assert.IsType<WorkDoneProgressBegin>(progressReport.Value),
+            progressReport => Assert.IsType<WorkDoneProgressReport>(progressReport.Value),
+            progressReport => Assert.IsType<WorkDoneProgressEnd>(progressReport.Value));
+
+        Assert.Equal(CancelledMessage, ((WorkDoneProgressEnd)progressReports[2].Value).Message);
+    }
+
+    private async Task<TestLspServer> CreateTestServerAsync(bool mutatingLspWorkspace, ClientCallbackTarget clientCallbackTarget)
+    {
+        var initializationOptions = new InitializationOptions
+        {
+            ClientCapabilities = new ClientCapabilities
+            {
+                Window = new WindowClientCapabilities
+                {
+                    WorkDoneProgress = true,
+                },
+            },
+            ClientTarget = clientCallbackTarget,
+            ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer,
+        };
+
+        return await CreateTestLspServerAsync(string.Empty, mutatingLspWorkspace, initializationOptions);
+    }
+
+    private static TestWorkDoneProgressService GetTestService(TestLspServer server)
+        => server.GetRequiredLspService<TestWorkDoneProgressService>();
+
+    [ExportCSharpVisualBasicLspServiceFactory(typeof(TestWorkDoneProgressService)), PartNotDiscoverable, Shared]
+    [method: ImportingConstructor]
+    [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    internal sealed class TestWorkDoneProgressServiceFactory() : ILspServiceFactory
+    {
+        public ILspService CreateILspService(LspServices lspServices, WellKnownLspServerKinds serverKind)
+            => new TestWorkDoneProgressService(lspServices.GetRequiredService<WorkDoneProgressManager>());
+    }
+
+    internal sealed class TestWorkDoneProgressService(WorkDoneProgressManager workDoneProgressManager) : ILspService
+    {
+        public async Task<bool> RunCompleteWorkDoneProgress()
+        {
+            await using var progress = await CreateProgressAndReport(CancellationToken.None);
+            return true;
+        }
+
+        public async Task<bool> RunThrowingWorkDoneProgress()
+        {
+            await using var progress = await CreateProgressAndReport(CancellationToken.None);
+            throw new InvalidOperationException("Test progress failed.");
+        }
+
+        public async Task<bool> RunClientCancellationWorkDoneProgress()
+        {
+            await using var progress = await CreateProgressAndReport(CancellationToken.None);
+            return await WaitForCancellationAsync(progress.CancellationToken);
+        }
+
+        public async Task<bool> RunServerCancellationWorkDoneProgress(CancellationToken serverCancellationToken)
+        {
+            await using var progress = await CreateProgressAndReport(serverCancellationToken);
+            return await WaitForCancellationAsync(serverCancellationToken);
+        }
+
+        private async Task<IWorkDoneProgressReporter> CreateProgressAndReport(CancellationToken cancellationToken)
+        {
+            var progress = await workDoneProgressManager.CreateWorkDoneProgressAsync(
+                reportProgressToClient: true,
+                title: Title,
+                startMessage: StartMessage,
+                endMessage: EndMessage,
+                clientCanCancel: true,
+                serverCancellationToken: cancellationToken);
+
+            progress.Report(new WorkDoneProgressReport
+            {
+                Message = ReportMessage,
+                Cancellable = true,
+                Percentage = 50,
+            });
+
+            return progress;
+        }
+
+        private static async Task<bool> WaitForCancellationAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                await Task.Delay(Timeout.Infinite, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+            }
+
+            return true;
+        }
+    }
+
+    private sealed class ClientCallbackTarget
+    {
+        private readonly object _gate = new();
+        private bool _createReceived = false;
+        private readonly TaskCompletionSource<ProgressReportParams> _reportSource = CreateTaskCompletionSource<ProgressReportParams>();
+        private readonly TaskCompletionSource<ProgressReportParams> _endSource = CreateTaskCompletionSource<ProgressReportParams>();
+        private readonly TaskCompletionSource<ProgressReportParams> _cancelledEndSource = CreateTaskCompletionSource<ProgressReportParams>();
+        private readonly List<ProgressReportParams> _progressReports = [];
+
+        [JsonRpcMethod(Methods.WindowWorkDoneProgressCreateName, UseSingleObjectParameterDeserialization = true)]
+        public Task HandleCreateWorkDoneProgressAsync(WorkDoneProgressCreateParams _, CancellationToken _1)
+        {
+            lock (_gate)
+            {
+                Contract.ThrowIfTrue(_createReceived, "Received multiple create progress calls.");
+                _createReceived = true;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        [JsonRpcMethod(Methods.ProgressNotificationName, UseSingleObjectParameterDeserialization = true)]
+        public Task HandleProgressAsync(JsonElement progressParams, CancellationToken _)
+        {
+            var progressReport = progressParams.Deserialize<ProgressReportParams>(ProtocolConversions.LspJsonSerializerOptions);
+
+            lock (_gate)
+            {
+                Contract.ThrowIfFalse(_createReceived, "Received progress report before create.");
+                _progressReports.Add(progressReport);
+                switch (progressReport.Value)
+                {
+                    case WorkDoneProgressReport:
+                        _reportSource.TrySetResult(progressReport);
+                        break;
+                    case WorkDoneProgressEnd { Message: EndMessage }:
+                        _endSource.TrySetResult(progressReport);
+                        break;
+                    case WorkDoneProgressEnd { Message: CancelledMessage }:
+                        _cancelledEndSource.TrySetResult(progressReport);
+                        break;
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public async Task<ProgressReportParams> WaitForReportAsync()
+            => await _reportSource.Task;
+
+        public async Task<ProgressReportParams> WaitForEndAsync()
+            => await _endSource.Task;
+
+        public async Task<ProgressReportParams> WaitForServerCancelledAsync()
+            => await _cancelledEndSource.Task;
+
+        public ImmutableArray<ProgressReportParams> GetProgressReports()
+        {
+            lock (_gate)
+            {
+                return [.. _progressReports];
+            }
+        }
+
+        private static TaskCompletionSource<T> CreateTaskCompletionSource<T>()
+            => new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    private readonly record struct ProgressReportParams(
+        [property: JsonPropertyName("token")] string Token,
+        [property: JsonPropertyName("value")] WorkDoneProgress Value);
+}

--- a/src/LanguageServer/ProtocolUnitTests/WorkDoneProgressTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/WorkDoneProgressTests.cs
@@ -109,7 +109,7 @@ public sealed class WorkDoneProgressTests : AbstractLanguageServerProtocolTests
 
         var serverCancellationTokenSource = new CancellationTokenSource();
 
-        // Task to hold open the progress on the server until we've observed client cancellation.
+        // Task to hold open the progress on the server until we've observed the server cancellation on the client.
         var serverProgressCompletionSource = new TaskCompletionSource<object?>();
         var requestTask = GetTestService(server).RunServerCancellationWorkDoneProgress(serverProgressCompletionSource, serverCancellationTokenSource.Token);
         await clientCallbackTarget.WaitForReportAsync();

--- a/src/LanguageServer/ProtocolUnitTests/WorkDoneProgressTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/WorkDoneProgressTests.cs
@@ -108,12 +108,18 @@ public sealed class WorkDoneProgressTests : AbstractLanguageServerProtocolTests
         await using var server = await CreateTestServerAsync(mutatingLspWorkspace, clientCallbackTarget);
 
         var serverCancellationTokenSource = new CancellationTokenSource();
-        var requestTask = GetTestService(server).RunServerCancellationWorkDoneProgress(serverCancellationTokenSource.Token);
+
+        // Task to hold open the progress on the server until we've observed client cancellation.
+        var serverProgressCompletionSource = new TaskCompletionSource<bool>();
+        var requestTask = GetTestService(server).RunServerCancellationWorkDoneProgress(serverProgressCompletionSource, serverCancellationTokenSource.Token);
         await clientCallbackTarget.WaitForReportAsync();
 
+        // Cancel the progress using the fake server cancellation token.  This should cause the client to receive a progress end with a cancellation message.
         serverCancellationTokenSource.Cancel();
-
         await clientCallbackTarget.WaitForServerCancelledAsync();
+
+        // Complete the server progress task to allow the server to finish and dispose of the progress reporter.
+        serverProgressCompletionSource.SetResult(true);
         await requestTask;
 
         var progressReports = clientCallbackTarget.GetProgressReports();
@@ -176,10 +182,12 @@ public sealed class WorkDoneProgressTests : AbstractLanguageServerProtocolTests
             return await WaitForCancellationAsync(progress.CancellationToken);
         }
 
-        public async Task<bool> RunServerCancellationWorkDoneProgress(CancellationToken serverCancellationToken)
+        public async Task<bool> RunServerCancellationWorkDoneProgress(TaskCompletionSource<bool> serverProgressCompletedSource, CancellationToken serverCancellationToken)
         {
             await using var progress = await CreateProgressAndReport(serverCancellationToken);
-            return await WaitForCancellationAsync(serverCancellationToken);
+            await WaitForCancellationAsync(serverCancellationToken);
+
+            return await serverProgressCompletedSource.Task;
         }
 
         private async Task<IWorkDoneProgressReporter> CreateProgressAndReport(CancellationToken cancellationToken)
@@ -248,14 +256,14 @@ public sealed class WorkDoneProgressTests : AbstractLanguageServerProtocolTests
                 _progressReports.Add(progressReport);
                 switch (progressReport.Value)
                 {
-                    case WorkDoneProgressReport:
-                        _reportSource.TrySetResult(progressReport);
-                        break;
                     case WorkDoneProgressEnd { Message: EndMessage }:
                         _endSource.TrySetResult(progressReport);
                         break;
                     case WorkDoneProgressEnd { Message: CancelledMessage }:
                         _cancelledEndSource.TrySetResult(progressReport);
+                        break;
+                    case WorkDoneProgressReport:
+                        _reportSource.TrySetResult(progressReport);
                         break;
                 }
             }

--- a/src/LanguageServer/ProtocolUnitTests/WorkDoneProgressTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/WorkDoneProgressTests.cs
@@ -30,7 +30,7 @@ public sealed class WorkDoneProgressTests : AbstractLanguageServerProtocolTests
     private const string StartMessage = "Starting";
     private const string ReportMessage = "Working";
     private const string EndMessage = "Finished";
-    private const string CancelledMessage = "Cancelled";
+    private static readonly string CancelledMessage = LanguageServerProtocolResources.Cancelled;
 
     public WorkDoneProgressTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
     {
@@ -44,7 +44,7 @@ public sealed class WorkDoneProgressTests : AbstractLanguageServerProtocolTests
         var clientCallbackTarget = new ClientCallbackTarget();
         await using var server = await CreateTestServerAsync(mutatingLspWorkspace, clientCallbackTarget);
 
-        var response = await GetTestService(server).RunCompleteWorkDoneProgress();
+        await GetTestService(server).RunCompleteWorkDoneProgress();
 
         var end = await clientCallbackTarget.WaitForEndAsync();
         var progressReports = clientCallbackTarget.GetProgressReports();
@@ -92,7 +92,7 @@ public sealed class WorkDoneProgressTests : AbstractLanguageServerProtocolTests
             Token = report.Token,
         });
 
-        var response = await requestTask;
+        await requestTask;
 
         var progressReports = clientCallbackTarget.GetProgressReports();
         Assert.Collection(
@@ -110,7 +110,7 @@ public sealed class WorkDoneProgressTests : AbstractLanguageServerProtocolTests
         var serverCancellationTokenSource = new CancellationTokenSource();
 
         // Task to hold open the progress on the server until we've observed client cancellation.
-        var serverProgressCompletionSource = new TaskCompletionSource<bool>();
+        var serverProgressCompletionSource = new TaskCompletionSource<object?>();
         var requestTask = GetTestService(server).RunServerCancellationWorkDoneProgress(serverProgressCompletionSource, serverCancellationTokenSource.Token);
         await clientCallbackTarget.WaitForReportAsync();
 
@@ -119,7 +119,7 @@ public sealed class WorkDoneProgressTests : AbstractLanguageServerProtocolTests
         await clientCallbackTarget.WaitForServerCancelledAsync();
 
         // Complete the server progress task to allow the server to finish and dispose of the progress reporter.
-        serverProgressCompletionSource.SetResult(true);
+        serverProgressCompletionSource.SetResult(null);
         await requestTask;
 
         var progressReports = clientCallbackTarget.GetProgressReports();
@@ -164,30 +164,29 @@ public sealed class WorkDoneProgressTests : AbstractLanguageServerProtocolTests
 
     internal sealed class TestWorkDoneProgressService(WorkDoneProgressManager workDoneProgressManager) : ILspService
     {
-        public async Task<bool> RunCompleteWorkDoneProgress()
+        public async Task RunCompleteWorkDoneProgress()
         {
             await using var progress = await CreateProgressAndReport(CancellationToken.None);
-            return true;
         }
 
-        public async Task<bool> RunThrowingWorkDoneProgress()
+        public async Task RunThrowingWorkDoneProgress()
         {
             await using var progress = await CreateProgressAndReport(CancellationToken.None);
             throw new InvalidOperationException("Test progress failed.");
         }
 
-        public async Task<bool> RunClientCancellationWorkDoneProgress()
+        public async Task RunClientCancellationWorkDoneProgress()
         {
             await using var progress = await CreateProgressAndReport(CancellationToken.None);
-            return await WaitForCancellationAsync(progress.CancellationToken);
+            await WaitForCancellationAsync(progress.CancellationToken);
         }
 
-        public async Task<bool> RunServerCancellationWorkDoneProgress(TaskCompletionSource<bool> serverProgressCompletedSource, CancellationToken serverCancellationToken)
+        public async Task RunServerCancellationWorkDoneProgress(TaskCompletionSource<object?> serverProgressCompletedSource, CancellationToken serverCancellationToken)
         {
             await using var progress = await CreateProgressAndReport(serverCancellationToken);
             await WaitForCancellationAsync(serverCancellationToken);
 
-            return await serverProgressCompletedSource.Task;
+            await serverProgressCompletedSource.Task;
         }
 
         private async Task<IWorkDoneProgressReporter> CreateProgressAndReport(CancellationToken cancellationToken)
@@ -210,7 +209,7 @@ public sealed class WorkDoneProgressTests : AbstractLanguageServerProtocolTests
             return progress;
         }
 
-        private static async Task<bool> WaitForCancellationAsync(CancellationToken cancellationToken)
+        private static async Task WaitForCancellationAsync(CancellationToken cancellationToken)
         {
             try
             {
@@ -219,8 +218,6 @@ public sealed class WorkDoneProgressTests : AbstractLanguageServerProtocolTests
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
             }
-
-            return true;
         }
     }
 
@@ -228,9 +225,9 @@ public sealed class WorkDoneProgressTests : AbstractLanguageServerProtocolTests
     {
         private readonly object _gate = new();
         private bool _createReceived = false;
-        private readonly TaskCompletionSource<ProgressReportParams> _reportSource = CreateTaskCompletionSource<ProgressReportParams>();
-        private readonly TaskCompletionSource<ProgressReportParams> _endSource = CreateTaskCompletionSource<ProgressReportParams>();
-        private readonly TaskCompletionSource<ProgressReportParams> _cancelledEndSource = CreateTaskCompletionSource<ProgressReportParams>();
+        private readonly TaskCompletionSource<ProgressReportParams> _reportSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<ProgressReportParams> _endSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<ProgressReportParams> _cancelledEndSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly List<ProgressReportParams> _progressReports = [];
 
         [JsonRpcMethod(Methods.WindowWorkDoneProgressCreateName, UseSingleObjectParameterDeserialization = true)]
@@ -259,7 +256,7 @@ public sealed class WorkDoneProgressTests : AbstractLanguageServerProtocolTests
                     case WorkDoneProgressEnd { Message: EndMessage }:
                         _endSource.TrySetResult(progressReport);
                         break;
-                    case WorkDoneProgressEnd { Message: CancelledMessage }:
+                    case WorkDoneProgressEnd { Message: var message } when message == CancelledMessage:
                         _cancelledEndSource.TrySetResult(progressReport);
                         break;
                     case WorkDoneProgressReport:
@@ -287,9 +284,6 @@ public sealed class WorkDoneProgressTests : AbstractLanguageServerProtocolTests
                 return [.. _progressReports];
             }
         }
-
-        private static TaskCompletionSource<T> CreateTaskCompletionSource<T>()
-            => new(TaskCreationOptions.RunContinuationsAsynchronously);
     }
 
     private readonly record struct ProgressReportParams(


### PR DESCRIPTION
Previously, the API for work done progress on our side required the caller to handle calling end.  This was not done for project initialization, so end never got sent.  This changes the work done progress API to automatically call end on dispose instead.

Also added tests.

```
2026-05-14T01:48:48.714Z [DEBUG] LSP csharp server for C:\Users\dabarbet\source\repos\trash\CopilotCLILocalRoslyn: Progress started: Loading 1 projects... - Loading 1 projects...
2026-05-14T01:48:48.726Z [DEBUG] LSP csharp server for C:\Users\dabarbet\source\repos\trash\CopilotCLILocalRoslyn: Progress complete: Loaded 1 projects
```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83686)