### PR TITLE
[16.11] Update RoslynTools installation script with add-source

### DIFF
--- a/eng/pipelines/insert.yml
+++ b/eng/pipelines/insert.yml
@@ -56,7 +56,7 @@ steps:
     inputs:
       version: 8.0.x
 
-  - script: dotnet tool install Microsoft.RoslynTools --tool-path "$(Build.SourcesDirectory)\.tools" --prerelease --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json
+  - script: dotnet tool install Microsoft.RoslynTools --tool-path "$(Build.SourcesDirectory)\.tools" --prerelease --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json
     displayName: 'Install roslyn-tools'
 
   - powershell: |


### PR DESCRIPTION
The --source option had not been added in 8.0.4xx. Change to use --add-source instead
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83806)