### PR TITLE
Pool validation: add more tracking

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
@@ -4105,7 +4105,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     static void assemble(SequenceTests toAssemble, ArrayBuilder<Tests> tests)
                     {
                         var length = toAssemble.RemainingTests.Length;
-                        var newSequence = ArrayBuilder<Tests>.GetInstance(length, null!);
+                        var newSequence = ArrayBuilder<Tests>.GetInstance(length, fillWithValue: null!);
                         for (int i = length - 1; i >= 0; i--)
                         {
                             newSequence[i] = tests.Pop();

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// that the variable in VariableIdentifier.Symbol is a root, i.e. not nested within another
         /// tracked variable. Slots less than 0 are illegal.
         /// </summary>
-        protected readonly ArrayBuilder<VariableIdentifier> variableBySlot = ArrayBuilder<VariableIdentifier>.GetInstance(1, default);
+        protected readonly ArrayBuilder<VariableIdentifier> variableBySlot = ArrayBuilder<VariableIdentifier>.GetInstance(1, fillWithValue: default);
 
         /// <summary>
         /// Some variables that should be considered initially assigned.  Used for region analysis.

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.Variables.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.Variables.cs
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// that the variable in VariableIdentifier.Symbol is a root, i.e. not nested within another
             /// tracked variable. Slots less than 0 are illegal.
             /// </summary>
-            private readonly ArrayBuilder<VariableIdentifier> _variableBySlot = ArrayBuilder<VariableIdentifier>.GetInstance(1, default);
+            private readonly ArrayBuilder<VariableIdentifier> _variableBySlot = ArrayBuilder<VariableIdentifier>.GetInstance(1, fillWithValue: default);
 
             internal static Variables Create(Symbol? symbol)
             {

--- a/src/Dependencies/Collections/Extensions/FixedSizeArrayBuilder.cs
+++ b/src/Dependencies/Collections/Extensions/FixedSizeArrayBuilder.cs
@@ -40,7 +40,7 @@ using Microsoft.CodeAnalysis.PooledObjects;
 /// </list>
 /// If any of the above are not true (for example, the capacity is a rough hint, or the exact number of elements may not
 /// match the capacity specified, or if it's intended as a scratch buffer, and won't realize a final array), then <see
-/// cref="ArrayBuilder{T}.GetInstance(int, T)"/> should be used instead.
+/// cref="ArrayBuilder{T}"/>.<c>GetInstance</c> should be used instead.
 /// </remarks>
 [NonCopyable]
 internal struct FixedSizeArrayBuilder<T>(int capacity)

--- a/src/Dependencies/PooledObjects/ArrayBuilder.cs
+++ b/src/Dependencies/PooledObjects/ArrayBuilder.cs
@@ -1007,26 +1007,76 @@ namespace Microsoft.CodeAnalysis.PooledObjects
 
         private static readonly ObjectPool<ArrayBuilder<T>> s_keepLargeInstancesPool = CreatePool();
 
-        public static PooledDisposer<ArrayBuilder<T>> GetInstance(out ArrayBuilder<T> instance)
-            => GetInstance(discardLargeInstances: true, out instance);
+        public static PooledDisposer<ArrayBuilder<T>> GetInstance(
+            out ArrayBuilder<T> instance
+#if DEBUG
+            , [CallerFilePath] string? filePath = null
+            , [CallerLineNumber] int lineNumber = 0
+#endif
+            )
+            => GetInstance(discardLargeInstances: true, out instance
+#if DEBUG
+                , filePath, lineNumber
+#endif
+                );
 
-        public static PooledDisposer<ArrayBuilder<T>> GetInstance(int capacity, out ArrayBuilder<T> instance)
+        public static PooledDisposer<ArrayBuilder<T>> GetInstance(
+            int capacity,
+            out ArrayBuilder<T> instance
+#if DEBUG
+            , [CallerFilePath] string? filePath = null
+            , [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
-            instance = GetInstance(capacity);
+            instance = GetInstance(capacity
+#if DEBUG
+                , filePath, lineNumber
+#endif
+                );
             return new PooledDisposer<ArrayBuilder<T>>(instance);
         }
 
-        public static PooledDisposer<ArrayBuilder<T>> GetInstance(int capacity, T fillWithValue, out ArrayBuilder<T> instance)
+        public static PooledDisposer<ArrayBuilder<T>> GetInstance(
+            int capacity,
+            T fillWithValue,
+            out ArrayBuilder<T> instance
+#if DEBUG
+            , [CallerFilePath] string? filePath = null
+            , [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
-            instance = GetInstance(capacity, fillWithValue);
+            instance = GetInstance(capacity, fillWithValue
+#if DEBUG
+                , filePath, lineNumber
+#endif
+                );
             return new PooledDisposer<ArrayBuilder<T>>(instance);
         }
 
-        public static PooledDisposer<ArrayBuilder<T>> GetInstance(bool discardLargeInstances, out ArrayBuilder<T> instance)
+        public static PooledDisposer<ArrayBuilder<T>> GetInstance(
+            bool discardLargeInstances,
+            out ArrayBuilder<T> instance
+#if DEBUG
+            , [CallerFilePath] string? filePath = null
+            , [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
             // If we're discarding large instances (the default behavior), then just use the normal pool.  If we're not, use
             // a specific pool so that *other* normal callers don't accidentally get it and discard it.
-            instance = discardLargeInstances ? GetInstance() : s_keepLargeInstancesPool.Allocate();
+            instance = discardLargeInstances
+                ? GetInstance(
+#if DEBUG
+                    filePath, lineNumber
+#endif
+                    )
+                : s_keepLargeInstancesPool.Allocate(
+#if DEBUG
+                    filePath, lineNumber
+#endif
+                    );
             return new PooledDisposer<ArrayBuilder<T>>(instance, discardLargeInstances);
         }
 

--- a/src/Dependencies/PooledObjects/ArrayBuilder.cs
+++ b/src/Dependencies/PooledObjects/ArrayBuilder.cs
@@ -11,6 +11,10 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
+#if DEBUG
+using System.Runtime.CompilerServices;
+#endif
+
 namespace Microsoft.CodeAnalysis.PooledObjects
 {
     [DebuggerDisplay("Count = {Count,nq}")]
@@ -502,23 +506,53 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         // 2) Expose the pool or the way to create a pool or the way to get an instance.
         //    for now we will expose both and figure which way works better
         private static readonly ObjectPool<ArrayBuilder<T>> s_poolInstance = CreatePool();
-        public static ArrayBuilder<T> GetInstance()
+        public static ArrayBuilder<T> GetInstance(
+#if DEBUG
+            [CallerFilePath] string? filePath = null,
+            [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
-            var builder = s_poolInstance.Allocate();
+            var builder = s_poolInstance.Allocate(
+#if DEBUG
+                filePath, lineNumber
+#endif
+                );
             Debug.Assert(builder.Count == 0);
             return builder;
         }
 
-        public static ArrayBuilder<T> GetInstance(int capacity)
+        public static ArrayBuilder<T> GetInstance(
+            int capacity
+#if DEBUG
+            , [CallerFilePath] string? filePath = null
+            , [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
-            var builder = GetInstance();
+            var builder = GetInstance(
+#if DEBUG
+                filePath, lineNumber
+#endif
+                );
             builder.EnsureCapacity(capacity);
             return builder;
         }
 
-        public static ArrayBuilder<T> GetInstance(int capacity, T fillWithValue)
+        public static ArrayBuilder<T> GetInstance(
+            int capacity,
+            T fillWithValue
+#if DEBUG
+            , [CallerFilePath] string? filePath = null
+            , [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
-            var builder = GetInstance();
+            var builder = GetInstance(
+#if DEBUG
+                filePath, lineNumber
+#endif
+                );
             builder.EnsureCapacity(capacity);
 
             for (var i = 0; i < capacity; i++)
@@ -530,18 +564,32 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         }
 
         public static ObjectPool<ArrayBuilder<T>> CreatePool(
-            [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
-            [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0)
+#if DEBUG
+            [CallerFilePath] string filePath = "",
+            [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
-            return CreatePool(128, filePath, lineNumber); // we rarely need more than 10
+            return CreatePool(128
+#if DEBUG
+                , filePath, lineNumber
+#endif
+                ); // we rarely need more than 10
         }
 
-        public static ObjectPool<ArrayBuilder<T>> CreatePool(int size,
-            [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
-            [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0)
+        public static ObjectPool<ArrayBuilder<T>> CreatePool(int size
+#if DEBUG
+            , [CallerFilePath] string filePath = ""
+            , [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
             ObjectPool<ArrayBuilder<T>>? pool = null;
-            pool = new ObjectPool<ArrayBuilder<T>>(() => new ArrayBuilder<T>(pool!), size, filePath: filePath, lineNumber: lineNumber);
+            pool = new ObjectPool<ArrayBuilder<T>>(() => new ArrayBuilder<T>(pool!), size
+#if DEBUG
+                , filePath: filePath, lineNumber: lineNumber
+#endif
+                );
             return pool;
         }
 

--- a/src/Dependencies/PooledObjects/ArrayBuilder.cs
+++ b/src/Dependencies/PooledObjects/ArrayBuilder.cs
@@ -508,7 +508,7 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         private static readonly ObjectPool<ArrayBuilder<T>> s_poolInstance = CreatePool();
         public static ArrayBuilder<T> GetInstance(
 #if DEBUG
-            [CallerFilePath] string? filePath = null,
+            [CallerFilePath] string filePath = "",
             [CallerLineNumber] int lineNumber = 0
 #endif
             )
@@ -525,7 +525,7 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         public static ArrayBuilder<T> GetInstance(
             int capacity
 #if DEBUG
-            , [CallerFilePath] string? filePath = null
+            , [CallerFilePath] string filePath = ""
             , [CallerLineNumber] int lineNumber = 0
 #endif
             )
@@ -543,7 +543,7 @@ namespace Microsoft.CodeAnalysis.PooledObjects
             int capacity,
             T fillWithValue
 #if DEBUG
-            , [CallerFilePath] string? filePath = null
+            , [CallerFilePath] string filePath = ""
             , [CallerLineNumber] int lineNumber = 0
 #endif
             )
@@ -1010,7 +1010,7 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         public static PooledDisposer<ArrayBuilder<T>> GetInstance(
             out ArrayBuilder<T> instance
 #if DEBUG
-            , [CallerFilePath] string? filePath = null
+            , [CallerFilePath] string filePath = ""
             , [CallerLineNumber] int lineNumber = 0
 #endif
             )
@@ -1024,7 +1024,7 @@ namespace Microsoft.CodeAnalysis.PooledObjects
             int capacity,
             out ArrayBuilder<T> instance
 #if DEBUG
-            , [CallerFilePath] string? filePath = null
+            , [CallerFilePath] string filePath = ""
             , [CallerLineNumber] int lineNumber = 0
 #endif
             )
@@ -1042,7 +1042,7 @@ namespace Microsoft.CodeAnalysis.PooledObjects
             T fillWithValue,
             out ArrayBuilder<T> instance
 #if DEBUG
-            , [CallerFilePath] string? filePath = null
+            , [CallerFilePath] string filePath = ""
             , [CallerLineNumber] int lineNumber = 0
 #endif
             )
@@ -1059,7 +1059,7 @@ namespace Microsoft.CodeAnalysis.PooledObjects
             bool discardLargeInstances,
             out ArrayBuilder<T> instance
 #if DEBUG
-            , [CallerFilePath] string? filePath = null
+            , [CallerFilePath] string filePath = ""
             , [CallerLineNumber] int lineNumber = 0
 #endif
             )

--- a/src/Dependencies/PooledObjects/ObjectPool`1.cs
+++ b/src/Dependencies/PooledObjects/ObjectPool`1.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         /// </remarks>
         internal T Allocate(
 #if DEBUG
-            [CallerFilePath] string? filePath = null,
+            [CallerFilePath] string filePath = "",
             [CallerLineNumber] int lineNumber = 0
 #endif
             )

--- a/src/Dependencies/PooledObjects/ObjectPool`1.cs
+++ b/src/Dependencies/PooledObjects/ObjectPool`1.cs
@@ -8,6 +8,11 @@ using System;
 using System.Diagnostics;
 using System.Threading;
 
+#if DEBUG
+using System.Runtime.CompilerServices;
+using System.IO;
+#endif
+
 namespace Microsoft.CodeAnalysis.PooledObjects
 {
     /// <summary>
@@ -66,16 +71,26 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         private readonly string _poolName;
 #endif
 
-        internal ObjectPool(Factory factory, bool trimOnFree = true, bool trackLeaks = true,
-            [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
-            [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0)
-            : this(factory, Environment.ProcessorCount * 2, trimOnFree, trackLeaks, filePath, lineNumber)
+        internal ObjectPool(Factory factory, bool trimOnFree = true, bool trackLeaks = true
+#if DEBUG
+            , [CallerFilePath] string filePath = ""
+            , [CallerLineNumber] int lineNumber = 0
+#endif
+            )
+            : this(factory, Environment.ProcessorCount * 2, trimOnFree, trackLeaks
+#if DEBUG
+                , filePath, lineNumber
+#endif
+                )
         {
         }
 
-        internal ObjectPool(Factory factory, int size, bool trimOnFree = true, bool trackLeaks = true,
-            [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
-            [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0)
+        internal ObjectPool(Factory factory, int size, bool trimOnFree = true, bool trackLeaks = true
+#if DEBUG
+            , [CallerFilePath] string filePath = ""
+            , [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
             Debug.Assert(size >= 1);
             _factory = factory;
@@ -83,20 +98,23 @@ namespace Microsoft.CodeAnalysis.PooledObjects
             TrimOnFree = trimOnFree;
 #if DEBUG
             _trackLeaks = trackLeaks;
-            _poolName = System.IO.Path.GetFileName(filePath) + ":" + lineNumber;
+            _poolName = Path.GetFileName(filePath) + ":" + lineNumber;
 #endif
         }
 
-        internal ObjectPool(Func<ObjectPool<T>, T> factory, int size,
-            [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
-            [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0)
+        internal ObjectPool(Func<ObjectPool<T>, T> factory, int size
+#if DEBUG
+            , [CallerFilePath] string filePath = ""
+            , [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
             Debug.Assert(size >= 1);
             _factory = () => factory(this);
             _items = new Element[size - 1];
 #if DEBUG
             _trackLeaks = true;
-            _poolName = System.IO.Path.GetFileName(filePath) + ":" + lineNumber;
+            _poolName = Path.GetFileName(filePath) + ":" + lineNumber;
 #endif
         }
 
@@ -114,7 +132,12 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         /// Note that Free will try to store recycled objects close to the start thus statistically 
         /// reducing how far we will typically search.
         /// </remarks>
-        internal T Allocate()
+        internal T Allocate(
+#if DEBUG
+            [CallerFilePath] string? filePath = null,
+            [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
             // PERF: Examine the first element. If that fails, AllocateSlow will look at the remaining elements.
             // Note that the initial read is optimistically not synchronized. That is intentional. 
@@ -128,7 +151,7 @@ namespace Microsoft.CodeAnalysis.PooledObjects
 
 #if DEBUG
             if (_trackLeaks)
-                PoolTracker.OnAllocate(inst, _poolName);
+                PoolTracker.OnAllocate(inst, _poolName, filePath, lineNumber);
 #endif
             return inst;
         }

--- a/src/Dependencies/PooledObjects/PoolTracker.cs
+++ b/src/Dependencies/PooledObjects/PoolTracker.cs
@@ -62,7 +62,7 @@ internal static class PoolTracker
     /// Records that a pooled object has been allocated.
     /// </summary>
     [Conditional("DEBUG")]
-    internal static void OnAllocate(object obj, string? poolName = null, string? filePath = null, int lineNumber = 0)
+    internal static void OnAllocate(object obj, string? poolName = null, string filePath = "", int lineNumber = 0)
     {
 #if DEBUG
         if (s_activeTrackers > 0)
@@ -117,7 +117,7 @@ internal sealed class PoolTrackingContext
         _traceLeaks = traceLeaks;
     }
 
-    internal void OnAllocate(object obj, string? poolName, string? filePath, int lineNumber)
+    internal void OnAllocate(object obj, string? poolName, string filePath, int lineNumber)
     {
         _outstanding.TryAdd(obj, new AllocationInfo(obj.GetType(), poolName, filePath, lineNumber, _traceLeaks ? Environment.StackTrace : null));
     }
@@ -154,7 +154,7 @@ internal sealed class PoolTrackingContext
             var poolInfo = group.Key.PoolName is not null
                 ? $" (from {group.Key.PoolName})"
                 : "";
-            var allocSite = group.Key.FilePath is not null
+            var allocSite = !string.IsNullOrEmpty(group.Key.FilePath)
                 ? $" (allocated at {Path.GetFileName(group.Key.FilePath)}:{group.Key.LineNumber})"
                 : "";
             sb.AppendLine($"  {group.Key.Type}{poolInfo}{allocSite}: {group.Count()}");
@@ -172,11 +172,11 @@ internal sealed class PoolTrackingContext
         return sb.ToString();
     }
 
-    private readonly struct AllocationInfo(Type type, string? poolName, string? filePath, int lineNumber, string? stackTrace)
+    private readonly struct AllocationInfo(Type type, string? poolName, string filePath, int lineNumber, string? stackTrace)
     {
         public readonly Type Type = type;
         public readonly string? PoolName = poolName;
-        public readonly string? FilePath = filePath;
+        public readonly string FilePath = filePath;
         public readonly int LineNumber = lineNumber;
         public readonly string? StackTrace = stackTrace;
     }

--- a/src/Dependencies/PooledObjects/PoolTracker.cs
+++ b/src/Dependencies/PooledObjects/PoolTracker.cs
@@ -67,8 +67,7 @@ internal static class PoolTracker
 #if DEBUG
         if (s_activeTrackers > 0)
         {
-            var allocSite = filePath is not null ? Path.GetFileName(filePath) + ":" + lineNumber : poolName;
-            s_currentContext.Value?.OnAllocate(obj, allocSite);
+            s_currentContext.Value?.OnAllocate(obj, poolName, filePath, lineNumber);
         }
 #endif
     }
@@ -118,9 +117,9 @@ internal sealed class PoolTrackingContext
         _traceLeaks = traceLeaks;
     }
 
-    internal void OnAllocate(object obj, string? poolName)
+    internal void OnAllocate(object obj, string? poolName, string? filePath, int lineNumber)
     {
-        _outstanding.TryAdd(obj, new AllocationInfo(obj.GetType(), poolName, _traceLeaks ? Environment.StackTrace : null));
+        _outstanding.TryAdd(obj, new AllocationInfo(obj.GetType(), poolName, filePath, lineNumber, _traceLeaks ? Environment.StackTrace : null));
     }
 
     internal void OnFree(object obj)
@@ -150,10 +149,15 @@ internal sealed class PoolTrackingContext
         var sb = new StringBuilder();
         sb.AppendLine("Pool leak detected! The following pooled objects were not returned:");
 
-        foreach (var group in _outstanding.Values.GroupBy(v => (v.Type, v.PoolName)).OrderByDescending(g => g.Count()))
+        foreach (var group in _outstanding.Values.GroupBy(v => (v.Type, v.PoolName, v.FilePath, v.LineNumber)).OrderByDescending(g => g.Count()))
         {
-            var poolInfo = group.Key.PoolName is not null ? $" (from {group.Key.PoolName})" : "";
-            sb.AppendLine($"  {group.Key.Type}{poolInfo}: {group.Count()}");
+            var poolInfo = group.Key.PoolName is not null
+                ? $" (from {group.Key.PoolName})"
+                : "";
+            var allocSite = group.Key.FilePath is not null
+                ? $" (allocated at {Path.GetFileName(group.Key.FilePath)}:{group.Key.LineNumber})"
+                : "";
+            sb.AppendLine($"  {group.Key.Type}{poolInfo}{allocSite}: {group.Count()}");
 
             foreach (var info in group)
             {
@@ -168,10 +172,12 @@ internal sealed class PoolTrackingContext
         return sb.ToString();
     }
 
-    private readonly struct AllocationInfo(Type type, string? poolName, string? stackTrace)
+    private readonly struct AllocationInfo(Type type, string? poolName, string? filePath, int lineNumber, string? stackTrace)
     {
         public readonly Type Type = type;
         public readonly string? PoolName = poolName;
+        public readonly string? FilePath = filePath;
+        public readonly int LineNumber = lineNumber;
         public readonly string? StackTrace = stackTrace;
     }
 }

--- a/src/Dependencies/PooledObjects/PoolTracker.cs
+++ b/src/Dependencies/PooledObjects/PoolTracker.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -61,12 +62,13 @@ internal static class PoolTracker
     /// Records that a pooled object has been allocated.
     /// </summary>
     [Conditional("DEBUG")]
-    internal static void OnAllocate(object obj, string? poolName = null)
+    internal static void OnAllocate(object obj, string? poolName = null, string? filePath = null, int lineNumber = 0)
     {
 #if DEBUG
         if (s_activeTrackers > 0)
         {
-            s_currentContext.Value?.OnAllocate(obj, poolName);
+            var allocSite = filePath is not null ? Path.GetFileName(filePath) + ":" + lineNumber : poolName;
+            s_currentContext.Value?.OnAllocate(obj, allocSite);
         }
 #endif
     }

--- a/src/Dependencies/PooledObjects/PooledDictionary.cs
+++ b/src/Dependencies/PooledObjects/PooledDictionary.cs
@@ -8,6 +8,10 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 
+#if DEBUG
+using System.Runtime.CompilerServices;
+#endif
+
 namespace Microsoft.CodeAnalysis.PooledObjects
 {
     // Dictionary that can be recycled via an object pool
@@ -52,17 +56,36 @@ namespace Microsoft.CodeAnalysis.PooledObjects
             return pool;
         }
 
-        public static PooledDictionary<K, V> GetInstance()
+        public static PooledDictionary<K, V> GetInstance(
+#if DEBUG
+            [CallerFilePath] string? filePath = null,
+            [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
-            var instance = s_poolInstance.Allocate();
+            var instance = s_poolInstance.Allocate(
+#if DEBUG
+                filePath, lineNumber
+#endif
+                );
             Debug.Assert(instance.Count == 0);
             return instance;
         }
 
 #if !MICROSOFT_CODEANALYSIS_POOLEDOBJECTS_NO_POOLED_DISPOSER
-        public static PooledDisposer<PooledDictionary<K, V>> GetInstance(out PooledDictionary<K, V> instance)
+        public static PooledDisposer<PooledDictionary<K, V>> GetInstance(
+            out PooledDictionary<K, V> instance
+#if DEBUG
+            , [CallerFilePath] string? filePath = null
+            , [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
-            instance = GetInstance();
+            instance = GetInstance(
+#if DEBUG
+                filePath, lineNumber
+#endif
+                );
             return new PooledDisposer<PooledDictionary<K, V>>(instance);
         }
 

--- a/src/Dependencies/PooledObjects/PooledDictionary.cs
+++ b/src/Dependencies/PooledObjects/PooledDictionary.cs
@@ -58,8 +58,8 @@ namespace Microsoft.CodeAnalysis.PooledObjects
 
         public static PooledDictionary<K, V> GetInstance(
 #if DEBUG
-            [CallerFilePath] string? filePath = null,
-            [CallerLineNumber] int lineNumber = 0
+            [CallerLineNumber] int lineNumber = 0,
+            [CallerFilePath] string? filePath = null
 #endif
             )
         {
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         {
             instance = GetInstance(
 #if DEBUG
-                filePath, lineNumber
+                lineNumber, filePath
 #endif
                 );
             return new PooledDisposer<PooledDictionary<K, V>>(instance);

--- a/src/Dependencies/PooledObjects/PooledDictionary.cs
+++ b/src/Dependencies/PooledObjects/PooledDictionary.cs
@@ -58,8 +58,8 @@ namespace Microsoft.CodeAnalysis.PooledObjects
 
         public static PooledDictionary<K, V> GetInstance(
 #if DEBUG
-            [CallerLineNumber] int lineNumber = 0,
-            [CallerFilePath] string? filePath = null
+            [CallerFilePath] string filePath = "",
+            [CallerLineNumber] int lineNumber = 0
 #endif
             )
         {
@@ -76,14 +76,14 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         public static PooledDisposer<PooledDictionary<K, V>> GetInstance(
             out PooledDictionary<K, V> instance
 #if DEBUG
-            , [CallerFilePath] string? filePath = null
+            , [CallerFilePath] string filePath = ""
             , [CallerLineNumber] int lineNumber = 0
 #endif
             )
         {
             instance = GetInstance(
 #if DEBUG
-                lineNumber, filePath
+                filePath, lineNumber
 #endif
                 );
             return new PooledDisposer<PooledDictionary<K, V>>(instance);

--- a/src/Dependencies/PooledObjects/PooledHashSet.cs
+++ b/src/Dependencies/PooledObjects/PooledHashSet.cs
@@ -47,8 +47,8 @@ namespace Microsoft.CodeAnalysis.PooledObjects
 
         public static PooledHashSet<T> GetInstance(
 #if DEBUG
-            [CallerLineNumber] int lineNumber = 0,
-            [CallerFilePath] string? filePath = null
+            [CallerFilePath] string filePath = "",
+            [CallerLineNumber] int lineNumber = 0
 #endif
             )
         {
@@ -65,14 +65,14 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         public static PooledDisposer<PooledHashSet<T>> GetInstance(
             out PooledHashSet<T> instance
 #if DEBUG
-            , [CallerFilePath] string? filePath = null
+            , [CallerFilePath] string filePath = ""
             , [CallerLineNumber] int lineNumber = 0
 #endif
             )
         {
             instance = GetInstance(
 #if DEBUG
-                lineNumber, filePath
+                filePath, lineNumber
 #endif
                 );
             return new PooledDisposer<PooledHashSet<T>>(instance);

--- a/src/Dependencies/PooledObjects/PooledHashSet.cs
+++ b/src/Dependencies/PooledObjects/PooledHashSet.cs
@@ -7,6 +7,10 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 
+#if DEBUG
+using System.Runtime.CompilerServices;
+#endif
+
 namespace Microsoft.CodeAnalysis.PooledObjects
 {
     // HashSet that can be recycled via an object pool
@@ -41,17 +45,36 @@ namespace Microsoft.CodeAnalysis.PooledObjects
             return pool;
         }
 
-        public static PooledHashSet<T> GetInstance()
+        public static PooledHashSet<T> GetInstance(
+#if DEBUG
+            [CallerFilePath] string? filePath = null,
+            [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
-            var instance = s_poolInstance.Allocate();
+            var instance = s_poolInstance.Allocate(
+#if DEBUG
+                filePath, lineNumber
+#endif
+                );
             Debug.Assert(instance.Count == 0);
             return instance;
         }
 
 #if !MICROSOFT_CODEANALYSIS_POOLEDOBJECTS_NO_POOLED_DISPOSER
-        public static PooledDisposer<PooledHashSet<T>> GetInstance(out PooledHashSet<T> instance)
+        public static PooledDisposer<PooledHashSet<T>> GetInstance(
+            out PooledHashSet<T> instance
+#if DEBUG
+            , [CallerFilePath] string? filePath = null
+            , [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
-            instance = GetInstance();
+            instance = GetInstance(
+#if DEBUG
+                filePath, lineNumber
+#endif
+                );
             return new PooledDisposer<PooledHashSet<T>>(instance);
         }
 

--- a/src/Dependencies/PooledObjects/PooledHashSet.cs
+++ b/src/Dependencies/PooledObjects/PooledHashSet.cs
@@ -47,8 +47,8 @@ namespace Microsoft.CodeAnalysis.PooledObjects
 
         public static PooledHashSet<T> GetInstance(
 #if DEBUG
-            [CallerFilePath] string? filePath = null,
-            [CallerLineNumber] int lineNumber = 0
+            [CallerLineNumber] int lineNumber = 0,
+            [CallerFilePath] string? filePath = null
 #endif
             )
         {
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         {
             instance = GetInstance(
 #if DEBUG
-                filePath, lineNumber
+                lineNumber, filePath
 #endif
                 );
             return new PooledDisposer<PooledHashSet<T>>(instance);

--- a/src/Dependencies/PooledObjects/PooledStringBuilder.cs
+++ b/src/Dependencies/PooledObjects/PooledStringBuilder.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.PooledObjects
 
         public static PooledStringBuilder GetInstance(
 #if DEBUG
-            [CallerFilePath] string? filePath = null,
+            [CallerFilePath] string filePath = "",
             [CallerLineNumber] int lineNumber = 0
 #endif
             )

--- a/src/Dependencies/PooledObjects/PooledStringBuilder.cs
+++ b/src/Dependencies/PooledObjects/PooledStringBuilder.cs
@@ -7,6 +7,10 @@
 using System.Diagnostics;
 using System.Text;
 
+#if DEBUG
+using System.Runtime.CompilerServices;
+#endif
+
 namespace Microsoft.CodeAnalysis.PooledObjects
 {
     /// <summary>
@@ -89,9 +93,18 @@ namespace Microsoft.CodeAnalysis.PooledObjects
             return pool;
         }
 
-        public static PooledStringBuilder GetInstance()
+        public static PooledStringBuilder GetInstance(
+#if DEBUG
+            [CallerFilePath] string? filePath = null,
+            [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
-            var builder = s_poolInstance.Allocate();
+            var builder = s_poolInstance.Allocate(
+#if DEBUG
+                filePath, lineNumber
+#endif
+                );
             Debug.Assert(builder.Builder.Length == 0);
             return builder;
         }

--- a/src/RoslynAnalyzers/Utilities/Compiler/PooledObjects/PooledDictionary.cs
+++ b/src/RoslynAnalyzers/Utilities/Compiler/PooledObjects/PooledDictionary.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         public static PooledDictionary<K, V> GetInstance(
             IEqualityComparer<K>? keyComparer
 #if DEBUG
-            , [CallerFilePath] string? filePath = null
+            , [CallerFilePath] string filePath = ""
             , [CallerLineNumber] int lineNumber = 0
 #endif
             )
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.PooledObjects
             IEnumerable<KeyValuePair<K, V>> initializer,
             IEqualityComparer<K>? keyComparer = null
 #if DEBUG
-            , [CallerFilePath] string? filePath = null
+            , [CallerFilePath] string filePath = ""
             , [CallerLineNumber] int lineNumber = 0
 #endif
             )

--- a/src/RoslynAnalyzers/Utilities/Compiler/PooledObjects/PooledDictionary.cs
+++ b/src/RoslynAnalyzers/Utilities/Compiler/PooledObjects/PooledDictionary.cs
@@ -8,6 +8,10 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 
+#if DEBUG
+using System.Runtime.CompilerServices;
+#endif
+
 #pragma warning disable CA1000 // Do not declare static members on generic types
 
 namespace Microsoft.CodeAnalysis.PooledObjects
@@ -38,19 +42,40 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         private static readonly ConcurrentDictionary<IEqualityComparer<K>, ObjectPool<PooledDictionary<K, V>>> s_poolInstancesByComparer
             = new();
 
-        public static PooledDictionary<K, V> GetInstance(IEqualityComparer<K>? keyComparer = null)
+        public static PooledDictionary<K, V> GetInstance(
+            IEqualityComparer<K>? keyComparer
+#if DEBUG
+            , [CallerFilePath] string? filePath = null
+            , [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
             var pool = keyComparer == null ?
                 s_poolInstance :
                 s_poolInstancesByComparer.GetOrAdd(keyComparer, CreatePool);
-            var instance = pool.Allocate();
+            var instance = pool.Allocate(
+#if DEBUG
+                filePath, lineNumber
+#endif
+                );
             Debug.Assert(instance.Count == 0);
             return instance;
         }
 
-        public static PooledDictionary<K, V> GetInstance(IEnumerable<KeyValuePair<K, V>> initializer, IEqualityComparer<K>? keyComparer = null)
+        public static PooledDictionary<K, V> GetInstance(
+            IEnumerable<KeyValuePair<K, V>> initializer,
+            IEqualityComparer<K>? keyComparer = null
+#if DEBUG
+            , [CallerFilePath] string? filePath = null
+            , [CallerLineNumber] int lineNumber = 0
+#endif
+            )
         {
-            var instance = GetInstance(keyComparer);
+            var instance = GetInstance(keyComparer
+#if DEBUG
+                , filePath, lineNumber
+#endif
+                );
             foreach (var kvp in initializer)
             {
                 instance.Add(kvp.Key, kvp.Value);


### PR DESCRIPTION
To help narrow down https://github.com/dotnet/roslyn/issues/83972.

Example from build https://dev.azure.com/dnceng-public/public/_build/results?buildId=1428228&view=ms.vss-test-web.build-test-results-tab&runId=39683766&resultId=112157&paneView=debug:

```
Pool leak detected! The following pooled objects were not returned:
Microsoft.CodeAnalysis.PooledObjects.ArrayBuilder1[Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE.PENamedTypeSymbol] (from ArrayBuilder.cs:508) (allocated at ArrayBuilder.cs:638): 47
Microsoft.CodeAnalysis.PooledObjects.ArrayBuilder1[Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE.PENamedTypeSymbol] (from ArrayBuilder.cs:508) (allocated at PENamespaceSymbol.cs:284): 1
```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83799)