### PR TITLE
Add IAsyncLifetime overhead adjustment to test scheduling

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -302,9 +302,6 @@
     <PackageVersion Include="Basic.Reference.Assemblies.NetStandard13" Version="$(_BasicReferenceAssembliesVersion)" />
     <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="$(_BasicReferenceAssembliesVersion)" />
     <PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="$(_BasicReferenceAssembliesVersion)" />
-    <PackageVersion Include="Microsoft.TeamFoundationServer.Client" Version="19.232.0-preview" />
-    <PackageVersion Include="System.Data.SqlClient" Version="$(SystemDataSqlClientVersion)" />
-    <!-- fix of vulnerability in 6.0.0 coming via Microsoft.TeamFoundationServer.Client -->
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
     <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="$(SystemSecurityCryptographyPkcsVersion)" />
     <!--

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,11 +56,6 @@
   <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
     <MicrosoftIORedistVersion>6.1.0</MicrosoftIORedistVersion>
     <SystemBuffersVersion>4.6.1</SystemBuffersVersion>
-    <!--
-    Microsoft.TeamFoundationServer.Client is referencing System.Data.SqlClient causing CG alert
-    When it updates its referenced System.Data.SqlClient version this should be removed
-    -->
-    <SystemDataSqlClientVersion>4.8.6</SystemDataSqlClientVersion>
     <SystemMemoryVersion>4.6.3</SystemMemoryVersion>
     <SystemNumericsVectorsVersion>4.6.1</SystemNumericsVectorsVersion>
     <SystemRuntimeCompilerServicesUnsafeVersion>6.1.2</SystemRuntimeCompilerServicesUnsafeVersion>

--- a/src/Tools/RunTests/AssemblyInfo.cs
+++ b/src/Tools/RunTests/AssemblyInfo.cs
@@ -24,7 +24,7 @@ public readonly record struct TypeInfo(string Name, string FullyQualifiedName, I
     public override string ToString() => $"[Type]{FullyQualifiedName}";
 }
 
-public readonly record struct TestMethodInfo(string Name, string FullyQualifiedName, TimeSpan ExecutionTime)
+public readonly record struct TestMethodInfo(string Name, string FullyQualifiedName, TimeSpan ExecutionTime, bool HasAsyncLifetime)
 {
     public override string ToString() => $"[Method]{FullyQualifiedName}";
 }

--- a/src/Tools/RunTests/AssemblyScheduler.cs
+++ b/src/Tools/RunTests/AssemblyScheduler.cs
@@ -138,7 +138,16 @@ namespace RunTests
                 // We didn't find the local type from our assembly in test run historical data.
                 // This usually occurs when tests have been added in between the last passing branch run and this PR.
                 unmatchedLocalTests.Add(methodInfo.FullyQualifiedName);
-                return methodInfo with { ExecutionTime = averageExecutionTime };
+                var fallbackExecutionTime = averageExecutionTime;
+
+                // If the test class implements IAsyncLifetime, add overhead for at least one instance
+                // to account for InitializeAsync/DisposeAsync time not captured in the average duration.
+                if (methodInfo.HasAsyncLifetime)
+                {
+                    fallbackExecutionTime += HelixTestRunner.AsyncLifetimeInstanceOverhead;
+                }
+
+                return methodInfo with { ExecutionTime = fallbackExecutionTime };
             }
 
             void WriteResults()

--- a/src/Tools/RunTests/AssemblyScheduler.cs
+++ b/src/Tools/RunTests/AssemblyScheduler.cs
@@ -26,7 +26,7 @@ namespace RunTests
 
         public static ImmutableArray<HelixWorkItem> Schedule(
             IEnumerable<string> assemblyFilePaths,
-            ImmutableDictionary<string, TimeSpan> testHistory)
+            ImmutableDictionary<string, (TimeSpan Duration, int TestTheoryInstances)> testHistory)
         {
             var orderedTypeInfos = assemblyFilePaths.ToImmutableSortedDictionary(x => x, GetTypeInfoList);
             ConsoleUtil.WriteLine($"Scheduling {orderedTypeInfos.Count} assemblies");
@@ -67,16 +67,16 @@ namespace RunTests
             return workItems;
         }
 
-        private static void LogLongTests(ImmutableDictionary<string, TimeSpan> testHistory)
+        private static void LogLongTests(ImmutableDictionary<string, (TimeSpan Duration, int TestTheoryInstances)> testHistory)
         {
             var longTests = testHistory
-                .Where(kvp => kvp.Value > HelixTestRunner.WorkItemScheduleTime)
+                .Where(kvp => kvp.Value.Duration > HelixTestRunner.WorkItemScheduleTime)
                 .OrderBy(kvp => kvp.Key)
                 .ToList();
             if (longTests.Count > 0)
             {
                 ConsoleUtil.Warning($"There are {longTests.Count} tests have execution times greater than the maximum execution time of {HelixTestRunner.WorkItemScheduleTime:hh\\:mm\\:ss}.  These tests will be scheduled in their own individual work items and may indicate tests that should be optimized or removed if they are no longer providing value.");
-                foreach (var (test, time) in longTests)
+                foreach (var (test, (time, _)) in longTests)
                 {
                     ConsoleUtil.WriteLine($"\t{test} - {time:hh\\:mm\\:ss}");
                 }
@@ -85,10 +85,16 @@ namespace RunTests
 
         private static ImmutableSortedDictionary<string, ImmutableArray<TypeInfo>> UpdateTestsWithExecutionTimes(
             ImmutableSortedDictionary<string, ImmutableArray<TypeInfo>> assemblyTypes,
-            ImmutableDictionary<string, TimeSpan> testHistory)
+            ImmutableDictionary<string, (TimeSpan Duration, int TestTheoryInstances)> testHistory)
         {
+            // In xUnit v2, the ExecutionTimer in TestInvoker does NOT include IAsyncLifetime
+            // .InitializeAsync() or .DisposeAsync() in DurationInMs. Test base classes that
+            // perform expensive per-test async setup/teardown (MEF composition, workspace creation)
+            // will have overhead not reflected in the reported duration. We add an empirical
+            // adjustment per test theory instance for tests whose class implements IAsyncLifetime.
+
             // Determine the average execution time so that we can use it for tests that do not have any history.
-            var averageExecutionTime = TimeSpan.FromMilliseconds(testHistory.Values.Average(t => t.TotalMilliseconds));
+            var averageExecutionTime = TimeSpan.FromMilliseconds(testHistory.Values.Average(t => t.Duration.TotalMilliseconds));
 
             // Store the tests we found locally that were missing remote historical data.
             var unmatchedLocalTests = new HashSet<string>();
@@ -114,9 +120,18 @@ namespace RunTests
                 // Match by fully qualified test method name to azure devops historical data.
                 // Note for combinatorial tests, azure devops helpfully groups all sub-runs under a top level method (with combined test run times) with the same fully qualified method name
                 // that we get during test discovery.  Since we only filter by the single method name (and not individual combinatorial runs) we do want the combined execution time.
-                if (testHistory.TryGetValue(methodInfo.FullyQualifiedName, out var executionTime))
+                if (testHistory.TryGetValue(methodInfo.FullyQualifiedName, out var historyEntry))
                 {
                     matchedRemoteTests.Add(methodInfo.FullyQualifiedName);
+                    var executionTime = historyEntry.Duration;
+
+                    // If the test class implements IAsyncLifetime, add overhead per theory instance
+                    // to account for InitializeAsync/DisposeAsync time not captured in DurationInMs.
+                    if (methodInfo.HasAsyncLifetime)
+                    {
+                        executionTime += TimeSpan.FromMilliseconds(historyEntry.TestTheoryInstances * HelixTestRunner.AsyncLifetimeInstanceOverhead.TotalMilliseconds);
+                    }
+
                     return methodInfo with { ExecutionTime = executionTime };
                 }
 
@@ -245,14 +260,17 @@ namespace RunTests
                 throw new ArgumentException($"{testListPath} does not exist");
             }
 
-            var deserialized = JsonSerializer.Deserialize<List<string>>(File.ReadAllText(testListPath));
-            if (deserialized == null)
+            var deserialized = JsonSerializer.Deserialize<List<TestDiscoveryEntry>>(File.ReadAllText(testListPath));
+            if (deserialized is null)
             {
                 throw new InvalidOperationException($"Could not deserialize {testListPath}");
             }
 
-            var tests = deserialized.GroupBy(GetTypeName)
-                .Select(group => new TypeInfo(GetName(group.Key), group.Key, group.Select(test => new TestMethodInfo(GetName(test), test, TimeSpan.Zero)).ToImmutableArray()))
+            var tests = deserialized.GroupBy(e => GetTypeName(e.MethodName!))
+                .Select(group => new TypeInfo(
+                    GetName(group.Key),
+                    group.Key,
+                    group.Select(e => new TestMethodInfo(GetName(e.MethodName!), e.MethodName!, TimeSpan.Zero, e.HasAsyncLifetime)).ToImmutableArray()))
                 .ToImmutableArray();
             return tests;
 
@@ -267,6 +285,12 @@ namespace RunTests
                 var lastPeriod = fullyQualifiedName.LastIndexOf(".");
                 return fullyQualifiedName[(lastPeriod + 1)..];
             }
+        }
+
+        private sealed class TestDiscoveryEntry
+        {
+            public string? MethodName { get; set; }
+            public bool HasAsyncLifetime { get; set; }
         }
 
         /// <summary>

--- a/src/Tools/RunTests/AzdoClient.cs
+++ b/src/Tools/RunTests/AzdoClient.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -136,12 +135,9 @@ internal sealed class AzdoClient : IDisposable
         return result.Value;
     }
 
-    private sealed class AzdoListResponse<T>
+    private sealed record AzdoListResponse<T>
     {
-        [JsonPropertyName("count")]
         public int Count { get; init; }
-
-        [JsonPropertyName("value")]
         public required List<T> Value { get; init; }
     }
 }
@@ -149,54 +145,28 @@ internal sealed class AzdoClient : IDisposable
 /// <summary>
 /// Represents an Azure DevOps build from the REST API.
 /// </summary>
-internal sealed class AzdoBuild
+internal sealed record AzdoBuild
 {
-    [JsonPropertyName("id")]
     public int Id { get; init; }
-
-    [JsonPropertyName("buildNumber")]
     public string? BuildNumber { get; init; }
-
-    [JsonPropertyName("status")]
     public string? Status { get; init; }
-
-    [JsonPropertyName("result")]
     public string? Result { get; init; }
-
-    [JsonPropertyName("url")]
     public string? Url { get; init; }
-
-    [JsonPropertyName("sourceBranch")]
     public string? SourceBranch { get; init; }
-
-    [JsonPropertyName("queueTime")]
     public DateTime? QueueTime { get; init; }
-
-    [JsonPropertyName("finishTime")]
     public DateTime? FinishTime { get; init; }
 }
 
 /// <summary>
 /// Represents an Azure DevOps test run from the REST API.
 /// </summary>
-internal sealed class AzdoTestRun
+internal sealed record AzdoTestRun
 {
-    [JsonPropertyName("id")]
     public int Id { get; init; }
-
-    [JsonPropertyName("name")]
     public required string Name { get; init; }
-
-    [JsonPropertyName("totalTests")]
     public int TotalTests { get; init; }
-
-    [JsonPropertyName("passedTests")]
     public int PassedTests { get; init; }
-
-    [JsonPropertyName("unanalyzedTests")]
     public int UnanalyzedTests { get; init; }
-
-    [JsonPropertyName("notApplicableTests")]
     public int NotApplicableTests { get; init; }
 }
 
@@ -205,18 +175,11 @@ internal sealed class AzdoTestRun
 /// Includes <see cref="SubResultsCount"/> which exposes the number of sub-results
 /// (e.g. xUnit theory instances) that are not available through the old TFS client library.
 /// </summary>
-internal sealed class AzdoTestResult
+internal sealed record AzdoTestResult
 {
-    [JsonPropertyName("id")]
     public int Id { get; init; }
-
-    [JsonPropertyName("automatedTestName")]
     public required string AutomatedTestName { get; init; }
-
-    [JsonPropertyName("durationInMs")]
     public double DurationInMs { get; init; }
-
-    [JsonPropertyName("outcome")]
     public string? Outcome { get; init; }
 
     /// <summary>
@@ -226,9 +189,7 @@ internal sealed class AzdoTestResult
     /// This field is only available through the REST API and was the motivation for removing
     /// the Microsoft.TeamFoundationServer.Client dependency.
     /// </summary>
-    [JsonPropertyName("subResultsCount")]
     public int SubResultsCount { get; init; }
 
-    [JsonPropertyName("resultGroupType")]
     public string? ResultGroupType { get; init; }
 }

--- a/src/Tools/RunTests/AzdoClient.cs
+++ b/src/Tools/RunTests/AzdoClient.cs
@@ -1,0 +1,234 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RunTests;
+
+/// <summary>
+/// A lightweight Azure DevOps REST API client that replaces the heavy
+/// Microsoft.TeamFoundationServer.Client package. Inspired by
+/// https://github.com/jaredpar/tiger/blob/main/src/Tiger/AzdoClient.cs
+/// </summary>
+internal sealed class AzdoClient : IDisposable
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly HttpClient _httpClient;
+
+    private AzdoClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public static AzdoClient Create(string projectUri, string accessToken)
+    {
+        // projectUri is the collection URI (e.g. https://dev.azure.com/dnceng-public/)
+        // Ensure it ends with a slash for relative URI resolution
+        if (!projectUri.EndsWith("/"))
+            projectUri += "/";
+
+        var httpClient = new HttpClient
+        {
+            BaseAddress = new Uri(projectUri),
+        };
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Basic",
+            Convert.ToBase64String(System.Text.Encoding.ASCII.GetBytes($":{accessToken}")));
+
+        return new AzdoClient(httpClient);
+    }
+
+    public void Dispose() => _httpClient.Dispose();
+
+    /// <summary>
+    /// Gets the most recent successful CI build for the given definition and branch.
+    /// </summary>
+    public async Task<AzdoBuild?> GetLastSuccessfulBuildAsync(
+        string project,
+        int definitionId,
+        string branchName,
+        CancellationToken cancellationToken)
+    {
+        var url = $"{project}/_apis/build/builds?api-version=7.1" +
+            $"&definitions={definitionId}" +
+            $"&resultFilter=succeeded" +
+            $"&queryOrder=finishTimeDescending" +
+            $"&$top=1" +
+            $"&reasonFilter=individualCI" +
+            $"&branchName={Uri.EscapeDataString(branchName)}";
+
+        var builds = await GetListAsync<AzdoBuild>(url, cancellationToken);
+        return builds.FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Gets test runs for a build within the build's time range, matching a stage/phase name.
+    /// </summary>
+    public async Task<AzdoTestRun?> GetRunForStageAsync(
+        string project,
+        AzdoBuild build,
+        string phaseName,
+        CancellationToken cancellationToken)
+    {
+        var minTime = build.QueueTime!.Value.ToString("o");
+        var maxTime = build.FinishTime!.Value.ToString("o");
+
+        var url = $"{project}/_apis/test/runs?api-version=7.1" +
+            $"&minLastUpdatedDate={Uri.EscapeDataString(minTime)}" +
+            $"&maxLastUpdatedDate={Uri.EscapeDataString(maxTime)}" +
+            $"&buildIds={build.Id}";
+
+        var runs = await GetListAsync<AzdoTestRun>(url, cancellationToken);
+
+        // If the last successful build had multiple attempts then there are potentially multiple runs with
+        // the same name. Take the last one as it will be the successful one.
+        return runs.LastOrDefault(r => r.Name.Contains(phaseName));
+    }
+
+    /// <summary>
+    /// Gets test results for a run with pagination support.
+    /// When <paramref name="includeSubResults"/> is true, the request includes
+    /// <c>detailsToInclude=SubResults</c> which populates <see cref="AzdoTestResult.SubResultsCount"/>
+    /// with the number of sub-results (e.g. individual xUnit theory instances) for grouped tests.
+    /// </summary>
+    public async Task<List<AzdoTestResult>> GetTestResultsAsync(
+        string project,
+        int runId,
+        int skip,
+        int top,
+        bool includeSubResults,
+        CancellationToken cancellationToken)
+    {
+        var url = $"{project}/_apis/test/Runs/{runId}/results?api-version=7.1" +
+            $"&$skip={skip}" +
+            $"&$top={top}";
+
+        if (includeSubResults)
+        {
+            url += "&detailsToInclude=SubResults";
+        }
+
+        return await GetListAsync<AzdoTestResult>(url, cancellationToken);
+    }
+
+    private async Task<List<T>> GetListAsync<T>(string url, CancellationToken cancellationToken)
+    {
+        var response = await _httpClient.GetAsync(url, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync(cancellationToken);
+        var result = JsonSerializer.Deserialize<AzdoListResponse<T>>(json, s_jsonOptions)
+            ?? throw new InvalidOperationException($"Failed to deserialize response from {url}");
+
+        return result.Value;
+    }
+
+    private sealed class AzdoListResponse<T>
+    {
+        [JsonPropertyName("count")]
+        public int Count { get; init; }
+
+        [JsonPropertyName("value")]
+        public required List<T> Value { get; init; }
+    }
+}
+
+/// <summary>
+/// Represents an Azure DevOps build from the REST API.
+/// </summary>
+internal sealed class AzdoBuild
+{
+    [JsonPropertyName("id")]
+    public int Id { get; init; }
+
+    [JsonPropertyName("buildNumber")]
+    public string? BuildNumber { get; init; }
+
+    [JsonPropertyName("status")]
+    public string? Status { get; init; }
+
+    [JsonPropertyName("result")]
+    public string? Result { get; init; }
+
+    [JsonPropertyName("url")]
+    public string? Url { get; init; }
+
+    [JsonPropertyName("sourceBranch")]
+    public string? SourceBranch { get; init; }
+
+    [JsonPropertyName("queueTime")]
+    public DateTime? QueueTime { get; init; }
+
+    [JsonPropertyName("finishTime")]
+    public DateTime? FinishTime { get; init; }
+}
+
+/// <summary>
+/// Represents an Azure DevOps test run from the REST API.
+/// </summary>
+internal sealed class AzdoTestRun
+{
+    [JsonPropertyName("id")]
+    public int Id { get; init; }
+
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("totalTests")]
+    public int TotalTests { get; init; }
+
+    [JsonPropertyName("passedTests")]
+    public int PassedTests { get; init; }
+
+    [JsonPropertyName("unanalyzedTests")]
+    public int UnanalyzedTests { get; init; }
+
+    [JsonPropertyName("notApplicableTests")]
+    public int NotApplicableTests { get; init; }
+}
+
+/// <summary>
+/// Represents an individual test result from the Azure DevOps REST API.
+/// Includes <see cref="SubResultsCount"/> which exposes the number of sub-results
+/// (e.g. xUnit theory instances) that are not available through the old TFS client library.
+/// </summary>
+internal sealed class AzdoTestResult
+{
+    [JsonPropertyName("id")]
+    public int Id { get; init; }
+
+    [JsonPropertyName("automatedTestName")]
+    public required string AutomatedTestName { get; init; }
+
+    [JsonPropertyName("durationInMs")]
+    public double DurationInMs { get; init; }
+
+    [JsonPropertyName("outcome")]
+    public string? Outcome { get; init; }
+
+    /// <summary>
+    /// The number of sub-results for this test result. For grouped tests (e.g. xUnit theories),
+    /// this indicates how many individual theory instances were executed under this parent result.
+    /// This is only populated when the request includes <c>detailsToInclude=SubResults</c>.
+    /// This field is only available through the REST API and was the motivation for removing
+    /// the Microsoft.TeamFoundationServer.Client dependency.
+    /// </summary>
+    [JsonPropertyName("subResultsCount")]
+    public int SubResultsCount { get; init; }
+
+    [JsonPropertyName("resultGroupType")]
+    public string? ResultGroupType { get; init; }
+}

--- a/src/Tools/RunTests/HelixTestRunner.cs
+++ b/src/Tools/RunTests/HelixTestRunner.cs
@@ -45,6 +45,13 @@ internal sealed partial class HelixTestRunner
     internal static TimeSpan WorkItemScheduleTime { get; } = TimeSpan.FromMinutes(10);
 
     /// <summary>
+    /// In xUnit v2, IAsyncLifetime.InitializeAsync and DisposeAsync are not included in the
+    /// reported test duration (DurationInMs). This is the per-theory-instance overhead adjustment
+    /// applied to tests whose class implements IAsyncLifetime.
+    /// </summary>
+    internal static TimeSpan AsyncLifetimeInstanceOverhead { get; } = TimeSpan.FromMilliseconds(700);
+
+    /// <summary>
     /// This is the amount of time we will wait for a helix work item to complete before we consider it a severe error
     /// and cancel the helix job entirely.
     /// </summary>

--- a/src/Tools/RunTests/RunTests.csproj
+++ b/src/Tools/RunTests/RunTests.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="System.Management" />
     <PackageReference Include="Mono.Options" />
     <PackageReference Include="Newtonsoft.Json" />
-    <PackageReference Include="Microsoft.TeamFoundationServer.Client" />
     <ProjectReference Include="..\..\Compilers\Test\Core\Microsoft.CodeAnalysis.Test.Utilities.csproj" />
   </ItemGroup>
   <Import Project="..\..\Dependencies\Contracts\Microsoft.CodeAnalysis.Contracts.projitems" />

--- a/src/Tools/RunTests/TestHistoryManager.cs
+++ b/src/Tools/RunTests/TestHistoryManager.cs
@@ -25,9 +25,13 @@ internal class TestHistoryManager
 
     /// <summary>
     /// Looks up the last passing test run for the current build and stage to estimate execution times for each
-    /// tests. The dictionary is indexed by test full name.
+    /// tests. The dictionary is indexed by test full name and contains the body duration and theory instance count.
+    ///
+    /// Note: the duration returned is the sum of body execution times (DurationInMs) as reported by xUnit.
+    /// In xUnit v2, DurationInMs does NOT include IAsyncLifetime.InitializeAsync or DisposeAsync time.
+    /// The caller is responsible for adjusting the duration based on the HasAsyncLifetime flag from test discovery.
     /// </summary>
-    public static async Task<ImmutableDictionary<string, TimeSpan>> GetTestHistoryAsync(Options options, CancellationToken cancellationToken)
+    public static async Task<ImmutableDictionary<string, (TimeSpan Duration, int TestTheoryInstances)>> GetTestHistoryAsync(Options options, CancellationToken cancellationToken)
     {
         // Access token that has permissions to lookup test history.  This typically comes from the pipeline.
         var accessToken = options.AccessToken ?? GetEnvironmentVariable("SYSTEM_ACCESSTOKEN");
@@ -52,7 +56,7 @@ internal class TestHistoryManager
         if (string.IsNullOrEmpty(accessToken) || string.IsNullOrEmpty(projectUri) || string.IsNullOrEmpty(phaseName) || string.IsNullOrEmpty(targetBranch) || !int.TryParse(pipelineDefinitionIdStr, out var pipelineDefinitionId))
         {
             ConsoleUtil.Warning($"Missing required options to lookup test history, projectUri={projectUri}, phaseName={phaseName}, targetBranchName={targetBranch}, pipelineDefinitionId={pipelineDefinitionIdStr}");
-            return ImmutableDictionary<string, TimeSpan>.Empty;
+            return ImmutableDictionary<string, (TimeSpan Duration, int TestTheoryInstances)>.Empty;
         }
 
         var credentials = new Microsoft.VisualStudio.Services.Common.VssBasicCredential(string.Empty, accessToken);
@@ -78,7 +82,7 @@ internal class TestHistoryManager
         {
             // If this is a new branch we may not have any historical data for it.
             ConsoleUtil.Warning($"Unable to get the last successful build for definition {pipelineDefinitionId} in {projectUri} and branch {targetBranch}");
-            return ImmutableDictionary<string, TimeSpan>.Empty;
+            return ImmutableDictionary<string, (TimeSpan Duration, int TestTheoryInstances)>.Empty;
         }
 
         using var testClient = connection.GetClient<TestResultsHttpClient>();
@@ -87,14 +91,14 @@ internal class TestHistoryManager
         {
             // If this is a new stage, historical runs will not have any data for it.
             ConsoleUtil.Warning($"Unable to get a run with name {phaseName} from build {lastSuccessfulBuild.Url}.");
-            return ImmutableDictionary<string, TimeSpan>.Empty;
+            return ImmutableDictionary<string, (TimeSpan Duration, int TestTheoryInstances)>.Empty;
         }
 
         ConsoleUtil.WriteLine($"Looking up test execution data for build {lastSuccessfulBuild.Id} on branch {targetBranch} and stage {phaseName}");
 
         var totalTests = runForThisStage.TotalTests;
 
-        Dictionary<string, TimeSpan> testInfos = new();
+        Dictionary<string, (TimeSpan Duration, int TestTheoryInstances)> testInfos = new();
         var duplicateCount = 0;
 
         // Get runtimes for all tests.
@@ -114,7 +118,7 @@ internal class TestHistoryManager
 
                 var testName = CleanTestName(testResult.AutomatedTestName);
 
-                if (!testInfos.TryAdd(testName, TimeSpan.FromMilliseconds(testResult.DurationInMs)))
+                if (testInfos.TryGetValue(testName, out var existing))
                 {
                     // We can get duplicate tests if a test file is included in multiple assemblies (e.g. analyzer codestyle tests).
                     // This is fine, we'll just use capture one of the run times since it is the same test being run in both cases and unlikely to have different run times.
@@ -122,7 +126,14 @@ internal class TestHistoryManager
                     // Another case that can happen is if a test is incorrectly authored to have the same name and namespace as a test in another assembly.  For example
                     // a test that applies to both VB and C#, but the tests in both the C# and VB assembly accidentally use the C# namespace.
                     // It may have a different run time, but ADO does not let us differentiate by assembly name, so we just have to pick one.
+                    //
+                    // Keep tracking the count of theory instances so we can apply async lifetime adjustment.
+                    testInfos[testName] = (existing.Duration, existing.TestTheoryInstances + 1);
                     duplicateCount++;
+                }
+                else
+                {
+                    testInfos[testName] = (TimeSpan.FromMilliseconds(testResult.DurationInMs), 1);
                 }
             }
         }
@@ -134,7 +145,7 @@ internal class TestHistoryManager
             Logger.Log($"Found {duplicateCount} duplicate tests in run {runForThisStage.Name}.");
         }
 
-        var totalTestRuntime = TimeSpan.FromMilliseconds(testInfos.Values.Sum(t => t.TotalMilliseconds));
+        var totalTestRuntime = TimeSpan.FromMilliseconds(testInfos.Values.Sum(t => t.Duration.TotalMilliseconds));
         ConsoleUtil.WriteLine($"Retrieved {testInfos.Keys.Count} tests from AzureDevops in {timer.Elapsed}.  Total runtime of all tests is {totalTestRuntime}");
         return testInfos.ToImmutableDictionary();
     }

--- a/src/Tools/RunTests/TestHistoryManager.cs
+++ b/src/Tools/RunTests/TestHistoryManager.cs
@@ -9,10 +9,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.TeamFoundation.Build.WebApi;
-using Microsoft.TeamFoundation.TestManagement.WebApi;
-using Microsoft.VisualStudio.Services.TestResults.WebApi;
-using Microsoft.VisualStudio.Services.WebApi;
 
 namespace RunTests;
 
@@ -26,6 +22,8 @@ internal class TestHistoryManager
     /// <summary>
     /// Looks up the last passing test run for the current build and stage to estimate execution times for each
     /// tests. The dictionary is indexed by test full name and contains the body duration and theory instance count.
+    /// The theory instance count is sourced from the AzDO <c>subResultsCount</c> field which represents individual
+    /// theory invocations reported under a grouped test result.
     ///
     /// Note: the duration returned is the sum of body execution times (DurationInMs) as reported by xUnit.
     /// In xUnit v2, DurationInMs does NOT include IAsyncLifetime.InitializeAsync or DisposeAsync time.
@@ -59,23 +57,19 @@ internal class TestHistoryManager
             return ImmutableDictionary<string, (TimeSpan Duration, int TestTheoryInstances)>.Empty;
         }
 
-        var credentials = new Microsoft.VisualStudio.Services.Common.VssBasicCredential(string.Empty, accessToken);
-
-        var connection = new VssConnection(new Uri(projectUri), credentials);
-
-        using var buildClient = connection.GetClient<BuildHttpClient>();
+        using var azdoClient = AzdoClient.Create(projectUri, accessToken);
 
         ConsoleUtil.WriteLine($"Getting last successful build for branch {targetBranch}");
         var adoBranch = targetBranch.StartsWith("refs/heads/", StringComparison.OrdinalIgnoreCase)
             ? targetBranch
             : $"refs/heads/{targetBranch}";
-        var lastSuccessfulBuild = await GetLastSuccessfulBuildAsync(pipelineDefinitionId, adoBranch, buildClient, cancellationToken);
+        var lastSuccessfulBuild = await GetLastSuccessfulBuildAsync(azdoClient, pipelineDefinitionId, adoBranch, cancellationToken);
         if (lastSuccessfulBuild == null && adoBranch != "refs/heads/main")
         {
             // If this is a new branch or has no successful builds, fall back to main history
             // to avoid the expensive method-count fallback that creates hundreds of work items.
             ConsoleUtil.Warning($"Unable to get the last successful build for branch {adoBranch}, falling back to refs/heads/main");
-            lastSuccessfulBuild = await GetLastSuccessfulBuildAsync(pipelineDefinitionId, "refs/heads/main", buildClient, cancellationToken);
+            lastSuccessfulBuild = await GetLastSuccessfulBuildAsync(azdoClient, pipelineDefinitionId, "refs/heads/main", cancellationToken);
         }
 
         if (lastSuccessfulBuild == null)
@@ -85,8 +79,7 @@ internal class TestHistoryManager
             return ImmutableDictionary<string, (TimeSpan Duration, int TestTheoryInstances)>.Empty;
         }
 
-        using var testClient = connection.GetClient<TestResultsHttpClient>();
-        var runForThisStage = await GetRunForStageAsync(lastSuccessfulBuild, phaseName, testClient, cancellationToken);
+        var runForThisStage = await GetRunForStageAsync(azdoClient, lastSuccessfulBuild, phaseName, cancellationToken);
         if (runForThisStage == null)
         {
             // If this is a new stage, historical runs will not have any data for it.
@@ -106,7 +99,7 @@ internal class TestHistoryManager
         timer.Start();
         for (var i = 0; i < totalTests; i += MaxTestsReturnedPerRequest)
         {
-            var testResults = await GetTestResultsAsync(runForThisStage, i, MaxTestsReturnedPerRequest, testClient, cancellationToken);
+            var testResults = await GetTestResultsAsync(azdoClient, runForThisStage, i, MaxTestsReturnedPerRequest, cancellationToken);
             foreach (var testResult in testResults)
             {
                 // Helix outputs results for the whole dll work item suffixed with WorkItemExecution which we should ignore.
@@ -128,12 +121,12 @@ internal class TestHistoryManager
                     // It may have a different run time, but ADO does not let us differentiate by assembly name, so we just have to pick one.
                     //
                     // Keep tracking the count of theory instances so we can apply async lifetime adjustment.
-                    testInfos[testName] = (existing.Duration, existing.TestTheoryInstances + 1);
+                    testInfos[testName] = (existing.Duration, existing.TestTheoryInstances + testResult.SubResultsCount);
                     duplicateCount++;
                 }
                 else
                 {
-                    testInfos[testName] = (TimeSpan.FromMilliseconds(testResult.DurationInMs), 1);
+                    testInfos[testName] = (TimeSpan.FromMilliseconds(testResult.DurationInMs), testResult.SubResultsCount);
                 }
             }
         }
@@ -168,20 +161,11 @@ internal class TestHistoryManager
         return beforeMethodArgs;
     }
 
-    private static async Task<Build?> GetLastSuccessfulBuildAsync(int definitionId, string branchName, BuildHttpClient buildClient, CancellationToken cancellationToken)
+    private static async Task<AzdoBuild?> GetLastSuccessfulBuildAsync(AzdoClient azdoClient, int definitionId, string branchName, CancellationToken cancellationToken)
     {
         try
         {
-            var builds = await buildClient.GetBuildsAsync2(
-                        project: "public",
-                        new int[] { definitionId },
-                        resultFilter: BuildResult.Succeeded,
-                        queryOrder: BuildQueryOrder.FinishTimeDescending,
-                        maxBuildsPerDefinition: 1,
-                        reasonFilter: BuildReason.IndividualCI,
-                        branchName: branchName,
-                        cancellationToken: cancellationToken);
-            return builds?.FirstOrDefault();
+            return await azdoClient.GetLastSuccessfulBuildAsync("public", definitionId, branchName, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -191,19 +175,11 @@ internal class TestHistoryManager
         }
     }
 
-    private static async Task<TestRun?> GetRunForStageAsync(Build build, string phaseName, TestResultsHttpClient testClient, CancellationToken cancellationToken)
+    private static async Task<AzdoTestRun?> GetRunForStageAsync(AzdoClient azdoClient, AzdoBuild build, string phaseName, CancellationToken cancellationToken)
     {
         try
         {
-            // API requires us to pass a time range to query runs for.  So just pass the times from the build.
-            var minTime = build.QueueTime!.Value;
-            var maxTime = build.FinishTime!.Value;
-            var runsInBuild = await testClient.QueryTestRunsAsync2("public", minTime, maxTime, buildIds: new int[] { build.Id }, cancellationToken: cancellationToken);
-
-            // If the last successful builds had multiple attempts then there are potentially multiple runs with 
-            // the same name. Take the last one as it will be the successful one.
-            var runForThisStage = runsInBuild.LastOrDefault(r => r.Name.Contains(phaseName));
-            return runForThisStage;
+            return await azdoClient.GetRunForStageAsync("public", build, phaseName, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -213,18 +189,17 @@ internal class TestHistoryManager
         }
     }
 
-    private static async Task<List<TestCaseResult>> GetTestResultsAsync(TestRun testRun, int skip, int top, TestResultsHttpClient testClient, CancellationToken cancellationToken)
+    private static async Task<List<AzdoTestResult>> GetTestResultsAsync(AzdoClient azdoClient, AzdoTestRun testRun, int skip, int top, CancellationToken cancellationToken)
     {
         try
         {
-            var testResults = await testClient.GetTestResultsAsync("public", testRun.Id, skip: skip, top: top, cancellationToken: cancellationToken);
-            return testResults ?? new List<TestCaseResult>();
+            return await azdoClient.GetTestResultsAsync("public", testRun.Id, skip, top, includeSubResults: true, cancellationToken);
         }
         catch (Exception ex)
         {
             // We will fallback to test count partitioning if we fail to query ADO.
             ConsoleUtil.WriteLine($"Caught exception querying ADO for test runs: {ex}");
-            return new List<TestCaseResult>();
+            return new List<AzdoTestResult>();
         }
     }
 }

--- a/src/Tools/TestDiscoveryWorker/Program.cs
+++ b/src/Tools/TestDiscoveryWorker/Program.cs
@@ -77,10 +77,11 @@ try
                 messageSink: sink,
                 discoveryOptions: TestFrameworkOptions.ForDiscovery(configuration));
 
-    var testsToWrite = new HashSet<string>();
-    await foreach (var fullyQualifiedName in sink.GetTestCaseNamesAsync().ConfigureAwait(false))
+    var testsToWrite = new Dictionary<string, bool>();
+    await foreach (var (fullyQualifiedName, hasAsyncLifetime) in sink.GetTestCaseInfosAsync().ConfigureAwait(false))
     {
-        testsToWrite.Add(fullyQualifiedName);
+        if (!testsToWrite.ContainsKey(fullyQualifiedName))
+            testsToWrite[fullyQualifiedName] = hasAsyncLifetime;
     }
 
     if (sink.AnyWriteFailures)
@@ -91,8 +92,12 @@ try
 
     Console.WriteLine($"{testsToWrite.Count} found");
 
+    var testInfos = testsToWrite
+        .OrderBy(x => x.Key)
+        .Select(x => new TestInfo(x.Key, x.Value))
+        .ToArray();
     using var fileStream = new FileStream(outputFilePath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None);
-    await JsonSerializer.SerializeAsync(fileStream, testsToWrite.OrderBy(x => x)).ConfigureAwait(false);
+    await JsonSerializer.SerializeAsync(fileStream, testInfos).ConfigureAwait(false);
     return ExitSuccess;
 }
 catch (OptionException e)
@@ -108,18 +113,33 @@ catch (Exception ex)
     return ExitFailure;
 }
 
+file class TestInfo
+{
+    public string MethodName { get; set; } = "";
+    public bool HasAsyncLifetime { get; set; }
+
+    public TestInfo() { }
+
+    public TestInfo(string methodName, bool hasAsyncLifetime)
+    {
+        MethodName = methodName;
+        HasAsyncLifetime = hasAsyncLifetime;
+    }
+}
+
 file class Sink : IMessageSink
 {
     public bool AnyWriteFailures { get; private set; }
 
     public Sink()
     {
-        _channel = Channel.CreateUnbounded<string>();
+        _channel = Channel.CreateUnbounded<(string FullName, bool HasAsyncLifetime)>();
     }
 
-    private readonly Channel<string> _channel;
+    private readonly Channel<(string FullName, bool HasAsyncLifetime)> _channel;
+    private readonly Dictionary<string, bool> _asyncLifetimeCache = new();
 
-    public async IAsyncEnumerable<string> GetTestCaseNamesAsync()
+    public async IAsyncEnumerable<(string FullName, bool HasAsyncLifetime)> GetTestCaseInfosAsync()
     {
         while (await _channel.Reader.WaitToReadAsync(CancellationToken.None).ConfigureAwait(false))
         {
@@ -147,12 +167,26 @@ file class Sink : IMessageSink
 
     private void OnTestDiscovered(ITestCaseDiscoveryMessage testCaseDiscovered)
     {
-        var fullName = $"{testCaseDiscovered.TestCase.TestMethod.TestClass.Class.Name}.{testCaseDiscovered.TestCase.TestMethod.Method.Name}";
+        var testClass = testCaseDiscovered.TestCase.TestMethod.TestClass.Class;
+        var fullName = $"{testClass.Name}.{testCaseDiscovered.TestCase.TestMethod.Method.Name}";
+        var hasAsyncLifetime = HasAsyncLifetime(testClass);
+
         // this shouldn't happen as our channel is unbounded but we are Paranoid Coding™️
-        if (!_channel.Writer.TryWrite(fullName))
+        if (!_channel.Writer.TryWrite((fullName, hasAsyncLifetime)))
         {
             AnyWriteFailures = true;
         }
+    }
+
+    private bool HasAsyncLifetime(ITypeInfo typeInfo)
+    {
+        var typeName = typeInfo.Name;
+        if (_asyncLifetimeCache.TryGetValue(typeName, out var cached))
+            return cached;
+
+        var result = typeInfo.Interfaces.Any(i => i.Name == "Xunit.IAsyncLifetime");
+        _asyncLifetimeCache[typeName] = result;
+        return result;
     }
 }
 


### PR DESCRIPTION
xUnit v2's TestInvoker does not include IAsyncLifetime.InitializeAsync or DisposeAsync in DurationInMs, causing the scheduler to significantly underestimate execution time for tests with expensive async setup (e.g. MEF composition, workspace creation). This led to partitions targeting ~10 minutes consistently running ~30 minutes.

Changes:
- TestDiscoveryWorker now emits HasAsyncLifetime per test method by checking if the test class implements IAsyncLifetime (directly or via base types)
- TestHistoryManager returns theory instance counts alongside durations
- AssemblyScheduler applies a 700ms per-theory-instance overhead for tests marked HasAsyncLifetime

This is a stop-gap solution until we find a better way to measure the actual IAsyncLifetime overhead, such as computing it from wall-clock timestamps or switching to a test framework that includes it in reported durations.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83915)