### PR TITLE
Speculative fix for exception formatting collection expression

### DIFF
--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -12865,6 +12865,14 @@ public sealed class FormattingTests : CSharpFormattingTestBase
                 { NewLineBeforeOpenBrace, NewLineBeforeOpenBracePlacement.None }
             });
 
+    [Fact, WorkItem("https://github.com/dotnet/vscode-csharp/issues/9339")]
+    public Task CollectionExpressionAtStartOfFile()
+        => AssertFormatAsync("""
+            [1].ToString();
+            """, """
+            [1].ToString();
+            """);
+
     [Fact]
     public Task TopLevelLocalFunctionBraceStillFormatsWhenMethodBraceOptionIsOff()
         => AssertFormatAsync(

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/IndentBlockFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/IndentBlockFormattingRule.cs
@@ -276,6 +276,12 @@ internal sealed class IndentBlockFormattingRule : BaseFormattingRule
             var lastToken = node.GetLastToken(includeZeroWidth: true);
             var baseToken = firstToken.GetPreviousToken(includeZeroWidth: true);
 
+            // If the collection expression / list pattern is at the very start of the file there is no
+            // preceding token to align to.  Skip the relative-indentation operation in that case to avoid
+            // passing a default SyntaxToken (RawKind == 0) into the formatting engine.
+            if (baseToken.RawKind == 0)
+                return;
+
             SetAlignmentBlockOperation(list, baseToken, firstToken, lastToken, option);
         }
     }


### PR DESCRIPTION
Speculative fix for https://github.com/dotnet/vscode-csharp/issues/9339

I don't have the actual code that caused the original report, but this seems plausible (and the test hit the same exception).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83933)