### PR TITLE
Add RazorCodeDocument.GetCSharpDocuments() returning multiple docs

### DIFF
--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeDocument.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeDocument.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -261,17 +262,35 @@ public sealed partial class RazorCodeDocument
         return new RazorCodeDocument(Source, Imports, ParserOptions, CodeGenerationOptions, _tagHelpers, _referencedTagHelpers, _syntaxTree, _tagHelperRewrittenSyntaxTree, _importSyntaxTrees, _tagHelperContext, value, _csharpDocument, _declCSharpDocument, _directiveTagHelperContributions);
     }
 
+    [Obsolete("Use GetCSharpDocuments instead; a RazorCodeDocument may now have multiple generated C# documents.")]
     internal bool TryGetCSharpDocument([NotNullWhen(true)] out RazorCSharpDocument? result)
     {
         result = _csharpDocument;
         return result is not null;
     }
 
+    [Obsolete("Use GetCSharpDocuments instead; a RazorCodeDocument may now have multiple generated C# documents.")]
     internal RazorCSharpDocument? GetCSharpDocument()
         => _csharpDocument;
 
+    [Obsolete("Use GetCSharpDocuments instead; a RazorCodeDocument may now have multiple generated C# documents.")]
     internal RazorCSharpDocument GetRequiredCSharpDocument()
         => _csharpDocument.AssumeNotNull();
+
+    internal ImmutableArray<RazorCSharpDocument> GetCSharpDocuments()
+    {
+        if (_csharpDocument is null)
+        {
+            return [];
+        }
+
+        if (_declCSharpDocument is not null)
+        {
+            return [_declCSharpDocument, _csharpDocument];
+        }
+
+        return [_csharpDocument];
+    }
 
     internal RazorCodeDocument WithCSharpDocument(RazorCSharpDocument value)
     {

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeDocument.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeDocument.cs
@@ -1,7 +1,6 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -262,18 +261,15 @@ public sealed partial class RazorCodeDocument
         return new RazorCodeDocument(Source, Imports, ParserOptions, CodeGenerationOptions, _tagHelpers, _referencedTagHelpers, _syntaxTree, _tagHelperRewrittenSyntaxTree, _importSyntaxTrees, _tagHelperContext, value, _csharpDocument, _declCSharpDocument, _directiveTagHelperContributions);
     }
 
-    [Obsolete("Use GetCSharpDocuments instead; a RazorCodeDocument may now have multiple generated C# documents.")]
     internal bool TryGetCSharpDocument([NotNullWhen(true)] out RazorCSharpDocument? result)
     {
         result = _csharpDocument;
         return result is not null;
     }
 
-    [Obsolete("Use GetCSharpDocuments instead; a RazorCodeDocument may now have multiple generated C# documents.")]
     internal RazorCSharpDocument? GetCSharpDocument()
         => _csharpDocument;
 
-    [Obsolete("Use GetCSharpDocuments instead; a RazorCodeDocument may now have multiple generated C# documents.")]
     internal RazorCSharpDocument GetRequiredCSharpDocument()
         => _csharpDocument.AssumeNotNull();
 

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/RazorSourceGenerator.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/RazorSourceGenerator.cs
@@ -91,7 +91,9 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 
                     var codeGen = projectEngine.Process(sourceItem, cancellationToken);
 
+#pragma warning disable CS0618 // The generator intentionally targets the single C# doc produced by the declaration-only engine.
                     var result = new SourceGeneratorText(codeGen.GetRequiredCSharpDocument().Text);
+#pragma warning restore CS0618
 
                     RazorSourceGeneratorEventSource.Log.GenerateDeclarationCodeStop(sourceItem.FilePath);
 
@@ -334,7 +336,9 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                     return (
                         hintName: GetIdentifierFromPath(filePath),
                         codeDocument: document.CodeDocument,
+#pragma warning disable CS0618 // The generator intentionally targets the main C# doc here; multi-doc emit will be wired up alongside the rest of the multi-doc generator changes.
                         csharpDocument: document.CodeDocument.GetRequiredCSharpDocument());
+#pragma warning restore CS0618
                 })
                 .WithLambdaComparer(static (a, b) =>
                 {

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/RazorSourceGenerator.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/RazorSourceGenerator.cs
@@ -91,9 +91,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 
                     var codeGen = projectEngine.Process(sourceItem, cancellationToken);
 
-#pragma warning disable CS0618 // The generator intentionally targets the single C# doc produced by the declaration-only engine.
                     var result = new SourceGeneratorText(codeGen.GetRequiredCSharpDocument().Text);
-#pragma warning restore CS0618
 
                     RazorSourceGeneratorEventSource.Log.GenerateDeclarationCodeStop(sourceItem.FilePath);
 
@@ -336,9 +334,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                     return (
                         hintName: GetIdentifierFromPath(filePath),
                         codeDocument: document.CodeDocument,
-#pragma warning disable CS0618 // The generator intentionally targets the main C# doc here; multi-doc emit will be wired up alongside the rest of the multi-doc generator changes.
                         csharpDocument: document.CodeDocument.GetRequiredCSharpDocument());
-#pragma warning restore CS0618
                 })
                 .WithLambdaComparer(static (a, b) =>
                 {


### PR DESCRIPTION
With the Sonic feature branch a single Razor document can produce more than one generated C# document (e.g. a decl doc alongside the main doc). The tooling today only ever expects a single matching C# file per Razor document, which will no longer be true.

This PR is a small **additive API change** that introduces the multi-doc accessor:

- Adds a new `internal ImmutableArray<RazorCSharpDocument> GetCSharpDocuments()` on `RazorCodeDocument`:
  - returns `[]` if no main C# doc has been generated yet
  - returns `[declDoc, mainDoc]` when a decl doc exists
  - returns `[mainDoc]` otherwise

Setters (`WithCSharpDocument`) and the decl-doc-specific accessors (`GetDeclCSharpDocument` / `WithDeclCSharpDocument`) are left untouched. The existing single-doc accessors (`TryGetCSharpDocument` / `GetCSharpDocument` / `GetRequiredCSharpDocument`) are also untouched in this PR.

### Why no `[Obsolete]` yet

An earlier revision of this PR marked the singletons `[Obsolete]` so the 41 stale tooling call sites would surface as warnings. That approach was dropped: it forced the IDE/tooling layer (`Razor.Workspaces`, `Razor.Test.Common`, microbench) to migrate *before* the compiler-side transition was in place, which conflicts with letting the compiler-side decl/impl-split work (3.x / 4 / 5) continue in parallel.

The intended sequence is:

1. **This PR** — additive: introduce `GetCSharpDocuments()`, no behaviour changes.
2. **Sonic 3.2+** — additive compiler change: emit decl + impl alongside the existing combined doc, switch compiler-internal callers to `GetCSharpDocuments()`. IDE remains on the legacy combined doc and keeps working.
3. **Follow-up PR** — re-apply `[Obsolete]` on the singleton accessors. Hand the warning list off to the IDE team.
4. **Final cleanup PR** — once the singleton callers are migrated, drop the obsolete APIs and stop emitting the legacy combined doc.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83881)