### PR TITLE
Fix Razor @{ completion regression in VS Code CSHTML files

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/ImplicitExpressionSuggestionModeRewriter.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/ImplicitExpressionSuggestionModeRewriter.cs
@@ -8,19 +8,26 @@ using Microsoft.CodeAnalysis.Text;
 namespace Microsoft.CodeAnalysis.Razor.Completion.Delegation;
 
 /// <summary>
-/// Clears <see cref="Roslyn.LanguageServer.Protocol.VSInternalCompletionList.SuggestionMode"/> for C# completions
-/// at the top level of implicit Razor expressions.
+/// Manages completion behavior for C# completions at the top level of implicit Razor expressions.
 /// </summary>
 /// <remarks>
-/// In implicit expressions (e.g., <c>@h</c>), the Razor compiler generates C# like
-/// <c>__builder.AddContent(seq, h)</c>. Because <c>RenderTreeBuilder.AddContent</c> has a
-/// <c>RenderFragment</c> (delegate) overload, Roslyn's suggestion-mode completion provider detects
-/// a potential lambda context and enables suggestion mode. This is a false positive at the top level
-/// of an implicit expression—users almost always intend to reference an identifier, not start a lambda.
+/// This rewriter handles two cases:
+///
+/// 1. **At the @ transition** (cursor immediately after <c>@</c>): clears all commit characters
+///    and sets <c>IsIncomplete = true</c>. This prevents characters like <c>{</c> from committing a
+///    completion item when the user intends <c>@{</c> (a code block). The <c>IsIncomplete</c> flag
+///    ensures the client re-queries on the next keystroke, restoring normal commit behavior.
+///
+/// 2. **At the top level of the implicit expression** (e.g., <c>@h|</c>): clears false-positive
+///    <see cref="Roslyn.LanguageServer.Protocol.VSInternalCompletionList.SuggestionMode"/>. In implicit
+///    expressions, the Razor compiler generates C# like <c>__builder.AddContent(seq, h)</c>. Because
+///    <c>RenderTreeBuilder.AddContent</c> has a <c>RenderFragment</c> (delegate) overload, Roslyn's
+///    suggestion-mode completion provider detects a potential lambda context and enables suggestion mode.
+///    This is a false positive—users almost always intend to reference an identifier, not start a lambda.
 ///
 /// However, implicit expressions can contain nested method calls with balanced parentheses
 /// (e.g., <c>@items.Where(x =&gt; x.Name)</c>), where suggestion mode from the inner method's
-/// delegate parameter is legitimate. This rewriter only clears suggestion mode when the cursor is
+/// delegate parameter is legitimate. Case 2 only clears suggestion mode when the cursor is
 /// at the top level of the implicit expression (not inside parentheses).
 /// </remarks>
 internal class ImplicitExpressionSuggestionModeRewriter : IDelegatedCSharpCompletionResponseRewriter
@@ -45,12 +52,11 @@ internal class ImplicitExpressionSuggestionModeRewriter : IDelegatedCSharpComple
             .GetRequiredSyntaxRoot()
             .FindInnermostNode(hostDocumentIndex - 1);
 
-        // Check if cursor is at the @ transition itself (no identifier typed yet).
-        // At @|, FindInnermostNode returns the CSharpTransitionSyntax whose parent is the implicit expression.
-        // We clear commit characters to prevent characters like '{' from committing (the user may
-        // intend @{ for a code block). We also mark the list incomplete so the client re-queries on the
-        // next keystroke — otherwise the client would filter locally and keep empty commit characters even
-        // after an identifier is typed (e.g., @ba), when normal commit behavior should be restored.
+        // Check if cursor is immediately after the @ transition in an implicit expression.
+        // FindInnermostNode at the @ position returns the CSharpTransitionSyntax whose parent is
+        // the implicit expression. We clear commit characters to prevent characters like '{' from
+        // committing (the user may intend @{ for a code block). We also mark the list incomplete
+        // so the client re-queries on the next keystroke, restoring normal commit behavior.
         if (owner is CSharpTransitionSyntax { Parent: CSharpImplicitExpressionSyntax })
         {
             completionList.IsIncomplete = true;

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/ImplicitExpressionSuggestionModeRewriter.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/ImplicitExpressionSuggestionModeRewriter.cs
@@ -32,11 +32,6 @@ internal class ImplicitExpressionSuggestionModeRewriter : IDelegatedCSharpComple
         Position projectedPosition,
         RazorCompletionOptions completionOptions)
     {
-        if (!completionList.SuggestionMode)
-        {
-            return completionList;
-        }
-
         // The cursor is positioned right after the last typed character.  For example, in @h|
         // the host document index points at the character after 'h', which is typically the
         // start of the next token (e.g., '<' in '</div>').  To find the token the user is
@@ -49,6 +44,24 @@ internal class ImplicitExpressionSuggestionModeRewriter : IDelegatedCSharpComple
         var owner = codeDocument
             .GetRequiredSyntaxRoot()
             .FindInnermostNode(hostDocumentIndex - 1);
+
+        // Check if cursor is at the @ transition itself (no identifier typed yet).
+        // At @|, FindInnermostNode returns the CSharpTransitionSyntax whose parent is the implicit expression.
+        // We clear commit characters to prevent characters like '{' from committing (the user may
+        // intend @{ for a code block). We also mark the list incomplete so the client re-queries on the
+        // next keystroke — otherwise the client would filter locally and keep empty commit characters even
+        // after an identifier is typed (e.g., @ba), when normal commit behavior should be restored.
+        if (owner is CSharpTransitionSyntax { Parent: CSharpImplicitExpressionSyntax })
+        {
+            completionList.IsIncomplete = true;
+            ClearCommitCharacters(completionList);
+            return completionList;
+        }
+
+        if (!completionList.SuggestionMode)
+        {
+            return completionList;
+        }
 
         var implicitExpression = owner is { Parent: CSharpCodeBlockSyntax { Parent: CSharpImplicitExpressionBodySyntax { Parent: CSharpImplicitExpressionSyntax expr } } }
             ? expr
@@ -91,5 +104,26 @@ internal class ImplicitExpressionSuggestionModeRewriter : IDelegatedCSharpComple
         }
 
         return depth > 0;
+    }
+
+    /// <summary>
+    /// Clears all commit characters from the completion list to prevent unwanted commits
+    /// at the @ transition position. This is necessary for VS Code (which ignores SuggestionMode)
+    /// and also prevents commit characters from firing in VS IDE.
+    /// </summary>
+    private static void ClearCommitCharacters(RazorVSInternalCompletionList completionList)
+    {
+        completionList.CommitCharacters = null;
+
+        if (completionList.ItemDefaults is { } itemDefaults)
+        {
+            itemDefaults.CommitCharacters = null;
+        }
+
+        foreach (var item in completionList.Items)
+        {
+            item.CommitCharacters = null;
+            item.VsCommitCharacters = null;
+        }
     }
 }

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/ImplicitExpressionSuggestionModeRewriterTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/ImplicitExpressionSuggestionModeRewriterTest.cs
@@ -41,6 +41,34 @@ public class ImplicitExpressionSuggestionModeRewriterTest
         Assert.False(result.SuggestionMode);
     }
 
+    [Theory]
+    [InlineData("<div>@$$</div>", RazorFileKind.Component)]      // Component file
+    [InlineData("<div>@$$</div>", RazorFileKind.Legacy)]          // CSHTML file
+    [InlineData("@$$", RazorFileKind.Component)]                  // Bare @ at start
+    public void AtTransition_SetsIsIncompleteAndClearsCommitChars(string markup, RazorFileKind fileKind)
+    {
+        // When cursor is immediately after @ with no identifier typed, commit characters must be
+        // cleared to prevent '{' from committing a completion item when the user intends @{ (code block).
+        // IsIncomplete must also be set so the client re-queries on the next keystroke, allowing
+        // normal commit characters to be restored once an identifier character is typed.
+        var (codeDocument, cursorIndex) = Parse(markup, fileKind);
+
+        var completionList = CreateCompletionList(suggestionMode: false);
+        completionList.CommitCharacters = new string[] { "{", "(" };
+        completionList.ItemDefaults = new() { CommitCharacters = new string[] { "{", "." } };
+        completionList.Items[0].CommitCharacters = new string[] { "{" };
+        completionList.Items[0].VsCommitCharacters = new VSInternalCommitCharacter[] { new() { Character = "{" } };
+
+        var result = _rewriter.Rewrite(completionList, codeDocument, cursorIndex, new Position(), new RazorCompletionOptions());
+
+        Assert.True(result.IsIncomplete);
+        Assert.False(result.SuggestionMode); // SuggestionMode is not modified
+        Assert.Null(result.CommitCharacters);
+        Assert.Null(result.ItemDefaults!.CommitCharacters);
+        Assert.Null(result.Items[0].CommitCharacters);
+        Assert.Null(result.Items[0].VsCommitCharacters);
+    }
+
     /// <summary>
     /// Parses the input, invokes the rewriter with SuggestionMode=true, and returns the resulting SuggestionMode value.
     /// </summary>
@@ -54,7 +82,7 @@ public class ImplicitExpressionSuggestionModeRewriterTest
         return result.SuggestionMode;
     }
 
-    private static (RazorCodeDocument CodeDocument, int CursorIndex) Parse(string textWithMarker)
+    private static (RazorCodeDocument CodeDocument, int CursorIndex) Parse(string textWithMarker, RazorFileKind fileKind = RazorFileKind.Component)
     {
         var cursorIndex = textWithMarker.IndexOf("$$");
         Assert.True(cursorIndex >= 0, "Test input must contain $$ cursor marker");
@@ -62,7 +90,7 @@ public class ImplicitExpressionSuggestionModeRewriterTest
         var text = textWithMarker.Remove(cursorIndex, 2);
 
         var sourceDocument = TestRazorSourceDocument.Create(text);
-        var options = new RazorParserOptions.Builder(RazorLanguageVersion.Latest, RazorFileKind.Component).ToOptions();
+        var options = new RazorParserOptions.Builder(RazorLanguageVersion.Latest, fileKind).ToOptions();
         var syntaxTree = RazorSyntaxTree.Parse(sourceDocument, options);
 
         var codeDocument = RazorCodeDocument.Create(sourceDocument);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-dotnettools/issues/3140

Problem

In VS Code, typing @{ in a .cshtml file auto-completes to @AbandonedMutexException{} instead of producing a code block. This regression was introduced by #83438, which fixed a spurious suggestion mode issue caused by CompletionService.IsAllPunctuation("") returning true for empty strings.

The fix in #83438 was correct for the general case, but it had an unintended side effect: at the @ position in CSHTML implicit expressions, the empty filter text was previously (accidentally) causing CompletionHandler.FilterCompletionList to compute isHardSelection = false. This server-side determination flows into CompletionResultFactory, where isSuggestionMode = !isHardSelection controls whether commit characters are stripped from items before the response is sent to VS Code (line 168-171). After #83438, isHardSelection is correctly computed as true for empty filter text, so isSuggestionMode becomes false and items retain their full commit characters including {.

Blazor .razor files were unaffected because __builder.AddContent() has a RenderFragment delegate overload, causing Roslyn's CSharpSuggestionModeCompletionProvider to return a SuggestionModeItem — which independently forces isHardSelection = false regardless of the IsAllPunctuation logic.

Fix

In ImplicitExpressionSuggestionModeRewriter, when the cursor is at the @ transition itself (no identifier typed yet), we now:

 1. Clear all commit characters — nulls out CommitCharacters at the list level, ItemDefaults.CommitCharacters, and per-item CommitCharacters/VsCommitCharacters.
 2. Set IsIncomplete = true — forces the client to re-query the server on the next keystroke. Without this, the client would filter locally and keep empty commit characters even after the user types an identifier (e.g., @bar), where normal commit behavior should be restored.

Why commit character clearing instead of SuggestionMode

VS Code ignores VSInternalCompletionList.SuggestionMode entirely — it's a VS IDE-specific LSP extension. The only way to prevent character commits in VS Code is to remove the commit characters. This approach also works for VS IDE (where commit characters are separate from Enter/Tab commit behavior), making it a universal fix without requiring changes to the VS Editor's async completion layer. A SuggestionMode-based approach would have required VS Editor changes to support transitioning into suggestion mode during IsIncomplete re-queries.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83919)