### PR TITLE
Fix test scheduling underestimation for parameterized tests

### DIFF
--- a/src/Tools/RunTests/AssemblyInfo.cs
+++ b/src/Tools/RunTests/AssemblyInfo.cs
@@ -24,7 +24,7 @@ public readonly record struct TypeInfo(string Name, string FullyQualifiedName, I
     public override string ToString() => $"[Type]{FullyQualifiedName}";
 }
 
-public readonly record struct TestMethodInfo(string Name, string FullyQualifiedName, TimeSpan ExecutionTime)
+public readonly record struct TestMethodInfo(string Name, string FullyQualifiedName, TimeSpan ExecutionTime, bool HasAsyncLifetime)
 {
     public override string ToString() => $"[Method]{FullyQualifiedName}";
 }

--- a/src/Tools/RunTests/AssemblyScheduler.cs
+++ b/src/Tools/RunTests/AssemblyScheduler.cs
@@ -112,8 +112,10 @@ namespace RunTests
             TestMethodInfo WithTestExecutionTime(TestMethodInfo methodInfo)
             {
                 // Match by fully qualified test method name to azure devops historical data.
-                // Note for combinatorial tests, azure devops helpfully groups all sub-runs under a top level method (with combined test run times) with the same fully qualified method name
-                // that we get during test discovery.  Since we only filter by the single method name (and not individual combinatorial runs) we do want the combined execution time.
+                // Note for combinatorial tests, CleanTestName in TestHistoryManager strips
+                // parameter arguments and sums run times for all variants under the base
+                // method name.  Since we only filter by the single method name (and not
+                // individual combinatorial runs) we do want the combined execution time.
                 if (testHistory.TryGetValue(methodInfo.FullyQualifiedName, out var executionTime))
                 {
                     matchedRemoteTests.Add(methodInfo.FullyQualifiedName);

--- a/src/Tools/RunTests/AssemblyScheduler.cs
+++ b/src/Tools/RunTests/AssemblyScheduler.cs
@@ -26,7 +26,7 @@ namespace RunTests
 
         public static ImmutableArray<HelixWorkItem> Schedule(
             IEnumerable<string> assemblyFilePaths,
-            ImmutableDictionary<string, TimeSpan> testHistory)
+            ImmutableDictionary<string, (TimeSpan Duration, int TestTheoryInstances)> testHistory)
         {
             var orderedTypeInfos = assemblyFilePaths.ToImmutableSortedDictionary(x => x, GetTypeInfoList);
             ConsoleUtil.WriteLine($"Scheduling {orderedTypeInfos.Count} assemblies");
@@ -67,16 +67,16 @@ namespace RunTests
             return workItems;
         }
 
-        private static void LogLongTests(ImmutableDictionary<string, TimeSpan> testHistory)
+        private static void LogLongTests(ImmutableDictionary<string, (TimeSpan Duration, int TestTheoryInstances)> testHistory)
         {
             var longTests = testHistory
-                .Where(kvp => kvp.Value > HelixTestRunner.WorkItemScheduleTime)
+                .Where(kvp => kvp.Value.Duration > HelixTestRunner.WorkItemScheduleTime)
                 .OrderBy(kvp => kvp.Key)
                 .ToList();
             if (longTests.Count > 0)
             {
                 ConsoleUtil.Warning($"There are {longTests.Count} tests have execution times greater than the maximum execution time of {HelixTestRunner.WorkItemScheduleTime:hh\\:mm\\:ss}.  These tests will be scheduled in their own individual work items and may indicate tests that should be optimized or removed if they are no longer providing value.");
-                foreach (var (test, time) in longTests)
+                foreach (var (test, (time, _)) in longTests)
                 {
                     ConsoleUtil.WriteLine($"\t{test} - {time:hh\\:mm\\:ss}");
                 }
@@ -85,10 +85,16 @@ namespace RunTests
 
         private static ImmutableSortedDictionary<string, ImmutableArray<TypeInfo>> UpdateTestsWithExecutionTimes(
             ImmutableSortedDictionary<string, ImmutableArray<TypeInfo>> assemblyTypes,
-            ImmutableDictionary<string, TimeSpan> testHistory)
+            ImmutableDictionary<string, (TimeSpan Duration, int TestTheoryInstances)> testHistory)
         {
+            // In xUnit v2, the ExecutionTimer in TestInvoker does NOT include IAsyncLifetime
+            // .InitializeAsync() or .DisposeAsync() in DurationInMs. Test base classes that
+            // perform expensive per-test async setup/teardown (MEF composition, workspace creation)
+            // will have overhead not reflected in the reported duration. We add an empirical
+            // adjustment per test theory instance for tests whose class implements IAsyncLifetime.
+
             // Determine the average execution time so that we can use it for tests that do not have any history.
-            var averageExecutionTime = TimeSpan.FromMilliseconds(testHistory.Values.Average(t => t.TotalMilliseconds));
+            var averageExecutionTime = TimeSpan.FromMilliseconds(testHistory.Values.Average(t => t.Duration.TotalMilliseconds));
 
             // Store the tests we found locally that were missing remote historical data.
             var unmatchedLocalTests = new HashSet<string>();
@@ -113,12 +119,21 @@ namespace RunTests
             {
                 // Match by fully qualified test method name to azure devops historical data.
                 // Note for combinatorial tests, CleanTestName in TestHistoryManager strips
-                // parameter arguments and sums run times for all variants under the base
+                // parameter arguments and sums run times for all instances under the base
                 // method name.  Since we only filter by the single method name (and not
                 // individual combinatorial runs) we do want the combined execution time.
-                if (testHistory.TryGetValue(methodInfo.FullyQualifiedName, out var executionTime))
+                if (testHistory.TryGetValue(methodInfo.FullyQualifiedName, out var historyEntry))
                 {
                     matchedRemoteTests.Add(methodInfo.FullyQualifiedName);
+                    var executionTime = historyEntry.Duration;
+
+                    // If the test class implements IAsyncLifetime, add overhead per theory instance
+                    // to account for InitializeAsync/DisposeAsync time not captured in DurationInMs.
+                    if (methodInfo.HasAsyncLifetime)
+                    {
+                        executionTime += TimeSpan.FromMilliseconds(historyEntry.TestTheoryInstances * HelixTestRunner.AsyncLifetimeInstanceOverhead.TotalMilliseconds);
+                    }
+
                     return methodInfo with { ExecutionTime = executionTime };
                 }
 
@@ -247,14 +262,17 @@ namespace RunTests
                 throw new ArgumentException($"{testListPath} does not exist");
             }
 
-            var deserialized = JsonSerializer.Deserialize<List<string>>(File.ReadAllText(testListPath));
-            if (deserialized == null)
+            var deserialized = JsonSerializer.Deserialize<List<TestDiscoveryEntry>>(File.ReadAllText(testListPath));
+            if (deserialized is null)
             {
                 throw new InvalidOperationException($"Could not deserialize {testListPath}");
             }
 
-            var tests = deserialized.GroupBy(GetTypeName)
-                .Select(group => new TypeInfo(GetName(group.Key), group.Key, group.Select(test => new TestMethodInfo(GetName(test), test, TimeSpan.Zero)).ToImmutableArray()))
+            var tests = deserialized.GroupBy(e => GetTypeName(e.MethodName!))
+                .Select(group => new TypeInfo(
+                    GetName(group.Key),
+                    group.Key,
+                    group.Select(e => new TestMethodInfo(GetName(e.MethodName!), e.MethodName!, TimeSpan.Zero, e.HasAsyncLifetime)).ToImmutableArray()))
                 .ToImmutableArray();
             return tests;
 
@@ -269,6 +287,12 @@ namespace RunTests
                 var lastPeriod = fullyQualifiedName.LastIndexOf(".");
                 return fullyQualifiedName[(lastPeriod + 1)..];
             }
+        }
+
+        private sealed class TestDiscoveryEntry
+        {
+            public string? MethodName { get; set; }
+            public bool HasAsyncLifetime { get; set; }
         }
 
         /// <summary>

--- a/src/Tools/RunTests/HelixTestRunner.cs
+++ b/src/Tools/RunTests/HelixTestRunner.cs
@@ -45,6 +45,13 @@ internal sealed partial class HelixTestRunner
     internal static TimeSpan WorkItemScheduleTime { get; } = TimeSpan.FromMinutes(10);
 
     /// <summary>
+    /// In xUnit v2, IAsyncLifetime.InitializeAsync and DisposeAsync are not included in the
+    /// reported test duration (DurationInMs). This is the per-theory-instance overhead adjustment
+    /// applied to tests whose class implements IAsyncLifetime.
+    /// </summary>
+    internal static TimeSpan AsyncLifetimeInstanceOverhead { get; } = TimeSpan.FromMilliseconds(700);
+
+    /// <summary>
     /// This is the amount of time we will wait for a helix work item to complete before we consider it a severe error
     /// and cancel the helix job entirely.
     /// </summary>

--- a/src/Tools/RunTests/TestHistoryManager.cs
+++ b/src/Tools/RunTests/TestHistoryManager.cs
@@ -95,7 +95,6 @@ internal class TestHistoryManager
         var totalTests = runForThisStage.TotalTests;
 
         Dictionary<string, TimeSpan> testInfos = new();
-        var duplicateCount = 0;
 
         // Get runtimes for all tests.
         var timer = new Stopwatch();
@@ -113,26 +112,24 @@ internal class TestHistoryManager
                 }
 
                 var testName = CleanTestName(testResult.AutomatedTestName);
+                var duration = TimeSpan.FromMilliseconds(testResult.DurationInMs);
 
-                if (!testInfos.TryAdd(testName, TimeSpan.FromMilliseconds(testResult.DurationInMs)))
+                // CleanTestName strips parameterized arguments, so multiple AzDO results
+                // (one per parameter combination) map to the same base method name. We need
+                // to sum their durations because vstest runs every variant when filtered by
+                // the base method name.
+                if (testInfos.TryGetValue(testName, out var existing))
                 {
-                    // We can get duplicate tests if a test file is included in multiple assemblies (e.g. analyzer codestyle tests).
-                    // This is fine, we'll just use capture one of the run times since it is the same test being run in both cases and unlikely to have different run times.
-                    //
-                    // Another case that can happen is if a test is incorrectly authored to have the same name and namespace as a test in another assembly.  For example
-                    // a test that applies to both VB and C#, but the tests in both the C# and VB assembly accidentally use the C# namespace.
-                    // It may have a different run time, but ADO does not let us differentiate by assembly name, so we just have to pick one.
-                    duplicateCount++;
+                    testInfos[testName] = existing + duration;
+                }
+                else
+                {
+                    testInfos[testName] = duration;
                 }
             }
         }
 
         timer.Stop();
-
-        if (duplicateCount > 0)
-        {
-            Logger.Log($"Found {duplicateCount} duplicate tests in run {runForThisStage.Name}.");
-        }
 
         var totalTestRuntime = TimeSpan.FromMilliseconds(testInfos.Values.Sum(t => t.TotalMilliseconds));
         ConsoleUtil.WriteLine($"Retrieved {testInfos.Keys.Count} tests from AzureDevops in {timer.Elapsed}.  Total runtime of all tests is {totalTestRuntime}");

--- a/src/Tools/RunTests/TestHistoryManager.cs
+++ b/src/Tools/RunTests/TestHistoryManager.cs
@@ -25,9 +25,13 @@ internal class TestHistoryManager
 
     /// <summary>
     /// Looks up the last passing test run for the current build and stage to estimate execution times for each
-    /// tests. The dictionary is indexed by test full name.
+    /// tests. The dictionary is indexed by test full name and contains the body duration and theory instance count.
+    ///
+    /// Note: the duration returned is the sum of body execution times (DurationInMs) as reported by xUnit.
+    /// In xUnit v2, DurationInMs does NOT include IAsyncLifetime.InitializeAsync or DisposeAsync time.
+    /// The caller is responsible for adjusting the duration based on the HasAsyncLifetime flag from test discovery.
     /// </summary>
-    public static async Task<ImmutableDictionary<string, TimeSpan>> GetTestHistoryAsync(Options options, CancellationToken cancellationToken)
+    public static async Task<ImmutableDictionary<string, (TimeSpan Duration, int TestTheoryInstances)>> GetTestHistoryAsync(Options options, CancellationToken cancellationToken)
     {
         // Access token that has permissions to lookup test history.  This typically comes from the pipeline.
         var accessToken = options.AccessToken ?? GetEnvironmentVariable("SYSTEM_ACCESSTOKEN");
@@ -52,7 +56,7 @@ internal class TestHistoryManager
         if (string.IsNullOrEmpty(accessToken) || string.IsNullOrEmpty(projectUri) || string.IsNullOrEmpty(phaseName) || string.IsNullOrEmpty(targetBranch) || !int.TryParse(pipelineDefinitionIdStr, out var pipelineDefinitionId))
         {
             ConsoleUtil.Warning($"Missing required options to lookup test history, projectUri={projectUri}, phaseName={phaseName}, targetBranchName={targetBranch}, pipelineDefinitionId={pipelineDefinitionIdStr}");
-            return ImmutableDictionary<string, TimeSpan>.Empty;
+            return ImmutableDictionary<string, (TimeSpan Duration, int TestTheoryInstances)>.Empty;
         }
 
         var credentials = new Microsoft.VisualStudio.Services.Common.VssBasicCredential(string.Empty, accessToken);
@@ -78,7 +82,7 @@ internal class TestHistoryManager
         {
             // If this is a new branch we may not have any historical data for it.
             ConsoleUtil.Warning($"Unable to get the last successful build for definition {pipelineDefinitionId} in {projectUri} and branch {targetBranch}");
-            return ImmutableDictionary<string, TimeSpan>.Empty;
+            return ImmutableDictionary<string, (TimeSpan Duration, int TestTheoryInstances)>.Empty;
         }
 
         using var testClient = connection.GetClient<TestResultsHttpClient>();
@@ -87,14 +91,14 @@ internal class TestHistoryManager
         {
             // If this is a new stage, historical runs will not have any data for it.
             ConsoleUtil.Warning($"Unable to get a run with name {phaseName} from build {lastSuccessfulBuild.Url}.");
-            return ImmutableDictionary<string, TimeSpan>.Empty;
+            return ImmutableDictionary<string, (TimeSpan Duration, int TestTheoryInstances)>.Empty;
         }
 
         ConsoleUtil.WriteLine($"Looking up test execution data for build {lastSuccessfulBuild.Id} on branch {targetBranch} and stage {phaseName}");
 
         var totalTests = runForThisStage.TotalTests;
 
-        Dictionary<string, TimeSpan> testInfos = new();
+        Dictionary<string, (TimeSpan Duration, int TestTheoryInstances)> testInfos = new();
 
         // Get runtimes for all tests.
         var timer = new Stopwatch();
@@ -116,22 +120,22 @@ internal class TestHistoryManager
 
                 // CleanTestName strips parameterized arguments, so multiple AzDO results
                 // (one per parameter combination) map to the same base method name. We need
-                // to sum their durations because vstest runs every variant when filtered by
-                // the base method name.
+                // to sum their durations and count theory instances because vstest runs every instance
+                // when filtered by the base method name.
                 if (testInfos.TryGetValue(testName, out var existing))
                 {
-                    testInfos[testName] = existing + duration;
+                    testInfos[testName] = (existing.Duration + duration, existing.TestTheoryInstances + 1);
                 }
                 else
                 {
-                    testInfos[testName] = duration;
+                    testInfos[testName] = (duration, 1);
                 }
             }
         }
 
         timer.Stop();
 
-        var totalTestRuntime = TimeSpan.FromMilliseconds(testInfos.Values.Sum(t => t.TotalMilliseconds));
+        var totalTestRuntime = TimeSpan.FromMilliseconds(testInfos.Values.Sum(t => t.Duration.TotalMilliseconds));
         ConsoleUtil.WriteLine($"Retrieved {testInfos.Keys.Count} tests from AzureDevops in {timer.Elapsed}.  Total runtime of all tests is {totalTestRuntime}");
         return testInfos.ToImmutableDictionary();
     }

--- a/src/Tools/TestDiscoveryWorker/Program.cs
+++ b/src/Tools/TestDiscoveryWorker/Program.cs
@@ -77,10 +77,11 @@ try
                 messageSink: sink,
                 discoveryOptions: TestFrameworkOptions.ForDiscovery(configuration));
 
-    var testsToWrite = new HashSet<string>();
-    await foreach (var fullyQualifiedName in sink.GetTestCaseNamesAsync().ConfigureAwait(false))
+    var testsToWrite = new Dictionary<string, bool>();
+    await foreach (var (fullyQualifiedName, hasAsyncLifetime) in sink.GetTestCaseInfosAsync().ConfigureAwait(false))
     {
-        testsToWrite.Add(fullyQualifiedName);
+        if (!testsToWrite.ContainsKey(fullyQualifiedName))
+            testsToWrite[fullyQualifiedName] = hasAsyncLifetime;
     }
 
     if (sink.AnyWriteFailures)
@@ -91,8 +92,12 @@ try
 
     Console.WriteLine($"{testsToWrite.Count} found");
 
+    var testInfos = testsToWrite
+        .OrderBy(x => x.Key)
+        .Select(x => new TestInfo(x.Key, x.Value))
+        .ToArray();
     using var fileStream = new FileStream(outputFilePath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None);
-    await JsonSerializer.SerializeAsync(fileStream, testsToWrite.OrderBy(x => x)).ConfigureAwait(false);
+    await JsonSerializer.SerializeAsync(fileStream, testInfos).ConfigureAwait(false);
     return ExitSuccess;
 }
 catch (OptionException e)
@@ -108,18 +113,33 @@ catch (Exception ex)
     return ExitFailure;
 }
 
+file class TestInfo
+{
+    public string MethodName { get; set; } = "";
+    public bool HasAsyncLifetime { get; set; }
+
+    public TestInfo() { }
+
+    public TestInfo(string methodName, bool hasAsyncLifetime)
+    {
+        MethodName = methodName;
+        HasAsyncLifetime = hasAsyncLifetime;
+    }
+}
+
 file class Sink : IMessageSink
 {
     public bool AnyWriteFailures { get; private set; }
 
     public Sink()
     {
-        _channel = Channel.CreateUnbounded<string>();
+        _channel = Channel.CreateUnbounded<(string FullName, bool HasAsyncLifetime)>();
     }
 
-    private readonly Channel<string> _channel;
+    private readonly Channel<(string FullName, bool HasAsyncLifetime)> _channel;
+    private readonly Dictionary<string, bool> _asyncLifetimeCache = new();
 
-    public async IAsyncEnumerable<string> GetTestCaseNamesAsync()
+    public async IAsyncEnumerable<(string FullName, bool HasAsyncLifetime)> GetTestCaseInfosAsync()
     {
         while (await _channel.Reader.WaitToReadAsync(CancellationToken.None).ConfigureAwait(false))
         {
@@ -147,12 +167,26 @@ file class Sink : IMessageSink
 
     private void OnTestDiscovered(ITestCaseDiscoveryMessage testCaseDiscovered)
     {
-        var fullName = $"{testCaseDiscovered.TestCase.TestMethod.TestClass.Class.Name}.{testCaseDiscovered.TestCase.TestMethod.Method.Name}";
+        var testClass = testCaseDiscovered.TestCase.TestMethod.TestClass.Class;
+        var fullName = $"{testClass.Name}.{testCaseDiscovered.TestCase.TestMethod.Method.Name}";
+        var hasAsyncLifetime = HasAsyncLifetime(testClass);
+
         // this shouldn't happen as our channel is unbounded but we are Paranoid Coding™️
-        if (!_channel.Writer.TryWrite(fullName))
+        if (!_channel.Writer.TryWrite((fullName, hasAsyncLifetime)))
         {
             AnyWriteFailures = true;
         }
+    }
+
+    private bool HasAsyncLifetime(ITypeInfo typeInfo)
+    {
+        var typeName = typeInfo.Name;
+        if (_asyncLifetimeCache.TryGetValue(typeName, out var cached))
+            return cached;
+
+        var result = typeInfo.Interfaces.Any(i => i.Name == "Xunit.IAsyncLifetime");
+        _asyncLifetimeCache[typeName] = result;
+        return result;
     }
 }
 


### PR DESCRIPTION
CleanTestName strips parameter arguments, collapsing all parameterized variants to the base method name. However TryAdd only stored the first variant's duration and discarded the rest as "duplicates." This caused the scheduler to underestimate execution time by Nx (where N is the number of parameter combinations), packing far too many tests into a single work item.

Fix by summing durations for all variants that map to the same base method name, which matches the actual vstest behavior when filtering by the base name.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83897)