### PR TITLE
Don't gate LSP server shutdown on JSON-RPC stream completion

### DIFF
--- a/src/EditorFeatures/Core/LanguageServer/AbstractInProcLanguageClient.cs
+++ b/src/EditorFeatures/Core/LanguageServer/AbstractInProcLanguageClient.cs
@@ -108,7 +108,7 @@ internal abstract partial class AbstractInProcLanguageClient(
         {
             try
             {
-                await _languageServer.WaitForExitAsync().WithCancellation(cancellationToken).ConfigureAwait(false);
+                await _languageServer.EnsureExitAsync().WithCancellation(cancellationToken).ConfigureAwait(false);
             }
             catch (ServerNotShutDownException)
             {

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ServerDisconnectTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ServerDisconnectTests.cs
@@ -38,7 +38,7 @@ public sealed class ServerDisconnectTests(ITestOutputHelper testOutputHelper) : 
     [Fact]
     public async Task ServerExitsOnExitNotificationWithoutClosingTransport()
     {
-        // Verify that the server terminates after it recieves the exit notification, even if the client
+        // Verify that the server terminates after it receives the exit notification, even if the client
         // never closes its end of the transport.
         var server = await CreateLanguageServerAsync();
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ServerDisconnectTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ServerDisconnectTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Text;
+using Roslyn.LanguageServer.Protocol;
 using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests;
@@ -31,6 +32,20 @@ public sealed class ServerDisconnectTests(ITestOutputHelper testOutputHelper) : 
         server.ServerToClientPipe.Reader.Complete();
 
         // Server should exit cleanly without throwing.
+        await server.ServerExitTask;
+    }
+
+    [Fact]
+    public async Task ServerExitsOnExitNotificationWithoutClosingTransport()
+    {
+        // Verify that the server terminates after it recieves the exit notification, even if the client
+        // never closes its end of the transport.
+        var server = await CreateLanguageServerAsync();
+
+        await server.ExecuteRequestAsync<object, object>(Methods.ShutdownName, new object(), CancellationToken.None);
+        await server.ExecuteNotification0Async(Methods.ExitName);
+
+        // Server should exit even though we never complete the client->server pipe.
         await server.ServerExitTask;
     }
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/LanguageServerHost.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/LanguageServerHost.cs
@@ -61,21 +61,18 @@ internal sealed class LanguageServerHost
         Instance = this;
     }
 
-    public async Task WaitForExitAsync()
+    public Task WaitForExitAsync()
     {
-        try
-        {
-            await _jsonRpc.Completion;
-        }
-        catch (Exception)
-        {
-            // The JsonRpc connection threw an exception.  This usually means the client disconnected unexpectedly while
-            // the server was reading from it.  We don't need this to cause the process to crash and trigger watsons,
-            // so we handle it and let the process exit.  The server handles the JSON RPC disconnect event and will
-            // propagate unexpected errors through WaitForExitAsync.
-        }
-
-        await _roslynLanguageServer.WaitForExitAsync();
+        // Wait until the server exits.  Once complete, we can return and proceed with shutdown.
+        // The server is responsible for cleaning up its resources and disposing of the `_jsonRpc` instance.
+        //
+        // Note - we specifically do not await `_jsonRpc.Completion` here.  This is safe (and preferred) for a few reasons:
+        //   1.  The server exiting is the only signal we need to know that we're done.  Either the client has sent an explicit `exit`, or the
+        //       server observed an unexpected disconnect which internally triggers a clean server exit.
+        //   2.  On some platforms (Unix), `_jsonRpc.Completion` will not complete until the client closes its end of the transport or sends new data
+        //       even if the `_jsonRpc` instance has been disposed of (due to a synchronous read syscall that does not observe disposal).  The server
+        //       should still shutdown regardless - we've been told to exit, so exit.
+        return _roslynLanguageServer.WaitForExitAsync();
     }
 
     public T GetRequiredLspService<T>() where T : ILspService

--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/AbstractLanguageServer.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/AbstractLanguageServer.cs
@@ -223,7 +223,23 @@ internal abstract class AbstractLanguageServer<TRequestContext>
         }
     }
 
+    /// <summary>
+    /// Waits for the server to exit. Unlike <see cref="EnsureExitAsync"/>, this does not require
+    /// that a prior shutdown request was received - it can safely be awaited from server startup
+    /// and will simply remain incomplete until exit actually happens (either via the LSP
+    /// <c>exit</c> notification, or via the framework's JSON-RPC disconnect handling).
+    /// </summary>
     public Task WaitForExitAsync()
+    {
+        return _serverExitedSource.Task;
+    }
+
+    /// <summary>
+    /// Like <see cref="WaitForExitAsync"/>, but throws <see cref="ServerNotShutDownException"/>
+    /// if the server has not yet been asked to shut down. Useful for callers that need to assert
+    /// a prior shutdown request as part of their lifecycle contract.
+    /// </summary>
+    public Task EnsureExitAsync()
     {
         lock (_lifeCycleLock)
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/82069

### Theory
The server appears to be stuck calling `_jsonRpc.Completion` after the client sends LSP exit.  Normally, as part of handling LSP `exit` the server disposes of the `_jsonRpc` instance:
https://github.com/dotnet/roslyn/blob/c95465e6cf2ba43f8cad2a07e3fbdf7b47d3ce58/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/AbstractLanguageServer.cs#L320-L321

The expectation was that this would trigger the `_jsonRpc.Completion` task to complete, and the server would proceed to `WaitForExitAsync`.

However - the `Completion` task waits on the stream read task before completing.  On unix, this is a blocking read syscall that is not cancelled by the dispose (closing the resource) - it is only cancelled by receiving new data or the write end (client) closing it.  So the `Completion` task does not complete unless the client closes the connection or sends new data.

It looks like the vscode client closes the connection after it sends exit, allowing the read task to complete, but neovim may not be.  Additionally on windows, the disposal (closing the resource) does unblock the read operation, allowing `Completion` to complete.

This updates the server to not require the `_jsonRpc.Completion` task to complete - the client calling exit is enough of a signal that we should close the server.