### PR TITLE
Enable parallel builds in the LSP when loading projects

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/CanonicalMiscellaneousFilesProjectProvider.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/CanonicalMiscellaneousFilesProjectProvider.cs
@@ -72,7 +72,7 @@ internal sealed class CanonicalMiscellaneousFilesProjectProvider : IDisposable
             _workspaceProvider.Workspace.Services.SolutionServices.GetSupportedLanguages<ICommandLineParserService>(),
             globalMSBuildProperties: [],
             binaryLogPathProvider: null,
-            _loggerFactory);
+            loggerFactory: _loggerFactory);
         var buildHost = await buildHostProcessManager.GetBuildHostAsync(BuildHostProcessKind.NetCore, virtualProjectPath, dotnetPath: null, cancellationToken);
         var loadedFile = await buildHost.LoadProjectAsync(virtualProjectPath, virtualProjectXml, languageName: LanguageNames.CSharp, cancellationToken);
         return await loadedFile.GetProjectFileInfosAsync(cancellationToken);

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
@@ -175,6 +175,7 @@ internal abstract class LanguageServerProjectLoader
                 knownCommandLineParserLanguages: _workspaceFactory.HostWorkspace.Services.SolutionServices.GetSupportedLanguages<ICommandLineParserService>(),
                 globalMSBuildProperties: AdditionalProperties,
                 binaryLogPathProvider: _binLogPathProvider,
+                maxNodeCount: Math.Max(Environment.ProcessorCount / 2, 1), // Don't overload the machine, so leave some CPU cores open. This chosen without much support evidence, other than it's still pretty close to max.
                 loggerFactory: LoggerFactory))
             {
                 var toastErrorReporter = new ToastErrorReporter(_clientLanguageServerManager);

--- a/src/Workspaces/MSBuild/BuildHost/AbstractBuildHost.cs
+++ b/src/Workspaces/MSBuild/BuildHost/AbstractBuildHost.cs
@@ -40,6 +40,11 @@ internal abstract class AbstractBuildHost :
     /// </summary>
     private string? _binaryLogPath;
 
+    /// <summary>
+    /// The maximum number of MSBuild nodes that may build concurrently, or <see langword="null"/> to use MSBuild's default; should not be changed once the <see cref="_buildManager"/> is initialized.
+    /// </summary>
+    private int? _maxNodeCount;
+
     public AbstractBuildHost(BuildHostLogger logger, RpcServer server)
     {
         Logger = logger;
@@ -93,7 +98,7 @@ internal abstract class AbstractBuildHost :
                 Logger.LogInformation($"Logging builds to {_binaryLogPath}");
             }
 
-            _buildManager = new ProjectBuildManager(_knownCommandLineParserLanguages, _globalMSBuildProperties, logger);
+            _buildManager = new ProjectBuildManager(_knownCommandLineParserLanguages, _globalMSBuildProperties, logger, _maxNodeCount);
         }
     }
 
@@ -112,16 +117,17 @@ internal abstract class AbstractBuildHost :
         Contract.ThrowIfFalse(TryEnsureMSBuildLoaded(projectFilePath), $"We don't have an MSBuild to use; {nameof(HasUsableMSBuild)} should have been called first to check.");
     }
 
-    public void ConfigureGlobalState(string[] knownCommandLineParserLanguages, Dictionary<string, string> globalProperties, string? binlogPath)
+    public void ConfigureGlobalState(string[] knownCommandLineParserLanguages, Dictionary<string, string> globalProperties, string? binlogPath, int? maxNodeCount)
     {
         lock (_gate)
         {
             if (_buildManager != null)
                 throw new InvalidOperationException($"{nameof(_buildManager)} has already been initialized and cannot be changed");
 
+            _knownCommandLineParserLanguages = knownCommandLineParserLanguages;
             _globalMSBuildProperties = globalProperties;
             _binaryLogPath = binlogPath;
-            _knownCommandLineParserLanguages = knownCommandLineParserLanguages;
+            _maxNodeCount = maxNodeCount;
         }
     }
 

--- a/src/Workspaces/MSBuild/BuildHost/Build/ProjectBuildManager.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Build/ProjectBuildManager.cs
@@ -300,56 +300,29 @@ internal sealed class ProjectBuildManager : IDisposable
         return projectInstance;
     }
 
-    // this lock is static because we are using the default build manager, and there is only one per process
-    private static readonly SemaphoreSlim s_buildManagerLock = new(initialCount: 1);
-
     private async Task<MSB.Execution.BuildResult> BuildAsync(MSB.Execution.BuildRequestData requestData, DiagnosticLog log, CancellationToken cancellationToken)
     {
-        // only allow one build to use the default build manager at a time
-        using (await s_buildManagerLock.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
-        {
-            return await BuildAsync(MSB.Execution.BuildManager.DefaultBuildManager, requestData, log, cancellationToken).ConfigureAwait(false);
-        }
-    }
+        // MSBuild doesn't have a way to cancel a single submission, so we'll only check the token before we start. In practice this is fine --
+        // the RPC layer we use to call into the BuildHost doesn't support cancellation anyways so there's no reason to have lots of extra code.
+        cancellationToken.ThrowIfCancellationRequested();
 
-    private Task<MSB.Execution.BuildResult> BuildAsync(MSB.Execution.BuildManager buildManager, MSB.Execution.BuildRequestData requestData, DiagnosticLog log, CancellationToken cancellationToken)
-    {
-        var taskSource = new TaskCompletionSource<MSB.Execution.BuildResult>();
+        var submission = MSB.Execution.BuildManager.DefaultBuildManager.PendBuildRequest(requestData);
 
-        // enable cancellation of build
-        CancellationTokenRegistration registration = default;
-        if (cancellationToken.CanBeCanceled)
-        {
-            registration = cancellationToken.Register(() =>
-            {
-                // Note: We only ever expect that a single submission is being built,
-                // even though we're calling CancelAllSubmissions(). If MSBuildWorkspace is
-                // ever updated to support parallel builds, we'll likely need to update this code.
-
-                taskSource.TrySetCanceled();
-                buildManager.CancelAllSubmissions();
-                registration.Dispose();
-            });
-        }
-
-        // execute build async
-        int? submissionId = null;
         try
         {
             // The SubmissionId is assigned by PendBuildRequest and is the same SubmissionId that appears on the
             // BuildEventContext of every event raised while this submission builds.
-            var submission = buildManager.PendBuildRequest(requestData);
-            submissionId = submission.SubmissionId;
             _buildLogger.RegisterLog(submission.SubmissionId, log);
 
+            var taskSource = new TaskCompletionSource<MSB.Execution.BuildResult>();
+
+            // Start the job
             submission.ExecuteAsync(sub =>
             {
                 // when finished
                 try
                 {
-                    _buildLogger.UnregisterLog(sub.SubmissionId);
                     var result = sub.BuildResult;
-                    registration.Dispose();
                     taskSource.TrySetResult(result);
                 }
                 catch (Exception e)
@@ -357,15 +330,13 @@ internal sealed class ProjectBuildManager : IDisposable
                     taskSource.TrySetException(e);
                 }
             }, null);
+
+            return await taskSource.Task.ConfigureAwait(false);
         }
-        catch (Exception e)
+        finally
         {
-            if (submissionId is not null)
-                _buildLogger.UnregisterLog(submissionId.Value);
-
-            taskSource.SetException(e);
+            // Ensure the log is cleaned up if it's still there no matter if we take an exceptional path or not
+            _buildLogger.TryUnregisterLog(submission.SubmissionId);
         }
-
-        return taskSource.Task;
     }
 }

--- a/src/Workspaces/MSBuild/BuildHost/Build/ProjectBuildManager.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Build/ProjectBuildManager.cs
@@ -65,7 +65,7 @@ internal sealed class ProjectBuildManager : IDisposable
     };
     private bool _disposed;
 
-    public ProjectBuildManager(string[] knownCommandLineParserLanguages, Dictionary<string, string> globalProperties, ILogger? msbuildLogger = null)
+    public ProjectBuildManager(string[] knownCommandLineParserLanguages, Dictionary<string, string> globalProperties, ILogger? msbuildLogger = null, int? maxNodeCount = null)
     {
         KnownCommandLineParserLanguages = knownCommandLineParserLanguages;
 
@@ -89,10 +89,17 @@ internal sealed class ProjectBuildManager : IDisposable
             // The loggers are not inherited from the project collection, so specify both the
             // binlog logger and the _buildLogger for the build steps.
             Loggers = [.. loggers, _buildLogger],
+
             // If we have an additional logger and it's diagnostic, then we need to opt into task inputs globally, or otherwise
             // it won't get any log events. This logic matches https://github.com/dotnet/msbuild/blob/fa6710d2720dcf1230a732a8858ffe71bcdbe110/src/Build/Instance/ProjectInstance.cs#L2365-L2371
-            LogTaskInputs = msbuildLogger is not null && msbuildLogger.Verbosity == LoggerVerbosity.Diagnostic
+            LogTaskInputs = msbuildLogger is not null && msbuildLogger.Verbosity == LoggerVerbosity.Diagnostic,
+
+            // Disable node reuse so nodes don't live around once we're done
+            EnableNodeReuse = false
         };
+
+        if (maxNodeCount is int nodeCount)
+            buildParameters.MaxNodeCount = nodeCount;
 
         MSB.Execution.BuildManager.DefaultBuildManager.BeginBuild(buildParameters);
     }

--- a/src/Workspaces/MSBuild/BuildHost/MSBuild/Logging/MSBuildDiagnosticLogger.cs
+++ b/src/Workspaces/MSBuild/BuildHost/MSBuild/Logging/MSBuildDiagnosticLogger.cs
@@ -34,8 +34,8 @@ internal sealed class MSBuildDiagnosticLogger : MSB.Framework.ILogger
     public void RegisterLog(int submissionId, DiagnosticLog log)
         => Contract.ThrowIfFalse(_logsBySubmissionId.TryAdd(submissionId, log), $"A log is already registered for submission {submissionId}.");
 
-    public void UnregisterLog(int submissionId)
-        => Contract.ThrowIfFalse(_logsBySubmissionId.TryRemove(submissionId, out _), $"No log is registered for submission {submissionId}.");
+    public bool TryUnregisterLog(int submissionId)
+        => _logsBySubmissionId.TryRemove(submissionId, out _);
 
     private void OnErrorRaised(object sender, MSB.Framework.BuildErrorEventArgs e)
         => AddLogItem(DiagnosticLogItemKind.Error, e.BuildEventContext, e.ProjectFile, e.Message, e.File, e.LineNumber, e.ColumnNumber);

--- a/src/Workspaces/MSBuild/Contracts/IBuildHost.cs
+++ b/src/Workspaces/MSBuild/Contracts/IBuildHost.cs
@@ -34,7 +34,8 @@ internal interface IBuildHost
     /// contain paths (which can have escaping issues) or could be quite large (which could run into length limits).
     /// </summary>
     /// <param name="knownCommandLineParserLanguages">Languages whose command line parser we understand (ICommandLineParserService).</param>
-    void ConfigureGlobalState(string[] knownCommandLineParserLanguages, Dictionary<string, string> globalProperties, string? binlogPath);
+    /// <param name="maxNodeCount">The maximum number of MSBuild nodes that may build concurrently, or <see langword="null"/> to use MSBuild's default. Builds submitted in parallel can run in parallel up to this limit.</param>
+    void ConfigureGlobalState(string[] knownCommandLineParserLanguages, Dictionary<string, string> globalProperties, string? binlogPath, int? maxNodeCount);
 
     Task<int> LoadProjectFileAsync(string projectFilePath, string languageName, CancellationToken cancellationToken);
 

--- a/src/Workspaces/MSBuild/Core/MSBuild/BuildHostProcessManager.cs
+++ b/src/Workspaces/MSBuild/Core/MSBuild/BuildHostProcessManager.cs
@@ -28,6 +28,7 @@ internal sealed class BuildHostProcessManager : IAsyncDisposable
     private readonly ILoggerFactory? _loggerFactory;
     private readonly ILogger? _logger;
     private readonly IBinLogPathProvider? _binaryLogPathProvider;
+    private readonly int? _maxNodeCount;
 
     private readonly SemaphoreSlim _gate = new(initialCount: 1);
     private readonly Dictionary<BuildHostProcessKind, BuildHostProcess> _processes = [];
@@ -41,6 +42,7 @@ internal sealed class BuildHostProcessManager : IAsyncDisposable
         ImmutableArray<string> knownCommandLineParserLanguages,
         ImmutableDictionary<string, string>? globalMSBuildProperties = null,
         IBinLogPathProvider? binaryLogPathProvider = null,
+        int? maxNodeCount = null,
         ILoggerFactory? loggerFactory = null)
     {
         _knownCommandLineParserLanguages = knownCommandLineParserLanguages;
@@ -48,6 +50,7 @@ internal sealed class BuildHostProcessManager : IAsyncDisposable
         _binaryLogPathProvider = binaryLogPathProvider;
         _loggerFactory = loggerFactory;
         _logger = loggerFactory?.CreateLogger<BuildHostProcessManager>();
+        _maxNodeCount = maxNodeCount;
     }
 
     /// <summary>
@@ -134,7 +137,7 @@ internal sealed class BuildHostProcessManager : IAsyncDisposable
                 throw new Exception($"The build host was started but we were unable to connect to it's pipe. The process exited with {process.ExitCode}. Process output:{Environment.NewLine}{buildHostProcess.GetBuildHostProcessOutput()}", innerException: e);
             }
 
-            await buildHostProcess.BuildHost.ConfigureGlobalStateAsync(_knownCommandLineParserLanguages, _globalMSBuildProperties, _binaryLogPathProvider?.GetNewLogPath(), cancellationToken).ConfigureAwait(false);
+            await buildHostProcess.BuildHost.ConfigureGlobalStateAsync(_knownCommandLineParserLanguages, _globalMSBuildProperties, _binaryLogPathProvider?.GetNewLogPath(), _maxNodeCount, cancellationToken).ConfigureAwait(false);
 
             if (buildHostKind != BuildHostProcessKind.NetCore
                 || projectOrSolutionFilePath is null

--- a/src/Workspaces/MSBuild/Core/MSBuild/MSBuildProjectLoader.cs
+++ b/src/Workspaces/MSBuild/Core/MSBuild/MSBuildProjectLoader.cs
@@ -259,7 +259,7 @@ public partial class MSBuildProjectLoader
             ? new BinLogPathProvider(fileName)
             : null;
 
-        var buildHostProcessManager = new BuildHostProcessManager(_knownCommandLineParserLanguages, Properties, binLogPathProvider, _loggerFactory);
+        var buildHostProcessManager = new BuildHostProcessManager(_knownCommandLineParserLanguages, Properties, binLogPathProvider, loggerFactory: _loggerFactory);
         await using var _ = buildHostProcessManager.ConfigureAwait(false);
 
         var projectFileProvider = new BuildHostProjectFileInfoProvider(

--- a/src/Workspaces/MSBuild/Core/Rpc/RemoteBuildHost.cs
+++ b/src/Workspaces/MSBuild/Core/Rpc/RemoteBuildHost.cs
@@ -42,8 +42,8 @@ internal sealed class RemoteBuildHost
         => _client.InvokeAsync<bool>(BuildHostTargetObject, nameof(IBuildHost.HasUsableMSBuild), parameters: [projectOrSolutionFilePath], cancellationToken);
 
     /// <inheritdoc cref="IBuildHost.ConfigureGlobalState"/>
-    public Task ConfigureGlobalStateAsync(ImmutableArray<string> knownCommandLineParserLanguages, ImmutableDictionary<string, string> globalProperties, string? binlogPath, CancellationToken cancellationToken)
-        => _client.InvokeAsync(BuildHostTargetObject, nameof(IBuildHost.ConfigureGlobalState), parameters: [knownCommandLineParserLanguages.ToArray(), new Dictionary<string, string>(globalProperties), binlogPath], cancellationToken);
+    public Task ConfigureGlobalStateAsync(ImmutableArray<string> knownCommandLineParserLanguages, ImmutableDictionary<string, string> globalProperties, string? binlogPath, int? maxNodeCount, CancellationToken cancellationToken)
+        => _client.InvokeAsync(BuildHostTargetObject, nameof(IBuildHost.ConfigureGlobalState), parameters: [knownCommandLineParserLanguages.ToArray(), new Dictionary<string, string>(globalProperties), binlogPath, maxNodeCount], cancellationToken);
 
     public async Task<RemoteProjectFile> LoadProjectFileAsync(string projectFilePath, string languageName, CancellationToken cancellationToken)
     {


### PR DESCRIPTION
This removes the global semaphore that currently exists in ProjectBuildManager, and then enables parallel loading in the LSP when loading projects.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83982)