### PR TITLE
Enable immediate asset publishing, remove post-build validation

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -390,6 +390,7 @@ extends:
       - template: /eng/common/templates-official/job/publish-build-assets.yml@self
         parameters:
           publishUsingPipelines: true
+          publishAssetsImmediately: true
           dependsOn:
           - OfficialBuild
           pool:
@@ -434,6 +435,9 @@ extends:
       - template: /eng/common/templates-official/post-build/post-build.yml@self
         parameters:
           publishingInfraVersion: 3
+          publishAssetsImmediately: true
+          enableSigningValidation: false
+          enableNugetValidation: false
           enableSourceLinkValidation: false
           # Enable SDL validation, passing through values from the 'DotNet-Roslyn-SDLValidation-Params' group.
           SDLValidationParameters:

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -408,7 +408,7 @@ extends:
 
     - stage: insert
       dependsOn:
-      - publish_using_darc
+      - build
       displayName: Insert to VS
 
       jobs:


### PR DESCRIPTION
Enable immediate asset publishing by setting publishAssetsImmediately in both the publish-build-assets job and the post-build template. This moves Darc publishing inline into the publish-build-assets job, eliminating the separate 'Publish using Darc' stage and its inter-stage dispatch gap.

Disable Signing Validation and NuGet Validation in the post-build template. Analysis of 1,564 official builds on main over the past year shows:
- NuGet Validation: 0 failures out of 1,564 runs (0.0%)
- Signing Validation: 22 failures out of 1,564 runs (1.4%) in last year. Most were infra. There was one real failure, due to not signing a test binary (intentional). I do NOT think this warrants another 30 mins build time.

These stages add ~23 minutes to every build's critical path (14m validation
+ 9m inter-stage gap). Combined with eliminating the Publish using Darc stage (~25m + 9m gap), this saves ~33 minutes per official build and ~818 AzDO-agent-hours per year.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83811)