### PR TITLE
Reset smart rename auto-suggestions to off for token billing

### DIFF
--- a/src/EditorFeatures/Core/InlineRename/InlineRenameUIOptionsStorage.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameUIOptionsStorage.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineRename;
 internal sealed class InlineRenameUIOptionsStorage
 {
     public static readonly Option2<bool> CollapseUI = new("dotnet_collapse_inline_rename_ui", defaultValue: false);
-    public static readonly Option2<bool> CollapseSuggestionsPanel = new("dotnet_collapse_suggestions_in_inline_rename_ui", defaultValue: false);
+    public static readonly Option2<bool> CollapseSuggestionsPanel = new("dotnet_collapse_suggestions_in_inline_rename_ui_v2", defaultValue: true);
     public static readonly Option2<bool> GetSuggestionsAutomatically = new("dotnet_rename_get_suggestions_automatically", defaultValue: false);
     public static readonly Option2<bool> GetSuggestionsContext = new("visual_studio_enable_copilot_rename_context", defaultValue: false);
 }

--- a/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
+++ b/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
@@ -373,7 +373,7 @@ internal abstract class VisualStudioOptionStorage
         {"dotnet_suppress_inlay_hints_for_parameters_that_match_method_intent", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.InlineParameterNameHints.SuppressForParametersThatMatchMethodIntent")},
         {"dotnet_collapse_inline_rename_ui", new RoamingProfileStorage("TextEditor.CollapseRenameUI")},
         {"dotnet_preview_inline_rename_changes", new RoamingProfileStorage("TextEditor.Specific.PreviewRename")},
-        {"dotnet_collapse_suggestions_in_inline_rename_ui", new RoamingProfileStorage("TextEditor.CollapseRenameSuggestionsUI")},
+        {"dotnet_collapse_suggestions_in_inline_rename_ui_v2", new RoamingProfileStorage("TextEditor.CollapseRenameSuggestionsUI2")},
         {"dotnet_rename_get_suggestions_automatically", new FeatureFlagStorage(@"Editor.AutoSmartRenameSuggestions")},
         // Option is deprecated, don't use the same RoamingProfileStorage key
         {"dotnet_rename_file", new RoamingProfileStorage("TextEditor.Specific.RenameFile")},


### PR DESCRIPTION
With upcoming token-based billing, smart rename suggestions should be off by default so automatic Copilot rename suggestions are not fetched unless the user explicitly enables them.

Version the storage key for `CollapseSuggestionsPanel` (suffix `_v2`) so that all users who previously had the toggle enabled are reset to the default. Flip the default to `true` (panel collapsed -> auto suggestions off). Users who want automatic suggestions will need to re-enable the toggle.

Mirrors VSLanguageServerClient PR 728902 for the equivalent setting in the LSP-based rename UI.

Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2939559
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83709)