### PR TITLE
[16.11] Upgrade .NET SDK version from 8.0.x to 10.0.x

### DIFF
--- a/eng/pipelines/insert.yml
+++ b/eng/pipelines/insert.yml
@@ -54,9 +54,9 @@ steps:
   # Install an SDK that can run the roslyn-tools tool.
   - task: UseDotNet@2
     inputs:
-      version: 8.0.x
+      version: 10.0.x
 
-  - script: dotnet tool install Microsoft.RoslynTools --tool-path "$(Build.SourcesDirectory)\.tools" --prerelease --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json
+  - script: dotnet tool install Microsoft.RoslynTools --tool-path "$(Build.SourcesDirectory)\.tools" --prerelease --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json
     displayName: 'Install roslyn-tools'
 
   - powershell: |


### PR DESCRIPTION
--add-source adds a source on top of the configured nuget feed. Since this is running without a checkout that means it uses nuget.org directly. This fails because network isolation. This PR changes the installed SDK to 10 so we can use --source which will be the only feed considered.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83809)