### PR TITLE
Revert "[PAT Migration] Replace devdiv/engineering SC with WIF (WI 10126)"

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -295,7 +295,7 @@ extends:
         # Authenticate with service connections to be able to publish packages to external nuget feeds.
         - task: NuGetAuthenticate@1
           inputs:
-            nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk, devdiv-engineering-feed-r-wif, devdiv/dotnet-core-internal-tooling
+            nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk, devdiv/engineering, devdiv/dotnet-core-internal-tooling
 
         # Needed for SBOM tool
         - task: UseDotNet@2


### PR DESCRIPTION
Official build errors with 

```
The pipeline is not valid. Job OfficialBuild: Step NuGetAuthenticate input nuGetServiceConnections expects a service connection of type ExternalNuGetFeed but the provided service connection devdiv-engineering-feed-r-wif is of type workloadidentityuser.
```

Reverts dotnet/roslyn#83723

cc: @missymessa 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83917)