### PR TITLE
Reset Hot Reload _disabled flag when a new debug session starts

### DIFF
--- a/src/EditorFeatures/Core/EditAndContinue/ManagedHotReloadLanguageServiceImpl.cs
+++ b/src/EditorFeatures/Core/EditAndContinue/ManagedHotReloadLanguageServiceImpl.cs
@@ -71,10 +71,11 @@ internal sealed class ManagedHotReloadLanguageServiceImpl(
     {
         sessionState.IsSessionActive = true;
 
-        if (_disabled)
-        {
-            return;
-        }
+        // Reset the disabled flag so that a previous session's failure does not permanently
+        // disable Hot Reload for subsequent sessions. Any exception that caused _disabled to be
+        // set is a product bug, but resetting here gives the user a chance to try again after
+        // restarting the debug session, instead of having to restart the Roslyn process.
+        _disabled = false;
 
         try
         {


### PR DESCRIPTION
`ManagedHotReloadLanguageServiceImpl._disabled` is set to true whenever an unexpected exception is caught `StartSessionAsync`, `BreakStateOrCapabilitiesChangedAsync`, `EndSessionAsync`. Once set, the flag is never cleared - `EndSessionAsync` does not reset it and `StartSessionAsync`  early-returns when it is true. This means a single failure permanently disables Hot Reload for the lifetime of the Roslyn process, even across debug session restarts. Users have to restart Visual Studio / the Roslyn LSP server to recover.

This change clears `_disabled` at the start of `StartSessionAsync` so that a fresh debug session is always given a chance to initialize. Any exception that flipped the flag is still a product bug worth fixing on its own, but this avoids a confusing and unrecoverable user-facing state where Hot Reload silently does nothing for the rest of the IDE session. Also will be useful for development activities and debugging.

Investigated as part of a report where Hot Reload worked exactly once per Roslyn process and then stopped responding until the process was restarted.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83747)