### PR TITLE
Fix x86 test host OOM in TemporaryStorageService

### DIFF
--- a/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageService.Factory.cs
+++ b/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageService.Factory.cs
@@ -27,7 +27,13 @@ internal sealed partial class TemporaryStorageService
             if (PlatformInformation.IsWindows || PlatformInformation.IsRunningOnMono)
             {
                 var textFactory = workspaceServices.GetRequiredService<ITextFactoryService>();
-                return new TemporaryStorageService(workspaceThreadingService, textFactory);
+
+                // On x86 processes, force each allocation into its own dedicated memory mapped file. The
+                // bump-pointer allocator packs small items into shared 8 MB blocks, but a single surviving
+                // handle keeps the entire block mapped. Over long test runs this accumulates hundreds of
+                // blocks and exhausts the 4 GB virtual address space limit.
+                var forceSingleFile = !Environment.Is64BitProcess;
+                return new TemporaryStorageService(workspaceThreadingService, textFactory, forceSingleFile);
             }
             else
             {

--- a/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageService.cs
+++ b/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageService.cs
@@ -54,6 +54,14 @@ internal sealed partial class TemporaryStorageService : ITemporaryStorageService
     private readonly ITextFactoryService _textFactory;
 
     /// <summary>
+    /// When <see langword="true"/>, all allocations get their own dedicated memory mapped file instead of being
+    /// packed into shared blocks via the bump-pointer allocator. This avoids the fragmentation problem where a
+    /// single surviving handle keeps an entire shared block alive, which can exhaust virtual address space in
+    /// x86 processes during long-running test hosts.
+    /// </summary>
+    private readonly bool _forceSingleFile;
+
+    /// <summary>
     /// The synchronization object for accessing the memory mapped file related fields (indicated in the remarks
     /// of each field).
     /// </summary>
@@ -88,10 +96,11 @@ internal sealed partial class TemporaryStorageService : ITemporaryStorageService
     private long _offset;
 
     [Obsolete(MefConstruction.FactoryMethodMessage, error: true)]
-    private TemporaryStorageService(IWorkspaceThreadingService? workspaceThreadingService, ITextFactoryService textFactory)
+    private TemporaryStorageService(IWorkspaceThreadingService? workspaceThreadingService, ITextFactoryService textFactory, bool forceSingleFile)
     {
         _workspaceThreadingService = workspaceThreadingService;
         _textFactory = textFactory;
+        _forceSingleFile = forceSingleFile;
     }
 
     ITemporaryStorageTextHandle ITemporaryStorageServiceInternal.WriteToTemporaryStorage(SourceText text, CancellationToken cancellationToken)
@@ -197,14 +206,23 @@ internal sealed partial class TemporaryStorageService : ITemporaryStorageService
     /// <remarks>
     /// <para>"Small" requests are fulfilled from oversized memory mapped files which support several individual
     /// storage units. Larger requests are allocated in their own memory mapped files.</para>
+    /// <para>When <see cref="_forceSingleFile"/> is set, all requests get their own dedicated memory mapped file
+    /// to avoid the fragmentation problem where a single surviving handle keeps an entire shared block alive.</para>
     /// </remarks>
     /// <param name="size">The size of the shared storage block to allocate.</param>
     /// <returns>A <see cref="MemoryMappedInfo"/> describing the allocated block.</returns>
     private MemoryMappedInfo CreateTemporaryStorage(long size)
     {
-        // Larger blocks are allocated separately
-        if (size >= SingleFileThreshold)
-            return MemoryMappedInfo.CreateNew(CreateUniqueName(size), size: size);
+        // Larger blocks are always allocated separately. When _forceSingleFile is set, all blocks are allocated
+        // separately to avoid the fragmentation problem where one surviving handle in a shared block keeps the
+        // entire block mapped — exhausting virtual address space in x86 processes.
+        if (_forceSingleFile || size >= SingleFileThreshold)
+        {
+            var name = CreateUniqueName(size);
+            // MemoryMappedFile requires a capacity of at least 1 byte.
+            var memoryMappedFile = MemoryMappedFile.CreateNew(name, Math.Max(size, 1));
+            return new MemoryMappedInfo(memoryMappedFile, name, offset: 0, size: size);
+        }
 
         lock (_gate)
         {


### PR DESCRIPTION
TemporaryStorageService uses a bump-pointer allocator that packs small items into shared 8 MB memory-mapped file (MMF) blocks. When any single handle in a block survives, the entire 8 MB block stays mapped. Over the course of ~16K tests in EditorFeatures, hundreds of blocks accumulate because transient items keep entire blocks pinned — consuming ~4.2 GB of virtual address space and crashing the x86 test host (4 GB VA limit).

This change adds a 'forceSingleFile' flag to TemporaryStorageService that bypasses the bump-pointer allocator, giving each item its own dedicated MMF. The flag is set to true on x86 processes only (!Environment.Is64BitProcess), preserving the existing bump-pointer behavior on x64 to avoid any production performance regression.

Measurements were taken using pvanalyze (gcstats) for GC metrics and a process monitor script tracking PeakVM/PeakWS of the testhost process during full test suite runs on x86 net472.

CSharp.EditorFeatures.UnitTests (x86, net472, ~16,591 tests):

| Approach         | PeakVM  | Result        | Delta |
|------------------|---------|---------------|-------|
| Baseline         | 3714 MB | CRASH (OOM)   |       |
| With fix         | 2688 MB | Completes     | -28%  |

Workspaces.UnitTests (x86, net472, ~2,300 tests):

| Approach         | PeakVM  | Result        | Delta |
|------------------|---------|---------------|-------|
| Baseline         | 1462 MB | Pass          |       |
| With fix         | 1136 MB | Pass          | -22%  |

Analysis indicates this is not a case where we're actively leaking memory in our tests. The types we control, like `Workspace`  instances, are properly disposed and not rooted. They just exist in the Gen2 layer and nothing in the test is forcing Gen2 collections so this contributes indirectly to the problem. A longer analysis is in the below gist. 

This work involved a lot of experimentation using an agent + pvanalyze to test out the ideas. A full write up of the problem + various experiments tried is available in [this gist](https://gist.github.com/jaredpar/1ee57cc1e9eb337a7683bba3ed37ab53).

Fixes #83640
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83952)