### PR TITLE
Free pooled object in Verify helper

### DIFF
--- a/src/Compilers/Test/Core/Diagnostics/DiagnosticExtensions.cs
+++ b/src/Compilers/Test/Core/Diagnostics/DiagnosticExtensions.cs
@@ -98,6 +98,7 @@ namespace Microsoft.CodeAnalysis
                 var text = DiagnosticDescription.GetAssertText(expected, actual, unmatchedExpected.ToArray(), actual.Select((a, i) => (a, i)).Join(unmatchedActualIndex, ai => ai.i, i => i, (ai, _) => ai.a));
                 unmatchedExpected.Free();
                 Assert.Fail(text);
+                return;
             }
 
             unmatchedExpected.Free();

--- a/src/Compilers/Test/Core/Diagnostics/DiagnosticExtensions.cs
+++ b/src/Compilers/Test/Core/Diagnostics/DiagnosticExtensions.cs
@@ -96,6 +96,7 @@ namespace Microsoft.CodeAnalysis
             if (unmatchedActualDescription.Count > 0 || unmatchedExpected.Count > 0)
             {
                 var text = DiagnosticDescription.GetAssertText(expected, actual, unmatchedExpected.ToArray(), actual.Select((a, i) => (a, i)).Join(unmatchedActualIndex, ai => ai.i, i => i, (ai, _) => ai.a));
+                unmatchedExpected.Free();
                 Assert.Fail(text);
             }
 


### PR DESCRIPTION
To avoid overly verbose error messages when `VerifyDiagnostics` and similar test helpers fail.

Without this, an aggregate exception of the original diagnostic and pool leak is thrown, something like this:

```
    /_/src/Compilers/Test/Core/Diagnostics/DiagnosticExtensions.cs(99): error TESTERROR: 
      Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics.UnsafeEvolutionTests.SafeModifier_Declarations_SafeOnly (124ms): Error Message: System.AggregateException : One or more error
      s occurred.
      ---- 
      Expected:
      Actual:
                      // (4,5): error CS9385: The 'safe' modifier may only be used on extern members that are not marked 'unsafe'.
                      //     safe public void M1() { }
                      Diagnostic(ErrorCode.ERR_SafeModifierUnsupportedTarget, "safe").WithLocation(4, 5),
                      // (5,5): error CS9385: The 'safe' modifier may only be used on extern members that are not marked 'unsafe'.
                      //     safe public int P1 { get; set; }
                      Diagnostic(ErrorCode.ERR_SafeModifierUnsupportedTarget, "safe").WithLocation(5, 5),
                      // (6,5): error CS9385: The 'safe' modifier may only be used on extern members that are not marked 'unsafe'.
                      //     safe public int this[int i] { get => i; set { } }
                      Diagnostic(ErrorCode.ERR_SafeModifierUnsupportedTarget, "safe").WithLocation(6, 5),
                      // (7,5): error CS9385: The 'safe' modifier may only be used on extern members that are not marked 'unsafe'.
                      //     safe public event System.Action E1;
                      Diagnostic(ErrorCode.ERR_SafeModifierUnsupportedTarget, "safe").WithLocation(7, 5),
                      // (8,5): error CS9385: The 'safe' modifier may only be used on extern members that are not marked 'unsafe'.
                      //     safe public C() { }
                      Diagnostic(ErrorCode.ERR_SafeModifierUnsupportedTarget, "safe").WithLocation(8, 5),
                      // (9,5): error CS9385: The 'safe' modifier may only be used on extern members that are not marked 'unsafe'.
                      //     safe public static C operator +(C x, C y) => x;
                      Diagnostic(ErrorCode.ERR_SafeModifierUnsupportedTarget, "safe").WithLocation(9, 5),
                      // (10,5): error CS9385: The 'safe' modifier may only be used on extern members that are not marked 'unsafe'.
                      //     safe public static explicit operator int(C c) => 0;
                      Diagnostic(ErrorCode.ERR_SafeModifierUnsupportedTarget, "safe").WithLocation(10, 5),
                      // (11,21): error CS0106: The modifier 'safe' is not valid for this item
                      //     safe public int F;
                      Diagnostic(ErrorCode.ERR_BadMemberFlag, "F").WithArguments("safe").WithLocation(11, 21),
                      // (12,23): error CS0106: The modifier 'safe' is not valid for this item
                      //     safe public class NestedClass { }
                      Diagnostic(ErrorCode.ERR_BadMemberFlag, "NestedClass").WithArguments("safe").WithLocation(12, 23),
                      // (13,24): error CS0106: The modifier 'safe' is not valid for this item
                      //     safe public struct NestedStruct { }
                      Diagnostic(ErrorCode.ERR_BadMemberFlag, "NestedStruct").WithArguments("safe").WithLocation(13, 24),
                      // (14,27): error CS0106: The modifier 'safe' is not valid for this item
                      //     safe public interface INested { }
                      Diagnostic(ErrorCode.ERR_BadMemberFlag, "INested").WithArguments("safe").WithLocation(14, 27),
                      // (15,22): error CS0106: The modifier 'safe' is not valid for this item
                      //     safe public enum ENested { }
                      Diagnostic(ErrorCode.ERR_BadMemberFlag, "ENested").WithArguments("safe").WithLocation(15, 22),
                      // (16,31): error CS0106: The modifier 'safe' is not valid for this item
                      //     safe public delegate void D();
                      Diagnostic(ErrorCode.ERR_BadMemberFlag, "D").WithArguments("safe").WithLocation(16, 31),
                      // (19,9): error CS9385: The 'safe' modifier may only be used on extern members that are not marked 'unsafe'.
                      //         safe void Local() { }
                      Diagnostic(ErrorCode.ERR_SafeModifierUnsupportedTarget, "safe").WithLocation(19, 9)
      Diff:
      ++>                 Diagnostic(ErrorCode.ERR_SafeModifierUnsupportedTarget, "safe").WithLocation(4, 5)
      ++>                 Diagnostic(ErrorCode.ERR_SafeModifierUnsupportedTarget, "safe").WithLocation(5, 5)
      ++>                 Diagnostic(ErrorCode.ERR_SafeModifierUnsupportedTarget, "safe").WithLocation(6, 5)
      ++>                 Diagnostic(ErrorCode.ERR_SafeModifierUnsupportedTarget, "safe").WithLocation(7, 5)
      ++>                 Diagnostic(ErrorCode.ERR_SafeModifierUnsupportedTarget, "safe").WithLocation(8, 5)
      ++>                 Diagnostic(ErrorCode.ERR_SafeModifierUnsupportedTarget, "safe").WithLocation(9, 5)
      ++>                 Diagnostic(ErrorCode.ERR_SafeModifierUnsupportedTarget, "safe").WithLocation(10, 5)
      ++>                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "F").WithArguments("safe").WithLocation(11, 21)
      ++>                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "NestedClass").WithArguments("safe").WithLocation(12, 23)
      ++>                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "NestedStruct").WithArguments("safe").WithLocation(13, 24)
      ++>                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "INested").WithArguments("safe").WithLocation(14, 27)
      ++>                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "ENested").WithArguments("safe").WithLocation(15, 22)
      ++>                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "D").WithArguments("safe").WithLocation(16, 31)
      ++>                 Diagnostic(ErrorCode.ERR_SafeModifierUnsupportedTarget, "safe").WithLocation(19, 9)
      ---- Pool leak detected! The following pooled objects were not returned:
        Microsoft.CodeAnalysis.PooledObjects.ArrayBuilder`1[Microsoft.CodeAnalysis.Test.Utilities.DiagnosticDescription] (from ArrayBuilder.cs:504): 1
      
      Stack Trace:
      
      ----- Inner Stack Trace #1 (Xunit.Sdk.FailException) -----
         at Microsoft.CodeAnalysis.DiagnosticExtensions.Verify(IEnumerable`1 actual, DiagnosticDescription[] expected, Boolean errorCodeOnly) in /_/src/Compilers/Test/Core/Diagnosti
      cs/DiagnosticExtensions.cs:line 99
         at Microsoft.CodeAnalysis.DiagnosticExtensions.Verify(IEnumerable`1 actual, DiagnosticDescription[] expected) in /_/src/Compilers/Test/Core/Diagnostics/DiagnosticExtensions
      .cs:line 48
         at Microsoft.CodeAnalysis.DiagnosticExtensions.Verify(ImmutableArray`1 actual, DiagnosticDescription[] expected) in /_/src/Compilers/Test/Core/Diagnostics/DiagnosticExtensi
      ons.cs:line 63
         at Microsoft.CodeAnalysis.DiagnosticExtensions.VerifyDiagnostics[TCompilation](TCompilation c, DiagnosticDescription[] expected) in /_/src/Compilers/Test/Core/Diagnostics/D
      iagnosticExtensions.cs:line 109
         at Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics.UnsafeEvolutionTests.SafeModifier_Declarations_SafeOnly() in /_/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests
      .cs:line 12063
         at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
         at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
      ----- Inner Stack Trace #2 (Xunit.Sdk.XunitException) -----
         at Roslyn.Test.Utilities.ValidatePooledObjectsAttribute.After(MethodInfo methodUnderTest) in /_/src/Compilers/Test/Core/Assert/ValidatePooledObjectsAttribute.cs:line 101
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83834)