### PR TITLE
Use non-recursive file watches when watching individual files

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/DefaultFileChangeWatcherTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/DefaultFileChangeWatcherTests.cs
@@ -42,6 +42,7 @@ public sealed class DefaultFileChangeWatcherTests : IDisposable
         var watchedDirectory = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
         Assert.Equal(tempDirectory.Path, watchedDirectory.path);
         Assert.Empty(watchedDirectory.filters);
+        Assert.True(watchedDirectory.includeSubdirectories);
     }
 
     [Fact]
@@ -56,6 +57,7 @@ public sealed class DefaultFileChangeWatcherTests : IDisposable
         var watchedDirectory = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
         Assert.Equal(TempRoot.Root, watchedDirectory.path);
         Assert.Empty(watchedDirectory.filters);
+        Assert.True(watchedDirectory.includeSubdirectories);
     }
 
     [Fact]
@@ -74,6 +76,7 @@ public sealed class DefaultFileChangeWatcherTests : IDisposable
         var watchedDirectory = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
         Assert.Equal(root.Path, watchedDirectory.path);
         Assert.Empty(watchedDirectory.filters);
+        Assert.True(watchedDirectory.includeSubdirectories);
     }
 
     [Fact]
@@ -92,6 +95,7 @@ public sealed class DefaultFileChangeWatcherTests : IDisposable
         var watchedDirectory = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
         Assert.Equal(root.Path, watchedDirectory.path);
         Assert.Empty(watchedDirectory.filters);
+        Assert.True(watchedDirectory.includeSubdirectories);
     }
 
     [Fact]
@@ -110,6 +114,7 @@ public sealed class DefaultFileChangeWatcherTests : IDisposable
         var watchedDirectory = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
         Assert.Equal(root.Path, watchedDirectory.path);
         AssertEx.SetEqual(watchedDirectory.filters, ["*.cs", "*.vb"]);
+        Assert.True(watchedDirectory.includeSubdirectories);
     }
 
     [Fact]
@@ -171,6 +176,7 @@ public sealed class DefaultFileChangeWatcherTests : IDisposable
         var watchedDirectory = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
         Assert.Equal(tempDirectory.Path, watchedDirectory.path);
         Assert.Equal("*.cs", Assert.Single(watchedDirectory.filters));
+        Assert.False(watchedDirectory.includeSubdirectories);
     }
 
     [Fact]
@@ -190,6 +196,25 @@ public sealed class DefaultFileChangeWatcherTests : IDisposable
 
         Assert.Equal(tempDirectory.Path, watchedDirectory.path);
         Assert.Equal("*.cs", Assert.Single(watchedDirectory.filters));
+        Assert.False(watchedDirectory.includeSubdirectories);
+    }
+
+    [Fact]
+    public void EnqueueWatchingFile_FileInExistingSubdirectory_UsesSeparateNonRecursiveWatchers()
+    {
+        var root = _tempRoot.CreateDirectory();
+        var child = root.CreateDirectory("child");
+        var watcher = new DefaultFileChangeWatcher();
+        using var context = watcher.CreateContext([]);
+
+        using var rootFileWatch = context.EnqueueWatchingFile(Path.Combine(root.Path, "root.cs"));
+        using var childFileWatch = context.EnqueueWatchingFile(Path.Combine(child.Path, "child.cs"));
+
+        var watchedDirectories = DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher).ToArray();
+        Assert.Equal(2, watchedDirectories.Length);
+
+        Assert.All(watchedDirectories, w => Assert.Equal("*.cs", Assert.Single(w.filters)));
+        Assert.All(watchedDirectories, w => Assert.False(w.includeSubdirectories));
     }
 
     [Fact]
@@ -234,6 +259,52 @@ public sealed class DefaultFileChangeWatcherTests : IDisposable
         using var context = watcher.CreateContext([]);
         using var watchedFile = context.EnqueueWatchingFile(nonExistentPath);
         Assert.NotNull(watchedFile);
+
+        var watchedDirectory = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
+        Assert.Equal(TempRoot.Root, watchedDirectory.path);
+        Assert.True(watchedDirectory.includeSubdirectories);
+    }
+
+    [Fact]
+    public void EnqueueWatchingFile_WithNonExistentDirectory_MergesWithParentWatch_SameExtension()
+    {
+        var watcher = new DefaultFileChangeWatcher();
+        var nonExistentPath = Path.Combine(TempRoot.Root, "NonExistent", "file.cs");
+
+        using var context = watcher.CreateContext([]);
+        using var fileInExistingDirectory = context.EnqueueWatchingFile(Path.Combine(TempRoot.Root, "file.cs"));
+        var watchedDirectory = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
+        Assert.Equal(TempRoot.Root, watchedDirectory.path);
+        Assert.False(watchedDirectory.includeSubdirectories);
+
+        using var fileInNonExistingDirectory = context.EnqueueWatchingFile(nonExistentPath);
+
+        // We should still have a single watch, but was converted to watch directories
+        watchedDirectory = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
+        Assert.Equal(TempRoot.Root, watchedDirectory.path);
+        Assert.True(watchedDirectory.includeSubdirectories);
+        Assert.Equal("*.cs", Assert.Single(watchedDirectory.filters));
+    }
+
+    [Fact]
+    public void EnqueueWatchingFile_WithNonExistentDirectory_MergesWithParentWatch_DifferentExtension()
+    {
+        var watcher = new DefaultFileChangeWatcher();
+        var nonExistentPath = Path.Combine(TempRoot.Root, "NonExistent", "file.cs");
+
+        using var context = watcher.CreateContext([]);
+        using var fileInExistingDirectory = context.EnqueueWatchingFile(Path.Combine(TempRoot.Root, "file.vb"));
+        var watchedDirectory = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
+        Assert.Equal(TempRoot.Root, watchedDirectory.path);
+        Assert.False(watchedDirectory.includeSubdirectories);
+
+        using var fileInNonExistingDirectory = context.EnqueueWatchingFile(nonExistentPath);
+
+        // We should still have a single watch, but was converted to watch directories
+        watchedDirectory = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
+        Assert.Equal(TempRoot.Root, watchedDirectory.path);
+        Assert.True(watchedDirectory.includeSubdirectories);
+        AssertEx.SetEqual(["*.cs", "*.vb"], watchedDirectory.filters);
     }
 
     [Fact]
@@ -350,6 +421,46 @@ public sealed class DefaultFileChangeWatcherTests : IDisposable
         // Consolidation should keep the active watcher count bounded
         Assert.InRange(watchedPaths.Length, 1, 10);
         Assert.All(watchedPaths, w => Assert.Contains("*.cs", w.filters));
+        Assert.Contains(watchedPaths, w => w.includeSubdirectories);
+    }
+
+    [Fact]
+    public void Consolidate_Works_FileWatchedFirst()
+    {
+        var root = _tempRoot.CreateDirectory();
+
+        var watcher = new DefaultFileChangeWatcher(maxWatcherCount: 10);
+        using var context = watcher.CreateContext([]);
+        using var firstFile = context.EnqueueWatchingFile(Path.Combine(root.Path, "root.cs"));
+
+        for (var i = 0; i < 20; i++)
+        {
+            var subdirectory = root.CreateDirectory($"subdir{i}");
+            context.EnqueueWatchingFile(Path.Combine(subdirectory.Path, "file.cs"));
+        }
+
+        var watchedPaths = DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher).ToArray();
+
+        // We would have had to consolidate to a single watcher at the root
+        var watchedPath = Assert.Single(watchedPaths);
+        Assert.Equal(root.Path, watchedPath.path);
+        Assert.True(watchedPath.includeSubdirectories);
+    }
+
+    [Fact]
+    public void Consolidate_WithExistingNonRecursiveWatcher_MergesFilter()
+    {
+        var root = _tempRoot.CreateDirectory();
+        var watcher = new DefaultFileChangeWatcher(maxWatcherCount: 10);
+        using var context = watcher.CreateContext([]);
+
+        using var firstWatch = context.EnqueueWatchingFile(Path.Combine(root.Path, "one.cs"));
+        using var secondWatch = context.EnqueueWatchingFile(Path.Combine(root.Path, "two.vb"));
+
+        var watchedDirectory = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
+        Assert.Equal(root.Path, watchedDirectory.path);
+        AssertEx.SetEqual(watchedDirectory.filters, ["*.cs", "*.vb"]);
+        Assert.False(watchedDirectory.includeSubdirectories);
     }
 
     [Fact]
@@ -761,6 +872,41 @@ public sealed class DefaultFileChangeWatcherTests : IDisposable
         var watchedPath = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
         Assert.Equal(tempDirectory.Path, watchedPath.path);
         Assert.Empty(watchedPath.filters);
+        Assert.True(watchedPath.includeSubdirectories);
+    }
+
+    [Fact]
+    public void SharedWatcher_MultipleContexts_FileAndDirectoryShareSameWatcherAndFilter()
+    {
+        var tempDirectory = _tempRoot.CreateDirectory();
+        var watcher = new DefaultFileChangeWatcher();
+
+        using var context1 = watcher.CreateContext([]);
+        using var file = context1.EnqueueWatchingFile(Path.Combine(tempDirectory.Path, "file.cs"));
+
+        using var context2 = watcher.CreateContext([new WatchedDirectory(tempDirectory.Path, extensionFilters: [".cs"])]);
+
+        var watchedPath = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
+        Assert.Equal(tempDirectory.Path, watchedPath.path);
+        AssertEx.SetEqual(["*.cs"], watchedPath.filters);
+        Assert.True(watchedPath.includeSubdirectories);
+    }
+
+    [Fact]
+    public void SharedWatcher_MultipleContexts_FileAndDirectoryShareSameWatcherButClearsFilter()
+    {
+        var tempDirectory = _tempRoot.CreateDirectory();
+        var watcher = new DefaultFileChangeWatcher();
+
+        using var context1 = watcher.CreateContext([]);
+        using var file = context1.EnqueueWatchingFile(Path.Combine(tempDirectory.Path, "file.cs"));
+
+        using var context2 = watcher.CreateContext([new WatchedDirectory(tempDirectory.Path, [])]);
+
+        var watchedPath = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
+        Assert.Equal(tempDirectory.Path, watchedPath.path);
+        Assert.Empty(watchedPath.filters);
+        Assert.True(watchedPath.includeSubdirectories);
     }
 
     [Fact]
@@ -777,6 +923,7 @@ public sealed class DefaultFileChangeWatcherTests : IDisposable
         var watchedPath = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
         Assert.Equal(tempDirectory.Path, watchedPath.path);
         Assert.Empty(watchedPath.filters);
+        Assert.True(watchedPath.includeSubdirectories);
     }
 
     [Fact]
@@ -791,6 +938,7 @@ public sealed class DefaultFileChangeWatcherTests : IDisposable
         // Shared watcher should exist
         var watchedPath = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
         Assert.Equal(tempDirectory.Path, watchedPath.path);
+        Assert.True(watchedPath.includeSubdirectories);
 
         // Dispose context1
         context1.Dispose();
@@ -798,6 +946,7 @@ public sealed class DefaultFileChangeWatcherTests : IDisposable
         // Shared watcher should still exist for context2
         watchedPath = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
         Assert.Equal(tempDirectory.Path, watchedPath.path);
+        Assert.True(watchedPath.includeSubdirectories);
 
         // Dispose context2
         context2.Dispose();
@@ -872,6 +1021,7 @@ public sealed class DefaultFileChangeWatcherTests : IDisposable
 
         var watchedPath = Assert.Single(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
         Assert.Equal(tempDirectory.Path, watchedPath.path);
+        Assert.True(watchedPath.includeSubdirectories);
     }
 
     #endregion

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/DefaultFileChangeWatcher.FileChangeContext.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/DefaultFileChangeWatcher.FileChangeContext.cs
@@ -29,7 +29,7 @@ internal sealed partial class DefaultFileChangeWatcher
 
         /// <summary>
         /// A map from a file path to the number of times <see cref="EnqueueWatchingFile(string)"/> was called for that file path, and the IDisposable for the
-        /// return from <see cref="DefaultFileChangeWatcher.AcquireDirectoryWatch(WatchedDirectory, FileChangeContext)"/> when it was called for the first time.
+        /// return from <see cref="DefaultFileChangeWatcher.AcquireDirectoryWatch"/> when it was called for the first time.
         /// </summary>
         private readonly Dictionary<string, (int count, IDisposable directoryWatch)> _explicitlyWatchedFiles = new(s_pathStringComparer);
 
@@ -44,7 +44,7 @@ internal sealed partial class DefaultFileChangeWatcher
             // could get notified immediatly after the directory is watched.
             _watchedDirectoriesWatches = new List<IDisposable>(_watchedDirectories.Length);
             foreach (var watchedDirectory in _watchedDirectories)
-                _watchedDirectoriesWatches.Add(_owner.AcquireDirectoryWatch(watchedDirectory, this));
+                _watchedDirectoriesWatches.Add(_owner.AcquireDirectoryWatch(watchedDirectory, this, includeSubdirectories: true));
         }
 
         public event EventHandler<string>? FileChanged;
@@ -68,7 +68,10 @@ internal sealed partial class DefaultFileChangeWatcher
                 else
                 {
                     var extension = Path.GetExtension(filePath);
-                    var directoryWatchToken = _owner.AcquireDirectoryWatch(new WatchedDirectory(parentDirectory, extensionFilters: string.IsNullOrEmpty(extension) ? [] : [extension]), this);
+                    var directoryWatchToken = _owner.AcquireDirectoryWatch(
+                        new WatchedDirectory(parentDirectory, extensionFilters: string.IsNullOrEmpty(extension) ? [] : [extension]),
+                        this,
+                        includeSubdirectories: false);
                     countAndWatcher = (count: 1, directoryWatchToken);
                     _explicitlyWatchedFiles.Add(filePath, countAndWatcher);
                 }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/DefaultFileChangeWatcher.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/DefaultFileChangeWatcher.cs
@@ -47,7 +47,7 @@ internal sealed partial class DefaultFileChangeWatcher : IFileChangeWatcher
     public IFileChangeContext CreateContext(ImmutableArray<WatchedDirectory> watchedDirectories)
         => new FileChangeContext(this, watchedDirectories);
 
-    private IDisposable AcquireDirectoryWatch(WatchedDirectory watchedDirectory, FileChangeContext fileChangeContext)
+    private IDisposable AcquireDirectoryWatch(WatchedDirectory watchedDirectory, FileChangeContext fileChangeContext, bool includeSubdirectories)
     {
         var watchedDirectoryPath = watchedDirectory.Path.AsSpan();
 
@@ -74,12 +74,13 @@ internal sealed partial class DefaultFileChangeWatcher : IFileChangeWatcher
                 if (pathComponent.Length == 0)
                     continue;
 
-                if (node.Watcher is not null)
+                // If this is already watching all subdirectories, we can just reuse this
+                if (node.Watcher is { IncludeSubdirectories: true })
                 {
                     if (!parentAlreadyHadFileWatch)
                     {
                         // We already have a watcher on this node, so we can just reuse it, but need to ensure filters are good enough to include us
-                        ExpandFiltersToCover(node.Watcher.Filters, watchedDirectory.ExtensionFilters.SelectAsArray(static extension => '*' + extension));
+                        ExpandWatcherToCover(node.Watcher, watchedDirectory.ExtensionFilters.SelectAsArray(static extension => '*' + extension), includeSubdirectories);
                         node.ActiveContexts = node.ActiveContexts.Add(fileChangeContext);
                     }
 
@@ -102,7 +103,7 @@ internal sealed partial class DefaultFileChangeWatcher : IFileChangeWatcher
                 if (node.Watcher is not null)
                 {
                     // We already have a watcher on this node, so we can just reuse it, but need to ensure filters are good enough to include us
-                    ExpandFiltersToCover(node.Watcher.Filters, watchedDirectory.ExtensionFilters.SelectAsArray(static extension => '*' + extension));
+                    ExpandWatcherToCover(node.Watcher, watchedDirectory.ExtensionFilters.SelectAsArray(static extension => '*' + extension), includeSubdirectories);
                     node.ActiveContexts = node.ActiveContexts.Add(fileChangeContext);
                 }
                 else
@@ -114,25 +115,43 @@ internal sealed partial class DefaultFileChangeWatcher : IFileChangeWatcher
                     {
                         if (Directory.Exists(parentNodeForWatch.Path))
                         {
-                            parentNodeForWatch.CreateNewFileWatcher(watchedDirectory.ExtensionFilters.SelectAsArray(static extension => '*' + extension));
-                            _currentWatcherCount++;
+                            if (parentNodeForWatch.Watcher is null)
+                            {
+                                parentNodeForWatch.CreateNewFileWatcher(watchedDirectory.ExtensionFilters.SelectAsArray(static extension => '*' + extension), includeSubdirectories);
+                                _currentWatcherCount++;
+                            }
+                            else
+                            {
+                                // We know that node != parentNodeForWatch -- it can't be the first time through the loop since we handled that case
+                                // earlier.
+                                Contract.ThrowIfTrue(node == parentNodeForWatch);
+                                Contract.ThrowIfFalse(includeSubdirectories);
 
-                            // It's possible this is a watch higher up than a directory we've previously watched, so consolidate any further children
+                                ExpandWatcherToCover(parentNodeForWatch.Watcher, watchedDirectory.ExtensionFilters.SelectAsArray(static extension => '*' + extension), includeSubdirectories);
+                            }
+
                             var allActiveContextsBuilder = parentNodeForWatch.ActiveContexts.ToBuilder();
                             allActiveContextsBuilder.Capacity = parentNodeForWatch.ActiveContextsRecursiveCount - parentNodeForWatch.ActiveContexts.Length + 1;
                             allActiveContextsBuilder.Add(fileChangeContext);
 
-                            IList<string>? filters = parentNodeForWatch.Watcher.Filters;
+                            if (includeSubdirectories)
+                            {
+                                // It's possible this is a watch higher up than a directory we've previously watched, so consolidate any further children
+                                IList<string>? filters = parentNodeForWatch.Watcher.Filters;
 
-                            RemoveWatchersFromChildrenForConsolidation_NoLock(parentNodeForWatch, ref filters, allActiveContextsBuilder);
+                                RemoveWatchersFromChildrenForConsolidation_NoLock(parentNodeForWatch, ref filters, allActiveContextsBuilder);
 
-                            Contract.ThrowIfFalse(filters == parentNodeForWatch.Watcher.Filters, "We should have been updating the existing list of filters.");
+                                Contract.ThrowIfFalse(filters == parentNodeForWatch.Watcher.Filters, "We should have been updating the existing list of filters.");
+                            }
 
                             parentNodeForWatch.ActiveContexts = allActiveContextsBuilder.ToImmutable();
+
                             break;
                         }
                         else
                         {
+                            // At this point, any parent directory watch has to be recursive
+                            includeSubdirectories = true;
                             parentNodeForWatch = parentNodeForWatch.Parent;
                         }
                     }
@@ -233,13 +252,24 @@ internal sealed partial class DefaultFileChangeWatcher : IFileChangeWatcher
                 IList<string>? filters = null;
                 var activeContexts = ImmutableArray.CreateBuilder<FileChangeContext>(initialCapacity: nodeToConsolidate.ActiveContextsRecursiveCount);
 
+                activeContexts.AddRange(nodeToConsolidate.ActiveContexts);
+
                 RemoveWatchersFromChildrenForConsolidation_NoLock(nodeToConsolidate, ref filters, activeContexts);
 
                 Contract.ThrowIfNull(filters, "We knew we had at least one watcher to consolidate, so we should have consolidated it's filters.");
                 Contract.ThrowIfTrue(activeContexts.Count == 0, "We had at least one watcher to consolidate, and that should have had at least one context listening.");
-                nodeToConsolidate.CreateNewFileWatcher(filters.ToImmutableArray());
+
+                if (nodeToConsolidate.Watcher is not null)
+                {
+                    ExpandWatcherToCover(nodeToConsolidate.Watcher, filters, includeSubdirectories: true);
+                }
+                else
+                {
+                    nodeToConsolidate.CreateNewFileWatcher(filters.ToImmutableArray(), includeSubdirectories: true);
+                    _currentWatcherCount++;
+                }
+
                 nodeToConsolidate.ActiveContexts = activeContexts.ToImmutable();
-                _currentWatcherCount++;
                 break;
             }
         }
@@ -283,7 +313,8 @@ internal sealed partial class DefaultFileChangeWatcher : IFileChangeWatcher
                 child.DisposeWatcher();
                 _currentWatcherCount--;
             }
-            else if (child.ActiveWatchersRecursiveCount > 0)
+
+            if (child.ActiveWatchersRecursiveCount > 0)
             {
                 RemoveWatchersFromChildrenForConsolidation_NoLock(child, ref filters, activeContexts);
             }
@@ -326,7 +357,7 @@ internal sealed partial class DefaultFileChangeWatcher : IFileChangeWatcher
         public int ActiveWatchersRecursiveCount { get; private set; }
 
         [MemberNotNull(nameof(Watcher))]
-        public void CreateNewFileWatcher(ImmutableArray<string> filters)
+        public void CreateNewFileWatcher(ImmutableArray<string> filters, bool includeSubdirectories)
         {
             Contract.ThrowIfTrue(Watcher is not null);
             Contract.ThrowIfFalse(ActiveContexts.IsEmpty);
@@ -339,7 +370,7 @@ internal sealed partial class DefaultFileChangeWatcher : IFileChangeWatcher
             Watcher.Renamed += OnFileSystemWatcherEvent;
             Watcher.Deleted += OnFileSystemWatcherEvent;
 
-            Watcher.IncludeSubdirectories = true;
+            Watcher.IncludeSubdirectories = includeSubdirectories;
             Watcher.EnableRaisingEvents = true;
 
             UpdateActiveWatchersRecursiveCountIncludingAllParents(delta: 1);
@@ -401,6 +432,14 @@ internal sealed partial class DefaultFileChangeWatcher : IFileChangeWatcher
         }
     }
 
+    private static void ExpandWatcherToCover(FileSystemWatcher watcher, IEnumerable<string> newFilters, bool includeSubdirectories)
+    {
+        ExpandFiltersToCover(watcher.Filters, newFilters);
+
+        if (includeSubdirectories && !watcher.IncludeSubdirectories)
+            watcher.IncludeSubdirectories = true;
+    }
+
     /// <summary>
     /// Merges the list of filters in <paramref name="newFilters"/> into <paramref name="watcherFilters"/>. The convention is an empty list
     /// means everything, so if either list is empty, the result is an empty list. Otherwise, we merge the two lists and remove duplicates.
@@ -426,9 +465,9 @@ internal sealed partial class DefaultFileChangeWatcher : IFileChangeWatcher
 
     internal static class TestAccessor
     {
-        public static IEnumerable<(string path, ImmutableArray<string> filters)> GetWatchedDirectories(DefaultFileChangeWatcher watcher)
+        public static IEnumerable<(string path, ImmutableArray<string> filters, bool includeSubdirectories)> GetWatchedDirectories(DefaultFileChangeWatcher watcher)
         {
-            var paths = new List<(string path, ImmutableArray<string> filters)>(capacity: watcher._currentWatcherCount);
+            var paths = new List<(string path, ImmutableArray<string> filters, bool includeSubdirectories)>(capacity: watcher._currentWatcherCount);
 
             int currentWatcherCountPerRoots = 0;
 
@@ -446,7 +485,7 @@ internal sealed partial class DefaultFileChangeWatcher : IFileChangeWatcher
             void AddWatchedDirectoryPaths(DirectoryNode node)
             {
                 if (node.Watcher is not null)
-                    paths.Add((node.Path, node.Watcher.Filters.ToImmutableArray()));
+                    paths.Add((node.Path, node.Watcher.Filters.ToImmutableArray(), node.Watcher.IncludeSubdirectories));
 
                 foreach (var child in node.Children.Values)
                     AddWatchedDirectoryPaths(child);


### PR DESCRIPTION
We were always creating recursive file watchers, even if we had to watch just a single file. This might be bad if we were trying to watch a single file in the root, since that might end up trying to recursively watch the entire file system.

Fixes https://github.com/dotnet/roslyn/issues/83716
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83725)