### PR TITLE
Reduce SumConverter exceptions by peeking at array element types

### DIFF
--- a/src/LanguageServer/Protocol/Protocol/Converters/SumConverter.cs
+++ b/src/LanguageServer/Protocol/Protocol/Converters/SumConverter.cs
@@ -10,15 +10,15 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.LanguageServer;
 
 namespace Roslyn.LanguageServer.Protocol;
 
 internal sealed class SumConverter : JsonConverterFactory
 {
-    // These caches are defined on the non-generic class so they are shared across all
+    // This cache is defined on the non-generic class so it is shared across all
     // SumConverter<T> instantiations rather than duplicated per generic type argument.
-    internal static readonly ConcurrentDictionary<Type, bool> HasCustomJsonConverterCache = new();
     internal static readonly ConcurrentDictionary<Type, SumTypeInfoCache> SumTypeCache = new();
 
     public override bool CanConvert(Type typeToConvert)
@@ -229,29 +229,39 @@ internal sealed class SumConverter<T> : JsonConverter<T>
                 }
             }
 
+            // Track which arms were skipped by token filtering so pass 2 only retries those.
+            using var _ = ArrayBuilder<SumConverter.SumTypeInfoCache.UnionTypeInfo>.GetInstance(out var untestedArms);
+
+            // Pass 1: Try only token-compatible arms (avoids costly exception-based probing)
             for (var i = 0; i < applicableUnionTypeInfos.Count; i++)
             {
                 var unionTypeInfo = applicableUnionTypeInfos[i];
-
-                if (!IsTokenCompatibleWithType(ref reader, unionTypeInfo))
-                {
-                    continue;
-                }
 
                 if (unionTypeInfo.KindAttribute != null)
                 {
                     continue;
                 }
 
-                try
+                if (!IsTokenCompatibleWithType(ref reader, unionTypeInfo))
                 {
-                    var result = ((SumConverter.SumTypeInfoCache.UnionTypeInfo.StjReader<T>)unionTypeInfo.StjReaderFunction).Invoke(ref reader, options);
+                    untestedArms.Add(unionTypeInfo);
+                    continue;
+                }
+
+                if (TryDeserializeArm(ref reader, backupReader, unionTypeInfo, options, out var result))
+                {
                     return result;
                 }
-                catch
+            }
+
+            // Pass 2: If no token-compatible arm succeeded, fall back to trying untested arms.
+            // This handles types whose converters accept unexpected token types (e.g.,
+            // converters registered at the property level or via JsonSerializerOptions).
+            for (var i = 0; i < untestedArms.Count; i++)
+            {
+                if (TryDeserializeArm(ref reader, backupReader, untestedArms[i], options, out var result))
                 {
-                    reader = backupReader;
-                    continue;
+                    return result;
                 }
             }
         }
@@ -284,6 +294,21 @@ internal sealed class SumConverter<T> : JsonConverter<T>
         }
     }
 
+    private static bool TryDeserializeArm(ref Utf8JsonReader reader, Utf8JsonReader backupReader, SumConverter.SumTypeInfoCache.UnionTypeInfo unionTypeInfo, JsonSerializerOptions options, out T result)
+    {
+        try
+        {
+            result = ((SumConverter.SumTypeInfoCache.UnionTypeInfo.StjReader<T>)unionTypeInfo.StjReaderFunction).Invoke(ref reader, options);
+            return true;
+        }
+        catch
+        {
+            reader = backupReader;
+            result = default!;
+            return false;
+        }
+    }
+
     private static bool IsTokenCompatibleWithType(ref Utf8JsonReader reader, SumConverter.SumTypeInfoCache.UnionTypeInfo unionTypeInfo)
     {
         return IsTokenCompatibleWithType(ref reader, unionTypeInfo.Type);
@@ -291,14 +316,6 @@ internal sealed class SumConverter<T> : JsonConverter<T>
 
     private static bool IsTokenCompatibleWithType(ref Utf8JsonReader reader, Type type)
     {
-        // If the type has a custom JsonConverter (e.g., nested SumType elements), we can't
-        // reason about token compatibility since the converter may accept multiple
-        // token types. Treat as compatible and let the normal try/catch handle it.
-        if (HasCustomJsonConverterAttribute(type))
-        {
-            return true;
-        }
-
         return reader.TokenType switch
         {
             JsonTokenType.True or JsonTokenType.False => IsBooleanType(type),
@@ -339,11 +356,6 @@ internal sealed class SumConverter<T> : JsonConverter<T>
                type == typeof(short) || type == typeof(ushort) ||
                type == typeof(byte) || type == typeof(sbyte) ||
                type == typeof(double) || type == typeof(float);
-    }
-
-    private static bool HasCustomJsonConverterAttribute(Type type)
-    {
-        return SumConverter.HasCustomJsonConverterCache.GetOrAdd(type, static t => t.GetCustomAttribute<JsonConverterAttribute>() is not null);
     }
 
     /// <summary>

--- a/src/LanguageServer/Protocol/Protocol/Converters/SumConverter.cs
+++ b/src/LanguageServer/Protocol/Protocol/Converters/SumConverter.cs
@@ -16,6 +16,11 @@ namespace Roslyn.LanguageServer.Protocol;
 
 internal sealed class SumConverter : JsonConverterFactory
 {
+    // These caches are defined on the non-generic class so they are shared across all
+    // SumConverter<T> instantiations rather than duplicated per generic type argument.
+    internal static readonly ConcurrentDictionary<Type, bool> HasCustomJsonConverterCache = new();
+    internal static readonly ConcurrentDictionary<Type, SumTypeInfoCache> SumTypeCache = new();
+
     public override bool CanConvert(Type typeToConvert)
     {
         return typeof(ISumType).IsAssignableFrom(typeToConvert);
@@ -182,7 +187,6 @@ internal sealed class SumConverter : JsonConverterFactory
 internal sealed class SumConverter<T> : JsonConverter<T>
     where T : struct, ISumType
 {
-    private static readonly ConcurrentDictionary<Type, SumConverter.SumTypeInfoCache> SumTypeCache = new();
 
     /// <inheritdoc/>
     public override T Read(ref Utf8JsonReader reader, Type objectType, JsonSerializerOptions options)
@@ -195,7 +199,7 @@ internal sealed class SumConverter<T> : JsonConverter<T>
 
         // objectType will be one of the various SumType variants. In order for this converter to work with all SumTypes it has to use reflection.
         // This method works by attempting to deserialize the json into each of the type parameters to a SumType and stops at the first success.
-        var sumTypeInfoCache = SumTypeCache.GetOrAdd(objectType, (t) => new SumConverter.SumTypeInfoCache(t));
+        var sumTypeInfoCache = SumConverter.SumTypeCache.GetOrAdd(objectType, (t) => new SumConverter.SumTypeInfoCache(t));
 
         var applicableUnionTypeInfos = sumTypeInfoCache.GetApplicableInfos(reader.TokenType);
         if (applicableUnionTypeInfos.Count > 0)
@@ -287,10 +291,10 @@ internal sealed class SumConverter<T> : JsonConverter<T>
 
     private static bool IsTokenCompatibleWithType(ref Utf8JsonReader reader, Type type)
     {
-        // If the type has a custom JsonConverter (e.g., SumType elements), we can't
+        // If the type has a custom JsonConverter (e.g., nested SumType elements), we can't
         // reason about token compatibility since the converter may accept multiple
         // token types. Treat as compatible and let the normal try/catch handle it.
-        if (type.GetCustomAttribute<JsonConverterAttribute>() is not null)
+        if (HasCustomJsonConverterAttribute(type))
         {
             return true;
         }
@@ -340,6 +344,11 @@ internal sealed class SumConverter<T> : JsonConverter<T>
                type == typeof(short) || type == typeof(ushort) ||
                type == typeof(byte) || type == typeof(sbyte) ||
                type == typeof(double) || type == typeof(float);
+    }
+
+    private static bool HasCustomJsonConverterAttribute(Type type)
+    {
+        return SumConverter.HasCustomJsonConverterCache.GetOrAdd(type, static t => t.GetCustomAttribute<JsonConverterAttribute>() is not null);
     }
 
     /// <summary>

--- a/src/LanguageServer/Protocol/Protocol/Converters/SumConverter.cs
+++ b/src/LanguageServer/Protocol/Protocol/Converters/SumConverter.cs
@@ -321,7 +321,7 @@ internal sealed class SumConverter<T> : JsonConverter<T>
             JsonTokenType.True or JsonTokenType.False => IsBooleanType(type),
             JsonTokenType.Number => IsNumericType(type),
             JsonTokenType.String => IsStringLikeType(type),
-            JsonTokenType.StartObject => !IsSerializedAsJsonPrimitiveType(type),
+            JsonTokenType.StartObject => !IsSerializedAsJsonPrimitiveType(type) && !type.IsArray,
             JsonTokenType.StartArray => IsArrayElementCompatible(ref reader, type),
             _ => true,
         };
@@ -355,7 +355,8 @@ internal sealed class SumConverter<T> : JsonConverter<T>
                type == typeof(long) || type == typeof(ulong) ||
                type == typeof(short) || type == typeof(ushort) ||
                type == typeof(byte) || type == typeof(sbyte) ||
-               type == typeof(double) || type == typeof(float);
+               type == typeof(double) || type == typeof(float) ||
+               type == typeof(decimal);
     }
 
     /// <summary>

--- a/src/LanguageServer/Protocol/Protocol/Converters/SumConverter.cs
+++ b/src/LanguageServer/Protocol/Protocol/Converters/SumConverter.cs
@@ -287,6 +287,14 @@ internal sealed class SumConverter<T> : JsonConverter<T>
 
     private static bool IsTokenCompatibleWithType(ref Utf8JsonReader reader, Type type)
     {
+        // If the type has a custom JsonConverter (e.g., SumType elements), we can't
+        // reason about token compatibility since the converter may accept multiple
+        // token types. Treat as compatible and let the normal try/catch handle it.
+        if (type.GetCustomAttribute<JsonConverterAttribute>() is not null)
+        {
+            return true;
+        }
+
         return reader.TokenType switch
         {
             JsonTokenType.True or JsonTokenType.False
@@ -341,14 +349,6 @@ internal sealed class SumConverter<T> : JsonConverter<T>
         }
 
         var elementType = arrayType.GetElementType()!;
-
-        // If the element type has a custom JsonConverter (e.g., SumType elements),
-        // we can't reason about token compatibility since the converter may accept
-        // multiple token types. Let the normal try/catch handle it.
-        if (elementType.GetCustomAttribute<JsonConverterAttribute>() is not null)
-        {
-            return true;
-        }
 
         // Peek at first array element to disambiguate array types.
         var peekReader = reader;

--- a/src/LanguageServer/Protocol/Protocol/Converters/SumConverter.cs
+++ b/src/LanguageServer/Protocol/Protocol/Converters/SumConverter.cs
@@ -342,11 +342,19 @@ internal sealed class SumConverter<T> : JsonConverter<T>
 
         var elementType = arrayType.GetElementType()!;
 
+        // If the element type has a custom JsonConverter (e.g., SumType elements),
+        // we can't reason about token compatibility since the converter may accept
+        // multiple token types. Let the normal try/catch handle it.
+        if (elementType.GetCustomAttribute<JsonConverterAttribute>() is not null)
+        {
+            return true;
+        }
+
         // Peek at first array element to disambiguate array types.
         var peekReader = reader;
         if (!peekReader.Read())
         {
-            // Can't read into the array — let the normal try/catch handle it.
+            // Can't read into the array, let the normal try/catch handle it.
             return true;
         }
 

--- a/src/LanguageServer/Protocol/Protocol/Converters/SumConverter.cs
+++ b/src/LanguageServer/Protocol/Protocol/Converters/SumConverter.cs
@@ -301,16 +301,11 @@ internal sealed class SumConverter<T> : JsonConverter<T>
 
         return reader.TokenType switch
         {
-            JsonTokenType.True or JsonTokenType.False
-                => IsBooleanType(type),
-            JsonTokenType.Number
-                => IsNumericType(type),
-            JsonTokenType.String
-                => IsStringLikeType(type),
-            JsonTokenType.StartObject
-                => !IsSerializedAsJsonPrimitiveType(type),
-            JsonTokenType.StartArray
-                => IsArrayElementCompatible(ref reader, type),
+            JsonTokenType.True or JsonTokenType.False => IsBooleanType(type),
+            JsonTokenType.Number => IsNumericType(type),
+            JsonTokenType.String => IsStringLikeType(type),
+            JsonTokenType.StartObject => !IsSerializedAsJsonPrimitiveType(type),
+            JsonTokenType.StartArray => IsArrayElementCompatible(ref reader, type),
             _ => true,
         };
     }

--- a/src/LanguageServer/Protocol/Protocol/Converters/SumConverter.cs
+++ b/src/LanguageServer/Protocol/Protocol/Converters/SumConverter.cs
@@ -282,33 +282,80 @@ internal sealed class SumConverter<T> : JsonConverter<T>
 
     private static bool IsTokenCompatibleWithType(ref Utf8JsonReader reader, SumConverter.SumTypeInfoCache.UnionTypeInfo unionTypeInfo)
     {
-        var isCompatible = true;
-        switch (reader.TokenType)
+        return IsTokenCompatibleWithType(ref reader, unionTypeInfo.Type);
+    }
+
+    private static bool IsTokenCompatibleWithType(ref Utf8JsonReader reader, Type type)
+    {
+        return reader.TokenType switch
         {
-            case JsonTokenType.True:
-            case JsonTokenType.False:
-                isCompatible = unionTypeInfo.Type == typeof(bool);
-                break;
-            case JsonTokenType.Number:
-                isCompatible = unionTypeInfo.Type == typeof(int) ||
-                               unionTypeInfo.Type == typeof(uint) ||
-                               unionTypeInfo.Type == typeof(long) ||
-                               unionTypeInfo.Type == typeof(ulong) ||
-                               unionTypeInfo.Type == typeof(short) ||
-                               unionTypeInfo.Type == typeof(ushort) ||
-                               unionTypeInfo.Type == typeof(byte) ||
-                               unionTypeInfo.Type == typeof(sbyte) ||
-                               unionTypeInfo.Type == typeof(double) ||
-                               unionTypeInfo.Type == typeof(float);
-                break;
-            case JsonTokenType.String:
-                isCompatible = unionTypeInfo.Type == typeof(string) ||
-                               unionTypeInfo.Type == typeof(Uri) ||
-                               unionTypeInfo.Type == typeof(DocumentUri) ||
-                               typeof(IStringEnum).IsAssignableFrom(unionTypeInfo.Type);
-                break;
+            JsonTokenType.True or JsonTokenType.False
+                => type == typeof(bool),
+            JsonTokenType.Number
+                => type == typeof(int) || type == typeof(uint) ||
+                   type == typeof(long) || type == typeof(ulong) ||
+                   type == typeof(short) || type == typeof(ushort) ||
+                   type == typeof(byte) || type == typeof(sbyte) ||
+                   type == typeof(double) || type == typeof(float),
+            JsonTokenType.String
+                => type == typeof(string) ||
+                   type == typeof(Uri) ||
+                   type == typeof(DocumentUri) ||
+                   typeof(IStringEnum).IsAssignableFrom(type),
+            JsonTokenType.StartObject
+                => !IsSerializedAsJsonPrimitiveType(type),
+            JsonTokenType.StartArray
+                => IsArrayElementCompatible(ref reader, type),
+            _ => true,
+        };
+    }
+
+    /// <summary>
+    /// Returns true for types that are serialized as JSON primitives (strings, numbers, booleans)
+    /// rather than JSON objects. Used by array element peeking to reject incompatible element types.
+    /// </summary>
+    private static bool IsSerializedAsJsonPrimitiveType(Type type)
+    {
+        return type == typeof(bool) ||
+               type == typeof(string) ||
+               type == typeof(Uri) ||
+               type == typeof(DocumentUri) ||
+               typeof(IStringEnum).IsAssignableFrom(type) ||
+               type == typeof(int) || type == typeof(uint) ||
+               type == typeof(long) || type == typeof(ulong) ||
+               type == typeof(short) || type == typeof(ushort) ||
+               type == typeof(byte) || type == typeof(sbyte) ||
+               type == typeof(double) || type == typeof(float);
+    }
+
+    /// <summary>
+    /// For array SumType variants, peeks at the first array element to determine compatibility.
+    /// This avoids costly exception-based type probing (e.g., trying to deserialize
+    /// VSInternalCommitCharacter[] as string[] which throws InvalidOperationException per attempt).
+    /// </summary>
+    private static bool IsArrayElementCompatible(ref Utf8JsonReader reader, Type arrayType)
+    {
+        if (!arrayType.IsArray)
+        {
+            return false;
         }
 
-        return isCompatible;
+        var elementType = arrayType.GetElementType()!;
+
+        // Peek at first array element to disambiguate array types.
+        var peekReader = reader;
+        if (!peekReader.Read())
+        {
+            // Can't read into the array — let the normal try/catch handle it.
+            return true;
+        }
+
+        // Empty array is compatible with any array type.
+        if (peekReader.TokenType == JsonTokenType.EndArray)
+        {
+            return true;
+        }
+
+        return IsTokenCompatibleWithType(ref peekReader, elementType);
     }
 }

--- a/src/LanguageServer/Protocol/Protocol/Converters/SumConverter.cs
+++ b/src/LanguageServer/Protocol/Protocol/Converters/SumConverter.cs
@@ -298,18 +298,11 @@ internal sealed class SumConverter<T> : JsonConverter<T>
         return reader.TokenType switch
         {
             JsonTokenType.True or JsonTokenType.False
-                => type == typeof(bool),
+                => IsBooleanType(type),
             JsonTokenType.Number
-                => type == typeof(int) || type == typeof(uint) ||
-                   type == typeof(long) || type == typeof(ulong) ||
-                   type == typeof(short) || type == typeof(ushort) ||
-                   type == typeof(byte) || type == typeof(sbyte) ||
-                   type == typeof(double) || type == typeof(float),
+                => IsNumericType(type),
             JsonTokenType.String
-                => type == typeof(string) ||
-                   type == typeof(Uri) ||
-                   type == typeof(DocumentUri) ||
-                   typeof(IStringEnum).IsAssignableFrom(type),
+                => IsStringLikeType(type),
             JsonTokenType.StartObject
                 => !IsSerializedAsJsonPrimitiveType(type),
             JsonTokenType.StartArray
@@ -320,16 +313,29 @@ internal sealed class SumConverter<T> : JsonConverter<T>
 
     /// <summary>
     /// Returns true for types that are serialized as JSON primitives (strings, numbers, booleans)
-    /// rather than JSON objects. Used by array element peeking to reject incompatible element types.
+    /// rather than JSON objects. Used to reject incompatible types for StartObject tokens.
     /// </summary>
     private static bool IsSerializedAsJsonPrimitiveType(Type type)
     {
-        return type == typeof(bool) ||
-               type == typeof(string) ||
+        return IsBooleanType(type) || IsStringLikeType(type) || IsNumericType(type);
+    }
+
+    private static bool IsBooleanType(Type type)
+    {
+        return type == typeof(bool);
+    }
+
+    private static bool IsStringLikeType(Type type)
+    {
+        return type == typeof(string) ||
                type == typeof(Uri) ||
                type == typeof(DocumentUri) ||
-               typeof(IStringEnum).IsAssignableFrom(type) ||
-               type == typeof(int) || type == typeof(uint) ||
+               typeof(IStringEnum).IsAssignableFrom(type);
+    }
+
+    private static bool IsNumericType(Type type)
+    {
+        return type == typeof(int) || type == typeof(uint) ||
                type == typeof(long) || type == typeof(ulong) ||
                type == typeof(short) || type == typeof(ushort) ||
                type == typeof(byte) || type == typeof(sbyte) ||

--- a/src/LanguageServer/ProtocolUnitTests/Converters/SumConverterTypeFilteringTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Converters/SumConverterTypeFilteringTests.cs
@@ -101,6 +101,28 @@ public sealed class SumConverterTypeFilteringTests
         Assert.Equal("hello", str);
     }
 
+    [Fact]
+    public void Deserialize_ArrayWithOptionsRegisteredElementConverter_MatchesViaFallback()
+    {
+        // StringWrapper has no type-level [JsonConverter], so IsTokenCompatibleWithType
+        // sees a String element token and rejects StringWrapper[] (StringWrapper isn't
+        // string/Uri/etc.). int[] is also rejected (Number != String token).
+        // Pass 1 skips both; pass 2 retries and StringWrapper[] succeeds because the
+        // converter registered via options handles String tokens for StringWrapper.
+        // Without the two-pass approach, this would throw "No sum type match".
+        var json = """{"value": ["hello", "world"]}""";
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new StringWrapperConverter());
+
+        var result = JsonSerializer.Deserialize<IntOrStringWrapperArrayHolder>(json, options);
+
+        Assert.NotNull(result);
+        Assert.True(result.Value.TryGetSecond(out var wrappers));
+        Assert.Equal(2, wrappers.Length);
+        Assert.Equal("hello", wrappers[0].Text);
+        Assert.Equal("world", wrappers[1].Text);
+    }
+
     /// <summary>
     /// Deserializes JSON while asserting that no exceptions are thrown internally.
     /// This verifies that the type filtering logic is actually skipping incompatible
@@ -160,5 +182,33 @@ public sealed class SumConverterTypeFilteringTests
     {
         [JsonPropertyName("value")]
         public SumType<SumType<string, int>[], bool> Value { get; set; }
+    }
+
+    private sealed class IntOrStringWrapperArrayHolder
+    {
+        [JsonPropertyName("value")]
+        public SumType<int[], StringWrapper[]> Value { get; set; }
+    }
+
+    /// <summary>
+    /// A type with no [JsonConverter] attribute. Its converter is registered via
+    /// JsonSerializerOptions to test the two-pass fallback for options-level converters.
+    /// </summary>
+    internal sealed class StringWrapper
+    {
+        public string Text { get; set; } = string.Empty;
+    }
+
+    private sealed class StringWrapperConverter : JsonConverter<StringWrapper>
+    {
+        public override StringWrapper Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return new StringWrapper { Text = reader.GetString()! };
+        }
+
+        public override void Write(Utf8JsonWriter writer, StringWrapper value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.Text);
+        }
     }
 }

--- a/src/LanguageServer/ProtocolUnitTests/Converters/SumConverterTypeFilteringTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Converters/SumConverterTypeFilteringTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Converters;
 /// type probing by rejecting incompatible SumType arms based on the JSON token type.
 /// This includes StartObject rejection for primitive types and array element peeking.
 /// </summary>
-public class SumConverterTypeFilteringTests
+public sealed class SumConverterTypeFilteringTests
 {
     [Fact]
     public void Deserialize_StringArray_MatchesStringArrayArm()

--- a/src/LanguageServer/ProtocolUnitTests/Converters/SumConverterTypeFilteringTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Converters/SumConverterTypeFilteringTests.cs
@@ -1,14 +1,16 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;
 using System.Runtime.ExceptionServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Roslyn.LanguageServer.Protocol;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.Razor.Serialization;
+namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Converters;
 
 /// <summary>
 /// Tests for SumConverter's type filtering logic, which avoids costly exception-based

--- a/src/LanguageServer/ProtocolUnitTests/Converters/SumConverterTypeFilteringTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Converters/SumConverterTypeFilteringTests.cs
@@ -12,6 +12,9 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Converters;
 
+[CollectionDefinition("SumConverterTypeFiltering", DisableParallelization = true)]
+public class SumConverterTypeFilteringCollection;
+
 /// <summary>
 /// Tests for SumConverter's type filtering logic, which avoids costly exception-based
 /// type probing by rejecting incompatible SumType arms based on the JSON token type.

--- a/src/LanguageServer/ProtocolUnitTests/Converters/SumConverterTypeFilteringTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Converters/SumConverterTypeFilteringTests.cs
@@ -12,15 +12,11 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Converters;
 
-[CollectionDefinition("SumConverterTypeFiltering", DisableParallelization = true)]
-public class SumConverterTypeFilteringCollection;
-
 /// <summary>
 /// Tests for SumConverter's type filtering logic, which avoids costly exception-based
 /// type probing by rejecting incompatible SumType arms based on the JSON token type.
 /// This includes StartObject rejection for primitive types and array element peeking.
 /// </summary>
-[Collection("SumConverterTypeFiltering")]
 public class SumConverterTypeFilteringTests
 {
     [Fact]
@@ -113,7 +109,12 @@ public class SumConverterTypeFilteringTests
     private static T DeserializeWithNoExceptions<T>(string json)
     {
         var exceptions = new List<Exception>();
-        void handler(object? sender, FirstChanceExceptionEventArgs e) => exceptions.Add(e.Exception);
+        var threadId = Environment.CurrentManagedThreadId;
+        void handler(object? sender, FirstChanceExceptionEventArgs e)
+        {
+            if (Environment.CurrentManagedThreadId == threadId)
+                exceptions.Add(e.Exception);
+        }
 
         AppDomain.CurrentDomain.FirstChanceException += handler;
         try

--- a/src/LanguageServer/ProtocolUnitTests/Converters/SumConverterTypeFilteringTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Converters/SumConverterTypeFilteringTests.cs
@@ -102,6 +102,23 @@ public sealed class SumConverterTypeFilteringTests
     }
 
     [Fact]
+    public void Deserialize_ObjectArray_SkipsNestedArrayTypeArm()
+    {
+        // Array element peeking sees a StartObject token in the first element.
+        // int[][] should be rejected because its element type (int[]) is an array
+        // and a JSON object can never deserialize into an array type. Without the
+        // !type.IsArray check on the StartObject case, int[] would pass the filter
+        // (it's not a primitive type) causing an unnecessary deserialization attempt.
+        var json = """{"value": [{"name": "a"}, {"name": "b"}]}""";
+        var result = DeserializeWithNoExceptions<NestedIntArrayOrObjectArrayHolder>(json);
+
+        Assert.True(result.Value.TryGetSecond(out var objects));
+        Assert.Equal(2, objects.Length);
+        Assert.Equal("a", objects[0].Name);
+        Assert.Equal("b", objects[1].Name);
+    }
+
+    [Fact]
     public void Deserialize_ArrayWithOptionsRegisteredElementConverter_MatchesViaFallback()
     {
         // StringWrapper has no type-level [JsonConverter], so IsTokenCompatibleWithType
@@ -188,6 +205,18 @@ public sealed class SumConverterTypeFilteringTests
     {
         [JsonPropertyName("value")]
         public SumType<int[], StringWrapper[]> Value { get; set; }
+    }
+
+    private sealed class NestedIntArrayOrObjectArrayHolder
+    {
+        [JsonPropertyName("value")]
+        public SumType<int[][], SimpleObject[]> Value { get; set; }
+    }
+
+    internal sealed class SimpleObject
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
     }
 
     /// <summary>

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Serialization/SumConverterTypeFilteringTests.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Serialization/SumConverterTypeFilteringTests.cs
@@ -1,0 +1,136 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.ExceptionServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Razor.Serialization;
+
+/// <summary>
+/// Tests for SumConverter's type filtering logic, which avoids costly exception-based
+/// type probing by rejecting incompatible SumType arms based on the JSON token type.
+/// This includes StartObject rejection for primitive types and array element peeking.
+/// </summary>
+public class SumConverterTypeFilteringTests
+{
+    [Fact]
+    public void Deserialize_StringArray_MatchesStringArrayArm()
+    {
+        var json = """{"value": ["a", "b", "c"]}""";
+        var result = DeserializeWithNoExceptions<StringOrVSInternalCommitCharacterArrayHolder>(json);
+
+        Assert.True(result.Value.TryGetFirst(out var strings));
+        Assert.Equal(["a", "b", "c"], strings);
+    }
+
+    [Fact]
+    public void Deserialize_ObjectArray_MatchesObjectArrayArm()
+    {
+        var json = """{"value": [{"_vs_character": "x", "_vs_insert": false}]}""";
+        var result = DeserializeWithNoExceptions<StringOrVSInternalCommitCharacterArrayHolder>(json);
+
+        Assert.True(result.Value.TryGetSecond(out var objects));
+        Assert.Single(objects);
+        Assert.Equal("x", objects[0].Character);
+        Assert.False(objects[0].Insert);
+    }
+
+    [Fact]
+    public void Deserialize_EmptyArray_MatchesFirstArrayArm()
+    {
+        var json = """{"value": []}""";
+        var result = DeserializeWithNoExceptions<StringOrVSInternalCommitCharacterArrayHolder>(json);
+
+        // Empty array is compatible with any array type; first arm wins.
+        Assert.True(result.Value.TryGetFirst(out _));
+    }
+
+    [Fact]
+    public void Deserialize_NumberArray_MatchesIntArrayArm()
+    {
+        var json = """{"value": [1, 2, 3]}""";
+        var result = DeserializeWithNoExceptions<IntOrStringArrayHolder>(json);
+
+        Assert.True(result.Value.TryGetFirst(out var ints));
+        Assert.Equal([1, 2, 3], ints);
+    }
+
+    [Fact]
+    public void Deserialize_NumberArray_DoesNotMatchStringArrayArm()
+    {
+        // When the SumType has string[] first and int[] second,
+        // a number array should skip string[] and match int[].
+        var json = """{"value": [42]}""";
+        var result = DeserializeWithNoExceptions<StringOrIntArrayHolder>(json);
+
+        Assert.True(result.Value.TryGetSecond(out var ints));
+        Assert.Equal([42], ints);
+    }
+
+    [Fact]
+    public void Deserialize_NestedArrays_MatchesCorrectArm()
+    {
+        // SumType<string[][], int[]> — nested array should match string[][] not int[]
+        var json = """{"value": [["a", "b"], ["c"]]}""";
+        var result = DeserializeWithNoExceptions<NestedStringOrIntArrayHolder>(json);
+
+        Assert.True(result.Value.TryGetFirst(out var nested));
+        Assert.Equal(2, nested.Length);
+        Assert.Equal(["a", "b"], nested[0]);
+        Assert.Equal(["c"], nested[1]);
+    }
+
+    /// <summary>
+    /// Deserializes JSON while asserting that no exceptions are thrown internally.
+    /// This verifies that the type filtering logic is actually skipping incompatible
+    /// arms rather than relying on the old try/catch fallback behavior.
+    /// </summary>
+    private static T DeserializeWithNoExceptions<T>(string json)
+    {
+        var exceptions = new List<Exception>();
+        void handler(object? sender, FirstChanceExceptionEventArgs e) => exceptions.Add(e.Exception);
+
+        AppDomain.CurrentDomain.FirstChanceException += handler;
+        try
+        {
+            var result = JsonSerializer.Deserialize<T>(json);
+            Assert.NotNull(result);
+            Assert.Empty(exceptions);
+            return result;
+        }
+        finally
+        {
+            AppDomain.CurrentDomain.FirstChanceException -= handler;
+        }
+    }
+
+    // Test holder types — SumType is deserialized by SumConverter via [JsonConverter] attribute
+
+    private sealed class StringOrVSInternalCommitCharacterArrayHolder
+    {
+        [JsonPropertyName("value")]
+        public SumType<string[], VSInternalCommitCharacter[]> Value { get; set; }
+    }
+
+    private sealed class IntOrStringArrayHolder
+    {
+        [JsonPropertyName("value")]
+        public SumType<int[], string[]> Value { get; set; }
+    }
+
+    private sealed class StringOrIntArrayHolder
+    {
+        [JsonPropertyName("value")]
+        public SumType<string[], int[]> Value { get; set; }
+    }
+
+    private sealed class NestedStringOrIntArrayHolder
+    {
+        [JsonPropertyName("value")]
+        public SumType<string[][], int[]> Value { get; set; }
+    }
+}

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Serialization/SumConverterTypeFilteringTests.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Serialization/SumConverterTypeFilteringTests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.CodeAnalysis.Razor.Serialization;
 /// type probing by rejecting incompatible SumType arms based on the JSON token type.
 /// This includes StartObject rejection for primitive types and array element peeking.
 /// </summary>
+[Collection("SumConverterTypeFiltering")]
 public class SumConverterTypeFilteringTests
 {
     [Fact]
@@ -74,7 +75,7 @@ public class SumConverterTypeFilteringTests
     [Fact]
     public void Deserialize_NestedArrays_MatchesCorrectArm()
     {
-        // SumType<string[][], int[]> — nested array should match string[][] not int[]
+        // SumType<string[][], int[]>: nested array should match string[][] not int[]
         var json = """{"value": [["a", "b"], ["c"]]}""";
         var result = DeserializeWithNoExceptions<NestedStringOrIntArrayHolder>(json);
 
@@ -82,6 +83,21 @@ public class SumConverterTypeFilteringTests
         Assert.Equal(2, nested.Length);
         Assert.Equal(["a", "b"], nested[0]);
         Assert.Equal(["c"], nested[1]);
+    }
+
+    [Fact]
+    public void Deserialize_SumTypeElementArray_MatchesCorrectArm()
+    {
+        // When the array element type is itself a SumType (has a custom JsonConverter),
+        // peeking cannot determine compatibility, so the array arm must not be rejected.
+        var json = """{"value": ["hello"]}""";
+        var result = JsonSerializer.Deserialize<SumTypeOrBoolArrayHolder>(json);
+
+        Assert.NotNull(result);
+        Assert.True(result.Value.TryGetFirst(out var array));
+        Assert.Single(array);
+        Assert.True(array[0].TryGetFirst(out var str));
+        Assert.Equal("hello", str);
     }
 
     /// <summary>
@@ -108,7 +124,7 @@ public class SumConverterTypeFilteringTests
         }
     }
 
-    // Test holder types — SumType is deserialized by SumConverter via [JsonConverter] attribute
+    // Test holder types: SumType is deserialized by SumConverter via [JsonConverter] attribute
 
     private sealed class StringOrVSInternalCommitCharacterArrayHolder
     {
@@ -132,5 +148,11 @@ public class SumConverterTypeFilteringTests
     {
         [JsonPropertyName("value")]
         public SumType<string[][], int[]> Value { get; set; }
+    }
+
+    private sealed class SumTypeOrBoolArrayHolder
+    {
+        [JsonPropertyName("value")]
+        public SumType<SumType<string, int>[], bool> Value { get; set; }
     }
 }


### PR DESCRIPTION
SumConverter previously used exception-based type probing for all SumType arms, attempting deserialization and catching failures. For array variants like SumType<string[], VSInternalCommitCharacter[]> (used by VSInternalCompletionItem.VsCommitCharacters and VSInternalCompletionList.CommitCharacters), this caused InvalidOperationException on every mismatched attempt.

This change adds array element peeking: before attempting deserialization, it reads the first array element's token type to determine compatibility. A string token matches string[] but not VSInternalCommitCharacter[], and a StartObject token matches VSInternalCommitCharacter[] but not string[], eliminating exception-based fallback for these cases.

Refactors IsTokenCompatibleWithType into a core Type overload so array element peeking can reuse the same compatibility logic. Adds SumConverterTypeFilteringTests that verify correct arm selection and assert zero first-chance exceptions during deserialization.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83708)