### PR TITLE
Fix local build failures on Windows ARM machines

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,5 +2,14 @@
 <Project>
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
   <Import Project="eng\targets\Settings.props" />
-</Project>
 
+  <!-- This must be after the Arcade SDK import so CI/official-build properties are available. -->
+  <PropertyGroup>
+    <_RoslynNativeOSArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</_RoslynNativeOSArchitecture>
+    <RoslynUseInProcBuildTasks Condition="'$(RoslynUseInProcBuildTasks)' == '' and
+                                           '$(ContinuousIntegrationBuild)' != 'true' and
+                                           '$(OfficialBuild)' != 'true' and
+                                           '$(MSBuildRuntimeType)' == 'Full' and
+                                           '$(_RoslynNativeOSArchitecture)' == 'Arm64'">true</RoslynUseInProcBuildTasks>
+  </PropertyGroup>
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,14 +2,4 @@
 <Project>
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
   <Import Project="eng\targets\Settings.props" />
-
-  <!-- This must be after the Arcade SDK import so CI/official-build properties are available. -->
-  <PropertyGroup>
-    <_RoslynNativeOSArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</_RoslynNativeOSArchitecture>
-    <RoslynUseInProcBuildTasks Condition="'$(RoslynUseInProcBuildTasks)' == '' and
-                                           '$(ContinuousIntegrationBuild)' != 'true' and
-                                           '$(OfficialBuild)' != 'true' and
-                                           '$(MSBuildRuntimeType)' == 'Full' and
-                                           '$(_RoslynNativeOSArchitecture)' == 'Arm64'">true</RoslynUseInProcBuildTasks>
-  </PropertyGroup>
 </Project>

--- a/eng/targets/GeneratePkgDef.targets
+++ b/eng/targets/GeneratePkgDef.targets
@@ -72,11 +72,8 @@
   -->
   
   <!-- TODO: Remove UsingTasks when upgrading to Arcade 11: https://github.com/dotnet/roslyn/issues/83095 -->
-  <!-- On local Windows Arm64 full-MSBuild builds, Runtime="NET" routes through an external x64 task host that currently fails to start, so keep these tasks in-proc there. -->
-  <UsingTask TaskName="Microsoft.DotNet.Build.Tasks.VisualStudio.GetPkgDefAssemblyDependencyGuid" AssemblyFile="$(ArcadeVisualStudioBuildTasksAssembly)" Condition="'$(RoslynUseInProcBuildTasks)' == 'true'" />
-  <UsingTask TaskName="Microsoft.DotNet.Build.Tasks.VisualStudio.GetPkgDefAssemblyDependencyGuid" AssemblyFile="$(ArcadeVisualStudioBuildTasksAssembly)" Runtime="NET" Condition="'$(RoslynUseInProcBuildTasks)' != 'true'" />
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GetAssemblyFullName" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Condition="'$(RoslynUseInProcBuildTasks)' == 'true'" />
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GetAssemblyFullName" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" Condition="'$(RoslynUseInProcBuildTasks)' != 'true'" />
+  <UsingTask TaskName="Microsoft.DotNet.Build.Tasks.VisualStudio.GetPkgDefAssemblyDependencyGuid" AssemblyFile="$(ArcadeVisualStudioBuildTasksAssembly)" Runtime="$(_BuildTaskRuntime)" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GetAssemblyFullName" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="$(_BuildTaskRuntime)" />
 
   <Target Name="_SetGeneratePkgDefInputsOutputs">
     <PropertyGroup>

--- a/eng/targets/GeneratePkgDef.targets
+++ b/eng/targets/GeneratePkgDef.targets
@@ -72,7 +72,7 @@
   -->
   
   <!-- TODO: Remove UsingTasks when upgrading to Arcade 11: https://github.com/dotnet/roslyn/issues/83095 -->
-  <!-- Use in-proc task loading only for local Windows Arm64 Full-MSBuild builds to avoid external .NET task host startup. -->
+  <!-- On local Windows Arm64 full-MSBuild builds, Runtime="NET" routes through an external x64 task host that currently fails to start, so keep these tasks in-proc there. -->
   <UsingTask TaskName="Microsoft.DotNet.Build.Tasks.VisualStudio.GetPkgDefAssemblyDependencyGuid" AssemblyFile="$(ArcadeVisualStudioBuildTasksAssembly)" Condition="'$(RoslynUseInProcBuildTasks)' == 'true'" />
   <UsingTask TaskName="Microsoft.DotNet.Build.Tasks.VisualStudio.GetPkgDefAssemblyDependencyGuid" AssemblyFile="$(ArcadeVisualStudioBuildTasksAssembly)" Runtime="NET" Condition="'$(RoslynUseInProcBuildTasks)' != 'true'" />
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GetAssemblyFullName" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Condition="'$(RoslynUseInProcBuildTasks)' == 'true'" />

--- a/eng/targets/GeneratePkgDef.targets
+++ b/eng/targets/GeneratePkgDef.targets
@@ -72,8 +72,11 @@
   -->
   
   <!-- TODO: Remove UsingTasks when upgrading to Arcade 11: https://github.com/dotnet/roslyn/issues/83095 -->
-  <UsingTask TaskName="Microsoft.DotNet.Build.Tasks.VisualStudio.GetPkgDefAssemblyDependencyGuid" AssemblyFile="$(ArcadeVisualStudioBuildTasksAssembly)" Runtime="NET" />
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GetAssemblyFullName" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" />
+  <!-- Use in-proc task loading only for local Windows Arm64 Full-MSBuild builds to avoid external .NET task host startup. -->
+  <UsingTask TaskName="Microsoft.DotNet.Build.Tasks.VisualStudio.GetPkgDefAssemblyDependencyGuid" AssemblyFile="$(ArcadeVisualStudioBuildTasksAssembly)" Condition="'$(RoslynUseInProcBuildTasks)' == 'true'" />
+  <UsingTask TaskName="Microsoft.DotNet.Build.Tasks.VisualStudio.GetPkgDefAssemblyDependencyGuid" AssemblyFile="$(ArcadeVisualStudioBuildTasksAssembly)" Runtime="NET" Condition="'$(RoslynUseInProcBuildTasks)' != 'true'" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GetAssemblyFullName" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Condition="'$(RoslynUseInProcBuildTasks)' == 'true'" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GetAssemblyFullName" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" Condition="'$(RoslynUseInProcBuildTasks)' != 'true'" />
 
   <Target Name="_SetGeneratePkgDefInputsOutputs">
     <PropertyGroup>

--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -174,11 +174,8 @@
   </Target>
 
   <!-- TODO: Remove UsingTasks when upgrading to Arcade 11: https://github.com/dotnet/roslyn/issues/83095 -->
-  <!-- On local Windows Arm64 full-MSBuild builds, Runtime="NET" routes through an external x64 task host that currently fails to start, so keep these tasks in-proc there. -->
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.CompareVersions" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Condition="'$(RoslynUseInProcBuildTasks)' == 'true'" />
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.CompareVersions" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" Condition="'$(RoslynUseInProcBuildTasks)' != 'true'" />
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SingleError" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Condition="'$(RoslynUseInProcBuildTasks)' == 'true'" />
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SingleError" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" Condition="'$(RoslynUseInProcBuildTasks)' != 'true'" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.CompareVersions" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="$(_BuildTaskRuntime)" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SingleError" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="$(_BuildTaskRuntime)" />
 
   <Target Name="_CheckRequiredMSBuildVersion" BeforeTargets="BeforeBuild" Condition="'$(DotNetBuildSourceOnly)' != 'true'">
     <CompareVersions Left="$(MSBuildVersion)" Right="$(MinimumMSBuildVersion)">

--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -174,7 +174,7 @@
   </Target>
 
   <!-- TODO: Remove UsingTasks when upgrading to Arcade 11: https://github.com/dotnet/roslyn/issues/83095 -->
-  <!-- Use in-proc task loading only for local Windows Arm64 Full-MSBuild builds to avoid external .NET task host startup. -->
+  <!-- On local Windows Arm64 full-MSBuild builds, Runtime="NET" routes through an external x64 task host that currently fails to start, so keep these tasks in-proc there. -->
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.CompareVersions" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Condition="'$(RoslynUseInProcBuildTasks)' == 'true'" />
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.CompareVersions" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" Condition="'$(RoslynUseInProcBuildTasks)' != 'true'" />
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SingleError" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Condition="'$(RoslynUseInProcBuildTasks)' == 'true'" />

--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -174,8 +174,11 @@
   </Target>
 
   <!-- TODO: Remove UsingTasks when upgrading to Arcade 11: https://github.com/dotnet/roslyn/issues/83095 -->
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.CompareVersions" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" />
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SingleError" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" />
+  <!-- Use in-proc task loading only for local Windows Arm64 Full-MSBuild builds to avoid external .NET task host startup. -->
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.CompareVersions" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Condition="'$(RoslynUseInProcBuildTasks)' == 'true'" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.CompareVersions" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" Condition="'$(RoslynUseInProcBuildTasks)' != 'true'" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SingleError" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Condition="'$(RoslynUseInProcBuildTasks)' == 'true'" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SingleError" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" Condition="'$(RoslynUseInProcBuildTasks)' != 'true'" />
 
   <Target Name="_CheckRequiredMSBuildVersion" BeforeTargets="BeforeBuild" Condition="'$(DotNetBuildSourceOnly)' != 'true'">
     <CompareVersions Left="$(MSBuildVersion)" Right="$(MinimumMSBuildVersion)">

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -26,6 +26,13 @@
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <ToolsetPackagesDir>$(RepoRoot)build\ToolsetPackages\</ToolsetPackagesDir>
     <UseSharedCompilation>true</UseSharedCompilation>
+    <!-- Local Windows Arm64 full-MSBuild builds currently fail when Arcade tasks use the external x64 .NET task host. -->
+    <_RoslynNativeOSArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</_RoslynNativeOSArchitecture>
+    <RoslynUseInProcBuildTasks Condition="'$(RoslynUseInProcBuildTasks)' == '' and
+                                           '$(ContinuousIntegrationBuild)' != 'true' and
+                                           '$(OfficialBuild)' != 'true' and
+                                           '$(MSBuildRuntimeType)' == 'Full' and
+                                           '$(_RoslynNativeOSArchitecture)' == 'Arm64'">true</RoslynUseInProcBuildTasks>
 
     <Features>strict</Features>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -26,13 +26,13 @@
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <ToolsetPackagesDir>$(RepoRoot)build\ToolsetPackages\</ToolsetPackagesDir>
     <UseSharedCompilation>true</UseSharedCompilation>
-    <!-- Local Windows Arm64 full-MSBuild builds currently fail when Arcade tasks use the external x64 .NET task host. -->
+    <_BuildTaskRuntime>NET</_BuildTaskRuntime>
+    <!-- Use Runtime="*" for local Windows Arm64 full-MSBuild builds to stay in-proc instead of routing through the external x64 .NET task host, which currently fails to start. -->
     <_RoslynNativeOSArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</_RoslynNativeOSArchitecture>
-    <RoslynUseInProcBuildTasks Condition="'$(RoslynUseInProcBuildTasks)' == '' and
-                                           '$(ContinuousIntegrationBuild)' != 'true' and
-                                           '$(OfficialBuild)' != 'true' and
-                                           '$(MSBuildRuntimeType)' == 'Full' and
-                                           '$(_RoslynNativeOSArchitecture)' == 'Arm64'">true</RoslynUseInProcBuildTasks>
+    <_BuildTaskRuntime Condition="'$(ContinuousIntegrationBuild)' != 'true' and
+                                  '$(OfficialBuild)' != 'true' and
+                                  '$(MSBuildRuntimeType)' == 'Full' and
+                                  '$(_RoslynNativeOSArchitecture)' == 'Arm64'">*</_BuildTaskRuntime>
 
     <Features>strict</Features>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>

--- a/src/NuGet/VS.Tools.Roslyn.Package/VS.Tools.Roslyn.Package.csproj
+++ b/src/NuGet/VS.Tools.Roslyn.Package/VS.Tools.Roslyn.Package.csproj
@@ -46,7 +46,8 @@
     Workaround for https://github.com/dotnet/roslyn/issues/17864.
   -->
   <!-- TODO: Remove UsingTask when upgrading to Arcade 11: https://github.com/dotnet/roslyn/issues/83095 -->
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SetCorFlags" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SetCorFlags" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Condition="'$(RoslynUseInProcBuildTasks)' == 'true'" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SetCorFlags" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" Condition="'$(RoslynUseInProcBuildTasks)' != 'true'" />
 
   <Target Name="_Generate32BitCsc" 
           AfterTargets="Build"

--- a/src/NuGet/VS.Tools.Roslyn.Package/VS.Tools.Roslyn.Package.csproj
+++ b/src/NuGet/VS.Tools.Roslyn.Package/VS.Tools.Roslyn.Package.csproj
@@ -46,8 +46,7 @@
     Workaround for https://github.com/dotnet/roslyn/issues/17864.
   -->
   <!-- TODO: Remove UsingTask when upgrading to Arcade 11: https://github.com/dotnet/roslyn/issues/83095 -->
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SetCorFlags" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Condition="'$(RoslynUseInProcBuildTasks)' == 'true'" />
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SetCorFlags" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" Condition="'$(RoslynUseInProcBuildTasks)' != 'true'" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SetCorFlags" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="$(_BuildTaskRuntime)" />
 
   <Target Name="_Generate32BitCsc" 
           AfterTargets="Build"

--- a/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
+++ b/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
@@ -9,9 +9,13 @@
   </PropertyGroup>
 
   <!-- TODO: Remove UsingTasks when upgrading to Arcade 11: https://github.com/dotnet/roslyn/issues/83095 -->
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GetAssemblyFullName" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" />
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GroupItemsBy" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" />
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.Unsign" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" />
+  <!-- Use in-proc task loading only for local Windows Arm64 Full-MSBuild builds to avoid external .NET task host startup. -->
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GetAssemblyFullName" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Condition="'$(RoslynUseInProcBuildTasks)' == 'true'" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GetAssemblyFullName" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" Condition="'$(RoslynUseInProcBuildTasks)' != 'true'" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GroupItemsBy" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Condition="'$(RoslynUseInProcBuildTasks)' == 'true'" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GroupItemsBy" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" Condition="'$(RoslynUseInProcBuildTasks)' != 'true'" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.Unsign" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Condition="'$(RoslynUseInProcBuildTasks)' == 'true'" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.Unsign" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" Condition="'$(RoslynUseInProcBuildTasks)' != 'true'" />
   <UsingTask TaskName="Microsoft.DotNet.Tools.ReplacePackageParts" AssemblyFile="$(_NuGetRepackAssembly)" />
 
   <UsingTask TaskName="Microsoft.NET.Build.Tasks.JoinItems" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />

--- a/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
+++ b/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
@@ -9,13 +9,9 @@
   </PropertyGroup>
 
   <!-- TODO: Remove UsingTasks when upgrading to Arcade 11: https://github.com/dotnet/roslyn/issues/83095 -->
-  <!-- On local Windows Arm64 full-MSBuild builds, Runtime="NET" routes through an external x64 task host that currently fails to start, so keep these tasks in-proc there. -->
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GetAssemblyFullName" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Condition="'$(RoslynUseInProcBuildTasks)' == 'true'" />
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GetAssemblyFullName" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" Condition="'$(RoslynUseInProcBuildTasks)' != 'true'" />
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GroupItemsBy" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Condition="'$(RoslynUseInProcBuildTasks)' == 'true'" />
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GroupItemsBy" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" Condition="'$(RoslynUseInProcBuildTasks)' != 'true'" />
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.Unsign" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Condition="'$(RoslynUseInProcBuildTasks)' == 'true'" />
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.Unsign" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" Condition="'$(RoslynUseInProcBuildTasks)' != 'true'" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GetAssemblyFullName" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="$(_BuildTaskRuntime)" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GroupItemsBy" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="$(_BuildTaskRuntime)" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.Unsign" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="$(_BuildTaskRuntime)" />
   <UsingTask TaskName="Microsoft.DotNet.Tools.ReplacePackageParts" AssemblyFile="$(_NuGetRepackAssembly)" />
 
   <UsingTask TaskName="Microsoft.NET.Build.Tasks.JoinItems" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />

--- a/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
+++ b/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <!-- TODO: Remove UsingTasks when upgrading to Arcade 11: https://github.com/dotnet/roslyn/issues/83095 -->
-  <!-- Use in-proc task loading only for local Windows Arm64 Full-MSBuild builds to avoid external .NET task host startup. -->
+  <!-- On local Windows Arm64 full-MSBuild builds, Runtime="NET" routes through an external x64 task host that currently fails to start, so keep these tasks in-proc there. -->
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GetAssemblyFullName" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Condition="'$(RoslynUseInProcBuildTasks)' == 'true'" />
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GetAssemblyFullName" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" Condition="'$(RoslynUseInProcBuildTasks)' != 'true'" />
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GroupItemsBy" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Condition="'$(RoslynUseInProcBuildTasks)' == 'true'" />

--- a/src/Tools/SemanticSearch/ReferenceAssemblies/SemanticSearch.ReferenceAssemblies.csproj
+++ b/src/Tools/SemanticSearch/ReferenceAssemblies/SemanticSearch.ReferenceAssemblies.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>$(NetVS)</TargetFramework>
 
     <_BuildTaskRuntime>*</_BuildTaskRuntime>
-    <_BuildTaskRuntime Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(MSBuildAssemblyVersion)', '18.0'))">NET</_BuildTaskRuntime>
+    <_BuildTaskRuntime Condition="'$(RoslynUseInProcBuildTasks)' != 'true' and $([MSBuild]::VersionGreaterThanOrEquals('$(MSBuildAssemblyVersion)', '18.0'))">NET</_BuildTaskRuntime>
     <_BuildTaskTfm Condition="'$(MSBuildRuntimeType)' == 'Core' or '$(_BuildTaskRuntime)' == 'NET'">$(NetRoslyn)</_BuildTaskTfm>
     <_BuildTaskTfm Condition="'$(_BuildTaskTfm)' == ''">net472</_BuildTaskTfm>
     <_BuildTaskAssemblyFile>$(ArtifactsBinDir)SemanticSearch.BuildTask\$(Configuration)\$(_BuildTaskTfm)\SemanticSearch.BuildTask.dll</_BuildTaskAssemblyFile>
@@ -44,7 +44,8 @@
     in subsequent builds because the task assembly can't be written by the
     next build.
   -->
-  <UsingTask TaskName="Microsoft.CodeAnalysis.Tools.GenerateFilteredReferenceAssembliesTask" AssemblyFile="$(_BuildTaskAssemblyFile)" TaskFactory="TaskHostFactory" Runtime="$(_BuildTaskRuntime)" />
+  <UsingTask TaskName="Microsoft.CodeAnalysis.Tools.GenerateFilteredReferenceAssembliesTask" AssemblyFile="$(_BuildTaskAssemblyFile)" TaskFactory="TaskHostFactory" Condition="'$(RoslynUseInProcBuildTasks)' == 'true'" />
+  <UsingTask TaskName="Microsoft.CodeAnalysis.Tools.GenerateFilteredReferenceAssembliesTask" AssemblyFile="$(_BuildTaskAssemblyFile)" TaskFactory="TaskHostFactory" Runtime="$(_BuildTaskRuntime)" Condition="'$(RoslynUseInProcBuildTasks)' != 'true'" />
 
   <Target Name="_CalculateFilteredReferenceAssembliesInputsAndOutputs" DependsOnTargets="ResolveAssemblyReferences">
     <PropertyGroup>

--- a/src/Tools/SemanticSearch/ReferenceAssemblies/SemanticSearch.ReferenceAssemblies.csproj
+++ b/src/Tools/SemanticSearch/ReferenceAssemblies/SemanticSearch.ReferenceAssemblies.csproj
@@ -4,9 +4,9 @@
     <!-- Semantic search queries run in VS OOP. -->
     <TargetFramework>$(NetVS)</TargetFramework>
 
-    <_BuildTaskRuntime>*</_BuildTaskRuntime>
-    <_BuildTaskRuntime Condition="'$(RoslynUseInProcBuildTasks)' != 'true' and $([MSBuild]::VersionGreaterThanOrEquals('$(MSBuildAssemblyVersion)', '18.0'))">NET</_BuildTaskRuntime>
-    <_BuildTaskTfm Condition="'$(MSBuildRuntimeType)' == 'Core' or '$(_BuildTaskRuntime)' == 'NET'">$(NetRoslyn)</_BuildTaskTfm>
+    <_EffectiveBuildTaskRuntime>*</_EffectiveBuildTaskRuntime>
+    <_EffectiveBuildTaskRuntime Condition="'$(_BuildTaskRuntime)' == 'NET' and $([MSBuild]::VersionGreaterThanOrEquals('$(MSBuildAssemblyVersion)', '18.0'))">NET</_EffectiveBuildTaskRuntime>
+    <_BuildTaskTfm Condition="'$(MSBuildRuntimeType)' == 'Core' or '$(_EffectiveBuildTaskRuntime)' == 'NET'">$(NetRoslyn)</_BuildTaskTfm>
     <_BuildTaskTfm Condition="'$(_BuildTaskTfm)' == ''">net472</_BuildTaskTfm>
     <_BuildTaskAssemblyFile>$(ArtifactsBinDir)SemanticSearch.BuildTask\$(Configuration)\$(_BuildTaskTfm)\SemanticSearch.BuildTask.dll</_BuildTaskAssemblyFile>
     <_ApisDir>$(MSBuildThisFileDirectory)Apis\</_ApisDir>
@@ -44,8 +44,7 @@
     in subsequent builds because the task assembly can't be written by the
     next build.
   -->
-  <UsingTask TaskName="Microsoft.CodeAnalysis.Tools.GenerateFilteredReferenceAssembliesTask" AssemblyFile="$(_BuildTaskAssemblyFile)" TaskFactory="TaskHostFactory" Condition="'$(RoslynUseInProcBuildTasks)' == 'true'" />
-  <UsingTask TaskName="Microsoft.CodeAnalysis.Tools.GenerateFilteredReferenceAssembliesTask" AssemblyFile="$(_BuildTaskAssemblyFile)" TaskFactory="TaskHostFactory" Runtime="$(_BuildTaskRuntime)" Condition="'$(RoslynUseInProcBuildTasks)' != 'true'" />
+  <UsingTask TaskName="Microsoft.CodeAnalysis.Tools.GenerateFilteredReferenceAssembliesTask" AssemblyFile="$(_BuildTaskAssemblyFile)" TaskFactory="TaskHostFactory" Runtime="$(_EffectiveBuildTaskRuntime)" />
 
   <Target Name="_CalculateFilteredReferenceAssembliesInputsAndOutputs" DependsOnTargets="ResolveAssemblyReferences">
     <PropertyGroup>


### PR DESCRIPTION
Local Windows Arm64 builds under full-framework MSBuild currently fail when `UsingTask` entries opt into `Runtime="NET"` on full MSBuild, as the task host that gets used is x64, which fails.

This change keeps those tasks in-proc only for local Windows Arm64 + full-MSBuild builds, while leaving CI, official builds, and other environments on the existing path. I kept the workaround scoped to the specific Arcade task registrations that were failing.

_DavidW: Above was written by AI. Apologies, it edited the description without my approval_