### PR TITLE
Log Razor messages to normal LSP log endpoint

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Logging/LspLogMessageLogger.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Logging/LspLogMessageLogger.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis.LanguageServer.LanguageServer;
+using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.Extensions.Logging;
 using Roslyn.LanguageServer.Protocol;
 using StreamJsonRpc;
@@ -51,8 +52,6 @@ internal sealed class LspLogMessageLogger(string categoryName, ILoggerFactory fa
 
         string messagePrefix = "";
 
-        var logMethod = Methods.WindowLogMessageName;
-
         _externalScopeProvider?.ForEachScope((scope, _) =>
         {
             if (scope is LspLoggingScope lspLoggingScope)
@@ -62,13 +61,9 @@ internal sealed class LspLogMessageLogger(string categoryName, ILoggerFactory fa
                     messagePrefix += $"[{lspLoggingScope.Context}] ";
                 }
 
-                if (lspLoggingScope.Language is not null)
+                if (lspLoggingScope.Language is not null && lspLoggingScope.Language != LanguageServerConstants.DefaultLanguageName)
                 {
-                    logMethod = lspLoggingScope.Language switch
-                    {
-                        LanguageInfoProvider.RazorLanguageName => "razor/log",
-                        _ => logMethod,
-                    };
+                    messagePrefix += $"[{lspLoggingScope.Language}] ";
                 }
             }
         }, state);
@@ -77,7 +72,7 @@ internal sealed class LspLogMessageLogger(string categoryName, ILoggerFactory fa
 
         try
         {
-            var _ = server.GetRequiredLspService<IClientLanguageServerManager>().SendNotificationAsync(logMethod, new LogMessageParams()
+            var _ = server.GetRequiredLspService<IClientLanguageServerManager>().SendNotificationAsync(Methods.WindowLogMessageName, new LogMessageParams()
             {
                 Message = $"{messagePrefix} {message}",
                 MessageType = LogLevelToMessageType(logLevel),

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Services/LspLogger.cs
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Services/LspLogger.cs
@@ -9,11 +9,8 @@ using Microsoft.VisualStudio.Threading;
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
 /// <summary>
-/// ILogger implementation that logs via the razor/log LSP method
+/// ILogger implementation that logs via the window/logMessage LSP method.
 /// </summary>
-/// <remarks>
-/// The handler for this custom log message is implemented in the C# extension and is responsible for writing the message to the output window.
-/// </remarks>
 internal class LspLogger(string categoryName, RazorClientServerManagerProvider razorClientServerManagerProvider) : ILogger
 {
     private readonly string _categoryName = categoryName;
@@ -39,8 +36,8 @@ internal class LspLogger(string categoryName, RazorClientServerManagerProvider r
             LogLevel.Error => MessageType.Error,
             LogLevel.Warning => MessageType.Warning,
             LogLevel.Information => MessageType.Info,
-            LogLevel.Debug => MessageType.Log,
-            LogLevel.Trace => MessageType.Log,
+            LogLevel.Debug => MessageType.Debug,
+            LogLevel.Trace => MessageType.Debug,
             _ => throw new NotImplementedException(),
         };
 
@@ -52,6 +49,6 @@ internal class LspLogger(string categoryName, RazorClientServerManagerProvider r
             Message = formattedMessage,
         };
 
-        clientLanguageServerManager.SendNotificationAsync("razor/log", @params, CancellationToken.None).Forget();
+        clientLanguageServerManager.SendNotificationAsync(Methods.WindowLogMessageName, @params, CancellationToken.None).Forget();
     }
 }


### PR DESCRIPTION
This makes Razor log to the normal C# LSP end point.  This is desired for a couple of reasons:
1.  The custom razor/log endpoint cannot exist in standalone language server scenarios (copilot cli).
2.  c# Logs attached to issues will now properly capture full exception details for razor exceptions

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83935)