### PR TITLE
Fix macOS test failure in ValidSignificantChange_ApplyBeforeFileWatch…

### DIFF
--- a/src/Features/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
+++ b/src/Features/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
@@ -3139,6 +3139,7 @@ public sealed class EditAndContinueWorkspaceServiceTests : EditAndContinueWorksp
         //                                                               file watcher: workspace update
 
         var checksumAlg = SourceHashAlgorithms.Default;
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
         var sjis = Encoding.GetEncoding("SJIS");
 
         var source0 = "class C1 { void こんにちは() { System.Console.WriteLine(0); } }";


### PR DESCRIPTION
…erEvent

PR #82905 introduced SJIS encoding usage in this test but missed adding Encoding.RegisterProvider(CodePagesEncodingProvider.Instance) which is required on macOS where SJIS isn't available by default. Other SJIS-using tests in the same file already include this registration.

Impacted builds:
- https://dev.azure.com/dnceng-public/public/_build/results?buildId=1430795
- https://dev.azure.com/dnceng-public/public/_build/results?buildId=1430674
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83832)