### PR TITLE
Complete server shutdown when mutex is closed

### DIFF
--- a/src/Compilers/Server/VBCSCompilerTests/BuildServerConnectionTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/BuildServerConnectionTests.cs
@@ -3,13 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Linq;
-using System.Text;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CommandLine;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Roslyn.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -136,6 +135,22 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             }
 
             Assert.Equal(5, count);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/msbuild/issues/13844")]
+        public async Task WaitForServerProcessExitAsync_CompletesWhenServerMutexIsNotOpen()
+        {
+            var pipeName = ServerUtil.GetPipeName();
+            var mutexName = BuildServerConnection.GetServerMutexName(pipeName);
+            using var currentProcess = Process.GetCurrentProcess();
+            using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            Assert.False(currentProcess.HasExited);
+            Assert.False(BuildServerConnection.WasServerMutexOpen(mutexName));
+
+            var waitTask = BuildServerConnection.WaitForServerProcessExitAsync(pipeName, currentProcess.Id, cancellationTokenSource.Token);
+            var completedTask = await Task.WhenAny(waitTask, Task.Delay(TimeSpan.FromSeconds(5), cancellationTokenSource.Token));
+            Assert.Same(waitTask, completedTask);
+            await waitTask;
         }
 
         [Fact]

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -130,12 +130,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
                     {
                         try
                         {
-                            var process = Process.GetProcessById(shutdownBuildResponse.ServerProcessId);
-#if NET5_0_OR_GREATER
-                            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
-#else
-                            process.WaitForExit();
-#endif
+                            await WaitForServerProcessExitAsync(pipeName, shutdownBuildResponse.ServerProcessId, cancellationToken).ConfigureAwait(false);
                         }
                         catch (Exception)
                         {
@@ -162,6 +157,20 @@ namespace Microsoft.CodeAnalysis.CommandLine
             {
                 string mutexName = GetServerMutexName(pipeName);
                 return WasServerMutexOpen(mutexName);
+            }
+        }
+
+        internal static async Task WaitForServerProcessExitAsync(
+            string pipeName,
+            int serverProcessId,
+            CancellationToken cancellationToken)
+        {
+            var mutexName = GetServerMutexName(pipeName);
+            using var process = Process.GetProcessById(serverProcessId);
+
+            while (!process.HasExited && WasServerMutexOpen(mutexName))
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken).ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
See https://github.com/dotnet/msbuild/issues/13844.

Validation: [before](https://github.com/dotnet/dotnet/pull/6899) (see timeouts in the offline leg); [after](https://github.com/dotnet/dotnet/pull/6894) (no timeouts in the same leg)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83921)