### PR TITLE
Don't offer IDE0058 for Null-conditional assignment

### DIFF
--- a/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedValueExpressionStatementTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedValueExpressionStatementTests.cs
@@ -342,6 +342,64 @@ public sealed partial class RemoveUnusedValueExpressionStatementTests : RemoveUn
             """,
             parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp14));
 
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/80766")]
+    [InlineData(nameof(PreferDiscard), "_ = (c?.M2())")]
+    [InlineData(nameof(PreferUnusedLocal), "var unused = c?.M2()")]
+    public Task ExpressionStatement_NullConditionalInvocation(string optionName, string fixedStatement)
+        => TestInRegularAndScriptAsync(
+            """
+            class C
+            {
+                void M(C c)
+                {
+                    [|c?.M2()|];
+                }
+
+                int M2() => 0;
+            }
+            """,
+            $$"""
+            class C
+            {
+                void M(C c)
+                {
+                    {{fixedStatement}};
+                }
+
+                int M2() => 0;
+            }
+            """, optionName);
+
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/80766")]
+    [InlineData(nameof(PreferDiscard), "_ = (c?.Inner?.M2())")]
+    [InlineData(nameof(PreferUnusedLocal), "var unused = c?.Inner?.M2()")]
+    public Task ExpressionStatement_NestedNullConditionalInvocation(string optionName, string fixedStatement)
+        => TestInRegularAndScriptAsync(
+            """
+            class C
+            {
+                void M(C c)
+                {
+                    [|c?.Inner?.M2()|];
+                }
+
+                public C Inner { get; set; }
+                int M2() => 0;
+            }
+            """,
+            $$"""
+            class C
+            {
+                void M(C c)
+                {
+                    {{fixedStatement}};
+                }
+
+                public C Inner { get; set; }
+                int M2() => 0;
+            }
+            """, optionName);
+
     [Theory]
     [InlineData("x++")]
     [InlineData("x--")]

--- a/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedValueExpressionStatementTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedValueExpressionStatementTests.cs
@@ -285,6 +285,63 @@ public sealed partial class RemoveUnusedValueExpressionStatementTests : RemoveUn
             }
             """);
 
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/80766")]
+    [InlineData("=")]
+    [InlineData("+=")]
+    [InlineData("??=")]
+    public Task ExpressionStatement_NullConditionalAssignmentExpression(string op)
+        => TestMissingInRegularAndScriptWithAllOptionsAsync(
+            $$"""
+            class C
+            {
+                void M(C c)
+                {
+                    [|c?.Value {{op}} 0|];
+                }
+
+                public int? Value { get; set; }
+            }
+            """,
+            parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp14));
+
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/80766")]
+    [InlineData("=")]
+    [InlineData("+=")]
+    [InlineData("??=")]
+    public Task ExpressionStatement_NestedNullConditionalAssignmentExpression(string op)
+        => TestMissingInRegularAndScriptWithAllOptionsAsync(
+            $$"""
+            class C
+            {
+                void M(C c)
+                {
+                    [|c?.Inner?.Value {{op}} 0|];
+                }
+
+                public C? Inner { get; set; }
+                public int? Value { get; set; }
+            }
+            """,
+            parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp14));
+
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/80766"), WorkItem("https://github.com/dotnet/roslyn/issues/80499")]
+    [InlineData("=")]
+    [InlineData("+=")]
+    [InlineData("??=")]
+    public Task ExpressionStatement_NullConditionalIndexAssignmentExpression(string op)
+        => TestMissingInRegularAndScriptWithAllOptionsAsync(
+            $$"""
+            using System.Collections.Generic;
+            class C
+            {
+                void M(Dictionary<int, int?> d)
+                {
+                    [|d?[0] {{op}} 0|];
+                }
+            }
+            """,
+            parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp14));
+
     [Theory]
     [InlineData("x++")]
     [InlineData("x--")]

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.BlockAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.BlockAnalyzer.cs
@@ -201,7 +201,15 @@ internal abstract partial class AbstractRemoveUnusedParametersAndValuesDiagnosti
                     return;
                 }
 
-                //  5. Bail out if there is language specific syntax to indicate an explicit discard.
+                //  5. Bail out for null-conditional assignments (e.g. `a?.b = c`, possibly nested),
+                //     where the innermost WhenNotNull of the IConditionalAccessOperation is an assignment.
+                if (value is IConditionalAccessOperation conditionalAccess &&
+                    GetInnermostWhenNotNull(conditionalAccess) is IAssignmentOperation)
+                {
+                    return;
+                }
+
+                //  6. Bail out if there is language specific syntax to indicate an explicit discard.
                 //     For example, VB call statement is used to explicitly ignore the value returned by
                 //     an invocation by prefixing the invocation with keyword "Call".
                 //     Similarly, we do not want to flag an expression of a C# expression body.
@@ -219,6 +227,15 @@ internal abstract partial class AbstractRemoveUnusedParametersAndValuesDiagnosti
                                                          additionalLocations: null,
                                                          properties);
                 context.ReportDiagnostic(diagnostic);
+            }
+
+            private static IOperation GetInnermostWhenNotNull(IConditionalAccessOperation operation)
+            {
+                var current = operation.WhenNotNull;
+                while (current is IConditionalAccessOperation nested)
+                    current = nested.WhenNotNull;
+
+                return current;
             }
 
             private void AnalyzeDelegateCreationOrAnonymousFunction(OperationAnalysisContext operationAnalysisContext)

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.BlockAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.BlockAnalyzer.cs
@@ -231,11 +231,10 @@ internal abstract partial class AbstractRemoveUnusedParametersAndValuesDiagnosti
 
             private static IOperation GetInnermostWhenNotNull(IConditionalAccessOperation operation)
             {
-                var current = operation.WhenNotNull;
-                while (current is IConditionalAccessOperation nested)
-                    current = nested.WhenNotNull;
+                while (operation is { WhenNotNull: IConditionalAccessOperation inner })
+                    operation = inner;
 
-                return current;
+                return operation;
             }
 
             private void AnalyzeDelegateCreationOrAnonymousFunction(OperationAnalysisContext operationAnalysisContext)

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.BlockAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.BlockAnalyzer.cs
@@ -231,10 +231,10 @@ internal abstract partial class AbstractRemoveUnusedParametersAndValuesDiagnosti
 
             private static IOperation GetInnermostWhenNotNull(IConditionalAccessOperation operation)
             {
-                while (operation is { WhenNotNull: IConditionalAccessOperation inner })
+                while (operation.WhenNotNull is IConditionalAccessOperation inner)
                     operation = inner;
 
-                return operation;
+                return operation.WhenNotNull;
             }
 
             private void AnalyzeDelegateCreationOrAnonymousFunction(OperationAnalysisContext operationAnalysisContext)

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.BlockAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.BlockAnalyzer.cs
@@ -202,7 +202,7 @@ internal abstract partial class AbstractRemoveUnusedParametersAndValuesDiagnosti
                 }
 
                 //  5. Bail out for null-conditional assignments (e.g. `a?.b = c`, possibly nested),
-                //     where the innermost WhenNotNull of the IConditionalAccessOperation is an assignment.
+                //     The analyzer is expected to behave the same way as it does with assignments(4).
                 if (value is IConditionalAccessOperation conditionalAccess &&
                     GetInnermostWhenNotNull(conditionalAccess) is IAssignmentOperation)
                 {


### PR DESCRIPTION
Fixes #80766

Null-conditional assignment was introduced in C# 14. While it was expected to be used in the same way as traditional assignment operators, IDE0058 would flag it, forcing users to apply a discard pattern like `_ = a?.B = c;`.

For users who have modified the severity of IDE0058 in their .editorconfig, this has become a deterrent to adopting the new syntax.

This change adds a bail-out branch to IDE0058 so that if the expression is an IConditionalAccessOperation, it will no longer be targeted by IDE0058 detection.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83817)