### PR TITLE
Avoid Runtime="NET" usage with Arcade 10

### DIFF
--- a/eng/targets/GeneratePkgDef.targets
+++ b/eng/targets/GeneratePkgDef.targets
@@ -72,8 +72,8 @@
   -->
   
   <!-- TODO: Remove UsingTasks when upgrading to Arcade 11: https://github.com/dotnet/roslyn/issues/83095 -->
-  <UsingTask TaskName="Microsoft.DotNet.Build.Tasks.VisualStudio.GetPkgDefAssemblyDependencyGuid" AssemblyFile="$(ArcadeVisualStudioBuildTasksAssembly)" Runtime="NET" />
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GetAssemblyFullName" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" />
+  <UsingTask TaskName="Microsoft.DotNet.Build.Tasks.VisualStudio.GetPkgDefAssemblyDependencyGuid" AssemblyFile="$(ArcadeVisualStudioBuildTasksAssembly)" Condition="$(ArcadeSdkVersion.StartsWith('10'))"  />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GetAssemblyFullName" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Condition="$(ArcadeSdkVersion.StartsWith('10'))" />
 
   <Target Name="_SetGeneratePkgDefInputsOutputs">
     <PropertyGroup>

--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -174,8 +174,8 @@
   </Target>
 
   <!-- TODO: Remove UsingTasks when upgrading to Arcade 11: https://github.com/dotnet/roslyn/issues/83095 -->
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.CompareVersions" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" />
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SingleError" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.CompareVersions" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Condition="$(ArcadeSdkVersion.StartsWith('10'))" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SingleError" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Condition="$(ArcadeSdkVersion.StartsWith('10'))" />
 
   <Target Name="_CheckRequiredMSBuildVersion" BeforeTargets="BeforeBuild" Condition="'$(DotNetBuildSourceOnly)' != 'true'">
     <CompareVersions Left="$(MSBuildVersion)" Right="$(MinimumMSBuildVersion)">

--- a/src/NuGet/VS.Tools.Roslyn.Package/VS.Tools.Roslyn.Package.csproj
+++ b/src/NuGet/VS.Tools.Roslyn.Package/VS.Tools.Roslyn.Package.csproj
@@ -46,7 +46,7 @@
     Workaround for https://github.com/dotnet/roslyn/issues/17864.
   -->
   <!-- TODO: Remove UsingTask when upgrading to Arcade 11: https://github.com/dotnet/roslyn/issues/83095 -->
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SetCorFlags" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SetCorFlags" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Condition="$(ArcadeSdkVersion.StartsWith('10'))" />
 
   <Target Name="_Generate32BitCsc" 
           AfterTargets="Build"

--- a/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
+++ b/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <!-- TODO: Remove UsingTasks when upgrading to Arcade 11: https://github.com/dotnet/roslyn/issues/83095 -->
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GetAssemblyFullName" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" />
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GroupItemsBy" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" />
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.Unsign" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Runtime="NET" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GetAssemblyFullName" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Condition="$(ArcadeSdkVersion.StartsWith('10'))" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GroupItemsBy" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Condition="$(ArcadeSdkVersion.StartsWith('10'))" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.Unsign" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" Condition="$(ArcadeSdkVersion.StartsWith('10'))" />
   <UsingTask TaskName="Microsoft.DotNet.Tools.ReplacePackageParts" AssemblyFile="$(_NuGetRepackAssembly)" />
 
   <UsingTask TaskName="Microsoft.NET.Build.Tasks.JoinItems" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />


### PR DESCRIPTION
Fixes the build when using VS msbuild. In thbe VMR with Arcade 11, the UsingTasks are provided by the Arcade SDK automatically. There's already a tracking issue for that.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83907)