### PR TITLE
Modify VSCode HTML completion to use the VSCode HTML language server again

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
@@ -134,7 +134,7 @@ internal sealed class CohostDocumentCompletionEndpoint(
             SnippetsSupported: true, // always true in non-legacy Razor, always false in legacy Razor
             AutoInsertAttributeQuotes: clientSettings.AdvancedSettings.AutoInsertAttributeQuotes,
             CommitElementsWithSpace: clientSettings.AdvancedSettings.CommitElementsWithSpace,
-            UseVsCodeCompletionCommitCharacters: !_clientCapabilitiesService.ClientCapabilities.SupportsVisualStudioExtensions);
+            IsVsCode: !_clientCapabilitiesService.ClientCapabilities.SupportsVisualStudioExtensions);
 
         _logger.LogDebug($"Calling OOP to get completion items at {request.Position} invoked by typing '{request.Context?.TriggerCharacter}'");
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/BlazorDataAttributeCompletionItemProvider.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/BlazorDataAttributeCompletionItemProvider.cs
@@ -121,7 +121,7 @@ internal class BlazorDataAttributeCompletionItemProvider : IRazorCompletionItemP
             }
 
             // VSCode doesn't use commit characters for attribute completions
-            var commitCharacters = context.Options.UseVsCodeCompletionCommitCharacters
+            var commitCharacters = context.Options.IsVsCode
                 ? ImmutableArray<RazorCommitCharacter>.Empty
                 : AttributeCommitCharacters;
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
@@ -283,7 +283,7 @@ internal partial class DirectiveAttributeCompletionItemProvider : DirectiveAttri
         using var completionItems = new PooledArrayBuilder<RazorCompletionItem>(capacity: attributeCompletions.Count);
 
         // VS Code handles commit characters separately upstream, so we don't send any.
-        var suppressCommitCharacters = completionContext.Options.UseVsCodeCompletionCommitCharacters;
+        var suppressCommitCharacters = completionContext.Options.IsVsCode;
 
         foreach (var (displayText, (kind, descriptions, commitCharacters)) in attributeCompletions)
         {

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionOptions.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionOptions.cs
@@ -7,4 +7,4 @@ internal record struct RazorCompletionOptions(
     bool SnippetsSupported,
     bool AutoInsertAttributeQuotes,
     bool CommitElementsWithSpace,
-    bool UseVsCodeCompletionCommitCharacters);
+    bool IsVsCode);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/TagHelperCompletionProvider.cs
@@ -153,7 +153,7 @@ internal class TagHelperCompletionProvider(ITagHelperCompletionService tagHelper
             }
 
             var attributeContext = ResolveAttributeContext(boundAttributes, isIndexer, options.SnippetsSupported);
-            var attributeCommitCharacters = options.UseVsCodeCompletionCommitCharacters ? [] : ResolveAttributeCommitCharacters(attributeContext);
+            var attributeCommitCharacters = options.IsVsCode ? [] : ResolveAttributeCommitCharacters(attributeContext);
             var isSnippet = false;
             var insertText = filterText;
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
@@ -243,7 +243,7 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
                     }
                 }
 
-                if (!razorCompletionOptions.UseVsCodeCompletionCommitCharacters)
+                if (!razorCompletionOptions.IsVsCode)
                 {
                     // Store resolve context so that completionItem/resolve can populate Detail
                     // and Documentation in O(1) without walking the HTML schema.
@@ -257,7 +257,7 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
                 }
             }
 
-            if (razorCompletionOptions.UseVsCodeCompletionCommitCharacters)
+            if (razorCompletionOptions.IsVsCode)
             {
                 // VSCode should fallback to the html language server for html completions
                 localHtmlCompletionList = null;

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
@@ -145,27 +145,15 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
         var documentSnapshot = remoteDocumentContext.Snapshot;
         var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
-        // Build a shared completion context — reused by both local HTML and Razor providers
-        // to avoid duplicate tree walks for finding the Owner node.
-        var razorCompletionContext = RazorCompletionListProvider.CreateCompletionContext(
-            codeDocument, documentPositionInfo.HostDocumentIndex, completionContext, razorCompletionOptions);
-
-        // Compute local HTML completions from the shared context
-        RazorVSInternalCompletionList? localHtmlCompletionList = null;
-        if (isHtmlTrigger
-            && LocalHtmlCompletionProvider.TryGetHtmlCompletionList(razorCompletionContext, out localHtmlCompletionList, out var htmlResolveContext)
-            && localHtmlCompletionList.Items.Length > 0)
-        {
-            // Store resolve context so that completionItem/resolve can populate Detail
-            // and Documentation in O(1) without walking the HTML schema.
-            var resultId = _completionListCache.Add(localHtmlCompletionList, htmlResolveContext);
-            localHtmlCompletionList.SetResultId(resultId, _clientCapabilitiesService.ClientCapabilities);
-
-            // Optimize here to reduce OOP→devenv JSON payload. The devenv-side optimizer
-            // is resilient to re-optimizing after merge (it dematerializes list-level chars).
-            var completionCapability = _clientCapabilitiesService.ClientCapabilities.TextDocument?.Completion;
-            localHtmlCompletionList = CompletionListOptimizer.Optimize(localHtmlCompletionList, completionCapability);
-        }
+        GetRazorCompletionContextAndLocalHtmlCompletionList(
+            completionContext,
+            razorCompletionOptions,
+            documentPositionInfo,
+            isRazorTrigger,
+            isHtmlTrigger,
+            codeDocument,
+            out var razorCompletionContext,
+            out var localHtmlCompletionList);
 
         if (!isCSharpTrigger && !isRazorTrigger)
         {
@@ -196,37 +184,9 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
                 .ConfigureAwait(false);
         }
 
-        RazorVSInternalCompletionList? razorCompletionList = null;
-
-        if (isRazorTrigger)
-        {
-            // When local HTML completions are available, attach their labels to the context
-            // so that HTML-dependent providers (e.g., TagHelperCompletionProvider) can use them
-            // inline without a separate round-trip.
-            if (localHtmlCompletionList is { Items: { Length: > 0 } items })
-            {
-                // Only include element names — these are used by TagHelperCompletionProvider
-                // to deduplicate tag helpers that share a name with an HTML element.
-                using var _ = ListPool<string>.GetPooledObject(out var elementLabels);
-                foreach (var item in items)
-                {
-                    if (item.Kind == CompletionItemKind.Element)
-                    {
-                        elementLabels.Add(item.Label);
-                    }
-                }
-
-                if (elementLabels.Count > 0)
-                {
-                    var htmlLabels = new HashSet<string>(elementLabels, StringComparer.OrdinalIgnoreCase);
-                    razorCompletionContext = razorCompletionContext with { HtmlLabels = htmlLabels };
-                }
-            }
-
-            razorCompletionList = _razorCompletionListProvider.GetCompletionList(
-                razorCompletionContext,
-                _clientCapabilitiesService.ClientCapabilities);
-        }
+        var razorCompletionList = isRazorTrigger
+            ? _razorCompletionListProvider.GetCompletionList(razorCompletionContext, _clientCapabilitiesService.ClientCapabilities)
+            : null;
 
         var mergedList = CompletionListMerger.Merge(razorCompletionList, csharpCompletionList);
         if (mergedList is not null)
@@ -236,6 +196,73 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
         }
 
         return CompletionResults.Create(mergedList, localHtmlCompletionList);
+    }
+
+    private void GetRazorCompletionContextAndLocalHtmlCompletionList(
+        VSInternalCompletionContext completionContext,
+        RazorCompletionOptions razorCompletionOptions,
+        DocumentPositionInfo documentPositionInfo,
+        bool isRazorTrigger,
+        bool isHtmlTrigger,
+        RazorCodeDocument codeDocument,
+        out RazorCompletionContext razorCompletionContext,
+        out RazorVSInternalCompletionList? localHtmlCompletionList)
+    {
+        // Build a shared completion context — reused by both local HTML and Razor providers
+        // to avoid duplicate tree walks for finding the Owner node.
+        razorCompletionContext = RazorCompletionListProvider.CreateCompletionContext(
+            codeDocument, documentPositionInfo.HostDocumentIndex, completionContext, razorCompletionOptions);
+
+        // Compute local HTML completions from the shared context
+        localHtmlCompletionList = null;
+        if (isHtmlTrigger
+            && LocalHtmlCompletionProvider.TryGetHtmlCompletionList(razorCompletionContext, out localHtmlCompletionList, out var htmlResolveContext))
+        {
+            // When local HTML completions are available, attach their labels to the context
+            // so that HTML-dependent providers (e.g., TagHelperCompletionProvider) can use them
+            // inline without a separate round-trip.
+            if (localHtmlCompletionList.Items.Length > 0)
+            {
+                if (isRazorTrigger)
+                {
+                    // Only include element names — these are used by TagHelperCompletionProvider
+                    // to deduplicate tag helpers that share a name with an HTML element.
+                    using var _ = ListPool<string>.GetPooledObject(out var elementLabels);
+                    foreach (var item in localHtmlCompletionList.Items)
+                    {
+                        if (item.Kind == CompletionItemKind.Element)
+                        {
+                            elementLabels.Add(item.Label);
+                        }
+                    }
+
+                    if (elementLabels.Count > 0)
+                    {
+                        var htmlLabels = new HashSet<string>(elementLabels, StringComparer.OrdinalIgnoreCase);
+                        razorCompletionContext = razorCompletionContext with { HtmlLabels = htmlLabels };
+                    }
+                }
+
+                if (!razorCompletionOptions.UseVsCodeCompletionCommitCharacters)
+                {
+                    // Store resolve context so that completionItem/resolve can populate Detail
+                    // and Documentation in O(1) without walking the HTML schema.
+                    var resultId = _completionListCache.Add(localHtmlCompletionList, htmlResolveContext);
+                    localHtmlCompletionList.SetResultId(resultId, _clientCapabilitiesService.ClientCapabilities);
+
+                    // Optimize here to reduce OOP→devenv JSON payload. The devenv-side optimizer
+                    // is resilient to re-optimizing after merge (it dematerializes list-level chars).
+                    var completionCapability = _clientCapabilitiesService.ClientCapabilities.TextDocument?.Completion;
+                    localHtmlCompletionList = CompletionListOptimizer.Optimize(localHtmlCompletionList, completionCapability);
+                }
+            }
+
+            if (razorCompletionOptions.UseVsCodeCompletionCommitCharacters)
+            {
+                // VSCode should fallback to the html language server for html completions
+                localHtmlCompletionList = null;
+            }
+        }
     }
 
     private async ValueTask<RazorVSInternalCompletionList?> GetCSharpCompletionAsync(

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
@@ -1746,11 +1746,11 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
 
         ClientSettingsManager.Update(ClientAdvancedSettings.Default with { AutoInsertAttributeQuotes = autoInsertAttributeQuotes, CommitElementsWithSpace = commitElementsWithSpace });
 
-        // If htmlItemLabels wasn't supplied, supply our own to ensure delegation isn't happening and causing a false positive result
 #if VSCODE
         // VS Code always delegates to the HTML LSP, so there's no "unexpected delegation" scenario to catch.
         htmlItemLabels ??= [];
 #else
+        // If htmlItemLabels wasn't supplied, supply our own to ensure delegation isn't happening and causing a false positive result.
         const string InvalidLabel = "_INVALID_";
         htmlItemLabels ??= [InvalidLabel];
 #endif

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -389,8 +389,10 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerCharacter = "<",
                 TriggerKind = CompletionTriggerKind.TriggerCharacter
             },
-            expectedItemLabels: ["text", "EditForm", "InputDate", "div"],
-            htmlItemLabels: ["div"]);
+#if VSCODE
+            htmlItemLabels: ["div"],
+#endif
+            expectedItemLabels: ["text", "EditForm", "InputDate", "div"]);
     }
 
     [Fact]
@@ -453,7 +455,9 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerKind = CompletionTriggerKind.TriggerCharacter
             },
             expectedItemLabels: ["LayoutView", "EditForm", "ValidationMessage", "div"],
+#if VSCODE
             htmlItemLabels: ["div"],
+#endif
             itemToResolve: "EditForm",
             expectedResolvedItemDescription: "Microsoft.AspNetCore.Components.Forms.EditForm");
     }
@@ -475,8 +479,10 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerCharacter = "<",
                 TriggerKind = CompletionTriggerKind.TriggerCharacter
             },
-            expectedItemLabels: ["div", "h1", "LayoutView", "EditForm", "ValidationMessage"],
-            htmlItemLabels: ["div", "h1"]);
+#if VSCODE
+            htmlItemLabels: ["div", "h1"],
+#endif
+            expectedItemLabels: ["div", "h1", "LayoutView", "EditForm", "ValidationMessage"]);
     }
 
     [Fact]
@@ -496,7 +502,9 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerKind = CompletionTriggerKind.TriggerCharacter
             },
             expectedItemLabels: ["my-bold", "strong"],
+#if VSCODE
             htmlItemLabels: ["strong"],
+#endif
             fileKind: RazorFileKind.Legacy,
             additionalFiles: [("TestTagHelper.cs", """
                 using Microsoft.AspNetCore.Razor.TagHelpers;
@@ -618,7 +626,9 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
             },
             unexpectedItemLabels: ["priority"],
             expectedItemLabels: ["style"],
+#if VSCODE
             htmlItemLabels: ["style"],
+#endif
             fileKind: RazorFileKind.Legacy,
             additionalFiles: [("TestTagHelper.cs", """
                 using Microsoft.AspNetCore.Razor.TagHelpers;
@@ -1010,8 +1020,10 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerKind = CompletionTriggerKind.TriggerCharacter
             },
             expectedItemLabels: ["div", "h1", "LayoutView", "EditForm", "ValidationMessage"],
-            unexpectedItemLabels: ["snippet1", "snippet2"],
-            htmlItemLabels: ["div", "h1"]);
+#if VSCODE
+            htmlItemLabels: ["div", "h1"],
+#endif
+            unexpectedItemLabels: ["snippet1", "snippet2"]);
     }
 
     [Fact]
@@ -1049,8 +1061,10 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerKind = CompletionTriggerKind.TriggerCharacter
             },
             expectedItemLabels: ["div", "h1", "LayoutView", "EditForm", "ValidationMessage"],
-            commitElementsWithSpace: false,
-            htmlItemLabels: ["div", "h1"]);
+#if VSCODE
+            htmlItemLabels: ["div", "h1"],
+#endif
+            commitElementsWithSpace: false);
     }
 
     // Tests HTML attributes and DirectiveAttributeTransitionCompletionItemProvider
@@ -1071,8 +1085,10 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerCharacter = null,
                 TriggerKind = CompletionTriggerKind.Invoked
             },
-            expectedItemLabels: ["style", "dir", "@..."],
-            htmlItemLabels: ["style", "dir"]);
+#if VSCODE
+            htmlItemLabels: ["style", "dir"],
+#endif
+            expectedItemLabels: ["style", "dir", "@..."]);
     }
 
     // Tests HTML attributes and DirectiveAttributeCompletionItemProvider
@@ -1094,9 +1110,9 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerKind = CompletionTriggerKind.TriggerCharacter
             },
             expectedItemLabels: ["style", "dir", "@rendermode", "@bind-..."],
-            htmlItemLabels: ["style", "dir"],
             itemToResolve: "@rendermode",
 #if VSCODE
+            htmlItemLabels: ["style", "dir"],
             expectedResolvedItemDescription: """
                 IComponentRenderMode RenderMode.RenderMode
 
@@ -1307,9 +1323,9 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerKind = CompletionTriggerKind.Invoked
             },
             expectedItemLabels: ["style", "dir", "FormName", "OnValidSubmit", "@..."],
-            htmlItemLabels: ["style", "dir"],
             itemToResolve: "FormName",
 #if VSCODE
+            htmlItemLabels: ["style", "dir"],
             expectedResolvedItemDescription: "string EditForm.FormName");
 #else
             expectedResolvedItemDescription: "string Microsoft.AspNetCore.Components.Forms.EditForm.FormName");
@@ -1334,9 +1350,9 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerKind = CompletionTriggerKind.Invoked
             },
             expectedItemLabels: ["style", "dir", "FormName", "OnValidSubmit", "@..."],
-            htmlItemLabels: ["style", "dir"],
             itemToResolve: "FormName",
 #if VSCODE
+            htmlItemLabels: ["style", "dir"],
             expectedResolvedItemDescription: "string EditForm.FormName");
 #else
             expectedResolvedItemDescription: "string Microsoft.AspNetCore.Components.Forms.EditForm.FormName");
@@ -1358,8 +1374,10 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerCharacter = null,
                 TriggerKind = CompletionTriggerKind.Invoked
             },
-            expectedItemLabels: ["style", "dir", "FormName", "OnValidSubmit", "@..."],
-            htmlItemLabels: ["style", "dir"]);
+#if VSCODE
+            htmlItemLabels: ["style", "dir"],
+#endif
+            expectedItemLabels: ["style", "dir", "FormName", "OnValidSubmit", "@..."]);
     }
 
     [Fact]
@@ -1380,7 +1398,9 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerKind = CompletionTriggerKind.Invoked
             },
             expectedItemLabels: ["FormName", "OnValidSubmit", "@...", "style"],
+#if VSCODE
             htmlItemLabels: ["style"],
+#endif
             autoInsertAttributeQuotes: false);
     }
 
@@ -1464,7 +1484,9 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerKind = CompletionTriggerKind.TriggerCharacter
             },
             expectedItemLabels: ["LayoutView", "EditForm", "ValidationMessage", "div", "Router", SR.FormatComponentCompletionWithRequiredAttributesLabel("Router")],
+#if VSCODE
             htmlItemLabels: ["div"],
+#endif
             itemToResolve: SR.FormatComponentCompletionWithRequiredAttributesLabel("Router"),
             expectedResolvedItemDescription: "Microsoft.AspNetCore.Components.Routing.Router",
             expected: $"""
@@ -1494,8 +1516,10 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerCharacter = null,
                 TriggerKind = CompletionTriggerKind.Invoked
             },
-            expectedItemLabels: ["data-enhance", "data-enhance-nav", "data-permanent", "dir", "@..."],
-            htmlItemLabels: ["dir"]);
+#if VSCODE
+            htmlItemLabels: ["dir"],
+#endif
+            expectedItemLabels: ["data-enhance", "data-enhance-nav", "data-permanent", "dir", "@..."]);
     }
 
     [Fact]
@@ -1517,7 +1541,9 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerKind = CompletionTriggerKind.Invoked
             },
             expectedItemLabels: ["data-enhance-nav", "data-permanent", "dir", "@..."],
+#if VSCODE
             htmlItemLabels: ["dir"],
+#endif
             unexpectedItemLabels: ["data-enhance"]);
     }
 
@@ -1540,7 +1566,9 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerKind = CompletionTriggerKind.Invoked
             },
             expectedItemLabels: ["data-enhance-nav", "data-permanent", "dir", "@..."],
+#if VSCODE
             htmlItemLabels: ["dir"],
+#endif
             unexpectedItemLabels: ["data-enhance"]);
     }
 
@@ -1563,7 +1591,9 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerKind = CompletionTriggerKind.Invoked
             },
             expectedItemLabels: ["data-enhance-nav", "data-permanent", "dir", "@..."],
+#if VSCODE
             htmlItemLabels: ["dir"],
+#endif
             unexpectedItemLabels: ["data-enhance"]);
     }
 

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
@@ -389,7 +389,8 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerCharacter = "<",
                 TriggerKind = CompletionTriggerKind.TriggerCharacter
             },
-            expectedItemLabels: ["text", "EditForm", "InputDate", "div"]);
+            expectedItemLabels: ["text", "EditForm", "InputDate", "div"],
+            htmlItemLabels: ["div"]);
     }
 
     [Fact]
@@ -452,6 +453,7 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerKind = CompletionTriggerKind.TriggerCharacter
             },
             expectedItemLabels: ["LayoutView", "EditForm", "ValidationMessage", "div"],
+            htmlItemLabels: ["div"],
             itemToResolve: "EditForm",
             expectedResolvedItemDescription: "Microsoft.AspNetCore.Components.Forms.EditForm");
     }
@@ -473,7 +475,8 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerCharacter = "<",
                 TriggerKind = CompletionTriggerKind.TriggerCharacter
             },
-            expectedItemLabels: ["div", "h1", "LayoutView", "EditForm", "ValidationMessage"]);
+            expectedItemLabels: ["div", "h1", "LayoutView", "EditForm", "ValidationMessage"],
+            htmlItemLabels: ["div", "h1"]);
     }
 
     [Fact]
@@ -493,6 +496,7 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerKind = CompletionTriggerKind.TriggerCharacter
             },
             expectedItemLabels: ["my-bold", "strong"],
+            htmlItemLabels: ["strong"],
             fileKind: RazorFileKind.Legacy,
             additionalFiles: [("TestTagHelper.cs", """
                 using Microsoft.AspNetCore.Razor.TagHelpers;
@@ -614,6 +618,7 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
             },
             unexpectedItemLabels: ["priority"],
             expectedItemLabels: ["style"],
+            htmlItemLabels: ["style"],
             fileKind: RazorFileKind.Legacy,
             additionalFiles: [("TestTagHelper.cs", """
                 using Microsoft.AspNetCore.Razor.TagHelpers;
@@ -641,6 +646,7 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 """)]);
     }
 
+#if !VSCODE
     [Fact]
     public async Task HtmlCompletionFailure_LocalProviderStillSucceeds()
     {
@@ -661,11 +667,7 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
         // Use a TestHtmlRequestInvoker that returns null (simulating HTML server not ready)
         var requestInvoker = new TestHtmlRequestInvoker((Methods.TextDocumentCompletionName, (object?)null));
 
-#if VSCODE
-        ISnippetCompletionItemProvider? snippetCompletionItemProvider = null;
-#else
         var snippetCompletionItemProvider = new SnippetCompletionItemProvider(new SnippetCache());
-#endif
 
         var completionListCache = new CompletionListCache();
         var endpoint = new CohostDocumentCompletionEndpoint(
@@ -702,12 +704,11 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
         Assert.Contains(result.Items, item => item.Label == "div");
         Assert.Contains(result.Items, item => item.Label == "span");
     }
+#endif
 
     [Fact]
-    public async Task ElementCompletion_SkipsHtmlDelegation()
+    public async Task ElementCompletion_HtmlDelegationBehavior()
     {
-        // Configure a fake WebTools response — if delegation occurred, this label would
-        // appear in the results. We verify it does NOT, proving the local provider handled it.
         await VerifyCompletionListAsync(
             input: """
                 This is a Razor document.
@@ -722,13 +723,20 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerCharacter = "<",
                 TriggerKind = CompletionTriggerKind.TriggerCharacter
             },
+#if VSCODE
+            // VS Code always delegates to HTML LSP
+            expectedItemLabels: ["html-from-lsp"],
+            htmlItemLabels: ["html-from-lsp"]);
+#else
+            // VS handles locally — no delegation occurs
             expectedItemLabels: ["div", "span", "a", "p"],
             unexpectedItemLabels: ["html-should-not-delegate"],
             htmlItemLabels: ["html-should-not-delegate"]);
+#endif
     }
 
     [Fact]
-    public async Task AttributeCompletion_SkipsHtmlDelegation()
+    public async Task AttributeCompletion_HtmlDelegationBehavior()
     {
         await VerifyCompletionListAsync(
             input: """
@@ -743,13 +751,18 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 InvokeKind = VSInternalCompletionInvokeKind.Explicit,
                 TriggerKind = CompletionTriggerKind.Invoked
             },
+#if VSCODE
+            expectedItemLabels: ["html-from-lsp"],
+            htmlItemLabels: ["html-from-lsp"]);
+#else
             expectedItemLabels: ["id", "class", "style"],
             unexpectedItemLabels: ["html-should-not-delegate"],
             htmlItemLabels: ["html-should-not-delegate"]);
+#endif
     }
 
     [Fact]
-    public async Task AttributeValueCompletion_SkipsHtmlDelegation()
+    public async Task AttributeValueCompletion_HtmlDelegationBehavior()
     {
         await VerifyCompletionListAsync(
             input: """
@@ -764,9 +777,14 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 InvokeKind = VSInternalCompletionInvokeKind.Typing,
                 TriggerKind = CompletionTriggerKind.Invoked
             },
+#if VSCODE
+            expectedItemLabels: ["html-from-lsp"],
+            htmlItemLabels: ["html-from-lsp"]);
+#else
             expectedItemLabels: ["text", "tel"],
             unexpectedItemLabels: ["html-should-not-delegate"],
             htmlItemLabels: ["html-should-not-delegate"]);
+#endif
     }
 
 #if !VSCODE // "/" is only a registered trigger character in VS, not VS Code
@@ -794,7 +812,7 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
 #endif
 
     [Fact]
-    public async Task EntityCompletion_SkipsHtmlDelegation()
+    public async Task EntityCompletion_HtmlDelegationBehavior()
     {
         await VerifyCompletionListAsync(
             input: """
@@ -809,17 +827,20 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 InvokeKind = VSInternalCompletionInvokeKind.Typing,
                 TriggerKind = CompletionTriggerKind.Invoked
             },
+#if VSCODE
+            expectedItemLabels: ["html-from-lsp"],
+            htmlItemLabels: ["html-from-lsp"],
+#else
             expectedItemLabels: ["&amp; (&)", "&lt; (<)", "&gt; (>)", "&nbsp; (\u00A0)"],
             unexpectedItemLabels: ["html-should-not-delegate"],
             htmlItemLabels: ["html-should-not-delegate"],
+#endif
             snippetLabels: []);
     }
 
     [Fact]
-    public async Task PlainTextContent_SkipsHtmlDelegation()
+    public async Task PlainTextContent_HtmlDelegationBehavior()
     {
-        // Plain text content between tags returns empty (no HTML completions apply)
-        // but should NOT delegate to WebTools.
         await VerifyCompletionListAsync(
             input: """
                 This is a Razor document.
@@ -833,9 +854,16 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 InvokeKind = VSInternalCompletionInvokeKind.Explicit,
                 TriggerKind = CompletionTriggerKind.Invoked
             },
+#if VSCODE
+            // VS Code always delegates to HTML LSP, even for plain text content
+            expectedItemLabels: ["html-from-lsp"],
+            htmlItemLabels: ["html-from-lsp"],
+#else
+            // VS handles locally — plain text returns empty, no delegation
             expectedItemLabels: [],
             unexpectedItemLabels: ["html-should-not-delegate"],
             htmlItemLabels: ["html-should-not-delegate"],
+#endif
             snippetLabels: []);
     }
 
@@ -982,7 +1010,8 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerKind = CompletionTriggerKind.TriggerCharacter
             },
             expectedItemLabels: ["div", "h1", "LayoutView", "EditForm", "ValidationMessage"],
-            unexpectedItemLabels: ["snippet1", "snippet2"]);
+            unexpectedItemLabels: ["snippet1", "snippet2"],
+            htmlItemLabels: ["div", "h1"]);
     }
 
     [Fact]
@@ -1020,7 +1049,8 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerKind = CompletionTriggerKind.TriggerCharacter
             },
             expectedItemLabels: ["div", "h1", "LayoutView", "EditForm", "ValidationMessage"],
-            commitElementsWithSpace: false);
+            commitElementsWithSpace: false,
+            htmlItemLabels: ["div", "h1"]);
     }
 
     // Tests HTML attributes and DirectiveAttributeTransitionCompletionItemProvider
@@ -1041,7 +1071,8 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerCharacter = null,
                 TriggerKind = CompletionTriggerKind.Invoked
             },
-            expectedItemLabels: ["style", "dir", "@..."]);
+            expectedItemLabels: ["style", "dir", "@..."],
+            htmlItemLabels: ["style", "dir"]);
     }
 
     // Tests HTML attributes and DirectiveAttributeCompletionItemProvider
@@ -1063,6 +1094,7 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerKind = CompletionTriggerKind.TriggerCharacter
             },
             expectedItemLabels: ["style", "dir", "@rendermode", "@bind-..."],
+            htmlItemLabels: ["style", "dir"],
             itemToResolve: "@rendermode",
 #if VSCODE
             expectedResolvedItemDescription: """
@@ -1275,6 +1307,7 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerKind = CompletionTriggerKind.Invoked
             },
             expectedItemLabels: ["style", "dir", "FormName", "OnValidSubmit", "@..."],
+            htmlItemLabels: ["style", "dir"],
             itemToResolve: "FormName",
 #if VSCODE
             expectedResolvedItemDescription: "string EditForm.FormName");
@@ -1301,6 +1334,7 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerKind = CompletionTriggerKind.Invoked
             },
             expectedItemLabels: ["style", "dir", "FormName", "OnValidSubmit", "@..."],
+            htmlItemLabels: ["style", "dir"],
             itemToResolve: "FormName",
 #if VSCODE
             expectedResolvedItemDescription: "string EditForm.FormName");
@@ -1324,7 +1358,8 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerCharacter = null,
                 TriggerKind = CompletionTriggerKind.Invoked
             },
-            expectedItemLabels: ["style", "dir", "FormName", "OnValidSubmit", "@..."]);
+            expectedItemLabels: ["style", "dir", "FormName", "OnValidSubmit", "@..."],
+            htmlItemLabels: ["style", "dir"]);
     }
 
     [Fact]
@@ -1345,6 +1380,7 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerKind = CompletionTriggerKind.Invoked
             },
             expectedItemLabels: ["FormName", "OnValidSubmit", "@...", "style"],
+            htmlItemLabels: ["style"],
             autoInsertAttributeQuotes: false);
     }
 
@@ -1366,7 +1402,8 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerKind = CompletionTriggerKind.Invoked
             },
             expectedItemLabels: ["FormName", "OnValidSubmit", "@...", "style"],
-            autoInsertAttributeQuotes: false);
+            autoInsertAttributeQuotes: false,
+            htmlItemLabels: ["style"]);
 
         Assert.NotNull(list);
         Assert.All(list.Items, item => Assert.DoesNotContain("=", item.CommitCharacters ?? []));
@@ -1427,6 +1464,7 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerKind = CompletionTriggerKind.TriggerCharacter
             },
             expectedItemLabels: ["LayoutView", "EditForm", "ValidationMessage", "div", "Router", SR.FormatComponentCompletionWithRequiredAttributesLabel("Router")],
+            htmlItemLabels: ["div"],
             itemToResolve: SR.FormatComponentCompletionWithRequiredAttributesLabel("Router"),
             expectedResolvedItemDescription: "Microsoft.AspNetCore.Components.Routing.Router",
             expected: $"""
@@ -1456,7 +1494,8 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerCharacter = null,
                 TriggerKind = CompletionTriggerKind.Invoked
             },
-            expectedItemLabels: ["data-enhance", "data-enhance-nav", "data-permanent", "dir", "@..."]);
+            expectedItemLabels: ["data-enhance", "data-enhance-nav", "data-permanent", "dir", "@..."],
+            htmlItemLabels: ["dir"]);
     }
 
     [Fact]
@@ -1478,6 +1517,7 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerKind = CompletionTriggerKind.Invoked
             },
             expectedItemLabels: ["data-enhance-nav", "data-permanent", "dir", "@..."],
+            htmlItemLabels: ["dir"],
             unexpectedItemLabels: ["data-enhance"]);
     }
 
@@ -1500,6 +1540,7 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerKind = CompletionTriggerKind.Invoked
             },
             expectedItemLabels: ["data-enhance-nav", "data-permanent", "dir", "@..."],
+            htmlItemLabels: ["dir"],
             unexpectedItemLabels: ["data-enhance"]);
     }
 
@@ -1522,6 +1563,7 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 TriggerKind = CompletionTriggerKind.Invoked
             },
             expectedItemLabels: ["data-enhance-nav", "data-permanent", "dir", "@..."],
+            htmlItemLabels: ["dir"],
             unexpectedItemLabels: ["data-enhance"]);
     }
 
@@ -1704,10 +1746,14 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
 
         ClientSettingsManager.Update(ClientAdvancedSettings.Default with { AutoInsertAttributeQuotes = autoInsertAttributeQuotes, CommitElementsWithSpace = commitElementsWithSpace });
 
+        // If htmlItemLabels wasn't supplied, supply our own to ensure delegation isn't happening and causing a false positive result
+#if VSCODE
+        // VS Code always delegates to the HTML LSP, so there's no "unexpected delegation" scenario to catch.
+        htmlItemLabels ??= [];
+#else
         const string InvalidLabel = "_INVALID_";
-
-        // If delegatedItemLabels wasn't supplied, supply our own to ensure delegation isn't happening and causing a false positive result
         htmlItemLabels ??= [InvalidLabel];
+#endif
         var response = new RazorVSInternalCompletionList()
         {
             Items = [.. htmlItemLabels.Select((label) => new VSInternalCompletionItem()
@@ -1783,7 +1829,9 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
         using var _ = HashSetPool<string>.GetPooledObject(out var labelSet);
         labelSet.AddRange(result.Items.SelectAsArray((item) => item.Label));
 
+#if !VSCODE
         Assert.DoesNotContain(InvalidLabel, labelSet);
+#endif
 
         foreach (var expectedItemLabel in expectedItemLabels)
         {
@@ -1800,7 +1848,7 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
 
         if (!commitElementsWithSpace)
         {
-            Assert.False(result.Items.Any(item => item.CommitCharacters?.First().Contains(' ') ?? false));
+            Assert.False(result.Items.Any(item => item.CommitCharacters?.Any(commitCharacter => commitCharacter.Contains(' ')) ?? false));
         }
 
         if (!autoInsertAttributeQuotes)

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/BlazorDataAttributeCompletionItemProviderTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/BlazorDataAttributeCompletionItemProviderTest.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
@@ -27,7 +27,7 @@ public class BlazorDataAttributeCompletionItemProviderTest : RazorToolingIntegra
             SnippetsSupported: true,
             AutoInsertAttributeQuotes: true,
             CommitElementsWithSpace: true,
-            UseVsCodeCompletionCommitCharacters: false);
+            IsVsCode: false);
     }
 
     [Fact]
@@ -187,7 +187,7 @@ public class BlazorDataAttributeCompletionItemProviderTest : RazorToolingIntegra
             SnippetsSupported: false,
             AutoInsertAttributeQuotes: true,
             CommitElementsWithSpace: true,
-            UseVsCodeCompletionCommitCharacters: false);
+            IsVsCode: false);
         TestCode testCode = "<form d$$></form>";
         var codeDocument = GetCodeDocument(testCode.Text);
         var syntaxTree = codeDocument.GetRequiredTagHelperRewrittenSyntaxTree();

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/DirectiveAttributeCompletionItemProviderTest.AttributeNames.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/DirectiveAttributeCompletionItemProviderTest.AttributeNames.cs
@@ -34,7 +34,7 @@ public partial class DirectiveAttributeCompletionItemProviderTest : RazorTooling
 
         var codeDocument = GetCodeDocument(string.Empty);
         _defaultTagHelperContext = codeDocument.GetRequiredTagHelperContext();
-        _defaultRazorCompletionOptions = new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true, UseVsCodeCompletionCommitCharacters: false);
+        _defaultRazorCompletionOptions = new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true, IsVsCode: false);
     }
 
     private RazorCodeDocument GetCodeDocument(string content)
@@ -73,7 +73,7 @@ public partial class DirectiveAttributeCompletionItemProviderTest : RazorTooling
     public void GetCompletionItems_OnDirectiveAttributeName_bind_VsCode_ReturnsEmptyCommitCharacters()
     {
         // Arrange
-        var vsCodeOptions = new RazorCompletionOptions(SnippetsSupported: false, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true, UseVsCodeCompletionCommitCharacters: true);
+        var vsCodeOptions = new RazorCompletionOptions(SnippetsSupported: false, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true, IsVsCode: true);
         var context = CreateRazorCompletionContext("<input @$$  />") with
         {
             Options = vsCodeOptions
@@ -285,7 +285,7 @@ public partial class DirectiveAttributeCompletionItemProviderTest : RazorTooling
     public void GetAttributeCompletions_WithNoAutoQuotesOption_ReturnsNonQuotedSnippet()
     {
         // Arrange
-        var noAutoQuotesRazorCompletionOptions = new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: false, CommitElementsWithSpace: true, UseVsCodeCompletionCommitCharacters: false);
+        var noAutoQuotesRazorCompletionOptions = new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: false, CommitElementsWithSpace: true, IsVsCode: false);
         var context = GetDefaultDirectivateAttributeCompletionContext("@") with
         {
             Options = noAutoQuotesRazorCompletionOptions
@@ -302,7 +302,7 @@ public partial class DirectiveAttributeCompletionItemProviderTest : RazorTooling
     public void GetAttributeCompletions_WithNoSnippetsOption_ReturnsNoSnippets()
     {
         // Arrange
-        var noAutoQuotesRazorCompletionOptions = new RazorCompletionOptions(SnippetsSupported: false, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true, UseVsCodeCompletionCommitCharacters: false);
+        var noAutoQuotesRazorCompletionOptions = new RazorCompletionOptions(SnippetsSupported: false, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true, IsVsCode: false);
         var context = GetDefaultDirectivateAttributeCompletionContext("@") with
         {
             UseSnippets = false,
@@ -320,7 +320,7 @@ public partial class DirectiveAttributeCompletionItemProviderTest : RazorTooling
     public void GetAttributeCompletions_ExistingAttributeWithValue_ReturnsNoSnippets()
     {
         // Arrange
-        var noAutoQuotesRazorCompletionOptions = new RazorCompletionOptions(SnippetsSupported: false, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true, UseVsCodeCompletionCommitCharacters: false);
+        var noAutoQuotesRazorCompletionOptions = new RazorCompletionOptions(SnippetsSupported: false, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true, IsVsCode: false);
         var context = GetDefaultDirectivateAttributeCompletionContext("@") with
         {
             UseSnippets = false,

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/LocalHtmlCompletionProviderTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/LocalHtmlCompletionProviderTest.cs
@@ -29,7 +29,7 @@ public class LocalHtmlCompletionProviderTest
         SnippetsSupported: true,
         AutoInsertAttributeQuotes: true,
         CommitElementsWithSpace: true,
-        UseVsCodeCompletionCommitCharacters: false);
+        IsVsCode: false);
 
     #region Element Completion
 

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/RazorCompletionListProviderTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/RazorCompletionListProviderTest.cs
@@ -47,7 +47,7 @@ public class RazorCompletionListProviderTest
         };
 
         _defaultCompletionContext = new VSInternalCompletionContext();
-        _razorCompletionOptions = new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true, UseVsCodeCompletionCommitCharacters: false);
+        _razorCompletionOptions = new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true, IsVsCode: false);
 
         _loggerFactory = new TestOutputLoggerFactory(testOutput);
     }
@@ -528,7 +528,7 @@ public class RazorCompletionListProviderTest
         var codeDocument = CreateCodeDocument("<test  ", documentPath, [tagHelper]);
 
         // Set up desired options
-        var razorCompletionOptions = new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: false, CommitElementsWithSpace: true, UseVsCodeCompletionCommitCharacters: false);
+        var razorCompletionOptions = new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: false, CommitElementsWithSpace: true, IsVsCode: false);
 
         var completionFactsService = new LspRazorCompletionFactsService(GetCompletionProviders());
         var provider = new RazorCompletionListProvider(completionFactsService, _completionListCache, _loggerFactory);

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/TagHelperCompletionProviderTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/TagHelperCompletionProviderTest.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
@@ -35,7 +35,7 @@ public class TagHelperCompletionProviderTest(ITestOutputHelper testOutput) : Too
             syntaxTree,
             tagHelperContext,
             CompletionReason.Invoked,
-            new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true, UseVsCodeCompletionCommitCharacters: false));
+            new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true, IsVsCode: false));
 
         var provider = new TagHelperCompletionProvider(new TagHelperCompletionService());
 
@@ -69,7 +69,7 @@ public class TagHelperCompletionProviderTest(ITestOutputHelper testOutput) : Too
             syntaxTree,
             tagHelperContext,
             CompletionReason.Invoked,
-            new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true, UseVsCodeCompletionCommitCharacters: false));
+            new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true, IsVsCode: false));
 
         var provider = new TagHelperCompletionProvider(new TagHelperCompletionService());
 
@@ -117,7 +117,7 @@ public class TagHelperCompletionProviderTest(ITestOutputHelper testOutput) : Too
             syntaxTree,
             tagHelperContext,
             CompletionReason.Invoked,
-            new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true, UseVsCodeCompletionCommitCharacters: false));
+            new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true, IsVsCode: false));
 
         var provider = new TagHelperCompletionProvider(new TagHelperCompletionService());
 


### PR DESCRIPTION
This was recently changed to use to our own "local" html calculations by default, but the behaviors differ enough in VSCode that we'll just always enable the html language server fallback to maintain consistency with the VSCode html editor.

Additionally, the snippet behavior in text context was changed due to it being super annoying in VS, but it's how the VSCode html editor works too, so I'm switching that back.

Note that these caused quite a few test behavior changes, so the fallout there is a bit larger than you would expect as the VSCode runs on the tests would fail without supplying the htmlItemLabels.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83783)