### PR TITLE
Check modified files in build boss

### DIFF
--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Syntax.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Syntax.Generated.cs
@@ -10794,6 +10794,7 @@ public sealed partial class UnionDeclarationSyntax : TypeDeclarationSyntax
     public override void Accept(CSharpSyntaxVisitor visitor) => visitor.VisitUnionDeclaration(this);
     public override TResult? Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) where TResult : default => visitor.VisitUnionDeclaration(this);
 
+    [Experimental(global::Microsoft.CodeAnalysis.RoslynExperiments.PreviewLanguageFeatureApi, UrlFormat = @"https://github.com/dotnet/roslyn/issues/82567")]
     public UnionDeclarationSyntax Update(SyntaxList<AttributeListSyntax> attributeLists, SyntaxTokenList modifiers, SyntaxToken keyword, SyntaxToken identifier, TypeParameterListSyntax? typeParameterList, ParameterListSyntax? parameterList, BaseListSyntax? baseList, SyntaxList<TypeParameterConstraintClauseSyntax> constraintClauses, SyntaxToken openBraceToken, SyntaxList<MemberDeclarationSyntax> members, SyntaxToken closeBraceToken, SyntaxToken semicolonToken)
     {
         if (attributeLists != this.AttributeLists || modifiers != this.Modifiers || keyword != this.Keyword || identifier != this.Identifier || typeParameterList != this.TypeParameterList || parameterList != this.ParameterList || baseList != this.BaseList || constraintClauses != this.ConstraintClauses || openBraceToken != this.OpenBraceToken || members != this.Members || closeBraceToken != this.CloseBraceToken || semicolonToken != this.SemicolonToken)

--- a/src/Tools/BuildBoss/GeneratedFilesCheckerUtil.cs
+++ b/src/Tools/BuildBoss/GeneratedFilesCheckerUtil.cs
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Diagnostics;
+
+namespace BuildBoss;
+
+internal sealed class GeneratedFilesCheckerUtil : ICheckerUtil
+{
+    private readonly string _targetDir;
+
+    internal GeneratedFilesCheckerUtil(string targetDir)
+    {
+        _targetDir = targetDir;
+    }
+
+    public bool Check(TextWriter textWriter)
+    {
+        try
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "git",
+                Arguments = "status --porcelain",
+                WorkingDirectory = _targetDir,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+            };
+
+            using var process = Process.Start(startInfo);
+            var output = process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            if (process.ExitCode != 0)
+            {
+                textWriter.WriteLine($"git status failed with exit code {process.ExitCode}");
+                WriteOutput(textWriter, output, error);
+                return false;
+            }
+
+            if (output.Length > 0)
+            {
+                textWriter.WriteLine("Generated files are out of date. Build the solution and commit the generated changes.");
+                WriteOutput(textWriter, output, error);
+                return false;
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            textWriter.WriteLine($"Error running git status: {ex.Message}");
+            return false;
+        }
+    }
+
+    private static void WriteOutput(TextWriter textWriter, string output, string error)
+    {
+        if (output.Length > 0)
+        {
+            textWriter.Write(output);
+        }
+
+        if (error.Length > 0)
+        {
+            textWriter.Write(error);
+        }
+    }
+}

--- a/src/Tools/BuildBoss/GeneratedFilesCheckerUtil.cs
+++ b/src/Tools/BuildBoss/GeneratedFilesCheckerUtil.cs
@@ -3,8 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.IO;
 using System.Diagnostics;
+using System.IO;
 
 namespace BuildBoss;
 
@@ -32,9 +32,11 @@ internal sealed class GeneratedFilesCheckerUtil : ICheckerUtil
             };
 
             using var process = Process.Start(startInfo);
-            var output = process.StandardOutput.ReadToEnd();
-            var error = process.StandardError.ReadToEnd();
+            var outputTask = process.StandardOutput.ReadToEndAsync();
+            var errorTask = process.StandardError.ReadToEndAsync();
             process.WaitForExit();
+            var output = outputTask.Result;
+            var error = errorTask.Result;
 
             if (process.ExitCode != 0)
             {
@@ -54,7 +56,7 @@ internal sealed class GeneratedFilesCheckerUtil : ICheckerUtil
         }
         catch (Exception ex)
         {
-            textWriter.WriteLine($"Error running git status: {ex.Message}");
+            textWriter.WriteLine($"Error running git status: {ex}");
             return false;
         }
     }

--- a/src/Tools/BuildBoss/Program.cs
+++ b/src/Tools/BuildBoss/Program.cs
@@ -103,6 +103,7 @@ namespace BuildBoss
 
             var artifactsDirectory = Path.Combine(repositoryDirectory, "artifacts");
 
+            allGood &= ProcessGeneratedFiles(repositoryDirectory);
             allGood &= ProcessTargets(repositoryDirectory);
             allGood &= ProcessPackages(repositoryDirectory, artifactsDirectory, configuration);
             allGood &= ProcessStructuredLog(artifactsDirectory, configuration);
@@ -137,6 +138,12 @@ namespace BuildBoss
         {
             var util = new SolutionCheckerUtil(solutionFilePath, isPrimarySolution);
             return CheckCore(util, $"Solution {solutionFilePath}");
+        }
+
+        private static bool ProcessGeneratedFiles(string repositoryDirectory)
+        {
+            var checker = new GeneratedFilesCheckerUtil(repositoryDirectory);
+            return CheckCore(checker, $"Generated files {repositoryDirectory}");
         }
 
         private static bool ProcessTargets(string repositoryDirectory)


### PR DESCRIPTION
Currently reports

```
Processing Generated files D:\a\_work\1\s/ ... FAILED
Generated files are out of date. Build the solution and commit the generated changes.
 M src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Syntax.Generated.cs
```

Because that file is indeed outdated (fixed in the second commit). The existing `eng\generate-compiler-code.cs` doesn't check/generate this file - it leaves that to the source generator, but nothing in CI checked that files are not modified after build.

Fixes https://github.com/dotnet/roslyn/issues/83910.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83909)