### PR TITLE
Unions: `not` pattern is applied to the incoming value itself

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -476,11 +476,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool hasErrors,
             BindingDiagnosticBag diagnostics)
         {
-            // Note that these labels are for the convenience of the compilation of patterns, and are not necessarily emitted into the lowered code.
-            LabelSymbol whenTrueLabel = new GeneratedLabelSymbol("isPatternSuccess");
-            LabelSymbol whenFalseLabel = new GeneratedLabelSymbol("isPatternFailure");
-
             bool negated = pattern.IsNegated(out var innerPattern);
+
+            // Note that these labels are for the convenience of the compilation of patterns, and are not necessarily emitted into the lowered code.
+            LabelSymbol whenTrueLabel = new GeneratedLabelSymbol(negated ? "isPatternFailure" : "isPatternSuccess");
+            LabelSymbol whenFalseLabel = new GeneratedLabelSymbol(negated ? "isPatternSuccess" : "isPatternFailure");
+
             BoundDecisionDag decisionDag = DecisionDagBuilder.CreateDecisionDagForIsPattern(
                 this.Compilation, pattern.Syntax, expression, innerPattern, hasUnionMatching, whenTrueLabel: whenTrueLabel, whenFalseLabel: whenFalseLabel, diagnostics);
 
@@ -2407,27 +2408,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool underIsPattern,
             out bool hasUnionMatching)
         {
-            NamedTypeSymbol? unionMatchingInputType = PrepareForUnionMatchingIfAppropriateAndReturnUnionMatchingInputType(node, ref inputType, ref unionType, diagnostics);
-            bool isUnionMatching = unionMatchingInputType is not null;
-
-            if (unionMatchingInputType is not null && (unionMatchingInputType.TypeKind != TypeKind.Struct || unionMatchingInputType.IsNullableType()))
-            {
-                // When we are not 'underIsPattern', we don't 'permitDesignations'. See an assignment and a comment below.
-                // Only 'BindIsPatternExpression' passes true for 'underIsPattern' and only 'BindUnaryPattern' propagates it. 
-                // Since we are doing Union matching, we are effectively in a sub-pattern, thus we are not directly under
-                // "is pattern", but we can still make things work for struct types (excluding Nullable<T>), because they
-                // do not have an implicit null check for the Union instance itself.
-                // The effect of this logic can be observed in unit-tests 'UnionMatching_15_Negated' and 'UnionMatching_16_Negated', for example.   
-                underIsPattern = false;
-            }
-
             MessageID.IDS_FeatureNotPattern.CheckFeatureAvailability(diagnostics, node.OperatorToken);
 
             bool permitDesignations = underIsPattern; // prevent designators under 'not' except under an is-pattern
             NamedTypeSymbol? currentUnionType = unionType;
             var subPattern = BindPattern(node.Pattern, ref currentUnionType, inputType, permitDesignations, hasErrors, diagnostics, out hasUnionMatching, underIsPattern);
-            hasUnionMatching |= isUnionMatching;
-            return new BoundNegatedPattern(node, subPattern, isUnionMatching: isUnionMatching, inputType: unionMatchingInputType ?? inputType, narrowedType: inputType, hasErrors);
+            return new BoundNegatedPattern(node, subPattern, inputType: inputType, narrowedType: inputType, hasErrors);
         }
 
         private BoundPattern BindBinaryPattern(

--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder_CheckOrReachability.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder_CheckOrReachability.cs
@@ -367,7 +367,7 @@ start:
                 // but our method for detecting redundancies only detects those in `or` cases (which we bring to the top after normalization).
                 // By analyzing `not A` too we can report more redundancies.
                 // For example: `if (o is not (<any pattern including a redundancy>))`, `if (i is 42 and not 43)` (which is the negation of `not 42 or 43`)
-                var negated = new BoundNegatedPattern(pattern.Syntax, negated: pattern, isUnionMatching: false, pattern.InputType, narrowedType: pattern.InputType);
+                var negated = new BoundNegatedPattern(pattern.Syntax, negated: pattern, pattern.InputType, narrowedType: pattern.InputType);
                 var normalizedNegatedPattern = PatternNormalizer.Rewrite(negated, rootIdentifier.Type);
 
 #if ROSLYN_TEST_REDUNDANT_PATTERN
@@ -937,7 +937,7 @@ start:
                     return negated;
                 }
 
-                var result = new BoundNegatedPattern(node.Syntax, node, isUnionMatching: false, node.InputType, narrowedType: node.InputType);
+                var result = new BoundNegatedPattern(node.Syntax, node, node.InputType, narrowedType: node.InputType);
                 if (node.WasCompilerGenerated)
                 {
                     result.MakeCompilerGenerated();
@@ -1008,7 +1008,7 @@ start:
                 {
                     return negatedPattern.Update(
                         WithInputTypeCheckIfNeeded(negatedPattern.Negated, inputType),
-                        isUnionMatching: false, inputType, inputType);
+                        inputType, inputType);
                 }
 
                 if (pattern is BoundConstantPattern constantPattern)
@@ -1097,7 +1097,7 @@ start:
                     var nullCheck = new BoundConstantPattern(node.Syntax,
                         new BoundLiteral(node.Syntax, constantValueOpt: ConstantValue.Null, type: node.InputType, hasErrors: false),
                         ConstantValue.Null, isUnionMatching: false, node.InputType, node.InputType, hasErrors: false);
-                    initialCheck = new BoundNegatedPattern(node.Syntax, nullCheck, isUnionMatching: false, node.InputType, narrowedType: node.InputType);
+                    initialCheck = new BoundNegatedPattern(node.Syntax, nullCheck, node.InputType, narrowedType: node.InputType);
                 }
                 else
                 {

--- a/src/Compilers/CSharp/Portable/Binder/UnionMatchingRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UnionMatchingRewriter.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     return new BoundBinaryPattern(
                         node.Syntax, disjunction: true,
-                        left: node.Update(node.Value, node.ConstantValue, isUnionMatching: false, node.InputType, node.InputType),
+                        left: node.Update(node.Value, node.ConstantValue, isUnionMatching: false, node.InputType, node.InputType).MakeCompilerGenerated(),
                         right: RewritePatternWithUnionMatchingToPropertyPattern(underlyingValueMatching),
                         inputType: node.InputType,
                         narrowedType: node.InputType)
@@ -197,18 +197,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitNegatedPattern(BoundNegatedPattern node)
         {
+            Debug.Assert(!node.IsUnionMatching);
             BoundPattern negated = RewritePatternWithUnionMatchingToPropertyPattern((BoundPattern)this.Visit(node.Negated));
-            TypeSymbol? inputType = node.InputType;
-            TypeSymbol? narrowedType = node.NarrowedType;
-
-            if (node.IsUnionMatching)
-            {
-                return CreatePatternWithUnionMatching(
-                    (NamedTypeSymbol)node.InputType,
-                    node.Update(negated, isUnionMatching: false, inputType: ObjectType, narrowedType));
-            }
-
-            return node.Update(negated, isUnionMatching: false, inputType, narrowedType);
+            return node.Update(negated, node.InputType, node.NarrowedType);
         }
 
         public override BoundNode? VisitSlicePattern(BoundSlicePattern node)

--- a/src/Compilers/CSharp/Portable/Binder/UnionMatchingRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UnionMatchingRewriter.cs
@@ -25,8 +25,6 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// 
     /// A pattern 'unionTypeInstance is int^' is transformed to 'unionTypeInstance is { Value: int }'.
     /// 
-    /// A pattern 'unionTypeInstance is not^(int or string)' is transformed to 'unionTypeInstance is { Value: not (int or string) }'.
-    ///
     /// A pattern 'unionTypeInstance is int^ or string^' is transformed to 'unionTypeInstance is { Value: int } or { Value: string }'.
     ///
     /// A pattern 'unionTypeInstance is int^ and 15 or string^' is transformed to 'unionTypeInstance is { Value: int and 15 } or { Value: string }'.

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNegatedPattern.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNegatedPattern.cs
@@ -11,18 +11,10 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         private partial void Validate()
         {
-            if (IsUnionMatching)
-            {
-                Debug.Assert(NarrowedType.IsObjectType());
-                Debug.Assert(Negated.InputType.IsObjectType());
-            }
-            else
-            {
-                Debug.Assert(NarrowedType.Equals(InputType, TypeCompareKind.AllIgnoreOptions));
-                Debug.Assert(Negated.InputType.Equals(InputType, TypeCompareKind.AllIgnoreOptions));
-            }
-
+            Debug.Assert(NarrowedType.Equals(InputType, TypeCompareKind.AllIgnoreOptions));
+            Debug.Assert(Negated.InputType.Equals(InputType, TypeCompareKind.AllIgnoreOptions));
             Debug.Assert(Negated is not BoundPatternWithUnionMatching);
+            Debug.Assert(!IsUnionMatching);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -2601,10 +2601,9 @@
     <Field Name="Right" Type="BoundPattern"/>
   </Node>
 
-  <!-- NarrowedType is 'object' for Union matching, and the InputType otherwise -->
+  <!-- NarrowedType is the InputType -->
   <Node Name="BoundNegatedPattern" Base="BoundPattern" HasValidate="true">
     <Field Name="Negated" Type="BoundPattern"/>
-    <Field Name="IsUnionMatching" Type="bool" PropertyOverrides="true"/>
   </Node>
 
   <!-- 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundPattern.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundPattern.cs
@@ -19,17 +19,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             innerPattern = this;
             bool negated = false;
 
-            if (innerPattern is BoundNegatedPattern { IsUnionMatching: true })
-            {
-                // This node doesn't represent a negation at the top level, it really represents a negation
-                // in a property sub-pattern. Therefore, doing a semantically equivalent unwrapping for such
-                // BoundNegatedPattern isn't trivial since we need to preserve the "union matching" piece stored
-                // in the node, probably by rewriting innerPattern.Negated.
-                // Bottom line, this will not be a trivial unwrapping. Since the unwrapping is not necessary for
-                // correctness, we simply don't do it.
-                return negated;
-            }
-
             while (innerPattern is BoundNegatedPattern negatedPattern)
             {
                 Debug.Assert(!negatedPattern.IsUnionMatching);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -931,54 +931,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool negated = node.Pattern.IsNegated(out var pattern);
             Debug.Assert(negated == node.IsNegated);
 
-            // Note that 'IsNegated' helper used above doesn't unwrap a negation utilizing a Union matchig.
-            // A comment in 'IsNegated' explains why.
-            // However, for the purposes of this component we have to do the unwrapping because
-            // 'DefiniteAssignmentPass.VisitPattern' never considers pattern locals under 'NegatedPattern'
-            // as definitely assigned. In this particular situation, when we are dealing with a struct
-            // Union type, they should be considered definitely assigned. Therefore, we perform a semantically
-            // equivalent rewrite, first by rewriting to a recursive pattern, and then by pulling negation out
-            // of the sub-pattern. In this situation a pattern '{Value: not (...) }' is equivalent to a pattern
-            // 'not {Value:  (...) }'  
-            if (node.HasUnionMatching &&
-                pattern is BoundNegatedPattern { IsUnionMatching: true } &&
-                UnionMatchingRewriter.Rewrite(compilation, pattern) is BoundRecursivePattern
-                {
-                    WasCompilerGenerated: true,
-                    DeclaredType: null,
-                    InputType: NamedTypeSymbol { TypeKind: TypeKind.Struct, IsUnionType: true } inputType,
-                    DeconstructMethod: null,
-                    Deconstruction: { IsDefault: true },
-                    Properties:
-                        [
-                        {
-                            Pattern: { } nestedPattern,
-                            Member:
-                            { Type.SpecialType: SpecialType.System_Object, Symbol: var possibleUnionValueSymbol } and
-                            ({ Symbol: PropertySymbol { Name: WellKnownMemberNames.ValuePropertyName } } or { Symbol: null, HasErrors: true })
-                        } propertySubpattern
-                        ],
-                    Variable: null,
-                    VariableAccess: null,
-                    IsUnionMatching: false,
-                } rewritten &&
-                (possibleUnionValueSymbol is null || Binder.IsUnionTypeValueProperty(inputType, possibleUnionValueSymbol)))
-            {
-                Debug.Assert(!inputType.IsNullableType());
-                Debug.Assert(!negated);
-
-                negated ^= nestedPattern.IsNegated(out var negatedNestedPattern);
-
-                if (nestedPattern != negatedNestedPattern)
-                {
-                    pattern = rewritten.Update(
-                        rewritten.DeclaredType, rewritten.DeconstructMethod, rewritten.Deconstruction,
-                        [propertySubpattern.Update(propertySubpattern.Member, propertySubpattern.IsLengthOrCount, negatedNestedPattern)],
-                        rewritten.IsExplicitNotNullTest, rewritten.Variable, rewritten.VariableAccess, rewritten.IsUnionMatching,
-                        rewritten.InputType, rewritten.NarrowedType);
-                }
-            }
-
             if (VisitPossibleConditionalAccess(node.Expression, out var stateWhenNotNull))
             {
                 Debug.Assert(!IsConditionalState);

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -8687,7 +8687,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundNegatedPattern : BoundPattern
     {
-        public BoundNegatedPattern(SyntaxNode syntax, BoundPattern negated, bool isUnionMatching, TypeSymbol inputType, TypeSymbol narrowedType, bool hasErrors = false)
+        public BoundNegatedPattern(SyntaxNode syntax, BoundPattern negated, TypeSymbol inputType, TypeSymbol narrowedType, bool hasErrors = false)
             : base(BoundKind.NegatedPattern, syntax, inputType, narrowedType, hasErrors || negated.HasErrors())
         {
 
@@ -8696,7 +8696,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             RoslynDebug.Assert(narrowedType is object, "Field 'narrowedType' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
 
             this.Negated = negated;
-            this.IsUnionMatching = isUnionMatching;
             Validate();
         }
 
@@ -8704,16 +8703,15 @@ namespace Microsoft.CodeAnalysis.CSharp
         private partial void Validate();
 
         public BoundPattern Negated { get; }
-        public override bool IsUnionMatching { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitNegatedPattern(this);
 
-        public BoundNegatedPattern Update(BoundPattern negated, bool isUnionMatching, TypeSymbol inputType, TypeSymbol narrowedType)
+        public BoundNegatedPattern Update(BoundPattern negated, TypeSymbol inputType, TypeSymbol narrowedType)
         {
-            if (negated != this.Negated || isUnionMatching != this.IsUnionMatching || !TypeSymbol.Equals(inputType, this.InputType, TypeCompareKind.ConsiderEverything) || !TypeSymbol.Equals(narrowedType, this.NarrowedType, TypeCompareKind.ConsiderEverything))
+            if (negated != this.Negated || !TypeSymbol.Equals(inputType, this.InputType, TypeCompareKind.ConsiderEverything) || !TypeSymbol.Equals(narrowedType, this.NarrowedType, TypeCompareKind.ConsiderEverything))
             {
-                var result = new BoundNegatedPattern(this.Syntax, negated, isUnionMatching, inputType, narrowedType, this.HasErrors);
+                var result = new BoundNegatedPattern(this.Syntax, negated, inputType, narrowedType, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -12629,7 +12627,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundPattern negated = (BoundPattern)this.Visit(node.Negated);
             TypeSymbol? inputType = this.VisitType(node.InputType);
             TypeSymbol? narrowedType = this.VisitType(node.NarrowedType);
-            return node.Update(negated, node.IsUnionMatching, inputType, narrowedType);
+            return node.Update(negated, inputType, narrowedType);
         }
         public override BoundNode? VisitRelationalPattern(BoundRelationalPattern node)
         {
@@ -15313,7 +15311,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol inputType = GetUpdatedSymbol(node, node.InputType);
             TypeSymbol narrowedType = GetUpdatedSymbol(node, node.NarrowedType);
             BoundPattern negated = (BoundPattern)this.Visit(node.Negated);
-            return node.Update(negated, node.IsUnionMatching, inputType, narrowedType);
+            return node.Update(negated, inputType, narrowedType);
         }
 
         public override BoundNode? VisitRelationalPattern(BoundRelationalPattern node)
@@ -17586,7 +17584,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override TreeDumperNode VisitNegatedPattern(BoundNegatedPattern node, object? arg) => new TreeDumperNode("negatedPattern", null, new TreeDumperNode[]
         {
             new TreeDumperNode("negated", null, new TreeDumperNode[] { Visit(node.Negated, null) }),
-            new TreeDumperNode("isUnionMatching", node.IsUnionMatching, null),
             new TreeDumperNode("inputType", node.InputType, null),
             new TreeDumperNode("narrowedType", node.NarrowedType, null),
             new TreeDumperNode("hasErrors", node.HasErrors, null)

--- a/src/Compilers/CSharp/Test/CSharp15/UnionsTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/UnionsTests.cs
@@ -3825,7 +3825,7 @@ class Program
         System.Console.Write(Test6(new S1(""11"")));
         System.Console.Write(Test6(null));
     }
- 
+
     static int Test5(S1 u)
     {
         if (u is not int x)
@@ -3835,7 +3835,7 @@ class Program
 
         return x;
     }   
- 
+
     static int Test6(S1 u)
     {
         if (u is not not not int x)

--- a/src/Compilers/CSharp/Test/CSharp15/UnionsTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/UnionsTests.cs
@@ -3618,21 +3618,24 @@ class Program
 
             comp = CreateCompilation([src, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular14);
             comp.VerifyDiagnostics(
-                // (46,21): error CS8652: The feature 'unions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (46,25): error CS8652: The feature 'unions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         return u is not 10;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "not 10").WithArguments("unions").WithLocation(46, 21),
-                // (51,21): error CS8652: The feature 'unions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "10").WithArguments("unions").WithLocation(46, 25),
+                // (51,26): error CS8652: The feature 'unions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         return u is not (10 or 11);
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "not (10 or 11)").WithArguments("unions").WithLocation(51, 21),
-                // (56,21): error CS8652: The feature 'unions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "10").WithArguments("unions").WithLocation(51, 26),
+                // (51,32): error CS8652: The feature 'unions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //         return u is not (10 or 11);
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "11").WithArguments("unions").WithLocation(51, 32),
+                // (56,26): error CS8652: The feature 'unions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         return u is not ("11" and ['1', '1']);
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, @"not (""11"" and ['1', '1'])").WithArguments("unions").WithLocation(56, 21),
-                // (61,21): error CS8652: The feature 'unions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, @"""11""").WithArguments("unions").WithLocation(56, 26),
+                // (61,25): error CS8652: The feature 'unions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         return u is not null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "not null").WithArguments("unions").WithLocation(61, 21),
-                // (66,21): error CS8652: The feature 'unions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "null").WithArguments("unions").WithLocation(61, 25),
+                // (66,26): error CS8652: The feature 'unions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         return u is not ({ } and int);
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "not ({ } and int)").WithArguments("unions").WithLocation(66, 21)
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "{ }").WithArguments("unions").WithLocation(66, 26)
                 );
         }
 
@@ -3714,33 +3717,36 @@ class Program
 }
 ";
             var comp = CreateCompilation([src, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe);
-            CompileAndVerify(comp, expectedOutput: ExecutionConditionUtil.IsMonoOrCoreClr ? "FalseTrueTrueTrueFalse FalseTrueTrueTrueFalseFalse TrueTrueFalseFalse TrueFalseTrueFalse FalseTrueTrueFalseFalse" : null, verify: Verification.FailsPEVerify).VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: ExecutionConditionUtil.IsMonoOrCoreClr ? "FalseTrueTrueTrueTrue FalseTrueTrueTrueFalseTrue TrueTrueFalseTrue TrueFalseTrueFalse FalseTrueTrueFalseTrue" : null, verify: Verification.FailsPEVerify).VerifyDiagnostics();
 
             comp = CreateCompilation([src, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe, parseOptions: TestOptions.RegularNext);
-            CompileAndVerify(comp, expectedOutput: ExecutionConditionUtil.IsMonoOrCoreClr ? "FalseTrueTrueTrueFalse FalseTrueTrueTrueFalseFalse TrueTrueFalseFalse TrueFalseTrueFalse FalseTrueTrueFalseFalse" : null, verify: Verification.FailsPEVerify).VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: ExecutionConditionUtil.IsMonoOrCoreClr ? "FalseTrueTrueTrueTrue FalseTrueTrueTrueFalseTrue TrueTrueFalseTrue TrueFalseTrueFalse FalseTrueTrueFalseTrue" : null, verify: Verification.FailsPEVerify).VerifyDiagnostics();
 
             comp = CreateCompilation([src, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular14);
             comp.VerifyDiagnostics(
-                // (51,21): error CS8652: The feature 'unions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (51,25): error CS8652: The feature 'unions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         return u is not 10;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "not 10").WithArguments("unions").WithLocation(51, 21),
-                // (56,21): error CS8652: The feature 'unions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "10").WithArguments("unions").WithLocation(51, 25),
+                // (56,26): error CS8652: The feature 'unions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         return u is not (10 or 11);
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "not (10 or 11)").WithArguments("unions").WithLocation(56, 21),
-                // (61,21): error CS8652: The feature 'unions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "10").WithArguments("unions").WithLocation(56, 26),
+                // (56,32): error CS8652: The feature 'unions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //         return u is not (10 or 11);
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "11").WithArguments("unions").WithLocation(56, 32),
+                // (61,26): error CS8652: The feature 'unions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         return u is not ("11" and ['1', '1']);
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, @"not (""11"" and ['1', '1'])").WithArguments("unions").WithLocation(61, 21),
-                // (66,21): error CS8652: The feature 'unions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, @"""11""").WithArguments("unions").WithLocation(61, 26),
+                // (66,25): error CS8652: The feature 'unions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         return u is not null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "not null").WithArguments("unions").WithLocation(66, 21),
-                // (71,21): error CS8652: The feature 'unions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "null").WithArguments("unions").WithLocation(66, 25),
+                // (71,26): error CS8652: The feature 'unions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         return u is not ({ } and int);
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "not ({ } and int)").WithArguments("unions").WithLocation(71, 21)
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "{ }").WithArguments("unions").WithLocation(71, 26)
                 );
         }
 
         [Fact]
-        public void UnionMatching_15_Negated()
+        public void UnionMatching_15_Negated_01()
         {
             var src = @"
 [System.Runtime.CompilerServices.Union]
@@ -3792,7 +3798,115 @@ class Program
         }
 
         [Fact]
-        public void UnionMatching_16_Negated()
+        public void UnionMatching_15_Negated_02()
+        {
+            var src = @"
+[System.Runtime.CompilerServices.Union]
+class S1
+{
+    private readonly object _value;
+    public S1(int x) { _value = x; }
+    public S1(string x) { _value = x; }
+    public object Value => _value;
+}
+
+class Program
+{
+    static void Main()
+    {
+        System.Console.Write(Test5(new S1(11)));
+        System.Console.Write(Test5(default));
+        System.Console.Write(Test5(new S1(""11"")));
+        System.Console.Write(Test5(null));
+
+        System.Console.Write(' ');
+        System.Console.Write(Test6(new S1(11)));
+        System.Console.Write(Test6(default));
+        System.Console.Write(Test6(new S1(""11"")));
+        System.Console.Write(Test6(null));
+    }
+ 
+    static int Test5(S1 u)
+    {
+        if (u is not int x)
+        {
+            return -1;
+        }
+
+        return x;
+    }   
+ 
+    static int Test6(S1 u)
+    {
+        if (u is not not not int x)
+        {
+            return -1;
+        }
+
+        return x;
+    }   
+}
+";
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseExe);
+            CompileAndVerify(comp, expectedOutput: "11-1-1-1 11-1-1-1").VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void UnionMatching_15_Negated_03()
+        {
+            var src = @"
+[System.Runtime.CompilerServices.Union]
+struct S1
+{
+    private readonly object _value;
+    public S1(int x) { _value = x; }
+    public S1(string x) { _value = x; }
+    public object Value => _value;
+}
+
+class Program
+{
+    static void Main()
+    {
+        System.Console.Write(Test5(new S1(11)));
+        System.Console.Write(Test5(default));
+        System.Console.Write(Test5(new S1(""11"")));
+        System.Console.Write(Test5(null));
+
+        System.Console.Write(' ');
+        System.Console.Write(Test6(new S1(11)));
+        System.Console.Write(Test6(default));
+        System.Console.Write(Test6(new S1(""11"")));
+        System.Console.Write(Test6(null));
+    }
+ 
+    static int Test5(S1? u)
+    {
+        if (u is not int x)
+        {
+            return -1;
+        }
+
+        return x;
+    }   
+ 
+    static int Test6(S1? u)
+    {
+        if (u is not not not int x)
+        {
+            return -1;
+        }
+
+        return x;
+    }   
+}
+";
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseExe);
+            CompileAndVerify(comp, expectedOutput: "11-1-1-1 11-1-1-1").VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void UnionMatching_16_Negated_01()
         {
             var src = @"
 [System.Runtime.CompilerServices.Union]
@@ -3806,17 +3920,6 @@ sealed class C1
 
 class Program
 {
-    static int Test5(C1 u)
-    {
-#line 14
-        if (u is not int x)
-        {
-            return -1;
-        }
-#line 19
-        return x;
-    }   
-
     static int Test6(S1 u)
     {
         if (u is not not int y)
@@ -3825,17 +3928,6 @@ class Program
         }
 #line 29
         return y;
-    }   
-
-    static int Test7(S1? u)
-    {
-#line 34
-        if (u is not int z)
-        {
-            return -1;
-        }
-#line 39
-        return z;
     }   
  
     static bool Test8(S1 u)
@@ -3848,6 +3940,16 @@ class Program
     {
 #line 49
         return u is not (S1 and int);
+    }   
+
+    static int Test10(C1 u)
+    {
+        if (u is not not int y)
+        {
+            return y - 1;
+        }
+#line 100
+        return y;
     }   
 }
 
@@ -3863,21 +3965,9 @@ struct S1
             var comp = CreateCompilation([src, UnionAttributeSource]);
             // There is an implicit null check for class union types and for Nullable<Union>.  
             comp.VerifyDiagnostics(
-                // (14,26): error CS8780: A variable may not be declared within a 'not' or 'or' pattern.
-                //         if (u is not int x)
-                Diagnostic(ErrorCode.ERR_DesignatorBeneathPatternCombinator, "x").WithLocation(14, 26),
-                // (19,16): error CS0165: Use of unassigned local variable 'x'
-                //         return x;
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(19, 16),
                 // (29,16): error CS0165: Use of unassigned local variable 'y'
                 //         return y;
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "y").WithArguments("y").WithLocation(29, 16),
-                // (34,26): error CS8780: A variable may not be declared within a 'not' or 'or' pattern.
-                //         if (u is not int z)
-                Diagnostic(ErrorCode.ERR_DesignatorBeneathPatternCombinator, "z").WithLocation(34, 26),
-                // (39,16): error CS0165: Use of unassigned local variable 'z'
-                //         return z;
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "z").WithArguments("z").WithLocation(39, 16),
 
                 // https://github.com/dotnet/roslyn/issues/82636: The following diagnostics is somewhat confusing in these cases.
                 //            A type cannot be handled by the pattern of the same type.
@@ -3888,12 +3978,16 @@ struct S1
                 Diagnostic(ErrorCode.ERR_PatternWrongType, "S1").WithArguments("S1", "S1").WithLocation(44, 26),
                 // (49,26): error CS8121: An expression of type 'S1' cannot be handled by a pattern of type 'S1'.
                 //         return u is not (S1 and int);
-                Diagnostic(ErrorCode.ERR_PatternWrongType, "S1").WithArguments("S1", "S1").WithLocation(49, 26)
+                Diagnostic(ErrorCode.ERR_PatternWrongType, "S1").WithArguments("S1", "S1").WithLocation(49, 26),
+
+                // (100,16): error CS0165: Use of unassigned local variable 'y'
+                //         return y;
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "y").WithArguments("y").WithLocation(100, 16)
                 );
         }
 
         [Fact]
-        public void UnionMatching_17_Negated_01()
+        public void UnionMatching_16_Negated_02()
         {
             var src = @"
 [System.Runtime.CompilerServices.Union]
@@ -3941,6 +4035,18 @@ class Program
         System.Console.Write(Test4(new C1()));
         System.Console.Write(Test4(new C1(""11"")));
         System.Console.Write(Test4(null));
+
+        System.Console.Write(' ');
+        System.Console.Write(Test5(new S1(11)));
+        System.Console.Write(Test5(new S1()));
+        System.Console.Write(Test5(new S1(""11"")));
+        System.Console.Write(Test5(null));
+
+        System.Console.Write(' ');
+        System.Console.Write(Test6(new C1(11)));
+        System.Console.Write(Test6(new C1()));
+        System.Console.Write(Test6(new C1(""11"")));
+        System.Console.Write(Test6(null));
     }
 
     static bool Test1(S1? u)
@@ -3962,88 +4068,187 @@ class Program
     {
         return u is not not null;
     }   
+
+    static bool Test5(S1? u)
+    {
+        return u is null;
+    }   
+
+    static bool Test6(C1 u)
+    {
+        return u is null;
+    }   
 }
 ";
             var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseExe);
-            var verifier = CompileAndVerify(comp, expectedOutput: "TrueFalseTrueFalse TrueFalseTrueFalse FalseTrueFalseFalse FalseTrueFalseFalse").VerifyDiagnostics();
+            var verifier = CompileAndVerify(comp, expectedOutput: "TrueFalseTrueFalse TrueFalseTrueFalse FalseTrueFalseTrue FalseTrueFalseTrue FalseTrueFalseTrue FalseTrueFalseTrue").VerifyDiagnostics();
 
             verifier.VerifyIL("Program.Test1", @"
 {
-  // Code size       30 (0x1e)
+  // Code size       37 (0x25)
   .maxstack  2
-  .locals init (S1 V_0)
+  .locals init (S1 V_0,
+            bool V_1)
   IL_0000:  ldarga.s   V_0
   IL_0002:  call       ""bool S1?.HasValue.get""
-  IL_0007:  brfalse.s  IL_001c
+  IL_0007:  brfalse.s  IL_001a
   IL_0009:  ldarga.s   V_0
   IL_000b:  call       ""S1 S1?.GetValueOrDefault()""
   IL_0010:  stloc.0
   IL_0011:  ldloca.s   V_0
   IL_0013:  call       ""object S1.Value.get""
-  IL_0018:  ldnull
-  IL_0019:  cgt.un
-  IL_001b:  ret
-  IL_001c:  ldc.i4.0
-  IL_001d:  ret
+  IL_0018:  brtrue.s   IL_001e
+  IL_001a:  ldc.i4.1
+  IL_001b:  stloc.1
+  IL_001c:  br.s       IL_0020
+  IL_001e:  ldc.i4.0
+  IL_001f:  stloc.1
+  IL_0020:  ldloc.1
+  IL_0021:  ldc.i4.0
+  IL_0022:  ceq
+  IL_0024:  ret
 }
 ");
 
             verifier.VerifyIL("Program.Test2", @"
 {
-  // Code size       15 (0xf)
+  // Code size       22 (0x16)
   .maxstack  2
+  .locals init (bool V_0)
   IL_0000:  ldarg.0
-  IL_0001:  brfalse.s  IL_000d
+  IL_0001:  brfalse.s  IL_000b
   IL_0003:  ldarg.0
   IL_0004:  callvirt   ""object C1.Value.get""
-  IL_0009:  ldnull
-  IL_000a:  cgt.un
-  IL_000c:  ret
-  IL_000d:  ldc.i4.0
-  IL_000e:  ret
+  IL_0009:  brtrue.s   IL_000f
+  IL_000b:  ldc.i4.1
+  IL_000c:  stloc.0
+  IL_000d:  br.s       IL_0011
+  IL_000f:  ldc.i4.0
+  IL_0010:  stloc.0
+  IL_0011:  ldloc.0
+  IL_0012:  ldc.i4.0
+  IL_0013:  ceq
+  IL_0015:  ret
 }
 ");
-
-            verifier.VerifyIL("Program.Test3", @"
+            var test3 = @"
 {
-  // Code size       30 (0x1e)
-  .maxstack  2
-  .locals init (S1 V_0)
+  // Code size       34 (0x22)
+  .maxstack  1
+  .locals init (S1 V_0,
+            bool V_1)
   IL_0000:  ldarga.s   V_0
   IL_0002:  call       ""bool S1?.HasValue.get""
-  IL_0007:  brfalse.s  IL_001c
+  IL_0007:  brfalse.s  IL_001a
   IL_0009:  ldarga.s   V_0
   IL_000b:  call       ""S1 S1?.GetValueOrDefault()""
   IL_0010:  stloc.0
   IL_0011:  ldloca.s   V_0
   IL_0013:  call       ""object S1.Value.get""
-  IL_0018:  ldnull
-  IL_0019:  ceq
-  IL_001b:  ret
-  IL_001c:  ldc.i4.0
-  IL_001d:  ret
+  IL_0018:  brtrue.s   IL_001e
+  IL_001a:  ldc.i4.1
+  IL_001b:  stloc.1
+  IL_001c:  br.s       IL_0020
+  IL_001e:  ldc.i4.0
+  IL_001f:  stloc.1
+  IL_0020:  ldloc.1
+  IL_0021:  ret
 }
-");
+";
 
-            verifier.VerifyIL("Program.Test4", @"
+            var test4 = @"
 {
-  // Code size       15 (0xf)
-  .maxstack  2
+  // Code size       19 (0x13)
+  .maxstack  1
+  .locals init (bool V_0)
   IL_0000:  ldarg.0
-  IL_0001:  brfalse.s  IL_000d
+  IL_0001:  brfalse.s  IL_000b
   IL_0003:  ldarg.0
   IL_0004:  callvirt   ""object C1.Value.get""
-  IL_0009:  ldnull
-  IL_000a:  ceq
-  IL_000c:  ret
-  IL_000d:  ldc.i4.0
-  IL_000e:  ret
+  IL_0009:  brtrue.s   IL_000f
+  IL_000b:  ldc.i4.1
+  IL_000c:  stloc.0
+  IL_000d:  br.s       IL_0011
+  IL_000f:  ldc.i4.0
+  IL_0010:  stloc.0
+  IL_0011:  ldloc.0
+  IL_0012:  ret
 }
-");
+";
+
+            verifier.VerifyIL("Program.Test3", test3);
+            verifier.VerifyIL("Program.Test5", test3);
+
+            verifier.VerifyIL("Program.Test4", test4);
+            verifier.VerifyIL("Program.Test6", test4);
         }
 
         [Fact]
-        public void UnionMatching_17_Negated_02()
+        public void UnionMatching_16_Negated_03()
+        {
+            var src = @"
+[System.Runtime.CompilerServices.Union]
+class C1
+{
+    private readonly object _value;
+    public C1() {}
+    public C1(int x) { _value = x; }
+    public C1(string x) { _value = x; }
+    public object Value => _value;
+}
+
+class Program
+{
+    static void Main()
+    {
+        System.Console.WriteLine();
+        System.Console.Write(""Test1: "");
+        System.Console.Write(Test1(new C1(11)));
+        System.Console.Write(Test1(new C1()));
+        System.Console.Write(Test1(new C1(""11"")));
+        System.Console.Write(Test1(null));
+
+        System.Console.WriteLine();
+        System.Console.Write(""Test2: "");
+        System.Console.Write(Test2(new C1(11)));
+        System.Console.Write(Test2(new C1()));
+        System.Console.Write(Test2(new C1(""11"")));
+        System.Console.Write(Test2(null));
+
+        System.Console.WriteLine();
+        System.Console.Write(""Test3: "");
+        System.Console.Write(Test3(new C1(11)));
+        System.Console.Write(Test3(new C1()));
+        System.Console.Write(Test3(new C1(""11"")));
+        System.Console.Write(Test3(null));
+    }
+
+    static bool Test1(C1 u)
+    {
+        return u is 11;
+    }   
+
+    static bool Test2(C1 u)
+    {
+        return u is not 11;
+    }   
+
+    static bool Test3(C1 u)
+    {
+        return u is not not 11;
+    }   
+}
+";
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseExe);
+            CompileAndVerify(comp, expectedOutput: @"
+Test1: TrueFalseFalseFalse
+Test2: FalseTrueTrueTrue
+Test3: TrueFalseFalseFalse
+").VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void UnionMatching_16_Negated_04()
         {
             var src = @"
 [System.Runtime.CompilerServices.Union]
@@ -4083,58 +4288,48 @@ class Program
 
     static bool Test1(S1? u)
     {
+#line 100
         return u is not (string)null;
     }   
 
     static bool Test2(C1 u)
     {
+#line 200
         return u is not (string)null;
+    }   
+
+    static bool Test3(S1? u)
+    {
+#line 300
+        return u is (string)null;
+    }   
+
+    static bool Test4(C1 u)
+    {
+#line 400
+        return u is (string)null;
     }   
 }
 ";
             var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseExe);
-            var verifier = CompileAndVerify(comp, expectedOutput: "TrueFalseTrueFalse TrueFalseTrueFalse").VerifyDiagnostics();
-
-            verifier.VerifyIL("Program.Test1", @"
-{
-  // Code size       30 (0x1e)
-  .maxstack  2
-  .locals init (S1 V_0)
-  IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""bool S1?.HasValue.get""
-  IL_0007:  brfalse.s  IL_001c
-  IL_0009:  ldarga.s   V_0
-  IL_000b:  call       ""S1 S1?.GetValueOrDefault()""
-  IL_0010:  stloc.0
-  IL_0011:  ldloca.s   V_0
-  IL_0013:  call       ""object S1.Value.get""
-  IL_0018:  ldnull
-  IL_0019:  cgt.un
-  IL_001b:  ret
-  IL_001c:  ldc.i4.0
-  IL_001d:  ret
-}
-");
-
-            verifier.VerifyIL("Program.Test2", @"
-{
-  // Code size       15 (0xf)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  brfalse.s  IL_000d
-  IL_0003:  ldarg.0
-  IL_0004:  callvirt   ""object C1.Value.get""
-  IL_0009:  ldnull
-  IL_000a:  cgt.un
-  IL_000c:  ret
-  IL_000d:  ldc.i4.0
-  IL_000e:  ret
-}
-");
+            comp.VerifyDiagnostics(
+                // (100,25): error CS9135: A constant value of type 'S1' is expected
+                //         return u is not (string)null;
+                Diagnostic(ErrorCode.ERR_ConstantValueOfTypeExpected, "(string)null").WithArguments("S1").WithLocation(100, 25),
+                // (200,25): error CS9135: A constant value of type 'C1' is expected
+                //         return u is not (string)null;
+                Diagnostic(ErrorCode.ERR_ConstantValueOfTypeExpected, "(string)null").WithArguments("C1").WithLocation(200, 25),
+                // (300,21): error CS9135: A constant value of type 'S1' is expected
+                //         return u is (string)null;
+                Diagnostic(ErrorCode.ERR_ConstantValueOfTypeExpected, "(string)null").WithArguments("S1").WithLocation(300, 21),
+                // (400,21): error CS9135: A constant value of type 'C1' is expected
+                //         return u is (string)null;
+                Diagnostic(ErrorCode.ERR_ConstantValueOfTypeExpected, "(string)null").WithArguments("C1").WithLocation(400, 21)
+                );
         }
 
         [Fact]
-        public void UnionMatching_17_Negated_03()
+        public void UnionMatching_16_Negated_05()
         {
             var src = @"
 [System.Runtime.CompilerServices.Union]
@@ -9188,10 +9383,6 @@ class Program
                 // (1150,18): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
                 //         return u switch { not null => 1 };
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(1150, 18),
-                // (1200,42): hidden CS9335: The pattern is redundant.
-                //         return u switch { null => 3, not null => 1 };
-                // Note the location, the diagnostic is for 'null' in 'not null' of the second case rather than for 'null' in the first case.  
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(1200, 42),
                 // (1300,42): hidden CS9335: The pattern is redundant.
                 //         return u switch { not null => 3, null => 1 };
                 Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(1300, 42),
@@ -10457,9 +10648,6 @@ class Program
                 // (900,18): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
                 //         return u switch { not null => 1 };
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(900, 18),
-                // (1000,42): hidden CS9335: The pattern is redundant.
-                //         return u switch { null => 3, not null => 1 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(1000, 42),
                 // (1100,42): hidden CS9335: The pattern is redundant.
                 //         return u switch { not null => 3, null => 1 };
                 Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(1100, 42),
@@ -20466,14 +20654,10 @@ class Program
 ";
             var comp = CreateCompilation([src, UnionAttributeSource]);
 
-            // https://github.com/dotnet/roslyn/issues/82636: This is another case of behavior consistent with explicit property patterns. See below
             comp.VerifyDiagnostics(
                 // (100,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
                 //             _ = s switch { int => 1, bool => 3 };
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(100, 19),
-                // (200,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
-                //             _ = s switch { int => 1, bool => 3 };
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(200, 19)
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(100, 19)
                 );
 
             var src2 = @"
@@ -20503,6 +20687,7 @@ class Program
 ";
             var comp2 = CreateCompilation(src2);
 
+            // https://github.com/dotnet/roslyn/issues/83568
             comp2.VerifyDiagnostics(
                 // (1000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
                 //             _ = s switch { { Value: {} } => 1 };
@@ -20727,14 +20912,10 @@ class Program
 ";
             var comp = CreateCompilation([src, UnionAttributeSource]);
 
-            // https://github.com/dotnet/roslyn/issues/82636: This is another case of behavior consistent with explicit property patterns. See below
             comp.VerifyDiagnostics(
                 // (100,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
                 //             _ = s switch { int => 1, bool => 3 };
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(100, 19),
-                // (200,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
-                //             _ = s switch { int => 1, bool => 3 };
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(200, 19)
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(100, 19)
                 );
 
             var src2 = @"
@@ -20764,6 +20945,7 @@ class Program
 ";
             var comp2 = CreateCompilation(src2);
 
+            // https://github.com/dotnet/roslyn/issues/83568
             comp2.VerifyDiagnostics(
                 // (1000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
                 //             _ = s switch { { Value: {} } => 1 };
@@ -21924,7 +22106,7 @@ struct S1
     private readonly object _value;
     public S1(int x) { _value = x; }
     public S1(string x) { _value = x; }
-    public object Value => _value;
+    public object Value => throw null;
     public bool HasValue => _value != null;
 
     static void Main()
@@ -21963,11 +22145,15 @@ struct S1
 
             verifier.VerifyIL("S1.Test2", @"
 {
-  // Code size        8 (0x8)
-  .maxstack  1
+  // Code size       14 (0xe)
+  .maxstack  2
   IL_0000:  ldarga.s   V_0
   IL_0002:  call       ""bool S1.HasValue.get""
-  IL_0007:  ret
+  IL_0007:  ldc.i4.0
+  IL_0008:  ceq
+  IL_000a:  ldc.i4.0
+  IL_000b:  ceq
+  IL_000d:  ret
 }
 ");
         }
@@ -22022,13 +22208,15 @@ struct S1
 
             verifier.VerifyIL("S1.Test2", @"
 {
-  // Code size       11 (0xb)
+  // Code size       14 (0xe)
   .maxstack  2
   IL_0000:  ldarga.s   V_0
   IL_0002:  call       ""object S1.Value.get""
   IL_0007:  ldnull
-  IL_0008:  cgt.un
-  IL_000a:  ret
+  IL_0008:  ceq
+  IL_000a:  ldc.i4.0
+  IL_000b:  ceq
+  IL_000d:  ret
 }
 ");
         }
@@ -22092,15 +22280,23 @@ class S1
 
             verifier.VerifyIL("S1.Test2", @"
 {
-  // Code size       12 (0xc)
-  .maxstack  1
+  // Code size       22 (0x16)
+  .maxstack  2
+  .locals init (bool V_0)
   IL_0000:  ldarg.0
-  IL_0001:  brfalse.s  IL_000a
+  IL_0001:  brfalse.s  IL_000b
   IL_0003:  ldarg.0
   IL_0004:  callvirt   ""bool S1.HasValue.get""
-  IL_0009:  ret
-  IL_000a:  ldc.i4.0
-  IL_000b:  ret
+  IL_0009:  brtrue.s   IL_000f
+  IL_000b:  ldc.i4.1
+  IL_000c:  stloc.0
+  IL_000d:  br.s       IL_0011
+  IL_000f:  ldc.i4.0
+  IL_0010:  stloc.0
+  IL_0011:  ldloc.0
+  IL_0012:  ldc.i4.0
+  IL_0013:  ceq
+  IL_0015:  ret
 }
 ");
         }
@@ -22165,17 +22361,23 @@ class S1
 
             verifier.VerifyIL("S1.Test2", @"
 {
-  // Code size       15 (0xf)
+  // Code size       22 (0x16)
   .maxstack  2
+  .locals init (bool V_0)
   IL_0000:  ldarg.0
-  IL_0001:  brfalse.s  IL_000d
+  IL_0001:  brfalse.s  IL_000b
   IL_0003:  ldarg.0
   IL_0004:  callvirt   ""object S1.Value.get""
-  IL_0009:  ldnull
-  IL_000a:  cgt.un
-  IL_000c:  ret
-  IL_000d:  ldc.i4.0
-  IL_000e:  ret
+  IL_0009:  brtrue.s   IL_000f
+  IL_000b:  ldc.i4.1
+  IL_000c:  stloc.0
+  IL_000d:  br.s       IL_0011
+  IL_000f:  ldc.i4.0
+  IL_0010:  stloc.0
+  IL_0011:  ldloc.0
+  IL_0012:  ldc.i4.0
+  IL_0013:  ceq
+  IL_0015:  ret
 }
 ");
         }
@@ -22273,11 +22475,7 @@ struct S1
 }
 ";
             var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseExe);
-            var verifier = CompileAndVerify(comp, expectedOutput: "HasValue 1HasValue 0HasValue 1").VerifyDiagnostics(
-                // (26,42): hidden CS9335: The pattern is redundant.
-                //         return u switch { null => 0, not null => 1};
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(26, 42)
-                );
+            var verifier = CompileAndVerify(comp, expectedOutput: "HasValue 1HasValue 0HasValue 1").VerifyDiagnostics();
 
             verifier.VerifyIL("S1.Test2", @"
 {
@@ -22911,7 +23109,7 @@ class S1
 }
 ";
             var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseExe);
-            var verifier = CompileAndVerify(comp, expectedOutput: "TrueFalseFalseFalseFalseTrueTrueFalse").VerifyDiagnostics();
+            var verifier = CompileAndVerify(comp, expectedOutput: "TrueFalseFalseFalseFalseTrueTrueTrue").VerifyDiagnostics();
 
             verifier.VerifyIL("S1.Test1", @"
 {
@@ -22931,19 +23129,19 @@ class S1
 
             verifier.VerifyIL("S1.Test2", @"
 {
-  // Code size       17 (0x11)
+  // Code size       18 (0x12)
   .maxstack  2
   .locals init (int V_0)
   IL_0000:  ldarg.0
-  IL_0001:  brfalse.s  IL_000f
+  IL_0001:  brfalse.s  IL_000d
   IL_0003:  ldarg.0
   IL_0004:  ldloca.s   V_0
   IL_0006:  callvirt   ""bool S1.TryGetValue(out int)""
-  IL_000b:  ldc.i4.0
-  IL_000c:  ceq
-  IL_000e:  ret
-  IL_000f:  ldc.i4.0
-  IL_0010:  ret
+  IL_000b:  br.s       IL_000e
+  IL_000d:  ldc.i4.0
+  IL_000e:  ldc.i4.0
+  IL_000f:  ceq
+  IL_0011:  ret
 }
 ");
         }
@@ -23246,10 +23444,9 @@ struct S1
 
             verifier.VerifyIL("S1.Test2", @"
 {
-  // Code size       32 (0x20)
+  // Code size       29 (0x1d)
   .maxstack  2
-  .locals init (string V_0,
-                bool V_1)
+  .locals init (string V_0)
   IL_0000:  ldarga.s   V_0
   IL_0002:  ldloca.s   V_0
   IL_0004:  call       ""bool S1.TryGetValue(out string)""
@@ -23257,14 +23454,11 @@ struct S1
   IL_000b:  ldloc.0
   IL_000c:  ldstr      ""b""
   IL_0011:  call       ""bool string.op_Equality(string, string)""
-  IL_0016:  brtrue.s   IL_001c
-  IL_0018:  ldc.i4.1
-  IL_0019:  stloc.1
-  IL_001a:  br.s       IL_001e
-  IL_001c:  ldc.i4.0
-  IL_001d:  stloc.1
-  IL_001e:  ldloc.1
-  IL_001f:  ret
+  IL_0016:  br.s       IL_0019
+  IL_0018:  ldc.i4.0
+  IL_0019:  ldc.i4.0
+  IL_001a:  ceq
+  IL_001c:  ret
 }
 ");
         }
@@ -23306,7 +23500,7 @@ class S1
 }
 ";
             var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseExe);
-            var verifier = CompileAndVerify(comp, expectedOutput: "FalseFalseTrueFalseTrueTrueFalseFalse").VerifyDiagnostics();
+            var verifier = CompileAndVerify(comp, expectedOutput: "FalseFalseTrueFalseTrueTrueFalseTrue").VerifyDiagnostics();
 
             verifier.VerifyIL("S1.Test1", @"
 {
@@ -23330,12 +23524,11 @@ class S1
 
             verifier.VerifyIL("S1.Test2", @"
 {
-  // Code size       34 (0x22)
+  // Code size       31 (0x1f)
   .maxstack  2
-  .locals init (string V_0,
-                bool V_1)
+  .locals init (string V_0)
   IL_0000:  ldarg.0
-  IL_0001:  brfalse.s  IL_001e
+  IL_0001:  brfalse.s  IL_001a
   IL_0003:  ldarg.0
   IL_0004:  ldloca.s   V_0
   IL_0006:  callvirt   ""bool S1.TryGetValue(out string)""
@@ -23343,14 +23536,11 @@ class S1
   IL_000d:  ldloc.0
   IL_000e:  ldstr      ""b""
   IL_0013:  call       ""bool string.op_Equality(string, string)""
-  IL_0018:  brtrue.s   IL_001e
-  IL_001a:  ldc.i4.1
-  IL_001b:  stloc.1
-  IL_001c:  br.s       IL_0020
-  IL_001e:  ldc.i4.0
-  IL_001f:  stloc.1
-  IL_0020:  ldloc.1
-  IL_0021:  ret
+  IL_0018:  br.s       IL_001b
+  IL_001a:  ldc.i4.0
+  IL_001b:  ldc.i4.0
+  IL_001c:  ceq
+  IL_001e:  ret
 }
 ");
         }
@@ -28313,8 +28503,8 @@ struct S1
 [8]: t5 == 2 ? [9] : [12]
 [9]: t6 = t2.F12; [10]
 [10]: t6 == 3 ? [11] : [12]
-[11]: leaf <isPatternFailure> `u is not ((C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 })`
-[12]: leaf <isPatternSuccess> `not ((C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 })`
+[11]: leaf <isPatternFailure> `(C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 }`
+[12]: leaf <isPatternSuccess> `u is not ((C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 })`
 ",
 forLowering: true);
 
@@ -28349,7 +28539,7 @@ True
 
             verifier.VerifyIL("S1.Test1", @"
 {
-  // Code size       63 (0x3f)
+  // Code size       66 (0x42)
   .maxstack  2
   .locals init (object V_0,
                 C1 V_1,
@@ -28362,7 +28552,7 @@ True
   IL_0009:  isinst     ""C1""
   IL_000e:  stloc.1
   IL_000f:  ldloc.1
-  IL_0010:  brfalse.s  IL_0037
+  IL_0010:  brfalse.s  IL_003b
   IL_0012:  ldloc.1
   IL_0013:  ldfld      ""int C1.F11""
   IL_0018:  ldc.i4.1
@@ -28371,22 +28561,24 @@ True
   IL_001c:  isinst     ""C2""
   IL_0021:  stloc.2
   IL_0022:  ldloc.2
-  IL_0023:  brfalse.s  IL_0037
+  IL_0023:  brfalse.s  IL_003b
   IL_0025:  ldloc.2
   IL_0026:  ldfld      ""int C2.F2""
   IL_002b:  ldc.i4.2
-  IL_002c:  bne.un.s   IL_0037
+  IL_002c:  bne.un.s   IL_003b
   IL_002e:  ldloc.1
   IL_002f:  ldfld      ""int C1.F12""
   IL_0034:  ldc.i4.3
-  IL_0035:  beq.s      IL_003b
+  IL_0035:  bne.un.s   IL_003b
   IL_0037:  ldc.i4.1
   IL_0038:  stloc.3
   IL_0039:  br.s       IL_003d
   IL_003b:  ldc.i4.0
   IL_003c:  stloc.3
   IL_003d:  ldloc.3
-  IL_003e:  ret
+  IL_003e:  ldc.i4.0
+  IL_003f:  ceq
+  IL_0041:  ret
 }
 ");
         }
@@ -28482,8 +28674,8 @@ struct S1
 [9]: t6 == 2 ? [10] : [13]
 [10]: t7 = t2.F12; [11]
 [11]: t7 == 3 ? [12] : [13]
-[12]: leaf <isPatternFailure> `u is not ((C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 })`
-[13]: leaf <isPatternSuccess> `not ((C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 })`
+[12]: leaf <isPatternFailure> `(C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 }`
+[13]: leaf <isPatternSuccess> `u is not ((C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 })`
 ",
 forLowering: true);
 
@@ -28518,7 +28710,7 @@ True
 
             verifier.VerifyIL("S1.Test1", @"
 {
-  // Code size       59 (0x3b)
+  // Code size       62 (0x3e)
   .maxstack  2
   .locals init (C1 V_0,
             C1 V_1,
@@ -28527,7 +28719,7 @@ True
   IL_0000:  ldarga.s   V_0
   IL_0002:  ldloca.s   V_0
   IL_0004:  call       ""bool S1.TryGetValue(out C1)""
-  IL_0009:  brfalse.s  IL_0033
+  IL_0009:  brfalse.s  IL_0037
   IL_000b:  ldloc.0
   IL_000c:  stloc.1
   IL_000d:  ldloc.1
@@ -28537,22 +28729,24 @@ True
   IL_0016:  ldarga.s   V_0
   IL_0018:  ldloca.s   V_2
   IL_001a:  call       ""bool S1.TryGetValue(out C2)""
-  IL_001f:  brfalse.s  IL_0033
+  IL_001f:  brfalse.s  IL_0037
   IL_0021:  ldloc.2
   IL_0022:  ldfld      ""int C2.F2""
   IL_0027:  ldc.i4.2
-  IL_0028:  bne.un.s   IL_0033
+  IL_0028:  bne.un.s   IL_0037
   IL_002a:  ldloc.1
   IL_002b:  ldfld      ""int C1.F12""
   IL_0030:  ldc.i4.3
-  IL_0031:  beq.s      IL_0037
+  IL_0031:  bne.un.s   IL_0037
   IL_0033:  ldc.i4.1
   IL_0034:  stloc.3
   IL_0035:  br.s       IL_0039
   IL_0037:  ldc.i4.0
   IL_0038:  stloc.3
   IL_0039:  ldloc.3
-  IL_003a:  ret
+  IL_003a:  ldc.i4.0
+  IL_003b:  ceq
+  IL_003d:  ret
 }
 ");
         }
@@ -28654,8 +28848,8 @@ struct S1
 [15]: t6 == 1 ? [16] : [19]
 [16]: t8 = t4.F12; [17]
 [17]: t8 == 3 ? [18] : [19]
-[18]: leaf <isPatternFailure> `u is not ((C2 { F2: 2 } or C1 { F11: 1 }) and C1 { F12: 3 })`
-[19]: leaf <isPatternSuccess> `not ((C2 { F2: 2 } or C1 { F11: 1 }) and C1 { F12: 3 })`
+[18]: leaf <isPatternFailure> `(C2 { F2: 2 } or C1 { F11: 1 }) and C1 { F12: 3 }`
+[19]: leaf <isPatternSuccess> `u is not ((C2 { F2: 2 } or C1 { F11: 1 }) and C1 { F12: 3 })`
 ",
 forLowering: true);
 
@@ -28690,7 +28884,7 @@ True
 
             verifier.VerifyIL("S1.Test1", @"
 {
-  // Code size       76 (0x4c)
+  // Code size       79 (0x4f)
   .maxstack  2
   .locals init (C2 V_0,
                 C1 V_1,
@@ -28712,29 +28906,31 @@ True
   IL_001a:  ldloc.1
   IL_001b:  ldfld      ""int C1.F11""
   IL_0020:  ldc.i4.1
-  IL_0021:  bne.un.s   IL_0044
+  IL_0021:  bne.un.s   IL_0048
   IL_0023:  br.s       IL_003b
   IL_0025:  ldarga.s   V_0
   IL_0027:  ldloca.s   V_2
   IL_0029:  call       ""bool S1.TryGetValue(out C1)""
-  IL_002e:  brfalse.s  IL_0044
+  IL_002e:  brfalse.s  IL_0048
   IL_0030:  ldloc.2
   IL_0031:  stloc.1
   IL_0032:  ldloc.1
   IL_0033:  ldfld      ""int C1.F11""
   IL_0038:  ldc.i4.1
-  IL_0039:  bne.un.s   IL_0044
+  IL_0039:  bne.un.s   IL_0048
   IL_003b:  ldloc.1
   IL_003c:  ldfld      ""int C1.F12""
   IL_0041:  ldc.i4.3
-  IL_0042:  beq.s      IL_0048
+  IL_0042:  bne.un.s   IL_0048
   IL_0044:  ldc.i4.1
   IL_0045:  stloc.3
   IL_0046:  br.s       IL_004a
   IL_0048:  ldc.i4.0
   IL_0049:  stloc.3
   IL_004a:  ldloc.3
-  IL_004b:  ret
+  IL_004b:  ldc.i4.0
+  IL_004c:  ceq
+  IL_004e:  ret
 }
 ");
         }
@@ -28823,8 +29019,8 @@ struct S1
 [9]: t6 == 2 ? [10] : [13]
 [10]: t7 = t2.F12; [11]
 [11]: t7 == 3 ? [12] : [13]
-[12]: leaf <isPatternFailure> `u is not ((C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 })`
-[13]: leaf <isPatternSuccess> `not ((C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 })`
+[12]: leaf <isPatternFailure> `(C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 }`
+[13]: leaf <isPatternSuccess> `u is not ((C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 })`
 ",
 forLowering: true);
 
@@ -28859,7 +29055,7 @@ True
 
             verifier.VerifyIL("S1.Test1", @"
 {
-  // Code size       62 (0x3e)
+  // Code size       65 (0x41)
   .maxstack  2
   .locals init (C1 V_0,
                 C2 V_1,
@@ -28869,7 +29065,7 @@ True
   IL_0007:  isinst     ""C1""
   IL_000c:  stloc.0
   IL_000d:  ldloc.0
-  IL_000e:  brfalse.s  IL_0036
+  IL_000e:  brfalse.s  IL_003a
   IL_0010:  ldloc.0
   IL_0011:  ldfld      ""int C1.F11""
   IL_0016:  ldc.i4.1
@@ -28877,22 +29073,24 @@ True
   IL_0019:  ldarga.s   V_0
   IL_001b:  ldloca.s   V_1
   IL_001d:  call       ""bool S1.TryGetValue(out C2)""
-  IL_0022:  brfalse.s  IL_0036
+  IL_0022:  brfalse.s  IL_003a
   IL_0024:  ldloc.1
   IL_0025:  ldfld      ""int C2.F2""
   IL_002a:  ldc.i4.2
-  IL_002b:  bne.un.s   IL_0036
+  IL_002b:  bne.un.s   IL_003a
   IL_002d:  ldloc.0
   IL_002e:  ldfld      ""int C1.F12""
   IL_0033:  ldc.i4.3
-  IL_0034:  beq.s      IL_003a
+  IL_0034:  bne.un.s   IL_003a
   IL_0036:  ldc.i4.1
   IL_0037:  stloc.2
   IL_0038:  br.s       IL_003c
   IL_003a:  ldc.i4.0
   IL_003b:  stloc.2
   IL_003c:  ldloc.2
-  IL_003d:  ret
+  IL_003d:  ldc.i4.0
+  IL_003e:  ceq
+  IL_0040:  ret
 }
 ");
         }
@@ -28987,8 +29185,8 @@ struct S1
 [15]: t6 == 1 ? [16] : [19]
 [16]: t8 = t4.F12; [17]
 [17]: t8 == 3 ? [18] : [19]
-[18]: leaf <isPatternFailure> `u is not ((C2 { F2: 2 } or C1 { F11: 1 }) and C1 { F12: 3 })`
-[19]: leaf <isPatternSuccess> `not ((C2 { F2: 2 } or C1 { F11: 1 }) and C1 { F12: 3 })`
+[18]: leaf <isPatternFailure> `(C2 { F2: 2 } or C1 { F11: 1 }) and C1 { F12: 3 }`
+[19]: leaf <isPatternSuccess> `u is not ((C2 { F2: 2 } or C1 { F11: 1 }) and C1 { F12: 3 })`
 ",
 forLowering: true);
 
@@ -29023,7 +29221,7 @@ True
 
             verifier.VerifyIL("S1.Test1", @"
 {
-  // Code size       79 (0x4f)
+  // Code size       82 (0x52)
   .maxstack  2
   .locals init (C2 V_0,
                 C1 V_1,
@@ -29044,29 +29242,31 @@ True
   IL_001a:  ldloc.1
   IL_001b:  ldfld      ""int C1.F11""
   IL_0020:  ldc.i4.1
-  IL_0021:  bne.un.s   IL_0047
+  IL_0021:  bne.un.s   IL_004b
   IL_0023:  br.s       IL_003e
   IL_0025:  ldarga.s   V_0
   IL_0027:  call       ""object S1.Value.get""
   IL_002c:  isinst     ""C1""
   IL_0031:  stloc.1
   IL_0032:  ldloc.1
-  IL_0033:  brfalse.s  IL_0047
+  IL_0033:  brfalse.s  IL_004b
   IL_0035:  ldloc.1
   IL_0036:  ldfld      ""int C1.F11""
   IL_003b:  ldc.i4.1
-  IL_003c:  bne.un.s   IL_0047
+  IL_003c:  bne.un.s   IL_004b
   IL_003e:  ldloc.1
   IL_003f:  ldfld      ""int C1.F12""
   IL_0044:  ldc.i4.3
-  IL_0045:  beq.s      IL_004b
+  IL_0045:  bne.un.s   IL_004b
   IL_0047:  ldc.i4.1
   IL_0048:  stloc.2
   IL_0049:  br.s       IL_004d
   IL_004b:  ldc.i4.0
   IL_004c:  stloc.2
   IL_004d:  ldloc.2
-  IL_004e:  ret
+  IL_004e:  ldc.i4.0
+  IL_004f:  ceq
+  IL_0051:  ret
 }
 ");
         }
@@ -29154,8 +29354,8 @@ struct S1
 [8]: t5 == 2 ? [9] : [12]
 [9]: t6 = t2.F12; [10]
 [10]: t6 == 3 ? [11] : [12]
-[11]: leaf <isPatternFailure> `u is not ((C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 })`
-[12]: leaf <isPatternSuccess> `not ((C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 })`
+[11]: leaf <isPatternFailure> `(C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 }`
+[12]: leaf <isPatternSuccess> `u is not ((C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 })`
 ",
 forLowering: true);
 
@@ -29190,7 +29390,7 @@ True
 
             verifier.VerifyIL("S1.Test1", @"
 {
-  // Code size       58 (0x3a)
+  // Code size       61 (0x3d)
   .maxstack  2
   .locals init (C1 V_0,
             C1 V_1,
@@ -29199,7 +29399,7 @@ True
   IL_0000:  ldarga.s   V_0
   IL_0002:  ldloca.s   V_0
   IL_0004:  call       ""bool S1.TryGetValue(out C1)""
-  IL_0009:  brfalse.s  IL_0032
+  IL_0009:  brfalse.s  IL_0036
   IL_000b:  ldloc.0
   IL_000c:  stloc.1
   IL_000d:  ldloc.1
@@ -29210,22 +29410,24 @@ True
   IL_0017:  isinst     ""C2""
   IL_001c:  stloc.2
   IL_001d:  ldloc.2
-  IL_001e:  brfalse.s  IL_0032
+  IL_001e:  brfalse.s  IL_0036
   IL_0020:  ldloc.2
   IL_0021:  ldfld      ""int C2.F2""
   IL_0026:  ldc.i4.2
-  IL_0027:  bne.un.s   IL_0032
+  IL_0027:  bne.un.s   IL_0036
   IL_0029:  ldloc.1
   IL_002a:  ldfld      ""int C1.F12""
   IL_002f:  ldc.i4.3
-  IL_0030:  beq.s      IL_0036
+  IL_0030:  bne.un.s   IL_0036
   IL_0032:  ldc.i4.1
   IL_0033:  stloc.3
   IL_0034:  br.s       IL_0038
   IL_0036:  ldc.i4.0
   IL_0037:  stloc.3
   IL_0038:  ldloc.3
-  IL_0039:  ret
+  IL_0039:  ldc.i4.0
+  IL_003a:  ceq
+  IL_003c:  ret
 }
 ");
         }
@@ -29313,8 +29515,8 @@ struct S1
 [8]: t5 == 1 ? [9] : [12]
 [9]: t6 = t2.F12; [10]
 [10]: t6 == 3 ? [11] : [12]
-[11]: leaf <isPatternFailure> `u is not ((C2 { F2: 2 } or C1 { F11: 1 }) and C1 { F12: 3 })`
-[12]: leaf <isPatternSuccess> `not ((C2 { F2: 2 } or C1 { F11: 1 }) and C1 { F12: 3 })`
+[11]: leaf <isPatternFailure> `(C2 { F2: 2 } or C1 { F11: 1 }) and C1 { F12: 3 }`
+[12]: leaf <isPatternSuccess> `u is not ((C2 { F2: 2 } or C1 { F11: 1 }) and C1 { F12: 3 })`
 ",
 forLowering: true);
 
@@ -29349,7 +29551,7 @@ True
 
             verifier.VerifyIL("S1.Test1", @"
 {
-  // Code size       58 (0x3a)
+  // Code size       61 (0x3d)
   .maxstack  2
   .locals init (C1 V_0,
             C1 V_1,
@@ -29358,7 +29560,7 @@ True
   IL_0000:  ldarga.s   V_0
   IL_0002:  ldloca.s   V_0
   IL_0004:  call       ""bool S1.TryGetValue(out C1)""
-  IL_0009:  brfalse.s  IL_0032
+  IL_0009:  brfalse.s  IL_0036
   IL_000b:  ldloc.0
   IL_000c:  stloc.1
   IL_000d:  ldloc.1
@@ -29373,18 +29575,20 @@ True
   IL_0020:  ldloc.1
   IL_0021:  ldfld      ""int C1.F11""
   IL_0026:  ldc.i4.1
-  IL_0027:  bne.un.s   IL_0032
+  IL_0027:  bne.un.s   IL_0036
   IL_0029:  ldloc.1
   IL_002a:  ldfld      ""int C1.F12""
   IL_002f:  ldc.i4.3
-  IL_0030:  beq.s      IL_0036
+  IL_0030:  bne.un.s   IL_0036
   IL_0032:  ldc.i4.1
   IL_0033:  stloc.3
   IL_0034:  br.s       IL_0038
   IL_0036:  ldc.i4.0
   IL_0037:  stloc.3
   IL_0038:  ldloc.3
-  IL_0039:  ret
+  IL_0039:  ldc.i4.0
+  IL_003a:  ceq
+  IL_003c:  ret
 }
 ");
         }
@@ -30636,12 +30840,16 @@ struct S1 : S1.IUnionMembers
 
             verifier.VerifyIL("S1.Test2", @"
 {
-  // Code size       14 (0xe)
-  .maxstack  1
+  // Code size       20 (0x14)
+  .maxstack  2
   IL_0000:  ldarga.s   V_0
   IL_0002:  constrained. ""S1""
   IL_0008:  callvirt   ""bool S1.IUnionMembers.HasValue.get""
-  IL_000d:  ret
+  IL_000d:  ldc.i4.0
+  IL_000e:  ceq
+  IL_0010:  ldc.i4.0
+  IL_0011:  ceq
+  IL_0013:  ret
 }
 ");
         }
@@ -30715,15 +30923,23 @@ class S1 : S1.IUnionMembers
 
             verifier.VerifyIL("S1.Test2", @"
 {
-  // Code size       12 (0xc)
-  .maxstack  1
+  // Code size       22 (0x16)
+  .maxstack  2
+  .locals init (bool V_0)
   IL_0000:  ldarg.0
-  IL_0001:  brfalse.s  IL_000a
+  IL_0001:  brfalse.s  IL_000b
   IL_0003:  ldarg.0
   IL_0004:  callvirt   ""bool S1.IUnionMembers.HasValue.get""
-  IL_0009:  ret
-  IL_000a:  ldc.i4.0
-  IL_000b:  ret
+  IL_0009:  brtrue.s   IL_000f
+  IL_000b:  ldc.i4.1
+  IL_000c:  stloc.0
+  IL_000d:  br.s       IL_0011
+  IL_000f:  ldc.i4.0
+  IL_0010:  stloc.0
+  IL_0011:  ldloc.0
+  IL_0012:  ldc.i4.0
+  IL_0013:  ceq
+  IL_0015:  ret
 }
 ");
         }
@@ -30790,12 +31006,16 @@ struct S1 : S1.IUnionMembers
 
             verifier.VerifyIL("S1.Test2", @"
 {
-  // Code size       14 (0xe)
-  .maxstack  1
+  // Code size       20 (0x14)
+  .maxstack  2
   IL_0000:  ldarga.s   V_0
   IL_0002:  constrained. ""S1""
   IL_0008:  callvirt   ""bool S1.IUnionMembers.HasValue.get""
-  IL_000d:  ret
+  IL_000d:  ldc.i4.0
+  IL_000e:  ceq
+  IL_0010:  ldc.i4.0
+  IL_0011:  ceq
+  IL_0013:  ret
 }
 ");
         }
@@ -30860,14 +31080,16 @@ struct S1 : S1.IUnionMembers
 
             verifier.VerifyIL("S1.Test2", @"
 {
-  // Code size       17 (0x11)
+  // Code size       20 (0x14)
   .maxstack  2
   IL_0000:  ldarga.s   V_0
   IL_0002:  constrained. ""S1""
   IL_0008:  callvirt   ""object S1.IUnionMembers.Value.get""
   IL_000d:  ldnull
-  IL_000e:  cgt.un
-  IL_0010:  ret
+  IL_000e:  ceq
+  IL_0010:  ldc.i4.0
+  IL_0011:  ceq
+  IL_0013:  ret
 }
 ");
         }
@@ -31367,15 +31589,23 @@ class Program
             var verifier = CompileAndVerify(comp, expectedOutput: ExecutionConditionUtil.IsMonoOrCoreClr ? "TrueFalseTrueTrue" : null, verify: Verification.FailsPEVerify).VerifyDiagnostics();
             verifier.VerifyIL("Program.Test1", @"
 {
-  // Code size       12 (0xc)
-  .maxstack  1
+  // Code size       22 (0x16)
+  .maxstack  2
+  .locals init (bool V_0)
   IL_0000:  ldarg.0
-  IL_0001:  brfalse.s  IL_000a
+  IL_0001:  brfalse.s  IL_000b
   IL_0003:  ldarg.0
   IL_0004:  callvirt   ""bool S1.IUnionMembers.HasValue.get""
-  IL_0009:  ret
-  IL_000a:  ldc.i4.0
-  IL_000b:  ret
+  IL_0009:  brtrue.s   IL_000f
+  IL_000b:  ldc.i4.1
+  IL_000c:  stloc.0
+  IL_000d:  br.s       IL_0011
+  IL_000f:  ldc.i4.0
+  IL_0010:  stloc.0
+  IL_0011:  ldloc.0
+  IL_0012:  ldc.i4.0
+  IL_0013:  ceq
+  IL_0015:  ret
 }
 ");
         }
@@ -31766,7 +31996,7 @@ class S1 : S1.IUnionMembers
 }
 ";
             var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseExe);
-            var verifier = CompileAndVerify(comp, expectedOutput: "TrueFalseFalseFalseFalseTrueTrueFalse").VerifyDiagnostics();
+            var verifier = CompileAndVerify(comp, expectedOutput: "TrueFalseFalseFalseFalseTrueTrueTrue").VerifyDiagnostics();
 
             verifier.VerifyIL("S1.Test1", @"
 {
@@ -31786,19 +32016,19 @@ class S1 : S1.IUnionMembers
 
             verifier.VerifyIL("S1.Test2", @"
 {
-  // Code size       17 (0x11)
+  // Code size       18 (0x12)
   .maxstack  2
   .locals init (int V_0)
   IL_0000:  ldarg.0
-  IL_0001:  brfalse.s  IL_000f
+  IL_0001:  brfalse.s  IL_000d
   IL_0003:  ldarg.0
   IL_0004:  ldloca.s   V_0
   IL_0006:  callvirt   ""bool S1.IUnionMembers.TryGetValue(out int)""
-  IL_000b:  ldc.i4.0
-  IL_000c:  ceq
-  IL_000e:  ret
-  IL_000f:  ldc.i4.0
-  IL_0010:  ret
+  IL_000b:  br.s       IL_000e
+  IL_000d:  ldc.i4.0
+  IL_000e:  ldc.i4.0
+  IL_000f:  ceq
+  IL_0011:  ret
 }
 ");
         }
@@ -38322,8 +38552,8 @@ struct S1 : S1.IUnionMembers
 [8]: t5 == 2 ? [9] : [12]
 [9]: t6 = t2.F12; [10]
 [10]: t6 == 3 ? [11] : [12]
-[11]: leaf <isPatternFailure> `u is not ((C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 })`
-[12]: leaf <isPatternSuccess> `not ((C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 })`
+[11]: leaf <isPatternFailure> `(C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 }`
+[12]: leaf <isPatternSuccess> `u is not ((C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 })`
 ",
 forLowering: true);
 
@@ -38358,7 +38588,7 @@ True
 
             verifier.VerifyIL("S1.Test1", @"
 {
-  // Code size       69 (0x45)
+  // Code size       72 (0x48)
   .maxstack  2
   .locals init (object V_0,
             C1 V_1,
@@ -38372,7 +38602,7 @@ True
   IL_000f:  isinst     ""C1""
   IL_0014:  stloc.1
   IL_0015:  ldloc.1
-  IL_0016:  brfalse.s  IL_003d
+  IL_0016:  brfalse.s  IL_0041
   IL_0018:  ldloc.1
   IL_0019:  ldfld      ""int C1.F11""
   IL_001e:  ldc.i4.1
@@ -38381,22 +38611,24 @@ True
   IL_0022:  isinst     ""C2""
   IL_0027:  stloc.2
   IL_0028:  ldloc.2
-  IL_0029:  brfalse.s  IL_003d
+  IL_0029:  brfalse.s  IL_0041
   IL_002b:  ldloc.2
   IL_002c:  ldfld      ""int C2.F2""
   IL_0031:  ldc.i4.2
-  IL_0032:  bne.un.s   IL_003d
+  IL_0032:  bne.un.s   IL_0041
   IL_0034:  ldloc.1
   IL_0035:  ldfld      ""int C1.F12""
   IL_003a:  ldc.i4.3
-  IL_003b:  beq.s      IL_0041
+  IL_003b:  bne.un.s   IL_0041
   IL_003d:  ldc.i4.1
   IL_003e:  stloc.3
   IL_003f:  br.s       IL_0043
   IL_0041:  ldc.i4.0
   IL_0042:  stloc.3
   IL_0043:  ldloc.3
-  IL_0044:  ret
+  IL_0044:  ldc.i4.0
+  IL_0045:  ceq
+  IL_0047:  ret
 }
 ");
         }
@@ -38503,8 +38735,8 @@ struct S1 : S1.IUnionMembers
 [9]: t6 == 2 ? [10] : [13]
 [10]: t7 = t2.F12; [11]
 [11]: t7 == 3 ? [12] : [13]
-[12]: leaf <isPatternFailure> `u is not ((C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 })`
-[13]: leaf <isPatternSuccess> `not ((C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 })`
+[12]: leaf <isPatternFailure> `(C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 }`
+[13]: leaf <isPatternSuccess> `u is not ((C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 })`
 ",
 forLowering: true);
 
@@ -38539,7 +38771,7 @@ True
 
             verifier.VerifyIL("S1.Test1", @"
 {
-  // Code size       71 (0x47)
+  // Code size       74 (0x4a)
   .maxstack  2
   .locals init (C1 V_0,
                 C1 V_1,
@@ -38549,7 +38781,7 @@ True
   IL_0002:  ldloca.s   V_0
   IL_0004:  constrained. ""S1""
   IL_000a:  callvirt   ""bool S1.IUnionMembers.TryGetValue(out C1)""
-  IL_000f:  brfalse.s  IL_003f
+  IL_000f:  brfalse.s  IL_0043
   IL_0011:  ldloc.0
   IL_0012:  stloc.1
   IL_0013:  ldloc.1
@@ -38560,22 +38792,24 @@ True
   IL_001e:  ldloca.s   V_2
   IL_0020:  constrained. ""S1""
   IL_0026:  callvirt   ""bool S1.IUnionMembers.TryGetValue(out C2)""
-  IL_002b:  brfalse.s  IL_003f
+  IL_002b:  brfalse.s  IL_0043
   IL_002d:  ldloc.2
   IL_002e:  ldfld      ""int C2.F2""
   IL_0033:  ldc.i4.2
-  IL_0034:  bne.un.s   IL_003f
+  IL_0034:  bne.un.s   IL_0043
   IL_0036:  ldloc.1
   IL_0037:  ldfld      ""int C1.F12""
   IL_003c:  ldc.i4.3
-  IL_003d:  beq.s      IL_0043
+  IL_003d:  bne.un.s   IL_0043
   IL_003f:  ldc.i4.1
   IL_0040:  stloc.3
   IL_0041:  br.s       IL_0045
   IL_0043:  ldc.i4.0
   IL_0044:  stloc.3
   IL_0045:  ldloc.3
-  IL_0046:  ret
+  IL_0046:  ldc.i4.0
+  IL_0047:  ceq
+  IL_0049:  ret
 }
 ");
         }
@@ -38688,8 +38922,8 @@ struct S1 : S1.IUnionMembers
 [15]: t6 == 1 ? [16] : [19]
 [16]: t8 = t4.F12; [17]
 [17]: t8 == 3 ? [18] : [19]
-[18]: leaf <isPatternFailure> `u is not ((C2 { F2: 2 } or C1 { F11: 1 }) and C1 { F12: 3 })`
-[19]: leaf <isPatternSuccess> `not ((C2 { F2: 2 } or C1 { F11: 1 }) and C1 { F12: 3 })`
+[18]: leaf <isPatternFailure> `(C2 { F2: 2 } or C1 { F11: 1 }) and C1 { F12: 3 }`
+[19]: leaf <isPatternSuccess> `u is not ((C2 { F2: 2 } or C1 { F11: 1 }) and C1 { F12: 3 })`
 ",
 forLowering: true);
 
@@ -38724,7 +38958,7 @@ True
 
             verifier.VerifyIL("S1.Test1", @"
 {
-  // Code size       88 (0x58)
+  // Code size       91 (0x5b)
   .maxstack  2
   .locals init (C2 V_0,
                 C1 V_1,
@@ -38747,30 +38981,32 @@ True
   IL_0020:  ldloc.1
   IL_0021:  ldfld      ""int C1.F11""
   IL_0026:  ldc.i4.1
-  IL_0027:  bne.un.s   IL_0050
+  IL_0027:  bne.un.s   IL_0054
   IL_0029:  br.s       IL_0047
   IL_002b:  ldarga.s   V_0
   IL_002d:  ldloca.s   V_2
   IL_002f:  constrained. ""S1""
   IL_0035:  callvirt   ""bool S1.IUnionMembers.TryGetValue(out C1)""
-  IL_003a:  brfalse.s  IL_0050
+  IL_003a:  brfalse.s  IL_0054
   IL_003c:  ldloc.2
   IL_003d:  stloc.1
   IL_003e:  ldloc.1
   IL_003f:  ldfld      ""int C1.F11""
   IL_0044:  ldc.i4.1
-  IL_0045:  bne.un.s   IL_0050
+  IL_0045:  bne.un.s   IL_0054
   IL_0047:  ldloc.1
   IL_0048:  ldfld      ""int C1.F12""
   IL_004d:  ldc.i4.3
-  IL_004e:  beq.s      IL_0054
+  IL_004e:  bne.un.s   IL_0054
   IL_0050:  ldc.i4.1
   IL_0051:  stloc.3
   IL_0052:  br.s       IL_0056
   IL_0054:  ldc.i4.0
   IL_0055:  stloc.3
   IL_0056:  ldloc.3
-  IL_0057:  ret
+  IL_0057:  ldc.i4.0
+  IL_0058:  ceq
+  IL_005a:  ret
 }
 ");
         }
@@ -38869,8 +39105,8 @@ struct S1 : S1.IUnionMembers
 [9]: t6 == 2 ? [10] : [13]
 [10]: t7 = t2.F12; [11]
 [11]: t7 == 3 ? [12] : [13]
-[12]: leaf <isPatternFailure> `u is not ((C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 })`
-[13]: leaf <isPatternSuccess> `not ((C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 })`
+[12]: leaf <isPatternFailure> `(C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 }`
+[13]: leaf <isPatternSuccess> `u is not ((C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 })`
 ",
 forLowering: true);
 
@@ -38905,7 +39141,7 @@ True
 
             verifier.VerifyIL("S1.Test1", @"
 {
-  // Code size       74 (0x4a)
+  // Code size       77 (0x4d)
   .maxstack  2
   .locals init (C1 V_0,
             C2 V_1,
@@ -38916,7 +39152,7 @@ True
   IL_000d:  isinst     ""C1""
   IL_0012:  stloc.0
   IL_0013:  ldloc.0
-  IL_0014:  brfalse.s  IL_0042
+  IL_0014:  brfalse.s  IL_0046
   IL_0016:  ldloc.0
   IL_0017:  ldfld      ""int C1.F11""
   IL_001c:  ldc.i4.1
@@ -38925,22 +39161,24 @@ True
   IL_0021:  ldloca.s   V_1
   IL_0023:  constrained. ""S1""
   IL_0029:  callvirt   ""bool S1.IUnionMembers.TryGetValue(out C2)""
-  IL_002e:  brfalse.s  IL_0042
+  IL_002e:  brfalse.s  IL_0046
   IL_0030:  ldloc.1
   IL_0031:  ldfld      ""int C2.F2""
   IL_0036:  ldc.i4.2
-  IL_0037:  bne.un.s   IL_0042
+  IL_0037:  bne.un.s   IL_0046
   IL_0039:  ldloc.0
   IL_003a:  ldfld      ""int C1.F12""
   IL_003f:  ldc.i4.3
-  IL_0040:  beq.s      IL_0046
+  IL_0040:  bne.un.s   IL_0046
   IL_0042:  ldc.i4.1
   IL_0043:  stloc.2
   IL_0044:  br.s       IL_0048
   IL_0046:  ldc.i4.0
   IL_0047:  stloc.2
   IL_0048:  ldloc.2
-  IL_0049:  ret
+  IL_0049:  ldc.i4.0
+  IL_004a:  ceq
+  IL_004c:  ret
 }
 ");
         }
@@ -39045,8 +39283,8 @@ struct S1 : S1.IUnionMembers
 [15]: t6 == 1 ? [16] : [19]
 [16]: t8 = t4.F12; [17]
 [17]: t8 == 3 ? [18] : [19]
-[18]: leaf <isPatternFailure> `u is not ((C2 { F2: 2 } or C1 { F11: 1 }) and C1 { F12: 3 })`
-[19]: leaf <isPatternSuccess> `not ((C2 { F2: 2 } or C1 { F11: 1 }) and C1 { F12: 3 })`
+[18]: leaf <isPatternFailure> `(C2 { F2: 2 } or C1 { F11: 1 }) and C1 { F12: 3 }`
+[19]: leaf <isPatternSuccess> `u is not ((C2 { F2: 2 } or C1 { F11: 1 }) and C1 { F12: 3 })`
 ",
 forLowering: true);
 
@@ -39081,7 +39319,7 @@ True
 
             verifier.VerifyIL("S1.Test1", @"
 {
-  // Code size       91 (0x5b)
+  // Code size       94 (0x5e)
   .maxstack  2
   .locals init (C2 V_0,
             C1 V_1,
@@ -39103,7 +39341,7 @@ True
   IL_0020:  ldloc.1
   IL_0021:  ldfld      ""int C1.F11""
   IL_0026:  ldc.i4.1
-  IL_0027:  bne.un.s   IL_0053
+  IL_0027:  bne.un.s   IL_0057
   IL_0029:  br.s       IL_004a
   IL_002b:  ldarga.s   V_0
   IL_002d:  constrained. ""S1""
@@ -39111,22 +39349,24 @@ True
   IL_0038:  isinst     ""C1""
   IL_003d:  stloc.1
   IL_003e:  ldloc.1
-  IL_003f:  brfalse.s  IL_0053
+  IL_003f:  brfalse.s  IL_0057
   IL_0041:  ldloc.1
   IL_0042:  ldfld      ""int C1.F11""
   IL_0047:  ldc.i4.1
-  IL_0048:  bne.un.s   IL_0053
+  IL_0048:  bne.un.s   IL_0057
   IL_004a:  ldloc.1
   IL_004b:  ldfld      ""int C1.F12""
   IL_0050:  ldc.i4.3
-  IL_0051:  beq.s      IL_0057
+  IL_0051:  bne.un.s   IL_0057
   IL_0053:  ldc.i4.1
   IL_0054:  stloc.2
   IL_0055:  br.s       IL_0059
   IL_0057:  ldc.i4.0
   IL_0058:  stloc.2
   IL_0059:  ldloc.2
-  IL_005a:  ret
+  IL_005a:  ldc.i4.0
+  IL_005b:  ceq
+  IL_005d:  ret
 }
 ");
         }
@@ -39224,8 +39464,8 @@ struct S1 : S1.IUnionMembers
 [8]: t5 == 2 ? [9] : [12]
 [9]: t6 = t2.F12; [10]
 [10]: t6 == 3 ? [11] : [12]
-[11]: leaf <isPatternFailure> `u is not ((C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 })`
-[12]: leaf <isPatternSuccess> `not ((C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 })`
+[11]: leaf <isPatternFailure> `(C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 }`
+[12]: leaf <isPatternSuccess> `u is not ((C1 { F11: 1 } or C2 { F2: 2 }) and C1 { F12: 3 })`
 ",
 forLowering: true);
 
@@ -39260,7 +39500,7 @@ True
 
             verifier.VerifyIL("S1.Test1", @"
 {
-  // Code size       64 (0x40)
+  // Code size       67 (0x43)
   .maxstack  2
   .locals init (C1 V_0,
                 C1 V_1,
@@ -39270,7 +39510,7 @@ True
   IL_0002:  ldloca.s   V_0
   IL_0004:  constrained. ""S1""
   IL_000a:  callvirt   ""bool S1.IUnionMembers.TryGetValue(out C1)""
-  IL_000f:  brfalse.s  IL_0038
+  IL_000f:  brfalse.s  IL_003c
   IL_0011:  ldloc.0
   IL_0012:  stloc.1
   IL_0013:  ldloc.1
@@ -39281,22 +39521,24 @@ True
   IL_001d:  isinst     ""C2""
   IL_0022:  stloc.2
   IL_0023:  ldloc.2
-  IL_0024:  brfalse.s  IL_0038
+  IL_0024:  brfalse.s  IL_003c
   IL_0026:  ldloc.2
   IL_0027:  ldfld      ""int C2.F2""
   IL_002c:  ldc.i4.2
-  IL_002d:  bne.un.s   IL_0038
+  IL_002d:  bne.un.s   IL_003c
   IL_002f:  ldloc.1
   IL_0030:  ldfld      ""int C1.F12""
   IL_0035:  ldc.i4.3
-  IL_0036:  beq.s      IL_003c
+  IL_0036:  bne.un.s   IL_003c
   IL_0038:  ldc.i4.1
   IL_0039:  stloc.3
   IL_003a:  br.s       IL_003e
   IL_003c:  ldc.i4.0
   IL_003d:  stloc.3
   IL_003e:  ldloc.3
-  IL_003f:  ret
+  IL_003f:  ldc.i4.0
+  IL_0040:  ceq
+  IL_0042:  ret
 }
 ");
         }
@@ -39394,8 +39636,8 @@ struct S1 : S1.IUnionMembers
 [8]: t5 == 1 ? [9] : [12]
 [9]: t6 = t2.F12; [10]
 [10]: t6 == 3 ? [11] : [12]
-[11]: leaf <isPatternFailure> `u is not ((C2 { F2: 2 } or C1 { F11: 1 }) and C1 { F12: 3 })`
-[12]: leaf <isPatternSuccess> `not ((C2 { F2: 2 } or C1 { F11: 1 }) and C1 { F12: 3 })`
+[11]: leaf <isPatternFailure> `(C2 { F2: 2 } or C1 { F11: 1 }) and C1 { F12: 3 }`
+[12]: leaf <isPatternSuccess> `u is not ((C2 { F2: 2 } or C1 { F11: 1 }) and C1 { F12: 3 })`
 ",
 forLowering: true);
 
@@ -39430,7 +39672,7 @@ True
 
             verifier.VerifyIL("S1.Test1", @"
 {
-  // Code size       64 (0x40)
+  // Code size       67 (0x43)
   .maxstack  2
   .locals init (C1 V_0,
                 C1 V_1,
@@ -39440,7 +39682,7 @@ True
   IL_0002:  ldloca.s   V_0
   IL_0004:  constrained. ""S1""
   IL_000a:  callvirt   ""bool S1.IUnionMembers.TryGetValue(out C1)""
-  IL_000f:  brfalse.s  IL_0038
+  IL_000f:  brfalse.s  IL_003c
   IL_0011:  ldloc.0
   IL_0012:  stloc.1
   IL_0013:  ldloc.1
@@ -39455,18 +39697,20 @@ True
   IL_0026:  ldloc.1
   IL_0027:  ldfld      ""int C1.F11""
   IL_002c:  ldc.i4.1
-  IL_002d:  bne.un.s   IL_0038
+  IL_002d:  bne.un.s   IL_003c
   IL_002f:  ldloc.1
   IL_0030:  ldfld      ""int C1.F12""
   IL_0035:  ldc.i4.3
-  IL_0036:  beq.s      IL_003c
+  IL_0036:  bne.un.s   IL_003c
   IL_0038:  ldc.i4.1
   IL_0039:  stloc.3
   IL_003a:  br.s       IL_003e
   IL_003c:  ldc.i4.0
   IL_003d:  stloc.3
   IL_003e:  ldloc.3
-  IL_003f:  ret
+  IL_003f:  ldc.i4.0
+  IL_0040:  ceq
+  IL_0042:  ret
 }
 ");
         }


### PR DESCRIPTION
Corresponding speclet change is https://github.com/dotnet/csharplang/pull/10202
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83904)