### PR TITLE
Add caller location tracking to pool allocations for leak diagnostics

### DIFF
--- a/src/Dependencies/Collections/Extensions/FixedSizeArrayBuilder.cs
+++ b/src/Dependencies/Collections/Extensions/FixedSizeArrayBuilder.cs
@@ -39,8 +39,8 @@ using Microsoft.CodeAnalysis.PooledObjects;
 /// </item>
 /// </list>
 /// If any of the above are not true (for example, the capacity is a rough hint, or the exact number of elements may not
-/// match the capacity specified, or if it's intended as a scratch buffer, and won't realize a final array), then <see
-/// cref="ArrayBuilder{T}.GetInstance(int, T)"/> should be used instead.
+/// match the capacity specified, or if it's intended as a scratch buffer, and won't realize a final array), then
+/// <see cref="ArrayBuilder{T}"/>'s <c>GetInstance</c> should be used instead.
 /// </remarks>
 [NonCopyable]
 internal struct FixedSizeArrayBuilder<T>(int capacity)

--- a/src/Dependencies/PooledObjects/ArrayBuilder.cs
+++ b/src/Dependencies/PooledObjects/ArrayBuilder.cs
@@ -11,6 +11,10 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
+#if DEBUG
+using System.Runtime.CompilerServices;
+#endif
+
 namespace Microsoft.CodeAnalysis.PooledObjects
 {
     [DebuggerDisplay("Count = {Count,nq}")]
@@ -502,21 +506,43 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         // 2) Expose the pool or the way to create a pool or the way to get an instance.
         //    for now we will expose both and figure which way works better
         private static readonly ObjectPool<ArrayBuilder<T>> s_poolInstance = CreatePool();
-        public static ArrayBuilder<T> GetInstance()
+        public static ArrayBuilder<T> GetInstance(
+#if DEBUG
+            [CallerFilePath] string? filePath = null,
+            [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
-            var builder = s_poolInstance.Allocate();
+            var builder = s_poolInstance.Allocate(
+#if DEBUG
+                filePath, lineNumber
+#endif
+                );
             Debug.Assert(builder.Count == 0);
             return builder;
         }
 
-        public static ArrayBuilder<T> GetInstance(int capacity)
+        public static ArrayBuilder<T> GetInstance(
+            int capacity
+#if DEBUG
+            , [CallerFilePath] string? filePath = null,
+            [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
-            var builder = GetInstance();
+            var builder = GetInstance(
+#if DEBUG
+                filePath, lineNumber
+#endif
+                );
             builder.EnsureCapacity(capacity);
             return builder;
         }
 
-        public static ArrayBuilder<T> GetInstance(int capacity, T fillWithValue)
+        public static ArrayBuilder<T> GetInstance(
+            int capacity,
+            T fillWithValue
+            )
         {
             var builder = GetInstance();
             builder.EnsureCapacity(capacity);
@@ -530,15 +556,15 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         }
 
         public static ObjectPool<ArrayBuilder<T>> CreatePool(
-            [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
-            [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0)
+            [CallerFilePath] string filePath = "",
+            [CallerLineNumber] int lineNumber = 0)
         {
             return CreatePool(128, filePath, lineNumber); // we rarely need more than 10
         }
 
         public static ObjectPool<ArrayBuilder<T>> CreatePool(int size,
-            [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
-            [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0)
+            [CallerFilePath] string filePath = "",
+            [CallerLineNumber] int lineNumber = 0)
         {
             ObjectPool<ArrayBuilder<T>>? pool = null;
             pool = new ObjectPool<ArrayBuilder<T>>(() => new ArrayBuilder<T>(pool!), size, filePath: filePath, lineNumber: lineNumber);
@@ -959,26 +985,72 @@ namespace Microsoft.CodeAnalysis.PooledObjects
 
         private static readonly ObjectPool<ArrayBuilder<T>> s_keepLargeInstancesPool = CreatePool();
 
-        public static PooledDisposer<ArrayBuilder<T>> GetInstance(out ArrayBuilder<T> instance)
-            => GetInstance(discardLargeInstances: true, out instance);
+        public static PooledDisposer<ArrayBuilder<T>> GetInstance(
+            out ArrayBuilder<T> instance
+#if DEBUG
+            , [CallerFilePath] string? filePath = null,
+            [CallerLineNumber] int lineNumber = 0
+#endif
+            )
+            => GetInstance(discardLargeInstances: true, out instance
+#if DEBUG
+                , filePath, lineNumber
+#endif
+                );
 
-        public static PooledDisposer<ArrayBuilder<T>> GetInstance(int capacity, out ArrayBuilder<T> instance)
+        public static PooledDisposer<ArrayBuilder<T>> GetInstance(
+            int capacity,
+            out ArrayBuilder<T> instance
+#if DEBUG
+            , [CallerFilePath] string? filePath = null,
+            [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
-            instance = GetInstance(capacity);
+            instance = GetInstance(capacity
+#if DEBUG
+                , filePath, lineNumber
+#endif
+                );
             return new PooledDisposer<ArrayBuilder<T>>(instance);
         }
 
-        public static PooledDisposer<ArrayBuilder<T>> GetInstance(int capacity, T fillWithValue, out ArrayBuilder<T> instance)
+        public static PooledDisposer<ArrayBuilder<T>> GetInstance(
+            int capacity,
+            T fillWithValue,
+            out ArrayBuilder<T> instance
+#if DEBUG
+            , [CallerFilePath] string? filePath = null,
+            [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
             instance = GetInstance(capacity, fillWithValue);
             return new PooledDisposer<ArrayBuilder<T>>(instance);
         }
 
-        public static PooledDisposer<ArrayBuilder<T>> GetInstance(bool discardLargeInstances, out ArrayBuilder<T> instance)
+        public static PooledDisposer<ArrayBuilder<T>> GetInstance(
+            bool discardLargeInstances,
+            out ArrayBuilder<T> instance
+#if DEBUG
+            , [CallerFilePath] string? filePath = null,
+            [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
             // If we're discarding large instances (the default behavior), then just use the normal pool.  If we're not, use
             // a specific pool so that *other* normal callers don't accidentally get it and discard it.
-            instance = discardLargeInstances ? GetInstance() : s_keepLargeInstancesPool.Allocate();
+            instance = discardLargeInstances
+                ? GetInstance(
+#if DEBUG
+                    filePath, lineNumber
+#endif
+                    )
+                : s_keepLargeInstancesPool.Allocate(
+#if DEBUG
+                    filePath, lineNumber
+#endif
+                    );
             return new PooledDisposer<ArrayBuilder<T>>(instance, discardLargeInstances);
         }
 

--- a/src/Dependencies/PooledObjects/ObjectPool`1.cs
+++ b/src/Dependencies/PooledObjects/ObjectPool`1.cs
@@ -8,6 +8,10 @@ using System;
 using System.Diagnostics;
 using System.Threading;
 
+#if DEBUG
+using System.Runtime.CompilerServices;
+#endif
+
 namespace Microsoft.CodeAnalysis.PooledObjects
 {
     /// <summary>
@@ -67,15 +71,15 @@ namespace Microsoft.CodeAnalysis.PooledObjects
 #endif
 
         internal ObjectPool(Factory factory, bool trimOnFree = true, bool trackLeaks = true,
-            [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
-            [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0)
+            [CallerFilePath] string filePath = "",
+            [CallerLineNumber] int lineNumber = 0)
             : this(factory, Environment.ProcessorCount * 2, trimOnFree, trackLeaks, filePath, lineNumber)
         {
         }
 
         internal ObjectPool(Factory factory, int size, bool trimOnFree = true, bool trackLeaks = true,
-            [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
-            [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0)
+            [CallerFilePath] string filePath = "",
+            [CallerLineNumber] int lineNumber = 0)
         {
             Debug.Assert(size >= 1);
             _factory = factory;
@@ -88,8 +92,8 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         }
 
         internal ObjectPool(Func<ObjectPool<T>, T> factory, int size,
-            [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
-            [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0)
+            [CallerFilePath] string filePath = "",
+            [CallerLineNumber] int lineNumber = 0)
         {
             Debug.Assert(size >= 1);
             _factory = () => factory(this);
@@ -114,7 +118,12 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         /// Note that Free will try to store recycled objects close to the start thus statistically 
         /// reducing how far we will typically search.
         /// </remarks>
-        internal T Allocate()
+        internal T Allocate(
+#if DEBUG
+            [CallerFilePath] string? filePath = null,
+            [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
             // PERF: Examine the first element. If that fails, AllocateSlow will look at the remaining elements.
             // Note that the initial read is optimistically not synchronized. That is intentional. 
@@ -128,7 +137,7 @@ namespace Microsoft.CodeAnalysis.PooledObjects
 
 #if DEBUG
             if (_trackLeaks)
-                PoolTracker.OnAllocate(inst, _poolName);
+                PoolTracker.OnAllocate(inst, _poolName, filePath, lineNumber);
 #endif
             return inst;
         }

--- a/src/Dependencies/PooledObjects/PoolTracker.cs
+++ b/src/Dependencies/PooledObjects/PoolTracker.cs
@@ -61,12 +61,16 @@ internal static class PoolTracker
     /// Records that a pooled object has been allocated.
     /// </summary>
     [Conditional("DEBUG")]
-    internal static void OnAllocate(object obj, string? poolName = null)
+    internal static void OnAllocate(
+        object obj,
+        string? poolName = null,
+        string? filePath = null,
+        int lineNumber = 0)
     {
 #if DEBUG
         if (s_activeTrackers > 0)
         {
-            s_currentContext.Value?.OnAllocate(obj, poolName);
+            s_currentContext.Value?.OnAllocate(obj, poolName, filePath, lineNumber);
         }
 #endif
     }
@@ -116,9 +120,9 @@ internal sealed class PoolTrackingContext
         _traceLeaks = traceLeaks;
     }
 
-    internal void OnAllocate(object obj, string? poolName)
+    internal void OnAllocate(object obj, string? poolName, string? filePath, int lineNumber)
     {
-        _outstanding.TryAdd(obj, new AllocationInfo(obj.GetType(), poolName, _traceLeaks ? Environment.StackTrace : null));
+        _outstanding.TryAdd(obj, new AllocationInfo(obj.GetType(), poolName, filePath, lineNumber, _traceLeaks ? Environment.StackTrace : null));
     }
 
     internal void OnFree(object obj)
@@ -148,10 +152,15 @@ internal sealed class PoolTrackingContext
         var sb = new StringBuilder();
         sb.AppendLine("Pool leak detected! The following pooled objects were not returned:");
 
-        foreach (var group in _outstanding.Values.GroupBy(v => (v.Type, v.PoolName)).OrderByDescending(g => g.Count()))
+        foreach (var group in _outstanding.Values.GroupBy(v => (v.Type, v.PoolName, v.FilePath, v.LineNumber)).OrderByDescending(g => g.Count()))
         {
             var poolInfo = group.Key.PoolName is not null ? $" (from {group.Key.PoolName})" : "";
             sb.AppendLine($"  {group.Key.Type}{poolInfo}: {group.Count()}");
+
+            if (group.Key.FilePath is not null)
+            {
+                sb.AppendLine($"    Allocated at: {System.IO.Path.GetFileName(group.Key.FilePath)}:{group.Key.LineNumber}");
+            }
 
             foreach (var info in group)
             {
@@ -166,10 +175,12 @@ internal sealed class PoolTrackingContext
         return sb.ToString();
     }
 
-    private readonly struct AllocationInfo(Type type, string? poolName, string? stackTrace)
+    private readonly struct AllocationInfo(Type type, string? poolName, string? filePath, int lineNumber, string? stackTrace)
     {
         public readonly Type Type = type;
         public readonly string? PoolName = poolName;
+        public readonly string? FilePath = filePath;
+        public readonly int LineNumber = lineNumber;
         public readonly string? StackTrace = stackTrace;
     }
 }

--- a/src/Dependencies/PooledObjects/PooledDictionary.cs
+++ b/src/Dependencies/PooledObjects/PooledDictionary.cs
@@ -8,6 +8,10 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 
+#if DEBUG
+using System.Runtime.CompilerServices;
+#endif
+
 namespace Microsoft.CodeAnalysis.PooledObjects
 {
     // Dictionary that can be recycled via an object pool
@@ -52,17 +56,36 @@ namespace Microsoft.CodeAnalysis.PooledObjects
             return pool;
         }
 
-        public static PooledDictionary<K, V> GetInstance()
+        public static PooledDictionary<K, V> GetInstance(
+#if DEBUG
+            [CallerFilePath] string? filePath = null,
+            [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
-            var instance = s_poolInstance.Allocate();
+            var instance = s_poolInstance.Allocate(
+#if DEBUG
+                filePath, lineNumber
+#endif
+                );
             Debug.Assert(instance.Count == 0);
             return instance;
         }
 
 #if !MICROSOFT_CODEANALYSIS_POOLEDOBJECTS_NO_POOLED_DISPOSER
-        public static PooledDisposer<PooledDictionary<K, V>> GetInstance(out PooledDictionary<K, V> instance)
+        public static PooledDisposer<PooledDictionary<K, V>> GetInstance(
+            out PooledDictionary<K, V> instance
+#if DEBUG
+            , [CallerFilePath] string? filePath = null,
+            [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
-            instance = GetInstance();
+            instance = GetInstance(
+#if DEBUG
+                filePath, lineNumber
+#endif
+                );
             return new PooledDisposer<PooledDictionary<K, V>>(instance);
         }
 

--- a/src/Dependencies/PooledObjects/PooledHashSet.cs
+++ b/src/Dependencies/PooledObjects/PooledHashSet.cs
@@ -7,6 +7,10 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 
+#if DEBUG
+using System.Runtime.CompilerServices;
+#endif
+
 namespace Microsoft.CodeAnalysis.PooledObjects
 {
     // HashSet that can be recycled via an object pool
@@ -41,17 +45,36 @@ namespace Microsoft.CodeAnalysis.PooledObjects
             return pool;
         }
 
-        public static PooledHashSet<T> GetInstance()
+        public static PooledHashSet<T> GetInstance(
+#if DEBUG
+            [CallerFilePath] string? filePath = null,
+            [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
-            var instance = s_poolInstance.Allocate();
+            var instance = s_poolInstance.Allocate(
+#if DEBUG
+                filePath, lineNumber
+#endif
+                );
             Debug.Assert(instance.Count == 0);
             return instance;
         }
 
 #if !MICROSOFT_CODEANALYSIS_POOLEDOBJECTS_NO_POOLED_DISPOSER
-        public static PooledDisposer<PooledHashSet<T>> GetInstance(out PooledHashSet<T> instance)
+        public static PooledDisposer<PooledHashSet<T>> GetInstance(
+            out PooledHashSet<T> instance
+#if DEBUG
+            , [CallerFilePath] string? filePath = null,
+            [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
-            instance = GetInstance();
+            instance = GetInstance(
+#if DEBUG
+                filePath, lineNumber
+#endif
+                );
             return new PooledDisposer<PooledHashSet<T>>(instance);
         }
 

--- a/src/Dependencies/PooledObjects/PooledStringBuilder.cs
+++ b/src/Dependencies/PooledObjects/PooledStringBuilder.cs
@@ -7,6 +7,10 @@
 using System.Diagnostics;
 using System.Text;
 
+#if DEBUG
+using System.Runtime.CompilerServices;
+#endif
+
 namespace Microsoft.CodeAnalysis.PooledObjects
 {
     /// <summary>
@@ -89,9 +93,18 @@ namespace Microsoft.CodeAnalysis.PooledObjects
             return pool;
         }
 
-        public static PooledStringBuilder GetInstance()
+        public static PooledStringBuilder GetInstance(
+#if DEBUG
+            [CallerFilePath] string? filePath = null,
+            [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
-            var builder = s_poolInstance.Allocate();
+            var builder = s_poolInstance.Allocate(
+#if DEBUG
+                filePath, lineNumber
+#endif
+                );
             Debug.Assert(builder.Builder.Length == 0);
             return builder;
         }
@@ -104,14 +117,41 @@ namespace Microsoft.CodeAnalysis.PooledObjects
 #if !MICROSOFT_CODEANALYSIS_POOLEDOBJECTS_NO_POOLED_DISPOSER
         private static readonly ObjectPool<PooledStringBuilder> s_keepLargeInstancesPool = CreatePool();
 
-        public static PooledDisposer<PooledStringBuilder> GetInstance(out StringBuilder instance)
-            => GetInstance(discardLargeInstances: true, out instance);
+        public static PooledDisposer<PooledStringBuilder> GetInstance(
+            out StringBuilder instance
+#if DEBUG
+            , [CallerFilePath] string? filePath = null,
+            [CallerLineNumber] int lineNumber = 0
+#endif
+            )
+            => GetInstance(discardLargeInstances: true, out instance
+#if DEBUG
+                , filePath, lineNumber
+#endif
+                );
 
-        public static PooledDisposer<PooledStringBuilder> GetInstance(bool discardLargeInstances, out StringBuilder instance)
+        public static PooledDisposer<PooledStringBuilder> GetInstance(
+            bool discardLargeInstances,
+            out StringBuilder instance
+#if DEBUG
+            , [CallerFilePath] string? filePath = null,
+            [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
             // If we're discarding large instances (the default behavior), then just use the normal pool.  If we're not, use
             // a specific pool so that *other* normal callers don't accidentally get it and discard it.
-            var pooledInstance = discardLargeInstances ? GetInstance() : s_keepLargeInstancesPool.Allocate();
+            var pooledInstance = discardLargeInstances
+                ? GetInstance(
+#if DEBUG
+                    filePath, lineNumber
+#endif
+                    )
+                : s_keepLargeInstancesPool.Allocate(
+#if DEBUG
+                    filePath, lineNumber
+#endif
+                    );
             instance = pooledInstance;
             return new PooledDisposer<PooledStringBuilder>(pooledInstance, discardLargeInstances);
         }


### PR DESCRIPTION
Track CallerFilePath and CallerLineNumber in DEBUG builds for pooled object allocations (ArrayBuilder, PooledDictionary, PooledHashSet, PooledStringBuilder, ObjectPool). This enriches the pool leak summary with file:line information, making it easier to identify allocation sites without needing full stack traces.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83791)