### PR TITLE
Collect Sequence_*.xml files in Helix post command

### DIFF
--- a/src/Tools/RunTests/HelixTestRunner.cs
+++ b/src/Tools/RunTests/HelixTestRunner.cs
@@ -338,24 +338,34 @@ internal sealed class HelixTestRunner
         {
             var isUnix = testOS != TestOS.Windows;
 
-            // We want to collect any dumps during the post command step here; these commands are ran after the
-            // return value of the main command is captured; a Helix Job is considered to fail if the main command returns a
-            // non-zero error code, and we don't want the cleanup steps to interfere with that. PostCommands exist
-            // precisely to address this problem.
+            // We want to collect diagnostic artifacts during the post command step here; these commands
+            // are ran after the return value of the main command is captured. A Helix Job is considered
+            // to fail if the main command returns a non-zero error code, and we don't want the cleanup
+            // steps to interfere with that. PostCommands exist precisely to address this problem.
             //
-            // This is still necessary even with us setting DOTNET_DbgMiniDumpName because the system can create 
-            // non .NET Core dump files that aren't controlled by that value.
+            // The artifacts collected are:
+            //  - *.dmp: crash dump files. This is still necessary even with us setting
+            //    DOTNET_DbgMiniDumpName because the system can create non .NET Core dump files that
+            //    aren't controlled by that value.
+            //  - Sequence_*.xml: xunit sequence files that track the order of tests executed and which
+            //    ones were active when the test host crashed.
             string command;
 
             if (isUnix)
             {
                 // Write out this command into a separate file; unfortunately the use of single quotes and ; that is required
                 // for the command to work causes too much escaping issues in MSBuild.
-                command = "find . -name '*.dmp' -exec cp {} $HELIX_DUMP_FOLDER \\;";
+                command = """
+                    find . -name '*.dmp' -exec cp {} $HELIX_DUMP_FOLDER \;
+                    find . -name 'Sequence_*.xml' -exec cp {} $HELIX_DUMP_FOLDER \;
+                    """;
             }
             else
             {
-                command = "for /r %%f in (*.dmp) do copy %%f %HELIX_DUMP_FOLDER%";
+                command = """
+                    for /r %%f in (*.dmp) do copy %%f %HELIX_DUMP_FOLDER%
+                    for /r %%f in (Sequence_*.xml) do copy %%f %HELIX_DUMP_FOLDER%
+                    """;
             }
 
             return (isUnix ? "post-command.sh" : "post-command.cmd", command);


### PR DESCRIPTION
The post command step already copies crash dump files (\*.dmp) into HELIX_DUMP_FOLDER for diagnostic purposes. This change extends it to also collect Sequence_\*.xml files, which are generated by xunit on failure to record the order of tests executed and which tests were active when the test host crashed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83784)

This makes it easy to answer questions like 

> What test was executing when the test process crashed or timed out. 