### PR TITLE
Fix racecondition on UnsuedDirectiveCache.Set

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Diagnostics/UnusedDirectiveCache.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Diagnostics/UnusedDirectiveCache.cs
@@ -13,8 +13,15 @@ internal static class UnusedDirectiveCache
 
     public static void Set(RazorCodeDocument codeDocument, TextSpan[] spans)
     {
-        s_cache.Remove(codeDocument);
-        s_cache.Add(codeDocument, spans);
+#if NET
+        s_cache.AddOrUpdate(codeDocument, spans);
+#else
+        lock (s_cache)
+        {
+            s_cache.Remove(codeDocument);
+            s_cache.Add(codeDocument, spans);
+        }
+#endif
     }
 
     public static bool TryGet(RazorCodeDocument codeDocument, out TextSpan[] spans)


### PR DESCRIPTION
* Call threadsafe `AddOrUpdate` method
* Fallback for legacy netstandard2.0 and net472 which arent capable of `AddOrUpdate`

Closes #83692 