### PR TITLE
Migrate dn-bot-devdiv-drop-rw-code-rw PAT to WIF service connection

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -78,16 +78,16 @@ variables:
     value: true
 
   # To retrieve OptProf data we need to authenticate to the VS drop storage.
-  # Get access token with $dn-bot-devdiv-drop-rw-code-rw and dn-bot-dnceng-build-rw-code-rw from DotNet-VSTS-Infra-Access
+  # DevDiv drop access token is acquired via WIF service connection (dnceng-devdiv-drop-rw-code-rw-wif)
   # Get $AccessToken-dotnet-build-bot-public-repo from DotNet-Versions-Publish
   - group: DotNet-Versions-Publish
   - group: DotNet-VSTS-Infra-Access
   - group: DotNet-DevDiv-Insertion-Workflow-Variables
   - group: AzureDevOps-Artifact-Feeds-Pats
   - name: _DevDivDropAccessToken
-    value: $(dn-bot-devdiv-drop-rw-code-rw)
+    value: ''
   - name: ArtifactServices.Drop.PAT
-    value: $(dn-bot-devdiv-drop-rw-code-rw)
+    value: ''
   - group: AzureDevOps-Artifact-Feeds-Pats
 
   - name: BranchName
@@ -271,6 +271,18 @@ extends:
         - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"
           displayName: Setting VisualStudio.DropName variable
 
+        - task: AzureCLI@2
+          displayName: Get DevDiv Drop Access Token
+          inputs:
+            azureSubscription: 'dnceng-devdiv-drop-rw-code-rw-wif'
+            scriptType: pscore
+            scriptLocation: inlineScript
+            inlineScript: |
+              $token = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
+              Write-Host "##vso[task.setvariable variable=_DevDivDropAccessToken;issecret=true]$token"
+              Write-Host "##vso[task.setvariable variable=ArtifactServices.Drop.PAT;issecret=true]$token"
+          condition: succeeded()
+
         - task: NodeTool@0
           inputs:
             versionSpec: '16.x'
@@ -353,7 +365,7 @@ extends:
           condition: succeeded()
 
         # Publish OptProf configuration files to the artifact service
-        # This uses the ArtifactServices.Drop.PAT build variable which is required to enable cross account access using PAT (dnceng -> devdiv)
+        # ArtifactServices.Drop.PAT is set via WIF service connection for cross account access (dnceng -> devdiv)
         - task: 1ES.PublishArtifactsDrop@1
           inputs:
             dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'


### PR DESCRIPTION
## Summary

Replaces the \dn-bot-devdiv-drop-rw-code-rw\ PAT with a WIF-based service connection (\dnceng-devdiv-drop-rw-code-rw-wif\) for DevDiv drop access.

## Changes

- **Add AzureCLI@2 task** in the OfficialBuild job to acquire an Entra token via the WIF service connection
- **Set \_DevDivDropAccessToken\ and \ArtifactServices.Drop.PAT\** at runtime using the WIF-acquired token instead of the static PAT from \DotNet-VSTS-Infra-Access\ variable group
- **Remove static PAT variable references** from the variable declarations

## Context

This is part of the PAT-to-Entra migration tracked by [AB#10146](https://dev.azure.com/dnceng/internal/_workitems/edit/10146). The WIF service connection \dnceng-devdiv-drop-rw-code-rw-wif\ (backed by app registration \dnceng-devdiv-drop-rw-code-rw-wif\, App ID: \7106a410-fbcb-4750-a202-879077f925ec\) was previously created and verified. The same pattern was successfully deployed in [dotnet/fsharp#19598](https://github.com/dotnet/fsharp/pull/19598).

## Validation

> **Note:** PR validation pipelines read YAML from \main\, not the PR branch. The actual WIF migration will be validated on the first post-merge CI build.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83726)