### PR TITLE
Forgive leaks when ending compilation early

### DIFF
--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -1230,6 +1230,8 @@ namespace Microsoft.CodeAnalysis
             // But before we do so, we need to run diagnostic suppressors (if any) on all suppressable warnings/errors (if any).
             if (HasUnsuppressableErrors(diagnostics))
             {
+                PoolTracker.ForgiveLeaks();
+
                 if (analyzerDriver == null || !analyzerDriver.HasDiagnosticSuppressors || !HasSuppressableWarningsOrErrors(diagnostics))
                 {
                     return;

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -1230,7 +1230,12 @@ namespace Microsoft.CodeAnalysis
             // But before we do so, we need to run diagnostic suppressors (if any) on all suppressable warnings/errors (if any).
             if (HasUnsuppressableErrors(diagnostics))
             {
-                PoolTracker.ForgiveLeaks();
+                if (analyzerDriver != null)
+                {
+                    // Analyzer cleanup is cancellation-driven on early exit, but that cleanup does not currently
+                    // guarantee all pooled analyzer state is freed before leak tracking runs.
+                    PoolTracker.ForgiveLeaks();
+                }
 
                 if (analyzerDriver == null || !analyzerDriver.HasDiagnosticSuppressors || !HasSuppressableWarningsOrErrors(diagnostics))
                 {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/83749.

The leak path is:

  1. `CommonCompiler.RunCore` creates `analyzerDriver` which starts `_lazyInitializeTask` which allocates pooled objects
  1. Declaration errors exist (`HasUnsuppressableErrors = true`)
  1. `CommonCompiler.RunCore` returns early inside `if (HasUnsuppressableErrors(diagnostics))` without completing the event queue or awaiting analyzer tasks
  1. The init task is still running, pooled objects allocated but not yet freed
  1. Test checks for leaks → finds the allocation → false positive

We could wait for the queue to complete (see https://github.com/dotnet/roslyn/pull/83798) but that would result in unnecessary work. We could cancel the work and then wait for completion, but since we currently aren't returning pooled objects after exceptions, that wouldn't fix the problem.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83835)