### PR TITLE
Fix input nodes incorrectly picking duplicate elements

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -3011,6 +3011,303 @@ class C { }
         }
 
         [Fact]
+        [WorkItem("https://github.com/dotnet/vscode-csharp/issues/9211")]
+        public void ReplaceAdditionalTexts_Reordered_Does_Not_Duplicate_Entries()
+        {
+            // When the input count is unchanged, InputNode uses a "modify" heuristic instead of
+            // remove+add, which keeps the table the same size and avoids unnecessary downstream
+            // invalidation. This test verifies that reordering surviving items while simultaneously
+            // replacing one does not produce duplicate table entries -- each item appears exactly once,
+            // and only the slot whose item was removed gets a new value.
+            var source = @"
+class C { }
+";
+            var parseOptions = TestOptions.RegularPreview;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDllThrowing, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            var textA = new InMemoryAdditionalText("pathA.txt", "a");
+            var textB = new InMemoryAdditionalText("pathB.txt", "b");
+            var textC = new InMemoryAdditionalText("pathC.txt", "c");
+            var textD = new InMemoryAdditionalText("pathD.txt", "d");
+
+            var generator = new IncrementalGeneratorWrapper(new PipelineCallbackGenerator(ctx =>
+            {
+                ctx.RegisterImplementationSourceOutput(
+                    ctx.AdditionalTextsProvider.Select((t, _) => t.Path).WithTrackingName("Paths"),
+                    (spc, path) =>
+                    {
+                        spc.AddSource(path.Replace(".", "_"), "// " + path);
+                    });
+            }));
+
+            // Run 1: [A, B, C]
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(new ISourceGenerator[] { generator }, parseOptions: parseOptions, additionalTexts: new[] { textA, textB, textC }, driverOptions: TestOptions.GeneratorDriverOptions);
+            driver = driver.RunGenerators(compilation);
+            var runResult = driver.GetRunResult();
+            Assert.Empty(runResult.Diagnostics);
+            Assert.Equal(3, runResult.GeneratedTrees.Length);
+
+            // Run 2: [C, A, D] -- reorder C and A, remove B, add D.
+            // The new item D should land in B's old slot. A and C should remain cached.
+            driver = driver.ReplaceAdditionalTexts(ImmutableArray.Create<AdditionalText>(textC, textA, textD));
+            driver = driver.RunGenerators(compilation);
+            runResult = driver.GetRunResult();
+            Assert.Empty(runResult.Diagnostics);
+            Assert.Equal(3, runResult.GeneratedTrees.Length);
+
+            Assert.Collection(runResult.Results[0].TrackedSteps["Paths"],
+                step =>
+                {
+                    Assert.Equal("pathA.txt", step.Outputs[0].Value);
+                    Assert.Equal(IncrementalStepRunReason.Cached, step.Outputs[0].Reason);
+                },
+                step =>
+                {
+                    Assert.Equal("pathD.txt", step.Outputs[0].Value);
+                    Assert.Equal(IncrementalStepRunReason.Modified, step.Outputs[0].Reason);
+                },
+                step =>
+                {
+                    Assert.Equal("pathC.txt", step.Outputs[0].Value);
+                    Assert.Equal(IncrementalStepRunReason.Cached, step.Outputs[0].Reason);
+                });
+
+            // Run 3: same inputs again -- everything should be cached
+            driver = driver.RunGenerators(compilation);
+            runResult = driver.GetRunResult();
+            Assert.Empty(runResult.Diagnostics);
+            Assert.Equal(3, runResult.GeneratedTrees.Length);
+
+            Assert.Collection(runResult.Results[0].TrackedSteps["Paths"],
+                step => Assert.Equal(IncrementalStepRunReason.Cached, step.Outputs[0].Reason),
+                step => Assert.Equal(IncrementalStepRunReason.Cached, step.Outputs[0].Reason),
+                step => Assert.Equal(IncrementalStepRunReason.Cached, step.Outputs[0].Reason));
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/vscode-csharp/issues/9211")]
+        public void ReplaceAdditionalTexts_NewItem_Only_Modifies_Replaced_Slot()
+        {
+            // When an item is removed and a new one is added (same count), only the removed item's
+            // slot should receive Modified status. Surviving items must remain Cached regardless of
+            // where they or the new item appear in the input ordering, because the replacement cursor
+            // skips items that exist in the previous table and only selects genuinely new items.
+            var source = @"
+class C { }
+";
+            var parseOptions = TestOptions.RegularPreview;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDllThrowing, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            var textA = new InMemoryAdditionalText("pathA.txt", "a");
+            var textB = new InMemoryAdditionalText("pathB.txt", "b");
+            var textC = new InMemoryAdditionalText("pathC.txt", "c");
+            var textD = new InMemoryAdditionalText("pathD.txt", "d");
+
+            var generator = new IncrementalGeneratorWrapper(new PipelineCallbackGenerator(ctx =>
+            {
+                ctx.RegisterImplementationSourceOutput(
+                    ctx.AdditionalTextsProvider.Select((t, _) => t.Path).WithTrackingName("Paths"),
+                    (spc, path) =>
+                    {
+                        spc.AddSource(path.Replace(".", "_"), "// " + path);
+                    });
+            }));
+
+            // Run 1: [A, B, C]
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(new ISourceGenerator[] { generator }, parseOptions: parseOptions, additionalTexts: new[] { textA, textB, textC }, driverOptions: TestOptions.GeneratorDriverOptions);
+            driver = driver.RunGenerators(compilation);
+            Assert.Empty(driver.GetRunResult().Diagnostics);
+
+            // Run 2: [D, B, C] -- remove A (slot 0), add D at the front.
+            // D should replace A's slot. B and C remain cached. Only 1 Modified entry.
+            driver = driver.ReplaceAdditionalTexts(ImmutableArray.Create<AdditionalText>(textD, textB, textC));
+            driver = driver.RunGenerators(compilation);
+            var runResult = driver.GetRunResult();
+            Assert.Empty(runResult.Diagnostics);
+            Assert.Equal(3, runResult.GeneratedTrees.Length);
+
+            Assert.Collection(runResult.Results[0].TrackedSteps["Paths"],
+                step =>
+                {
+                    Assert.Equal("pathD.txt", step.Outputs[0].Value);
+                    Assert.Equal(IncrementalStepRunReason.Modified, step.Outputs[0].Reason);
+                },
+                step =>
+                {
+                    Assert.Equal("pathB.txt", step.Outputs[0].Value);
+                    Assert.Equal(IncrementalStepRunReason.Cached, step.Outputs[0].Reason);
+                },
+                step =>
+                {
+                    Assert.Equal("pathC.txt", step.Outputs[0].Value);
+                    Assert.Equal(IncrementalStepRunReason.Cached, step.Outputs[0].Reason);
+                });
+
+            // Run 3: [B, D, C] -- same items, just reorder D and B.
+            // No items changed, so everything should be cached.
+            driver = driver.ReplaceAdditionalTexts(ImmutableArray.Create<AdditionalText>(textB, textD, textC));
+            driver = driver.RunGenerators(compilation);
+            runResult = driver.GetRunResult();
+            Assert.Empty(runResult.Diagnostics);
+
+            Assert.Collection(runResult.Results[0].TrackedSteps["Paths"],
+                step => Assert.Equal(IncrementalStepRunReason.Cached, step.Outputs[0].Reason),
+                step => Assert.Equal(IncrementalStepRunReason.Cached, step.Outputs[0].Reason),
+                step => Assert.Equal(IncrementalStepRunReason.Cached, step.Outputs[0].Reason));
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/vscode-csharp/issues/9211")]
+        public void ReplaceAdditionalTexts_Multiple_Replacements_Only_Modify_Replaced_Slots()
+        {
+            // When multiple items are removed and an equal number of new items are added (same total
+            // count), the new items should be assigned to the removed slots in input order. Surviving
+            // items keep their existing table positions with Cached status, ensuring downstream nodes
+            // only re-evaluate the slots that actually changed.
+            var source = @"
+class C { }
+";
+            var parseOptions = TestOptions.RegularPreview;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDllThrowing, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            var textA = new InMemoryAdditionalText("pathA.txt", "a");
+            var textB = new InMemoryAdditionalText("pathB.txt", "b");
+            var textC = new InMemoryAdditionalText("pathC.txt", "c");
+            var textD = new InMemoryAdditionalText("pathD.txt", "d");
+            var textE = new InMemoryAdditionalText("pathE.txt", "e");
+            var textX = new InMemoryAdditionalText("pathX.txt", "x");
+            var textY = new InMemoryAdditionalText("pathY.txt", "y");
+
+            var generator = new IncrementalGeneratorWrapper(new PipelineCallbackGenerator(ctx =>
+            {
+                ctx.RegisterImplementationSourceOutput(
+                    ctx.AdditionalTextsProvider.Select((t, _) => t.Path).WithTrackingName("Paths"),
+                    (spc, path) =>
+                    {
+                        spc.AddSource(path.Replace(".", "_"), "// " + path);
+                    });
+            }));
+
+            // Run 1: [A, B, C, D, E]
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(new ISourceGenerator[] { generator }, parseOptions: parseOptions, additionalTexts: new[] { textA, textB, textC, textD, textE }, driverOptions: TestOptions.GeneratorDriverOptions);
+            driver = driver.RunGenerators(compilation);
+            Assert.Empty(driver.GetRunResult().Diagnostics);
+
+            // Run 2: [X, C, Y, D, A] -- remove B (slot 1) and E (slot 4), add X and Y.
+            // A, C, D survive. X and Y should fill the two removed slots.
+            driver = driver.ReplaceAdditionalTexts(ImmutableArray.Create<AdditionalText>(textX, textC, textY, textD, textA));
+            driver = driver.RunGenerators(compilation);
+            var runResult = driver.GetRunResult();
+            Assert.Empty(runResult.Diagnostics);
+            Assert.Equal(5, runResult.GeneratedTrees.Length);
+
+            var steps = runResult.Results[0].TrackedSteps["Paths"];
+            Assert.Equal(5, steps.Length);
+
+            // A (slot 0): survived -> Cached
+            Assert.Equal("pathA.txt", steps[0].Outputs[0].Value);
+            Assert.Equal(IncrementalStepRunReason.Cached, steps[0].Outputs[0].Reason);
+
+            // B's old slot (1): replaced by X (first new item in input order) -> Modified
+            Assert.Equal("pathX.txt", steps[1].Outputs[0].Value);
+            Assert.Equal(IncrementalStepRunReason.Modified, steps[1].Outputs[0].Reason);
+
+            // C (slot 2): survived -> Cached
+            Assert.Equal("pathC.txt", steps[2].Outputs[0].Value);
+            Assert.Equal(IncrementalStepRunReason.Cached, steps[2].Outputs[0].Reason);
+
+            // D (slot 3): survived -> Cached
+            Assert.Equal("pathD.txt", steps[3].Outputs[0].Value);
+            Assert.Equal(IncrementalStepRunReason.Cached, steps[3].Outputs[0].Reason);
+
+            // E's old slot (4): replaced by Y (second new item in input order) -> Modified
+            Assert.Equal("pathY.txt", steps[4].Outputs[0].Value);
+            Assert.Equal(IncrementalStepRunReason.Modified, steps[4].Outputs[0].Reason);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/vscode-csharp/issues/9211")]
+        public void ReplaceAdditionalTexts_Successive_Shuffles_Maintain_Correct_State()
+        {
+            // The input node table must remain consistent across multiple rounds of shuffling and
+            // replacing items. Items that survive every round should stay Cached, new items should
+            // be Modified in the round they appear, and a subsequent run with identical inputs should
+            // produce all Cached entries -- confirming the table converges to a stable state.
+            var source = @"
+class C { }
+";
+            var parseOptions = TestOptions.RegularPreview;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDllThrowing, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            var textA = new InMemoryAdditionalText("pathA.txt", "a");
+            var textB = new InMemoryAdditionalText("pathB.txt", "b");
+            var textC = new InMemoryAdditionalText("pathC.txt", "c");
+            var textD = new InMemoryAdditionalText("pathD.txt", "d");
+            var textE = new InMemoryAdditionalText("pathE.txt", "e");
+            var textF = new InMemoryAdditionalText("pathF.txt", "f");
+
+            var generator = new IncrementalGeneratorWrapper(new PipelineCallbackGenerator(ctx =>
+            {
+                ctx.RegisterImplementationSourceOutput(
+                    ctx.AdditionalTextsProvider.Select((t, _) => t.Path).WithTrackingName("Paths"),
+                    (spc, path) =>
+                    {
+                        spc.AddSource(path.Replace(".", "_"), "// " + path);
+                    });
+            }));
+
+            // Run 1: [A, B, C]
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(new ISourceGenerator[] { generator }, parseOptions: parseOptions, additionalTexts: new[] { textA, textB, textC }, driverOptions: TestOptions.GeneratorDriverOptions);
+            driver = driver.RunGenerators(compilation);
+            Assert.Empty(driver.GetRunResult().Diagnostics);
+
+            // Run 2: [C, D, A] -- remove B, add D, shuffle
+            driver = driver.ReplaceAdditionalTexts(ImmutableArray.Create<AdditionalText>(textC, textD, textA));
+            driver = driver.RunGenerators(compilation);
+            var runResult = driver.GetRunResult();
+            Assert.Empty(runResult.Diagnostics);
+            Assert.Equal(3, runResult.GeneratedTrees.Length);
+
+            // Run 3: [E, A, F] -- remove C and D, add E and F, shuffle
+            driver = driver.ReplaceAdditionalTexts(ImmutableArray.Create<AdditionalText>(textE, textA, textF));
+            driver = driver.RunGenerators(compilation);
+            runResult = driver.GetRunResult();
+            Assert.Empty(runResult.Diagnostics);
+            Assert.Equal(3, runResult.GeneratedTrees.Length);
+
+            // A should be Cached (survived all rounds). E and F should be Modified (replaced removed slots).
+            var steps = runResult.Results[0].TrackedSteps["Paths"];
+            Assert.Equal(3, steps.Length);
+
+            Assert.Equal("pathA.txt", steps[0].Outputs[0].Value);
+            Assert.Equal(IncrementalStepRunReason.Cached, steps[0].Outputs[0].Reason);
+
+            Assert.Equal(IncrementalStepRunReason.Modified, steps[1].Outputs[0].Reason);
+            Assert.Equal(IncrementalStepRunReason.Modified, steps[2].Outputs[0].Reason);
+
+            // The two modified slots should contain E and F (in input order of new items)
+            var modifiedValues = steps.Where(s => s.Outputs[0].Reason == IncrementalStepRunReason.Modified)
+                .Select(s => (string)s.Outputs[0].Value)
+                .ToArray();
+            Assert.Equal(new[] { "pathE.txt", "pathF.txt" }, modifiedValues);
+
+            // Run 4: same inputs [E, A, F] again -- everything should be cached
+            driver = driver.ReplaceAdditionalTexts(ImmutableArray.Create<AdditionalText>(textE, textA, textF));
+            driver = driver.RunGenerators(compilation);
+            runResult = driver.GetRunResult();
+            Assert.Empty(runResult.Diagnostics);
+
+            foreach (var step in runResult.Results[0].TrackedSteps["Paths"])
+            {
+                Assert.Equal(IncrementalStepRunReason.Cached, step.Outputs[0].Reason);
+            }
+        }
+
+        [Fact]
         public void Replaced_Input_Is_Treated_As_Modified()
         {
             var source = @"

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
@@ -25,6 +25,7 @@ namespace Microsoft.CodeAnalysis
         private readonly Action<IIncrementalGeneratorOutputNode> _registerOutput;
         private readonly IEqualityComparer<T> _inputComparer;
         private readonly IEqualityComparer<T>? _comparer;
+        private readonly ObjectPool<PooledHashSet<T>>? _hashSetPool;
         private readonly string? _name;
 
         public InputNode(Func<DriverStateTable.Builder, ImmutableArray<T>> getInput, IEqualityComparer<T>? inputComparer = null)
@@ -38,6 +39,9 @@ namespace Microsoft.CodeAnalysis
             _comparer = comparer;
             _inputComparer = inputComparer ?? EqualityComparer<T>.Default;
             _registerOutput = registerOutput ?? (o => throw ExceptionUtilities.Unreachable());
+            _hashSetPool = _inputComparer == EqualityComparer<T>.Default
+                ? null
+                : PooledHashSet<T>.CreatePool(_inputComparer);
             _name = name;
         }
 
@@ -48,12 +52,7 @@ namespace Microsoft.CodeAnalysis
             TimeSpan elapsedTime = stopwatch.Elapsed;
 
             // create a mutable hashset of the new items we can check against
-            var itemsSet = (_inputComparer == EqualityComparer<T>.Default) ? PooledHashSet<T>.GetInstance() : new HashSet<T>(_inputComparer);
-
-#if NET
-            itemsSet.EnsureCapacity(inputItems.Length);
-#endif
-
+            var itemsSet = getPooledHashSet(inputItems.Length);
             foreach (var item in inputItems)
             {
                 var added = itemsSet.Add(item);
@@ -67,8 +66,14 @@ namespace Microsoft.CodeAnalysis
 
             if (previousTable is not null)
             {
-                // for each item in the previous table, check if its still in the new items
-                int itemIndex = 0;
+                // When the item count is unchanged, instead of Remove+Add we can modify the removed item
+                // with a newly added item instead. This keeps the table the same size and avoids unnecessary
+                // downstream invalidation. The list of replacement items is computed lazily on first need
+                // so that pure reorders and identical inputs skip the work entirely.
+                var canReplace = inputItems.Length == previousTable.Count;
+                ImmutableArray<T> replacements = default;
+                int replacementIndex = 0;
+
                 foreach (var (oldItem, _, _, _) in previousTable)
                 {
                     if (itemsSet.Remove(oldItem))
@@ -77,38 +82,80 @@ namespace Microsoft.CodeAnalysis
                         var usedCache = tableBuilder.TryUseCachedEntries(elapsedTime, noInputStepsStepInfo);
                         Debug.Assert(usedCache);
                     }
-                    else if (inputItems.Length == previousTable.Count)
+                    else if (canReplace)
                     {
-                        // When the number of items matches the previous iteration, we use a heuristic to mark the input as modified
-                        // This allows us to correctly 'replace' items even when they aren't actually the same. In the case that the
-                        // item really isn't modified, but a new item, we still function correctly as we mostly treat them the same,
-                        // but will perform an extra comparison that is omitted in the pure 'added' case.
-                        var modified = tableBuilder.TryModifyEntry(inputItems[itemIndex], elapsedTime, noInputStepsStepInfo, EntryState.Modified);
+                        if (replacements.IsDefault)
+                            replacements = getNewInputItems(inputItems, previousTable);
+
+                        // The old item was removed. Use the next pre-computed replacement to modify in place.
+                        var replacementItem = replacements[replacementIndex++];
+                        var removed = itemsSet.Remove(replacementItem);
+                        Debug.Assert(removed);
+
+                        var modified = tableBuilder.TryModifyEntry(replacementItem, elapsedTime, noInputStepsStepInfo, EntryState.Modified);
                         Debug.Assert(modified);
-                        itemsSet.Remove(inputItems[itemIndex]);
                     }
                     else
                     {
                         var removed = tableBuilder.TryRemoveEntries(elapsedTime, noInputStepsStepInfo);
                         Debug.Assert(removed);
                     }
-                    itemIndex++;
                 }
             }
 
-            // any remaining new items are added
+            // When the count is unchanged, every new item was consumed as either a cache hit or a
+            // replacement above, so itemsSet is empty and this loop is a no-op. Otherwise, any items
+            // remaining in itemsSet are genuinely new and need to be added.
+            Debug.Assert(previousTable is null || inputItems.Length != previousTable.Count || itemsSet.Count == 0);
             foreach (var newItem in itemsSet)
             {
                 tableBuilder.AddEntry(newItem, EntryState.Added, elapsedTime, noInputStepsStepInfo, EntryState.Added);
             }
+            itemsSet.Free();
 
             var newTable = tableBuilder.ToImmutableAndFree();
             this.LogTables(previousTable, newTable, inputItems);
 
-            (itemsSet as PooledHashSet<T>)?.Free();
-
             return newTable;
 
+            PooledHashSet<T> getPooledHashSet(int capacity)
+            {
+                var set = _hashSetPool?.Allocate() ?? PooledHashSet<T>.GetInstance();
+#if NET
+                set.EnsureCapacity(capacity);
+#endif
+                return set;
+            }
+
+            // Builds an array of new items (present in inputItems but not in the previous
+            // table) in input order. These are used to populate a modified replacement slot
+            // rather than a pair of add/remove entries.
+            ImmutableArray<T> getNewInputItems(ImmutableArray<T> inputs, NodeStateTable<T> previous)
+            {
+                var previousItemsSet = getPooledHashSet(previous.Count);
+                try
+                {
+                    foreach (var (item, _, _, _) in previous)
+                    {
+                        previousItemsSet.Add(item);
+                    }
+
+                    var builder = ArrayBuilder<T>.GetInstance();
+                    foreach (var item in inputs)
+                    {
+                        if (!previousItemsSet.Contains(item))
+                        {
+                            builder.Add(item);
+                        }
+                    }
+
+                    return builder.ToImmutableAndFree();
+                }
+                finally
+                {
+                    previousItemsSet.Free();
+                }
+            }
         }
 
         public IIncrementalGeneratorNode<T> WithComparer(IEqualityComparer<T> comparer) => new InputNode<T>(_getInput, _registerOutput, _inputComparer, comparer, _name);

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
@@ -23,27 +23,33 @@ namespace Microsoft.CodeAnalysis
 
         private readonly Func<DriverStateTable.Builder, ImmutableArray<T>> _getInput;
         private readonly Action<IIncrementalGeneratorOutputNode> _registerOutput;
-        private readonly IEqualityComparer<T> _inputComparer;
         private readonly IEqualityComparer<T>? _comparer;
         private readonly ObjectPool<PooledHashSet<T>>? _hashSetPool;
         private readonly string? _name;
 
         public InputNode(Func<DriverStateTable.Builder, ImmutableArray<T>> getInput, IEqualityComparer<T>? inputComparer = null)
-            : this(getInput, registerOutput: null, inputComparer: inputComparer, comparer: null)
+            : this(getInput, registerOutput: null, CreateHashSetPool(inputComparer), comparer: null)
         {
         }
 
-        private InputNode(Func<DriverStateTable.Builder, ImmutableArray<T>> getInput, Action<IIncrementalGeneratorOutputNode>? registerOutput, IEqualityComparer<T>? inputComparer = null, IEqualityComparer<T>? comparer = null, string? name = null)
+        private InputNode(
+            Func<DriverStateTable.Builder, ImmutableArray<T>> getInput,
+            Action<IIncrementalGeneratorOutputNode>? registerOutput,
+            ObjectPool<PooledHashSet<T>>? hashSetPool,
+            IEqualityComparer<T>? comparer = null,
+            string? name = null)
         {
             _getInput = getInput;
             _comparer = comparer;
-            _inputComparer = inputComparer ?? EqualityComparer<T>.Default;
             _registerOutput = registerOutput ?? (o => throw ExceptionUtilities.Unreachable());
-            _hashSetPool = _inputComparer == EqualityComparer<T>.Default
-                ? null
-                : PooledHashSet<T>.CreatePool(_inputComparer);
+            _hashSetPool = hashSetPool;
             _name = name;
         }
+
+        private static ObjectPool<PooledHashSet<T>>? CreateHashSetPool(IEqualityComparer<T>? inputComparer)
+            => inputComparer is null || inputComparer == EqualityComparer<T>.Default
+                ? null
+                : PooledHashSet<T>.CreatePool(inputComparer);
 
         public NodeStateTable<T> UpdateStateTable(DriverStateTable.Builder graphState, NodeStateTable<T>? previousTable, CancellationToken cancellationToken)
         {
@@ -133,36 +139,30 @@ namespace Microsoft.CodeAnalysis
             ImmutableArray<T> getNewInputItems(ImmutableArray<T> inputs, NodeStateTable<T> previous)
             {
                 var previousItemsSet = getPooledHashSet(previous.Count);
-                try
+                foreach (var (item, _, _, _) in previous)
                 {
-                    foreach (var (item, _, _, _) in previous)
-                    {
-                        previousItemsSet.Add(item);
-                    }
-
-                    var builder = ArrayBuilder<T>.GetInstance();
-                    foreach (var item in inputs)
-                    {
-                        if (!previousItemsSet.Contains(item))
-                        {
-                            builder.Add(item);
-                        }
-                    }
-
-                    return builder.ToImmutableAndFree();
+                    previousItemsSet.Add(item);
                 }
-                finally
+
+                var builder = ArrayBuilder<T>.GetInstance();
+                foreach (var item in inputs)
                 {
-                    previousItemsSet.Free();
+                    if (!previousItemsSet.Contains(item))
+                    {
+                        builder.Add(item);
+                    }
                 }
+
+                previousItemsSet.Free();
+                return builder.ToImmutableAndFree();
             }
         }
 
-        public IIncrementalGeneratorNode<T> WithComparer(IEqualityComparer<T> comparer) => new InputNode<T>(_getInput, _registerOutput, _inputComparer, comparer, _name);
+        public IIncrementalGeneratorNode<T> WithComparer(IEqualityComparer<T> comparer) => new InputNode<T>(_getInput, _registerOutput, _hashSetPool, comparer, _name);
 
-        public IIncrementalGeneratorNode<T> WithTrackingName(string name) => new InputNode<T>(_getInput, _registerOutput, _inputComparer, _comparer, name);
+        public IIncrementalGeneratorNode<T> WithTrackingName(string name) => new InputNode<T>(_getInput, _registerOutput, _hashSetPool, _comparer, name);
 
-        public InputNode<T> WithRegisterOutput(Action<IIncrementalGeneratorOutputNode> registerOutput) => new InputNode<T>(_getInput, registerOutput, _inputComparer, _comparer, _name);
+        public InputNode<T> WithRegisterOutput(Action<IIncrementalGeneratorOutputNode> registerOutput) => new InputNode<T>(_getInput, registerOutput, _hashSetPool, _comparer, _name);
 
         public void RegisterOutput(IIncrementalGeneratorOutputNode output) => _registerOutput(output);
 


### PR DESCRIPTION
When a set of inputs both changes *and* re-orders but maintains the same overall number of items, it's possible for the generator driver to incorrectly pick the same item twice when building the state table.
 
When the number of input items matches the previous run, the generator driver has an optimization whereby instead of issuing pairs of add/remove for the changed items, it replaces the removed item with the new item and marks it as modified. This allows better caching of downstream nodes and is a significant performance win.
 
The way the optimization works is by iterating the previous table. If an item in the previous table is present in the new input set, it is kept as cached. If it is not present in the new input set, it is replaced with a new item from the input set.
 
Previously, the new item was picked by keeping a pointer into the input array and using the item at that position when we found a removed slot. This is a valid strategy iff the input set *does not change order* at the same time.
 
When the input set also re-orders, it is not guaranteed that the item at the current position hasn't already been consumed to fill an earlier cached slot, meaning the same item can end up in the state table twice while the genuinely new item ends up zero times. Essentially the bug is that we were using set semantics for one set of operations and positional semantics for the other.
 
This PR fixes this by pre-computing the list of genuinely new items (those in the new input but not in the previous table). When encountering a removed slot, we pick the next item from this replacements list, knowing that it can't have been consumed by a cache hit.

Fix for https://github.com/dotnet/vscode-csharp/issues/9211
Supersedes https://github.com/dotnet/roslyn/pull/83720
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83878)