### PR TITLE
Changing timeouts to test the new helix runner code.

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -413,6 +413,7 @@ function TestUsingRunTests() {
   }
 
   $runTests = GetProjectOutputBinary "RunTests.dll" -tfm "net10.0"
+  $timeout = 0;
 
   if (!(Test-Path $runTests)) {
     Write-Host "Test runner not found: '$runTests'. Run Build.cmd first." -ForegroundColor Red
@@ -426,7 +427,7 @@ function TestUsingRunTests() {
 
   if ($testCoreClr) {
     $args += " --runtime core"
-    $args += " --timeout 90"
+    $timeout = 90
     if ($testCompilerOnly) {
       $args += GetCompilerTestAssembliesIncludePaths
     } else {
@@ -435,7 +436,7 @@ function TestUsingRunTests() {
   }
   elseif ($testDesktop -or ($testIOperation -and -not $testCoreClr)) {
     $args += " --runtime framework"
-    $args += " --timeout 90"
+    $timeout = 90
 
     if ($testRuntimeAsync) {
       Write-Host "Cannot run desktop tests with runtime async validation enabled."
@@ -453,7 +454,7 @@ function TestUsingRunTests() {
     }
 
   } elseif ($testVsi) {
-    $args += " --timeout 220"
+    $timeout = 220
     $args += " --runtime both"
     $args += " --sequential"
     $args += " --include '\.IntegrationTests'"
@@ -482,6 +483,9 @@ function TestUsingRunTests() {
 
   if ($helix) {
     $args += " --helix"
+  }
+  else {
+    $args += " --timeout $timeout"
   }
 
   if ($helixQueueName) {

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -484,7 +484,7 @@ function TestUsingRunTests() {
   if ($helix) {
     $args += " --helix"
   }
-  else {
+  elseif ($timeout -gt 0) {
     $args += " --timeout $timeout"
   }
 

--- a/eng/pipelines/publish-logs.yml
+++ b/eng/pipelines/publish-logs.yml
@@ -5,6 +5,9 @@ parameters:
 - name: configuration
   type: string
   default: 'Debug'
+- name: testRunName
+  type: string
+  default: ''
 
 steps:
   - task: PowerShell@2
@@ -37,6 +40,15 @@ steps:
       targetFolder: '$(Build.SourcesDirectory)/artifacts/log/${{ parameters.configuration }}'
     continueOnError: true
     condition: always()
+
+  - task: PublishTestResults@2
+    displayName: Publish xUnit Test Results
+    inputs:
+        testRunner: XUnit
+        testResultsFiles: '$(Build.SourcesDirectory)/artifacts/TestResults/${{ parameters.configuration }}/*.xml'
+        mergeTestResults: true
+        testRunTitle: ${{ parameters.testRunName }}
+    condition: and(always(), ne('${{ parameters.testRunName }}', ''))
 
   - task: PublishPipelineArtifact@1
     displayName: Publish Logs

--- a/eng/pipelines/test-unix-job-single-machine.yml
+++ b/eng/pipelines/test-unix-job-single-machine.yml
@@ -54,16 +54,8 @@ jobs:
         args: --ci --configuration ${{ parameters.configuration }} ${{ parameters.testArguments }}
       displayName: Test
 
-    - task: PublishTestResults@2
-      displayName: Publish xUnit Test Results
-      inputs:
-        testRunner: XUnit
-        testResultsFiles: '$(Build.SourcesDirectory)/artifacts/TestResults/${{ parameters.configuration }}/*.xml'
-        mergeTestResults: true
-        testRunTitle: ${{ parameters.testRunName }}
-      condition: always()
-
     - template: publish-logs.yml
       parameters:
         configuration: ${{ parameters.configuration }}
         jobName: ${{ parameters.jobName }}
+        testRunName: ${{ parameters.testRunName }}

--- a/eng/pipelines/test-unix-job.yml
+++ b/eng/pipelines/test-unix-job.yml
@@ -26,7 +26,7 @@ parameters:
 jobs:
 - job: ${{ parameters.jobName }}
   pool: ${{ parameters.poolParameters }}
-  timeoutInMinutes: 120
+  timeoutInMinutes: 360
   steps:
     - checkout: none
 

--- a/eng/pipelines/test-unix-job.yml
+++ b/eng/pipelines/test-unix-job.yml
@@ -54,6 +54,15 @@ jobs:
       env:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
+    - task: PublishTestResults@2
+      displayName: Publish xUnit Test Results
+      inputs:
+        testRunner: XUnit
+        testResultsFiles: '$(Build.SourcesDirectory)/artifacts/TestResults/${{ parameters.configuration }}/*.xml'
+        mergeTestResults: true
+        testRunTitle: ${{ parameters.testRunName }}
+      condition: always()
+
     - template: publish-logs.yml
       parameters:
         configuration: ${{ parameters.configuration }}

--- a/eng/pipelines/test-unix-job.yml
+++ b/eng/pipelines/test-unix-job.yml
@@ -54,16 +54,8 @@ jobs:
       env:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
-    - task: PublishTestResults@2
-      displayName: Publish xUnit Test Results
-      inputs:
-        testRunner: XUnit
-        testResultsFiles: '$(Build.SourcesDirectory)/artifacts/TestResults/${{ parameters.configuration }}/*.xml'
-        mergeTestResults: true
-        testRunTitle: ${{ parameters.testRunName }}
-      condition: always()
-
     - template: publish-logs.yml
       parameters:
         configuration: ${{ parameters.configuration }}
         jobName: ${{ parameters.jobName }}
+        testRunName: ${{ parameters.testRunName }}

--- a/eng/pipelines/test-windows-job-single-machine.yml
+++ b/eng/pipelines/test-windows-job-single-machine.yml
@@ -53,16 +53,8 @@ jobs:
         filePath: eng/build.ps1
         arguments: -ci -configuration ${{ parameters.configuration }} ${{ parameters.testArguments }} -collectDumps
 
-    - task: PublishTestResults@2
-      displayName: Publish xUnit Test Results
-      inputs:
-        testRunner: XUnit
-        testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\${{ parameters.configuration }}\*.xml'
-        mergeTestResults: true
-        testRunTitle: '${{ parameters.testRunName }}'
-      condition: always()
-
     - template: publish-logs.yml
       parameters:
         configuration: ${{ parameters.configuration }}
         jobName: ${{ parameters.jobName }}
+        testRunName: ${{ parameters.testRunName }}

--- a/eng/pipelines/test-windows-job.yml
+++ b/eng/pipelines/test-windows-job.yml
@@ -26,7 +26,7 @@ parameters:
 jobs:
 - job: ${{ parameters.jobName }}
   pool: ${{ parameters.poolParameters }}
-  timeoutInMinutes: 120
+  timeoutInMinutes: 360
   steps:
     - checkout: none
 

--- a/eng/pipelines/test-windows-job.yml
+++ b/eng/pipelines/test-windows-job.yml
@@ -54,6 +54,15 @@ jobs:
       env:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
+    - task: PublishTestResults@2
+      displayName: Publish xUnit Test Results
+      inputs:
+        testRunner: XUnit
+        testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\${{ parameters.configuration }}\*.xml'
+        mergeTestResults: true
+        testRunTitle: '${{ parameters.testRunName }}'
+      condition: always()
+
     - template: publish-logs.yml
       parameters:
         configuration: ${{ parameters.configuration }}

--- a/eng/pipelines/test-windows-job.yml
+++ b/eng/pipelines/test-windows-job.yml
@@ -54,16 +54,8 @@ jobs:
       env:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
-    - task: PublishTestResults@2
-      displayName: Publish xUnit Test Results
-      inputs:
-        testRunner: XUnit
-        testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\${{ parameters.configuration }}\*.xml'
-        mergeTestResults: true
-        testRunTitle: '${{ parameters.testRunName }}'
-      condition: always()
-
     - template: publish-logs.yml
       parameters:
         configuration: ${{ parameters.configuration }}
         jobName: ${{ parameters.jobName }}
+        testRunName: ${{ parameters.testRunName }}

--- a/src/Tools/RunTests/AssemblyScheduler.cs
+++ b/src/Tools/RunTests/AssemblyScheduler.cs
@@ -18,15 +18,6 @@ namespace RunTests
 {
     internal sealed class AssemblyScheduler
     {
-        /// <summary>
-        /// We attempt to partition our tests into work items that execute in under 2 minutes 30s.  This is a derived limit based on a goal of running all tests
-        /// in under 5 minutes.  However because of overhead in setting up the test run, e.g.
-        ///   1.  Test discovery.
-        ///   2.  Downloading assets to the helix machine.
-        ///   3.  Setting up the test host for each assembly.
-        ///   
-        /// </summary>
-        private static readonly TimeSpan s_maxExecutionTime = TimeSpan.FromSeconds(60 * 10);
 
         /// <summary>
         /// If we were unable to find the test execution history, we fall back to partitioning by just method count.
@@ -71,7 +62,7 @@ namespace RunTests
             var workItems = BuildWorkItems(
                 orderedTypeInfos,
                 getWeightFunc: static test => test.ExecutionTime.TotalSeconds,
-                limit: s_maxExecutionTime.TotalSeconds);
+                limit: HelixTestRunner.WorkItemScheduleTime.TotalSeconds);
             LogWorkItems(workItems);
             return workItems;
         }
@@ -79,12 +70,12 @@ namespace RunTests
         private static void LogLongTests(ImmutableDictionary<string, TimeSpan> testHistory)
         {
             var longTests = testHistory
-                .Where(kvp => kvp.Value > s_maxExecutionTime)
+                .Where(kvp => kvp.Value > HelixTestRunner.WorkItemScheduleTime)
                 .OrderBy(kvp => kvp.Key)
                 .ToList();
             if (longTests.Count > 0)
             {
-                ConsoleUtil.Warning($"There are {longTests.Count} tests have execution times greater than the maximum execution time of {s_maxExecutionTime}");
+                ConsoleUtil.Warning($"There are {longTests.Count} tests have execution times greater than the maximum execution time of {HelixTestRunner.WorkItemScheduleTime:hh\\:mm\\:ss}.  These tests will be scheduled in their own individual work items and may indicate tests that should be optimized or removed if they are no longer providing value.");
                 foreach (var (test, time) in longTests)
                 {
                     ConsoleUtil.WriteLine($"\t{test} - {time:hh\\:mm\\:ss}");

--- a/src/Tools/RunTests/HelixApi.cs
+++ b/src/Tools/RunTests/HelixApi.cs
@@ -13,6 +13,10 @@ using System.Threading.Tasks;
 
 namespace RunTests;
 
+/// <summary>
+/// Helper class for interacting with the Helix API to query job and work item status, fetch logs, and cancel jobs. Based
+/// on the API documented at https://helix.dot.net/swagger/ui
+/// </summary>
 internal sealed class HelixApi : IDisposable
 {
     private const string HelixBaseUrl = "https://helix.dot.net";

--- a/src/Tools/RunTests/HelixApi.cs
+++ b/src/Tools/RunTests/HelixApi.cs
@@ -1,0 +1,191 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RunTests;
+
+internal sealed class HelixApi : IDisposable
+{
+    private const string HelixBaseUrl = "https://helix.dot.net";
+    private const string ApiVersion = "2019-06-17";
+
+    private readonly HttpClient _httpClient;
+
+    public HelixApi(string? bearerToken = null)
+    {
+        _httpClient = new HttpClient
+        {
+            BaseAddress = new Uri(HelixBaseUrl)
+        };
+        _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+        if (!string.IsNullOrEmpty(bearerToken))
+        {
+            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
+        }
+    }
+
+    /// <summary>
+    /// GET /api/jobs/{job}/details
+    /// Provides job summary data along with aggregated work item statistics.
+    /// </summary>
+    public async Task<HelixJobDetails> GetJobDetailsAsync(string job, CancellationToken cancellationToken = default)
+    {
+        var url = $"/api/jobs/{Uri.EscapeDataString(job)}/details?api-version={ApiVersion}";
+        return await GetAsync<HelixJobDetails>(url, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// POST /api/jobs/{job}/cancel
+    /// Cancels a running job. Requires authentication.
+    /// </summary>
+    public async Task CancelJobAsync(string job, string? jobCancellationToken = null, CancellationToken cancellationToken = default)
+    {
+        var url = $"/api/jobs/{Uri.EscapeDataString(job)}/cancel?api-version={ApiVersion}";
+        if (!string.IsNullOrEmpty(jobCancellationToken))
+        {
+            url += $"&jobCancellationToken={Uri.EscapeDataString(jobCancellationToken)}";
+        }
+
+        using var response = await _httpClient.PostAsync(url, content: null, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+    }
+
+    /// <summary>
+    /// GET /api/jobs/{job}/workitems/{id}
+    /// Fetches details about a single work item including logs and uploaded files.
+    /// </summary>
+    public async Task<HelixWorkItemDetails> GetWorkItemDetailsAsync(string job, string id, CancellationToken cancellationToken = default)
+    {
+        var url = $"/api/jobs/{Uri.EscapeDataString(job)}/workitems/{Uri.EscapeDataString(id)}?api-version={ApiVersion}";
+        return await GetAsync<HelixWorkItemDetails>(url, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// GET /api/jobs/{job}/workitems
+    /// Lists all work items for a given job.
+    /// </summary>
+    public async Task<List<HelixWorkItemSummary>> GetWorkItemsAsync(string job, CancellationToken cancellationToken = default)
+    {
+        var url = $"/api/jobs/{Uri.EscapeDataString(job)}/workitems?api-version={ApiVersion}";
+        return await GetAsync<List<HelixWorkItemSummary>>(url, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<T> GetAsync<T>(string url, CancellationToken cancellationToken)
+    {
+        using var response = await _httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+        var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        return await JsonSerializer.DeserializeAsync<T>(stream, JsonOptions, cancellationToken).ConfigureAwait(false)
+            ?? throw new InvalidOperationException($"Failed to deserialize response from {url}");
+    }
+
+    public void Dispose() => _httpClient.Dispose();
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+}
+
+// ---- Response model types ----
+
+internal sealed class HelixFailureReasonPart
+{
+    public string? Display { get; set; }
+    public string? Link { get; set; }
+}
+
+internal sealed class HelixFailureReason
+{
+    public HelixFailureReasonPart? Issue { get; set; }
+    public HelixFailureReasonPart? Owner { get; set; }
+}
+
+internal sealed class HelixWorkItemError
+{
+    public string Id { get; set; } = "";
+    public string Message { get; set; } = "";
+    public string? LogUri { get; set; }
+}
+
+internal sealed class HelixJobWorkItemCounts
+{
+    public int Unscheduled { get; set; }
+    public int Waiting { get; set; }
+    public int Running { get; set; }
+    public int Finished { get; set; }
+    public string ListUrl { get; set; } = "";
+}
+
+internal sealed class HelixJobDetails
+{
+    public HelixFailureReason? FailureReason { get; set; }
+    public string? QueueId { get; set; }
+    public string JobList { get; set; } = "";
+    public HelixJobWorkItemCounts WorkItems { get; set; } = new();
+    public string Name { get; set; } = "";
+    public string? Creator { get; set; }
+    public string? Created { get; set; }
+    public string? Finished { get; set; }
+    public int? InitialWorkItemCount { get; set; }
+    public string WaitUrl { get; set; } = "";
+    public string Source { get; set; } = "";
+    public string Type { get; set; } = "";
+    public string Build { get; set; } = "";
+    public object? Properties { get; set; }
+    public List<HelixWorkItemError>? Errors { get; set; }
+}
+
+internal sealed class HelixWorkItemSummary
+{
+    public string DetailsUrl { get; set; } = "";
+    public int? ExitCode { get; set; }
+    public string? ConsoleOutputUri { get; set; }
+    public string Job { get; set; } = "";
+    public string Name { get; set; } = "";
+    public string State { get; set; } = "";
+}
+
+internal sealed class HelixWorkItemLog
+{
+    public string Module { get; set; } = "";
+    public string Uri { get; set; } = "";
+}
+
+internal sealed class HelixWorkItemFile
+{
+    public string FileName { get; set; } = "";
+    public string Uri { get; set; } = "";
+}
+
+internal sealed class HelixWorkItemDetails
+{
+    public HelixFailureReason? FailureReason { get; set; }
+    public string? Queued { get; set; }
+    public string? Started { get; set; }
+    public string? Finished { get; set; }
+    public string? Delay { get; set; }
+    public string? Duration { get; set; }
+    public string Id { get; set; } = "";
+    public string MachineName { get; set; } = "";
+    public int? ExitCode { get; set; }
+    public string? ConsoleOutputUri { get; set; }
+    public List<HelixWorkItemError>? Errors { get; set; }
+    public List<HelixWorkItemError>? Warnings { get; set; }
+    public List<HelixWorkItemLog>? Logs { get; set; }
+    public List<HelixWorkItemFile>? Files { get; set; }
+    public List<object>? OtherEvents { get; set; }
+    public string Job { get; set; } = "";
+    public string Name { get; set; } = "";
+    public string State { get; set; } = "";
+}

--- a/src/Tools/RunTests/HelixTestRunner.cs
+++ b/src/Tools/RunTests/HelixTestRunner.cs
@@ -133,7 +133,7 @@ internal sealed partial class HelixTestRunner
             Console.WriteLine($"Waiting for all work items in Helix job {helixJobId} to start running...");
             do
             {
-                var delayTask = Task.Delay(TimeSpan.FromMinutes(1), cancellationToken);
+                var delayTask = Task.Delay(TimeSpan.FromMinutes(5), cancellationToken);
                 var completedTask = await Task.WhenAny(processWaitTask, delayTask);
                 if (completedTask == processWaitTask)
                 {
@@ -149,6 +149,7 @@ internal sealed partial class HelixTestRunner
                     if (workItems.Unscheduled != 0 && workItems.Waiting != 0)
                     {
                         Console.WriteLine($"All work items are running");
+                        return;
                     }
 
                     var elapsed = DateTime.UtcNow - startTime;
@@ -171,7 +172,7 @@ internal sealed partial class HelixTestRunner
         {
             do
             {
-                var delayTask = Task.Delay(TimeSpan.FromMinutes(1), cancellationToken);
+                var delayTask = Task.Delay(TimeSpan.FromMinutes(5), cancellationToken);
                 await Task.WhenAny(processWaitTask, delayTask);
 
                 if (processWaitTask.IsCompleted)

--- a/src/Tools/RunTests/HelixTestRunner.cs
+++ b/src/Tools/RunTests/HelixTestRunner.cs
@@ -48,6 +48,28 @@ internal sealed partial class HelixTestRunner
 
     internal static async Task<int> RunAsync(Options options, ImmutableArray<AssemblyInfo> assemblies, CancellationToken cancellationToken)
     {
+        var helixProjectFilePath = await CreateHelixArtifactsAsync(options, assemblies, cancellationToken).ConfigureAwait(false);
+        var (process, helixJobId) = await StartHelixJobAsync(options, helixProjectFilePath, cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            var processResult = await process.Result.ConfigureAwait(false);
+            return processResult.ExitCode;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            var jobDescription = helixJobId ?? "unknown helix job";
+            ConsoleUtil.Error($"(NETCORE_ENGINEERING_TELEMETRY=Test) Helix job timed out: {jobDescription}");
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Creates the helix project file and payload artifacts on disk. Returns the path to the
+    /// generated helix project file.
+    /// </summary>
+    internal static async Task<string> CreateHelixArtifactsAsync(Options options, ImmutableArray<AssemblyInfo> assemblies, CancellationToken cancellationToken)
+    {
         Verify(options.UseHelix);
         Verify(!options.IncludeHtml);
         Verify(string.IsNullOrEmpty(options.TestFilter));
@@ -84,7 +106,29 @@ internal sealed partial class HelixTestRunner
         var helixFilePath = Path.Combine(options.ArtifactsDirectory, "helix.proj");
         File.WriteAllText(helixFilePath, helixProjectFileContent);
 
-        var arguments = $"build -bl:{Path.Combine(logsDir, "helix.binlog")} {helixFilePath}";
+        CopyPayloadFilesToLogs(logsDir, payloadsDir);
+        File.Copy(helixFilePath, Path.Combine(logsDir, "helix.proj"));
+
+        return helixFilePath;
+
+        void Verify([DoesNotReturnIf(false)] bool condition, [CallerArgumentExpression("condition")] string? message = null)
+        {
+            if (!condition)
+            {
+                throw new Exception($"Verify failed: {message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Constructs the dotnet build arguments, launches the process, and returns the process info
+    /// along with the helix job id once it is parsed from the process output. The job id will be
+    /// <see langword="null"/> if the process exits before emitting a job id (e.g. build failure).
+    /// </summary>
+    internal static async Task<(ProcessInfo ProcessInfo, string? HelixJobId)> StartHelixJobAsync(Options options, string helixProjectFilePath, CancellationToken cancellationToken)
+    {
+        var logsDir = Path.Combine(options.ArtifactsDirectory, "log", options.Configuration);
+        var arguments = $"build -bl:{Path.Combine(logsDir, "helix.binlog")} {helixProjectFilePath}";
         if (!string.IsNullOrEmpty(options.HelixApiAccessToken))
         {
             // Internal queues require an access token.
@@ -98,10 +142,7 @@ internal sealed partial class HelixTestRunner
             arguments += $" -p:Creator=\"{queuedBy}\"";
         }
 
-        CopyPayloadFilesToLogs(logsDir, payloadsDir);
-        File.Copy(helixFilePath, Path.Combine(logsDir, "helix.proj"));
-
-        string? helixJobId = null;
+        var helixJobIdSource = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var process = ProcessRunner.CreateProcess(
             executable: options.DotnetFilePath,
@@ -112,36 +153,23 @@ internal sealed partial class HelixTestRunner
                 Debug.Assert(e.Data is not null);
                 ConsoleUtil.WriteLine(e.Data);
 
-                if (helixJobId is null)
+                if (!helixJobIdSource.Task.IsCompleted)
                 {
                     var match = HelixJobIdRegex().Match(e.Data);
                     if (match.Success)
                     {
-                        helixJobId = match.Groups[1].Value;
+                        helixJobIdSource.TrySetResult(match.Groups[1].Value);
                     }
                 }
             },
             cancellationToken: cancellationToken);
 
-        try
-        {
-            var processResult = await process.Result.ConfigureAwait(false);
-            return processResult.ExitCode;
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            var jobDescription = helixJobId ?? "unknown helix job";
-            ConsoleUtil.Error($"(NETCORE_ENGINEERING_TELEMETRY=Test) Helix job timed out: {jobDescription}");
-            throw;
-        }
+        // Wait for either the job id to be parsed from output, or for the process to exit
+        // (whichever comes first). If the process exits before we see a job id, return null.
+        await Task.WhenAny(helixJobIdSource.Task, process.Result).ConfigureAwait(false);
+        var helixJobId = helixJobIdSource.Task.IsCompletedSuccessfully ? helixJobIdSource.Task.Result : null;
 
-        void Verify([DoesNotReturnIf(false)] bool condition, [CallerArgumentExpression("condition")] string? message = null)
-        {
-            if (!condition)
-            {
-                throw new Exception($"Verify failed: {message}");
-            }
-        }
+        return (process, helixJobId);
     }
 
     /// <summary>

--- a/src/Tools/RunTests/HelixTestRunner.cs
+++ b/src/Tools/RunTests/HelixTestRunner.cs
@@ -71,24 +71,22 @@ internal sealed partial class HelixTestRunner
 
         var helixProjectFilePath = await CreateHelixArtifactsAsync(options, assemblies, cts.Token).ConfigureAwait(false);
         var (process, helixJobInfoTask) = StartHelixJob(options, helixProjectFilePath);
-        var processWaitTask = process.WaitForExitAsync();
-
-        var task = await Task.WhenAny(processWaitTask, helixJobInfoTask);
-        if (cts.IsCancellationRequested)
-        {
-            process.Kill(entireProcessTree: true);
-            return -1;
-        }
-
-        if (!helixJobInfoTask.IsCompletedSuccessfully)
-        {
-            ConsoleUtil.Error($"Helix completed without specifying a job id in the output. This breaks our tooling");
-            return -1;
-        }
-
-        var (helixJobId, helixJobCancellationToken) = await helixJobInfoTask;
         try
         {
+            var task = await Task.WhenAny(process.WaitForExitAsync(), helixJobInfoTask);
+            if (cts.IsCancellationRequested)
+            {
+                process.Kill(entireProcessTree: true);
+                return -1;
+            }
+
+            if (!helixJobInfoTask.IsCompletedSuccessfully)
+            {
+                ConsoleUtil.Error($"Helix completed without specifying a job id in the output. This breaks our tooling");
+                return -1;
+            }
+
+            var (helixJobId, helixJobCancellationToken) = await helixJobInfoTask;
             return await WaitForHelixJobCompletionAsync(process, helixJobId, helixJobCancellationToken, options.HelixApiAccessToken, Path.Combine(options.ArtifactsDirectory, "TestResults", options.Configuration), cts.Token);
         }
         finally
@@ -103,7 +101,7 @@ internal sealed partial class HelixTestRunner
     /// <summary>
     /// This method will wait for the helix job to complete using the timeout for Helix work item execution.
     /// 
-    /// The most important factor is the helix process itself. If that exits then the assumption is that it 
+    /// The most important factor is the local helix process itself. If that exits then the assumption is that it 
     /// successfully reported the status of work items. Hence the moment it is done we can stop waiting and
     /// return. The polling for Helix information is all about adding context and real errors to the tests
     /// in the case helix has issues and cannot complete the process successfully.
@@ -118,7 +116,6 @@ internal sealed partial class HelixTestRunner
         {
             await WaitForAllWorkItemsRunningAsync(helixApi, helixJobId, processWaitTask, cancellationToken);
             await WaitForWorkItemsToCompleteOrTimeoutAsync(helixApi, helixJobId, helixCancellationToken, testResultsDirectory, processWaitTask, cancellationToken);
-
             await process.WaitForExitAsync(cancellationToken);
             return process.ExitCode;
         }
@@ -129,6 +126,7 @@ internal sealed partial class HelixTestRunner
             throw;
         }
 
+        // Wait until all of the work items have started running
         static async Task WaitForAllWorkItemsRunningAsync(HelixApi helixApi, string helixJobId, Task processWaitTask, CancellationToken cancellationToken)
         {
             var startTime = DateTime.UtcNow;
@@ -142,10 +140,7 @@ internal sealed partial class HelixTestRunner
                     return;
                 }
 
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    return;
-                }
+                cancellationToken.ThrowIfCancellationRequested();
 
                 try
                 {
@@ -158,6 +153,11 @@ internal sealed partial class HelixTestRunner
 
                     var elapsed = DateTime.UtcNow - startTime;
                     Console.WriteLine($"Job Time: {elapsed:hh\\:mm} Work Item States Running: {workItems.Running} Unscheduled: {workItems.Unscheduled} Waiting: {workItems.Waiting} Finished: {workItems.Finished}");
+
+                    if (elapsed > TimeSpan.FromMinutes(20))
+                    {
+                        ConsoleUtil.Warning($"Helix job {helixJobId} has {details.WorkItems.Waiting} queued work items after {elapsed:hh\\:mm}. This indicates a queue backup");
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -179,10 +179,7 @@ internal sealed partial class HelixTestRunner
                     return;
                 }
 
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    return;
-                }
+                cancellationToken.ThrowIfCancellationRequested();
 
                 try
                 {

--- a/src/Tools/RunTests/HelixTestRunner.cs
+++ b/src/Tools/RunTests/HelixTestRunner.cs
@@ -154,7 +154,7 @@ internal sealed partial class HelixTestRunner
                     var elapsed = DateTime.UtcNow - startTime;
                     Console.WriteLine($"Job Time: {elapsed:hh\\:mm} Work Item States Running: {workItems.Running} Unscheduled: {workItems.Unscheduled} Waiting: {workItems.Waiting} Finished: {workItems.Finished}");
 
-                    if (elapsed > TimeSpan.FromMinutes(20))
+                    if (workItems.Waiting > 0 && elapsed > TimeSpan.FromMinutes(20))
                     {
                         ConsoleUtil.Warning($"Helix job {helixJobId} has {details.WorkItems.Waiting} queued work items after {elapsed:hh\\:mm}. This indicates a queue backup");
                     }

--- a/src/Tools/RunTests/HelixTestRunner.cs
+++ b/src/Tools/RunTests/HelixTestRunner.cs
@@ -49,12 +49,12 @@ internal sealed partial class HelixTestRunner
     /// <summary>
     /// This is the amount of time we will wait for a helix work item to complete before we time out the entire job.
     /// </summary>
-    internal static TimeSpan WorkItemExecutionTimeout { get; } = WorkItemScheduleTime * 2.5;
+    internal static TimeSpan WorkItemExecutionTimeout { get; } = TimeSpan.FromMinutes(1);
 
     /// <summary>
     /// This is the amount of time we will wait between polling the Helix service for updates.
     /// </summary>
-    private static TimeSpan HelixPollTime { get; } = TimeSpan.FromMinutes(5);
+    private static TimeSpan HelixPollTime { get; } = TimeSpan.FromMinutes(1);
 
     [GeneratedRegex(@"HelixJobId=(\S+) HelixJobCancellationToken=(\S+)")]
     private static partial Regex HelixJobInfoRegex();

--- a/src/Tools/RunTests/HelixTestRunner.cs
+++ b/src/Tools/RunTests/HelixTestRunner.cs
@@ -63,7 +63,7 @@ internal sealed partial class HelixTestRunner
 
     internal static async Task<int> RunAsync(Options options, ImmutableArray<AssemblyInfo> assemblies)
     {
-        var cts = new CancellationTokenSource();
+        using var cts = new CancellationTokenSource();
         Console.CancelKeyPress += delegate
         {
             cts.Cancel();
@@ -73,7 +73,7 @@ internal sealed partial class HelixTestRunner
         var (process, helixJobInfoTask) = StartHelixJob(options, helixProjectFilePath);
         try
         {
-            var task = await Task.WhenAny(process.WaitForExitAsync(), helixJobInfoTask);
+            await Task.WhenAny(process.WaitForExitAsync(), helixJobInfoTask);
             if (cts.IsCancellationRequested)
             {
                 process.Kill(entireProcessTree: true);
@@ -211,14 +211,14 @@ internal sealed partial class HelixTestRunner
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException and not TimeoutException)
                 {
-                    ConsoleUtil.Warning($"Error while usiung Helix API for job status: {ex.Message}");
+                    ConsoleUtil.Warning($"Error while using Helix API for job status: {ex.Message}");
                 }
             } while (true);
         }
 
+        // If a work item has been running for more than WorkItemExecutionTimeout, consider it timed out.
         static bool HasTimedOut(HelixWorkItemDetails details)
         {
-            // If a work item has been in the same state for more than 30 minutes, consider it timed out.
             if (details.Started is null)
             {
                 return false;

--- a/src/Tools/RunTests/HelixTestRunner.cs
+++ b/src/Tools/RunTests/HelixTestRunner.cs
@@ -151,7 +151,7 @@ internal sealed partial class HelixTestRunner
                 {
                     var details = await helixApi.GetJobDetailsAsync(helixJobId, cancellationToken);
                     var workItems = details.WorkItems;
-                    if (workItems.Unscheduled != 0 && workItems.Waiting != 0)
+                    if (workItems.Unscheduled == 0 && workItems.Waiting == 0)
                     {
                         Console.WriteLine($"All work items are running");
                         return;

--- a/src/Tools/RunTests/HelixTestRunner.cs
+++ b/src/Tools/RunTests/HelixTestRunner.cs
@@ -36,8 +36,8 @@ public sealed class HelixWorkItem(
 
 internal sealed partial class HelixTestRunner
 {
-    [GeneratedRegex(@"Waiting for completion of job ([0-9a-fA-F-]+) on ")]
-    private static partial Regex HelixJobIdRegex();
+    [GeneratedRegex(@"HelixJobId=(\S+) HelixJobCancellationToken=(\S+)")]
+    private static partial Regex HelixJobInfoRegex();
 
     internal enum TestOS
     {
@@ -46,21 +46,107 @@ internal sealed partial class HelixTestRunner
         Mac,
     }
 
-    internal static async Task<int> RunAsync(Options options, ImmutableArray<AssemblyInfo> assemblies, CancellationToken cancellationToken)
+    internal static async Task<int> RunAsync(Options options, ImmutableArray<AssemblyInfo> assemblies)
     {
-        var helixProjectFilePath = await CreateHelixArtifactsAsync(options, assemblies, cancellationToken).ConfigureAwait(false);
-        var (process, helixJobId) = await StartHelixJobAsync(options, helixProjectFilePath, cancellationToken).ConfigureAwait(false);
+        var cts = new CancellationTokenSource();
+        Console.CancelKeyPress += delegate
+        {
+            cts.Cancel();
+        };
 
+        var helixProjectFilePath = await CreateHelixArtifactsAsync(options, assemblies, cts.Token).ConfigureAwait(false);
+        var (process, helixJobInfoTask) = StartHelixJob(options, helixProjectFilePath);
+        var processWaitTask = process.WaitForExitAsync();
+
+        var task = await Task.WhenAny(processWaitTask, helixJobInfoTask);
+        if (cts.IsCancellationRequested)
+        {
+            process.Kill(entireProcessTree: true);
+            return -1;
+        }
+
+        if (!helixJobInfoTask.IsCompletedSuccessfully)
+        {
+            ConsoleUtil.Error($"Helix completed without specifying a job id in the output. This breaks our tooling");
+            return -1;
+        }
+
+        var (helixJobId, helixJobCancellationToken) = await helixJobInfoTask;
         try
         {
-            var processResult = await process.Result.ConfigureAwait(false);
-            return processResult.ExitCode;
+            return await WaitForHelixJobCompletionAsync(process, helixJobId, options.HelixApiAccessToken, cts.Token);
         }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        finally
         {
-            var jobDescription = helixJobId ?? "unknown helix job";
-            ConsoleUtil.Error($"(NETCORE_ENGINEERING_TELEMETRY=Test) Helix job timed out: {jobDescription}");
-            throw;
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+    }
+
+    private static async Task<int> WaitForHelixJobCompletionAsync(Process process, string helixJobId, string? helixApiAccessToken, CancellationToken cancellationToken)
+    {
+        ConsoleUtil.WriteLine($"Waiting for Helix job {helixJobId} to complete...");
+        using var helixApi = new HelixApi(helixApiAccessToken);
+        var workItemNameList = (await helixApi.GetWorkItemsAsync(helixJobId, cancellationToken))
+            .Select(w => w.Name)
+            .ToList();
+
+        var helixTimeout = TimeSpan.FromMinutes(30);
+
+        do
+        {
+            await Task.Delay(TimeSpan.FromMinutes(1), cancellationToken);
+
+            if (process.HasExited)
+            {
+                Console.WriteLine($"Helix process completed with exit code {process.ExitCode}");
+                return process.ExitCode;
+            }
+
+            try
+            {
+                var index = 0;
+                while (index < workItemNameList.Count)
+                {
+                    var name = workItemNameList[index];
+                    var details = await helixApi.GetWorkItemDetailsAsync(helixJobId, name, cancellationToken);
+                    if (details.Finished is not null)
+                    {
+                        ConsoleUtil.WriteLine($"Helix Job {helixJobId} Work item {name} finished with state {details.State}");
+                        workItemNameList.RemoveAt(index);
+                        continue;
+                    }
+
+                    if (HasTimedOut(details))
+                    {
+                        ConsoleUtil.Error($"Helix Job {helixJobId} Work item {name} has been in state {details.State} for more than {helixTimeout}. Timing out the job.");
+                        return -1;
+                    }
+
+                    index++;
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                ConsoleUtil.Error($"Error while polling Helix API for job status: {ex.Message}");
+            }
+        } while (workItemNameList.Count > 0);
+
+        await process.WaitForExitAsync(cancellationToken);
+        return process.ExitCode;
+
+        bool HasTimedOut(HelixWorkItemDetails details)
+        {
+            // If a work item has been in the same state for more than 30 minutes, consider it timed out.
+            if (details.Started is null)
+            {
+                return false;
+            }
+
+            var started = DateTimeOffset.Parse(details.Started);
+            return DateTimeOffset.UtcNow - started > helixTimeout;
         }
     }
 
@@ -121,11 +207,10 @@ internal sealed partial class HelixTestRunner
     }
 
     /// <summary>
-    /// Constructs the dotnet build arguments, launches the process, and returns the process info
-    /// along with the helix job id once it is parsed from the process output. The job id will be
-    /// <see langword="null"/> if the process exits before emitting a job id (e.g. build failure).
+    /// Constructs the dotnet build arguments, launches the process, and returns the process
+    /// along with a task that completes with the helix job id once it is parsed from process output.
     /// </summary>
-    internal static async Task<(ProcessInfo ProcessInfo, string? HelixJobId)> StartHelixJobAsync(Options options, string helixProjectFilePath, CancellationToken cancellationToken)
+    internal static (Process Process, Task<(string HelixJobId, string HelixJobCancellationToken)> HelixJobInfo) StartHelixJob(Options options, string helixProjectFilePath)
     {
         var logsDir = Path.Combine(options.ArtifactsDirectory, "log", options.Configuration);
         var arguments = $"build -bl:{Path.Combine(logsDir, "helix.binlog")} {helixProjectFilePath}";
@@ -142,34 +227,51 @@ internal sealed partial class HelixTestRunner
             arguments += $" -p:Creator=\"{queuedBy}\"";
         }
 
-        var helixJobIdSource = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var helixJobInfoSource = new TaskCompletionSource<(string HelixJobId, string HelixJobCancellationToken)>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        var process = ProcessRunner.CreateProcess(
-            executable: options.DotnetFilePath,
-            arguments: arguments,
-            captureOutput: true,
-            onOutputDataReceived: (e) =>
+        var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
             {
-                Debug.Assert(e.Data is not null);
-                ConsoleUtil.WriteLine(e.Data);
-
-                if (!helixJobIdSource.Task.IsCompleted)
-                {
-                    var match = HelixJobIdRegex().Match(e.Data);
-                    if (match.Success)
-                    {
-                        helixJobIdSource.TrySetResult(match.Groups[1].Value);
-                    }
-                }
+                FileName = options.DotnetFilePath,
+                Arguments = arguments,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
             },
-            cancellationToken: cancellationToken);
+            EnableRaisingEvents = true
+        };
 
-        // Wait for either the job id to be parsed from output, or for the process to exit
-        // (whichever comes first). If the process exits before we see a job id, return null.
-        await Task.WhenAny(helixJobIdSource.Task, process.Result).ConfigureAwait(false);
-        var helixJobId = helixJobIdSource.Task.IsCompletedSuccessfully ? helixJobIdSource.Task.Result : null;
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data is null)
+                return;
 
-        return (process, helixJobId);
+            ConsoleUtil.WriteLine(e.Data);
+
+            if (!helixJobInfoSource.Task.IsCompleted)
+            {
+                var match = HelixJobInfoRegex().Match(e.Data);
+                if (match.Success)
+                {
+                    helixJobInfoSource.TrySetResult((match.Groups[1].Value, match.Groups[2].Value));
+                }
+            }
+        };
+
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data is not null)
+            {
+                ConsoleUtil.Error(e.Data);
+            }
+        };
+
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        return (process, helixJobInfoSource.Task);
     }
 
     /// <summary>
@@ -232,6 +334,16 @@ internal sealed partial class HelixTestRunner
 
         builder.AppendLine("""
               </ItemGroup>
+
+              <!-- 
+                This target runs after the tests have executed but before the project finishes. 
+                It's used to print out the HelixJobId and HelixJobCancellationToken properties to the console
+                so we can grab them in the process output and setup our helix watching.
+              -->
+              <Target Name="PrintHelixInfo" AfterTargets="CoreTest">                                                                                       
+                <Message Text="HelixJobId=$(HelixJobId) HelixJobCancellationToken=$(HelixJobCancellationToken)" Importance="high" />                                                
+              </Target>        
+
             </Project>
             """);
 

--- a/src/Tools/RunTests/HelixTestRunner.cs
+++ b/src/Tools/RunTests/HelixTestRunner.cs
@@ -49,7 +49,7 @@ internal sealed partial class HelixTestRunner
     /// <summary>
     /// This is the amount of time we will wait for a helix work item to complete before we time out the entire job.
     /// </summary>
-    internal static TimeSpan WorkItemExecutionTimeout { get; } = TimeSpan.FromMinutes(30);
+    internal static TimeSpan WorkItemExecutionTimeout { get; } = WorkItemScheduleTime * 2.5;
 
     [GeneratedRegex(@"HelixJobId=(\S+) HelixJobCancellationToken=(\S+)")]
     private static partial Regex HelixJobInfoRegex();
@@ -89,7 +89,7 @@ internal sealed partial class HelixTestRunner
         var (helixJobId, helixJobCancellationToken) = await helixJobInfoTask;
         try
         {
-            return await WaitForHelixJobCompletionAsync(process, helixJobId, helixJobCancellationToken, options.HelixApiAccessToken, cts.Token);
+            return await WaitForHelixJobCompletionAsync(process, helixJobId, helixJobCancellationToken, options.HelixApiAccessToken, Path.Combine(options.ArtifactsDirectory, "TestResults", options.Configuration), cts.Token);
         }
         finally
         {
@@ -108,7 +108,7 @@ internal sealed partial class HelixTestRunner
     /// return. The polling for Helix information is all about adding context and real errors to the tests
     /// in the case helix has issues and cannot complete the process successfully.
     /// </summary>
-    private static async Task<int> WaitForHelixJobCompletionAsync(Process process, string helixJobId, string helixCancellationToken, string? helixApiAccessToken, CancellationToken cancellationToken)
+    private static async Task<int> WaitForHelixJobCompletionAsync(Process process, string helixJobId, string helixCancellationToken, string? helixApiAccessToken, string testResultsDirectory, CancellationToken cancellationToken)
     {
         ConsoleUtil.WriteLine($"Waiting for Helix job {helixJobId} to complete...");
         using var helixApi = new HelixApi(helixApiAccessToken);
@@ -117,7 +117,7 @@ internal sealed partial class HelixTestRunner
         try
         {
             await WaitForAllWorkItemsRunningAsync(helixApi, helixJobId, processWaitTask, cancellationToken);
-            await WaitForWorkItemsToCompleteOrTimeoutAsync(helixApi, helixJobId, helixCancellationToken, processWaitTask, cancellationToken);
+            await WaitForWorkItemsToCompleteOrTimeoutAsync(helixApi, helixJobId, helixCancellationToken, testResultsDirectory, processWaitTask, cancellationToken);
 
             await process.WaitForExitAsync(cancellationToken);
             return process.ExitCode;
@@ -131,6 +131,7 @@ internal sealed partial class HelixTestRunner
 
         static async Task WaitForAllWorkItemsRunningAsync(HelixApi helixApi, string helixJobId, Task processWaitTask, CancellationToken cancellationToken)
         {
+            var startTime = DateTime.UtcNow;
             Console.WriteLine($"Waiting for all work items in Helix job {helixJobId} to start running...");
             do
             {
@@ -155,7 +156,8 @@ internal sealed partial class HelixTestRunner
                         Console.WriteLine($"All work items are running");
                     }
 
-                    Console.WriteLine($"Running: {workItems.Running} Unscheduled: {workItems.Unscheduled} Waiting: {workItems.Waiting} Finished: {workItems.Finished}");
+                    var elapsed = DateTime.UtcNow - startTime;
+                    Console.WriteLine($"Job Time: {elapsed:hh\\:mm} Work Item States Running: {workItems.Running} Unscheduled: {workItems.Unscheduled} Waiting: {workItems.Waiting} Finished: {workItems.Finished}");
                 }
                 catch (Exception ex)
                 {
@@ -165,7 +167,7 @@ internal sealed partial class HelixTestRunner
             } while (true);
         }
 
-        static async Task WaitForWorkItemsToCompleteOrTimeoutAsync(HelixApi helixApi, string helixJobId, string helixCancellationToken, Task processWaitTask, CancellationToken cancellationToken)
+        static async Task WaitForWorkItemsToCompleteOrTimeoutAsync(HelixApi helixApi, string helixJobId, string helixCancellationToken, string testResultsDirectory, Task processWaitTask, CancellationToken cancellationToken)
         {
             do
             {
@@ -188,7 +190,7 @@ internal sealed partial class HelixTestRunner
                     var workItemGroups = workItemList.GroupBy(x => x.State).Select(g => $"{g.Key}: {g.Count()}");
                     Console.WriteLine($"Work item states: {string.Join(", ", workItemGroups)}");
 
-                    var hitTimeout = false;
+                    var timedOutWorkItems = new List<string>();
                     foreach (var workItem in workItemList.Where(x => x.State == "Running"))
                     {
                         var details = await helixApi.GetWorkItemDetailsAsync(helixJobId, workItem.Name, cancellationToken);
@@ -200,16 +202,17 @@ internal sealed partial class HelixTestRunner
                         if (HasTimedOut(details))
                         {
                             ConsoleUtil.Error($"Helix Job {helixJobId} Work item {workItem.Name} has been in state {details.State} for more than {WorkItemExecutionTimeout}. Timing out the job.");
-                            hitTimeout = true;
+                            timedOutWorkItems.Add(workItem.Name);
                         }
                     }
 
-                    if (hitTimeout)
+                    if (timedOutWorkItems.Count > 0)
                     {
-                        throw new Exception($"One or more work items in Helix job {helixJobId} have timed out. Timing out the entire job.");
+                        WriteSyntheticTimeoutResults(testResultsDirectory, helixJobId, timedOutWorkItems);
+                        throw new TimeoutException($"One or more work items in Helix job {helixJobId} have timed out. Timing out the entire job.");
                     }
                 }
-                catch (Exception ex) when (ex is not OperationCanceledException)
+                catch (Exception ex) when (ex is not OperationCanceledException and not TimeoutException)
                 {
                     ConsoleUtil.Warning($"Error while usiung Helix API for job status: {ex.Message}");
                 }
@@ -228,6 +231,48 @@ internal sealed partial class HelixTestRunner
             return DateTimeOffset.UtcNow - started > WorkItemExecutionTimeout;
         }
 
+        static void WriteSyntheticTimeoutResults(string testResultsDirectory, string helixJobId, List<string> timedOutWorkItems)
+        {
+            try
+            {
+                if (!Directory.Exists(testResultsDirectory))
+                {
+                    Directory.CreateDirectory(testResultsDirectory);
+                }
+
+                foreach (var workItemName in timedOutWorkItems)
+                {
+                    var escapedWorkItemName = System.Security.SecurityElement.Escape(workItemName);
+                    var escapedJobId = System.Security.SecurityElement.Escape(helixJobId);
+                    var xml = $"""
+                        <?xml version="1.0" encoding="utf-8"?>
+                        <assemblies>
+                          <assembly name="{escapedWorkItemName}" total="1" passed="0" failed="1" skipped="0">
+                            <collection name="Helix Timeout Detection" total="1" passed="0" failed="1" skipped="0">
+                              <test name="[TIMEOUT] {escapedWorkItemName}" type="RunTests.TimeoutDetection" method="{escapedWorkItemName}" time="0" result="Fail">
+                                <failure exception-type="WorkItemTimeoutException">
+                                  <message>Helix work item '{escapedWorkItemName}' in job '{escapedJobId}' exceeded the maximum execution time of {WorkItemExecutionTimeout}.
+                        https://helix.dot.net/api/jobs/{helixJobId}/workitems/{workItemName}</message>
+                                  <stack-trace>The work item was still in the Running state when the timeout was detected.
+                        See https://helix.dot.net/api/jobs/{helixJobId}/workitems/{workItemName} for more details.</stack-trace>
+                                </failure>
+                              </test>
+                            </collection>
+                          </assembly>
+                        </assemblies>
+                        """;
+
+                    var fileName = $"helix_timeout_{workItemName}.xml";
+                    var filePath = Path.Combine(testResultsDirectory, fileName);
+                    File.WriteAllText(filePath, xml);
+                    ConsoleUtil.WriteLine($"Wrote synthetic timeout result to {filePath}");
+                }
+            }
+            catch (Exception ex)
+            {
+                ConsoleUtil.Warning($"Failed to write synthetic timeout test results: {ex.Message}");
+            }
+        }
     }
 
     /// <summary>

--- a/src/Tools/RunTests/HelixTestRunner.cs
+++ b/src/Tools/RunTests/HelixTestRunner.cs
@@ -51,6 +51,11 @@ internal sealed partial class HelixTestRunner
     /// </summary>
     internal static TimeSpan WorkItemExecutionTimeout { get; } = WorkItemScheduleTime * 2.5;
 
+    /// <summary>
+    /// This is the amount of time we will wait between polling the Helix service for updates.
+    /// </summary>
+    private static TimeSpan HelixPollTime { get; } = TimeSpan.FromMinutes(5);
+
     [GeneratedRegex(@"HelixJobId=(\S+) HelixJobCancellationToken=(\S+)")]
     private static partial Regex HelixJobInfoRegex();
 
@@ -133,7 +138,7 @@ internal sealed partial class HelixTestRunner
             Console.WriteLine($"Waiting for all work items in Helix job {helixJobId} to start running...");
             do
             {
-                var delayTask = Task.Delay(TimeSpan.FromMinutes(5), cancellationToken);
+                var delayTask = Task.Delay(HelixPollTime, cancellationToken);
                 var completedTask = await Task.WhenAny(processWaitTask, delayTask);
                 if (completedTask == processWaitTask)
                 {
@@ -172,7 +177,7 @@ internal sealed partial class HelixTestRunner
         {
             do
             {
-                var delayTask = Task.Delay(TimeSpan.FromMinutes(5), cancellationToken);
+                var delayTask = Task.Delay(HelixPollTime, cancellationToken);
                 await Task.WhenAny(processWaitTask, delayTask);
 
                 if (processWaitTask.IsCompleted)

--- a/src/Tools/RunTests/HelixTestRunner.cs
+++ b/src/Tools/RunTests/HelixTestRunner.cs
@@ -36,6 +36,21 @@ public sealed class HelixWorkItem(
 
 internal sealed partial class HelixTestRunner
 {
+    /// <summary>
+    /// We attempt to partition our tests into work items that execute in under 2 minutes 30s.  This is a derived limit based on a goal of running all tests
+    /// in under 5 minutes.  However because of overhead in setting up the test run, e.g.
+    ///   1.  Test discovery.
+    ///   2.  Downloading assets to the helix machine.
+    ///   3.  Setting up the test host for each assembly.
+    ///   
+    /// </summary>
+    internal static TimeSpan WorkItemScheduleTime { get; } = TimeSpan.FromMinutes(10);
+
+    /// <summary>
+    /// This is the amount of time we will wait for a helix work item to complete before we time out the entire job.
+    /// </summary>
+    internal static TimeSpan WorkItemExecutionTimeout { get; } = TimeSpan.FromMinutes(30);
+
     [GeneratedRegex(@"HelixJobId=(\S+) HelixJobCancellationToken=(\S+)")]
     private static partial Regex HelixJobInfoRegex();
 
@@ -74,7 +89,7 @@ internal sealed partial class HelixTestRunner
         var (helixJobId, helixJobCancellationToken) = await helixJobInfoTask;
         try
         {
-            return await WaitForHelixJobCompletionAsync(process, helixJobId, options.HelixApiAccessToken, cts.Token);
+            return await WaitForHelixJobCompletionAsync(process, helixJobId, helixJobCancellationToken, options.HelixApiAccessToken, cts.Token);
         }
         finally
         {
@@ -85,59 +100,123 @@ internal sealed partial class HelixTestRunner
         }
     }
 
-    private static async Task<int> WaitForHelixJobCompletionAsync(Process process, string helixJobId, string? helixApiAccessToken, CancellationToken cancellationToken)
+    /// <summary>
+    /// This method will wait for the helix job to complete using the timeout for Helix work item execution.
+    /// 
+    /// The most important factor is the helix process itself. If that exits then the assumption is that it 
+    /// successfully reported the status of work items. Hence the moment it is done we can stop waiting and
+    /// return. The polling for Helix information is all about adding context and real errors to the tests
+    /// in the case helix has issues and cannot complete the process successfully.
+    /// </summary>
+    private static async Task<int> WaitForHelixJobCompletionAsync(Process process, string helixJobId, string helixCancellationToken, string? helixApiAccessToken, CancellationToken cancellationToken)
     {
         ConsoleUtil.WriteLine($"Waiting for Helix job {helixJobId} to complete...");
         using var helixApi = new HelixApi(helixApiAccessToken);
-        var workItemNameList = (await helixApi.GetWorkItemsAsync(helixJobId, cancellationToken))
-            .Select(w => w.Name)
-            .ToList();
+        var processWaitTask = process.WaitForExitAsync(cancellationToken);
 
-        var helixTimeout = TimeSpan.FromMinutes(30);
-
-        do
+        try
         {
-            await Task.Delay(TimeSpan.FromMinutes(1), cancellationToken);
+            await WaitForAllWorkItemsRunningAsync(helixApi, helixJobId, processWaitTask, cancellationToken);
+            await WaitForWorkItemsToCompleteOrTimeoutAsync(helixApi, helixJobId, helixCancellationToken, processWaitTask, cancellationToken);
 
-            if (process.HasExited)
-            {
-                Console.WriteLine($"Helix process completed with exit code {process.ExitCode}");
-                return process.ExitCode;
-            }
+            await process.WaitForExitAsync(cancellationToken);
+            return process.ExitCode;
+        }
+        catch (OperationCanceledException)
+        {
+            ConsoleUtil.WriteLine($"Cancellation requested. Attempting to cancel Helix job {helixJobId}...");
+            await helixApi.CancelJobAsync(helixJobId, helixCancellationToken, CancellationToken.None);
+            throw;
+        }
 
-            try
+        static async Task WaitForAllWorkItemsRunningAsync(HelixApi helixApi, string helixJobId, Task processWaitTask, CancellationToken cancellationToken)
+        {
+            Console.WriteLine($"Waiting for all work items in Helix job {helixJobId} to start running...");
+            do
             {
-                var index = 0;
-                while (index < workItemNameList.Count)
+                var delayTask = Task.Delay(TimeSpan.FromMinutes(1), cancellationToken);
+                var completedTask = await Task.WhenAny(processWaitTask, delayTask);
+                if (completedTask == processWaitTask)
                 {
-                    var name = workItemNameList[index];
-                    var details = await helixApi.GetWorkItemDetailsAsync(helixJobId, name, cancellationToken);
-                    if (details.Finished is not null)
-                    {
-                        ConsoleUtil.WriteLine($"Helix Job {helixJobId} Work item {name} finished with state {details.State}");
-                        workItemNameList.RemoveAt(index);
-                        continue;
-                    }
-
-                    if (HasTimedOut(details))
-                    {
-                        ConsoleUtil.Error($"Helix Job {helixJobId} Work item {name} has been in state {details.State} for more than {helixTimeout}. Timing out the job.");
-                        return -1;
-                    }
-
-                    index++;
+                    return;
                 }
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException)
+
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                try
+                {
+                    var details = await helixApi.GetJobDetailsAsync(helixJobId, cancellationToken);
+                    var workItems = details.WorkItems;
+                    if (workItems.Unscheduled != 0 && workItems.Waiting != 0)
+                    {
+                        Console.WriteLine($"All work items are running");
+                    }
+
+                    Console.WriteLine($"Running: {workItems.Running} Unscheduled: {workItems.Unscheduled} Waiting: {workItems.Waiting} Finished: {workItems.Finished}");
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Error while polling Helix API for job status: {ex.Message}");
+                }
+
+            } while (true);
+        }
+
+        static async Task WaitForWorkItemsToCompleteOrTimeoutAsync(HelixApi helixApi, string helixJobId, string helixCancellationToken, Task processWaitTask, CancellationToken cancellationToken)
+        {
+            do
             {
-                ConsoleUtil.Error($"Error while polling Helix API for job status: {ex.Message}");
-            }
-        } while (workItemNameList.Count > 0);
+                var delayTask = Task.Delay(TimeSpan.FromMinutes(1), cancellationToken);
+                await Task.WhenAny(processWaitTask, delayTask);
 
-        await process.WaitForExitAsync(cancellationToken);
-        return process.ExitCode;
+                if (processWaitTask.IsCompleted)
+                {
+                    return;
+                }
 
-        bool HasTimedOut(HelixWorkItemDetails details)
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                try
+                {
+                    var workItemList = await helixApi.GetWorkItemsAsync(helixJobId, cancellationToken);
+                    var workItemGroups = workItemList.GroupBy(x => x.State).Select(g => $"{g.Key}: {g.Count()}");
+                    Console.WriteLine($"Work item states: {string.Join(", ", workItemGroups)}");
+
+                    var hitTimeout = false;
+                    foreach (var workItem in workItemList.Where(x => x.State == "Running"))
+                    {
+                        var details = await helixApi.GetWorkItemDetailsAsync(helixJobId, workItem.Name, cancellationToken);
+                        if (details.Finished is not null)
+                        {
+                            continue;
+                        }
+
+                        if (HasTimedOut(details))
+                        {
+                            ConsoleUtil.Error($"Helix Job {helixJobId} Work item {workItem.Name} has been in state {details.State} for more than {WorkItemExecutionTimeout}. Timing out the job.");
+                            hitTimeout = true;
+                        }
+                    }
+
+                    if (hitTimeout)
+                    {
+                        throw new Exception($"One or more work items in Helix job {helixJobId} have timed out. Timing out the entire job.");
+                    }
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    ConsoleUtil.Warning($"Error while usiung Helix API for job status: {ex.Message}");
+                }
+            } while (true);
+        }
+
+        static bool HasTimedOut(HelixWorkItemDetails details)
         {
             // If a work item has been in the same state for more than 30 minutes, consider it timed out.
             if (details.Started is null)
@@ -146,8 +225,9 @@ internal sealed partial class HelixTestRunner
             }
 
             var started = DateTimeOffset.Parse(details.Started);
-            return DateTimeOffset.UtcNow - started > helixTimeout;
+            return DateTimeOffset.UtcNow - started > WorkItemExecutionTimeout;
         }
+
     }
 
     /// <summary>

--- a/src/Tools/RunTests/Program.cs
+++ b/src/Tools/RunTests/Program.cs
@@ -39,6 +39,12 @@ namespace RunTests
             ConsoleUtil.WriteLine(string.Join(Environment.NewLine, dotnetResult.OutputLines));
             ConsoleUtil.WriteLine(ConsoleColor.Red, string.Join(Environment.NewLine, dotnetResult.ErrorLines));
 
+            if (options.UseHelix)
+            {
+                var assemblyFilePaths = GetAssemblyFilePaths(options);
+                return await HelixTestRunner.RunAsync(options, assemblyFilePaths);
+            }
+
             if (options.CollectDumps)
             {
                 if (!DumpUtil.IsAdministrator())
@@ -120,13 +126,6 @@ namespace RunTests
         private static async Task<int> RunAsync(Options options, CancellationToken cancellationToken)
         {
             var assemblyFilePaths = GetAssemblyFilePaths(options);
-            if (options.UseHelix)
-            {
-                return await HelixTestRunner.RunAsync(
-                    options,
-                    assemblyFilePaths,
-                    cancellationToken);
-            }
 
             var testExecutor = new ProcessTestExecutor();
             var testRunner = new TestRunner(options, testExecutor);


### PR DESCRIPTION

This is deliberately lowering our Helix Work Item timeouts to a point that we will trigger our cancellation path. This is meant to test the capabilities of #83803. 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83821)