### PR TITLE
Migrate more Razor code to DocumentUri and System.Uri helpers

### DIFF
--- a/src/LanguageServer/Protocol/Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj
+++ b/src/LanguageServer/Protocol/Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj
@@ -37,6 +37,7 @@
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Razor.Workspaces" Key="$(RazorKey)" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Remote.Razor" Key="$(RazorKey)" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.Razor" Key="$(RazorKey)" />
+    <InternalsVisibleTo Include="Microsoft.VisualStudio.RazorExtension" Key="$(RazorKey)" />
     <InternalsVisibleTo Include="Microsoft.VisualStudioCode.RazorExtension" Key="$(RazorKey)" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.Razor.Test.Common.Tooling" Key="$(RazorKey)" />
     <!-- Restricted IVT for protocol types for Razor tests and other non shipping code -->

--- a/src/Razor/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Formatting/DocumentFormattingBenchmark.cs
+++ b/src/Razor/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Formatting/DocumentFormattingBenchmark.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
+using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.Razor.Formatting;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -42,7 +43,7 @@ public class DocumentFormattingBenchmark
     private const string DocumentRelativePath = "DocumentFormattingBenchmark.cshtml";
     private const string RootNamespace = "Benchmark";
 
-    private static readonly Uri s_documentUri = new(DocumentFilePath);
+    private static readonly DocumentUri s_documentUri = ProtocolConversions.CreateAbsoluteDocumentUri(DocumentFilePath);
     private static readonly AnalyzerFileReference s_razorSourceGeneratorReference = new(
         typeof(RazorSourceGenerator).Assembly.Location,
         AnalyzerAssemblyLoader.Instance);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/CallHierarchy/CohostPrepareCallHierarchyEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/CallHierarchy/CohostPrepareCallHierarchyEndpoint.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
+using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.CallHierarchy;
@@ -71,7 +72,7 @@ internal sealed class CohostPrepareCallHierarchyEndpoint(
 
     private static CallHierarchyItem WrapRazorItem(CallHierarchyItem item, TextDocumentIdentifier textDocument)
     {
-        var uri = item.Uri.GetRequiredSystemUri();
+        var uri = item.Uri;
         return uri.GetDocumentFilePathFromUri().IsRazorFilePath()
             ? RazorCallHierarchyResolveData.Wrap(item, textDocument.WithUri(uri))
             : item;

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/IncompatibleProjectService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/IncompatibleProjectService.cs
@@ -30,7 +30,7 @@ internal sealed class IncompatibleProjectService(IIncompatibleProjectNotifier in
             return;
         }
 
-        if (textDocumentIdentifier?.DocumentUri.ParsedUri is not Uri uri)
+        if (textDocumentIdentifier?.DocumentUri.GetSystemUri() is not Uri uri)
         {
             // Can't do anything without a uri
             return;

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Navigation/CohostGoToDefinitionEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Navigation/CohostGoToDefinitionEndpoint.cs
@@ -98,11 +98,11 @@ internal sealed class CohostGoToDefinitionEndpoint(
 
         if (result.TryGetFirst(out var singleLocation))
         {
-            return LspFactory.CreateLocation(RemapVirtualHtmlUri(singleLocation.DocumentUri.GetRequiredSystemUri()), singleLocation.Range.ToLinePositionSpan());
+            return LspFactory.CreateLocation(RemapVirtualHtmlUri(singleLocation.DocumentUri.GetRequiredSystemUri()).CreateDocumentUriFromSystemUri(), singleLocation.Range.ToLinePositionSpan());
         }
         else if (result.TryGetSecond(out var multipleLocations))
         {
-            return Array.ConvertAll(multipleLocations, l => LspFactory.CreateLocation(RemapVirtualHtmlUri(l.DocumentUri.GetRequiredSystemUri()), l.Range.ToLinePositionSpan()));
+            return Array.ConvertAll(multipleLocations, l => LspFactory.CreateLocation(RemapVirtualHtmlUri(l.DocumentUri.GetRequiredSystemUri()).CreateDocumentUriFromSystemUri(), l.Range.ToLinePositionSpan()));
         }
         else if (result.TryGetThird(out var documentLinks))
         {
@@ -112,7 +112,7 @@ internal sealed class CohostGoToDefinitionEndpoint(
             {
                 if (documentLink.DocumentTarget is DocumentUri target)
                 {
-                    builder.Add(LspFactory.CreateDocumentLink(RemapVirtualHtmlUri(target.GetRequiredSystemUri()), documentLink.Range.ToLinePositionSpan()));
+                    builder.Add(LspFactory.CreateDocumentLink(RemapVirtualHtmlUri(target.GetRequiredSystemUri()).CreateDocumentUriFromSystemUri(), documentLink.Range.ToLinePositionSpan()));
                 }
             }
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Navigation/CohostGoToImplementationEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Navigation/CohostGoToImplementationEndpoint.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Cohost;
 using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
@@ -117,10 +118,10 @@ internal sealed class CohostGoToImplementationEndpoint(
 
     private void RemapVirtualHtmlUri(LspLocation? location)
     {
-        if (location?.DocumentUri.ParsedUri is { } uri &&
+        if (location?.DocumentUri.GetSystemUri() is { } uri &&
             _filePathService.IsVirtualHtmlFile(uri))
         {
-            location.DocumentUri = new(_filePathService.GetRazorDocumentUri(uri));
+            location.DocumentUri = _filePathService.GetRazorDocumentUri(uri).CreateDocumentUriFromSystemUri();
         }
     }
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/TypeHierarchy/CohostPrepareTypeHierarchyEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/TypeHierarchy/CohostPrepareTypeHierarchyEndpoint.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
+using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Cohost;
@@ -69,7 +70,7 @@ internal sealed class CohostPrepareTypeHierarchyEndpoint(
 
     private static TypeHierarchyItem WrapRazorItem(TypeHierarchyItem item, TextDocumentIdentifier textDocument)
     {
-        var uri = item.Uri.GetRequiredSystemUri();
+        var uri = item.Uri;
         return uri.GetDocumentFilePathFromUri().IsRazorFilePath()
             ? RazorTypeHierarchyResolveData.Wrap(item, textDocument.WithUri(uri))
             : item;

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/DelegatedCompletionHelper.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/DelegatedCompletionHelper.cs
@@ -373,7 +373,7 @@ internal static class DelegatedCompletionHelper
                 {
                     args[0] = new TextDocumentIdentifier()
                     {
-                        DocumentUri = new(documentContext.Uri),
+                        DocumentUri = documentContext.Uri,
                     };
                     args[1] = formattedTextEdit;
                     if (nextCursorPosition >= 0)

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/RazorEditService_WorkspaceEdit.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/RazorEditService_WorkspaceEdit.cs
@@ -54,7 +54,7 @@ internal partial class RazorEditService
             var razorUri = _filePathService.GetRazorDocumentUri(generatedDocumentUri);
             entry.TextDocument = new OptionalVersionedTextDocumentIdentifier()
             {
-                DocumentUri = new(razorUri),
+                DocumentUri = razorUri.CreateDocumentUriFromSystemUri(),
             };
             return;
         }
@@ -89,7 +89,7 @@ internal partial class RazorEditService
         // Update the entry in-place
         entry.TextDocument = new OptionalVersionedTextDocumentIdentifier()
         {
-            DocumentUri = new(razorDocumentUri),
+            DocumentUri = razorDocumentUri.CreateDocumentUriFromSystemUri(),
         };
         entry.Edits = mappedEdits.SelectAsPlainArray(static e => new SumType<TextEdit, AnnotatedTextEdit>(e));
     }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/LspExtensions_TextDocumentIdentifier.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/LspExtensions_TextDocumentIdentifier.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 namespace Roslyn.LanguageServer.Protocol;
 
 internal static partial class LspExtensions
@@ -12,23 +11,22 @@ internal static partial class LspExtensions
             : null;
 
     /// <summary>
-    /// Returns a copy of the passed in <see cref="TextDocumentIdentifier"/> with the passed in <see cref="Uri"/>.
+    /// Returns a copy of the passed in <see cref="TextDocumentIdentifier"/> with the passed in <see cref="DocumentUri"/>.
     /// </summary>
-    public static TextDocumentIdentifier WithUri(this TextDocumentIdentifier textDocumentIdentifier, Uri uri)
+    public static TextDocumentIdentifier WithUri(this TextDocumentIdentifier textDocumentIdentifier, DocumentUri uri)
     {
-        var documentUri = new DocumentUri(uri);
         if (textDocumentIdentifier is VSTextDocumentIdentifier vsTdi)
         {
             return new VSTextDocumentIdentifier
             {
-                DocumentUri = documentUri,
+                DocumentUri = uri,
                 ProjectContext = vsTdi.ProjectContext
             };
         }
 
         return new TextDocumentIdentifier
         {
-            DocumentUri = documentUri
+            DocumentUri = uri
         };
     }
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/LspFactory.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/LspFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
 
@@ -164,20 +165,17 @@ internal static class LspFactory
     public static LspLocation CreateLocation(string filePath, LinePositionSpan span)
         => CreateLocation(CreateFilePathUri(filePath), CreateRange(span));
 
-    public static LspLocation CreateLocation(Uri uri, LinePositionSpan span)
+    public static LspLocation CreateLocation(DocumentUri uri, LinePositionSpan span)
         => CreateLocation(uri, CreateRange(span));
 
     public static LspLocation CreateLocation(string filePath, LspRange range)
         => CreateLocation(CreateFilePathUri(filePath), range);
 
-    public static LspLocation CreateLocation(Uri uri, LspRange range)
-        => new() { DocumentUri = new(uri), Range = range };
+    public static LspLocation CreateLocation(DocumentUri uri, LspRange range)
+        => new() { DocumentUri = uri, Range = range };
 
-    public static DocumentLink CreateDocumentLink(Uri target, LspRange range)
-        => new() { DocumentTarget = new(target), Range = range };
-
-    public static DocumentLink CreateDocumentLink(Uri target, LinePositionSpan span)
-        => new() { DocumentTarget = new(target), Range = CreateRange(span) };
+    public static DocumentLink CreateDocumentLink(DocumentUri target, LinePositionSpan span)
+        => new() { DocumentTarget = target, Range = CreateRange(span) };
 
     public static TextEdit CreateTextEdit(Range range, string newText)
         => new() { Range = range, NewText = newText };
@@ -206,7 +204,7 @@ internal static class LspFactory
     public static TextEdit CreateTextEdit((int line, int character) position, string newText)
         => CreateTextEdit(CreateZeroWidthRange(position), newText);
 
-    public static Uri CreateFilePathUri(string filePath, LanguageServerFeatureOptions options)
+    public static DocumentUri CreateFilePathUri(string filePath, LanguageServerFeatureOptions options)
     {
         // VS Code in Windows expects path to start with '/'
         var updateFilePath = options.ReturnCodeActionAndRenamePathsWithPrefixedSlash && !filePath.StartsWith('/')
@@ -216,7 +214,7 @@ internal static class LspFactory
         return CreateFilePathUri(updateFilePath);
     }
 
-    public static Uri CreateFilePathUri(string filePath)
+    public static DocumentUri CreateFilePathUri(string filePath)
     {
         var builder = new UriBuilder
         {
@@ -225,7 +223,7 @@ internal static class LspFactory
             Host = string.Empty,
         };
 
-        return builder.Uri;
+        return builder.Uri.CreateDocumentUriFromSystemUri();
     }
 
     public static FoldingRange CreateFoldingRange(FoldingRangeKind kind, LinePositionSpan linePositionSpan)

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentContext.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentContext.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,12 +10,12 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
-internal class DocumentContext(Uri uri, IDocumentSnapshot snapshot)
+internal class DocumentContext(DocumentUri uri, IDocumentSnapshot snapshot)
 {
     private RazorCodeDocument? _codeDocument;
     private SourceText? _sourceText;
 
-    public Uri Uri { get; } = uri;
+    public DocumentUri Uri { get; } = uri;
     public IDocumentSnapshot Snapshot { get; } = snapshot;
 
     private bool TryGetCodeDocument([NotNullWhen(true)] out RazorCodeDocument? codeDocument)

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/DevTools/DocumentContentsRequest.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/DevTools/DocumentContentsRequest.cs
@@ -18,7 +18,7 @@ internal sealed class DocumentContentsRequest
     {
         return new DocumentContentsRequest
         {
-            TextDocument = new TextDocumentIdentifier { DocumentUri = new(hostDocumentUri) },
+            TextDocument = new TextDocumentIdentifier { DocumentUri = hostDocumentUri.CreateDocumentUriFromSystemUri() },
             Kind = kind
         };
     }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/NestedFiles/AddNestedFileParams.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/NestedFiles/AddNestedFileParams.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Text.Json.Serialization;
 using Microsoft.CodeAnalysis.Razor.NestedFiles;
 
@@ -24,11 +23,11 @@ internal sealed class AddNestedFileParams : ITextDocumentParams
     [JsonPropertyName("fileKind")]
     public required NestedFileKind FileKind { get; set; }
 
-    public static AddNestedFileParams Create(Uri razorFileUri, NestedFileKind fileKind)
+    public static AddNestedFileParams Create(DocumentUri razorFileUri, NestedFileKind fileKind)
     {
         return new AddNestedFileParams
         {
-            TextDocument = new TextDocumentIdentifier { DocumentUri = new(razorFileUri) },
+            TextDocument = new TextDocumentIdentifier { DocumentUri = razorFileUri },
             FileKind = fileKind
         };
     }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Rename/RenameService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Rename/RenameService.cs
@@ -136,8 +136,8 @@ internal class RenameService(
     private RenameFile GetRenameFileEdit(string oldFilePath, string newFilePath)
         => new()
         {
-            OldDocumentUri = new(LspFactory.CreateFilePathUri(oldFilePath, _languageServerFeatureOptions)),
-            NewDocumentUri = new(LspFactory.CreateFilePathUri(newFilePath, _languageServerFeatureOptions)),
+            OldDocumentUri = LspFactory.CreateFilePathUri(oldFilePath, _languageServerFeatureOptions),
+            NewDocumentUri = LspFactory.CreateFilePathUri(newFilePath, _languageServerFeatureOptions),
         };
 
     private static string MakeNewPath(string originalPath, string newName)

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/UriExtensions.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/UriExtensions.cs
@@ -12,10 +12,16 @@ namespace Microsoft.CodeAnalysis.Razor;
 internal static class UriExtensions
 {
     public static Uri GetRequiredSystemUri(this DocumentUri uri)
-        => uri.ParsedUri.AssumeNotNull();
+        => GetSystemUri(uri).AssumeNotNull();
+
+    public static Uri? GetSystemUri(this DocumentUri uri)
+        => uri.ParsedUri;
 
     public static Uri CreateSystemUri(this TextDocument document)
         => document.GetURI().GetRequiredSystemUri();
+
+    public static DocumentUri CreateDocumentUriFromSystemUri(this Uri uri)
+        => new DocumentUri(uri);
 
     public static string GetDocumentFilePathFromUri(this Uri uri)
     {

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CallHierarchy/RemoteCallHierarchyService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CallHierarchy/RemoteCallHierarchyService.cs
@@ -222,7 +222,7 @@ internal sealed class RemoteCallHierarchyService(in ServiceArgs args) : RazorDoc
             Kind = item.Kind,
             Tags = item.Tags,
             Detail = item.Detail,
-            Uri = new(mappedDocumentUri),
+            Uri = mappedDocumentUri.CreateDocumentUriFromSystemUri(),
             Range = mappedRange,
             SelectionRange = mappedSelectionRange,
             Data = item.Data,

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/CSharp/CSharpCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/CSharp/CSharpCodeActionResolver.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.CodeActions;
 using Microsoft.CodeAnalysis.Razor.Formatting;
@@ -81,7 +82,7 @@ internal sealed class CSharpCodeActionResolver(
             if (formattedChange is { } change)
             {
                 var sourceText = await editDocumentContext.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
-                textDocumentEdit.TextDocument = new() { DocumentUri = new(editDocumentContext.Uri) };
+                textDocumentEdit.TextDocument = new() { DocumentUri = editDocumentContext.Uri };
                 textDocumentEdit.Edits = [sourceText.GetTextEdit(change)];
             }
             else
@@ -106,6 +107,6 @@ internal sealed class CSharpCodeActionResolver(
         }
 
         var razorDocumentSnapshot = _snapshotManager.GetSnapshot(razorDocument);
-        return new RemoteDocumentContext(razorDocument.CreateSystemUri(), razorDocumentSnapshot);
+        return new RemoteDocumentContext(razorDocument.GetURI(), razorDocumentSnapshot);
     }
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/CSharp/UnformattedRemappingCSharpCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/CSharp/UnformattedRemappingCSharpCodeActionResolver.cs
@@ -70,7 +70,7 @@ internal sealed class UnformattedRemappingCSharpCodeActionResolver(IDocumentMapp
 
         var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier()
         {
-            DocumentUri = new(documentContext.Uri),
+            DocumentUri = documentContext.Uri,
         };
         codeAction.Edit = new WorkspaceEdit()
         {

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/AddUsingsCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/AddUsingsCodeActionResolver.cs
@@ -32,7 +32,7 @@ internal sealed class AddUsingsCodeActionResolver : IRazorCodeActionResolver
         var documentSnapshot = documentContext.Snapshot;
 
         var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
-        var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = new(documentContext.Uri) };
+        var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentContext.Uri };
 
         using var documentChanges = new PooledArrayBuilder<TextDocumentEdit>();
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/CreateComponentCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/CreateComponentCodeActionResolver.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
@@ -46,7 +45,7 @@ internal sealed class CreateComponentCodeActionResolver(LanguageServerFeatureOpt
         var newComponentUri = LspFactory.CreateFilePathUri(actionParams.Path, _languageServerFeatureOptions);
 
         using var documentChanges = new PooledArrayBuilder<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>>();
-        documentChanges.Add(new CreateFile() { DocumentUri = new(newComponentUri) });
+        documentChanges.Add(new CreateFile() { DocumentUri = newComponentUri });
 
         TryAddNamespaceDirective(codeDocument, newComponentUri, ref documentChanges.AsRef());
 
@@ -56,7 +55,7 @@ internal sealed class CreateComponentCodeActionResolver(LanguageServerFeatureOpt
         };
     }
 
-    private static void TryAddNamespaceDirective(RazorCodeDocument codeDocument, Uri newComponentUri, ref PooledArrayBuilder<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>> documentChanges)
+    private static void TryAddNamespaceDirective(RazorCodeDocument codeDocument, DocumentUri newComponentUri, ref PooledArrayBuilder<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>> documentChanges)
     {
         var syntaxRoot = codeDocument.GetRequiredSyntaxRoot();
         var namespaceDirective = syntaxRoot.DescendantNodes()
@@ -65,7 +64,7 @@ internal sealed class CreateComponentCodeActionResolver(LanguageServerFeatureOpt
 
         if (namespaceDirective != null)
         {
-            var documentIdentifier = new OptionalVersionedTextDocumentIdentifier { DocumentUri = new(newComponentUri) };
+            var documentIdentifier = new OptionalVersionedTextDocumentIdentifier { DocumentUri = newComponentUri };
             documentChanges.Add(new TextDocumentEdit
             {
                 TextDocument = documentIdentifier,

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
@@ -54,12 +54,12 @@ internal sealed class ExtractToCodeBehindCodeActionResolver(
         var codeBlockContent = text.ToString(new TextSpan(actionParams.ExtractStart, actionParams.ExtractEnd - actionParams.ExtractStart)).Trim();
         var codeBehindContent = GenerateCodeBehindClass(className, actionParams.Namespace, codeBlockContent, codeDocument);
 
-        codeBehindContent = await _roslynCodeActionHelpers.GetFormattedNewFileContentsAsync(documentContext.Snapshot.Project, codeBehindUri, codeBehindContent, cancellationToken).ConfigureAwait(false);
+        codeBehindContent = await _roslynCodeActionHelpers.GetFormattedNewFileContentsAsync(documentContext.Snapshot.Project, codeBehindUri.GetRequiredSystemUri(), codeBehindContent, cancellationToken).ConfigureAwait(false);
 
         var removeRange = codeDocument.Source.Text.GetRange(actionParams.RemoveStart, actionParams.RemoveEnd);
 
-        var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier { DocumentUri = new(documentContext.Uri) };
-        var codeBehindDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier { DocumentUri = new(codeBehindUri) };
+        var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier { DocumentUri = documentContext.Uri };
+        var codeBehindDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier { DocumentUri = codeBehindUri };
 
         var documentChanges = new SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>[]
         {

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToComponentCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToComponentCodeActionResolver.cs
@@ -52,7 +52,7 @@ internal sealed class ExtractToComponentCodeActionResolver(
         var templatePath = Path.Combine(directoryName, "Component.razor");
         var componentPath = FileUtilities.GenerateUniquePath(templatePath, ".razor");
         var componentName = Path.GetFileNameWithoutExtension(componentPath);
-        var newComponentUri = new DocumentUri(LspFactory.CreateFilePathUri(componentPath, _languageServerFeatureOptions));
+        var newComponentUri = LspFactory.CreateFilePathUri(componentPath, _languageServerFeatureOptions);
 
         using var _ = StringBuilderPool.GetPooledObject(out var builder);
 
@@ -88,7 +88,7 @@ internal sealed class ExtractToComponentCodeActionResolver(
             new CreateFile { DocumentUri = newComponentUri },
             new TextDocumentEdit
             {
-                TextDocument = new OptionalVersionedTextDocumentIdentifier { DocumentUri = new(documentContext.Uri) },
+                TextDocument = new OptionalVersionedTextDocumentIdentifier { DocumentUri = documentContext.Uri },
                 Edits =
                 [
                     new TextEdit

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToCssCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToCssCodeActionResolver.cs
@@ -50,8 +50,8 @@ internal sealed class ExtractToCssCodeActionResolver(
         var cssContent = text.ToString(new TextSpan(actionParams.ExtractStart, actionParams.ExtractEnd - actionParams.ExtractStart)).Trim();
         var removeRange = codeDocument.Source.Text.GetRange(actionParams.RemoveStart, actionParams.RemoveEnd);
 
-        var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier { DocumentUri = new(documentContext.Uri) };
-        var cssDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier { DocumentUri = new(cssFileUri) };
+        var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier { DocumentUri = documentContext.Uri };
+        var cssDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier { DocumentUri = cssFileUri };
 
         using var changes = new PooledArrayBuilder<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>>(capacity: 3);
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/GenerateEventHandlerCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/GenerateEventHandlerCodeActionResolver.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.CodeActions;
 using Microsoft.CodeAnalysis.Razor.CodeActions.Models;
@@ -65,7 +66,7 @@ internal sealed class GenerateEventHandlerCodeActionResolver(
 
         var codeBehindUri = LspFactory.CreateFilePathUri(codeBehindPath);
 
-        var codeBehindTextDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = new(codeBehindUri) };
+        var codeBehindTextDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = codeBehindUri };
 
         var classLocationLineSpan = classDecl.GetLocation().GetLineSpan();
         var text = await syntaxTree.GetTextAsync(cancellationToken).ConfigureAwait(false);
@@ -78,7 +79,7 @@ internal sealed class GenerateEventHandlerCodeActionResolver(
             character: 0,
             eventHandler);
 
-        var result = await _roslynCodeActionHelpers.GetSimplifiedTextEditsAsync(documentContext, codeBehindUri, edit, cancellationToken).ConfigureAwait(false);
+        var result = await _roslynCodeActionHelpers.GetSimplifiedTextEditsAsync(documentContext, codeBehindUri.GetRequiredSystemUri(), edit, cancellationToken).ConfigureAwait(false);
 
         var codeBehindTextDocEdit = new TextDocumentEdit()
         {
@@ -135,7 +136,7 @@ internal sealed class GenerateEventHandlerCodeActionResolver(
             DocumentChanges = new[] {
                 new TextDocumentEdit()
                 {
-                    TextDocument = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = new(documentContext.Uri) },
+                    TextDocument = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentContext.Uri },
                     Edits = [code.Source.Text.GetTextEdit(razorChange)],
                 }
             }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/PromoteUsingCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/PromoteUsingCodeActionResolver.cs
@@ -44,7 +44,7 @@ internal sealed class PromoteUsingCodeActionResolver(IFileSystem fileSystem) : I
         var file = FilePathNormalizer.Normalize(documentContext.Uri.GetAbsoluteOrUNCPath());
         var folder = Path.GetDirectoryName(file).AssumeNotNull();
         var importsFile = Path.GetFullPath(Path.Combine(folder, "..", importsFileName));
-        var importFileUri = new DocumentUri(LspFactory.CreateFilePathUri(importsFile));
+        var importFileUri = LspFactory.CreateFilePathUri(importsFile);
 
         using var edits = new PooledArrayBuilder<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>>();
 
@@ -78,7 +78,7 @@ internal sealed class PromoteUsingCodeActionResolver(IFileSystem fileSystem) : I
 
         edits.Add(new TextDocumentEdit
         {
-            TextDocument = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = new(documentContext.Uri) },
+            TextDocument = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentContext.Uri },
             Edits = [LspFactory.CreateTextEdit(removeRange, string.Empty)]
         });
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/RemoveUnnecessaryDirectivesCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/RemoveUnnecessaryDirectivesCodeActionResolver.cs
@@ -41,7 +41,7 @@ internal sealed class RemoveUnnecessaryDirectivesCodeActionResolver : IRazorCode
             {
                 new TextDocumentEdit
                 {
-                    TextDocument = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = new(documentContext.Uri) },
+                    TextDocument = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentContext.Uri },
                     Edits = edits.ToArrayAndClear(),
                 }
             }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/SimplifyFullyQualifiedComponentCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/SimplifyFullyQualifiedComponentCodeActionResolver.cs
@@ -36,7 +36,7 @@ internal sealed class SimplifyFullyQualifiedComponentCodeActionResolver : IRazor
         var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
         var text = codeDocument.Source.Text;
 
-        var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = new(documentContext.Uri) };
+        var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentContext.Uri };
 
         // Check if we need to add a using directive.
         // We check the tag helpers available in the document to see if the simple component name

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/SimplifyTagToSelfClosingCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/SimplifyTagToSelfClosingCodeActionResolver.cs
@@ -40,7 +40,7 @@ internal sealed class SimplifyTagToSelfClosingCodeActionResolver : IRazorCodeAct
         {
             new TextDocumentEdit
             {
-                TextDocument = new OptionalVersionedTextDocumentIdentifier { DocumentUri= new(documentContext.Uri) },
+                TextDocument = new OptionalVersionedTextDocumentIdentifier { DocumentUri= documentContext.Uri },
                 Edits =
                 [
                     new TextEdit

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/SortAndConsolidateUsingsCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/SortAndConsolidateUsingsCodeActionResolver.cs
@@ -32,7 +32,7 @@ internal sealed class SortAndConsolidateUsingsCodeActionResolver : IRazorCodeAct
         {
             new TextDocumentEdit
             {
-                TextDocument = new OptionalVersionedTextDocumentIdentifier { DocumentUri = new(documentContext.Uri) },
+                TextDocument = new OptionalVersionedTextDocumentIdentifier { DocumentUri = documentContext.Uri },
                 Edits = [.. edits],
             }
         };

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/WrapAttributesCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/WrapAttributesCodeActionResolver.cs
@@ -42,7 +42,7 @@ internal sealed class WrapAttributesCodeActionResolver : IRazorCodeActionResolve
 
         var tde = new TextDocumentEdit
         {
-            TextDocument = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = new(documentContext.Uri) },
+            TextDocument = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentContext.Uri },
             Edits = edits.ToArray()
         };
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentMapping/RemoteRazorEditService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentMapping/RemoteRazorEditService.cs
@@ -6,6 +6,7 @@ using System.Composition;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Telemetry;
@@ -43,7 +44,7 @@ internal sealed class RemoteRazorEditService(
 
         var razorDocumentSnapshot = _snapshotManager.GetSnapshot(razorDocument);
 
-        documentContext = new RemoteDocumentContext(razorDocumentUri, razorDocumentSnapshot);
+        documentContext = new RemoteDocumentContext(razorDocumentUri.CreateDocumentUriFromSystemUri(), razorDocumentSnapshot);
         return true;
     }
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentSymbols/RemoteDocumentSymbolService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentSymbols/RemoteDocumentSymbolService.cs
@@ -4,6 +4,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Protocol.DocumentSymbols;
 using Microsoft.CodeAnalysis.Razor.Remote;
@@ -53,7 +54,7 @@ internal sealed partial class RemoteDocumentSymbolService(in ServiceArgs args) :
         var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
         var csharpDocument = codeDocument.GetRequiredCSharpDocument();
 
-        return _documentSymbolService.GetDocumentSymbols(context.Snapshot.FileKind, context.Uri, csharpDocument, csharpSymbols);
+        return _documentSymbolService.GetDocumentSymbols(context.Snapshot.FileKind, context.Uri.GetRequiredSystemUri(), csharpDocument, csharpSymbols);
     }
 
     private static DocumentSymbol[] ConvertDocumentSymbols(DocumentSymbol[] roslynDocumentSymbols)

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/FindAllReferences/RemoteFindAllReferencesService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/FindAllReferences/RemoteFindAllReferencesService.cs
@@ -127,7 +127,7 @@ internal sealed class RemoteFindAllReferencesService(in ServiceArgs args) : Razo
                 }
             }
 
-            location.DocumentUri = new(mappedUri);
+            location.DocumentUri = mappedUri.CreateDocumentUriFromSystemUri();
             location.Range = mappedRange.ToRange();
 
             mappedResults.Add(result);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/GoToDefinition/RemoteGoToDefinitionService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/GoToDefinition/RemoteGoToDefinitionService.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.GoToDefinition;
 using Microsoft.CodeAnalysis.Razor.Protocol;
@@ -126,7 +127,7 @@ internal sealed class RemoteGoToDefinitionService(in ServiceArgs args) : RazorDo
                 .MapToHostDocumentUriAndRangeAsync(context.Snapshot, uri, range.ToLinePositionSpan(), cancellationToken)
                 .ConfigureAwait(false);
 
-            var mappedLocation = LspFactory.CreateLocation(mappedDocumentUri, mappedRange);
+            var mappedLocation = LspFactory.CreateLocation(mappedDocumentUri.CreateDocumentUriFromSystemUri(), mappedRange);
 
             mappedLocations.Add(mappedLocation);
         }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/GoToImplementation/RemoteGoToImplementationService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/GoToImplementation/RemoteGoToImplementationService.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Remote;
@@ -95,7 +96,7 @@ internal sealed class RemoteGoToImplementationService(in ServiceArgs args) : Raz
                 .MapToHostDocumentUriAndRangeAsync(context.Snapshot, uri, range.ToLinePositionSpan(), cancellationToken)
                 .ConfigureAwait(false);
 
-            var mappedLocation = LspFactory.CreateLocation(mappedDocumentUri, mappedRange);
+            var mappedLocation = LspFactory.CreateLocation(mappedDocumentUri.CreateDocumentUriFromSystemUri(), mappedRange);
 
             mappedLocations.Add(mappedLocation);
         }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/InlayHints/RemoteInlayHintService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/InlayHints/RemoteInlayHintService.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.PooledObjects;
-using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost.Handlers;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
@@ -17,6 +16,7 @@ using Microsoft.CodeAnalysis.Razor.Protocol.InlayHints;
 using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.LanguageServer;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor;
 
@@ -59,7 +59,7 @@ internal sealed class RemoteInlayHintService(in ServiceArgs args) : RazorDocumen
             .GetGeneratedDocumentAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        var textDocument = inlayHintParams.TextDocument.WithUri(generatedDocument.CreateSystemUri());
+        var textDocument = inlayHintParams.TextDocument.WithUri(generatedDocument.GetURI());
 
         using var inlayHintsBuilder = new PooledArrayBuilder<InlayHint>();
         var razorSourceText = codeDocument.Source.Text;

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/NestedFiles/RemoteAddNestedFileService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/NestedFiles/RemoteAddNestedFileService.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.CodeActions;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.NestedFiles;
@@ -61,7 +62,7 @@ internal sealed class RemoteAddNestedFileService(in ServiceArgs args)
 
         var nestedFileDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier
         {
-            DocumentUri = new DocumentUri(nestedFileUri)
+            DocumentUri = nestedFileUri
         };
 
         var documentChanges = new SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>[]
@@ -95,7 +96,7 @@ internal sealed class RemoteAddNestedFileService(in ServiceArgs args)
         NestedFileKind fileKind,
         RemoteDocumentContext documentContext,
         string razorFilePath,
-        Uri nestedFileUri,
+        DocumentUri nestedFileUri,
         CancellationToken cancellationToken)
     {
         return fileKind switch
@@ -125,7 +126,7 @@ internal sealed class RemoteAddNestedFileService(in ServiceArgs args)
     private async Task<string> GenerateCSharpContentAsync(
         RemoteDocumentContext documentContext,
         string razorFilePath,
-        Uri nestedFileUri,
+        DocumentUri nestedFileUri,
         CancellationToken cancellationToken)
     {
         var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
@@ -144,7 +145,7 @@ internal sealed class RemoteAddNestedFileService(in ServiceArgs args)
         // Format via Roslyn (handles file-scoped namespaces, indentation, etc.)
         content = await _roslynCodeActionHelpers.GetFormattedNewFileContentsAsync(
             documentContext.Snapshot.Project,
-            nestedFileUri,
+            nestedFileUri.GetRequiredSystemUri(),
             content,
             cancellationToken).ConfigureAwait(false);
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentContext.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentContext.cs
@@ -1,12 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
 
-internal sealed class RemoteDocumentContext(Uri uri, RemoteDocumentSnapshot snapshot) : DocumentContext(uri, snapshot)
+internal sealed class RemoteDocumentContext(DocumentUri uri, RemoteDocumentSnapshot snapshot) : DocumentContext(uri, snapshot)
 {
     public TextDocument TextDocument => Snapshot.TextDocument;
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorDocumentServiceBase.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorDocumentServiceBase.cs
@@ -5,12 +5,12 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.LanguageServer;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor;
 
@@ -91,6 +91,6 @@ internal abstract class RazorDocumentServiceBase(in ServiceArgs args) : RazorBro
 
         var documentSnapshot = SnapshotManager.GetSnapshot(razorDocument);
 
-        return new RemoteDocumentContext(razorDocument.CreateSystemUri(), documentSnapshot);
+        return new RemoteDocumentContext(razorDocument.GetURI(), documentSnapshot);
     }
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/TypeHierarchy/RemoteTypeHierarchyService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/TypeHierarchy/RemoteTypeHierarchyService.cs
@@ -183,7 +183,7 @@ internal sealed class RemoteTypeHierarchyService(in ServiceArgs args) : RazorDoc
             Kind = item.Kind,
             Tags = item.Tags,
             Detail = item.Detail,
-            Uri = new(mappedDocumentUri),
+            Uri = mappedDocumentUri.CreateDocumentUriFromSystemUri(),
             Range = mappedRange,
             SelectionRange = mappedSelectionRange,
             Data = item.Data,

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostDocumentPullDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostDocumentPullDiagnosticsEndpoint.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Cohost;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.Protocol;
@@ -125,7 +126,7 @@ internal sealed class CohostDocumentPullDiagnosticsEndpoint(
     {
         return new VSInternalDocumentDiagnosticsParams
         {
-            TextDocument = new TextDocumentIdentifier { DocumentUri = new(uri) }
+            TextDocument = new TextDocumentIdentifier { DocumentUri = uri.CreateDocumentUriFromSystemUri() }
         };
     }
 

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostTextPresentationEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostTextPresentationEndpoint.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Cohost;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 
@@ -68,10 +69,10 @@ internal sealed class CohostTextPresentationEndpoint(
         // CreateFile, RenameFile, or DeleteFile operations that may be in DocumentChanges.
         foreach (var edit in workspaceEdit.EnumerateTextDocumentEdits())
         {
-            if (edit.TextDocument.DocumentUri.ParsedUri is { } uri &&
+            if (edit.TextDocument.DocumentUri.GetSystemUri() is { } uri &&
                 _filePathService.IsVirtualHtmlFile(uri))
             {
-                edit.TextDocument = new OptionalVersionedTextDocumentIdentifier { DocumentUri = new(_filePathService.GetRazorDocumentUri(uri)) };
+                edit.TextDocument = new OptionalVersionedTextDocumentIdentifier { DocumentUri = _filePathService.GetRazorDocumentUri(uri).CreateDocumentUriFromSystemUri() };
             }
         }
 

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostUriPresentationEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostUriPresentationEndpoint.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Cohost;
 using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
@@ -109,10 +110,10 @@ internal sealed class CohostUriPresentationEndpoint(
         //       but if we move this all to OOP, per the above TODO, then that point is moot.
         foreach (var edit in workspaceEdit.EnumerateTextDocumentEdits())
         {
-            if (edit.TextDocument.DocumentUri.ParsedUri is { } uri &&
+            if (edit.TextDocument.DocumentUri.GetSystemUri() is { } uri &&
                 _filePathService.IsVirtualHtmlFile(uri))
             {
-                edit.TextDocument = new OptionalVersionedTextDocumentIdentifier { DocumentUri = new(_filePathService.GetRazorDocumentUri(uri)) };
+                edit.TextDocument = new OptionalVersionedTextDocumentIdentifier { DocumentUri = _filePathService.GetRazorDocumentUri(uri).CreateDocumentUriFromSystemUri() };
             }
         }
 

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlRequestInvoker.cs
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlRequestInvoker.cs
@@ -62,7 +62,7 @@ internal sealed class HtmlRequestInvoker(
 
         // If the request is for a text document, we need to update the Uri to point to the Html document,
         // and most importantly set it back again before leaving the method in case a caller uses it.
-        UpdateTextDocumentUri(request, new(htmlDocument.Uri), out var originalUri);
+        UpdateTextDocumentUri(request, htmlDocument.Uri.CreateDocumentUriFromSystemUri(), out var originalUri);
 
         try
         {

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -187,6 +187,7 @@
     </ProjectReference>
     <ProjectReference Include="..\..\..\..\..\VisualStudio\Core\Def\Microsoft.VisualStudio.LanguageServices.csproj" />
     <ProjectReference Include="..\..\..\..\..\Workspaces\Core\Portable\Microsoft.CodeAnalysis.Workspaces.csproj" />
+    <ProjectReference Include="..\..\..\..\..\LanguageServer\Protocol\Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj" />
     <ProjectReference Include="..\..\..\Compiler\Microsoft.CodeAnalysis.Razor.Compiler\src\Microsoft.CodeAnalysis.Razor.Compiler.csproj">
       <Name>Microsoft.CodeAnalysis.Razor.Compiler</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/NestedFiles/NestedFileCommandHandler.cs
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/NestedFiles/NestedFileCommandHandler.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Razor.Extensions;
 using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.Utilities;
+using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.Razor.NestedFiles;
 using Microsoft.CodeAnalysis.Razor.Protocol.NestedFiles;
 using Microsoft.VisualStudio.Razor.LanguageClient;
@@ -146,7 +147,7 @@ internal sealed class NestedFileCommandHandler(
         await _requestInvoker.Value.ReinvokeRequestOnServerAsync<AddNestedFileParams, object?>(
             RazorLSPConstants.AddNestedFileName,
             RazorLSPConstants.RoslynLanguageServerName,
-            AddNestedFileParams.Create(new Uri(razorFilePath), _fileKind),
+            AddNestedFileParams.Create(ProtocolConversions.CreateAbsoluteDocumentUri(razorFilePath), _fileKind),
             cancellationToken);
 
         if (File.Exists(nestedFilePath))

--- a/src/Razor/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Cohosting/CohostTestBase.cs
+++ b/src/Razor/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Cohosting/CohostTestBase.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.Mef;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
@@ -22,6 +23,7 @@ using Microsoft.CodeAnalysis.Remote.Razor;
 using Microsoft.CodeAnalysis.Remote.Razor.Logging;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Composition;
+using Roslyn.LanguageServer.Protocol;
 using Roslyn.Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
@@ -277,8 +279,8 @@ public abstract class CohostTestBase(ITestOutputHelper testOutputHelper) : Tooli
         return builder.Build(solution).GetAdditionalDocument(documentId).AssumeNotNull();
     }
 
-    protected static Uri FileUri(string projectRelativeFileName)
-        => new(FilePath(projectRelativeFileName));
+    private protected static DocumentUri FileUri(string projectRelativeFileName)
+        => ProtocolConversions.CreateAbsoluteDocumentUri(FilePath(projectRelativeFileName));
 
     protected static string FilePath(string projectRelativeFileName)
         => Path.GetFullPath(Path.Combine(TestProjectData.SomeProjectPath, projectRelativeFileName));

--- a/src/Razor/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/AssertExtensions.cs
+++ b/src/Razor/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/AssertExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -9,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.LanguageServer;
+using Microsoft.CodeAnalysis.Razor;
 using Roslyn.Test.Utilities;
 using Roslyn.Text.Adornments;
 using Xunit;
@@ -27,10 +27,6 @@ internal static class AssertExtensions
         Assert.Equal(expectedClassificationType, run.ClassificationTypeName);
         Assert.Equal(expectedClassificationStyle, run.Style);
     }
-
-    public static Task AssertWorkspaceEditAsync(this WorkspaceEdit workspaceEdit, Solution solution, IEnumerable<(Uri fileUri, string contents)> expectedChanges, CancellationToken cancellationToken)
-        => workspaceEdit.AssertWorkspaceEditAsync(solution, expectedChanges.Select(e => (new DocumentUri(e.fileUri), e.contents)), cancellationToken);
-
     public static async Task AssertWorkspaceEditAsync(this WorkspaceEdit workspaceEdit, Solution solution, IEnumerable<(DocumentUri fileUri, string contents)> expectedChanges, CancellationToken cancellationToken)
     {
         var changes = Assert.NotNull(workspaceEdit.DocumentChanges);

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/CohostCodeActionsEndpointTestBase.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/CohostCodeActionsEndpointTestBase.cs
@@ -36,7 +36,7 @@ public abstract class CohostCodeActionsEndpointTestBase(ITestOutputHelper testOu
         RazorFileKind? fileKind = null,
         string? documentFilePath = null,
         (string filePath, string contents)[]? additionalFiles = null,
-        (Uri fileUri, string contents)[]? additionalExpectedFiles = null,
+        (DocumentUri fileUri, string contents)[]? additionalExpectedFiles = null,
         bool addDefaultImports = true,
         bool makeDiagnosticsRequest = false)
     {
@@ -56,7 +56,7 @@ public abstract class CohostCodeActionsEndpointTestBase(ITestOutputHelper testOu
             ? codeAction.Edit.AssumeNotNull()
             : await ResolveCodeActionAsync(document, codeAction);
 
-        var expectedChanges = (additionalExpectedFiles ?? []).Select(e => (new DocumentUri(e.fileUri), e.contents)).Concat([(document.GetURI(), expected)]);
+        var expectedChanges = (additionalExpectedFiles ?? []).Select(e => (e.fileUri, e.contents)).Concat([(document.GetURI(), expected)]);
         await workspaceEdit.AssertWorkspaceEditAsync(document.Project.Solution, expectedChanges, DisposalToken);
     }
 

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostGoToDefinitionEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostGoToDefinitionEndpointTest.cs
@@ -1,7 +1,6 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -154,7 +153,7 @@ public class CohostGoToDefinitionEndpointTest(ITestOutputHelper testOutputHelper
         var locations = result.Value.Second;
         var location = Assert.Single(locations);
 
-        Assert.Equal(FileUri("SurveyPrompt.razor"), location.DocumentUri.GetRequiredSystemUri());
+        Assert.Equal(FileUri("SurveyPrompt.razor"), location.DocumentUri);
         var text = SourceText.From(surveyPrompt.Text);
         var range = text.GetRange(surveyPrompt.Span);
         Assert.Equal(range, location.Range);
@@ -189,7 +188,7 @@ public class CohostGoToDefinitionEndpointTest(ITestOutputHelper testOutputHelper
         var locations = result.Value.Second;
         var location = Assert.Single(locations);
 
-        Assert.Equal(FileUri("SurveyPrompt.razor"), location.DocumentUri.GetRequiredSystemUri());
+        Assert.Equal(FileUri("SurveyPrompt.razor"), location.DocumentUri);
         var text = SourceText.From(surveyPrompt.Text);
         var range = text.GetRange(surveyPrompt.Span);
         Assert.Equal(range, location.Range);
@@ -222,7 +221,7 @@ public class CohostGoToDefinitionEndpointTest(ITestOutputHelper testOutputHelper
         var locations = result.Value.Second;
         var location = Assert.Single(locations);
 
-        Assert.Equal(FileUri("SurveyPrompt.razor"), location.DocumentUri.GetRequiredSystemUri());
+        Assert.Equal(FileUri("SurveyPrompt.razor"), location.DocumentUri);
         var text = SourceText.From(surveyPrompt.Text);
         var range = text.GetRange(surveyPrompt.Span);
         Assert.Equal(range, location.Range);
@@ -255,7 +254,7 @@ public class CohostGoToDefinitionEndpointTest(ITestOutputHelper testOutputHelper
         var locations = result.Value.Second;
         var location = Assert.Single(locations);
 
-        Assert.Equal(FileUri("SurveyPrompt.razor"), location.DocumentUri.GetRequiredSystemUri());
+        Assert.Equal(FileUri("SurveyPrompt.razor"), location.DocumentUri);
         var text = SourceText.From(surveyPrompt.Text);
         var range = text.GetRange(surveyPrompt.Span);
         Assert.Equal(range, location.Range);
@@ -293,7 +292,7 @@ public class CohostGoToDefinitionEndpointTest(ITestOutputHelper testOutputHelper
         var locations = result.Value.Second;
         var location = Assert.Single(locations);
 
-        Assert.Equal(FileUri("File1.razor"), location.DocumentUri.GetRequiredSystemUri());
+        Assert.Equal(FileUri("File1.razor"), location.DocumentUri);
         var text = SourceText.From(input.Text);
         var range = text.GetRange(input.Span);
         Assert.Equal(range, location.Range);
@@ -335,7 +334,7 @@ public class CohostGoToDefinitionEndpointTest(ITestOutputHelper testOutputHelper
         var locations = result.Value.Second;
         var location = Assert.Single(locations);
 
-        Assert.Equal(FileUri("SurveyPrompt.cs"), location.DocumentUri.GetRequiredSystemUri());
+        Assert.Equal(FileUri("SurveyPrompt.cs"), location.DocumentUri);
         var text = SourceText.From(surveyPrompt.Text);
         var range = text.GetRange(surveyPrompt.Span);
         Assert.Equal(range, location.Range);
@@ -377,7 +376,7 @@ public class CohostGoToDefinitionEndpointTest(ITestOutputHelper testOutputHelper
         var locations = result.Value.Second;
         var location = Assert.Single(locations);
 
-        Assert.Equal(FileUri("SurveyPrompt.cs"), location.DocumentUri.GetRequiredSystemUri());
+        Assert.Equal(FileUri("SurveyPrompt.cs"), location.DocumentUri);
         var text = SourceText.From(surveyPrompt.Text);
         var range = text.GetRange(surveyPrompt.Span);
         Assert.Equal(range, location.Range);
@@ -448,10 +447,11 @@ public class CohostGoToDefinitionEndpointTest(ITestOutputHelper testOutputHelper
         var document = CreateProjectAndRazorDocument(input.Text);
         var inputText = await document.GetTextAsync(DisposalToken);
 
+        var uri = new DocumentUri($"{document.CreateSystemUri()}{document.Name}{LanguageServerConstants.HtmlVirtualDocumentSuffix}");
         var htmlResponse = new SumType<LspLocation, LspLocation[], DocumentLink[]>?(new LspLocation[]
         {
             new() {
-                DocumentUri = new(new Uri(document.CreateSystemUri(), document.Name + LanguageServerConstants.HtmlVirtualDocumentSuffix)),
+                DocumentUri = uri,
                 Range = inputText.GetRange(input.Span),
             },
         });
@@ -488,7 +488,7 @@ public class CohostGoToDefinitionEndpointTest(ITestOutputHelper testOutputHelper
         var locations = result.Value.Second;
         var location = Assert.Single(locations);
 
-        Assert.Equal(FileUri("AuthorViewComponent.cs"), location.DocumentUri.GetRequiredSystemUri());
+        Assert.Equal(FileUri("AuthorViewComponent.cs"), location.DocumentUri);
         Assert.Equal(expected.Span, SourceText.From(expected.Text).GetTextSpan(location.Range));
     }
 
@@ -524,7 +524,7 @@ public class CohostGoToDefinitionEndpointTest(ITestOutputHelper testOutputHelper
         var locations = result.Value.Second;
         var location = Assert.Single(locations);
 
-        Assert.Equal(FileUri("AboutBoxTagHelper.cs"), location.DocumentUri.GetRequiredSystemUri());
+        Assert.Equal(FileUri("AboutBoxTagHelper.cs"), location.DocumentUri);
         Assert.Equal(expected.Span, SourceText.From(expected.Text).GetTextSpan(location.Range));
     }
 
@@ -568,7 +568,7 @@ public class CohostGoToDefinitionEndpointTest(ITestOutputHelper testOutputHelper
         var locations = result.Value.Second;
         var location = Assert.Single(locations);
 
-        Assert.Equal(FileUri("AboutBoxTagHelper_1.cs"), location.DocumentUri.GetRequiredSystemUri());
+        Assert.Equal(FileUri("AboutBoxTagHelper_1.cs"), location.DocumentUri);
         Assert.Equal(expected.Span, SourceText.From(expected.Text).GetTextSpan(location.Range));
     }
 
@@ -606,7 +606,7 @@ public class CohostGoToDefinitionEndpointTest(ITestOutputHelper testOutputHelper
         var locations = result.Value.Second;
         var location = Assert.Single(locations);
 
-        Assert.Equal(FileUri("AboutBoxTagHelper.cs"), location.DocumentUri.GetRequiredSystemUri());
+        Assert.Equal(FileUri("AboutBoxTagHelper.cs"), location.DocumentUri);
         Assert.Equal(expected.Span, SourceText.From(expected.Text).GetTextSpan(location.Range));
     }
 
@@ -651,7 +651,7 @@ public class CohostGoToDefinitionEndpointTest(ITestOutputHelper testOutputHelper
         var locations = result.Value.Second;
         var location = Assert.Single(locations);
 
-        Assert.Equal(FileUri("AboutBoxTagHelper_2.cs"), location.DocumentUri.GetRequiredSystemUri());
+        Assert.Equal(FileUri("AboutBoxTagHelper_2.cs"), location.DocumentUri);
         Assert.Equal(expected.Span, SourceText.From(expected.Text).GetTextSpan(location.Range));
     }
 
@@ -715,7 +715,7 @@ public class CohostGoToDefinitionEndpointTest(ITestOutputHelper testOutputHelper
         var locations = result.Value.Second;
         var location = Assert.Single(locations);
 
-        Assert.Equal(FileUri("FooTagHelper.cs"), location.DocumentUri.GetRequiredSystemUri());
+        Assert.Equal(FileUri("FooTagHelper.cs"), location.DocumentUri);
         Assert.Equal(expected.Span, SourceText.From(expected.Text).GetTextSpan(location.Range));
     }
 
@@ -779,7 +779,7 @@ public class CohostGoToDefinitionEndpointTest(ITestOutputHelper testOutputHelper
         var locations = result.Value.Second;
         var location = Assert.Single(locations);
 
-        Assert.Equal(FileUri("FooTagHelper.cs"), location.DocumentUri.GetRequiredSystemUri());
+        Assert.Equal(FileUri("FooTagHelper.cs"), location.DocumentUri);
         Assert.Equal(expected.Span, SourceText.From(expected.Text).GetTextSpan(location.Range));
     }
 
@@ -866,11 +866,11 @@ public class CohostGoToDefinitionEndpointTest(ITestOutputHelper testOutputHelper
         Assert.Equal(expected.Spans.Length, locations.Length);
 
         var location = locations[0];
-        Assert.Equal(FileUri("TagHelpers.cs"), location.DocumentUri.GetRequiredSystemUri());
+        Assert.Equal(FileUri("TagHelpers.cs"), location.DocumentUri);
         Assert.Equal(expected.Spans[0], SourceText.From(expected.Text).GetTextSpan(location.Range));
 
         location = locations[1];
-        Assert.Equal(FileUri("TagHelpers.cs"), location.DocumentUri.GetRequiredSystemUri());
+        Assert.Equal(FileUri("TagHelpers.cs"), location.DocumentUri);
         Assert.Equal(expected.Spans[1], SourceText.From(expected.Text).GetTextSpan(location.Range));
     }
 
@@ -895,7 +895,7 @@ public class CohostGoToDefinitionEndpointTest(ITestOutputHelper testOutputHelper
         var locations = result.Value.Second;
         var location = Assert.Single(locations);
 
-        Assert.Equal(FileUri("Views/Shared/_Partial.cshtml"), location.DocumentUri.GetRequiredSystemUri());
+        Assert.Equal(FileUri("Views/Shared/_Partial.cshtml"), location.DocumentUri);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/razor/issues/4325")]
@@ -919,7 +919,7 @@ public class CohostGoToDefinitionEndpointTest(ITestOutputHelper testOutputHelper
         var locations = result.Value.Second;
         var location = Assert.Single(locations);
 
-        Assert.Equal(FileUri("_Partial.cshtml"), location.DocumentUri.GetRequiredSystemUri());
+        Assert.Equal(FileUri("_Partial.cshtml"), location.DocumentUri);
     }
 
     [Fact, WorkItem("https://github.com/dotnet/razor/issues/4325")]
@@ -949,7 +949,7 @@ public class CohostGoToDefinitionEndpointTest(ITestOutputHelper testOutputHelper
         var locations = result.Value.Second;
         var location = Assert.Single(locations);
 
-        Assert.Equal(FileUri("Pages/Counter.razor"), location.DocumentUri.GetRequiredSystemUri());
+        Assert.Equal(FileUri("Pages/Counter.razor"), location.DocumentUri);
     }
 
     [Theory, WorkItem("https://github.com/dotnet/razor/issues/4325")]

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostGoToDefinitionEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostGoToDefinitionEndpointTest.cs
@@ -447,7 +447,7 @@ public class CohostGoToDefinitionEndpointTest(ITestOutputHelper testOutputHelper
         var document = CreateProjectAndRazorDocument(input.Text);
         var inputText = await document.GetTextAsync(DisposalToken);
 
-        var uri = new DocumentUri($"{document.CreateSystemUri()}{document.Name}{LanguageServerConstants.HtmlVirtualDocumentSuffix}");
+        var uri = new DocumentUri($"{document.CreateSystemUri()}{LanguageServerConstants.HtmlVirtualDocumentSuffix}");
         var htmlResponse = new SumType<LspLocation, LspLocation[], DocumentLink[]>?(new LspLocation[]
         {
             new() {

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostGoToImplementationEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostGoToImplementationEndpointTest.cs
@@ -1,13 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.LanguageServer;
-using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Remote.Razor;
 using Microsoft.CodeAnalysis.Text;
@@ -103,9 +101,10 @@ public class CohostGoToImplementationEndpointTest(ITestOutputHelper testOutputHe
         var document = CreateProjectAndRazorDocument(input.Text);
         var inputText = await document.GetTextAsync(DisposalToken);
 
+        var uri = new DocumentUri($"{document.GetURI()}{document.Name}{LanguageServerConstants.HtmlVirtualDocumentSuffix}");
         var htmlResponse = new LspLocation
         {
-            DocumentUri = new(new Uri(document.CreateSystemUri(), document.Name + LanguageServerConstants.HtmlVirtualDocumentSuffix)),
+            DocumentUri = uri,
             Range = inputText.GetRange(input.Span),
         };
 
@@ -140,7 +139,7 @@ public class CohostGoToImplementationEndpointTest(ITestOutputHelper testOutputHe
         var locations = result.Value.First;
         var location = Assert.Single(locations);
 
-        Assert.Equal(FileUri("SurveyPrompt.razor"), location.DocumentUri.GetRequiredSystemUri());
+        Assert.Equal(FileUri("SurveyPrompt.razor"), location.DocumentUri);
         var text = SourceText.From(surveyPrompt.Text);
         var range = text.GetRange(surveyPrompt.Span);
         Assert.Equal(range, location.Range);

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostGoToImplementationEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostGoToImplementationEndpointTest.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.LanguageServer;
+using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Remote.Razor;
 using Microsoft.CodeAnalysis.Text;
@@ -101,7 +102,7 @@ public class CohostGoToImplementationEndpointTest(ITestOutputHelper testOutputHe
         var document = CreateProjectAndRazorDocument(input.Text);
         var inputText = await document.GetTextAsync(DisposalToken);
 
-        var uri = new DocumentUri($"{document.GetURI()}{document.Name}{LanguageServerConstants.HtmlVirtualDocumentSuffix}");
+        var uri = new DocumentUri($"{document.CreateSystemUri()}{LanguageServerConstants.HtmlVirtualDocumentSuffix}");
         var htmlResponse = new LspLocation
         {
             DocumentUri = uri,

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostRenameEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostRenameEndpointTest.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
@@ -1462,9 +1461,9 @@ public class CohostRenameEndpointTest(ITestOutputHelper testOutputHelper) : Coho
         string newName,
         string expected,
         RazorFileKind? fileKind = null,
-        Uri? newFileUri = null,
+        DocumentUri? newFileUri = null,
         (string fileName, string contents)[]? additionalFiles = null,
-        (Uri fileUri, string contents)[]? additionalExpectedFiles = null)
+        (DocumentUri fileUri, string contents)[]? additionalExpectedFiles = null)
     {
         TestFileMarkupParser.GetPosition(input, out var source, out var cursorPosition);
         var document = CreateProjectAndRazorDocument(source, fileKind, additionalFiles: additionalFiles);
@@ -1495,8 +1494,8 @@ public class CohostRenameEndpointTest(ITestOutputHelper testOutputHelper) : Coho
 
         Assert.NotNull(result);
 
-        var documentUri = newFileUri is null ? document.GetURI() : new(newFileUri);
-        var expectedChanges = (additionalExpectedFiles ?? []).Select(e => (new DocumentUri(e.fileUri), e.contents)).Concat([(documentUri, expected)]);
+        var documentUri = newFileUri is null ? document.GetURI() : newFileUri;
+        var expectedChanges = (additionalExpectedFiles ?? []).Select(e => (e.fileUri, e.contents)).Concat([(documentUri, expected)]);
         await result.AssertWorkspaceEditAsync(document.Project.Solution, expectedChanges, DisposalToken);
     }
 }

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostTypeHierarchyEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostTypeHierarchyEndpointTest.cs
@@ -1,14 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.LanguageServer;
-using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.TypeHierarchy;
 using Microsoft.CodeAnalysis.Text;
@@ -71,22 +69,22 @@ public class CohostTypeHierarchyEndpointTest(ITestOutputHelper testOutputHelper)
 
         var document = CreateProjectAndRazorDocument(input.Text);
         var preparedItem = Assert.Single(await GetPreparedItemsAsync(document, input.Position));
-        AssertItems([preparedItem], (document.GetURI().GetRequiredSystemUri(), input, ["derivedDef"]));
+        AssertItems([preparedItem], (document.GetURI(), input, ["derivedDef"]));
 
         var supertypes = await GetSupertypesAsync(document, preparedItem);
-        AssertItems(supertypes, (document.GetURI().GetRequiredSystemUri(), input, ["midDef"]));
+        AssertItems(supertypes, (document.GetURI(), input, ["midDef"]));
         var midItem = Assert.Single(supertypes);
 
         var midSupertypes = await GetSupertypesAsync(document, midItem);
-        AssertItems(midSupertypes, (document.GetURI().GetRequiredSystemUri(), input, ["baseDef"]));
+        AssertItems(midSupertypes, (document.GetURI(), input, ["baseDef"]));
         var baseItem = Assert.Single(midSupertypes);
 
         var baseSupertypes = await GetSupertypesAsync(document, baseItem);
-        AssertItems(baseSupertypes, (document.GetURI().GetRequiredSystemUri(), input, ["midInterfaceDef"]));
+        AssertItems(baseSupertypes, (document.GetURI(), input, ["midInterfaceDef"]));
         var midInterfaceItem = Assert.Single(baseSupertypes);
 
         var midInterfaceSupertypes = await GetSupertypesAsync(document, midInterfaceItem);
-        AssertItems(midInterfaceSupertypes, (document.GetURI().GetRequiredSystemUri(), input, ["topInterfaceDef"]));
+        AssertItems(midInterfaceSupertypes, (document.GetURI(), input, ["topInterfaceDef"]));
     }
 
     [Fact]
@@ -123,18 +121,18 @@ public class CohostTypeHierarchyEndpointTest(ITestOutputHelper testOutputHelper)
 
         var document = CreateProjectAndRazorDocument(input.Text);
         var preparedItem = Assert.Single(await GetPreparedItemsAsync(document, input.Position));
-        AssertItems([preparedItem], (document.GetURI().GetRequiredSystemUri(), input, ["rootDef"]));
+        AssertItems([preparedItem], (document.GetURI(), input, ["rootDef"]));
 
         var subtypes = await GetSubtypesAsync(document, preparedItem);
-        AssertItems(subtypes, (document.GetURI().GetRequiredSystemUri(), input, ["childDef", "directImplDef"]));
+        AssertItems(subtypes, (document.GetURI(), input, ["childDef", "directImplDef"]));
 
         var childItem = Assert.Single(subtypes, item => item.Name == "IChild");
         var childSubtypes = await GetSubtypesAsync(document, childItem);
-        AssertItems(childSubtypes, (document.GetURI().GetRequiredSystemUri(), input, ["grandchildDef"]));
+        AssertItems(childSubtypes, (document.GetURI(), input, ["grandchildDef"]));
         var grandchildItem = Assert.Single(childSubtypes);
 
         var grandchildSubtypes = await GetSubtypesAsync(document, grandchildItem);
-        AssertItems(grandchildSubtypes, (document.GetURI().GetRequiredSystemUri(), input, ["indirectImplDef"]));
+        AssertItems(grandchildSubtypes, (document.GetURI(), input, ["indirectImplDef"]));
     }
 
     private async Task<TypeHierarchyItem[]> GetPreparedItemsAsync(
@@ -192,7 +190,7 @@ public class CohostTypeHierarchyEndpointTest(ITestOutputHelper testOutputHelper)
     private static TypeHierarchyItem RoundTripItemData(TypeHierarchyItem item)
         => RazorTypeHierarchyResolveData.WithData(item, JsonSerializer.SerializeToElement(item.Data, JsonHelpers.JsonSerializerOptions));
 
-    private static void AssertItems(TypeHierarchyItem[] items, params (Uri uri, TestCode code, string[]? names)[] expectedSources)
+    private static void AssertItems(TypeHierarchyItem[] items, params (DocumentUri uri, TestCode code, string[]? names)[] expectedSources)
     {
         var expectedItems = GetExpectedItems(expectedSources);
         Assert.Equal(expectedItems.Length, items.Length);
@@ -207,12 +205,12 @@ public class CohostTypeHierarchyEndpointTest(ITestOutputHelper testOutputHelper)
     private static void AssertItem(TypeHierarchyItem item, ExpectedTypeHierarchyItem expectedItem)
     {
         Assert.Equal(expectedItem.Name, item.Name);
-        Assert.Equal(expectedItem.Uri, item.Uri.ParsedUri);
+        Assert.Equal(expectedItem.Uri, item.Uri);
         Assert.Equal(expectedItem.SelectionRange, item.SelectionRange);
         Assert.Equal(expectedItem.Uri, GetResolveDataDocumentUri(item));
     }
 
-    private static ExpectedTypeHierarchyItem[] GetExpectedItems((Uri uri, TestCode code, string[]? names)[] expectedSources)
+    private static ExpectedTypeHierarchyItem[] GetExpectedItems((DocumentUri uri, TestCode code, string[]? names)[] expectedSources)
     {
         return
         [
@@ -224,7 +222,7 @@ public class CohostTypeHierarchyEndpointTest(ITestOutputHelper testOutputHelper)
         ];
     }
 
-    private static ExpectedTypeHierarchyItem GetExpectedItem(Uri uri, TestCode code, string name)
+    private static ExpectedTypeHierarchyItem GetExpectedItem(DocumentUri uri, TestCode code, string name)
     {
         var span = Assert.Single(code.NamedSpans[name]);
         var sourceText = SourceText.From(code.Text);
@@ -234,7 +232,7 @@ public class CohostTypeHierarchyEndpointTest(ITestOutputHelper testOutputHelper)
             sourceText.GetRange(span));
     }
 
-    private static Uri GetResolveDataDocumentUri(TypeHierarchyItem item)
+    private static DocumentUri GetResolveDataDocumentUri(TypeHierarchyItem item)
     {
         var data = item.Data switch
         {
@@ -251,8 +249,8 @@ public class CohostTypeHierarchyEndpointTest(ITestOutputHelper testOutputHelper)
             : textDocument.GetProperty("Uri").GetString();
 
         Assert.NotNull(uriString);
-        return new Uri(uriString);
+        return new DocumentUri(uriString);
     }
 
-    private sealed record ExpectedTypeHierarchyItem(string Name, Uri Uri, TypeHierarchyRange SelectionRange);
+    private sealed record ExpectedTypeHierarchyItem(string Name, DocumentUri Uri, TypeHierarchyRange SelectionRange);
 }

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostWillRenameEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostWillRenameEndpointTest.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
@@ -158,10 +157,10 @@ public class CohostWillRenameEndpointTest(ITestOutputHelper testOutputHelper) : 
             ]);
 
     private async Task VerifyRenamesAsync(
-        Uri newName,
-        Uri oldName,
+        DocumentUri newName,
+        DocumentUri oldName,
         (string fileName, string contents)[] files,
-        (Uri fileUri, string contents)[] expectedFiles)
+        (DocumentUri FileDocumentUri, string contents)[] expectedFiles)
     {
         var document = CreateProjectAndRazorDocument(contents: "", additionalFiles: files);
 
@@ -175,8 +174,8 @@ public class CohostWillRenameEndpointTest(ITestOutputHelper testOutputHelper) : 
             Files = [
                 new FileRename
                 {
-                    OldUri = new(oldName),
-                    NewUri = new(newName),
+                    OldUri = oldName,
+                    NewUri = newName,
                 }
             ]
         };

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.UnitTests/CodeActions/HtmlCodeActionProviderTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.UnitTests/CodeActions/HtmlCodeActionProviderTest.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text.Json;
@@ -10,7 +9,6 @@ using System.Threading.Tasks;
 using Basic.Reference.Assemblies;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.CodeActions;
 using Microsoft.CodeAnalysis.Razor.CodeActions.Models;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
@@ -25,6 +23,7 @@ using Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 using Moq;
 using Roslyn.LanguageServer.Protocol;
 using Xunit;
+using Microsoft.CodeAnalysis.LanguageServer;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor.CodeActions;
 
@@ -38,10 +37,10 @@ public class HtmlCodeActionProviderTest
         TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
 
         var documentPath = TestProjectData.SomeProjectComponentFile1.FilePath;
-        var documentUri = new Uri(documentPath);
+        var documentUri = ProtocolConversions.CreateAbsoluteDocumentUri(documentPath);
         var request = new VSCodeActionParams()
         {
-            TextDocument = new VSTextDocumentIdentifier { DocumentUri = new(documentUri) },
+            TextDocument = new VSTextDocumentIdentifier { DocumentUri = documentUri },
             Range = LspFactory.DefaultRange,
             Context = new VSInternalCodeActionContext()
         };
@@ -71,10 +70,10 @@ public class HtmlCodeActionProviderTest
         TestFileMarkupParser.GetPositionAndSpan(contents, out contents, out var cursorPosition, out var span);
 
         var documentPath = TestProjectData.SomeProjectComponentFile1.FilePath;
-        var documentUri = new Uri(documentPath);
+        var documentUri = ProtocolConversions.CreateAbsoluteDocumentUri(documentPath);
         var request = new VSCodeActionParams()
         {
-            TextDocument = new VSTextDocumentIdentifier { DocumentUri = new(documentUri) },
+            TextDocument = new VSTextDocumentIdentifier { DocumentUri = documentUri },
             Range = LspFactory.DefaultRange,
             Context = new VSInternalCodeActionContext()
         };
@@ -89,7 +88,7 @@ public class HtmlCodeActionProviderTest
             {
                 Assert.IsType<RemoteDocumentSnapshot>(snapshot);
                 var textDocumentEdit = edit.EnumerateTextDocumentEdits().First();
-                textDocumentEdit.TextDocument.DocumentUri = new(documentPath);
+                textDocumentEdit.TextDocument.DocumentUri = ProtocolConversions.CreateAbsoluteDocumentUri(documentPath);
                 textDocumentEdit.Edits = [LspFactory.CreateTextEdit(context.SourceText.GetRange(span), "Goo /*~~~~~~~~~~~*/ Bar")];
             })
             .Returns(Task.CompletedTask);
@@ -108,7 +107,7 @@ public class HtmlCodeActionProviderTest
                         new() {
                             TextDocument = new OptionalVersionedTextDocumentIdentifier
                             {
-                                DocumentUri = new(new Uri(documentPath + ".html")),
+                                DocumentUri = ProtocolConversions.CreateAbsoluteDocumentUri(documentPath + ".html"),
                             },
                             Edits = [LspFactory.CreateTextEdit(position: (0, 0), "Goo")]
                         }
@@ -125,7 +124,7 @@ public class HtmlCodeActionProviderTest
         Assert.NotNull(action.Edit);
         var documentEdits = action.Edit.EnumerateTextDocumentEdits().ToArray();
         Assert.NotEmpty(documentEdits);
-        Assert.Equal(documentUri, documentEdits[0].TextDocument.DocumentUri.GetRequiredSystemUri());
+        Assert.Equal(documentUri, documentEdits[0].TextDocument.DocumentUri);
 
         var text = SourceText.From(contents);
         var changed = text.WithChanges(documentEdits[0].Edits.Select(e => text.GetTextChange((TextEdit)e)));

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.UnitTests/CodeActions/HtmlCodeActionResolverTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.UnitTests/CodeActions/HtmlCodeActionResolverTest.cs
@@ -1,14 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Basic.Reference.Assemblies;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.CodeActions.Models;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -20,6 +18,7 @@ using Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 using Moq;
 using Roslyn.LanguageServer.Protocol;
 using Xunit;
+using Microsoft.CodeAnalysis.LanguageServer;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor.CodeActions;
 
@@ -33,7 +32,7 @@ public class HtmlCodeActionResolverTest
         TestFileMarkupParser.GetPositionAndSpan(contents, out contents, out _, out var span);
 
         var documentPath = TestProjectData.SomeProjectComponentFile1.FilePath;
-        var documentUri = new Uri(documentPath);
+        var documentUri = ProtocolConversions.CreateAbsoluteDocumentUri(documentPath);
         var (context, sourceText, workspace) = CreateDocumentContext(documentUri, documentPath, contents);
         using var workspaceLifetime = workspace;
 
@@ -62,7 +61,7 @@ public class HtmlCodeActionResolverTest
                     {
                         TextDocument = new OptionalVersionedTextDocumentIdentifier
                         {
-                            DocumentUri = new(new Uri(documentPath + ".html")),
+                            DocumentUri = ProtocolConversions.CreateAbsoluteDocumentUri(documentPath + ".html"),
                         },
                         Edits = [LspFactory.CreateTextEdit(position: (0, 0), "Goo")]
                     }
@@ -77,14 +76,14 @@ public class HtmlCodeActionResolverTest
         Assert.NotNull(action.Edit);
         var documentEdits = action.Edit.EnumerateTextDocumentEdits().ToArray();
         Assert.NotEmpty(documentEdits);
-        Assert.Equal(documentUri, documentEdits[0].TextDocument.DocumentUri.GetRequiredSystemUri());
+        Assert.Equal(documentUri, documentEdits[0].TextDocument.DocumentUri);
 
         var text = SourceText.From(contents);
         var changed = text.WithChanges(documentEdits[0].Edits.Select(e => text.GetTextChange((TextEdit)e)));
         Assert.Equal("Goo @(DateTime.Now) Bar", changed.ToString());
     }
 
-    private static (RemoteDocumentContext Context, SourceText SourceText, AdhocWorkspace Workspace) CreateDocumentContext(Uri documentUri, string filePath, string text)
+    private static (RemoteDocumentContext Context, SourceText SourceText, AdhocWorkspace Workspace) CreateDocumentContext(DocumentUri documentUri, string filePath, string text)
     {
         var sourceText = SourceText.From(text);
 

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostApplyRenameEditEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostApplyRenameEditEndpointTest.cs
@@ -47,8 +47,8 @@ public class CohostApplyRenameEditEndpointTest(ITestOutputHelper testOutputHelpe
             Files = [
                 new FileRename
                 {
-                    OldUri = new(FileUri(oldName)),
-                    NewUri = new(FileUri(newName)),
+                    OldUri = FileUri(oldName),
+                    NewUri = FileUri(newName),
                 }
             ]
         };
@@ -116,8 +116,8 @@ public class CohostApplyRenameEditEndpointTest(ITestOutputHelper testOutputHelpe
             Files = [
                 new FileRename
                 {
-                    OldUri = new(FileUri(oldName)),
-                    NewUri = new(FileUri(newName)),
+                    OldUri = FileUri(oldName),
+                    NewUri = FileUri(newName),
                 }
             ]
         };
@@ -184,8 +184,8 @@ public class CohostApplyRenameEditEndpointTest(ITestOutputHelper testOutputHelpe
             Files = [
                 new FileRename
                 {
-                    OldUri = new(FileUri(oldName)),
-                    NewUri = new(FileUri(newName)),
+                    OldUri = FileUri(oldName),
+                    NewUri = FileUri(newName),
                 }
             ]
         };

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostTextPresentationEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostTextPresentationEndpointTest.cs
@@ -34,7 +34,7 @@ public class CohostTextPresentationEndpointTest(ITestOutputHelper testOutputHelp
                     {
                         TextDocument = new()
                         {
-                            DocumentUri = new(FileUri($"File1.razor{LanguageServerConstants.HtmlVirtualDocumentSuffix}"))
+                            DocumentUri = FileUri($"File1.razor{LanguageServerConstants.HtmlVirtualDocumentSuffix}")
                         },
                         Edits = [LspFactory.CreateTextEdit(position: (0, 0), "Hello World")]
                     }

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostUriPresentationEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostUriPresentationEndpointTest.cs
@@ -1,9 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.LanguageServer;
+using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
@@ -57,7 +58,7 @@ public class CohostUriPresentationEndpointTest(ITestOutputHelper testOutputHelpe
                     {
                         TextDocument = new()
                         {
-                            DocumentUri = new(FileUri($"File1.razor{LanguageServerConstants.HtmlVirtualDocumentSuffix}"))
+                            DocumentUri = FileUri($"File1.razor{LanguageServerConstants.HtmlVirtualDocumentSuffix}")
                         },
                         Edits = [LspFactory.CreateTextEdit(position: (0, 0), htmlTag)]
                     }
@@ -129,7 +130,7 @@ public class CohostUriPresentationEndpointTest(ITestOutputHelper testOutputHelpe
                     {
                         TextDocument = new()
                         {
-                            DocumentUri = new(FileUri("File1.razor.g.html"))
+                            DocumentUri = FileUri("File1.razor.g.html")
                         },
                         Edits = [LspFactory.CreateTextEdit(position: (0, 0), htmlTag)]
                     }
@@ -238,7 +239,7 @@ public class CohostUriPresentationEndpointTest(ITestOutputHelper testOutputHelpe
             expected: """<Component RequiredParameter="" />""");
     }
 
-    private async Task VerifyUriPresentationAsync(string input, Uri[] uris, string? expected, WorkspaceEdit? htmlResponse = null, (string fileName, string contents)[]? additionalFiles = null)
+    private async Task VerifyUriPresentationAsync(string input, DocumentUri[] uris, string? expected, WorkspaceEdit? htmlResponse = null, (string fileName, string contents)[]? additionalFiles = null)
     {
         TestFileMarkupParser.GetSpan(input, out input, out var span);
         var document = CreateProjectAndRazorDocument(input, additionalFiles: additionalFiles);
@@ -255,7 +256,7 @@ public class CohostUriPresentationEndpointTest(ITestOutputHelper testOutputHelpe
                 DocumentUri = document.GetURI()
             },
             Range = sourceText.GetRange(span),
-            Uris = uris
+            Uris = [.. uris.Select(u => u.GetRequiredSystemUri())]
         };
 
         var result = await endpoint.GetTestAccessor().HandleRequestAsync(request, document, DisposalToken);

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostWrapWithTagEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostWrapWithTagEndpointTest.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.Editor;
+using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.VisualStudio.Razor.LanguageClient.WrapWithTag;
@@ -193,15 +194,16 @@ public class CohostWrapWithTagEndpointTest(ITestOutputHelper testOutputHelper) :
 
         var requestInvoker = new TestHtmlRequestInvoker([(LanguageServerConstants.RazorWrapWithTagEndpoint, htmlResponse)]);
 
-        var documentUri = document.CreateSystemUri();
+        var documentUri = document.GetURI();
+        var systemUri = documentUri.GetRequiredSystemUri();
         var documentManager = new TestDocumentManager();
         if (htmlDocument is not null)
         {
             var snapshot = new StringTextSnapshot(htmlDocument);
             var buffer = new TestTextBuffer(snapshot);
-            var htmlSnapshot = new HtmlVirtualDocumentSnapshot(documentUri, snapshot, hostDocumentSyncVersion: 1, state: null);
-            var documentSnapshot = new TestLSPDocumentSnapshot(documentUri, version: 1, htmlSnapshot);
-            documentManager.AddDocument(documentUri, documentSnapshot);
+            var htmlSnapshot = new HtmlVirtualDocumentSnapshot(systemUri, snapshot, hostDocumentSyncVersion: 1, state: null);
+            var documentSnapshot = new TestLSPDocumentSnapshot(systemUri, version: 1, htmlSnapshot);
+            documentManager.AddDocument(systemUri, documentSnapshot);
         }
 
         var endpoint = new CohostWrapWithTagEndpoint(RemoteServiceInvoker, requestInvoker, documentManager, IncompatibleProjectService, LoggerFactory);
@@ -212,7 +214,7 @@ public class CohostWrapWithTagEndpointTest(ITestOutputHelper testOutputHelper) :
             new FormattingOptions(),
             new VersionedTextDocumentIdentifier()
             {
-                DocumentUri = new(documentUri)
+                DocumentUri = documentUri
             });
 
         var result = await endpoint.GetTestAccessor().HandleRequestAsync(request, document, DisposalToken);


### PR DESCRIPTION
Migrate more Razor APIs from System.Uri to DocumentUri or System.Uri helpers.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83810)