### PR TITLE
Remove the state from MSBuildDiagnosticLogger

### DIFF
--- a/src/Workspaces/MSBuild/BuildHost/Build/ProjectBuildManager.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Build/ProjectBuildManager.cs
@@ -285,11 +285,9 @@ internal sealed class ProjectBuildManager : IDisposable
             }
         }
 
-        _buildLogger.SetProjectAndLog(projectInstance.FullPath, log);
-
         var buildRequestData = new MSB.Execution.BuildRequestData(projectInstance, [.. targets]);
 
-        var result = await BuildAsync(buildRequestData, cancellationToken).ConfigureAwait(false);
+        var result = await BuildAsync(buildRequestData, log, cancellationToken).ConfigureAwait(false);
 
         if (result.OverallResult == MSB.Execution.BuildResultCode.Failure)
         {
@@ -305,16 +303,16 @@ internal sealed class ProjectBuildManager : IDisposable
     // this lock is static because we are using the default build manager, and there is only one per process
     private static readonly SemaphoreSlim s_buildManagerLock = new(initialCount: 1);
 
-    private static async Task<MSB.Execution.BuildResult> BuildAsync(MSB.Execution.BuildRequestData requestData, CancellationToken cancellationToken)
+    private async Task<MSB.Execution.BuildResult> BuildAsync(MSB.Execution.BuildRequestData requestData, DiagnosticLog log, CancellationToken cancellationToken)
     {
         // only allow one build to use the default build manager at a time
         using (await s_buildManagerLock.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
         {
-            return await BuildAsync(MSB.Execution.BuildManager.DefaultBuildManager, requestData, cancellationToken).ConfigureAwait(false);
+            return await BuildAsync(MSB.Execution.BuildManager.DefaultBuildManager, requestData, log, cancellationToken).ConfigureAwait(false);
         }
     }
 
-    private static Task<MSB.Execution.BuildResult> BuildAsync(MSB.Execution.BuildManager buildManager, MSB.Execution.BuildRequestData requestData, CancellationToken cancellationToken)
+    private Task<MSB.Execution.BuildResult> BuildAsync(MSB.Execution.BuildManager buildManager, MSB.Execution.BuildRequestData requestData, DiagnosticLog log, CancellationToken cancellationToken)
     {
         var taskSource = new TaskCompletionSource<MSB.Execution.BuildResult>();
 
@@ -335,13 +333,21 @@ internal sealed class ProjectBuildManager : IDisposable
         }
 
         // execute build async
+        int? submissionId = null;
         try
         {
-            buildManager.PendBuildRequest(requestData).ExecuteAsync(sub =>
+            // The SubmissionId is assigned by PendBuildRequest and is the same SubmissionId that appears on the
+            // BuildEventContext of every event raised while this submission builds.
+            var submission = buildManager.PendBuildRequest(requestData);
+            submissionId = submission.SubmissionId;
+            _buildLogger.RegisterLog(submission.SubmissionId, log);
+
+            submission.ExecuteAsync(sub =>
             {
                 // when finished
                 try
                 {
+                    _buildLogger.UnregisterLog(sub.SubmissionId);
                     var result = sub.BuildResult;
                     registration.Dispose();
                     taskSource.TrySetResult(result);
@@ -354,6 +360,9 @@ internal sealed class ProjectBuildManager : IDisposable
         }
         catch (Exception e)
         {
+            if (submissionId is not null)
+                _buildLogger.UnregisterLog(submissionId.Value);
+
             taskSource.SetException(e);
         }
 

--- a/src/Workspaces/MSBuild/BuildHost/MSBuild/Logging/DiagnosticLog.cs
+++ b/src/Workspaces/MSBuild/BuildHost/MSBuild/Logging/DiagnosticLog.cs
@@ -12,6 +12,9 @@ internal readonly struct DiagnosticLog() : IEnumerable<DiagnosticLogItem>
 {
     private readonly List<DiagnosticLogItem> _items = [];
 
+    // The reads below are intentionally not locked: a given DiagnosticLog is only read (e.g. via
+    // GetDiagnosticLogItems) once its build has completed, so no Add can be in flight concurrently
+    // with a read.
     public int Count => _items.Count;
     public DiagnosticLogItem this[int index] => _items[index];
     public bool IsEmpty => _items.Count == 0;
@@ -23,11 +26,16 @@ internal readonly struct DiagnosticLog() : IEnumerable<DiagnosticLogItem>
         => GetEnumerator();
 
     public void Add(DiagnosticLogItem item)
-        => _items.Add(item);
+    {
+        lock (_items)
+        {
+            _items.Add(item);
+        }
+    }
 
     public void Add(string message, string projectFilePath, DiagnosticLogItemKind kind = DiagnosticLogItemKind.Error)
-        => _items.Add(new DiagnosticLogItem(kind, message, projectFilePath));
+        => Add(new DiagnosticLogItem(kind, message, projectFilePath));
 
     public void Add(Exception exception, string projectFilePath, DiagnosticLogItemKind kind = DiagnosticLogItemKind.Error)
-        => _items.Add(new DiagnosticLogItem(kind, exception.Message, projectFilePath));
+        => Add(new DiagnosticLogItem(kind, exception.Message, projectFilePath));
 }

--- a/src/Workspaces/MSBuild/BuildHost/MSBuild/Logging/MSBuildDiagnosticLogger.cs
+++ b/src/Workspaces/MSBuild/BuildHost/MSBuild/Logging/MSBuildDiagnosticLogger.cs
@@ -2,36 +2,63 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Concurrent;
 using System.Diagnostics;
+using Roslyn.Utilities;
 using MSB = Microsoft.Build;
 
 namespace Microsoft.CodeAnalysis.MSBuild;
 
 internal sealed class MSBuildDiagnosticLogger : MSB.Framework.ILogger
 {
-    private string? _projectFilePath;
-    private DiagnosticLog? _log;
+    /// <summary>
+    /// Maps a build's <see cref="MSB.Framework.BuildEventContext.SubmissionId"/> to the
+    /// <see cref="DiagnosticLog"/> that should receive the errors and warnings raised while that
+    /// submission is building. This lets a single logger instance route events to the correct project
+    /// even when multiple builds are in flight. The id matches
+    /// <see cref="MSB.Execution.BuildSubmission.SubmissionId"/>.
+    /// </summary>
+    private readonly ConcurrentDictionary<int, DiagnosticLog> _logsBySubmissionId = new();
+
     private MSB.Framework.IEventSource? _eventSource;
 
     public string? Parameters { get; set; }
     public MSB.Framework.LoggerVerbosity Verbosity { get; set; }
 
-    public void SetProjectAndLog(string projectFilePath, DiagnosticLog log)
-    {
-        _projectFilePath = projectFilePath;
-        _log = log;
-    }
+    /// <summary>
+    /// Registers the <paramref name="log"/> that should receive diagnostics for the build submission with
+    /// the given <paramref name="submissionId"/>. Must be called after the submission's id has been
+    /// assigned (i.e. after <see cref="MSB.Execution.BuildManager.PendBuildRequest(MSB.Execution.BuildRequestData)"/>)
+    /// but before the submission starts executing, so no event can arrive before the log is registered.
+    /// </summary>
+    public void RegisterLog(int submissionId, DiagnosticLog log)
+        => Contract.ThrowIfFalse(_logsBySubmissionId.TryAdd(submissionId, log), $"A log is already registered for submission {submissionId}.");
+
+    public void UnregisterLog(int submissionId)
+        => Contract.ThrowIfFalse(_logsBySubmissionId.TryRemove(submissionId, out _), $"No log is registered for submission {submissionId}.");
 
     private void OnErrorRaised(object sender, MSB.Framework.BuildErrorEventArgs e)
-    {
-        Debug.Assert(_projectFilePath != null);
-        _log?.Add(new MSBuildDiagnosticLogItem(DiagnosticLogItemKind.Error, _projectFilePath, e.Message ?? "", e.File, e.LineNumber, e.ColumnNumber));
-    }
+        => AddLogItem(DiagnosticLogItemKind.Error, e.BuildEventContext, e.ProjectFile, e.Message, e.File, e.LineNumber, e.ColumnNumber);
 
     private void OnWarningRaised(object sender, MSB.Framework.BuildWarningEventArgs e)
+        => AddLogItem(DiagnosticLogItemKind.Warning, e.BuildEventContext, e.ProjectFile, e.Message, e.File, e.LineNumber, e.ColumnNumber);
+
+    private void AddLogItem(DiagnosticLogItemKind kind, MSB.Framework.BuildEventContext? buildEventContext, string? projectFile, string? message, string? file, int lineNumber, int columnNumber)
     {
-        Debug.Assert(_projectFilePath != null);
-        _log?.Add(new MSBuildDiagnosticLogItem(DiagnosticLogItemKind.Warning, _projectFilePath, e.Message ?? "", e.File, e.LineNumber, e.ColumnNumber));
+        // A build error or warning is always raised in the context of a building submission whose log we
+        // registered before executing it, so we expect a context and a log registered for its submission.
+        Debug.Assert(buildEventContext != null);
+        if (buildEventContext is null)
+            return;
+
+        if (!_logsBySubmissionId.TryGetValue(buildEventContext.SubmissionId, out var log))
+        {
+            // We don't expect this, but if it happens there's no log to attribute the event to, so ignore it.
+            Debug.Fail($"No log is registered for submission {buildEventContext.SubmissionId}.");
+            return;
+        }
+
+        log.Add(new MSBuildDiagnosticLogItem(kind, projectFile ?? "", message ?? "", file ?? "", lineNumber, columnNumber));
     }
 
     public void Initialize(MSB.Framework.IEventSource eventSource)
@@ -52,8 +79,7 @@ internal sealed class MSBuildDiagnosticLogger : MSB.Framework.ILogger
 
             _eventSource = null;
 
-            _projectFilePath = null;
-            _log = null;
+            _logsBySubmissionId.Clear();
         }
     }
 }


### PR DESCRIPTION
Before each build, we were explicitly setting the project name and DiagnosticLog for the build we were about to do. This approach forces us to run our builds one-at-a-time, which limits overall performance. Unfortunately we also called that before acquiring the lock, so there already could have been timing bugs where we reported results badly or lost diagnostics.

Removing the lock will come as a follow-up PR once we validate that everything else appears safe.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83977)