### PR TITLE
Add edit range merging and post-merge optimizer call

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
@@ -211,6 +211,12 @@ internal sealed class CohostDocumentCompletionEndpoint(
             return null;
         }
 
+        // Optimize the final list before returning to the editor. After merging Razor, C#, HTML,
+        // and snippet lists, re-promote common commit characters and edit ranges to list-level
+        // defaults to minimize the JSON payload.
+        var completionCapability = _clientCapabilitiesService.ClientCapabilities.TextDocument?.Completion;
+        combinedCompletionList = CompletionListOptimizer.Optimize(combinedCompletionList, completionCapability);
+
         RazorCompletionResolveData.Wrap(combinedCompletionList, originalTextDocumentIdentifier, _clientCapabilitiesService.ClientCapabilities);
 
         return combinedCompletionList;

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
@@ -212,8 +212,8 @@ internal sealed class CohostDocumentCompletionEndpoint(
         }
 
         // Optimize the final list before returning to the editor. After merging Razor, C#, HTML,
-        // and snippet lists, re-promote common commit characters and edit ranges to list-level
-        // defaults to minimize the JSON payload.
+        // and snippet lists, re-promote common commit characters and, when all items have
+        // promotable TextEdits, edit ranges to list-level defaults to minimize the JSON payload.
         var completionCapability = _clientCapabilitiesService.ClientCapabilities.TextDocument?.Completion;
         combinedCompletionList = CompletionListOptimizer.Optimize(combinedCompletionList, completionCapability);
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionListMerger.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionListMerger.cs
@@ -188,8 +188,8 @@ internal static class CompletionListMerger
             return;
         }
 
-        // If both lists share the same EditRange, no dematerialization needed —
-        // the optimizer will re-promote the same range after merge.
+        // If both lists share the same EditRange, no dematerialization is needed.
+        // Merge can preserve that shared range via the merged ItemDefaults.
         if (editRangeA is LspRange rangeA &&
             editRangeB is LspRange rangeB &&
             rangeA.Equals(rangeB))

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionListMerger.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionListMerger.cs
@@ -33,6 +33,7 @@ internal static class CompletionListMerger
         }
 
         EnsureMergeableCommitCharacters(razorCompletionList, delegatedCompletionList);
+        EnsureMergeableEditRange(razorCompletionList, delegatedCompletionList);
         EnsureMergeableData(razorCompletionList, delegatedCompletionList);
 
         var mergedIsIncomplete = razorCompletionList.IsIncomplete || delegatedCompletionList.IsIncomplete;
@@ -44,14 +45,17 @@ internal static class CompletionListMerger
         var mergedContinueWithCharacters = razorCompletionList.ContinueCharacters ?? delegatedCompletionList.ContinueCharacters;
 
         var mergedItemDefaultsData = MergeData(razorCompletionList.ItemDefaults?.Data, delegatedCompletionList.ItemDefaults?.Data);
-        // We don't fully support merging edit ranges currently. Razor doesn't currently use them so delegated completion lists always win.
-        var mergedItemDefaultsEditRange = razorCompletionList.ItemDefaults?.EditRange ?? delegatedCompletionList.ItemDefaults?.EditRange;
+
+        // After EnsureMergeableEditRange, one of three states holds:
+        // 1. At most one list had an EditRange (no conflict, pick the non-null one).
+        // 2. Both share the same range (safe to pick either).
+        // 3. Ranges differed and both were dematerialized to null.
+        var mergedEditRange = razorCompletionList.ItemDefaults?.EditRange ?? delegatedCompletionList.ItemDefaults?.EditRange;
 
         var mergedCompletionList = new RazorVSInternalCompletionList()
         {
-            // CommitCharacters intentionally null — EnsureMergeableCommitCharacters materialized
-            // list-level commit characters onto individual items before merging. This method does
-            // not re-promote a common group back to list-level defaults.
+            // CommitCharacters intentionally null — EnsureMergeableCommitCharacters dematerialized
+            // both lists to per-item. The post-merge optimizer will re-promote the best group.
             Data = mergedData,
             IsIncomplete = mergedIsIncomplete,
             Items = mergedItems,
@@ -60,7 +64,7 @@ internal static class CompletionListMerger
             ItemDefaults = new CompletionListItemDefaults()
             {
                 Data = mergedItemDefaultsData,
-                EditRange = mergedItemDefaultsEditRange,
+                EditRange = mergedEditRange,
             }
         };
 
@@ -168,6 +172,58 @@ internal static class CompletionListMerger
             {
                 var item = candidateCompletionList.Items[i];
                 item.Data ??= s_emptyData;
+            }
+        }
+    }
+
+    private static void EnsureMergeableEditRange(RazorVSInternalCompletionList completionListA, RazorVSInternalCompletionList completionListB)
+    {
+        var editRangeA = completionListA.ItemDefaults?.EditRange?.Value;
+        var editRangeB = completionListB.ItemDefaults?.EditRange?.Value;
+
+        if (editRangeA is null || editRangeB is null)
+        {
+            // At most one list uses EditRange — no conflict. The merged list can
+            // just take whichever is non-null (handled by the merged ItemDefaults).
+            return;
+        }
+
+        // If both lists share the same EditRange, no dematerialization needed —
+        // the optimizer will re-promote the same range after merge.
+        if (editRangeA is LspRange rangeA &&
+            editRangeB is LspRange rangeB &&
+            rangeA.Equals(rangeB))
+        {
+            return;
+        }
+
+        // Ranges differ — dematerialize both to per-item TextEdits so the post-merge
+        // optimizer can evaluate the full combined list correctly.
+        DematerializeEditRange(completionListA);
+        DematerializeEditRange(completionListB);
+
+        static void DematerializeEditRange(RazorVSInternalCompletionList completionList)
+        {
+            if (completionList.ItemDefaults?.EditRange?.Value is not LspRange range)
+            {
+                // Either no EditRange, or it's an InsertReplaceRange. InsertReplaceRange is intentionally
+                // not dematerialized — it requires reconstructing InsertReplaceEdit (two ranges per item),
+                // and no current provider produces it. Items using InsertReplaceRange remain valid after
+                // merge because the merged ItemDefaults preserves it via null-coalescing.
+                return;
+            }
+
+            completionList.ItemDefaults.EditRange = null;
+
+            foreach (var item in completionList.Items)
+            {
+                if (item.TextEdit is null)
+                {
+                    // Reconstruct TextEdit from EditRange + TextEditText (or Label as fallback).
+                    var newText = item.TextEditText ?? item.Label;
+                    item.TextEditText = null;
+                    item.TextEdit = new TextEdit { Range = range, NewText = newText };
+                }
             }
         }
     }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionListOptimizer.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionListOptimizer.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Linq;
+using System;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion;
 
@@ -19,7 +19,7 @@ internal static partial class CompletionListOptimizer
     {
         // Check if client supports editRange in ItemDefaults
         var itemDefaults = completionCapability?.CompletionListSetting?.ItemDefaults;
-        if (itemDefaults is null || !itemDefaults.Contains("editRange"))
+        if (itemDefaults is null || Array.IndexOf(itemDefaults, "editRange") < 0)
         {
             return completionList;
         }
@@ -58,8 +58,13 @@ internal static partial class CompletionListOptimizer
         foreach (var item in items)
         {
             var textEdit = (TextEdit)item.TextEdit!.Value;
-            item.TextEditText = textEdit.NewText;
             item.TextEdit = null;
+
+            // If TextEditText would equal Label, omit it — the client falls back to Label.
+            if (textEdit.NewText != item.Label)
+            {
+                item.TextEditText = textEdit.NewText;
+            }
         }
 
         return completionList;

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
@@ -67,15 +67,16 @@ internal partial class DirectiveAttributeCompletionItemProvider : DirectiveAttri
 
         var inSnippetContext = InSnippetContext(owner, context.Options);
 
-        // Compute the replacement range for directive attribute items. This covers from after the '@'
-        // through the end of the parameter name (if present) or the attribute name. This is needed
-        // because InsertText includes the colon and parameter (e.g., "bind-Value:after") but the
-        // editor's word-boundary heuristic stops at ':' causing duplication.
+        // Compute the replacement range for directive attribute items. This covers the full
+        // attribute name (including '@') through the end of the parameter name (if present).
+        // We include '@' in the range because the TextEdit replaces the entire attribute name,
+        // and including it allows the edit range to match the HTML provider's range — enabling
+        // the optimizer to promote a common EditRange across all items.
         LinePositionSpan? replacementRange = null;
         if (isAttributeRequest && attributeNameLocation.Length > 0)
         {
             var sourceText = context.CodeDocument.Source.Text;
-            var spanStart = attributeNameLocation.Start + 1; // skip '@'
+            var spanStart = attributeNameLocation.Start;
             var spanEnd = parameterNameLocation.Length > 0
                 ? parameterNameLocation.End
                 : attributeNameLocation.End;
@@ -310,46 +311,25 @@ internal partial class DirectiveAttributeCompletionItemProvider : DirectiveAttri
 
     private static string ComputeInsertText(string displayText, bool isIndexer, bool isSnippet, bool autoInsertAttributeQuotes)
     {
-        var originalInsertText = displayText.AsMemory();
-
-        // Strip off the @ from the insertion text. This change is here to align the insertion text with the
-        // completion hooks into VS and VSCode. Basically, completion triggers when `@` is typed so we don't
-        // want to insert `@bind` because `@` already exists.
-        var insertText = originalInsertText.Span.StartsWith('@')
-            ? originalInsertText[1..]
-            : originalInsertText;
-
-        // Indexer attribute, we don't want to insert with the triple dot.
+        // Indexer attribute: strip the trailing ellipsis (e.g., "@bind-Value..." → "@bind-Value")
         if (isIndexer)
         {
-            Debug.Assert(insertText.Span.EndsWith(Ellipsis, StringComparison.Ordinal));
-            return insertText[..^3].ToString();
+            Debug.Assert(displayText.EndsWith(Ellipsis, StringComparison.Ordinal));
+            return displayText[..^3];
         }
 
+        // Snippet: append ="$0" or =$0 suffix (e.g., "@bind-Visible" → "@bind-Visible=\"$0\"")
         if (isSnippet)
         {
             var suffixText = autoInsertAttributeQuotes
                 ? QuotedAttributeValueSnippetSuffix
                 : UnquotedAttributeValueSnippetSuffix;
 
-            // We are trying for snippet text only for non-indexer attributes, e.g. *not* something like "@bind-..."
-            return string.Create(
-                length: insertText.Length + suffixText.Length,
-                state: (insertText, suffixText),
-                static (destination, state) =>
-                {
-                    var (insertText, suffixText) = state;
-
-                    insertText.Span.CopyTo(destination);
-                    suffixText.AsSpan().CopyTo(destination[insertText.Length..]);
-                });
+            return displayText + suffixText;
         }
 
-        // Don't create another string unnecessarily, even though ReadOnlySpan.ToString() special-cases
-        // the string to avoid allocation.
-        return insertText.Span == originalInsertText.Span
-            ? displayText
-            : insertText.ToString();
+        // Simple case: InsertText == DisplayText — no allocation needed.
+        return displayText;
     }
 
     private static bool TryAddAttributeCompletion(

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
@@ -977,16 +977,17 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
 
         var item = Assert.Single(result.Items, i => i.Label == "@bind-value:format");
 
-        // The list should have a TextEdit that replaces the full "bind-Value:after" span (not just "bind-")
-        // This prevents the editor's word-boundary heuristic from stopping at the colon and duplicating ":after"
+        // The list should have an EditRange that replaces the full "@bind-Value:after" span.
+        // Since the TextEdit.NewText equals the Label ("@bind-value:format"), the optimizer
+        // omits TextEditText (the client falls back to Label as the replacement text).
         Assert.True(result.ItemDefaults!.EditRange.HasValue, "Expected ItemDefaults.EditRange on the completion list to prevent duplication");
-        Assert.Equal("bind-value:format", item.TextEditText);
+        Assert.Null(item.TextEditText);
         var textEditRange = Assert.IsType<LspRange>(result.ItemDefaults!.EditRange.Value.Value);
 
-        // The range should cover "bind-Value:after" (everything after '@' through end of parameter name)
+        // The range should cover "@bind-Value:after" (full attribute name including '@' through end of parameter name)
         Assert.Equal(textEditRange.Start.Line, textEditRange.End.Line);
         var replacedLength = textEditRange.End.Character - textEditRange.Start.Character;
-        Assert.Equal("bind-Value:after".Length, replacedLength);
+        Assert.Equal("@bind-Value:after".Length, replacedLength);
     }
 
     [Fact]

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/CompletionListMergerTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/CompletionListMergerTest.cs
@@ -207,4 +207,134 @@ public class CompletionListMergerTest : ToolingTestBase
             Assert.Same(sortedExpected[i], sortedActual[i]);
         }
     }
+
+    [Fact]
+    public void Merge_EditRange_NeitherListHasEditRange_NoChange()
+    {
+        // Arrange — neither list has EditRange
+        var item1 = new VSInternalCompletionItem { Label = "a", TextEdit = new TextEdit { Range = new LspRange { Start = new(0, 0), End = new(0, 1) }, NewText = "a" } };
+        var item2 = new VSInternalCompletionItem { Label = "b", TextEdit = new TextEdit { Range = new LspRange { Start = new(0, 0), End = new(0, 1) }, NewText = "b" } };
+        var list1 = new RazorVSInternalCompletionList { Items = [item1] };
+        var list2 = new RazorVSInternalCompletionList { Items = [item2] };
+
+        // Act
+        var merged = CompletionListMerger.Merge(list1, list2);
+
+        // Assert — items keep their TextEdits
+        Assert.NotNull(merged);
+        Assert.Null(merged.ItemDefaults?.EditRange);
+        Assert.NotNull(item1.TextEdit);
+        Assert.NotNull(item2.TextEdit);
+    }
+
+    [Fact]
+    public void Merge_EditRange_OnlyOneListHasEditRange_Preserved()
+    {
+        // Arrange — only list1 has EditRange
+        var range = new LspRange { Start = new(0, 5), End = new(0, 10) };
+        var item1 = new VSInternalCompletionItem { Label = "a", TextEditText = "alpha" };
+        var item2 = new VSInternalCompletionItem { Label = "b", TextEdit = new TextEdit { Range = new LspRange { Start = new(1, 0), End = new(1, 3) }, NewText = "beta" } };
+        var list1 = new RazorVSInternalCompletionList { Items = [item1], ItemDefaults = new CompletionListItemDefaults { EditRange = range } };
+        var list2 = new RazorVSInternalCompletionList { Items = [item2] };
+
+        // Act
+        var merged = CompletionListMerger.Merge(list1, list2);
+
+        // Assert — EditRange preserved from list1
+        Assert.NotNull(merged);
+        Assert.Equal(range, merged.ItemDefaults?.EditRange?.Value);
+    }
+
+    [Fact]
+    public void Merge_EditRange_BothListsSameRange_Preserved()
+    {
+        // Arrange — both lists share the same EditRange
+        var range = new LspRange { Start = new(0, 5), End = new(0, 10) };
+        var item1 = new VSInternalCompletionItem { Label = "a", TextEditText = "alpha" };
+        var item2 = new VSInternalCompletionItem { Label = "b", TextEditText = "beta" };
+        var list1 = new RazorVSInternalCompletionList { Items = [item1], ItemDefaults = new CompletionListItemDefaults { EditRange = range } };
+        var list2 = new RazorVSInternalCompletionList { Items = [item2], ItemDefaults = new CompletionListItemDefaults { EditRange = range } };
+
+        // Act
+        var merged = CompletionListMerger.Merge(list1, list2);
+
+        // Assert — same range preserved, items still use TextEditText
+        Assert.NotNull(merged);
+        Assert.Equal(range, merged.ItemDefaults?.EditRange?.Value);
+        Assert.Equal("alpha", item1.TextEditText);
+        Assert.Equal("beta", item2.TextEditText);
+        Assert.Null(item1.TextEdit);
+        Assert.Null(item2.TextEdit);
+    }
+
+    [Fact]
+    public void Merge_EditRange_DifferentRanges_DematerializesBoth()
+    {
+        // Arrange — two lists with different EditRanges
+        var range1 = new LspRange { Start = new(0, 5), End = new(0, 10) };
+        var range2 = new LspRange { Start = new(1, 0), End = new(1, 4) };
+        var item1 = new VSInternalCompletionItem { Label = "a", TextEditText = "alpha" };
+        var item2 = new VSInternalCompletionItem { Label = "b", TextEditText = "beta" };
+        var list1 = new RazorVSInternalCompletionList { Items = [item1], ItemDefaults = new CompletionListItemDefaults { EditRange = range1 } };
+        var list2 = new RazorVSInternalCompletionList { Items = [item2], ItemDefaults = new CompletionListItemDefaults { EditRange = range2 } };
+
+        // Act
+        var merged = CompletionListMerger.Merge(list1, list2);
+
+        // Assert — EditRange cleared, items get per-item TextEdits reconstructed
+        Assert.NotNull(merged);
+        Assert.Null(merged.ItemDefaults?.EditRange);
+
+        var textEdit1 = Assert.IsType<TextEdit>(item1.TextEdit!.Value.Value);
+        Assert.Equal(range1, textEdit1.Range);
+        Assert.Equal("alpha", textEdit1.NewText);
+        Assert.Null(item1.TextEditText);
+
+        var textEdit2 = Assert.IsType<TextEdit>(item2.TextEdit!.Value.Value);
+        Assert.Equal(range2, textEdit2.Range);
+        Assert.Equal("beta", textEdit2.NewText);
+        Assert.Null(item2.TextEditText);
+    }
+
+    [Fact]
+    public void Merge_EditRange_DifferentRanges_UsesLabelWhenNoTextEditText()
+    {
+        // Arrange — item has no TextEditText, should fall back to Label
+        var range1 = new LspRange { Start = new(0, 0), End = new(0, 3) };
+        var range2 = new LspRange { Start = new(1, 0), End = new(1, 2) };
+        var item1 = new VSInternalCompletionItem { Label = "foo" }; // no TextEditText
+        var item2 = new VSInternalCompletionItem { Label = "bar", TextEditText = "baz" };
+        var list1 = new RazorVSInternalCompletionList { Items = [item1], ItemDefaults = new CompletionListItemDefaults { EditRange = range1 } };
+        var list2 = new RazorVSInternalCompletionList { Items = [item2], ItemDefaults = new CompletionListItemDefaults { EditRange = range2 } };
+
+        // Act
+        var merged = CompletionListMerger.Merge(list1, list2);
+
+        // Assert — item1 uses Label as NewText
+        Assert.NotNull(merged);
+        var textEdit1 = Assert.IsType<TextEdit>(item1.TextEdit!.Value.Value);
+        Assert.Equal("foo", textEdit1.NewText);
+    }
+
+    [Fact]
+    public void Merge_EditRange_DifferentRanges_SkipsItemsWithExistingTextEdit()
+    {
+        // Arrange — item already has a TextEdit, should not be overwritten
+        var range1 = new LspRange { Start = new(0, 0), End = new(0, 3) };
+        var range2 = new LspRange { Start = new(1, 0), End = new(1, 2) };
+        var existingRange = new LspRange { Start = new(2, 0), End = new(2, 5) };
+        var item1 = new VSInternalCompletionItem { Label = "foo", TextEdit = new TextEdit { Range = existingRange, NewText = "existing" } };
+        var item2 = new VSInternalCompletionItem { Label = "bar", TextEditText = "baz" };
+        var list1 = new RazorVSInternalCompletionList { Items = [item1], ItemDefaults = new CompletionListItemDefaults { EditRange = range1 } };
+        var list2 = new RazorVSInternalCompletionList { Items = [item2], ItemDefaults = new CompletionListItemDefaults { EditRange = range2 } };
+
+        // Act
+        var merged = CompletionListMerger.Merge(list1, list2);
+
+        // Assert — item1's existing TextEdit is preserved
+        Assert.NotNull(merged);
+        var textEdit1 = Assert.IsType<TextEdit>(item1.TextEdit!.Value.Value);
+        Assert.Equal(existingRange, textEdit1.Range);
+        Assert.Equal("existing", textEdit1.NewText);
+    }
 }

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/CompletionListOptimizerTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/CompletionListOptimizerTest.cs
@@ -127,6 +127,47 @@ public class CompletionListOptimizerTest(ITestOutputHelper testOutput) : Tooling
     }
 
     [Fact]
+    public void PromoteEditRange_TextEditTextEqualsLabel_OmitsTextEditText()
+    {
+        // Arrange — when NewText equals Label, TextEditText should be omitted
+        // because the client falls back to Label automatically.
+        var sharedRange = new LspRange
+        {
+            Start = new Position { Line = 0, Character = 5 },
+            End = new Position { Line = 0, Character = 15 }
+        };
+        var completionList = new RazorVSInternalCompletionList()
+        {
+            Items = [
+                new VSInternalCompletionItem()
+                {
+                    Label = "span",
+                    TextEdit = new TextEdit { Range = sharedRange, NewText = "span" }
+                },
+                new VSInternalCompletionItem()
+                {
+                    Label = "div",
+                    TextEdit = new TextEdit { Range = sharedRange, NewText = "different-text" }
+                }
+            ]
+        };
+        var capabilities = new VSInternalCompletionSetting()
+        {
+            CompletionListSetting = new CompletionListSetting()
+            {
+                ItemDefaults = ["editRange"]
+            }
+        };
+
+        // Act
+        var result = CompletionListOptimizer.Optimize(completionList, capabilities);
+
+        // Assert — "span" item has TextEditText omitted (equals Label), "div" item retains it
+        Assert.Null(result.Items[0].TextEditText);
+        Assert.Equal("different-text", result.Items[1].TextEditText);
+    }
+
+    [Fact]
     public void PromoteEditRange_ItemsHaveDifferentRanges_DoesNotPromote()
     {
         // Arrange

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/DirectiveAttributeCompletionItemProviderTest.AttributeNames.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/DirectiveAttributeCompletionItemProviderTest.AttributeNames.cs
@@ -66,7 +66,7 @@ public partial class DirectiveAttributeCompletionItemProviderTest : RazorTooling
         var completions = _provider.GetCompletionItems(context);
 
         // Assert
-        AssertContains(completions, "bind", "@bind", ["=", " "]);
+        AssertContains(completions, "@bind", "@bind", ["=", " "]);
     }
 
     [Fact]
@@ -83,8 +83,8 @@ public partial class DirectiveAttributeCompletionItemProviderTest : RazorTooling
         var completions = _provider.GetCompletionItems(context);
 
         // Assert - VS Code handles commit characters upstream, so we should return empty
-        AssertContains(completions, "bind", "@bind", ImmutableArray<string>.Empty);
-        AssertContainsParameter(completions, "bind-value:format", "@bind-value:format", ImmutableArray<string>.Empty);
+        AssertContains(completions, "@bind", "@bind", ImmutableArray<string>.Empty);
+        AssertContainsParameter(completions, "@bind-value:format", "@bind-value:format", ImmutableArray<string>.Empty);
     }
 
     [Fact]
@@ -97,7 +97,7 @@ public partial class DirectiveAttributeCompletionItemProviderTest : RazorTooling
         var completions = _provider.GetCompletionItems(context);
 
         // Assert
-        AssertContainsParameter(completions, "bind-value:format", "@bind-value:format", ["=", " "]);
+        AssertContainsParameter(completions, "@bind-value:format", "@bind-value:format", ["=", " "]);
     }
 
     [Fact]
@@ -113,7 +113,7 @@ public partial class DirectiveAttributeCompletionItemProviderTest : RazorTooling
         var completions = _provider.GetCompletionItems(context);
 
         // Assert
-        AssertContainsParameter(completions, "bind-value:format=\"$0\"", "@bind-value:format", ["=", " "]);
+        AssertContainsParameter(completions, "@bind-value:format=\"$0\"", "@bind-value:format", ["=", " "]);
     }
 
     [Fact]
@@ -126,7 +126,7 @@ public partial class DirectiveAttributeCompletionItemProviderTest : RazorTooling
         var completions = _provider.GetCompletionItems(context);
 
         // Assert
-        AssertContains(completions, "attributes", "@attributes", ["=", " "]);
+        AssertContains(completions, "@attributes", "@attributes", ["=", " "]);
     }
 
     [Fact]
@@ -239,7 +239,7 @@ public partial class DirectiveAttributeCompletionItemProviderTest : RazorTooling
         var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions("input", context, _defaultTagHelperContext);
 
         // Assert
-        AssertContains(completions, "bind=\"$0\"", "@bind", ["=", " "]);
+        AssertContains(completions, "@bind=\"$0\"", "@bind", ["=", " "]);
     }
 
     [Fact]
@@ -252,7 +252,7 @@ public partial class DirectiveAttributeCompletionItemProviderTest : RazorTooling
         var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions("input", context, _defaultTagHelperContext);
 
         // Assert
-        AssertContains(completions, "bind-value=\"$0\"", "@bind-value", ["=", " "]);
+        AssertContains(completions, "@bind-value=\"$0\"", "@bind-value", ["=", " "]);
     }
 
     [Fact]
@@ -265,7 +265,7 @@ public partial class DirectiveAttributeCompletionItemProviderTest : RazorTooling
         var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions("input", context, _defaultTagHelperContext);
 
         // Assert
-        AssertContains(completions, "bind=\"$0\"", "@bind", ["=", " "]);
+        AssertContains(completions, "@bind=\"$0\"", "@bind", ["=", " "]);
     }
 
     [Fact]
@@ -278,7 +278,7 @@ public partial class DirectiveAttributeCompletionItemProviderTest : RazorTooling
         var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions("input", context, _defaultTagHelperContext);
 
         // Assert
-        AssertContains(completions, "bind=\"$0\"", "@bind", [new RazorCommitCharacter("=", Insert: false), new RazorCommitCharacter(" ", Insert: false)]);
+        AssertContains(completions, "@bind=\"$0\"", "@bind", [new RazorCommitCharacter("=", Insert: false), new RazorCommitCharacter(" ", Insert: false)]);
     }
 
     [Fact]
@@ -295,7 +295,7 @@ public partial class DirectiveAttributeCompletionItemProviderTest : RazorTooling
         var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions("input", context, _defaultTagHelperContext);
 
         // Assert
-        AssertContains(completions, "bind=$0", "@bind", ["=", " "]);
+        AssertContains(completions, "@bind=$0", "@bind", ["=", " "]);
     }
 
     [Fact]
@@ -313,7 +313,7 @@ public partial class DirectiveAttributeCompletionItemProviderTest : RazorTooling
         var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions("input", context, _defaultTagHelperContext);
 
         // Assert
-        AssertContains(completions, "bind", "@bind", ["=", " "]);
+        AssertContains(completions, "@bind", "@bind", ["=", " "]);
     }
 
     [Fact]
@@ -331,7 +331,7 @@ public partial class DirectiveAttributeCompletionItemProviderTest : RazorTooling
         var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions("input", context, _defaultTagHelperContext);
 
         // Assert
-        AssertContains(completions, "bind", "@bind", ["=", " "]);
+        AssertContains(completions, "@bind", "@bind", ["=", " "]);
     }
 
     [Fact]
@@ -344,7 +344,7 @@ public partial class DirectiveAttributeCompletionItemProviderTest : RazorTooling
         var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions("input", context, _defaultTagHelperContext);
 
         // Assert
-        AssertContains(completions, "bind-", "@bind-...", ImmutableArray<string>.Empty);
+        AssertContains(completions, "@bind-", "@bind-...", ImmutableArray<string>.Empty);
     }
 
     [Fact]
@@ -360,7 +360,7 @@ public partial class DirectiveAttributeCompletionItemProviderTest : RazorTooling
         var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions("input", context, _defaultTagHelperContext);
 
         // Assert
-        AssertContains(completions, "bind=\"$0\"", "@bind", ["=", " "]);
+        AssertContains(completions, "@bind=\"$0\"", "@bind", ["=", " "]);
     }
 
     [Fact]
@@ -376,7 +376,7 @@ public partial class DirectiveAttributeCompletionItemProviderTest : RazorTooling
         var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions("input", context, _defaultTagHelperContext);
 
         // Assert
-        AssertDoesNotContain(completions, "bind", "@bind");
+        AssertDoesNotContain(completions, "@bind", "@bind");
     }
 
     private static void AssertContainsParameter(ImmutableArray<RazorCompletionItem> completions, string insertText, string displayText, ImmutableArray<string> commitCharacters)

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/DirectiveAttributeCompletionItemProviderTest.ParameterNames.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/DirectiveAttributeCompletionItemProviderTest.ParameterNames.cs
@@ -185,11 +185,11 @@ public partial class DirectiveAttributeCompletionItemProviderTest
         //                       ^     ^    ^
         //                       |     |    `-- parameterLocation.End (index 19)
         //                       |     `-- colon (index 13)
-        //                       `-- @ is at index 7, so replacement starts at index 8 (skipping '@')
-        // "bind-:after" starts at character 8 and ends at character 19, all on line 0
+        //                       `-- @ is at index 7, replacement starts at index 7 (including '@')
+        // "@bind-:after" starts at character 7 and ends at character 19, all on line 0
         Assert.NotNull(itemWithParameter.ReplacementRange);
         Assert.Equal(0, itemWithParameter.ReplacementRange.Value.Start.Line);
-        Assert.Equal(8, itemWithParameter.ReplacementRange.Value.Start.Character);
+        Assert.Equal(7, itemWithParameter.ReplacementRange.Value.Start.Character);
         Assert.Equal(0, itemWithParameter.ReplacementRange.Value.End.Line);
         Assert.Equal(19, itemWithParameter.ReplacementRange.Value.End.Character);
     }


### PR DESCRIPTION
When merging two completion lists with different EditRange values in ItemDefaults, dematerialize both back to per-item TextEdits so the post-merge optimizer can re-evaluate the combined list correctly. If both lists share the same EditRange, or only one has it, no dematerialization is needed. InsertReplaceRange is intentionally not dematerialized as no current provider produces it, and items using it remain valid after merge because null-coalescing preserves the value in the merged ItemDefaults.

Also adds a CompletionListOptimizer.Optimize call after merge in CohostDocumentCompletionEndpoint. This re-promotes both commit haracters and edit ranges to list-level defaults on the final merged list, reducing the JSON payload sent to the editor.

Edit range alignment for directive attributes:

Includes @ in the directive attribute replacement range so that TextEdits for directive attributes (e.g., @bind, @bind-value:format) align with HTML attribute TextEdits. This enables the optimizer to promote a common EditRange across all items in a merged completion list. ComputeInsertText is simplified accordingly — since the range now covers @, the insert text includes it too.

PromoteEditRangeToListDefaults optimizations:

 - Replace LINQ .Contains() with Array.IndexOf for the itemDefaults capability check.
 - When promoting TextEdits to TextEditText, skip setting TextEditText when it equals Label (the client falls back to Label automatically, reducing payload size).