### PR TITLE
Complete event queue even on failure

### DIFF
--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -1230,12 +1230,17 @@ namespace Microsoft.CodeAnalysis
             // But before we do so, we need to run diagnostic suppressors (if any) on all suppressable warnings/errors (if any).
             if (HasUnsuppressableErrors(diagnostics))
             {
-                if (analyzerDriver == null || !analyzerDriver.HasDiagnosticSuppressors || !HasSuppressableWarningsOrErrors(diagnostics))
+                if (analyzerDriver != null && analyzerDriver.HasDiagnosticSuppressors && HasSuppressableWarningsOrErrors(diagnostics))
                 {
-                    return;
+                    analyzerDriver.ApplyProgrammaticSuppressions(diagnostics, compilation, cancellationToken);
                 }
 
-                analyzerDriver.ApplyProgrammaticSuppressions(diagnostics, compilation, cancellationToken);
+                if (analyzerDriver != null)
+                {
+                    compilation.EnsureCompilationEventQueueCompleted();
+                    analyzerDriver.GetDiagnosticsAsync(compilation, cancellationToken).Wait(cancellationToken);
+                }
+
                 return;
             }
 

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -1238,7 +1238,7 @@ namespace Microsoft.CodeAnalysis
                 if (analyzerDriver != null)
                 {
                     compilation.EnsureCompilationEventQueueCompleted();
-                    analyzerDriver.GetDiagnosticsAsync(compilation, cancellationToken).Wait(cancellationToken);
+                    analyzerDriver.WhenCompletedTask.Wait(cancellationToken);
                 }
 
                 return;


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/83749.

The leak path is:

  1. `CommonCompiler.RunCore` creates `analyzerDriver` which starts `_lazyInitializeTask` which allocates pooled objects
  1. Declaration errors exist (`HasUnsuppressableErrors = true`)
  1. `CommonCompiler.RunCore` returns early inside `if (HasUnsuppressableErrors(diagnostics))` without completing the event queue or awaiting analyzer tasks
  1. The init task is still running, pooled objects allocated but not yet freed
  1. Test checks for leaks → finds the allocation → false positive

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83798)