### PR TITLE
Fix formatting capability checks

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/CohostDocSyncEndpointRegistration.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/CohostDocSyncEndpointRegistration.cs
@@ -16,26 +16,31 @@ internal sealed class CohostDocSyncEndpointRegistration : IDynamicRegistrationPr
 {
     public ImmutableArray<Registration> GetRegistrations(VSInternalClientCapabilities clientCapabilities, RequestContext requestContext)
     {
-        return [
-            // DidOpen, DidChange, DidClose, for document synchronization
-            new Registration
-            {
-                Method = Methods.TextDocumentDidOpenName,
-                RegisterOptions = new TextDocumentRegistrationOptions()
-            },
-            new Registration
-            {
-                Method = Methods.TextDocumentDidChangeName,
-                RegisterOptions = new TextDocumentChangeRegistrationOptions()
+        if (clientCapabilities.TextDocument?.Synchronization?.DynamicRegistration is true)
+        {
+            return [
+                // DidOpen, DidChange, DidClose, for document synchronization
+                new Registration
                 {
-                    SyncKind = TextDocumentSyncKind.Incremental
-                }
-            },
-            new Registration
-            {
-                Method = Methods.TextDocumentDidCloseName,
-                RegisterOptions = new TextDocumentRegistrationOptions()
-            },
-        ];
+                    Method = Methods.TextDocumentDidOpenName,
+                    RegisterOptions = new TextDocumentRegistrationOptions()
+                },
+                new Registration
+                {
+                    Method = Methods.TextDocumentDidChangeName,
+                    RegisterOptions = new TextDocumentChangeRegistrationOptions()
+                    {
+                        SyncKind = TextDocumentSyncKind.Incremental
+                    }
+                },
+                new Registration
+                {
+                    Method = Methods.TextDocumentDidCloseName,
+                    RegisterOptions = new TextDocumentRegistrationOptions()
+                },
+            ];
+        }
+
+        return [];
     }
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Formatting/CohostOnTypeFormattingEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Formatting/CohostOnTypeFormattingEndpoint.cs
@@ -46,7 +46,7 @@ internal sealed class CohostOnTypeFormattingEndpoint(
 
     public ImmutableArray<Registration> GetRegistrations(VSInternalClientCapabilities clientCapabilities, RequestContext requestContext)
     {
-        if (clientCapabilities.TextDocument?.Formatting?.DynamicRegistration is true)
+        if (clientCapabilities.TextDocument?.OnTypeFormatting?.DynamicRegistration is true)
         {
             return [new Registration()
             {

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Formatting/CohostRangeFormattingEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Formatting/CohostRangeFormattingEndpoint.cs
@@ -45,7 +45,7 @@ internal sealed class CohostRangeFormattingEndpoint(
 
     public ImmutableArray<Registration> GetRegistrations(VSInternalClientCapabilities clientCapabilities, RequestContext requestContext)
     {
-        if (clientCapabilities.TextDocument?.Formatting?.DynamicRegistration is true)
+        if (clientCapabilities.TextDocument?.RangeFormatting?.DynamicRegistration is true)
         {
             return [new Registration()
             {


### PR DESCRIPTION
Found while perusing various roslyn.nvim user reports. This fixes a (harmless) warning at startup in that environment, and makes us generally a good citizen of the world.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83781)