### PR TITLE
[16.11] Update SDL CI image version to 2022

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -102,7 +102,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: NetCore1ESPool-Svc-Internal
-        image: 1es-windows-2019
+        image: 1es-windows-2022
         os: windows
       sbom:
         enabled: false


### PR DESCRIPTION
We are [seeing the following error](https://dev.azure.com/dnceng/internal/_build/results?buildId=2980303&view=logs&j=e7c20581-242d-5f93-f683-18928254784c&t=a20ad1d7-d6f6-5c62-8a30-0704ca78633b&l=40) in official builds:

```
check os deprecation
##[error]1ES PT Error: MMS Windows Server 2019 is being deprecated by 1ES Hosted Pool team. Please migrate to Windows 2022 or 2025 using these instructions: https://aka.ms/1espt/windows2019
```