### PR TITLE
Caching compiler: update timestamp of outputs

### DIFF
--- a/docs/compilers/Design/compiler-output-cache-experiment.md
+++ b/docs/compilers/Design/compiler-output-cache-experiment.md
@@ -140,7 +140,7 @@ For each eligible compilation request, the compiler server:
 1. Computes the deterministic key.
 2. Hashes that key.
 3. Looks for an existing entry under the cache root.
-4. If a valid cached assembly is present, copies the cached outputs to the requested output locations and reports success.
+4. If a valid cached assembly is present, copies the cached outputs to the requested output locations, stamps them with the UTC time captured immediately before input/key inspection began, and reports success.
 5. Otherwise performs a normal compilation.
 6. After a successful compilation, attempts to publish the outputs into the cache for future requests.
 

--- a/src/Compilers/Server/VBCSCompiler/CompilationCache.cs
+++ b/src/Compilers/Server/VBCSCompiler/CompilationCache.cs
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         /// <summary>
         /// Checks whether a cached result exists for the given DLL name and hash key.
         /// On a hit, all cached output files are copied to the paths specified by
-        /// <paramref name="outputFiles"/> and stamped with <paramref name="restoredOutputTimestampUtc"/>.
+        /// <paramref name="outputFiles"/> and stamped with <paramref name="outputTimestampUtc"/>.
         /// Returns <see langword="false"/> if no cached entry exists or if any required file copy fails.
         /// </summary>
         internal bool TryRestoreCachedResult(
@@ -146,11 +146,10 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             string hashKey,
             CompilationOutputFiles outputFiles,
             ICompilerServerLogger logger,
-            DateTime? restoredOutputTimestampUtc = null)
+            DateTime outputTimestampUtc)
         {
             var entryDir = GetCacheEntryDirectory(dllName, hashKey);
             var cachedAssemblyPath = Path.Combine(entryDir, AssemblyFileName);
-            var outputTimestampUtc = restoredOutputTimestampUtc ?? DateTime.UtcNow;
             Debug.Assert(outputTimestampUtc.Kind == DateTimeKind.Utc);
 
             try
@@ -182,7 +181,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
                 logger.Log($"Cache hit: {dllName} [{hashKey}]");
                 TouchLastUsed(entryDir, logger);
-                copyRestoredOutput(cachedAssemblyPath, outputFiles.AssemblyPath, outputTimestampUtc);
+                copyAndUpdateTimestamp(cachedAssemblyPath, outputFiles.AssemblyPath, outputTimestampUtc);
                 copyIfNeeded(entryDir, PdbFileName, outputFiles.PdbPath, outputTimestampUtc);
                 copyIfNeeded(entryDir, RefAssemblyFileName, outputFiles.RefAssemblyPath, outputTimestampUtc);
                 copyIfNeeded(entryDir, XmlDocFileName, outputFiles.XmlDocPath, outputTimestampUtc);
@@ -213,10 +212,10 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                     return;
                 }
 
-                copyRestoredOutput(Path.Combine(entryDir, cachedFileName), targetPath, outputTimestampUtc);
+                copyAndUpdateTimestamp(Path.Combine(entryDir, cachedFileName), targetPath, outputTimestampUtc);
             }
 
-            static void copyRestoredOutput(string sourcePath, string targetPath, DateTime outputTimestampUtc)
+            static void copyAndUpdateTimestamp(string sourcePath, string targetPath, DateTime outputTimestampUtc)
             {
                 File.Copy(sourcePath, targetPath, overwrite: true);
                 File.SetLastWriteTimeUtc(targetPath, outputTimestampUtc);

--- a/src/Compilers/Server/VBCSCompiler/CompilationCache.cs
+++ b/src/Compilers/Server/VBCSCompiler/CompilationCache.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -137,17 +138,20 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         /// <summary>
         /// Checks whether a cached result exists for the given DLL name and hash key.
         /// On a hit, all cached output files are copied to the paths specified by
-        /// <paramref name="outputFiles"/>. Returns <see langword="false"/> if no cached
-        /// entry exists or if any required file copy fails.
+        /// <paramref name="outputFiles"/> and stamped with <paramref name="restoredOutputTimestampUtc"/>.
+        /// Returns <see langword="false"/> if no cached entry exists or if any required file copy fails.
         /// </summary>
         internal bool TryRestoreCachedResult(
             string dllName,
             string hashKey,
             CompilationOutputFiles outputFiles,
-            ICompilerServerLogger logger)
+            ICompilerServerLogger logger,
+            DateTime? restoredOutputTimestampUtc = null)
         {
             var entryDir = GetCacheEntryDirectory(dllName, hashKey);
             var cachedAssemblyPath = Path.Combine(entryDir, AssemblyFileName);
+            var outputTimestampUtc = restoredOutputTimestampUtc ?? DateTime.UtcNow;
+            Debug.Assert(outputTimestampUtc.Kind == DateTimeKind.Utc);
 
             try
             {
@@ -178,10 +182,10 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
                 logger.Log($"Cache hit: {dllName} [{hashKey}]");
                 TouchLastUsed(entryDir, logger);
-                File.Copy(cachedAssemblyPath, outputFiles.AssemblyPath, overwrite: true);
-                copyIfNeeded(entryDir, PdbFileName, outputFiles.PdbPath);
-                copyIfNeeded(entryDir, RefAssemblyFileName, outputFiles.RefAssemblyPath);
-                copyIfNeeded(entryDir, XmlDocFileName, outputFiles.XmlDocPath);
+                copyRestoredOutput(cachedAssemblyPath, outputFiles.AssemblyPath, outputTimestampUtc);
+                copyIfNeeded(entryDir, PdbFileName, outputFiles.PdbPath, outputTimestampUtc);
+                copyIfNeeded(entryDir, RefAssemblyFileName, outputFiles.RefAssemblyPath, outputTimestampUtc);
+                copyIfNeeded(entryDir, XmlDocFileName, outputFiles.XmlDocPath, outputTimestampUtc);
             }
             catch (Exception ex)
             {
@@ -202,14 +206,20 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 return !File.Exists(Path.Combine(entryDir, cachedFileName));
             }
 
-            static void copyIfNeeded(string entryDir, string cachedFileName, string? targetPath)
+            static void copyIfNeeded(string entryDir, string cachedFileName, string? targetPath, DateTime outputTimestampUtc)
             {
                 if (targetPath is null)
                 {
                     return;
                 }
 
-                File.Copy(Path.Combine(entryDir, cachedFileName), targetPath, overwrite: true);
+                copyRestoredOutput(Path.Combine(entryDir, cachedFileName), targetPath, outputTimestampUtc);
+            }
+
+            static void copyRestoredOutput(string sourcePath, string targetPath, DateTime outputTimestampUtc)
+            {
+                File.Copy(sourcePath, targetPath, overwrite: true);
+                File.SetLastWriteTimeUtc(targetPath, outputTimestampUtc);
             }
         }
 

--- a/src/Compilers/Server/VBCSCompiler/CompilationCacheUtilities.cs
+++ b/src/Compilers/Server/VBCSCompiler/CompilationCacheUtilities.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             }
 
             var dllName = arguments.OutputFileName;
-            var restoredOutputTimestampUtc = DateTime.UtcNow;
+            var outputTimestampUtc = DateTime.UtcNow;
             try
             {
                 using var sourceLinkStream = arguments.SourceLink is not null
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             hashKey = CompilationCache.ComputeHashKey(deterministicKey);
 
             var outputFiles = BuildOutputFiles(arguments, dllName);
-            if (cache.TryRestoreCachedResult(dllName, hashKey, outputFiles, logger, restoredOutputTimestampUtc))
+            if (cache.TryRestoreCachedResult(dllName, hashKey, outputFiles, logger, outputTimestampUtc))
             {
                 logger.Log($"Cache hit satisfied: {dllName} [{hashKey}]");
                 return CommonCompiler.Succeeded;

--- a/src/Compilers/Server/VBCSCompiler/CompilationCacheUtilities.cs
+++ b/src/Compilers/Server/VBCSCompiler/CompilationCacheUtilities.cs
@@ -45,6 +45,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             }
 
             var dllName = arguments.OutputFileName;
+            var restoredOutputTimestampUtc = DateTime.UtcNow;
             try
             {
                 using var sourceLinkStream = arguments.SourceLink is not null
@@ -73,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             hashKey = CompilationCache.ComputeHashKey(deterministicKey);
 
             var outputFiles = BuildOutputFiles(arguments, dllName);
-            if (cache.TryRestoreCachedResult(dllName, hashKey, outputFiles, logger))
+            if (cache.TryRestoreCachedResult(dllName, hashKey, outputFiles, logger, restoredOutputTimestampUtc))
             {
                 logger.Log($"Cache hit satisfied: {dllName} [{hashKey}]");
                 return CommonCompiler.Succeeded;

--- a/src/Compilers/Server/VBCSCompilerTests/CompilationCacheTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilationCacheTests.cs
@@ -22,6 +22,8 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 {
     public class CompilationCacheTests : TestBase
     {
+        private static readonly DateTime s_outputTimestampUtc = new(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+
         private readonly ICompilerServerLogger _logger;
 
         public CompilationCacheTests(ITestOutputHelper testOutputHelper)
@@ -102,7 +104,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 AssemblyPath = Path.Combine(outputDir, "Util.dll"),
             };
 
-            var result = cache.TryRestoreCachedResult("Util.dll", "abc123", outputFiles, _logger);
+            var result = cache.TryRestoreCachedResult("Util.dll", "abc123", outputFiles, _logger, s_outputTimestampUtc);
 
             Assert.False(result);
             Assert.False(File.Exists(outputFiles.AssemblyPath));
@@ -127,7 +129,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 AssemblyPath = Path.Combine(outputDir, dllName),
             };
 
-            var result = cache.TryRestoreCachedResult(dllName, hashKey, outputFiles, _logger);
+            var result = cache.TryRestoreCachedResult(dllName, hashKey, outputFiles, _logger, s_outputTimestampUtc);
 
             Assert.True(result);
             Assert.True(File.Exists(outputFiles.AssemblyPath));
@@ -161,7 +163,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 
             Directory.CreateDirectory(Path.Combine(outputDir, "ref"));
 
-            var result = cache.TryRestoreCachedResult(dllName, hashKey, outputFiles, _logger);
+            var result = cache.TryRestoreCachedResult(dllName, hashKey, outputFiles, _logger, s_outputTimestampUtc);
 
             Assert.True(result);
             Assert.Equal([1], File.ReadAllBytes(outputFiles.AssemblyPath));
@@ -171,15 +173,15 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         }
 
         [Fact]
-        public void TryRestoreCachedResult_StampsRestoredOutputsWithSpecifiedTimestamp()
+        [WorkItem("https://github.com/dotnet/roslyn/issues/83801")]
+        public void TryRestoreCachedResult_CopiesAndUpdatesOutputTimestamps()
         {
             var cacheDir = Temp.CreateDirectory().Path;
             var cache = CreateCache(cacheDir);
             var dllName = "Timestamped.dll";
             var hashKey = "timestampedhash";
             var outputDir = Temp.CreateDirectory().Path;
-            var restoredTimestampUtc = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);
-            var cachedTimestampUtc = restoredTimestampUtc.AddDays(-1);
+            var cachedTimestampUtc = s_outputTimestampUtc.AddDays(-1);
 
             var entryDir = Path.Combine(cacheDir, dllName, hashKey);
             Directory.CreateDirectory(entryDir);
@@ -199,13 +201,13 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 
             Directory.CreateDirectory(Path.Combine(outputDir, "ref"));
 
-            var result = cache.TryRestoreCachedResult(dllName, hashKey, outputFiles, _logger, restoredTimestampUtc);
+            var result = cache.TryRestoreCachedResult(dllName, hashKey, outputFiles, _logger, s_outputTimestampUtc);
 
             Assert.True(result);
-            Assert.Equal(restoredTimestampUtc, File.GetLastWriteTimeUtc(outputFiles.AssemblyPath));
-            Assert.Equal(restoredTimestampUtc, File.GetLastWriteTimeUtc(outputFiles.PdbPath!));
-            Assert.Equal(restoredTimestampUtc, File.GetLastWriteTimeUtc(outputFiles.RefAssemblyPath!));
-            Assert.Equal(restoredTimestampUtc, File.GetLastWriteTimeUtc(outputFiles.XmlDocPath!));
+            Assert.Equal(s_outputTimestampUtc, File.GetLastWriteTimeUtc(outputFiles.AssemblyPath));
+            Assert.Equal(s_outputTimestampUtc, File.GetLastWriteTimeUtc(outputFiles.PdbPath!));
+            Assert.Equal(s_outputTimestampUtc, File.GetLastWriteTimeUtc(outputFiles.RefAssemblyPath!));
+            Assert.Equal(s_outputTimestampUtc, File.GetLastWriteTimeUtc(outputFiles.XmlDocPath!));
 
             void writeCachedFile(string fileName, byte[] contents)
             {
@@ -237,7 +239,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 
             var logMessages = new List<string>();
             var logger = new CollectingLogger(logMessages);
-            var result = cache.TryRestoreCachedResult(dllName, hashKey, outputFiles, logger);
+            var result = cache.TryRestoreCachedResult(dllName, hashKey, outputFiles, logger, s_outputTimestampUtc);
 
             // PDB was requested but not cached — should be treated as a cache miss.
             Assert.False(result);
@@ -265,7 +267,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             };
 
             using var entryLock = AcquireEntryMutex(cache, dllName, hashKey);
-            var result = cache.TryRestoreCachedResult(dllName, hashKey, outputFiles, logger);
+            var result = cache.TryRestoreCachedResult(dllName, hashKey, outputFiles, logger, s_outputTimestampUtc);
 
             Assert.True(result);
             Assert.Equal([1, 2, 3], File.ReadAllBytes(outputFiles.AssemblyPath));
@@ -291,7 +293,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             };
 
             using var entryLock = AcquireEntryMutex(cache, dllName, hashKey);
-            var result = cache.TryRestoreCachedResult(dllName, hashKey, outputFiles, logger);
+            var result = cache.TryRestoreCachedResult(dllName, hashKey, outputFiles, logger, s_outputTimestampUtc);
 
             Assert.False(result);
             Assert.False(File.Exists(outputFiles.AssemblyPath));
@@ -439,14 +441,14 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             };
 
             // Initially no cache hit.
-            Assert.False(cache.TryRestoreCachedResult(dllName, hashKey, restoreFiles, _logger));
+            Assert.False(cache.TryRestoreCachedResult(dllName, hashKey, restoreFiles, _logger, s_outputTimestampUtc));
 
             // Store the result.
             var storeFiles = new CompilationOutputFiles { AssemblyPath = assemblyPath };
             cache.TryStoreResult(dllName, hashKey, storeFiles, deterministicKey, _logger);
 
             // Now there should be a cache hit.
-            Assert.True(cache.TryRestoreCachedResult(dllName, hashKey, restoreFiles, _logger));
+            Assert.True(cache.TryRestoreCachedResult(dllName, hashKey, restoreFiles, _logger, s_outputTimestampUtc));
             Assert.Equal([0xAB, 0xCD], File.ReadAllBytes(restoreFiles.AssemblyPath));
         }
 
@@ -512,7 +514,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 AssemblyPath = Path.Combine(outputDir, dllName),
             };
 
-            var result = cache.TryRestoreCachedResult(dllName, hashKey, outputFiles, _logger);
+            var result = cache.TryRestoreCachedResult(dllName, hashKey, outputFiles, _logger, s_outputTimestampUtc);
             Assert.True(result);
 
             // The last-used file should exist after a cache hit

--- a/src/Compilers/Server/VBCSCompilerTests/CompilationCacheTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilationCacheTests.cs
@@ -171,6 +171,51 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         }
 
         [Fact]
+        public void TryRestoreCachedResult_StampsRestoredOutputsWithSpecifiedTimestamp()
+        {
+            var cacheDir = Temp.CreateDirectory().Path;
+            var cache = CreateCache(cacheDir);
+            var dllName = "Timestamped.dll";
+            var hashKey = "timestampedhash";
+            var outputDir = Temp.CreateDirectory().Path;
+            var restoredTimestampUtc = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+            var cachedTimestampUtc = restoredTimestampUtc.AddDays(-1);
+
+            var entryDir = Path.Combine(cacheDir, dllName, hashKey);
+            Directory.CreateDirectory(entryDir);
+
+            writeCachedFile("assembly", [1]);
+            writeCachedFile("pdb", [2]);
+            writeCachedFile("refassembly", [3]);
+            writeCachedFile("xmldoc", [4]);
+
+            var outputFiles = new CompilationOutputFiles
+            {
+                AssemblyPath = Path.Combine(outputDir, dllName),
+                PdbPath = Path.Combine(outputDir, "Timestamped.pdb"),
+                RefAssemblyPath = Path.Combine(outputDir, "ref", dllName),
+                XmlDocPath = Path.Combine(outputDir, "Timestamped.xml"),
+            };
+
+            Directory.CreateDirectory(Path.Combine(outputDir, "ref"));
+
+            var result = cache.TryRestoreCachedResult(dllName, hashKey, outputFiles, _logger, restoredTimestampUtc);
+
+            Assert.True(result);
+            Assert.Equal(restoredTimestampUtc, File.GetLastWriteTimeUtc(outputFiles.AssemblyPath));
+            Assert.Equal(restoredTimestampUtc, File.GetLastWriteTimeUtc(outputFiles.PdbPath!));
+            Assert.Equal(restoredTimestampUtc, File.GetLastWriteTimeUtc(outputFiles.RefAssemblyPath!));
+            Assert.Equal(restoredTimestampUtc, File.GetLastWriteTimeUtc(outputFiles.XmlDocPath!));
+
+            void writeCachedFile(string fileName, byte[] contents)
+            {
+                var path = Path.Combine(entryDir, fileName);
+                File.WriteAllBytes(path, contents);
+                File.SetLastWriteTimeUtc(path, cachedTimestampUtc);
+            }
+        }
+
+        [Fact]
         public void TryRestoreCachedResult_ReturnsFalse_WhenRequestedOutputFileMissingFromCache()
         {
             var cacheDir = Temp.CreateDirectory().Path;


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/83801.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83802)