### PR TITLE
Don't pass client capabilities via a string

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/SemanticTokens/IRazorSemanticTokensRefreshQueue.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/SemanticTokens/IRazorSemanticTokensRefreshQueue.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading;
@@ -16,7 +16,7 @@ internal interface IRazorSemanticTokensRefreshQueue : ILspService
     /// This MUST be called synchronously from an IOnInitialized handler, to avoid dual initialization when
     /// Roslyn and Razor both support semantic tokens
     /// </remarks>
-    void Initialize(string clientCapabilitiesString);
+    void Initialize(VSInternalClientCapabilities clientCapabilities);
 
     Task TryEnqueueRefreshComputationAsync(Project project, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/SemanticTokens/RazorSemanticTokensRefreshQueueWrapper.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/SemanticTokens/RazorSemanticTokensRefreshQueueWrapper.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Composition;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/SemanticTokens/RazorSemanticTokensRefreshQueueWrapper.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/SemanticTokens/RazorSemanticTokensRefreshQueueWrapper.cs
@@ -26,9 +26,8 @@ internal class RazorSemanticTokensRefreshQueueWrapperFactory() : ILspServiceFact
 
     internal class RazorSemanticTokensRefreshQueueWrapper(SemanticTokensRefreshQueue semanticTokensRefreshQueue) : IRazorSemanticTokensRefreshQueue
     {
-        public void Initialize(string clientCapabilitiesString)
+        public void Initialize(VSInternalClientCapabilities clientCapabilities)
         {
-            var clientCapabilities = JsonSerializer.Deserialize<VSInternalClientCapabilities>(clientCapabilitiesString) ?? new();
             // If Roslyn and Razor both support semantic tokens, then this call to Initialize is redundant, but the
             // Initialize method in the queue itself is resilient to being called twice, so it doesn't actually do
             // any harm.

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostSemanticTokensRegistration.cs
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostSemanticTokensRegistration.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Immutable;
 using System.Composition;
-using System.Text.Json;
 using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
@@ -25,8 +24,7 @@ internal sealed class CohostSemanticTokensRegistration(ISemanticTokensLegendServ
         if (clientCapabilities.TextDocument?.SemanticTokens?.DynamicRegistration == true)
         {
             var semanticTokensRefreshQueue = requestContext.GetRequiredService<IRazorSemanticTokensRefreshQueue>();
-            var clientCapabilitiesString = JsonSerializer.Serialize(clientCapabilities);
-            semanticTokensRefreshQueue.Initialize(clientCapabilitiesString);
+            semanticTokensRefreshQueue.Initialize(clientCapabilities);
 
             return [new Registration()
             {

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/SemanticTokens/CohostSemanticTokensRegistration.cs
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/SemanticTokens/CohostSemanticTokensRegistration.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Immutable;
 using System.Composition;
-using System.Text.Json;
 using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
@@ -23,8 +22,7 @@ internal sealed class CohostSemanticTokensRegistration(ISemanticTokensLegendServ
         if (clientCapabilities.TextDocument?.SemanticTokens?.DynamicRegistration == true)
         {
             var semanticTokensRefreshQueue = requestContext.GetRequiredService<IRazorSemanticTokensRefreshQueue>();
-            var clientCapabilitiesString = JsonSerializer.Serialize(clientCapabilities);
-            semanticTokensRefreshQueue.Initialize(clientCapabilitiesString);
+            semanticTokensRefreshQueue.Initialize(clientCapabilities);
 
             return [new Registration()
             {

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostEndpointTest.cs
@@ -183,7 +183,7 @@ public class CohostEndpointTest(ITestOutputHelper testOutputHelper) : ToolingTes
     [Export(typeof(IRazorSemanticTokensRefreshQueue)), PartNotDiscoverable]
     private class TestRazorSemanticTokensRefreshQueue : IRazorSemanticTokensRefreshQueue
     {
-        public void Initialize(VSInternalClientCapabilities clientCapabilitiesString) => throw new NotImplementedException();
+        public void Initialize(VSInternalClientCapabilities clientCapabilities) => throw new NotImplementedException();
         public Task TryEnqueueRefreshComputationAsync(Project project, CancellationToken cancellationToken) => throw new NotImplementedException();
     }
 }

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostEndpointTest.cs
@@ -183,7 +183,7 @@ public class CohostEndpointTest(ITestOutputHelper testOutputHelper) : ToolingTes
     [Export(typeof(IRazorSemanticTokensRefreshQueue)), PartNotDiscoverable]
     private class TestRazorSemanticTokensRefreshQueue : IRazorSemanticTokensRefreshQueue
     {
-        public void Initialize(string clientCapabilitiesString) => throw new NotImplementedException();
+        public void Initialize(VSInternalClientCapabilities clientCapabilitiesString) => throw new NotImplementedException();
         public Task TryEnqueueRefreshComputationAsync(Project project, CancellationToken cancellationToken) => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
We originally had to do this because Razor we on VS LSP types, then when we converted to Roslyn LSP types we left it because using even Roslyn LSP types at the Roslyn <-> Razor API boundary was risky.

Obviously neither of those reasons exist any more.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83871)