### PR TITLE
Fix marketplace name for dotnet/skills

### DIFF
--- a/.github/copilot/settings.json
+++ b/.github/copilot/settings.json
@@ -6,7 +6,7 @@
         "repo": "dotnet/arcade-skills"
       }
     },
-    "dotnet-skills": {
+    "dotnet-agent-skills": {
       "source": {
         "source": "github",
         "repo": "dotnet/skills"
@@ -15,8 +15,8 @@
   },
   "enabledPlugins": {
     "dotnet-dnceng@dotnet-arcade-skills": true,
-    "dotnet@dotnet-skills": true,
-    "dotnet-test@dotnet-skills": true,
+    "dotnet@dotnet-agent-skills": true,
+    "dotnet-test@dotnet-agent-skills": true,
     "dotnet-diag@dotnet-agent-skills": true,
     "dotnet-msbuild@dotnet-agent-skills": true,
     "dotnet-nuget@dotnet-agent-skills": true

--- a/docs/roslyn-language-server-copilot-plugin.md
+++ b/docs/roslyn-language-server-copilot-plugin.md
@@ -4,7 +4,7 @@ The `roslyn-language-server` is a .NET tool that provides C# language intelligen
 
 ## Quick Start
 
-For this repository specifically, the `dotnet` skill from the `dotnet-skills` marketplace is checked in at `.github/copilot/settings.json`, which includes the appropriate `lsp.json`.  The `.vscode/settings.json` points the server at `Roslyn.slnx`. That means opening this repo in Copilot CLI is enough to have the C# LSP configured automatically.
+For this repository specifically, the `dotnet` skill from the `dotnet-agent-skills` marketplace is checked in at `.github/copilot/settings.json`, which includes the appropriate `lsp.json`.  The `.vscode/settings.json` points the server at `Roslyn.slnx`. That means opening this repo in Copilot CLI is enough to have the C# LSP configured automatically.
 
 ### Install the plugin
 


### PR DESCRIPTION
The marketplace name there is dotnet-agent-skills, so be consistent everywhere. Otherwise somehow I was getting duplicate plugins installed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83961)