### PR TITLE
Bump main to 5.9.0 / 18.9 (post-snap config)

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,7 +5,7 @@
   <!-- Roslyn version -->
   <PropertyGroup>
     <MajorVersion>5</MajorVersion>
-    <MinorVersion>8</MinorVersion>
+    <MinorVersion>9</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <PreReleaseVersionLabel>1</PreReleaseVersionLabel>
     <PreReleaseVersionLabel Condition="'$(DotNetSignType)' == 'test'">$(PreReleaseVersionLabel)-test</PreReleaseVersionLabel>
@@ -30,8 +30,8 @@
 
   <!-- Razor tooling version -->
   <PropertyGroup>
-    <RazorVsixVersionPrefix>18.8.1</RazorVsixVersionPrefix>
-    <RazorAddinMajorVersion>18.8</RazorAddinMajorVersion>
+    <RazorVsixVersionPrefix>18.9.1</RazorVsixVersionPrefix>
+    <RazorAddinMajorVersion>18.9</RazorAddinMajorVersion>
     <RazorAddinVersion>$(RazorAddinMajorVersion)</RazorAddinVersion>
     <RazorAddinVersion Condition="'$(OfficialBuildId)' != ''">$(RazorAddinVersion).$(OfficialBuildId)</RazorAddinVersion>
     <RazorAddinVersion Condition="'$(OfficialBuildId)' == ''">$(RazorAddinVersion).42424242.42</RazorAddinVersion>

--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -115,7 +115,7 @@
       "NonShipping"
     ],
     "vsBranch": "main",
-    "insertionCreateDraftPR": false,
-    "insertionTitlePrefix": "[Main 18.8]"
+    "insertionCreateDraftPR": true,
+    "insertionTitlePrefix": "[Main 18.9]"
   }
 }

--- a/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.sarif
+++ b/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.Analyzers",
-        "version": "5.8.0",
+        "version": "5.9.0",
         "language": "en-US"
       },
       "rules": {
@@ -724,7 +724,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.CSharp.Analyzers",
-        "version": "5.8.0",
+        "version": "5.9.0",
         "language": "en-US"
       },
       "rules": {
@@ -957,7 +957,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.VisualBasic.Analyzers",
-        "version": "5.8.0",
+        "version": "5.9.0",
         "language": "en-US"
       },
       "rules": {

--- a/src/RoslynAnalyzers/Microsoft.CodeAnalysis.BannedApiAnalyzers/Microsoft.CodeAnalysis.BannedApiAnalyzers.sarif
+++ b/src/RoslynAnalyzers/Microsoft.CodeAnalysis.BannedApiAnalyzers/Microsoft.CodeAnalysis.BannedApiAnalyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.BannedApiAnalyzers",
-        "version": "5.8.0",
+        "version": "5.9.0",
         "language": "en-US"
       },
       "rules": {
@@ -14,7 +14,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers",
-        "version": "5.8.0",
+        "version": "5.9.0",
         "language": "en-US"
       },
       "rules": {
@@ -77,7 +77,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.VisualBasic.BannedApiAnalyzers",
-        "version": "5.8.0",
+        "version": "5.9.0",
         "language": "en-US"
       },
       "rules": {

--- a/src/RoslynAnalyzers/PerformanceSensitiveAnalyzers/Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.sarif
+++ b/src/RoslynAnalyzers/PerformanceSensitiveAnalyzers/Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers",
-        "version": "5.8.0",
+        "version": "5.9.0",
         "language": "en-US"
       },
       "rules": {
@@ -184,7 +184,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers.CodeFixes",
-        "version": "5.8.0",
+        "version": "5.9.0",
         "language": "en-US"
       },
       "rules": {
@@ -193,7 +193,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers",
-        "version": "5.8.0",
+        "version": "5.9.0",
         "language": "en-US"
       },
       "rules": {

--- a/src/RoslynAnalyzers/PublicApiAnalyzers/Microsoft.CodeAnalysis.PublicApiAnalyzers.sarif
+++ b/src/RoslynAnalyzers/PublicApiAnalyzers/Microsoft.CodeAnalysis.PublicApiAnalyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.PublicApiAnalyzers",
-        "version": "5.8.0",
+        "version": "5.9.0",
         "language": "en-US"
       },
       "rules": {
@@ -460,7 +460,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.PublicApiAnalyzers.CodeFixes",
-        "version": "5.8.0",
+        "version": "5.9.0",
         "language": "en-US"
       },
       "rules": {

--- a/src/RoslynAnalyzers/Roslyn.Diagnostics.Analyzers/Roslyn.Diagnostics.Analyzers.sarif
+++ b/src/RoslynAnalyzers/Roslyn.Diagnostics.Analyzers/Roslyn.Diagnostics.Analyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Roslyn.Diagnostics.Analyzers",
-        "version": "5.8.0",
+        "version": "5.9.0",
         "language": "en-US"
       },
       "rules": {
@@ -208,7 +208,7 @@
     {
       "tool": {
         "name": "Roslyn.Diagnostics.CSharp.Analyzers",
-        "version": "5.8.0",
+        "version": "5.9.0",
         "language": "en-US"
       },
       "rules": {
@@ -351,7 +351,7 @@
     {
       "tool": {
         "name": "Roslyn.Diagnostics.VisualBasic.Analyzers",
-        "version": "5.8.0",
+        "version": "5.9.0",
         "language": "en-US"
       },
       "rules": {

--- a/src/RoslynAnalyzers/Text.Analyzers/Text.Analyzers.sarif
+++ b/src/RoslynAnalyzers/Text.Analyzers/Text.Analyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Humanizer",
-        "version": "5.8.0",
+        "version": "5.9.0",
         "language": "en-US"
       },
       "rules": {
@@ -14,7 +14,7 @@
     {
       "tool": {
         "name": "Text.Analyzers",
-        "version": "5.8.0",
+        "version": "5.9.0",
         "language": "en-US"
       },
       "rules": {
@@ -86,7 +86,7 @@
     {
       "tool": {
         "name": "Text.CSharp.Analyzers",
-        "version": "5.8.0",
+        "version": "5.9.0",
         "language": "en-US"
       },
       "rules": {
@@ -95,7 +95,7 @@
     {
       "tool": {
         "name": "Text.VisualBasic.Analyzers",
-        "version": "5.8.0",
+        "version": "5.9.0",
         "language": "en-US"
       },
       "rules": {


### PR DESCRIPTION
Auto-generated by snap skill.

Post-snap config updates for main after the VS 18.8 snap:

- Bump Roslyn version 5.8.0 -> 5.9.0
- Bump Razor VSIX 18.8 -> 18.9 (RazorVsixVersionPrefix, RazorAddinMajorVersion)
- Razor SDK (10.4) deferred until the next .NET 10.0.5xx SDK channel is created
- PublishData.json: `insertionTitlePrefix` -> `[Main 18.9]`, `insertionCreateDraftPR` -> `true` (insertions stay drafts until VS snaps)
- Bump version 5.8.0 -> 5.9.0 in all src/RoslynAnalyzers/**/*.sarif files
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83896)