### PR TITLE
[PAT Migration] Replace devdiv/engineering SC with WIF using correct NuGetAuthenticate inputs (WI 10126)

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -295,7 +295,13 @@ extends:
         # Authenticate with service connections to be able to publish packages to external nuget feeds.
         - task: NuGetAuthenticate@1
           inputs:
-            nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk, devdiv/engineering, devdiv/dotnet-core-internal-tooling
+            nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk, devdiv/dotnet-core-internal-tooling
+
+        # Authenticate to DevDiv engineering feed via WIF service connection
+        - task: NuGetAuthenticate@1
+          inputs:
+            azureDevOpsServiceConnection: devdiv-engineering-feed-r-wif
+            feedUrl: https://devdiv.pkgs.visualstudio.com/_packaging/Engineering/nuget/v3/index.json
 
         # Needed for SBOM tool
         - task: UseDotNet@2


### PR DESCRIPTION
## Summary

Replaces the PAT-based \devdiv/engineering\ NuGet service connection with the WIF-backed \devdiv-engineering-feed-r-wif\ SC for DevDiv Engineering feed authentication.

## What went wrong with #83723

The previous attempt put \devdiv-engineering-feed-r-wif\ (type \workloadidentityuser\) into the \
uGetServiceConnections\ input, which only accepts \ExternalNuGetFeed\ type connections. This caused:

\\\
The pipeline is not valid. Job OfficialBuild: Step NuGetAuthenticate input nuGetServiceConnections
expects a service connection of type ExternalNuGetFeed but the provided service connection
devdiv-engineering-feed-r-wif is of type workloadidentityuser.
\\\

Reverted by #83917.

## Fix

WIF service connections use a different \NuGetAuthenticate@1\ input pair:
- \zureDevOpsServiceConnection\ — the WIF SC name
- \eedUrl\ — the target feed URL

These require a separate task invocation from the legacy \
uGetServiceConnections\ list.

## Changes

1. Remove \devdiv/engineering\ from the \
uGetServiceConnections\ comma list
2. Add a new \NuGetAuthenticate@1\ task with \zureDevOpsServiceConnection: devdiv-engineering-feed-r-wif\ and \eedUrl: https://devdiv.pkgs.visualstudio.com/_packaging/Engineering/nuget/v3/index.json\

## Identity

- SC: \devdiv-engineering-feed-r-wif\ (type: \workloadidentityuser\)
- Entra App: \dnceng-devdiv-engineering-feed-r-wif\
- Feed: DevDiv / Engineering (read access)

## Note

PR validation will run the old YAML from \main\, not this branch's YAML. The real verification happens on the first post-merge CI build.

Related: https://dev.azure.com/dnceng/internal/_workitems/edit/10126
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83918)