### PR TITLE
Fix service broker initializers to consistently be LSP services

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/BrokeredServices/ServiceBrokerFactory.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/BrokeredServices/ServiceBrokerFactory.cs
@@ -21,10 +21,10 @@ internal sealed class ServiceBrokerFactory : ILspService
     [ExportCSharpVisualBasicLspServiceFactory(typeof(ServiceBrokerFactory)), Shared]
     [method: ImportingConstructor]
     [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    private class ServiceBrokerFactoryFactory([ImportMany] IEnumerable<IServiceBrokerInitializer> onServiceBrokerInitialized,
-        ExportProvider exportProvider, ILoggerFactory loggerFactory) : ILspServiceFactory
+    private class ServiceBrokerFactoryFactory(ExportProvider exportProvider, ILoggerFactory loggerFactory) : ILspServiceFactory
     {
-        public ILspService CreateILspService(LspServices lspServices, WellKnownLspServerKinds serverKind) => new ServiceBrokerFactory(onServiceBrokerInitialized, exportProvider, loggerFactory);
+        public ILspService CreateILspService(LspServices lspServices, WellKnownLspServerKinds serverKind)
+            => new ServiceBrokerFactory(lspServices.GetRequiredServices<IServiceBrokerInitializer>(), exportProvider, loggerFactory);
     }
 
     private readonly ExportProvider _exportProvider;

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/DevKitProjectLoadingServiceContributor.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/DevKitProjectLoadingServiceContributor.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Composition;
 using Microsoft.CodeAnalysis.BrokeredServices;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CodeAnalysis.Remote.ProjectSystem;
 using Microsoft.Extensions.Logging;
 using Microsoft.ServiceHub.Framework;
@@ -20,12 +21,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
 /// Also creates the <see cref="ProjectInitializationHandler"/> with the actual service broker instance
 /// so it can subscribe to the remote project initialization status service.
 /// </summary>
-[Export(typeof(IServiceBrokerInitializer)), Shared]
+[ExportCSharpVisualBasicStatelessLspService(typeof(DevKitProjectLoadingServiceContributor)), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
 internal sealed class DevKitProjectLoadingServiceContributor(
     LanguageServerWorkspaceFactory workspaceFactory,
-    ILoggerFactory loggerFactory) : IServiceBrokerInitializer
+    ILoggerFactory loggerFactory) : IServiceBrokerInitializer, ILspService
 {
     public ImmutableDictionary<ServiceMoniker, ServiceRegistration> ServicesToRegister => new Dictionary<ServiceMoniker, ServiceRegistration>
     {

--- a/src/VisualStudio/DevKit/Impl/EditAndContinue/DevKitHotReloadServiceContributor.cs
+++ b/src/VisualStudio/DevKit/Impl/EditAndContinue/DevKitHotReloadServiceContributor.cs
@@ -5,12 +5,14 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.ComponentModel.Composition;
+using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.BrokeredServices;
 using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.Shell.ServiceBroker;
 using Microsoft.VisualStudio.Utilities.ServiceBroker;
@@ -21,12 +23,12 @@ namespace Microsoft.VisualStudio.LanguageServices.DevKit.EditAndContinue;
 /// Registers and proffers the <see cref="ManagedHotReloadLanguageService"/> brokered service
 /// into the Dev Kit <see cref="GlobalBrokeredServiceContainer"/> when the service broker is initialized.
 /// </summary>
-[Export(typeof(IServiceBrokerInitializer))]
+[ExportCSharpVisualBasicStatelessLspService(typeof(DevKitHotReloadServiceContributor)), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
 internal sealed class DevKitHotReloadServiceContributor(
     ManagedHotReloadLanguageServiceFactory factory,
-    SolutionSnapshotRegistry solutionSnapshotRegistry) : IServiceBrokerInitializer
+    SolutionSnapshotRegistry solutionSnapshotRegistry) : IServiceBrokerInitializer, ILspService
 {
     public ImmutableDictionary<ServiceMoniker, ServiceRegistration> ServicesToRegister => new Dictionary<ServiceMoniker, ServiceRegistration>
     {


### PR DESCRIPTION
I broke xaml hot reload in one service broker refactoring, as it exported its service broker initializer as an lsp service:
https://github.com/dotnet/roslyn/blob/b7144e3cd7866ace58811dee4643f6be69e2b8f5/src/LanguageServer/ExternalAccess/VisualDiagnostics/Internal/VisualDiagnosticsServiceFactory.cs#L25-L28

But the ServiceBrokerFactory imported them as normal MEF imports:
https://github.com/dotnet/roslyn/blob/b7144e3cd7866ace58811dee4643f6be69e2b8f5/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/BrokeredServices/ServiceBrokerFactory.cs#L24

This changes it so that all service broker initializers are LSP services.

<img width="2351" height="1160" alt="xaml_hot_reload_fix" src="https://github.com/user-attachments/assets/cbbf986f-b889-4a89-888e-8952157c967a" />


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83890)