### PR TITLE
Suppress Razor completion when @ is typed in Emmet numbering context

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
@@ -112,7 +112,6 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
     {
         // Suppress when '@' is typed as part of an Emmet abbreviation.
         // In Emmet syntax, '@' only appears after '$' for numbering modifiers.
-        // '$@' has no valid Razor meaning in HTML content, so suppressing here is safe.
         if (completionContext.TriggerKind == CompletionTriggerKind.TriggerCharacter
             && completionContext.TriggerCharacter == "@"
             && index > 1

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
@@ -111,11 +111,17 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
     private static bool ShouldSuppressCompletion(VSInternalCompletionContext completionContext, SourceText sourceText, int index)
     {
         // Suppress when '@' is typed as part of an Emmet abbreviation.
-        // In Emmet syntax, '@' only appears after '$' for numbering modifiers.
+        // In Emmet syntax, '@' only appears after '$' for numbering modifiers (e.g., item$@-).
+        // We also require an alphanumeric or '$' character before the '$' to distinguish Emmet
+        // from Razor expressions like "Your cost is $@price" (space before '$').
+        // This heuristic isn't perfect in either direction: Emmet text content like {text $@-}
+        // won't be suppressed, and unlikely-but-valid Razor like "thecostis$@price" will be.
+        // Both edge cases are uncommon enough to be acceptable tradeoffs.
         if (completionContext.TriggerKind == CompletionTriggerKind.TriggerCharacter
             && completionContext.TriggerCharacter == "@"
-            && index > 1
-            && sourceText[index - 2] == '$')
+            && index > 2
+            && sourceText[index - 2] == '$'
+            && (char.IsLetterOrDigit(sourceText[index - 3]) || sourceText[index - 3] == '$'))
         {
             return true;
         }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
@@ -70,6 +70,11 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
             return null;
         }
 
+        if (ShouldSuppressCompletion(completionContext, sourceText, index))
+        {
+            return null;
+        }
+
         var codeDocument = await remoteDocumentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
 
         var positionInfo = GetPositionInfo(codeDocument, index);
@@ -96,6 +101,27 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
             && !DelegatedCompletionHelper.IsInDirectiveAttributeParameterContext(codeDocument, index);
 
         return new CompletionPositionInfo(ProvisionalTextEdit: null, positionInfo, shouldIncludeSnippets, shouldIncludeHtmlCompletions, isStartTagContext);
+    }
+
+    /// <summary>
+    /// Determines whether completion should be suppressed for the current trigger context.
+    /// For example, '@' typed after '$' in Emmet numbering modifiers (e.g., ul>li.item$@-*5)
+    /// should not trigger Razor completion.
+    /// </summary>
+    private static bool ShouldSuppressCompletion(VSInternalCompletionContext completionContext, SourceText sourceText, int index)
+    {
+        // Suppress when '@' is typed as part of an Emmet abbreviation.
+        // In Emmet syntax, '@' only appears after '$' for numbering modifiers.
+        // '$@' has no valid Razor meaning in HTML content, so suppressing here is safe.
+        if (completionContext.TriggerKind == CompletionTriggerKind.TriggerCharacter
+            && completionContext.TriggerCharacter == "@"
+            && index > 1
+            && sourceText[index - 2] == '$')
+        {
+            return true;
+        }
+
+        return false;
     }
 
     public ValueTask<CompletionResponse> GetCompletionAsync(

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
@@ -98,6 +98,25 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
     }
 
     [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13074")]
+    public async Task DollarAtInNonEmmetContextStillShowsCompletion()
+    {
+        await VerifyCompletionListAsync(
+            input: """
+                <div>
+                    Your cost is $@$$
+                </div>
+                """,
+            completionContext: new VSInternalCompletionContext()
+            {
+                InvokeKind = VSInternalCompletionInvokeKind.Typing,
+                TriggerCharacter = "@",
+                TriggerKind = CompletionTriggerKind.TriggerCharacter
+            },
+            expectedItemLabels: ["char", "DateTime", "Exception"]);
+    }
+
+    [Fact]
     public async Task CSharpInEmptyExplicitStatement()
     {
         await VerifyCompletionListAsync(

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
@@ -61,6 +61,24 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
     }
 
     [Fact]
+    public async Task NotWhenAtSignFollowsDollarInEmmetAbbreviation()
+    {
+        await VerifyCompletionListAsync(
+            input: """
+                <div>
+                    ul>li.item$@$$
+                </div>
+                """,
+            completionContext: new VSInternalCompletionContext()
+            {
+                InvokeKind = VSInternalCompletionInvokeKind.Typing,
+                TriggerCharacter = "@",
+                TriggerKind = CompletionTriggerKind.TriggerCharacter
+            },
+            expectedItemLabels: null);
+    }
+
+    [Fact]
     public async Task CSharpInEmptyExplicitStatement()
     {
         await VerifyCompletionListAsync(

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
@@ -61,6 +61,7 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
     }
 
     [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13074")]
     public async Task NotWhenAtSignFollowsDollarInEmmetAbbreviation()
     {
         await VerifyCompletionListAsync(

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
@@ -80,6 +80,24 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
     }
 
     [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13074")]
+    public async Task ExplicitInvocationAtDollarAtStillShowsCompletion()
+    {
+        await VerifyCompletionListAsync(
+            input: """
+                <div>
+                    ul>li.item$@$$
+                </div>
+                """,
+            completionContext: new VSInternalCompletionContext()
+            {
+                InvokeKind = VSInternalCompletionInvokeKind.Explicit,
+                TriggerKind = CompletionTriggerKind.Invoked
+            },
+            expectedItemLabels: ["char", "DateTime", "Exception"]);
+    }
+
+    [Fact]
     public async Task CSharpInEmptyExplicitStatement()
     {
         await VerifyCompletionListAsync(


### PR DESCRIPTION
When typing Emmet abbreviations like ul>li.item$@-*5 in Razor files, the @ character triggers Razor completion because it's the Razor transition character. This is disruptive — the user is typing an Emmet numbering

modifier, not starting a C# expression.

This PR suppresses completion when @ is triggered immediately after $, which is the only context where @ appears in Emmet syntax (for numbering modifiers like $@-, $@3, $@-3). The sequence $@ has no valid meaning in Razor HTML content, so this suppression is safe.

Changes

 - RemoteCompletionService.cs: Extract ShouldSuppressCompletion method that returns true when the trigger is @ and the preceding character is $
 - CohostDocumentCompletionEndpointTest.cs: Add NotWhenAtSignFollowsDollarInEmmetAbbreviation test verifying no completion is returned in this context

Context

This is part of an effort to improve Emmet support in Razor documents outlined in https://github.com/dotnet/razor/issues/13074
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83837)