### PR TITLE
Port dictionary expression binding

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 11.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 11.md
@@ -283,3 +283,34 @@ If your code is impacted, you can either:
       Span<int> a = stackalloc int[5] { 0, 0, 0, 0, 0 };
   }
   ```
+
+## Dictionary interface overloads are applicable to collection expressions
+
+***Introduced in Visual Studio 2026 version 18.9***
+
+When the LangVersion is set to 15 or greater, collection expressions can convert to dictionary interface types such as `IDictionary<TKey, TValue>` and `IReadOnlyDictionary<TKey, TValue>`.
+This can change overload resolution because dictionary interface overloads that were previously not applicable may now be considered.
+
+```cs
+using System.Collections.Generic;
+
+class C
+{
+    static void Test()
+    {
+        M([]); // C# 14: calls M(List<int>); C# 15: error CS0121
+    }
+
+    static void M(List<int> value) { }
+    static void M(IDictionary<string, int> values) { }
+    static void M(IReadOnlyDictionary<string, int> values) { }
+}
+```
+
+If your code is impacted by this breaking change, use a cast or explicit target type to choose the intended overload:
+
+```cs
+M((List<int>)[]);
+M((IDictionary<string, int>)[]);
+M((IReadOnlyDictionary<string, int>)[]);
+```

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -4796,20 +4796,22 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Otherwise, we need to do deeper analysis to decide if this collection expression can escape, or if it has
             // to stay local.
-            var collectionTypeKind = ConversionsBase.GetCollectionExpressionTypeKind(_compilation, expr.Type, out var elementType);
+            var collectionTypeKind = expr.CollectionTypeKind;
             switch (collectionTypeKind)
             {
                 case CollectionExpressionTypeKind.ReadOnlySpan:
-                    Debug.Assert(elementType.Type is { });
+                    ConversionsBase.IsSpanOrListType(_compilation, expr.Type, WellKnownType.System_ReadOnlySpan_T, out var readOnlySpanElementType);
+                    Debug.Assert(readOnlySpanElementType.Type is { });
 
                     // An empty ReadOnlySpan can always be returned outwards.  Similarly if this is a span we're going
                     // to create out of a readonly-data segment of the program.
-                    return LocalRewriter.ShouldUseRuntimeHelpersCreateSpan(expr, elementType.Type)
+                    return LocalRewriter.ShouldUseRuntimeHelpersCreateSpan(expr, readOnlySpanElementType.Type)
                         ? SafeContext.CallingMethod
                         : _localScopeDepth;
 
                 case CollectionExpressionTypeKind.Span:
-                    Debug.Assert(elementType.Type is { });
+                    ConversionsBase.IsSpanOrListType(_compilation, expr.Type, WellKnownType.System_Span_T, out var spanElementType);
+                    Debug.Assert(spanElementType.Type is { });
                     return _localScopeDepth;
 
                 case CollectionExpressionTypeKind.CollectionBuilder:
@@ -4824,6 +4826,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return GetValEscape(expr.CollectionCreation);
 
                 case CollectionExpressionTypeKind.ImplementsIEnumerable:
+                case CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer:
                     var receiverScope = expr.CollectionCreation is { } collectionCreation
                         ? GetValEscape(collectionCreation)
                         : _localScopeDepth;

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -4875,6 +4875,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (element is BoundKeyValuePairElement keyValuePairElement)
             {
+                // PROTOTYPE: Is there a ref-returning indexer scenario to test here? Spec currently assumes there must be a
+                // set method (so indexer cannot return by ref), but is that a requirement we want to hold?
                 if (expr.IndexerSetMethod is { } indexerSetMethod)
                 {
                     // The key and value are stored into the collection via an invocation of the indexer's set

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -4830,7 +4830,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var scope = receiverScope;
                     foreach (var element in expr.Elements)
                     {
-                        if (TryGetCollectionExpressionElementValEscape(element, out var elementSafeContext))
+                        if (TryGetCollectionExpressionElementValEscape(expr, element, out var elementSafeContext))
                         {
                             scope = scope.Intersect(elementSafeContext);
                         }
@@ -4842,7 +4842,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private bool TryGetCollectionExpressionElementValEscape(BoundNode element, out SafeContext safeContext)
+        private bool TryGetCollectionExpressionElementValEscape(BoundCollectionExpression expr, BoundNode element, out SafeContext safeContext)
         {
             if (element is BoundCollectionElementInitializer colElement)
             {
@@ -4875,7 +4875,25 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (element is BoundKeyValuePairElement keyValuePairElement)
             {
-                safeContext = GetValEscape(keyValuePairElement.Key).Intersect(GetValEscape(keyValuePairElement.Value));
+                if (expr.IndexerSetMethod is { } indexerSetMethod)
+                {
+                    // The key and value are stored into the collection via an invocation of the indexer's set
+                    // accessor. If that accessor captures a ref to one of its arguments into the receiver (for
+                    // example, via an `[UnscopedRef] in` key parameter on a ref struct), then the collection's
+                    // safe-context is narrowed to the safe-context of that argument.
+                    Debug.Assert(expr.Placeholder is { });
+                    safeContext = GetInvocationEscapeToReceiver(
+                        MethodInvocationInfo.FromCallParts(
+                            indexerSetMethod,
+                            expr.Placeholder,
+                            [keyValuePairElement.Key, keyValuePairElement.Value],
+                            ThreeState.False));
+                }
+                else
+                {
+                    safeContext = GetValEscape(keyValuePairElement.Key).Intersect(GetValEscape(keyValuePairElement.Value));
+                }
+
                 return true;
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -4860,7 +4860,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     Debug.Assert(spreadElement.HasErrors
                         || spreadElement.IteratorBody is null
-                        or BoundExpressionStatement { Expression: BoundConversion or BoundValuePlaceholder or BoundDynamicCollectionElementInitializer });
+                        or BoundExpressionStatement { Expression: BoundConversion or BoundValuePlaceholder or BoundDynamicCollectionElementInitializer or BoundKeyValuePairConversion });
                     safeContext = GetValEscape(spreadElement.Expression);
                 }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -4873,6 +4873,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return true;
             }
 
+            if (element is BoundKeyValuePairElement keyValuePairElement)
+            {
+                safeContext = GetValEscape(keyValuePairElement.Key).Intersect(GetValEscape(keyValuePairElement.Value));
+                return true;
+            }
+
             Debug.Assert(element.HasErrors);
             safeContext = default;
             return false;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -1214,133 +1214,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 };
             }
 
-            private readonly BoundCollectionExpression? TryConvertCollectionExpressionDictionaryInterfaceType(TypeSymbol elementType)
-            {
-                var syntax = _node.Syntax;
-
-                var targetNamedType = (NamedTypeSymbol)_targetType;
-                var dictionaryType = _binder.GetWellKnownType(WellKnownType.System_Collections_Generic_Dictionary_KV, _diagnostics, syntax)
-                    .Construct(targetNamedType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics);
-
-                var useSiteInfo = _binder.GetNewCompoundUseSiteInfo(_diagnostics);
-                var dictionaryConversion = _binder.Conversions.ClassifyConversionFromType(dictionaryType, _targetType, isChecked: false, ref useSiteInfo);
-                _diagnostics.Add(syntax, useSiteInfo);
-                if (!dictionaryConversion.IsImplicit)
-                {
-                    Binder.GenerateImplicitConversionError(_diagnostics, _binder.Compilation, syntax, dictionaryConversion, dictionaryType, _targetType);
-                }
-
-                // Verify the existence of the Dictionary<K, V> ctors that may be used by with(...) overload resolution
-                // and lowering, even though not all will be used for any particular collection expression. Checking all
-                // gives a consistent behavior, regardless of collection expression elements / arguments. Per the
-                // dictionary-expressions proposal, only the mutable IDictionary<K, V> target offers the capacity-based
-                // ctors; the read-only and base-interface targets only offer the () and (IEqualityComparer<K>) ctors.
-                bool isIDictionary = targetNamedType.OriginalDefinition.Equals(
-                    _binder.Compilation.GetWellKnownType(WellKnownType.System_Collections_Generic_IDictionary_KV),
-                    TypeCompareKind.ConsiderEverything);
-
-                _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor, _diagnostics, syntax: syntax);
-                // PROTOTYPE: Confirm that this constructor is desired when targeting IReadOnlyDictionary<K, V>, and that it should reflect Dictionary<K, V>
-                // concretely
-                _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_IEqualityComparer_K, _diagnostics, syntax: syntax);
-                if (isIDictionary)
-                {
-                    _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_Int32, _diagnostics, syntax: syntax);
-                    _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_Int32_IEqualityComparer_K, _diagnostics, syntax: syntax);
-                }
-                var setMethod = (MethodSymbol?)_binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__set_Item, _diagnostics, syntax: syntax);
-                setMethod = (MethodSymbol?)setMethod?.SymbolAsMember(dictionaryType);
-
-                if (targetNamedType.OriginalDefinition.Equals(_binder.Compilation.GetWellKnownType(WellKnownType.System_Collections_Generic_IReadOnlyDictionary_KV), TypeCompareKind.ConsiderEverything))
-                {
-                    _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_ObjectModel_ReadOnlyDictionary_KV__ctor, _diagnostics, syntax: syntax);
-                }
-
-                var collectionCreation = bindDictionaryConstructorConstruction(in this, syntax, dictionaryType, isIDictionary);
-                if (collectionCreation.HasErrors)
-                {
-                    return null;
-                }
-
-                var elements = BindDictionaryInterfaceElements(elementType);
-
-                var placeholder = new BoundObjectOrCollectionValuePlaceholder(syntax, isNewInstance: true, dictionaryType) { WasCompilerGenerated = true };
-
-                return CreateCollectionExpression(
-                    CollectionExpressionTypeKind.DictionaryInterface,
-                    elements,
-                    placeholder: placeholder,
-                    collectionCreation: collectionCreation,
-                    indexerSetMethod: setMethod);
-
-                static BoundExpression bindDictionaryConstructorConstruction(ref readonly CollectionExpressionConverter @this, SyntaxNode syntax, NamedTypeSymbol dictionaryType, bool isIDictionary)
-                {
-                    // Mirrors bindCollectionArrayInterfaceConstruction in TryConvertCollectionExpressionArrayInterfaceType:
-                    // we form a subset of the Dictionary<K, V> instance constructors that with(...) is allowed to bind to,
-                    // and run overload resolution against just that subset. Any user-authored with(...) arguments are
-                    // applied to the underlying mutable Dictionary<K, V>; for IReadOnlyDictionary targets the LocalRewriter
-                    // additionally wraps the result in a ReadOnlyDictionary<K, V>.
-                    //
-                    // Per the dictionary-expressions proposal (mirrored from
-                    // https://github.com/dotnet/csharplang/blob/main/proposals/dictionary-expressions.md and
-                    // collection-expression-arguments.md), the allowed overloads are:
-                    //   - IDictionary<K, V>:        (), (IEqualityComparer<K>), (int capacity), (int capacity, IEqualityComparer<K>)
-                    //   - IReadOnlyDictionary<K, V> and base interfaces: (), (IEqualityComparer<K>)
-                    var withElement = @this._node.WithElement;
-                    var withSyntax = withElement?.Syntax ?? syntax;
-
-                    // Don't need to report diagnostics here. Our caller will have already done this.
-                    var compilation = @this._binder.Compilation;
-                    var candidateConstructorsBuilder = ArrayBuilder<MethodSymbol>.GetInstance();
-
-                    candidateConstructorsBuilder.AddIfNotNull(((MethodSymbol?)compilation.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor))?.AsMember(dictionaryType));
-                    // PROTOTYPE: Confirm that this constructor is desired when targeting IReadOnlyDictionary<K, V>, and that it should reflect Dictionary<K, V>
-                    // concretely
-                    candidateConstructorsBuilder.AddIfNotNull(((MethodSymbol?)compilation.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_IEqualityComparer_K))?.AsMember(dictionaryType));
-
-                    if (isIDictionary)
-                    {
-                        candidateConstructorsBuilder.AddIfNotNull(((MethodSymbol?)compilation.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_Int32))?.AsMember(dictionaryType));
-                        candidateConstructorsBuilder.AddIfNotNull(((MethodSymbol?)compilation.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_Int32_IEqualityComparer_K))?.AsMember(dictionaryType));
-                    }
-
-                    var candidateConstructors = candidateConstructorsBuilder.ToImmutableAndFree();
-
-                    var analyzedArguments = withElement is null
-                        ? AnalyzedArguments.GetInstance()
-                        : AnalyzedArguments.GetInstance(withElement.Arguments, withElement.ArgumentRefKindsOpt, withElement.ArgumentNamesOpt);
-
-                    var useSiteInfo = @this._binder.GetNewCompoundUseSiteInfo(@this._diagnostics);
-
-                    BoundExpression collectionCreation;
-                    if (@this._binder.TryPerformOverloadResolutionWithConstructorSubset(
-                            dictionaryType,
-                            ref candidateConstructors,
-                            candidateConstructors,
-                            analyzedArguments,
-                            dictionaryType.Name,
-                            withSyntax.GetFirstToken().GetLocation(),
-                            suppressResultDiagnostics: false,
-                            @this._diagnostics,
-                            out var memberResolutionResult,
-                            ref useSiteInfo,
-                            isParamsModifierValidation: false))
-                    {
-                        collectionCreation = @this._binder.BindClassCreationExpressionContinued(
-                            withSyntax, withSyntax, dictionaryType, analyzedArguments, initializerSyntaxOpt: null, initializerTypeOpt: null, wasTargetTyped: false, memberResolutionResult, candidateConstructors, useSiteInfo, @this._diagnostics);
-                    }
-                    else
-                    {
-                        collectionCreation = @this._binder.CreateBadClassCreationExpression(
-                            withSyntax, withSyntax, dictionaryType, analyzedArguments, initializerSyntaxOpt: null, initializerTypeOpt: null, memberResolutionResult, candidateConstructors, useSiteInfo, @this._diagnostics);
-                    }
-
-                    collectionCreation.WasCompilerGenerated = withElement is null;
-                    analyzedArguments.Free();
-                    return collectionCreation;
-                }
-            }
-
             private readonly ImmutableArray<BoundNode> BindDictionaryInterfaceElements(TypeSymbol elementType)
             {
                 var elements = _node.Elements;
@@ -1990,6 +1863,133 @@ namespace Microsoft.CodeAnalysis.CSharp
                     analyzedArguments.Free();
 
                     return (collectionCreation, collectionBuilderMethod, collectionBuilderElementsPlaceholder);
+                }
+            }
+
+            private readonly BoundCollectionExpression? TryConvertCollectionExpressionDictionaryInterfaceType(TypeSymbol elementType)
+            {
+                var syntax = _node.Syntax;
+
+                var targetNamedType = (NamedTypeSymbol)_targetType;
+                var dictionaryType = _binder.GetWellKnownType(WellKnownType.System_Collections_Generic_Dictionary_KV, _diagnostics, syntax)
+                    .Construct(targetNamedType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics);
+
+                var useSiteInfo = _binder.GetNewCompoundUseSiteInfo(_diagnostics);
+                var dictionaryConversion = _binder.Conversions.ClassifyConversionFromType(dictionaryType, _targetType, isChecked: false, ref useSiteInfo);
+                _diagnostics.Add(syntax, useSiteInfo);
+                if (!dictionaryConversion.IsImplicit)
+                {
+                    Binder.GenerateImplicitConversionError(_diagnostics, _binder.Compilation, syntax, dictionaryConversion, dictionaryType, _targetType);
+                }
+
+                // Verify the existence of the Dictionary<K, V> ctors that may be used by with(...) overload resolution
+                // and lowering, even though not all will be used for any particular collection expression. Checking all
+                // gives a consistent behavior, regardless of collection expression elements / arguments. Per the
+                // dictionary-expressions proposal, only the mutable IDictionary<K, V> target offers the capacity-based
+                // ctors; the read-only and base-interface targets only offer the () and (IEqualityComparer<K>) ctors.
+                bool isIDictionary = targetNamedType.OriginalDefinition.Equals(
+                    _binder.Compilation.GetWellKnownType(WellKnownType.System_Collections_Generic_IDictionary_KV),
+                    TypeCompareKind.ConsiderEverything);
+
+                _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor, _diagnostics, syntax: syntax);
+                // PROTOTYPE: Confirm that this constructor is desired when targeting IReadOnlyDictionary<K, V>, and that it should reflect Dictionary<K, V>
+                // concretely
+                _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_IEqualityComparer_K, _diagnostics, syntax: syntax);
+                if (isIDictionary)
+                {
+                    _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_Int32, _diagnostics, syntax: syntax);
+                    _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_Int32_IEqualityComparer_K, _diagnostics, syntax: syntax);
+                }
+                var setMethod = (MethodSymbol?)_binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__set_Item, _diagnostics, syntax: syntax);
+                setMethod = (MethodSymbol?)setMethod?.SymbolAsMember(dictionaryType);
+
+                if (targetNamedType.OriginalDefinition.Equals(_binder.Compilation.GetWellKnownType(WellKnownType.System_Collections_Generic_IReadOnlyDictionary_KV), TypeCompareKind.ConsiderEverything))
+                {
+                    _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_ObjectModel_ReadOnlyDictionary_KV__ctor, _diagnostics, syntax: syntax);
+                }
+
+                var collectionCreation = bindDictionaryConstructorConstruction(in this, syntax, dictionaryType, isIDictionary);
+                if (collectionCreation.HasErrors)
+                {
+                    return null;
+                }
+
+                var elements = BindDictionaryInterfaceElements(elementType);
+
+                var placeholder = new BoundObjectOrCollectionValuePlaceholder(syntax, isNewInstance: true, dictionaryType) { WasCompilerGenerated = true };
+
+                return CreateCollectionExpression(
+                    CollectionExpressionTypeKind.DictionaryInterface,
+                    elements,
+                    placeholder: placeholder,
+                    collectionCreation: collectionCreation,
+                    indexerSetMethod: setMethod);
+
+                static BoundExpression bindDictionaryConstructorConstruction(ref readonly CollectionExpressionConverter @this, SyntaxNode syntax, NamedTypeSymbol dictionaryType, bool isIDictionary)
+                {
+                    // Mirrors bindCollectionArrayInterfaceConstruction in TryConvertCollectionExpressionArrayInterfaceType:
+                    // we form a subset of the Dictionary<K, V> instance constructors that with(...) is allowed to bind to,
+                    // and run overload resolution against just that subset. Any user-authored with(...) arguments are
+                    // applied to the underlying mutable Dictionary<K, V>; for IReadOnlyDictionary targets the LocalRewriter
+                    // additionally wraps the result in a ReadOnlyDictionary<K, V>.
+                    //
+                    // Per the dictionary-expressions proposal (mirrored from
+                    // https://github.com/dotnet/csharplang/blob/main/proposals/dictionary-expressions.md and
+                    // collection-expression-arguments.md), the allowed overloads are:
+                    //   - IDictionary<K, V>:        (), (IEqualityComparer<K>), (int capacity), (int capacity, IEqualityComparer<K>)
+                    //   - IReadOnlyDictionary<K, V> and base interfaces: (), (IEqualityComparer<K>)
+                    var withElement = @this._node.WithElement;
+                    var withSyntax = withElement?.Syntax ?? syntax;
+
+                    // Don't need to report diagnostics here. Our caller will have already done this.
+                    var compilation = @this._binder.Compilation;
+                    var candidateConstructorsBuilder = ArrayBuilder<MethodSymbol>.GetInstance();
+
+                    candidateConstructorsBuilder.AddIfNotNull(((MethodSymbol?)compilation.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor))?.AsMember(dictionaryType));
+                    // PROTOTYPE: Confirm that this constructor is desired when targeting IReadOnlyDictionary<K, V>, and that it should reflect Dictionary<K, V>
+                    // concretely
+                    candidateConstructorsBuilder.AddIfNotNull(((MethodSymbol?)compilation.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_IEqualityComparer_K))?.AsMember(dictionaryType));
+
+                    if (isIDictionary)
+                    {
+                        candidateConstructorsBuilder.AddIfNotNull(((MethodSymbol?)compilation.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_Int32))?.AsMember(dictionaryType));
+                        candidateConstructorsBuilder.AddIfNotNull(((MethodSymbol?)compilation.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_Int32_IEqualityComparer_K))?.AsMember(dictionaryType));
+                    }
+
+                    var candidateConstructors = candidateConstructorsBuilder.ToImmutableAndFree();
+
+                    var analyzedArguments = withElement is null
+                        ? AnalyzedArguments.GetInstance()
+                        : AnalyzedArguments.GetInstance(withElement.Arguments, withElement.ArgumentRefKindsOpt, withElement.ArgumentNamesOpt);
+
+                    var useSiteInfo = @this._binder.GetNewCompoundUseSiteInfo(@this._diagnostics);
+
+                    BoundExpression collectionCreation;
+                    if (@this._binder.TryPerformOverloadResolutionWithConstructorSubset(
+                            dictionaryType,
+                            ref candidateConstructors,
+                            candidateConstructors,
+                            analyzedArguments,
+                            dictionaryType.Name,
+                            withSyntax.GetFirstToken().GetLocation(),
+                            suppressResultDiagnostics: false,
+                            @this._diagnostics,
+                            out var memberResolutionResult,
+                            ref useSiteInfo,
+                            isParamsModifierValidation: false))
+                    {
+                        collectionCreation = @this._binder.BindClassCreationExpressionContinued(
+                            withSyntax, withSyntax, dictionaryType, analyzedArguments, initializerSyntaxOpt: null, initializerTypeOpt: null, wasTargetTyped: false, memberResolutionResult, candidateConstructors, useSiteInfo, @this._diagnostics);
+                    }
+                    else
+                    {
+                        collectionCreation = @this._binder.CreateBadClassCreationExpression(
+                            withSyntax, withSyntax, dictionaryType, analyzedArguments, initializerSyntaxOpt: null, initializerTypeOpt: null, memberResolutionResult, candidateConstructors, useSiteInfo, @this._diagnostics);
+                    }
+
+                    collectionCreation.WasCompilerGenerated = withElement is null;
+                    analyzedArguments.Free();
+                    return collectionCreation;
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -935,6 +935,139 @@ namespace Microsoft.CodeAnalysis.CSharp
             return converter.Convert();
         }
 
+#nullable enable
+        private static BoundNode ConvertKeyValuePairElement(
+            Binder binder,
+            BoundKeyValuePairElement keyValuePairElement,
+            Conversion elementConversion,
+            TypeSymbol elementType,
+            (TypeSymbol Key, TypeSymbol Value)? elementKeyValueTypes,
+            bool useIndexer,
+            BoundObjectOrCollectionValuePlaceholder? implicitReceiver,
+            CollectionInitializerAddMethodBinder? collectionInitializerAddMethodBinder,
+            BindingDiagnosticBag diagnostics)
+        {
+            if (elementKeyValueTypes is (var elementKeyType, var elementValueType) &&
+                elementConversion.TryGetKeyValueConversions(out var keyConversion, out var valueConversion))
+            {
+                var keyValuePairSyntax = (KeyValuePairElementSyntax)keyValuePairElement.Syntax;
+                var keyValuePairConstructor = useIndexer ? null : (MethodSymbol?)binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__ctor, diagnostics, syntax: keyValuePairSyntax);
+                var key = binder.CreateConversion(keyValuePairElement.Key, keyConversion, elementKeyType, diagnostics);
+                var value = binder.CreateConversion(keyValuePairElement.Value, valueConversion, elementValueType, diagnostics);
+                if (collectionInitializerAddMethodBinder is { })
+                {
+                    Debug.Assert(implicitReceiver is { });
+                    if (keyValuePairConstructor is null)
+                    {
+                        return new BoundBadExpression(
+                            keyValuePairSyntax,
+                            LookupResultKind.Empty,
+                            symbols: [],
+                            childBoundNodes: [key, value],
+                            elementType)
+                        { WasCompilerGenerated = true };
+                    }
+                    var keyValuePair = new BoundObjectCreationExpression(
+                        keyValuePairSyntax,
+                        keyValuePairConstructor.AsMember((NamedTypeSymbol)elementType),
+                        key,
+                        value)
+                    { WasCompilerGenerated = true };
+                    return binder.BindCollectionInitializerElementAddMethod(
+                        keyValuePairSyntax,
+                        [keyValuePair],
+                        hasEnumerableInitializerType: true,
+                        collectionInitializerAddMethodBinder,
+                        diagnostics,
+                        implicitReceiver);
+                }
+                else
+                {
+                    return new BoundKeyValuePairElement(keyValuePairSyntax, key, value);
+                }
+            }
+            else
+            {
+                throw ExceptionUtilities.UnexpectedValue(elementConversion);
+            }
+        }
+
+        // Convert an expression element or the expression representing each item of a spread element.
+        private static BoundExpression ConvertCollectionExpressionItem(
+            Binder binder,
+            SyntaxNode expressionSyntax,
+            BoundExpression expressionElement,
+            Conversion elementConversion,
+            TypeSymbol elementType,
+            (TypeSymbol Key, TypeSymbol Value)? elementKeyValueTypes,
+            bool useIndexer,
+            BoundObjectOrCollectionValuePlaceholder? implicitReceiver,
+            CollectionInitializerAddMethodBinder? collectionInitializerAddMethodBinder,
+            BindingDiagnosticBag diagnostics)
+        {
+            if (elementKeyValueTypes is (var elementKeyType, var elementValueType) &&
+                elementConversion.TryGetKeyValueConversions(out var keyConversion, out var valueConversion))
+            {
+                if (!useIndexer)
+                {
+                    _ = binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__ctor, diagnostics, syntax: expressionSyntax);
+                }
+                _ = binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Key, diagnostics, syntax: expressionSyntax);
+                _ = binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Value, diagnostics, syntax: expressionSyntax);
+                if (!ConversionsBase.IsKeyValuePairType(binder.Compilation, expressionElement.Type, out var keyType, out var valueType))
+                {
+                    throw ExceptionUtilities.UnexpectedValue(expressionElement.Type);
+                }
+                BoundExpression convertedExpression = binder.BindToNaturalType(expressionElement, diagnostics);
+                var keyPlaceholder = new BoundValuePlaceholder(expressionSyntax, keyType);
+                var valuePlaceholder = new BoundValuePlaceholder(expressionSyntax, valueType);
+                var keyValuePairConversion = new BoundKeyValuePairConversion(
+                    expressionSyntax,
+                    expression: convertedExpression,
+                    keyPlaceholder: keyPlaceholder,
+                    valuePlaceholder: valuePlaceholder,
+                    keyConversion: binder.CreateConversion(keyPlaceholder, keyConversion, elementKeyType, diagnostics),
+                    valueConversion: binder.CreateConversion(valuePlaceholder, valueConversion, elementValueType, diagnostics),
+                    elementType);
+                if (collectionInitializerAddMethodBinder is { })
+                {
+                    Debug.Assert(implicitReceiver is { });
+                    return binder.BindCollectionInitializerElementAddMethod(
+                        expressionSyntax,
+                        [keyValuePairConversion],
+                        hasEnumerableInitializerType: true,
+                        collectionInitializerAddMethodBinder,
+                        diagnostics,
+                        implicitReceiver);
+                }
+                else
+                {
+                    return keyValuePairConversion;
+                }
+            }
+            else if (collectionInitializerAddMethodBinder is { })
+            {
+                Debug.Assert(implicitReceiver is { });
+                return binder.BindCollectionInitializerElementAddMethod(
+                    expressionSyntax,
+                    [expressionElement],
+                    hasEnumerableInitializerType: true,
+                    collectionInitializerAddMethodBinder,
+                    diagnostics,
+                    implicitReceiver);
+            }
+            else
+            {
+                if (useIndexer)
+                {
+                    _ = binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Key, diagnostics, syntax: expressionSyntax);
+                    _ = binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Value, diagnostics, syntax: expressionSyntax);
+                }
+                return binder.CreateConversion(expressionElement, elementConversion, elementType, diagnostics);
+            }
+        }
+#nullable disable
+
         private readonly struct CollectionExpressionConverter(
             Binder binder,
             BoundUnconvertedCollectionExpression node,
@@ -1150,32 +1283,41 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     var element = elements[i];
                     var elementConversion = elementConversions[i];
+                    BoundNode convertedElement;
                     switch (element)
                     {
                         case BoundCollectionExpressionSpreadElement spreadElement:
-                            builder.Add(bindSpreadElement(in this, spreadElement, elementType, elementConversion));
+                            convertedElement = bindSpreadElement(in this, spreadElement, elementType, elementConversion, elementKeyValueTypes);
                             break;
-                        case BoundKeyValuePairElement keyValuePairElement when
-                            elementKeyValueTypes is (var keyType, var valueType) &&
-                            elementConversion.TryGetKeyValueConversions(out var keyConversion, out var valueConversion):
-                            {
-                                var key = _binder.CreateConversion(keyValuePairElement.Key, keyConversion, keyType, _diagnostics);
-                                var value = _binder.CreateConversion(keyValuePairElement.Value, valueConversion, valueType, _diagnostics);
-                                builder.Add(new BoundKeyValuePairElement(keyValuePairElement.Syntax, key, value));
-                            }
+                        case BoundKeyValuePairElement keyValuePairElement:
+                            convertedElement = ConvertKeyValuePairElement(
+                                _binder,
+                                keyValuePairElement,
+                                elementConversion,
+                                elementType,
+                                elementKeyValueTypes,
+                                useIndexer: true,
+                                implicitReceiver: null,
+                                collectionInitializerAddMethodBinder: null,
+                                _diagnostics);
+                            break;
+                        case BoundExpression expressionElement:
+                            convertedElement = ConvertCollectionExpressionItem(
+                                _binder,
+                                expressionElement.Syntax,
+                                expressionElement,
+                                elementConversion,
+                                elementType,
+                                elementKeyValueTypes,
+                                useIndexer: true,
+                                implicitReceiver: null,
+                                collectionInitializerAddMethodBinder: null,
+                                _diagnostics);
                             break;
                         default:
-                            builder.Add(_binder.CreateConversion(
-                                element.Syntax,
-                                (BoundExpression)element,
-                                elementConversion,
-                                isCast: false,
-                                conversionGroupOpt: null,
-                                InConversionGroupFlags.Unspecified,
-                                destination: elementType,
-                                _diagnostics));
-                            break;
+                            throw ExceptionUtilities.UnexpectedValue(element);
                     }
+                    builder.Add(convertedElement);
                 }
 
                 _conversion.MarkUnderlyingConversionsChecked();
@@ -1183,32 +1325,32 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return builder.ToImmutableAndFree();
 
                 static BoundCollectionExpressionSpreadElement bindSpreadElement(
-                    ref readonly CollectionExpressionConverter @this, BoundCollectionExpressionSpreadElement element, TypeSymbol elementType, Conversion elementConversion)
+                    ref readonly CollectionExpressionConverter @this,
+                    BoundCollectionExpressionSpreadElement element,
+                    TypeSymbol elementType,
+                    Conversion elementConversion,
+                    (TypeSymbol Key, TypeSymbol Value)? elementKeyValueTypes)
                 {
-                    var enumeratorInfo = element.EnumeratorInfoOpt;
-                    Debug.Assert(enumeratorInfo is { });
-                    Debug.Assert(enumeratorInfo.ElementType is { }); // ElementType is set always, even for IEnumerable.
-
-                    var expressionSyntax = element.Expression.Syntax;
-                    var elementPlaceholder = new BoundValuePlaceholder(expressionSyntax, enumeratorInfo.ElementType) { WasCompilerGenerated = true };
-                    elementPlaceholder = (BoundValuePlaceholder)elementPlaceholder.WithSuppression(element.Expression.IsSuppressed);
-                    var convertElement = @this._binder.CreateConversion(
-                        expressionSyntax,
-                        elementPlaceholder,
-                        elementConversion,
-                        isCast: false,
-                        conversionGroupOpt: null,
-                        InConversionGroupFlags.Unspecified,
-                        destination: elementType,
+                    return @this._binder.BindCollectionExpressionSpreadElement(
+                        (SpreadElementSyntax)element.Syntax,
+                        element,
+                        implicitReceiver: null,
+                        static (binder, syntax, item, implicitReceiver, arg, diagnostics) =>
+                        {
+                            return ConvertCollectionExpressionItem(
+                                binder,
+                                syntax,
+                                item,
+                                arg.elementConversion,
+                                arg.elementType,
+                                arg.elementKeyValueTypes,
+                                useIndexer: true,
+                                implicitReceiver,
+                                collectionInitializerAddMethodBinder: null,
+                                diagnostics);
+                        },
+                        (elementType, elementConversion, elementKeyValueTypes),
                         @this._diagnostics);
-                    return element.Update(
-                        element.Expression,
-                        expressionPlaceholder: element.ExpressionPlaceholder,
-                        conversion: element.Conversion,
-                        enumeratorInfo,
-                        elementPlaceholder: elementPlaceholder,
-                        iteratorBody: new BoundExpressionStatement(expressionSyntax, convertElement) { WasCompilerGenerated = true },
-                        lengthOrCount: element.LengthOrCount);
                 }
             }
 
@@ -1217,12 +1359,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(collectionTypeKind is CollectionExpressionTypeKind.ImplementsIEnumerable or CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer);
                 var syntax = _node.Syntax;
                 var elementConversions = _conversion.UnderlyingConversions;
-                (TypeSymbol Key, TypeSymbol Value)? elementKeyValueTypes = null;
+                var elementKeyValueTypes = ConversionsBase.TryGetCollectionKeyValuePairTypes(_binder.Compilation, elementType);
                 MethodSymbol? setMethod = null;
 
                 if (collectionTypeKind == CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer)
                 {
-                    elementKeyValueTypes = ConversionsBase.TryGetCollectionKeyValuePairTypes(_binder.Compilation, elementType);
                     Debug.Assert(elementKeyValueTypes is not null);
                     var indexer = _binder.GetCollectionExpressionApplicableIndexer(syntax, _targetType, elementType, _diagnostics);
                     setMethod = indexer.GetOwnOrInheritedSetMethod();
@@ -1266,47 +1407,72 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // With an IEnumerable based collection, we can bind the elements up front to calls to the appropriate
                 // .Add method.  Note: lowering may choose to replace some of these with .AddRange calls if it desires.
-                var collectionInitializerAddMethodBinder = new CollectionInitializerAddMethodBinder(syntax, _targetType, _binder);
+                // For an IEnumerable based collection with an indexer, items are assigned via the indexer instead, so
+                // we don't bind Add method calls (addBinder is null).
+                var useIndexer = setMethod is not null;
+                var collectionInitializerAddMethodBinder = useIndexer
+                    ? null
+                    : new CollectionInitializerAddMethodBinder(syntax, _targetType, _binder);
 
                 var builder = ArrayBuilder<BoundNode>.GetInstance(elements.Length);
                 int conversionIndex = 0;
                 foreach (var element in elements)
                 {
                     var elementConversion = elementConversions[conversionIndex++];
-                    if (element is BoundCollectionExpressionSpreadElement spreadElement)
+                    BoundNode convertedElement;
+                    switch (element)
                     {
-                        builder.Add(_binder.BindCollectionExpressionSpreadElementAddMethod(
-                            (SpreadElementSyntax)spreadElement.Syntax,
-                            spreadElement,
-                            collectionInitializerAddMethodBinder,
-                            implicitReceiver,
-                            _diagnostics));
+                        case BoundCollectionExpressionSpreadElement spreadElement:
+                            convertedElement = _binder.BindCollectionExpressionSpreadElement(
+                                (SpreadElementSyntax)spreadElement.Syntax,
+                                spreadElement,
+                                implicitReceiver,
+                                static (binder, syntax, item, implicitReceiver, arg, diagnostics) =>
+                                {
+                                    return convertItem(
+                                        binder,
+                                        syntax,
+                                        item,
+                                        arg.elementConversion,
+                                        arg.elementType,
+                                        arg.elementKeyValueTypes,
+                                        arg.useIndexer,
+                                        implicitReceiver,
+                                        arg.collectionInitializerAddMethodBinder,
+                                        diagnostics);
+                                },
+                                (elementType, useIndexer, elementConversion, elementKeyValueTypes, collectionInitializerAddMethodBinder),
+                                _diagnostics);
+                            break;
+                        case BoundKeyValuePairElement keyValuePairElement:
+                            convertedElement = convertKeyValuePair(
+                                _binder,
+                                keyValuePairElement,
+                                elementConversion,
+                                elementType,
+                                elementKeyValueTypes,
+                                useIndexer,
+                                implicitReceiver,
+                                collectionInitializerAddMethodBinder,
+                                _diagnostics);
+                            break;
+                        case BoundExpression expressionElement:
+                            convertedElement = convertItem(
+                                _binder,
+                                expressionElement.Syntax,
+                                expressionElement,
+                                elementConversion,
+                                elementType,
+                                elementKeyValueTypes,
+                                useIndexer,
+                                implicitReceiver,
+                                collectionInitializerAddMethodBinder,
+                                _diagnostics);
+                            break;
+                        default:
+                            throw ExceptionUtilities.UnexpectedValue(element);
                     }
-                    else if (element is BoundKeyValuePairElement keyValuePairElement &&
-                        elementKeyValueTypes is (var keyType, var valueType) &&
-                        elementConversion.TryGetKeyValueConversions(out var keyConversion, out var valueConversion))
-                    {
-                        var key = _binder.CreateConversion(keyValuePairElement.Key, keyConversion, keyType, _diagnostics);
-                        var value = _binder.CreateConversion(keyValuePairElement.Value, valueConversion, valueType, _diagnostics);
-                        var keyValuePairExpression = createKeyValuePairExpression(_binder, keyValuePairElement, key, value, elementType, _diagnostics);
-                        builder.Add(_binder.BindCollectionInitializerElementAddMethod(
-                            element.Syntax,
-                            [keyValuePairExpression],
-                            hasEnumerableInitializerType: true,
-                            collectionInitializerAddMethodBinder,
-                            _diagnostics,
-                            implicitReceiver));
-                    }
-                    else
-                    {
-                        builder.Add(_binder.BindCollectionInitializerElementAddMethod(
-                            element.Syntax,
-                            [(BoundExpression)element],
-                            hasEnumerableInitializerType: true,
-                            collectionInitializerAddMethodBinder,
-                            _diagnostics,
-                            implicitReceiver));
-                    }
+                    builder.Add(convertedElement);
                 }
 
                 return CreateCollectionExpression(
@@ -1316,32 +1482,31 @@ namespace Microsoft.CodeAnalysis.CSharp
                     collectionCreation,
                     indexerSetMethod: setMethod);
 
-                static BoundExpression createKeyValuePairExpression(
+                static BoundNode convertKeyValuePair(
                     Binder binder,
                     BoundKeyValuePairElement keyValuePairElement,
-                    BoundExpression key,
-                    BoundExpression value,
-                    TypeSymbol? elementType,
+                    Conversion elementConversion,
+                    TypeSymbol elementType,
+                    (TypeSymbol Key, TypeSymbol Value)? elementKeyValueTypes,
+                    bool useIndexer,
+                    BoundObjectOrCollectionValuePlaceholder? implicitReceiver,
+                    CollectionInitializerAddMethodBinder? collectionInitializerAddMethodBinder,
                     BindingDiagnosticBag diagnostics)
-                {
-                    if (elementType is not NamedTypeSymbol namedType)
-                    {
-                        return new BoundBadExpression(keyValuePairElement.Syntax, LookupResultKind.Empty, symbols: [], childBoundNodes: [key, value], binder.CreateErrorType());
-                    }
+                    => ConvertKeyValuePairElement(binder, keyValuePairElement, elementConversion, elementType, elementKeyValueTypes, useIndexer, implicitReceiver, collectionInitializerAddMethodBinder, diagnostics);
 
-                    var constructor = (MethodSymbol?)binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__ctor, diagnostics, syntax: keyValuePairElement.Syntax);
-                    if (constructor is null)
-                    {
-                        return new BoundBadExpression(keyValuePairElement.Syntax, LookupResultKind.Empty, symbols: [], childBoundNodes: [key, value], namedType);
-                    }
-
-                    return new BoundObjectCreationExpression(
-                        keyValuePairElement.Syntax,
-                        constructor.AsMember(namedType),
-                        key,
-                        value)
-                    { WasCompilerGenerated = true };
-                }
+                // Convert an expression element or the expression representing each item of a spread element.
+                static BoundExpression convertItem(
+                    Binder binder,
+                    SyntaxNode expressionSyntax,
+                    BoundExpression expressionElement,
+                    Conversion elementConversion,
+                    TypeSymbol elementType,
+                    (TypeSymbol Key, TypeSymbol Value)? elementKeyValueTypes,
+                    bool useIndexer,
+                    BoundObjectOrCollectionValuePlaceholder? implicitReceiver,
+                    CollectionInitializerAddMethodBinder? collectionInitializerAddMethodBinder,
+                    BindingDiagnosticBag diagnostics)
+                    => ConvertCollectionExpressionItem(binder, expressionSyntax, expressionElement, elementConversion, elementType, elementKeyValueTypes, useIndexer, implicitReceiver, collectionInitializerAddMethodBinder, diagnostics);
 
                 static BoundExpression bindCollectionConstructorConstruction(
                     ref readonly CollectionExpressionConverter @this, SyntaxNode syntax, MethodSymbol? constructor)
@@ -1421,90 +1586,74 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     var element = elements[i];
                     var elementConversion = elementConversions[i];
-                    if (element is BoundCollectionExpressionSpreadElement spreadElement)
+                    BoundNode convertedElement;
+                    switch (element)
                     {
-                        builder.Add(bindSpreadElement(in this, spreadElement, elementType, elementConversion));
+                        case BoundCollectionExpressionSpreadElement spreadElement:
+                            convertedElement = bindSpreadElement(in this, spreadElement, elementType, elementConversion, elementKeyValueTypes);
+                            break;
+                        case BoundKeyValuePairElement keyValuePairElement:
+                            convertedElement = ConvertKeyValuePairElement(
+                                _binder,
+                                keyValuePairElement,
+                                elementConversion,
+                                elementType,
+                                elementKeyValueTypes,
+                                useIndexer: false,
+                                implicitReceiver: null,
+                                collectionInitializerAddMethodBinder: null,
+                                _diagnostics);
+                            break;
+                        case BoundExpression expressionElement:
+                            convertedElement = ConvertCollectionExpressionItem(
+                                _binder,
+                                expressionElement.Syntax,
+                                expressionElement,
+                                elementConversion,
+                                elementType,
+                                elementKeyValueTypes,
+                                useIndexer: false,
+                                implicitReceiver: null,
+                                collectionInitializerAddMethodBinder: null,
+                                _diagnostics);
+                            break;
+                        default:
+                            throw ExceptionUtilities.UnexpectedValue(element);
                     }
-                    else if (element is BoundKeyValuePairElement keyValuePairElement &&
-                        elementConversion.TryGetKeyValueConversions(out var keyConversion, out var valueConversion) &&
-                        elementKeyValueTypes is (var keyType, var valueType))
-                    {
-                        var key = _binder.CreateConversion(keyValuePairElement.Key, keyConversion, keyType, _diagnostics);
-                        var value = _binder.CreateConversion(keyValuePairElement.Value, valueConversion, valueType, _diagnostics);
-                        builder.Add(createKeyValuePairExpression(_binder, keyValuePairElement, key, value, elementType, _diagnostics));
-                    }
-                    else
-                    {
-                        builder.Add(_binder.CreateConversion(
-                            element.Syntax,
-                            (BoundExpression)element,
-                            elementConversion,
-                            isCast: false,
-                            conversionGroupOpt: null,
-                            InConversionGroupFlags.Unspecified,
-                            destination: elementType,
-                            _diagnostics));
-                    }
+                    builder.Add(convertedElement);
                 }
 
                 _conversion.MarkUnderlyingConversionsChecked();
 
                 return builder.ToImmutableAndFree();
 
-                static BoundExpression createKeyValuePairExpression(
-                    Binder binder,
-                    BoundKeyValuePairElement keyValuePairElement,
-                    BoundExpression key,
-                    BoundExpression value,
-                    TypeSymbol elementType,
-                    BindingDiagnosticBag diagnostics)
-                {
-                    if (elementType is not NamedTypeSymbol namedType)
-                    {
-                        return new BoundBadExpression(keyValuePairElement.Syntax, LookupResultKind.Empty, symbols: [], childBoundNodes: [key, value], binder.CreateErrorType());
-                    }
-
-                    var constructor = (MethodSymbol?)binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__ctor, diagnostics, syntax: keyValuePairElement.Syntax);
-                    if (constructor is null)
-                    {
-                        return new BoundBadExpression(keyValuePairElement.Syntax, LookupResultKind.Empty, symbols: [], childBoundNodes: [key, value], namedType);
-                    }
-
-                    return new BoundObjectCreationExpression(
-                        keyValuePairElement.Syntax,
-                        constructor.AsMember(namedType),
-                        key,
-                        value)
-                    { WasCompilerGenerated = true };
-                }
-
                 static BoundCollectionExpressionSpreadElement bindSpreadElement(
-                    ref readonly CollectionExpressionConverter @this, BoundCollectionExpressionSpreadElement element, TypeSymbol elementType, Conversion elementConversion)
+                    ref readonly CollectionExpressionConverter @this,
+                    BoundCollectionExpressionSpreadElement element,
+                    TypeSymbol elementType,
+                    Conversion elementConversion,
+                    (TypeSymbol Key, TypeSymbol Value)? elementKeyValueTypes)
                 {
-                    var enumeratorInfo = element.EnumeratorInfoOpt;
-                    Debug.Assert(enumeratorInfo is { });
-                    Debug.Assert(enumeratorInfo.ElementType is { }); // ElementType is set always, even for IEnumerable.
-
-                    var expressionSyntax = element.Expression.Syntax;
-                    var elementPlaceholder = new BoundValuePlaceholder(expressionSyntax, enumeratorInfo.ElementType) { WasCompilerGenerated = true };
-                    elementPlaceholder = (BoundValuePlaceholder)elementPlaceholder.WithSuppression(element.Expression.IsSuppressed);
-                    var convertElement = @this._binder.CreateConversion(
-                        expressionSyntax,
-                        elementPlaceholder,
-                        elementConversion,
-                        isCast: false,
-                        conversionGroupOpt: null,
-                        InConversionGroupFlags.Unspecified,
-                        destination: elementType,
+                    return @this._binder.BindCollectionExpressionSpreadElement(
+                        (SpreadElementSyntax)element.Syntax,
+                        element,
+                        implicitReceiver: null,
+                        static (binder, syntax, item, implicitReceiver, arg, diagnostics) =>
+                        {
+                            return ConvertCollectionExpressionItem(
+                                binder,
+                                syntax,
+                                item,
+                                arg.elementConversion,
+                                arg.elementType,
+                                arg.elementKeyValueTypes,
+                                useIndexer: false,
+                                implicitReceiver,
+                                collectionInitializerAddMethodBinder: null,
+                                diagnostics);
+                        },
+                        (elementType, elementConversion, elementKeyValueTypes),
                         @this._diagnostics);
-                    return element.Update(
-                        element.Expression,
-                        expressionPlaceholder: element.ExpressionPlaceholder,
-                        conversion: element.Conversion,
-                        enumeratorInfo,
-                        elementPlaceholder: elementPlaceholder,
-                        iteratorBody: new BoundExpressionStatement(expressionSyntax, convertElement) { WasCompilerGenerated = true },
-                        lengthOrCount: element.LengthOrCount);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -1198,22 +1198,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 // From this point out, all the remaining collection types end up converting all their elements
-                // to their actual element type and passing those along.
-
-                ImmutableArray<BoundNode> elements = collectionTypeKind == CollectionExpressionTypeKind.DictionaryInterface
-                    ? default
-                    : BindElements(elementType);
+                // to their actual element type and passing those along. Each helper binds its own elements (via
+                // BindElements / BindDictionaryInterfaceElements) so that all non-shared logic lives in the helper.
 
                 return collectionTypeKind switch
                 {
                     CollectionExpressionTypeKind.Array or CollectionExpressionTypeKind.Span or CollectionExpressionTypeKind.ReadOnlySpan
-                        => TryConvertCollectionExpressionArrayOrSpanType(collectionTypeKind, elements),
+                        => TryConvertCollectionExpressionArrayOrSpanType(collectionTypeKind, elementType),
 
                     CollectionExpressionTypeKind.ArrayInterface
-                        => TryConvertCollectionExpressionArrayInterfaceType(elements),
+                        => TryConvertCollectionExpressionArrayInterfaceType(elementType),
 
                     CollectionExpressionTypeKind.CollectionBuilder
-                        => TryConvertCollectionExpressionBuilderType(elements),
+                        => TryConvertCollectionExpressionBuilderType(elementType),
 
                     CollectionExpressionTypeKind.DictionaryInterface
                         => TryConvertCollectionExpressionDictionaryInterfaceType(elementType),
@@ -1614,9 +1611,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             private readonly BoundCollectionExpression? TryConvertCollectionExpressionArrayOrSpanType(
                 CollectionExpressionTypeKind collectionTypeKind,
-                ImmutableArray<BoundNode> elements)
+                TypeSymbol elementType)
             {
                 var syntax = _node.Syntax;
+                var elements = BindElements(elementType);
                 switch (collectionTypeKind)
                 {
                     case CollectionExpressionTypeKind.Span:
@@ -1641,8 +1639,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return CreateCollectionExpression(collectionTypeKind, elements);
             }
 
-            private readonly BoundCollectionExpression? TryConvertCollectionExpressionArrayInterfaceType(ImmutableArray<BoundNode> elements)
+            private readonly BoundCollectionExpression? TryConvertCollectionExpressionArrayInterfaceType(TypeSymbol elementType)
             {
+                var elements = BindElements(elementType);
                 if (_node.WithElement?.Arguments.Length > 0 &&
                     _targetType.IsReadOnlyArrayInterface(out _))
                 {
@@ -1729,8 +1728,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            private readonly BoundCollectionExpression? TryConvertCollectionExpressionBuilderType(ImmutableArray<BoundNode> elements)
+            private readonly BoundCollectionExpression? TryConvertCollectionExpressionBuilderType(TypeSymbol elementType)
             {
+                var elements = BindElements(elementType);
                 var (collectionCreation, collectionBuilderMethod, collectionBuilderElementsPlaceholder) = bindCollectionBuilderInfo(in this);
                 if (collectionCreation is null || collectionBuilderMethod is null || collectionBuilderElementsPlaceholder is null)
                     return null;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -1100,10 +1100,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 var elements = BindDictionaryInterfaceElements(elementType);
 
+                var placeholder = new BoundObjectOrCollectionValuePlaceholder(syntax, isNewInstance: true, dictionaryType) { WasCompilerGenerated = true };
+
                 return CreateCollectionExpression(
                     CollectionExpressionTypeKind.DictionaryInterface,
                     elements,
-                    placeholder: null,
+                    placeholder: placeholder,
                     collectionCreation: collectionCreation,
                     indexerSetMethod: setMethod);
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -944,7 +944,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             private readonly BindingDiagnosticBag _diagnostics = diagnostics;
 
             private BoundCollectionExpression CreateCollectionExpression(
-                CollectionExpressionTypeKind collectionTypeKind, ImmutableArray<BoundNode> elements, BoundObjectOrCollectionValuePlaceholder? placeholder = null, BoundExpression? collectionCreation = null, MethodSymbol? collectionBuilderMethod = null, BoundCollectionBuilderElementsPlaceholder? collectionBuilderElementsPlaceholder = null)
+                CollectionExpressionTypeKind collectionTypeKind,
+                ImmutableArray<BoundNode> elements,
+                BoundObjectOrCollectionValuePlaceholder? placeholder = null,
+                BoundExpression? collectionCreation = null,
+                MethodSymbol? collectionBuilderMethod = null,
+                MethodSymbol? indexerSetMethod = null,
+                BoundCollectionBuilderElementsPlaceholder? collectionBuilderElementsPlaceholder = null)
             {
                 return new BoundCollectionExpression(
                     _node.Syntax,
@@ -953,6 +959,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     collectionCreation,
                     collectionBuilderMethod,
                     collectionBuilderElementsPlaceholder,
+                    indexerSetMethod,
                     wasTargetTyped: true,
                     hasWithElement: _node.WithElement != null,
                     _node,
@@ -979,6 +986,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // case, spans are not 'allows ref struct' for their T element.  So they don't allow them either.  Finally,
                 // collection builders need to take in a ReadOnlySpan<T> so they are restricted for the same reason.
                 Debug.Assert(elementType is { });
+                // PROTOTYPE: ImplementsIEnumerableWithIndexer? Also update the above comment for dictionary interfaces
                 if (collectionTypeKind != CollectionExpressionTypeKind.ImplementsIEnumerable &&
                     elementType.IsRefLikeOrAllowsRefLikeType())
                 {
@@ -1019,8 +1027,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // Specialized handling for ienumerable-based normal collections.  These defer to the behavior we had
                 // since C# 3.0 where we will determine which .Add methods to call on an element by element basis.
-                if (collectionTypeKind == CollectionExpressionTypeKind.ImplementsIEnumerable)
-                    return TryConvertCollectionExpressionImplementsIEnumerableType(constructor);
+                if (collectionTypeKind is CollectionExpressionTypeKind.ImplementsIEnumerable or CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer)
+                    return TryConvertCollectionExpressionImplementsIEnumerableType(constructor, collectionTypeKind, elementType);
 
                 if (collectionTypeKind is CollectionExpressionTypeKind.ArrayInterface ||
                     hasSpreadElements)
@@ -1070,11 +1078,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 _diagnostics.Add(syntax, useSiteInfo);
                 if (!dictionaryConversion.IsImplicit)
                 {
-                    _binder.GenerateImplicitConversionError(_diagnostics, _binder.Compilation, syntax, dictionaryConversion, dictionaryType, _targetType);
+                    Binder.GenerateImplicitConversionError(_diagnostics, _binder.Compilation, syntax, dictionaryConversion, dictionaryType, _targetType);
                 }
 
                 _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor, _diagnostics, syntax: syntax);
-                _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__set_Item, _diagnostics, syntax: syntax);
+                var setMethod = (MethodSymbol?)_binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__set_Item, _diagnostics, syntax: syntax);
+                setMethod = (MethodSymbol?)setMethod?.SymbolAsMember(dictionaryType);
                 _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Key, _diagnostics, syntax: syntax);
                 _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Value, _diagnostics, syntax: syntax);
 
@@ -1095,7 +1104,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     CollectionExpressionTypeKind.DictionaryInterface,
                     elements,
                     placeholder: null,
-                    collectionCreation: collectionCreation);
+                    collectionCreation: collectionCreation,
+                    indexerSetMethod: setMethod);
 
                 static BoundExpression bindDictionaryConstructorConstruction(ref readonly CollectionExpressionConverter @this, SyntaxNode syntax, NamedTypeSymbol dictionaryType)
                 {
@@ -1195,13 +1205,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            private readonly BoundCollectionExpression? TryConvertCollectionExpressionImplementsIEnumerableType(MethodSymbol? constructor)
+            private readonly BoundCollectionExpression? TryConvertCollectionExpressionImplementsIEnumerableType(MethodSymbol? constructor, CollectionExpressionTypeKind collectionTypeKind, TypeSymbol elementType)
             {
+                Debug.Assert(collectionTypeKind is CollectionExpressionTypeKind.ImplementsIEnumerable or CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer);
                 var syntax = _node.Syntax;
                 var elementConversions = _conversion.UnderlyingConversions;
-                var elementKeyValueTypes = _conversion.GetCollectionExpressionTypeKind(out var elementType, out _, out _) != CollectionExpressionTypeKind.None
-                    ? ConversionsBase.TryGetCollectionKeyValuePairTypes(_binder.Compilation, elementType!)
-                    : null;
+                (TypeSymbol Key, TypeSymbol Value)? elementKeyValueTypes = null;
+                MethodSymbol? setMethod = null;
+
+                if (collectionTypeKind == CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer)
+                {
+                    elementKeyValueTypes = ConversionsBase.TryGetCollectionKeyValuePairTypes(_binder.Compilation, elementType);
+                    Debug.Assert(elementKeyValueTypes is not null);
+                    var indexer = _binder.GetCollectionExpressionApplicableIndexer(syntax, _targetType, elementType, _diagnostics);
+                    setMethod = indexer.GetOwnOrInheritedSetMethod();
+                    Debug.Assert(setMethod is not null);
+                }
 
                 // Report an error if this is an ImmutableArray<T> target type and we don't have the collection builder
                 // for it. This is virtually guaranteed to not give the user the right experience as this will be
@@ -1265,7 +1284,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var keyValuePairExpression = createKeyValuePairExpression(_binder, keyValuePairElement, key, value, elementType, _diagnostics);
                         builder.Add(_binder.BindCollectionInitializerElementAddMethod(
                             element.Syntax,
-                            ImmutableArray.Create(keyValuePairExpression),
+                            [keyValuePairExpression],
                             hasEnumerableInitializerType: true,
                             collectionInitializerAddMethodBinder,
                             _diagnostics,
@@ -1275,7 +1294,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         builder.Add(_binder.BindCollectionInitializerElementAddMethod(
                             element.Syntax,
-                            ImmutableArray.Create((BoundExpression)element),
+                            [(BoundExpression)element],
                             hasEnumerableInitializerType: true,
                             collectionInitializerAddMethodBinder,
                             _diagnostics,
@@ -1284,10 +1303,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 return CreateCollectionExpression(
-                    CollectionExpressionTypeKind.ImplementsIEnumerable,
+                    collectionTypeKind,
                     builder.ToImmutableAndFree(),
                     implicitReceiver,
-                    collectionCreation);
+                    collectionCreation,
+                    indexerSetMethod: setMethod);
 
                 static BoundExpression createKeyValuePairExpression(
                     Binder binder,
@@ -2666,6 +2686,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 collectionCreation,
                 collectionBuilderMethod: null,
                 collectionBuilderElementsPlaceholder: null,
+                indexerSetMethod: null,
                 wasTargetTyped: inConversion,
                 // Regardless of whether there was a 'with' element, we are in an error recovery scenario, and we've
                 // converted the args into a BadExpression in collectionCreate.  So treat this as not having a 'with'

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -953,6 +953,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 elementConversion.TryGetKeyValueConversions(out var keyConversion, out var valueConversion))
             {
                 var keyValuePairSyntax = (KeyValuePairElementSyntax)keyValuePairElement.Syntax;
+                Debug.Assert(keyValuePairSyntax.IsFeatureEnabled(MessageID.IDS_FeatureDictionaryExpressions));
                 var keyValuePairConstructor = useIndexer ? null : (MethodSymbol?)binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__ctor, diagnostics, syntax: keyValuePairSyntax);
                 var key = binder.CreateConversion(keyValuePairElement.Key, keyConversion, elementKeyType, diagnostics);
                 var value = binder.CreateConversion(keyValuePairElement.Value, valueConversion, elementValueType, diagnostics);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -946,6 +946,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             CollectionInitializerAddMethodBinder? collectionInitializerAddMethodBinder,
             BindingDiagnosticBag diagnostics)
         {
+            // A KeyValuePair conversion is only ever classified when the dictionary-expressions feature is available
+            // (see ConversionsBase.TryGetCollectionKeyValuePairTypes), so reaching this branch implies the element is
+            // being added to a dictionary-like target via separate key/value conversions.
             if (elementKeyValueTypes is (var elementKeyType, var elementValueType) &&
                 elementConversion.TryGetKeyValueConversions(out var keyConversion, out var valueConversion))
             {
@@ -1004,6 +1007,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             CollectionInitializerAddMethodBinder? collectionInitializerAddMethodBinder,
             BindingDiagnosticBag diagnostics)
         {
+            // Case 1: a KeyValuePair<K1, V1> source element/spread item flowing into a dictionary-like target.
+            // Decompose it and convert the key and value separately into the target's K and V.
             if (elementKeyValueTypes is (var elementKeyType, var elementValueType) &&
                 elementConversion.TryGetKeyValueConversions(out var keyConversion, out var valueConversion))
             {
@@ -1044,6 +1049,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return keyValuePairConversion;
                 }
             }
+            // Case 2: a regular IEnumerable-based collection that adds elements via an Add method.
             else if (collectionInitializerAddMethodBinder is { })
             {
                 Debug.Assert(implicitReceiver is { });
@@ -1055,6 +1061,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     diagnostics,
                     implicitReceiver);
             }
+            // Case 3: a direct element conversion (array/span/interface targets, or indexer assignment for
+            // dictionary targets, in which case we also need the KeyValuePair key/value accessors during lowering).
             else
             {
                 if (useIndexer)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -1240,6 +1240,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     TypeCompareKind.ConsiderEverything);
 
                 _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor, _diagnostics, syntax: syntax);
+                // PROTOTYPE: Confirm that this constructor is desired when targeting IReadOnlyDictionary<K, V>, and that it should reflect Dictionary<K, V>
+                // concretely
                 _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_IEqualityComparer_K, _diagnostics, syntax: syntax);
                 if (isIDictionary)
                 {
@@ -1289,20 +1291,19 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     // Don't need to report diagnostics here. Our caller will have already done this.
                     var compilation = @this._binder.Compilation;
-                    var ctor = (MethodSymbol?)compilation.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor);
-                    var ctorComparer = (MethodSymbol?)compilation.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_IEqualityComparer_K);
-                    var ctorInt32 = isIDictionary
-                        ? (MethodSymbol?)compilation.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_Int32)
-                        : null;
-                    var ctorInt32Comparer = isIDictionary
-                        ? (MethodSymbol?)compilation.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_Int32_IEqualityComparer_K)
-                        : null;
-
                     var candidateConstructorsBuilder = ArrayBuilder<MethodSymbol>.GetInstance();
-                    candidateConstructorsBuilder.AddIfNotNull(ctor?.AsMember(dictionaryType));
-                    candidateConstructorsBuilder.AddIfNotNull(ctorComparer?.AsMember(dictionaryType));
-                    candidateConstructorsBuilder.AddIfNotNull(ctorInt32?.AsMember(dictionaryType));
-                    candidateConstructorsBuilder.AddIfNotNull(ctorInt32Comparer?.AsMember(dictionaryType));
+
+                    candidateConstructorsBuilder.AddIfNotNull(((MethodSymbol?)compilation.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor))?.AsMember(dictionaryType));
+                    // PROTOTYPE: Confirm that this constructor is desired when targeting IReadOnlyDictionary<K, V>, and that it should reflect Dictionary<K, V>
+                    // concretely
+                    candidateConstructorsBuilder.AddIfNotNull(((MethodSymbol?)compilation.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_IEqualityComparer_K))?.AsMember(dictionaryType));
+
+                    if (isIDictionary)
+                    {
+                        candidateConstructorsBuilder.AddIfNotNull(((MethodSymbol?)compilation.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_Int32))?.AsMember(dictionaryType));
+                        candidateConstructorsBuilder.AddIfNotNull(((MethodSymbol?)compilation.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_Int32_IEqualityComparer_K))?.AsMember(dictionaryType));
+                    }
+
                     var candidateConstructors = candidateConstructorsBuilder.ToImmutableAndFree();
 
                     var analyzedArguments = withElement is null
@@ -1362,7 +1363,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 (SpreadElementSyntax)spreadElement.Syntax,
                                 spreadElement,
                                 implicitReceiver: null,
-                                static (binder, syntax, item, implicitReceiver, arg, diagnostics) =>
+                                bindItem: static (binder, syntax, item, implicitReceiver, arg, diagnostics) =>
                                 {
                                     return convertItem(
                                         binder,
@@ -1500,7 +1501,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 (SpreadElementSyntax)spreadElement.Syntax,
                                 spreadElement,
                                 implicitReceiver,
-                                static (binder, syntax, item, implicitReceiver, arg, diagnostics) =>
+                                bindItem: static (binder, syntax, item, implicitReceiver, arg, diagnostics) =>
                                 {
                                     return convertItem(
                                         binder,
@@ -1711,7 +1712,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         (SpreadElementSyntax)element.Syntax,
                         element,
                         implicitReceiver: null,
-                        static (binder, syntax, item, implicitReceiver, arg, diagnostics) =>
+                        bindItem: static (binder, syntax, item, implicitReceiver, arg, diagnostics) =>
                         {
                             return ConvertCollectionExpressionItem(
                                 binder,
@@ -2384,8 +2385,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         IsStatic: false,
                         DeclaredAccessibility: Accessibility.Public,
                         RefKind: RefKind.None,
-                        GetMethod: { DeclaredAccessibility: Accessibility.Public },
-                        SetMethod: { DeclaredAccessibility: Accessibility.Public },
+                        GetMethod.DeclaredAccessibility: Accessibility.Public,
+                        SetMethod.DeclaredAccessibility: Accessibility.Public,
                         Parameters: [{ RefKind: RefKind.None or RefKind.In } parameter]
                     } &&
                     Conversions.ClassifyImplicitConversionFromType(parameter.Type, keyType, ref useSiteInfo).IsIdentity &&

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -2978,28 +2978,51 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         case BoundExpression expressionElement:
                             {
+                                var expressionSyntax = expressionElement.Syntax;
                                 var elementConversion = Conversions.ClassifyImplicitConversionFromExpression(expressionElement, elementType, ref useSiteInfo);
-                                if (!elementConversion.Exists)
+                                if (elementConversion.Exists)
                                 {
-                                    GenerateImplicitConversionError(diagnostics, expressionElement.Syntax, elementConversion, expressionElement, elementType);
+                                    continue;
+                                }
+                                else if (expressionElement.Type is { } &&
+                                    keyValueTypes is (var keyType, var valueType) &&
+                                    ConversionsBase.IsKeyValuePairType(Compilation, expressionElement.Type, out var elementKeyType, out var elementValueType))
+                                {
+                                    generateImplicitConversionFromTypeError(diagnostics, expressionSyntax, elementKeyType, keyType, ref useSiteInfo, ref reportedErrors);
+                                    generateImplicitConversionFromTypeError(diagnostics, expressionSyntax, elementValueType, valueType, ref useSiteInfo, ref reportedErrors);
+                                }
+                                else
+                                {
+                                    GenerateImplicitConversionError(diagnostics, expressionSyntax, elementConversion, expressionElement, elementType);
                                     reportedErrors = true;
                                 }
                             }
                             break;
                         case BoundCollectionExpressionSpreadElement spreadElement:
                             {
+                                var expressionSyntax = spreadElement.Expression.Syntax;
                                 var enumeratorInfo = spreadElement.EnumeratorInfoOpt;
                                 if (enumeratorInfo is null)
                                 {
-                                    Error(diagnostics, ErrorCode.ERR_NoImplicitConv, spreadElement.Expression.Syntax, spreadElement.Expression.Display, elementType);
+                                    Error(diagnostics, ErrorCode.ERR_NoImplicitConv, expressionSyntax, spreadElement.Expression.Display, elementType);
                                     reportedErrors = true;
                                 }
                                 else
                                 {
                                     var elementConversion = Conversions.GetCollectionExpressionSpreadElementConversion(spreadElement.Syntax, elementType, enumeratorInfo, ref useSiteInfo);
-                                    if (!elementConversion.Exists)
+                                    if (elementConversion.Exists)
                                     {
-                                        GenerateImplicitConversionError(diagnostics, Compilation, spreadElement.Expression.Syntax, elementConversion, enumeratorInfo.ElementType, elementType);
+                                        continue;
+                                    }
+                                    else if (keyValueTypes is (var keyType, var valueType) &&
+                                        ConversionsBase.IsKeyValuePairType(Compilation, enumeratorInfo.ElementType, out var itemKeyType, out var itemValueType))
+                                    {
+                                        generateImplicitConversionFromTypeError(diagnostics, expressionSyntax, itemKeyType, keyType, ref useSiteInfo, ref reportedErrors);
+                                        generateImplicitConversionFromTypeError(diagnostics, expressionSyntax, itemValueType, valueType, ref useSiteInfo, ref reportedErrors);
+                                    }
+                                    else
+                                    {
+                                        GenerateImplicitConversionError(diagnostics, Compilation, expressionSyntax, elementConversion, enumeratorInfo.ElementType, elementType);
                                         reportedErrors = true;
                                     }
                                 }
@@ -3045,6 +3068,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (!elementConversion.Exists)
                 {
                     GenerateImplicitConversionError(diagnostics, expression.Syntax, elementConversion, expression, targetType);
+                    reportedErrors = true;
+                }
+            }
+
+            void generateImplicitConversionFromTypeError(
+                BindingDiagnosticBag diagnostics,
+                SyntaxNode syntax,
+                TypeSymbol sourceType,
+                TypeSymbol targetType,
+                ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo,
+                ref bool reportedErrors)
+            {
+                Conversion elementConversion = Conversions.ClassifyImplicitConversionFromType(sourceType, targetType, ref useSiteInfo);
+                if (!elementConversion.Exists)
+                {
+                    GenerateImplicitConversionError(diagnostics, Compilation, syntax, elementConversion, sourceType, targetType);
                     reportedErrors = true;
                 }
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -1219,7 +1219,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Binder.GenerateImplicitConversionError(_diagnostics, _binder.Compilation, syntax, dictionaryConversion, dictionaryType, _targetType);
                 }
 
+                // Verify the existence of the Dictionary<K, V> ctors that may be used by with(...) overload resolution
+                // and lowering, even though not all will be used for any particular collection expression. Checking all
+                // gives a consistent behavior, regardless of collection expression elements / arguments. Per the
+                // dictionary-expressions proposal, only the mutable IDictionary<K, V> target offers the capacity-based
+                // ctors; the read-only and base-interface targets only offer the () and (IEqualityComparer<K>) ctors.
+                bool isIDictionary = targetNamedType.OriginalDefinition.Equals(
+                    _binder.Compilation.GetWellKnownType(WellKnownType.System_Collections_Generic_IDictionary_KV),
+                    TypeCompareKind.ConsiderEverything);
+
                 _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor, _diagnostics, syntax: syntax);
+                _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_IEqualityComparer_K, _diagnostics, syntax: syntax);
+                if (isIDictionary)
+                {
+                    _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_Int32, _diagnostics, syntax: syntax);
+                    _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_Int32_IEqualityComparer_K, _diagnostics, syntax: syntax);
+                }
                 var setMethod = (MethodSymbol?)_binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__set_Item, _diagnostics, syntax: syntax);
                 setMethod = (MethodSymbol?)setMethod?.SymbolAsMember(dictionaryType);
 
@@ -1228,7 +1243,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_ObjectModel_ReadOnlyDictionary_KV__ctor, _diagnostics, syntax: syntax);
                 }
 
-                var collectionCreation = bindDictionaryConstructorConstruction(in this, syntax, dictionaryType);
+                var collectionCreation = bindDictionaryConstructorConstruction(in this, syntax, dictionaryType, isIDictionary);
                 if (collectionCreation.HasErrors)
                 {
                     return null;
@@ -1245,28 +1260,68 @@ namespace Microsoft.CodeAnalysis.CSharp
                     collectionCreation: collectionCreation,
                     indexerSetMethod: setMethod);
 
-                static BoundExpression bindDictionaryConstructorConstruction(ref readonly CollectionExpressionConverter @this, SyntaxNode syntax, NamedTypeSymbol dictionaryType)
+                static BoundExpression bindDictionaryConstructorConstruction(ref readonly CollectionExpressionConverter @this, SyntaxNode syntax, NamedTypeSymbol dictionaryType, bool isIDictionary)
                 {
-                    // The dictionary-expressions proposal (see ConvertCollectionExpression in the
-                    // features/dictionary-expressions-old branch) routes this through
-                    // BindInterfaceTargetCollectionMethodGroup / BindInterfaceTargetCollectionArguments,
-                    // which synthesizes a method group for the Dictionary<K, V> constructor overloads and
-                    // produces missing-member diagnostics for each. That machinery (the
-                    // CollectionArgumentsSignatureOnlyMethodSymbol "addSignature" mechanism) has not been
-                    // ported yet, so for now we bind the parameterless constructor directly via the normal
-                    // class-creation path.
+                    // Mirrors bindCollectionArrayInterfaceConstruction in TryConvertCollectionExpressionArrayInterfaceType:
+                    // we form a subset of the Dictionary<K, V> instance constructors that with(...) is allowed to bind to,
+                    // and run overload resolution against just that subset. Any user-authored with(...) arguments are
+                    // applied to the underlying mutable Dictionary<K, V>; for IReadOnlyDictionary targets the LocalRewriter
+                    // additionally wraps the result in a ReadOnlyDictionary<K, V>.
+                    //
+                    // Per the dictionary-expressions proposal (mirrored from
+                    // https://github.com/dotnet/csharplang/blob/main/proposals/dictionary-expressions.md and
+                    // collection-expression-arguments.md), the allowed overloads are:
+                    //   - IDictionary<K, V>:        (), (IEqualityComparer<K>), (int capacity), (int capacity, IEqualityComparer<K>)
+                    //   - IReadOnlyDictionary<K, V> and base interfaces: (), (IEqualityComparer<K>)
                     var withElement = @this._node.WithElement;
+                    var withSyntax = withElement?.Syntax ?? syntax;
+
+                    // Don't need to report diagnostics here. Our caller will have already done this.
+                    var compilation = @this._binder.Compilation;
+                    var ctor = (MethodSymbol?)compilation.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor);
+                    var ctorComparer = (MethodSymbol?)compilation.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_IEqualityComparer_K);
+                    var ctorInt32 = isIDictionary
+                        ? (MethodSymbol?)compilation.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_Int32)
+                        : null;
+                    var ctorInt32Comparer = isIDictionary
+                        ? (MethodSymbol?)compilation.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_Int32_IEqualityComparer_K)
+                        : null;
+
+                    var candidateConstructorsBuilder = ArrayBuilder<MethodSymbol>.GetInstance();
+                    candidateConstructorsBuilder.AddIfNotNull(ctor?.AsMember(dictionaryType));
+                    candidateConstructorsBuilder.AddIfNotNull(ctorComparer?.AsMember(dictionaryType));
+                    candidateConstructorsBuilder.AddIfNotNull(ctorInt32?.AsMember(dictionaryType));
+                    candidateConstructorsBuilder.AddIfNotNull(ctorInt32Comparer?.AsMember(dictionaryType));
+                    var candidateConstructors = candidateConstructorsBuilder.ToImmutableAndFree();
+
                     var analyzedArguments = withElement is null
                         ? AnalyzedArguments.GetInstance()
                         : AnalyzedArguments.GetInstance(withElement.Arguments, withElement.ArgumentRefKindsOpt, withElement.ArgumentNamesOpt);
 
-                    var collectionCreation = @this._binder.BindClassCreationExpression(
-                        syntax,
-                        dictionaryType.Name,
-                        syntax,
-                        dictionaryType,
-                        analyzedArguments,
-                        @this._diagnostics);
+                    var useSiteInfo = @this._binder.GetNewCompoundUseSiteInfo(@this._diagnostics);
+
+                    BoundExpression collectionCreation;
+                    if (@this._binder.TryPerformOverloadResolutionWithConstructorSubset(
+                            dictionaryType,
+                            ref candidateConstructors,
+                            candidateConstructors,
+                            analyzedArguments,
+                            dictionaryType.Name,
+                            withSyntax.GetFirstToken().GetLocation(),
+                            suppressResultDiagnostics: false,
+                            @this._diagnostics,
+                            out var memberResolutionResult,
+                            ref useSiteInfo,
+                            isParamsModifierValidation: false))
+                    {
+                        collectionCreation = @this._binder.BindClassCreationExpressionContinued(
+                            withSyntax, withSyntax, dictionaryType, analyzedArguments, initializerSyntaxOpt: null, initializerTypeOpt: null, wasTargetTyped: false, memberResolutionResult, candidateConstructors, useSiteInfo, @this._diagnostics);
+                    }
+                    else
+                    {
+                        collectionCreation = @this._binder.CreateBadClassCreationExpression(
+                            withSyntax, withSyntax, dictionaryType, analyzedArguments, initializerSyntaxOpt: null, initializerTypeOpt: null, memberResolutionResult, candidateConstructors, useSiteInfo, @this._diagnostics);
+                    }
 
                     collectionCreation.WasCompilerGenerated = withElement is null;
                     analyzedArguments.Free();

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -2350,7 +2350,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return false;
         }
 
-        internal bool HasParamsCollectionTypeApplicableIndexerInProgress(SyntaxNode syntax, TypeSymbol targetType)
+        internal bool HasParamsCollectionTypeApplicableIndexerInProgress(SyntaxNode syntax, TypeSymbol targetType, out TypeWithAnnotations iterationType)
         {
             Binder? current = this;
             do
@@ -2359,11 +2359,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                     binder.Syntax == syntax &&
                     object.ReferenceEquals(binder.CollectionType.OriginalDefinition, targetType.OriginalDefinition))
                 {
+                    iterationType = binder.IterationType;
                     return true;
                 }
                 current = current.Next;
             } while (current is { });
 
+            iterationType = default;
             return false;
         }
 
@@ -2943,13 +2945,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol targetType,
             BindingDiagnosticBag diagnostics)
         {
-            var collectionTypeKind = ConversionsBase.GetCollectionExpressionTypeKind(Compilation, targetType, out TypeWithAnnotations elementTypeWithAnnotations);
+            var collectionTypeKind = ConversionsBase.GetCollectionExpressionTypeKind(this, node.Syntax, targetType, out TypeWithAnnotations elementTypeWithAnnotations);
             switch (collectionTypeKind)
             {
                 case CollectionExpressionTypeKind.ImplementsIEnumerable:
+                case CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer:
                 case CollectionExpressionTypeKind.CollectionBuilder:
-                    Debug.Assert(elementTypeWithAnnotations.Type is null); // GetCollectionExpressionTypeKind() does not set elementType for these cases.
-                    if (!TryGetCollectionIterationType(node.Syntax, targetType, out elementTypeWithAnnotations))
+                    if (!elementTypeWithAnnotations.HasType)
                     {
                         Error(
                             diagnostics,
@@ -2972,7 +2974,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var elementType = elementTypeWithAnnotations.Type;
                 Debug.Assert(elementType is { });
 
-                if (collectionTypeKind == CollectionExpressionTypeKind.ImplementsIEnumerable)
+                if (collectionTypeKind is CollectionExpressionTypeKind.ImplementsIEnumerable or CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer)
                 {
                     if (!HasCollectionExpressionApplicableConstructor(
                             node.WithElement, node.WithElement?.Syntax ?? node.Syntax, targetType, constructor: out _, isExpanded: out _, diagnostics))
@@ -2980,7 +2982,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         reportedErrors = true;
                     }
 
-                    if (GetCollectionExpressionApplicableIndexer(node.Syntax, targetType, elementType, BindingDiagnosticBag.Discarded) is null &&
+                    if (collectionTypeKind == CollectionExpressionTypeKind.ImplementsIEnumerable &&
                         elements.Length > 0 &&
                         !HasCollectionExpressionApplicableAddMethod(node.Syntax, targetType, addMethods: out _, diagnostics))
                     {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -1898,9 +1898,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // gives a consistent behavior, regardless of collection expression elements / arguments. Per the
                 // dictionary-expressions proposal, only the mutable IDictionary<K, V> target offers the capacity-based
                 // ctors; the read-only and base-interface targets only offer the () and (IEqualityComparer<K>) ctors.
-                bool isIDictionary = targetNamedType.OriginalDefinition.Equals(
-                    _binder.Compilation.GetWellKnownType(WellKnownType.System_Collections_Generic_IDictionary_KV),
-                    TypeCompareKind.ConsiderEverything);
+                bool isIDictionary = ReferenceEquals(
+                    targetNamedType.OriginalDefinition,
+                    _binder.Compilation.GetWellKnownType(WellKnownType.System_Collections_Generic_IDictionary_KV));
 
                 _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor, _diagnostics, syntax: syntax);
                 // PROTOTYPE: Confirm that this constructor is desired when targeting IReadOnlyDictionary<K, V>, and that it should reflect Dictionary<K, V>
@@ -1914,7 +1914,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var setMethod = (MethodSymbol?)_binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__set_Item, _diagnostics, syntax: syntax);
                 setMethod = (MethodSymbol?)setMethod?.SymbolAsMember(dictionaryType);
 
-                if (targetNamedType.OriginalDefinition.Equals(_binder.Compilation.GetWellKnownType(WellKnownType.System_Collections_Generic_IReadOnlyDictionary_KV), TypeCompareKind.ConsiderEverything))
+                if (ReferenceEquals(targetNamedType.OriginalDefinition, _binder.Compilation.GetWellKnownType(WellKnownType.System_Collections_Generic_IReadOnlyDictionary_KV)))
                 {
                     _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_ObjectModel_ReadOnlyDictionary_KV__ctor, _diagnostics, syntax: syntax);
                 }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -1726,8 +1726,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 diagnostics);
                         },
                         (elementType, elementConversion, elementKeyValueTypes),
-                        @this._diagnostics,
-                        itemSyntax: element.Expression.Syntax);
+                        @this._diagnostics);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -995,7 +995,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        // Convert an expression element or the expression representing each item of a spread element.
+        /// <summary>
+        /// Converts an expression element, or the expression representing each item of a spread element.
+        /// </summary>
         private static BoundExpression ConvertCollectionExpressionItem(
             Binder binder,
             SyntaxNode expressionSyntax,
@@ -1024,8 +1026,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     throw ExceptionUtilities.UnexpectedValue(expressionElement.Type);
                 }
                 BoundExpression convertedExpression = binder.BindToNaturalType(expressionElement, diagnostics);
-                var keyPlaceholder = new BoundValuePlaceholder(expressionSyntax, keyType);
-                var valuePlaceholder = new BoundValuePlaceholder(expressionSyntax, valueType);
+                var keyPlaceholder = new BoundValuePlaceholder(expressionSyntax, keyType) { WasCompilerGenerated = true };
+                var valuePlaceholder = new BoundValuePlaceholder(expressionSyntax, valueType) { WasCompilerGenerated = true };
                 var keyValuePairConversion = new BoundKeyValuePairConversion(
                     expressionSyntax,
                     expression: convertedExpression,
@@ -1942,9 +1944,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // applied to the underlying mutable Dictionary<K, V>; for IReadOnlyDictionary targets the LocalRewriter
                     // additionally wraps the result in a ReadOnlyDictionary<K, V>.
                     //
-                    // Per the dictionary-expressions proposal (mirrored from
-                    // https://github.com/dotnet/csharplang/blob/main/proposals/dictionary-expressions.md and
-                    // collection-expression-arguments.md), the allowed overloads are:
+                    // Per the dictionary expressions and collection expression arguments proposals, the allowed
+                    // overloads are:
                     //   - IDictionary<K, V>:        (), (IEqualityComparer<K>), (int capacity), (int capacity, IEqualityComparer<K>)
                     //   - IReadOnlyDictionary<K, V> and base interfaces: (), (IEqualityComparer<K>)
                     var withElement = @this._node.WithElement;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -196,6 +196,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return CreateTupleLiteralConversion(syntax, (BoundTupleLiteral)source, conversion, isCast: isCast, conversionGroupOpt, inConversionGroupFlags, destination, diagnostics);
                 }
 
+                if (conversion.Kind == ConversionKind.KeyValuePair)
+                {
+                    return CreateKeyValuePairConversion(syntax, source, conversion, wasCompilerGenerated, destination, diagnostics);
+                }
+
                 if (conversion.Kind == ConversionKind.SwitchExpression)
                 {
                     var convertedSwitch = ConvertSwitchExpression((BoundUnconvertedSwitchExpression)source, destination, conversionIfTargetTyped: conversion, diagnostics);
@@ -639,6 +644,40 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        private BoundExpression CreateKeyValuePairConversion(
+            SyntaxNode syntax,
+            BoundExpression source,
+            Conversion conversion,
+            bool wasCompilerGenerated,
+            TypeSymbol destination,
+            BindingDiagnosticBag diagnostics)
+        {
+            Debug.Assert(conversion.Kind == ConversionKind.KeyValuePair);
+            Debug.Assert(source.Type is { });
+
+            if (!conversion.TryGetKeyValueConversions(out var keyConversion, out var valueConversion) ||
+                !ConversionsBase.IsKeyValuePairType(Compilation, source.Type, out var sourceKeyType, out var sourceValueType) ||
+                !ConversionsBase.IsKeyValuePairType(Compilation, destination, out var destinationKeyType, out var destinationValueType))
+            {
+                return new BoundBadExpression(syntax, LookupResultKind.Empty, symbols: [], childBoundNodes: [source], destination, hasErrors: true);
+            }
+
+            var keyPlaceholder = new BoundValuePlaceholder(syntax, sourceKeyType) { WasCompilerGenerated = true };
+            var valuePlaceholder = new BoundValuePlaceholder(syntax, sourceValueType) { WasCompilerGenerated = true };
+            var key = CreateConversion(keyPlaceholder, keyConversion, destinationKeyType, diagnostics);
+            var value = CreateConversion(valuePlaceholder, valueConversion, destinationValueType, diagnostics);
+
+            return new BoundKeyValuePairConversion(
+                syntax,
+                source,
+                keyPlaceholder,
+                valuePlaceholder,
+                key,
+                value,
+                destination)
+            { WasCompilerGenerated = wasCompilerGenerated };
+        }
+
         // {type}.op_Implicit(T[])
         internal static MethodSymbol? TryFindImplicitOperatorFromArray(TypeSymbol type)
         {
@@ -946,6 +985,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     _diagnostics.Add(ErrorCode.ERR_CollectionRefLikeElementType, _node.Syntax);
                 }
 
+                if (collectionTypeKind == CollectionExpressionTypeKind.DictionaryInterface)
+                {
+                    MessageID.IDS_FeatureDictionaryExpressions.CheckFeatureAvailability(_diagnostics, _node.Syntax);
+                }
+
                 var result = TryConvertCollectionExpression(collectionTypeKind, elementType, constructor);
                 if (result is null)
                     return _binder.BindCollectionExpressionForErrorRecovery(_node, _targetType, inConversion: true, _diagnostics);
@@ -1006,13 +1050,158 @@ namespace Microsoft.CodeAnalysis.CSharp
                     CollectionExpressionTypeKind.CollectionBuilder
                         => TryConvertCollectionExpressionBuilderType(elements),
 
+                    CollectionExpressionTypeKind.DictionaryInterface
+                        => TryConvertCollectionExpressionDictionaryInterfaceType(elementType),
+
                     _ => throw ExceptionUtilities.UnexpectedValue(collectionTypeKind),
                 };
+            }
+
+            private readonly BoundCollectionExpression? TryConvertCollectionExpressionDictionaryInterfaceType(TypeSymbol elementType)
+            {
+                var syntax = _node.Syntax;
+
+                var targetNamedType = (NamedTypeSymbol)_targetType;
+                var dictionaryType = _binder.GetWellKnownType(WellKnownType.System_Collections_Generic_Dictionary_KV, _diagnostics, syntax)
+                    .Construct(targetNamedType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics);
+
+                var useSiteInfo = _binder.GetNewCompoundUseSiteInfo(_diagnostics);
+                var dictionaryConversion = _binder.Conversions.ClassifyConversionFromType(dictionaryType, _targetType, isChecked: false, ref useSiteInfo);
+                _diagnostics.Add(syntax, useSiteInfo);
+                if (!dictionaryConversion.IsImplicit)
+                {
+                    _binder.GenerateImplicitConversionError(_diagnostics, _binder.Compilation, syntax, dictionaryConversion, dictionaryType, _targetType);
+                }
+
+                _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor, _diagnostics, syntax: syntax);
+                _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__set_Item, _diagnostics, syntax: syntax);
+                _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Key, _diagnostics, syntax: syntax);
+                _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Value, _diagnostics, syntax: syntax);
+
+                if (targetNamedType.OriginalDefinition.Equals(_binder.Compilation.GetWellKnownType(WellKnownType.System_Collections_Generic_IReadOnlyDictionary_KV), TypeCompareKind.ConsiderEverything))
+                {
+                    _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_ObjectModel_ReadOnlyDictionary_KV__ctor, _diagnostics, syntax: syntax);
+                }
+
+                var collectionCreation = bindDictionaryConstructorConstruction(in this, syntax, dictionaryType);
+                if (collectionCreation.HasErrors)
+                {
+                    return null;
+                }
+
+                var elements = BindDictionaryInterfaceElements(elementType);
+
+                return CreateCollectionExpression(
+                    CollectionExpressionTypeKind.DictionaryInterface,
+                    elements,
+                    placeholder: null,
+                    collectionCreation: collectionCreation);
+
+                static BoundExpression bindDictionaryConstructorConstruction(ref readonly CollectionExpressionConverter @this, SyntaxNode syntax, NamedTypeSymbol dictionaryType)
+                {
+                    var withElement = @this._node.WithElement;
+                    var analyzedArguments = withElement is null
+                        ? AnalyzedArguments.GetInstance()
+                        : AnalyzedArguments.GetInstance(withElement.Arguments, withElement.ArgumentRefKindsOpt, withElement.ArgumentNamesOpt);
+
+                    var collectionCreation = @this._binder.BindClassCreationExpression(
+                        syntax,
+                        dictionaryType.Name,
+                        syntax,
+                        dictionaryType,
+                        analyzedArguments,
+                        @this._diagnostics);
+
+                    collectionCreation.WasCompilerGenerated = withElement is null;
+                    analyzedArguments.Free();
+                    return collectionCreation;
+                }
+            }
+
+            private readonly ImmutableArray<BoundNode> BindDictionaryInterfaceElements(TypeSymbol elementType)
+            {
+                var elements = _node.Elements;
+                var builder = ArrayBuilder<BoundNode>.GetInstance(elements.Length);
+
+                var elementConversions = _conversion.UnderlyingConversions;
+                var elementKeyValueTypes = ConversionsBase.TryGetCollectionKeyValuePairTypes(_binder.Compilation, elementType);
+
+                Debug.Assert(elements.Length == elementConversions.Length);
+                Debug.Assert(elementConversions.All(c => c.Exists));
+
+                for (int i = 0; i < elements.Length; i++)
+                {
+                    var element = elements[i];
+                    var elementConversion = elementConversions[i];
+                    switch (element)
+                    {
+                        case BoundCollectionExpressionSpreadElement spreadElement:
+                            builder.Add(bindSpreadElement(in this, spreadElement, elementType, elementConversion));
+                            break;
+                        case BoundKeyValuePairElement keyValuePairElement when
+                            elementKeyValueTypes is (var keyType, var valueType) &&
+                            elementConversion.TryGetKeyValueConversions(out var keyConversion, out var valueConversion):
+                            {
+                                var key = _binder.CreateConversion(keyValuePairElement.Key, keyConversion, keyType, _diagnostics);
+                                var value = _binder.CreateConversion(keyValuePairElement.Value, valueConversion, valueType, _diagnostics);
+                                builder.Add(new BoundKeyValuePairElement(keyValuePairElement.Syntax, key, value));
+                            }
+                            break;
+                        default:
+                            builder.Add(_binder.CreateConversion(
+                                element.Syntax,
+                                (BoundExpression)element,
+                                elementConversion,
+                                isCast: false,
+                                conversionGroupOpt: null,
+                                InConversionGroupFlags.Unspecified,
+                                destination: elementType,
+                                _diagnostics));
+                            break;
+                    }
+                }
+
+                _conversion.MarkUnderlyingConversionsChecked();
+
+                return builder.ToImmutableAndFree();
+
+                static BoundCollectionExpressionSpreadElement bindSpreadElement(
+                    ref readonly CollectionExpressionConverter @this, BoundCollectionExpressionSpreadElement element, TypeSymbol elementType, Conversion elementConversion)
+                {
+                    var enumeratorInfo = element.EnumeratorInfoOpt;
+                    Debug.Assert(enumeratorInfo is { });
+                    Debug.Assert(enumeratorInfo.ElementType is { }); // ElementType is set always, even for IEnumerable.
+
+                    var expressionSyntax = element.Expression.Syntax;
+                    var elementPlaceholder = new BoundValuePlaceholder(expressionSyntax, enumeratorInfo.ElementType) { WasCompilerGenerated = true };
+                    elementPlaceholder = (BoundValuePlaceholder)elementPlaceholder.WithSuppression(element.Expression.IsSuppressed);
+                    var convertElement = @this._binder.CreateConversion(
+                        expressionSyntax,
+                        elementPlaceholder,
+                        elementConversion,
+                        isCast: false,
+                        conversionGroupOpt: null,
+                        InConversionGroupFlags.Unspecified,
+                        destination: elementType,
+                        @this._diagnostics);
+                    return element.Update(
+                        element.Expression,
+                        expressionPlaceholder: element.ExpressionPlaceholder,
+                        conversion: element.Conversion,
+                        enumeratorInfo,
+                        elementPlaceholder: elementPlaceholder,
+                        iteratorBody: new BoundExpressionStatement(expressionSyntax, convertElement) { WasCompilerGenerated = true },
+                        lengthOrCount: element.LengthOrCount);
+                }
             }
 
             private readonly BoundCollectionExpression? TryConvertCollectionExpressionImplementsIEnumerableType(MethodSymbol? constructor)
             {
                 var syntax = _node.Syntax;
+                var elementConversions = _conversion.UnderlyingConversions;
+                var elementKeyValueTypes = _conversion.GetCollectionExpressionTypeKind(out var elementType, out _, out _) != CollectionExpressionTypeKind.None
+                    ? ConversionsBase.TryGetCollectionKeyValuePairTypes(_binder.Compilation, elementType!)
+                    : null;
 
                 // Report an error if this is an ImmutableArray<T> target type and we don't have the collection builder
                 // for it. This is virtually guaranteed to not give the user the right experience as this will be
@@ -1054,22 +1243,44 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var collectionInitializerAddMethodBinder = new CollectionInitializerAddMethodBinder(syntax, _targetType, _binder);
 
                 var builder = ArrayBuilder<BoundNode>.GetInstance(elements.Length);
+                int conversionIndex = 0;
                 foreach (var element in elements)
                 {
-                    builder.Add(element is BoundCollectionExpressionSpreadElement spreadElement
-                        ? _binder.BindCollectionExpressionSpreadElementAddMethod(
+                    var elementConversion = elementConversions[conversionIndex++];
+                    if (element is BoundCollectionExpressionSpreadElement spreadElement)
+                    {
+                        builder.Add(_binder.BindCollectionExpressionSpreadElementAddMethod(
                             (SpreadElementSyntax)spreadElement.Syntax,
                             spreadElement,
                             collectionInitializerAddMethodBinder,
                             implicitReceiver,
-                            _diagnostics)
-                        : _binder.BindCollectionInitializerElementAddMethod(
+                            _diagnostics));
+                    }
+                    else if (element is BoundKeyValuePairElement keyValuePairElement &&
+                        elementKeyValueTypes is (var keyType, var valueType) &&
+                        elementConversion.TryGetKeyValueConversions(out var keyConversion, out var valueConversion))
+                    {
+                        var key = _binder.CreateConversion(keyValuePairElement.Key, keyConversion, keyType, _diagnostics);
+                        var value = _binder.CreateConversion(keyValuePairElement.Value, valueConversion, valueType, _diagnostics);
+                        var keyValuePairExpression = createKeyValuePairExpression(_binder, keyValuePairElement, key, value, elementType, _diagnostics);
+                        builder.Add(_binder.BindCollectionInitializerElementAddMethod(
+                            element.Syntax,
+                            ImmutableArray.Create(keyValuePairExpression),
+                            hasEnumerableInitializerType: true,
+                            collectionInitializerAddMethodBinder,
+                            _diagnostics,
+                            implicitReceiver));
+                    }
+                    else
+                    {
+                        builder.Add(_binder.BindCollectionInitializerElementAddMethod(
                             element.Syntax,
                             ImmutableArray.Create((BoundExpression)element),
                             hasEnumerableInitializerType: true,
                             collectionInitializerAddMethodBinder,
                             _diagnostics,
                             implicitReceiver));
+                    }
                 }
 
                 return CreateCollectionExpression(
@@ -1077,6 +1288,33 @@ namespace Microsoft.CodeAnalysis.CSharp
                     builder.ToImmutableAndFree(),
                     implicitReceiver,
                     collectionCreation);
+
+                static BoundExpression createKeyValuePairExpression(
+                    Binder binder,
+                    BoundKeyValuePairElement keyValuePairElement,
+                    BoundExpression key,
+                    BoundExpression value,
+                    TypeSymbol? elementType,
+                    BindingDiagnosticBag diagnostics)
+                {
+                    if (elementType is not NamedTypeSymbol namedType)
+                    {
+                        return new BoundBadExpression(keyValuePairElement.Syntax, LookupResultKind.Empty, symbols: [], childBoundNodes: [key, value], binder.CreateErrorType());
+                    }
+
+                    var constructor = (MethodSymbol?)binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__ctor, diagnostics, syntax: keyValuePairElement.Syntax);
+                    if (constructor is null)
+                    {
+                        return new BoundBadExpression(keyValuePairElement.Syntax, LookupResultKind.Empty, symbols: [], childBoundNodes: [key, value], namedType);
+                    }
+
+                    return new BoundObjectCreationExpression(
+                        keyValuePairElement.Syntax,
+                        constructor.AsMember(namedType),
+                        key,
+                        value)
+                    { WasCompilerGenerated = true };
+                }
 
                 static BoundExpression bindCollectionConstructorConstruction(
                     ref readonly CollectionExpressionConverter @this, SyntaxNode syntax, MethodSymbol? constructor)
@@ -1147,6 +1385,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var builder = ArrayBuilder<BoundNode>.GetInstance(elements.Length);
 
                 var elementConversions = _conversion.UnderlyingConversions;
+                var elementKeyValueTypes = ConversionsBase.TryGetCollectionKeyValuePairTypes(_binder.Compilation, elementType);
 
                 Debug.Assert(elements.Length == elementConversions.Length);
                 Debug.Assert(elementConversions.All(c => c.Exists));
@@ -1155,13 +1394,21 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     var element = elements[i];
                     var elementConversion = elementConversions[i];
-                    builder.Add(element is BoundCollectionExpressionSpreadElement spreadElement ?
-                        bindSpreadElement(
-                            in this,
-                            spreadElement,
-                            elementType,
-                            elementConversion) :
-                        _binder.CreateConversion(
+                    if (element is BoundCollectionExpressionSpreadElement spreadElement)
+                    {
+                        builder.Add(bindSpreadElement(in this, spreadElement, elementType, elementConversion));
+                    }
+                    else if (element is BoundKeyValuePairElement keyValuePairElement &&
+                        elementConversion.TryGetKeyValueConversions(out var keyConversion, out var valueConversion) &&
+                        elementKeyValueTypes is (var keyType, var valueType))
+                    {
+                        var key = _binder.CreateConversion(keyValuePairElement.Key, keyConversion, keyType, _diagnostics);
+                        var value = _binder.CreateConversion(keyValuePairElement.Value, valueConversion, valueType, _diagnostics);
+                        builder.Add(createKeyValuePairExpression(_binder, keyValuePairElement, key, value, elementType, _diagnostics));
+                    }
+                    else
+                    {
+                        builder.Add(_binder.CreateConversion(
                             element.Syntax,
                             (BoundExpression)element,
                             elementConversion,
@@ -1170,11 +1417,39 @@ namespace Microsoft.CodeAnalysis.CSharp
                             InConversionGroupFlags.Unspecified,
                             destination: elementType,
                             _diagnostics));
+                    }
                 }
 
                 _conversion.MarkUnderlyingConversionsChecked();
 
                 return builder.ToImmutableAndFree();
+
+                static BoundExpression createKeyValuePairExpression(
+                    Binder binder,
+                    BoundKeyValuePairElement keyValuePairElement,
+                    BoundExpression key,
+                    BoundExpression value,
+                    TypeSymbol elementType,
+                    BindingDiagnosticBag diagnostics)
+                {
+                    if (elementType is not NamedTypeSymbol namedType)
+                    {
+                        return new BoundBadExpression(keyValuePairElement.Syntax, LookupResultKind.Empty, symbols: [], childBoundNodes: [key, value], binder.CreateErrorType());
+                    }
+
+                    var constructor = (MethodSymbol?)binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__ctor, diagnostics, syntax: keyValuePairElement.Syntax);
+                    if (constructor is null)
+                    {
+                        return new BoundBadExpression(keyValuePairElement.Syntax, LookupResultKind.Empty, symbols: [], childBoundNodes: [key, value], namedType);
+                    }
+
+                    return new BoundObjectCreationExpression(
+                        keyValuePairElement.Syntax,
+                        constructor.AsMember(namedType),
+                        key,
+                        value)
+                    { WasCompilerGenerated = true };
+                }
 
                 static BoundCollectionExpressionSpreadElement bindSpreadElement(
                     ref readonly CollectionExpressionConverter @this, BoundCollectionExpressionSpreadElement element, TypeSymbol elementType, Conversion elementConversion)
@@ -1816,6 +2091,65 @@ namespace Microsoft.CodeAnalysis.CSharp
             return false;
         }
 
+        internal bool HasParamsCollectionTypeApplicableIndexerInProgress(SyntaxNode syntax, TypeSymbol targetType)
+        {
+            Binder? current = this;
+            do
+            {
+                if (current is ParamsCollectionTypeApplicableIndexerInProgress binder &&
+                    binder.Syntax == syntax &&
+                    object.ReferenceEquals(binder.CollectionType.OriginalDefinition, targetType.OriginalDefinition))
+                {
+                    return true;
+                }
+                current = current.Next;
+            } while (current is { });
+
+            return false;
+        }
+
+        internal PropertySymbol? GetCollectionExpressionApplicableIndexer(SyntaxNode syntax, TypeSymbol targetType, TypeSymbol elementType, BindingDiagnosticBag diagnostics)
+        {
+            if (!Compilation.IsFeatureEnabled(MessageID.IDS_FeatureDictionaryExpressions))
+            {
+                return null;
+            }
+
+            if (!ConversionsBase.IsKeyValuePairType(Compilation, elementType, out var keyType, out var valueType))
+            {
+                return null;
+            }
+
+            var receiver = new BoundValuePlaceholder(syntax, targetType);
+            var analyzedArguments = AnalyzedArguments.GetInstance();
+            analyzedArguments.Arguments.Add(new BoundValuePlaceholder(syntax, keyType));
+            var indexerAccess = BindIndexerAccess(syntax, receiver, analyzedArguments, diagnostics);
+            analyzedArguments.Free();
+
+            if (indexerAccess is BoundIndexerAccess { Indexer: { } indexer })
+            {
+                var useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
+                indexer = indexer.GetLeastOverriddenProperty(accessingTypeOpt: null);
+                if (indexer is
+                    {
+                        IsStatic: false,
+                        DeclaredAccessibility: Accessibility.Public,
+                        RefKind: RefKind.None,
+                        GetMethod: { DeclaredAccessibility: Accessibility.Public },
+                        SetMethod: { DeclaredAccessibility: Accessibility.Public },
+                        Parameters: [{ RefKind: RefKind.None or RefKind.In } parameter]
+                    } &&
+                    Conversions.ClassifyImplicitConversionFromType(parameter.Type, keyType, ref useSiteInfo).IsIdentity &&
+                    Conversions.ClassifyImplicitConversionFromType(indexer.Type, valueType, ref useSiteInfo).IsIdentity)
+                {
+                    diagnostics.Add(syntax, useSiteInfo);
+                    return indexer;
+                }
+            }
+
+            return null;
+        }
+
         internal bool HasCollectionExpressionApplicableAddMethod(SyntaxNode syntax, TypeSymbol targetType, out ImmutableArray<MethodSymbol> addMethods, BindingDiagnosticBag diagnostics)
         {
             Debug.Assert(!targetType.IsDynamic());
@@ -2313,9 +2647,16 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             foreach (var element in node.Elements)
             {
-                elementsBuilder.Add(element is BoundExpression expression
-                    ? BindToNaturalType(expression, diagnostics, reportNoTargetType)
-                    : element);
+                var result = element switch
+                {
+                    BoundCollectionExpressionSpreadElement spreadElement => (BoundNode)spreadElement,
+                    BoundKeyValuePairElement keyValuePairElement =>
+                        keyValuePairElement.Update(
+                            BindToNaturalType(keyValuePairElement.Key, diagnostics, reportNoTargetType),
+                            BindToNaturalType(keyValuePairElement.Value, diagnostics, reportNoTargetType)),
+                    _ => BindToNaturalType((BoundExpression)element, diagnostics, reportNoTargetType)
+                };
+                elementsBuilder.Add(result);
             }
 
             return new BoundCollectionExpression(
@@ -2379,42 +2720,66 @@ namespace Microsoft.CodeAnalysis.CSharp
                         reportedErrors = true;
                     }
 
-                    if (elements.Length > 0 &&
+                    if (GetCollectionExpressionApplicableIndexer(node.Syntax, targetType, elementType, BindingDiagnosticBag.Discarded) is null &&
+                        elements.Length > 0 &&
                         !HasCollectionExpressionApplicableAddMethod(node.Syntax, targetType, addMethods: out _, diagnostics))
                     {
                         reportedErrors = true;
                     }
                 }
 
+                var keyValueTypes = ConversionsBase.TryGetCollectionKeyValuePairTypes(Compilation, elementType);
                 var useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                 foreach (var element in elements)
                 {
-                    if (element is BoundCollectionExpressionSpreadElement spreadElement)
+                    switch (element)
                     {
-                        var enumeratorInfo = spreadElement.EnumeratorInfoOpt;
-                        if (enumeratorInfo is null)
-                        {
-                            Error(diagnostics, ErrorCode.ERR_NoImplicitConv, spreadElement.Expression.Syntax, spreadElement.Expression.Display, elementType);
-                            reportedErrors = true;
-                        }
-                        else
-                        {
-                            Conversion elementConversion = Conversions.GetCollectionExpressionSpreadElementConversion(spreadElement, elementType, ref useSiteInfo);
-                            if (!elementConversion.Exists)
+                        case BoundExpression expressionElement:
                             {
-                                GenerateImplicitConversionError(diagnostics, this.Compilation, spreadElement.Expression.Syntax, elementConversion, enumeratorInfo.ElementType, elementType);
-                                reportedErrors = true;
+                                var elementConversion = Conversions.ClassifyImplicitConversionFromExpression(expressionElement, elementType, ref useSiteInfo);
+                                if (!elementConversion.Exists)
+                                {
+                                    GenerateImplicitConversionError(diagnostics, expressionElement.Syntax, elementConversion, expressionElement, elementType);
+                                    reportedErrors = true;
+                                }
                             }
-                        }
-                    }
-                    else
-                    {
-                        Conversion elementConversion = Conversions.ClassifyImplicitConversionFromExpression((BoundExpression)element, elementType, ref useSiteInfo);
-                        if (!elementConversion.Exists)
-                        {
-                            GenerateImplicitConversionError(diagnostics, element.Syntax, elementConversion, (BoundExpression)element, elementType);
-                            reportedErrors = true;
-                        }
+                            break;
+                        case BoundCollectionExpressionSpreadElement spreadElement:
+                            {
+                                var enumeratorInfo = spreadElement.EnumeratorInfoOpt;
+                                if (enumeratorInfo is null)
+                                {
+                                    Error(diagnostics, ErrorCode.ERR_NoImplicitConv, spreadElement.Expression.Syntax, spreadElement.Expression.Display, elementType);
+                                    reportedErrors = true;
+                                }
+                                else
+                                {
+                                    var elementConversion = Conversions.GetCollectionExpressionSpreadElementConversion(spreadElement.Syntax, elementType, enumeratorInfo, ref useSiteInfo);
+                                    if (!elementConversion.Exists)
+                                    {
+                                        GenerateImplicitConversionError(diagnostics, Compilation, spreadElement.Expression.Syntax, elementConversion, enumeratorInfo.ElementType, elementType);
+                                        reportedErrors = true;
+                                    }
+                                }
+                            }
+                            break;
+                        case BoundKeyValuePairElement keyValuePairElement:
+                            {
+                                if (keyValueTypes is (var keyType, var valueType))
+                                {
+                                    generateImplicitConversionFromExpressionError(diagnostics, keyValuePairElement.Key, keyType, ref useSiteInfo, ref reportedErrors);
+                                    generateImplicitConversionFromExpressionError(diagnostics, keyValuePairElement.Value, valueType, ref useSiteInfo, ref reportedErrors);
+                                }
+                                else
+                                {
+                                    Error(diagnostics, ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, keyValuePairElement.Syntax, targetType);
+                                    reportedErrors = true;
+                                }
+                            }
+                            break;
+                        default:
+                            Debug.Assert(false);
+                            break;
                     }
                 }
                 Debug.Assert(reportedErrors);
@@ -2426,6 +2791,21 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return;
+
+            void generateImplicitConversionFromExpressionError(
+                BindingDiagnosticBag diagnostics,
+                BoundExpression expression,
+                TypeSymbol targetType,
+                ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo,
+                ref bool reportedErrors)
+            {
+                Conversion elementConversion = Conversions.ClassifyImplicitConversionFromExpression(expression, targetType, ref useSiteInfo);
+                if (!elementConversion.Exists)
+                {
+                    GenerateImplicitConversionError(diagnostics, expression.Syntax, elementConversion, expression, targetType);
+                    reportedErrors = true;
+                }
+            }
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -103,6 +103,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return false;
                 }
 
+                if (conversion.Kind == ConversionKind.KeyValuePair)
+                {
+                    return false;
+                }
+
                 if ((conversion.IsTupleLiteralConversion || (conversion.IsNullable && conversion.UnderlyingConversions[0].IsTupleLiteralConversion)))
                 {
                     return false;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -935,7 +935,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return converter.Convert();
         }
 
-#nullable enable
         private static BoundNode ConvertKeyValuePairElement(
             Binder binder,
             BoundKeyValuePairElement keyValuePairElement,
@@ -1066,7 +1065,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return binder.CreateConversion(expressionElement, elementConversion, elementType, diagnostics);
             }
         }
-#nullable disable
 
         private readonly struct CollectionExpressionConverter(
             Binder binder,
@@ -1183,7 +1181,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // From this point out, all the remaining collection types end up converting all their elements
                 // to their actual element type and passing those along.
 
-                var elements = BindElements(elementType);
+                ImmutableArray<BoundNode> elements = collectionTypeKind == CollectionExpressionTypeKind.DictionaryInterface
+                    ? default
+                    : BindElements(elementType);
 
                 return collectionTypeKind switch
                 {
@@ -1222,8 +1222,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor, _diagnostics, syntax: syntax);
                 var setMethod = (MethodSymbol?)_binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_Dictionary_KV__set_Item, _diagnostics, syntax: syntax);
                 setMethod = (MethodSymbol?)setMethod?.SymbolAsMember(dictionaryType);
-                _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Key, _diagnostics, syntax: syntax);
-                _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Value, _diagnostics, syntax: syntax);
 
                 if (targetNamedType.OriginalDefinition.Equals(_binder.Compilation.GetWellKnownType(WellKnownType.System_Collections_Generic_IReadOnlyDictionary_KV), TypeCompareKind.ConsiderEverything))
                 {
@@ -1249,6 +1247,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 static BoundExpression bindDictionaryConstructorConstruction(ref readonly CollectionExpressionConverter @this, SyntaxNode syntax, NamedTypeSymbol dictionaryType)
                 {
+                    // The dictionary-expressions proposal (see ConvertCollectionExpression in the
+                    // features/dictionary-expressions-old branch) routes this through
+                    // BindInterfaceTargetCollectionMethodGroup / BindInterfaceTargetCollectionArguments,
+                    // which synthesizes a method group for the Dictionary<K, V> constructor overloads and
+                    // produces missing-member diagnostics for each. That machinery (the
+                    // CollectionArgumentsSignatureOnlyMethodSymbol "addSignature" mechanism) has not been
+                    // ported yet, so for now we bind the parameterless constructor directly via the normal
+                    // class-creation path.
                     var withElement = @this._node.WithElement;
                     var analyzedArguments = withElement is null
                         ? AnalyzedArguments.GetInstance()
@@ -1271,47 +1277,56 @@ namespace Microsoft.CodeAnalysis.CSharp
             private readonly ImmutableArray<BoundNode> BindDictionaryInterfaceElements(TypeSymbol elementType)
             {
                 var elements = _node.Elements;
-                var builder = ArrayBuilder<BoundNode>.GetInstance(elements.Length);
-
                 var elementConversions = _conversion.UnderlyingConversions;
                 var elementKeyValueTypes = ConversionsBase.TryGetCollectionKeyValuePairTypes(_binder.Compilation, elementType);
 
                 Debug.Assert(elements.Length == elementConversions.Length);
                 Debug.Assert(elementConversions.All(c => c.Exists));
 
-                for (int i = 0; i < elements.Length; i++)
+                var builder = ArrayBuilder<BoundNode>.GetInstance(elements.Length);
+                int conversionIndex = 0;
+                foreach (var element in elements)
                 {
-                    var element = elements[i];
-                    var elementConversion = elementConversions[i];
+                    var elementConversion = elementConversions[conversionIndex++];
                     BoundNode convertedElement;
                     switch (element)
                     {
                         case BoundCollectionExpressionSpreadElement spreadElement:
-                            convertedElement = bindSpreadElement(in this, spreadElement, elementType, elementConversion, elementKeyValueTypes);
+                            convertedElement = _binder.BindCollectionExpressionSpreadElement(
+                                (SpreadElementSyntax)spreadElement.Syntax,
+                                spreadElement,
+                                implicitReceiver: null,
+                                static (binder, syntax, item, implicitReceiver, arg, diagnostics) =>
+                                {
+                                    return convertItem(
+                                        binder,
+                                        syntax,
+                                        item,
+                                        arg.elementConversion,
+                                        arg.elementType,
+                                        arg.elementKeyValueTypes,
+                                        diagnostics);
+                                },
+                                (elementType, elementConversion, elementKeyValueTypes),
+                                _diagnostics);
                             break;
                         case BoundKeyValuePairElement keyValuePairElement:
-                            convertedElement = ConvertKeyValuePairElement(
+                            convertedElement = convertKeyValuePair(
                                 _binder,
                                 keyValuePairElement,
                                 elementConversion,
                                 elementType,
                                 elementKeyValueTypes,
-                                useIndexer: true,
-                                implicitReceiver: null,
-                                collectionInitializerAddMethodBinder: null,
                                 _diagnostics);
                             break;
                         case BoundExpression expressionElement:
-                            convertedElement = ConvertCollectionExpressionItem(
+                            convertedElement = convertItem(
                                 _binder,
                                 expressionElement.Syntax,
                                 expressionElement,
                                 elementConversion,
                                 elementType,
                                 elementKeyValueTypes,
-                                useIndexer: true,
-                                implicitReceiver: null,
-                                collectionInitializerAddMethodBinder: null,
                                 _diagnostics);
                             break;
                         default:
@@ -1324,34 +1339,26 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 return builder.ToImmutableAndFree();
 
-                static BoundCollectionExpressionSpreadElement bindSpreadElement(
-                    ref readonly CollectionExpressionConverter @this,
-                    BoundCollectionExpressionSpreadElement element,
-                    TypeSymbol elementType,
+                // Dictionary-interface element conversion uses the indexer set method for assignment;
+                // no implicit receiver or add-method binder is needed.
+                static BoundNode convertKeyValuePair(
+                    Binder binder,
+                    BoundKeyValuePairElement keyValuePairElement,
                     Conversion elementConversion,
-                    (TypeSymbol Key, TypeSymbol Value)? elementKeyValueTypes)
-                {
-                    return @this._binder.BindCollectionExpressionSpreadElement(
-                        (SpreadElementSyntax)element.Syntax,
-                        element,
-                        implicitReceiver: null,
-                        static (binder, syntax, item, implicitReceiver, arg, diagnostics) =>
-                        {
-                            return ConvertCollectionExpressionItem(
-                                binder,
-                                syntax,
-                                item,
-                                arg.elementConversion,
-                                arg.elementType,
-                                arg.elementKeyValueTypes,
-                                useIndexer: true,
-                                implicitReceiver,
-                                collectionInitializerAddMethodBinder: null,
-                                diagnostics);
-                        },
-                        (elementType, elementConversion, elementKeyValueTypes),
-                        @this._diagnostics);
-                }
+                    TypeSymbol elementType,
+                    (TypeSymbol Key, TypeSymbol Value)? elementKeyValueTypes,
+                    BindingDiagnosticBag diagnostics)
+                    => ConvertKeyValuePairElement(binder, keyValuePairElement, elementConversion, elementType, elementKeyValueTypes, useIndexer: true, implicitReceiver: null, collectionInitializerAddMethodBinder: null, diagnostics);
+
+                static BoundExpression convertItem(
+                    Binder binder,
+                    SyntaxNode expressionSyntax,
+                    BoundExpression expressionElement,
+                    Conversion elementConversion,
+                    TypeSymbol elementType,
+                    (TypeSymbol Key, TypeSymbol Value)? elementKeyValueTypes,
+                    BindingDiagnosticBag diagnostics)
+                    => ConvertCollectionExpressionItem(binder, expressionSyntax, expressionElement, elementConversion, elementType, elementKeyValueTypes, useIndexer: true, implicitReceiver: null, collectionInitializerAddMethodBinder: null, diagnostics);
             }
 
             private readonly BoundCollectionExpression? TryConvertCollectionExpressionImplementsIEnumerableType(MethodSymbol? constructor, CollectionExpressionTypeKind collectionTypeKind, TypeSymbol elementType)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -1062,7 +1062,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                     _ = binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Key, diagnostics, syntax: expressionSyntax);
                     _ = binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Value, diagnostics, syntax: expressionSyntax);
                 }
-                return binder.CreateConversion(expressionElement, elementConversion, elementType, diagnostics);
+                return binder.CreateConversion(
+                    expressionSyntax,
+                    expressionElement,
+                    elementConversion,
+                    isCast: false,
+                    conversionGroupOpt: null,
+                    InConversionGroupFlags.Unspecified,
+                    destination: elementType,
+                    diagnostics);
             }
         }
 
@@ -1718,7 +1726,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 diagnostics);
                         },
                         (elementType, elementConversion, elementKeyValueTypes),
-                        @this._diagnostics);
+                        @this._diagnostics,
+                        itemSyntax: element.Expression.Syntax);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -1167,11 +1167,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return TryConvertCollectionExpressionImplementsIEnumerableType(constructor, collectionTypeKind, elementType);
 
                 if (collectionTypeKind is CollectionExpressionTypeKind.ArrayInterface ||
-                    hasSpreadElements)
+                    (hasSpreadElements && collectionTypeKind is not CollectionExpressionTypeKind.DictionaryInterface))
                 {
                     // Verify the existence of the List<T> members that may be used in lowering, even
                     // though not all will be used for any particular collection expression. Checking all
                     // gives a consistent behavior, regardless of collection expression elements.
+                    // DictionaryInterface targets are excluded: their spreads lower into a Dictionary<K, V>
+                    // via set_Item (see PopulateDictionary), never through List<T>, so the relevant
+                    // well-known members are checked in TryConvertCollectionExpressionDictionaryInterfaceType.
                     _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_List_T__ctor, _diagnostics, syntax: syntax);
                     _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_List_T__ctorInt32, _diagnostics, syntax: syntax);
                     _ = _binder.GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_List_T__Add, _diagnostics, syntax: syntax);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -5371,6 +5371,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     ExpressionElementSyntax { Expression: CollectionExpressionSyntax nestedCollectionExpression } => @this.BindCollectionExpression(nestedCollectionExpression, diagnostics, nestingLevel + 1),
                     ExpressionElementSyntax expressionElementSyntax => @this.BindValue(expressionElementSyntax.Expression, diagnostics, BindValueKind.RValue),
+                    KeyValuePairElementSyntax keyValuePairElementSyntax => @this.BindKeyValuePairElement(keyValuePairElementSyntax, diagnostics),
                     SpreadElementSyntax spreadElementSyntax => bindSpreadElement(spreadElementSyntax, diagnostics, @this),
                     _ => throw ExceptionUtilities.UnexpectedValue(syntax.Kind())
                 };
@@ -5498,6 +5499,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 analyzedArguments.Free();
                 return (withElement, badExpression);
             }
+        }
+
+        private BoundNode BindKeyValuePairElement(KeyValuePairElementSyntax syntax, BindingDiagnosticBag diagnostics)
+        {
+            MessageID.IDS_FeatureDictionaryExpressions.CheckFeatureAvailability(diagnostics, syntax, syntax.ColonToken.GetLocation());
+            var key = BindValue(syntax.KeyExpression, diagnostics, BindValueKind.RValue);
+            var value = BindValue(syntax.ValueExpression, diagnostics, BindValueKind.RValue);
+            return new BoundKeyValuePairElement(syntax, key, value);
         }
 #nullable disable
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -6721,7 +6721,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             SpreadElementSyntax syntax,
             BoundCollectionExpressionSpreadElement element,
             BoundObjectOrCollectionValuePlaceholder? implicitReceiver,
-            Func<Binder, SyntaxNode, BoundValuePlaceholder, BoundObjectOrCollectionValuePlaceholder?, TArg, BindingDiagnosticBag, BoundExpression> bindItem,
+            Func<Binder, ExpressionSyntax, BoundValuePlaceholder, BoundObjectOrCollectionValuePlaceholder?, TArg, BindingDiagnosticBag, BoundExpression> bindItem,
             TArg arg,
             BindingDiagnosticBag diagnostics)
         {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -6722,9 +6722,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             SpreadElementSyntax syntax,
             BoundCollectionExpressionSpreadElement element,
             BoundObjectOrCollectionValuePlaceholder? implicitReceiver,
-            Func<Binder, ExpressionSyntax, BoundValuePlaceholder, BoundObjectOrCollectionValuePlaceholder?, TArg, BindingDiagnosticBag, BoundExpression> bindItem,
+            Func<Binder, SyntaxNode, BoundValuePlaceholder, BoundObjectOrCollectionValuePlaceholder?, TArg, BindingDiagnosticBag, BoundExpression> bindItem,
             TArg arg,
-            BindingDiagnosticBag diagnostics)
+            BindingDiagnosticBag diagnostics,
+            SyntaxNode? itemSyntax = null)
         {
             var enumeratorInfo = element.EnumeratorInfoOpt;
             if (enumeratorInfo is null)
@@ -6740,11 +6741,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             Debug.Assert(enumeratorInfo.ElementType is { }); // ElementType is set always, even for IEnumerable.
-            var itemPlaceholder = new BoundValuePlaceholder(syntax, enumeratorInfo.ElementType) { WasCompilerGenerated = true };
+            // When binding to an array/span element, the caller passes the spread operand's expression syntax so
+            // that element conversion diagnostics (e.g. nullable warnings) are reported on the operand rather than
+            // on the whole spread element. Other callers (e.g. Add-method based collections) keep the spread element
+            // syntax for the placeholder so argument diagnostics continue to point at the spread element.
+            var placeholderSyntax = itemSyntax ?? syntax;
+            var bindItemSyntax = itemSyntax ?? syntax.Expression;
+            var itemPlaceholder = new BoundValuePlaceholder(placeholderSyntax, enumeratorInfo.ElementType) { WasCompilerGenerated = true };
             itemPlaceholder = (BoundValuePlaceholder)itemPlaceholder.WithSuppression(element.Expression.IsSuppressed);
             var item = bindItem(
                 this,
-                syntax.Expression,
+                bindItemSyntax,
                 itemPlaceholder,
                 implicitReceiver,
                 arg,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -5503,7 +5503,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundNode BindKeyValuePairElement(KeyValuePairElementSyntax syntax, BindingDiagnosticBag diagnostics)
         {
-            MessageID.IDS_FeatureDictionaryExpressions.CheckFeatureAvailability(diagnostics, syntax, syntax.ColonToken.GetLocation());
+            MessageID.IDS_FeatureDictionaryExpressions.CheckFeatureAvailability(diagnostics, syntax.ColonToken);
             var key = BindValue(syntax.KeyExpression, diagnostics, BindValueKind.RValue);
             var value = BindValue(syntax.ValueExpression, diagnostics, BindValueKind.RValue);
             return new BoundKeyValuePairElement(syntax, key, value);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -6717,15 +6717,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
 #nullable enable
-#nullable enable
         private BoundCollectionExpressionSpreadElement BindCollectionExpressionSpreadElement<TArg>(
             SpreadElementSyntax syntax,
             BoundCollectionExpressionSpreadElement element,
             BoundObjectOrCollectionValuePlaceholder? implicitReceiver,
             Func<Binder, SyntaxNode, BoundValuePlaceholder, BoundObjectOrCollectionValuePlaceholder?, TArg, BindingDiagnosticBag, BoundExpression> bindItem,
             TArg arg,
-            BindingDiagnosticBag diagnostics,
-            SyntaxNode? itemSyntax = null)
+            BindingDiagnosticBag diagnostics)
         {
             var enumeratorInfo = element.EnumeratorInfoOpt;
             if (enumeratorInfo is null)
@@ -6741,17 +6739,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             Debug.Assert(enumeratorInfo.ElementType is { }); // ElementType is set always, even for IEnumerable.
-            // When binding to an array/span element, the caller passes the spread operand's expression syntax so
-            // that element conversion diagnostics (e.g. nullable warnings) are reported on the operand rather than
-            // on the whole spread element. Other callers (e.g. Add-method based collections) keep the spread element
-            // syntax for the placeholder so argument diagnostics continue to point at the spread element.
-            var placeholderSyntax = itemSyntax ?? syntax;
-            var bindItemSyntax = itemSyntax ?? syntax.Expression;
-            var itemPlaceholder = new BoundValuePlaceholder(placeholderSyntax, enumeratorInfo.ElementType) { WasCompilerGenerated = true };
+            var spreadExpressionSyntax = syntax.Expression;
+            var itemPlaceholder = new BoundValuePlaceholder(spreadExpressionSyntax, enumeratorInfo.ElementType) { WasCompilerGenerated = true };
             itemPlaceholder = (BoundValuePlaceholder)itemPlaceholder.WithSuppression(element.Expression.IsSuppressed);
             var item = bindItem(
                 this,
-                bindItemSyntax,
+                spreadExpressionSyntax,
                 itemPlaceholder,
                 implicitReceiver,
                 arg,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -6717,11 +6717,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
 #nullable enable
-        private BoundCollectionExpressionSpreadElement BindCollectionExpressionSpreadElementAddMethod(
+#nullable enable
+        private BoundCollectionExpressionSpreadElement BindCollectionExpressionSpreadElement<TArg>(
             SpreadElementSyntax syntax,
             BoundCollectionExpressionSpreadElement element,
-            Binder collectionInitializerAddMethodBinder,
-            BoundObjectOrCollectionValuePlaceholder implicitReceiver,
+            BoundObjectOrCollectionValuePlaceholder? implicitReceiver,
+            Func<Binder, ExpressionSyntax, BoundValuePlaceholder, BoundObjectOrCollectionValuePlaceholder?, TArg, BindingDiagnosticBag, BoundExpression> bindItem,
+            TArg arg,
             BindingDiagnosticBag diagnostics)
         {
             var enumeratorInfo = element.EnumeratorInfoOpt;
@@ -6738,22 +6740,23 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             Debug.Assert(enumeratorInfo.ElementType is { }); // ElementType is set always, even for IEnumerable.
-            var addElementPlaceholder = new BoundValuePlaceholder(syntax, enumeratorInfo.ElementType);
-            var addMethodInvocation = BindCollectionInitializerElementAddMethod(
+            var itemPlaceholder = new BoundValuePlaceholder(syntax, enumeratorInfo.ElementType) { WasCompilerGenerated = true };
+            itemPlaceholder = (BoundValuePlaceholder)itemPlaceholder.WithSuppression(element.Expression.IsSuppressed);
+            var item = bindItem(
+                this,
                 syntax.Expression,
-                ImmutableArray.Create((BoundExpression)addElementPlaceholder),
-                hasEnumerableInitializerType: true,
-                collectionInitializerAddMethodBinder,
-                diagnostics,
-                implicitReceiver);
+                itemPlaceholder,
+                implicitReceiver,
+                arg,
+                diagnostics);
             return element.Update(
                 element.Expression,
                 expressionPlaceholder: element.ExpressionPlaceholder,
                 conversion: element.Conversion,
                 enumeratorInfo,
                 lengthOrCount: element.LengthOrCount,
-                elementPlaceholder: addElementPlaceholder,
-                iteratorBody: new BoundExpressionStatement(syntax, addMethodInvocation) { WasCompilerGenerated = true });
+                elementPlaceholder: itemPlaceholder,
+                iteratorBody: new BoundExpressionStatement(syntax, item) { WasCompilerGenerated = true });
         }
 #nullable disable
 

--- a/src/Compilers/CSharp/Portable/Binder/ParamsCollectionTypeApplicableIndexerInProgress.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ParamsCollectionTypeApplicableIndexerInProgress.cs
@@ -14,12 +14,14 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         internal readonly SyntaxNode Syntax;
         internal readonly TypeSymbol CollectionType;
+        internal readonly TypeWithAnnotations IterationType;
 
-        internal ParamsCollectionTypeApplicableIndexerInProgress(SyntaxNode syntax, TypeSymbol collectionType, Binder next) :
+        internal ParamsCollectionTypeApplicableIndexerInProgress(SyntaxNode syntax, TypeSymbol collectionType, TypeWithAnnotations iterationType, Binder next) :
             base(next)
         {
             Syntax = syntax;
             CollectionType = collectionType;
+            IterationType = iterationType;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/ParamsCollectionTypeApplicableIndexerInProgress.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ParamsCollectionTypeApplicableIndexerInProgress.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    /// <summary>
+    /// This binder keeps track of the type for which we are trying to determine
+    /// whether the params collection type has an applicable indexer.
+    /// </summary>
+    internal sealed class ParamsCollectionTypeApplicableIndexerInProgress : Binder
+    {
+        internal readonly SyntaxNode Syntax;
+        internal readonly TypeSymbol CollectionType;
+
+        internal ParamsCollectionTypeApplicableIndexerInProgress(SyntaxNode syntax, TypeSymbol collectionType, Binder next) :
+            base(next)
+        {
+            Syntax = syntax;
+            CollectionType = collectionType;
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
@@ -1400,7 +1400,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             Debug.Assert(spreadElement.HasErrors
                                 || spreadElement.IteratorBody is null
-                                or BoundExpressionStatement { Expression: BoundConversion or BoundValuePlaceholder or BoundDynamicCollectionElementInitializer });
+                                or BoundExpressionStatement { Expression: BoundConversion or BoundValuePlaceholder or BoundDynamicCollectionElementInitializer or BoundKeyValuePairConversion });
                         }
                     }
                 }

--- a/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
@@ -1406,7 +1406,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
-                    Debug.Assert(element is BoundCollectionElementInitializer or BoundExpression, $"Unexpected collection expression element {element}");
+                    Debug.Assert(element is BoundCollectionElementInitializer or BoundExpression or BoundKeyValuePairElement, $"Unexpected collection expression element {element}");
 
                     if (TryGetCollectionExpressionElementValEscape(element, out var elementSafeContext))
                     {

--- a/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
@@ -1378,7 +1378,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     using var _3 = new PlaceholderRegion(this, spreadPlaceholders);
 
-                    if (TryGetCollectionExpressionElementValEscape(element, out var spreadEscape))
+                    if (TryGetCollectionExpressionElementValEscape(node, element, out var spreadEscape))
                     {
                         elementsScope = elementsScope.Intersect(spreadEscape);
                     }
@@ -1408,7 +1408,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     Debug.Assert(element is BoundCollectionElementInitializer or BoundExpression or BoundKeyValuePairElement, $"Unexpected collection expression element {element}");
 
-                    if (TryGetCollectionExpressionElementValEscape(element, out var elementSafeContext))
+                    if (TryGetCollectionExpressionElementValEscape(node, element, out var elementSafeContext))
                     {
                         elementsScope = elementsScope.Intersect(elementSafeContext);
                     }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/CollectionExpressionTypeKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/CollectionExpressionTypeKind.cs
@@ -25,5 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </list>
         /// </summary>
         ArrayInterface,
+        ImplementsIEnumerableWithIndexer,
+        DictionaryInterface,
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -148,6 +148,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                     conversionMethod: null));
         }
 
+        internal static Conversion CreateKeyValuePairConversion(Conversion keyConversion, Conversion valueConversion)
+        {
+            return new Conversion(
+                ConversionKind.KeyValuePair,
+                new NestedUncommonData([keyConversion, valueConversion]));
+        }
+
         private Conversion(
             ConversionKind kind,
             UncommonData? uncommonData = null)
@@ -584,6 +591,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             constructor = null;
             isExpanded = false;
             return CollectionExpressionTypeKind.None;
+        }
+
+        internal bool TryGetKeyValueConversions(out Conversion keyConversion, out Conversion valueConversion)
+        {
+            if (Kind == ConversionKind.KeyValuePair)
+            {
+                Debug.Assert(_uncommonData is NestedUncommonData { _nestedConversionsOpt: [_, _] });
+                var nestedConversions = ((NestedUncommonData)_uncommonData)._nestedConversionsOpt;
+                keyConversion = nestedConversions[0];
+                valueConversion = nestedConversions[1];
+                return true;
+            }
+
+            keyConversion = NoConversion;
+            valueConversion = NoConversion;
+            return false;
         }
 
         // CONSIDER: public?

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
@@ -64,6 +64,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         DefaultLiteral, // a conversion from a `default` literal to any type
         ObjectCreation, // a conversion from a `new()` expression to any type
         CollectionExpression, // a conversion from a collection expression to any type
+        KeyValuePair, // A pair of Key and Value conversions for converting from one KeyValuePair<,> type to another. The conversion is not part of the language, it is an implementation detail.
 
         InterpolatedStringHandler, // A conversion from an interpolated string literal to a type attributed with InterpolatedStringBuilderAttribute
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
@@ -242,15 +242,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                             {
                                 return elementConversion;
                             }
-                            else if (elementKeyValueTypes is (var keyType, var valueType) &&
-                                IsKeyValuePairType(Compilation, enumeratorInfo.ElementType, out var itemKeyType, out var itemValueType))
+                            else if (elementKeyValueTypes is { } keyValueTypes)
                             {
-                                var keyConversion = ClassifyImplicitConversionFromType(itemKeyType, keyType, ref useSiteInfo);
-                                var valueConversion = ClassifyImplicitConversionFromType(itemValueType, valueType, ref useSiteInfo);
-                                if (keyConversion.Exists && valueConversion.Exists)
+                                var keyValuePairConversion = classifyKeyValuePairElementConversionFromType(enumeratorInfo.ElementType, keyValueTypes, ref useSiteInfo);
+                                if (keyValuePairConversion.Exists)
                                 {
-                                    Debug.Assert(!keyConversion.IsIdentity || !valueConversion.IsIdentity);
-                                    return Conversion.CreateKeyValuePairConversion(keyConversion, valueConversion);
+                                    Debug.Assert(!keyValuePairConversion.IsIdentity);
+                                    return keyValuePairConversion;
                                 }
                             }
                         }
@@ -276,16 +274,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             return elementConversion;
                         }
-                        else if (expressionElement.Type is { } &&
-                                 elementKeyValueTypes is (var keyType, var valueType) &&
-                                 IsKeyValuePairType(Compilation, expressionElement.Type, out var elementKeyType, out var elementValueType))
+                        else if (expressionElement.Type is { } expressionType &&
+                                 elementKeyValueTypes is { } keyValueTypes)
                         {
-                            var keyConversion = ClassifyImplicitConversionFromType(elementKeyType, keyType, ref useSiteInfo);
-                            var valueConversion = ClassifyImplicitConversionFromType(elementValueType, valueType, ref useSiteInfo);
-                            if (keyConversion.Exists && valueConversion.Exists)
+                            var keyValuePairConversion = classifyKeyValuePairElementConversionFromType(expressionType, keyValueTypes, ref useSiteInfo);
+                            if (keyValuePairConversion.Exists)
                             {
-                                Debug.Assert(!keyConversion.IsIdentity || !valueConversion.IsIdentity);
-                                return Conversion.CreateKeyValuePairConversion(keyConversion, valueConversion);
+                                return keyValuePairConversion;
                             }
                         }
                     }
@@ -293,19 +288,34 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return Conversion.NoConversion;
-        }
 
-        internal Conversion GetCollectionExpressionSpreadElementConversion(
-            BoundCollectionExpressionSpreadElement element,
-            TypeSymbol targetType,
-            ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
-        {
-            var enumeratorInfo = element.EnumeratorInfoOpt;
-            if (enumeratorInfo is null)
+            // Classifies the conversion of a spread item or expression element of type 'sourceType' to a dictionary
+            // element when the collection's element type is KeyValuePair<K, V>. Per the dictionary-expressions spec
+            // (https://github.com/dotnet/csharplang/blob/main/proposals/dictionary-expressions.md), a value of type
+            // KeyValuePair<K1, V1> converts to the dictionary element type KeyValuePair<K, V> when there is an implicit
+            // conversion from K1 to K and from V1 to V.
+            Conversion classifyKeyValuePairElementConversionFromType(
+                TypeSymbol sourceType,
+                (TypeSymbol Key, TypeSymbol Value) keyValueTypes,
+                ref CompoundUseSiteInfo<AssemblySymbol> elementUseSiteInfo)
             {
+                if (IsKeyValuePairType(Compilation, sourceType, out var sourceKeyType, out var sourceValueType))
+                {
+                    var keyConversion = ClassifyImplicitConversionFromType(sourceKeyType, keyValueTypes.Key, ref elementUseSiteInfo);
+                    var valueConversion = ClassifyImplicitConversionFromType(sourceValueType, keyValueTypes.Value, ref elementUseSiteInfo);
+                    if (keyConversion.Exists && valueConversion.Exists)
+                    {
+                        // The key and value conversions cannot both be identity conversions. If they were, the source
+                        // type would be identical to the element type KeyValuePair<K, V>, and the direct element
+                        // conversion attempted by the caller would already have succeeded, so this key-value pair
+                        // fallback would never be reached.
+                        Debug.Assert(!keyConversion.IsIdentity || !valueConversion.IsIdentity);
+                        return Conversion.CreateKeyValuePairConversion(keyConversion, valueConversion);
+                    }
+                }
+
                 return Conversion.NoConversion;
             }
-            return GetCollectionExpressionSpreadElementConversion(element.Syntax, targetType, enumeratorInfo, ref useSiteInfo);
         }
 
         internal Conversion GetCollectionExpressionSpreadElementConversion(

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
@@ -203,10 +203,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
+            var elementKeyValueTypes = TryGetCollectionKeyValuePairTypes(Compilation, elementType);
             var builder = ArrayBuilder<Conversion>.GetInstance(elements.Length);
             foreach (var element in elements)
             {
-                Conversion elementConversion = convertElement(element, elementType, ref useSiteInfo);
+                Conversion elementConversion = GetCollectionExpressionElementConversion(element, elementType, elementKeyValueTypes, ref useSiteInfo);
                 if (!elementConversion.Exists)
                 {
                     builder.Free();
@@ -217,15 +218,77 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return Conversion.CreateCollectionExpressionConversion(collectionTypeKind, elementType, constructor, isExpanded, builder.ToImmutableAndFree());
+        }
 
-            Conversion convertElement(BoundNode element, TypeSymbol elementType, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        private Conversion GetCollectionExpressionElementConversion(
+            BoundNode element,
+            TypeSymbol elementType,
+            (TypeSymbol Key, TypeSymbol Value)? elementKeyValueTypes,
+            ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        {
+            switch (element)
             {
-                return element switch
-                {
-                    BoundCollectionExpressionSpreadElement spreadElement => GetCollectionExpressionSpreadElementConversion(spreadElement, elementType, ref useSiteInfo),
-                    _ => ClassifyImplicitConversionFromExpression((BoundExpression)element, elementType, ref useSiteInfo),
-                };
+                case BoundCollectionExpressionSpreadElement spreadElement:
+                    {
+                        var enumeratorInfo = spreadElement.EnumeratorInfoOpt;
+                        if (enumeratorInfo is { })
+                        {
+                            var elementConversion = GetCollectionExpressionSpreadElementConversion(spreadElement.Syntax, elementType, enumeratorInfo, ref useSiteInfo);
+                            if (elementConversion.Exists)
+                            {
+                                return elementConversion;
+                            }
+                            else if (elementKeyValueTypes is (var keyType, var valueType) &&
+                                IsKeyValuePairType(Compilation, enumeratorInfo.ElementType, out var itemKeyType, out var itemValueType))
+                            {
+                                var keyConversion = ClassifyImplicitConversionFromType(itemKeyType, keyType, ref useSiteInfo);
+                                var valueConversion = ClassifyImplicitConversionFromType(itemValueType, valueType, ref useSiteInfo);
+                                if (keyConversion.Exists && valueConversion.Exists)
+                                {
+                                    Debug.Assert(!keyConversion.IsIdentity || !valueConversion.IsIdentity);
+                                    return Conversion.CreateKeyValuePairConversion(keyConversion, valueConversion);
+                                }
+                            }
+                        }
+                    }
+                    break;
+                case BoundKeyValuePairElement keyValuePairElement:
+                    {
+                        if (elementKeyValueTypes is (var keyType, var valueType))
+                        {
+                            var keyConversion = ClassifyImplicitConversionFromExpression(keyValuePairElement.Key, keyType, ref useSiteInfo);
+                            var valueConversion = ClassifyImplicitConversionFromExpression(keyValuePairElement.Value, valueType, ref useSiteInfo);
+                            if (keyConversion.Exists && valueConversion.Exists)
+                            {
+                                return Conversion.CreateKeyValuePairConversion(keyConversion, valueConversion);
+                            }
+                        }
+                    }
+                    break;
+                case BoundExpression expressionElement:
+                    {
+                        var elementConversion = ClassifyImplicitConversionFromExpression(expressionElement, elementType, ref useSiteInfo);
+                        if (elementConversion.Exists)
+                        {
+                            return elementConversion;
+                        }
+                        else if (expressionElement.Type is { } &&
+                            elementKeyValueTypes is (var keyType, var valueType) &&
+                            IsKeyValuePairType(Compilation, expressionElement.Type, out var elementKeyType, out var elementValueType))
+                        {
+                            var keyConversion = ClassifyImplicitConversionFromType(elementKeyType, keyType, ref useSiteInfo);
+                            var valueConversion = ClassifyImplicitConversionFromType(elementValueType, valueType, ref useSiteInfo);
+                            if (keyConversion.Exists && valueConversion.Exists)
+                            {
+                                Debug.Assert(!keyConversion.IsIdentity || !valueConversion.IsIdentity);
+                                return Conversion.CreateKeyValuePairConversion(keyConversion, valueConversion);
+                            }
+                        }
+                    }
+                    break;
             }
+
+            return Conversion.NoConversion;
         }
 
         internal Conversion GetCollectionExpressionSpreadElementConversion(
@@ -238,8 +301,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 return Conversion.NoConversion;
             }
+            return GetCollectionExpressionSpreadElementConversion(element.Syntax, targetType, enumeratorInfo, ref useSiteInfo);
+        }
+
+        internal Conversion GetCollectionExpressionSpreadElementConversion(
+            SyntaxNode syntax,
+            TypeSymbol targetType,
+            ForEachEnumeratorInfo enumeratorInfo,
+            ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        {
+            // This should be conversion from type rather than conversion from expression.
+            // The difference is in handling of dynamic, and fixing this would be a breaking
+            // change for that case. For instance, the following would become an error:
+            // dynamic[] x = [1, 2, 3];
+            // int[] y = [.. x];
             return ClassifyImplicitConversionFromExpression(
-                new BoundValuePlaceholder(element.Syntax, enumeratorInfo.ElementType),
+                new BoundValuePlaceholder(syntax, enumeratorInfo.ElementType),
                 targetType,
                 ref useSiteInfo);
         }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
             var syntax = node.Syntax;
-            var collectionTypeKind = GetCollectionExpressionTypeKind(Compilation, targetType, out TypeWithAnnotations elementTypeWithAnnotations);
+            var collectionTypeKind = GetCollectionExpressionTypeKind(_binder, syntax, targetType, out TypeWithAnnotations elementTypeWithAnnotations);
             var elementType = elementTypeWithAnnotations.Type;
             switch (collectionTypeKind)
             {
@@ -170,14 +170,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return Conversion.NoConversion;
 
                 case CollectionExpressionTypeKind.ImplementsIEnumerable:
+                case CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer:
                 case CollectionExpressionTypeKind.CollectionBuilder:
+                    if (elementType is null)
                     {
-                        _binder.TryGetCollectionIterationType(syntax, targetType, out elementTypeWithAnnotations);
-                        elementType = elementTypeWithAnnotations.Type;
-                        if (elementType is null)
-                        {
-                            return Conversion.NoConversion;
-                        }
+                        return Conversion.NoConversion;
                     }
                     break;
             }
@@ -188,7 +185,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             MethodSymbol? constructor = null;
             bool isExpanded = false;
 
-            if (collectionTypeKind == CollectionExpressionTypeKind.ImplementsIEnumerable)
+            if (collectionTypeKind is CollectionExpressionTypeKind.ImplementsIEnumerable or CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer)
             {
                 if (!_binder.HasCollectionExpressionApplicableConstructor(
                         node.WithElement, node.WithElement?.Syntax ?? syntax, targetType, out constructor, out isExpanded, BindingDiagnosticBag.Discarded))
@@ -196,12 +193,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return Conversion.NoConversion;
                 }
 
-                if (_binder.GetCollectionExpressionApplicableIndexer(syntax, targetType, elementTypeWithAnnotations.Type, BindingDiagnosticBag.Discarded) is { })
-                {
-                    collectionTypeKind = CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer;
-                }
-                else if (elements.Length > 0 &&
-                         !_binder.HasCollectionExpressionApplicableAddMethod(syntax, targetType, addMethods: out _, BindingDiagnosticBag.Discarded))
+                if (collectionTypeKind == CollectionExpressionTypeKind.ImplementsIEnumerable &&
+                    elements.Length > 0 &&
+                    !_binder.HasCollectionExpressionApplicableAddMethod(syntax, targetType, addMethods: out _, BindingDiagnosticBag.Discarded))
                 {
                     return Conversion.NoConversion;
                 }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
@@ -284,10 +284,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Conversion.NoConversion;
 
             // Classifies the conversion of a spread item or expression element of type 'sourceType' to a dictionary
-            // element when the collection's element type is KeyValuePair<K, V>. Per the dictionary-expressions spec
-            // (https://github.com/dotnet/csharplang/blob/main/proposals/dictionary-expressions.md), a value of type
-            // KeyValuePair<K1, V1> converts to the dictionary element type KeyValuePair<K, V> when there is an implicit
-            // conversion from K1 to K and from V1 to V.
+            // element when the collection's element type is KeyValuePair<K, V>. A value of type KeyValuePair<K1, V1>
+            // converts to the dictionary element type KeyValuePair<K, V> when there is an implicit conversion from K1
+            // to K and from V1 to V.
             Conversion classifyKeyValuePairElementConversionFromType(
                 TypeSymbol sourceType,
                 (TypeSymbol Key, TypeSymbol Value) keyValueTypes,
@@ -318,9 +317,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             ForEachEnumeratorInfo enumeratorInfo,
             ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
-            // This should be conversion from type rather than conversion from expression.
-            // The difference is in handling of dynamic, and fixing this would be a breaking
-            // change for that case. For instance, the following would become an error:
+            // The specification classifies this as a conversion from type, but using a conversion from expression here
+            // preserves existing dynamic behavior. Switching to conversion from type would be a breaking change for
+            // that case. For instance, the following would become an error:
             // dynamic[] x = [1, 2, 3];
             // int[] y = [.. x];
             return ClassifyImplicitConversionFromExpression(

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
@@ -196,8 +196,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return Conversion.NoConversion;
                 }
 
-                if (elements.Length > 0 &&
-                    !_binder.HasCollectionExpressionApplicableAddMethod(syntax, targetType, addMethods: out _, BindingDiagnosticBag.Discarded))
+                if (_binder.GetCollectionExpressionApplicableIndexer(syntax, targetType, elementTypeWithAnnotations.Type, BindingDiagnosticBag.Discarded) is { })
+                {
+                    collectionTypeKind = CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer;
+                }
+                else if (elements.Length > 0 &&
+                         !_binder.HasCollectionExpressionApplicableAddMethod(syntax, targetType, addMethods: out _, BindingDiagnosticBag.Discarded))
                 {
                     return Conversion.NoConversion;
                 }
@@ -273,8 +277,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             return elementConversion;
                         }
                         else if (expressionElement.Type is { } &&
-                            elementKeyValueTypes is (var keyType, var valueType) &&
-                            IsKeyValuePairType(Compilation, expressionElement.Type, out var elementKeyType, out var elementValueType))
+                                 elementKeyValueTypes is (var keyType, var valueType) &&
+                                 IsKeyValuePairType(Compilation, expressionElement.Type, out var elementKeyType, out var elementValueType))
                         {
                             var keyConversion = ClassifyImplicitConversionFromType(elementKeyType, keyType, ref useSiteInfo);
                             var valueConversion = ClassifyImplicitConversionFromType(elementValueType, valueType, ref useSiteInfo);

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -1666,10 +1666,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             return IsAnonymousFunctionCompatibleWithType((UnboundLambda)source, destination, compilation) == LambdaConversionResult.Success;
         }
 
-        internal static CollectionExpressionTypeKind GetCollectionExpressionTypeKind(CSharpCompilation compilation, TypeSymbol destination, out TypeWithAnnotations elementType)
+        internal static CollectionExpressionTypeKind GetCollectionExpressionTypeKind(Binder binder, SyntaxNode syntax, TypeSymbol destination, out TypeWithAnnotations elementType)
         {
-            Debug.Assert(compilation is { });
+            Debug.Assert(binder is { });
+            Debug.Assert(syntax is { });
 
+            var compilation = binder.Compilation;
             if (destination is ArrayTypeSymbol arrayType)
             {
                 if (arrayType.IsSZArray)
@@ -1688,7 +1690,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else if ((destination as NamedTypeSymbol)?.HasCollectionBuilderAttribute(out _, out _) == true)
             {
-                elementType = default;
+                binder.TryGetCollectionIterationType(syntax, destination, out elementType);
                 return CollectionExpressionTypeKind.CollectionBuilder;
             }
             else if (destination.IsInterfaceType())
@@ -1713,6 +1715,23 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // to check for nullable to disallow: Nullable<StructCollection> s = [];
                 // Instead, we just walk the implemented interfaces.
                 elementType = default;
+
+                if (binder.HasParamsCollectionTypeApplicableIndexerInProgress(syntax, destination, out TypeWithAnnotations inProgressIterationType))
+                {
+                    elementType = inProgressIterationType;
+                    return CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer;
+                }
+
+                if (binder.TryGetCollectionIterationType(syntax, destination, out TypeWithAnnotations iterationType))
+                {
+                    elementType = iterationType;
+                    var indexerBinder = new ParamsCollectionTypeApplicableIndexerInProgress(syntax, destination, iterationType, binder);
+                    if (indexerBinder.GetCollectionExpressionApplicableIndexer(syntax, destination, iterationType.Type, BindingDiagnosticBag.Discarded) is { })
+                    {
+                        return CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer;
+                    }
+                }
+
                 return CollectionExpressionTypeKind.ImplementsIEnumerable;
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -1756,7 +1756,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal static bool IsKeyValuePairType(
             CSharpCompilation compilation,
-            TypeSymbol? type,
+            [NotNullWhen(true)] TypeSymbol? type,
             [NotNullWhen(true)] out TypeSymbol? keyType,
             [NotNullWhen(true)] out TypeSymbol? valueType)
         {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -1754,32 +1754,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             return false;
         }
 
-        internal static bool IsKeyValuePairType(CSharpCompilation compilation, TypeSymbol? targetType, WellKnownType keyValuePairType, out TypeWithAnnotations keyType, out TypeWithAnnotations valueType)
-        {
-            if (targetType is NamedTypeSymbol { Arity: 2 } namedType
-                && ReferenceEquals(namedType.OriginalDefinition, compilation.GetWellKnownType(keyValuePairType)))
-            {
-                var typeArguments = namedType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics;
-                keyType = typeArguments[0];
-                valueType = typeArguments[1];
-                return true;
-            }
-
-            keyType = default;
-            valueType = default;
-            return false;
-        }
-
         internal static bool IsKeyValuePairType(
             CSharpCompilation compilation,
             TypeSymbol? type,
             [NotNullWhen(true)] out TypeSymbol? keyType,
             [NotNullWhen(true)] out TypeSymbol? valueType)
         {
-            if (IsKeyValuePairType(compilation, type, WellKnownType.System_Collections_Generic_KeyValuePair_KV, out var keyTypeWithAnnotations, out var valueTypeWithAnnotations))
+            if (type is NamedTypeSymbol { Arity: 2 } namedType
+                && ReferenceEquals(namedType.OriginalDefinition, compilation.GetWellKnownType(WellKnownType.System_Collections_Generic_KeyValuePair_KV)))
             {
-                keyType = keyTypeWithAnnotations.Type;
-                valueType = valueTypeWithAnnotations.Type;
+                var typeArguments = namedType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics;
+                keyType = typeArguments[0].Type;
+                valueType = typeArguments[1].Type;
                 return true;
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -1691,6 +1691,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                 elementType = default;
                 return CollectionExpressionTypeKind.CollectionBuilder;
             }
+            else if (destination.IsInterfaceType())
+            {
+                if (destination.IsArrayInterface(out elementType))
+                {
+                    return CollectionExpressionTypeKind.ArrayInterface;
+                }
+                else if (compilation.IsFeatureEnabled(MessageID.IDS_FeatureDictionaryExpressions) &&
+                    (isDictionaryType(compilation, destination, WellKnownType.System_Collections_Generic_IDictionary_KV, out elementType) ||
+                     isDictionaryType(compilation, destination, WellKnownType.System_Collections_Generic_IReadOnlyDictionary_KV, out elementType)))
+                {
+                    return CollectionExpressionTypeKind.DictionaryInterface;
+                }
+            }
             else if (implementsSpecialInterface(compilation, destination, SpecialType.System_Collections_IEnumerable))
             {
                 // ^ This implementation differs from Binder.CollectionInitializerTypeImplementsIEnumerable().
@@ -1702,23 +1715,34 @@ namespace Microsoft.CodeAnalysis.CSharp
                 elementType = default;
                 return CollectionExpressionTypeKind.ImplementsIEnumerable;
             }
-            else if (destination.IsArrayInterface(out elementType))
-            {
-                return CollectionExpressionTypeKind.ArrayInterface;
-            }
 
             elementType = default;
             return CollectionExpressionTypeKind.None;
 
             static bool implementsSpecialInterface(CSharpCompilation compilation, TypeSymbol targetType, SpecialType specialInterface)
             {
+                Debug.Assert(!targetType.IsInterfaceType());
                 var allInterfaces = targetType.GetAllInterfacesOrEffectiveInterfaces();
                 var specialType = compilation.GetSpecialType(specialInterface);
                 return allInterfaces.Any(static (a, b) => ReferenceEquals(a.OriginalDefinition, b), specialType);
             }
+
+            static bool isDictionaryType(CSharpCompilation compilation, TypeSymbol targetType, WellKnownType dictionaryType, out TypeWithAnnotations elementType)
+            {
+                if (targetType is NamedTypeSymbol { Arity: 2 } namedType &&
+                    ReferenceEquals(namedType.OriginalDefinition, compilation.GetWellKnownType(dictionaryType)))
+                {
+                    elementType = TypeWithAnnotations.Create(compilation.GetWellKnownType(WellKnownType.System_Collections_Generic_KeyValuePair_KV)
+                        .Construct(namedType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics));
+                    return true;
+                }
+
+                elementType = default;
+                return false;
+            }
         }
 
-        internal static bool IsSpanOrListType(CSharpCompilation compilation, TypeSymbol targetType, WellKnownType spanType, [NotNullWhen(true)] out TypeWithAnnotations elementType)
+        internal static bool IsSpanOrListType(CSharpCompilation compilation, TypeSymbol targetType, WellKnownType spanType, out TypeWithAnnotations elementType)
         {
             if (targetType is NamedTypeSymbol { Arity: 1 } namedType
                 && ReferenceEquals(namedType.OriginalDefinition, compilation.GetWellKnownType(spanType)))
@@ -1728,6 +1752,53 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             elementType = default;
             return false;
+        }
+
+        internal static bool IsKeyValuePairType(CSharpCompilation compilation, TypeSymbol? targetType, WellKnownType keyValuePairType, out TypeWithAnnotations keyType, out TypeWithAnnotations valueType)
+        {
+            if (targetType is NamedTypeSymbol { Arity: 2 } namedType
+                && ReferenceEquals(namedType.OriginalDefinition, compilation.GetWellKnownType(keyValuePairType)))
+            {
+                var typeArguments = namedType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics;
+                keyType = typeArguments[0];
+                valueType = typeArguments[1];
+                return true;
+            }
+
+            keyType = default;
+            valueType = default;
+            return false;
+        }
+
+        internal static bool IsKeyValuePairType(
+            CSharpCompilation compilation,
+            TypeSymbol? type,
+            [NotNullWhen(true)] out TypeSymbol? keyType,
+            [NotNullWhen(true)] out TypeSymbol? valueType)
+        {
+            if (IsKeyValuePairType(compilation, type, WellKnownType.System_Collections_Generic_KeyValuePair_KV, out var keyTypeWithAnnotations, out var valueTypeWithAnnotations))
+            {
+                keyType = keyTypeWithAnnotations.Type;
+                valueType = valueTypeWithAnnotations.Type;
+                return true;
+            }
+
+            keyType = null;
+            valueType = null;
+            return false;
+        }
+
+        internal static (TypeSymbol Key, TypeSymbol Value)? TryGetCollectionKeyValuePairTypes(
+            CSharpCompilation compilation,
+            TypeSymbol elementType)
+        {
+            if (compilation.IsFeatureEnabled(MessageID.IDS_FeatureDictionaryExpressions) &&
+                IsKeyValuePairType(compilation, elementType, out var keyType, out var valueType))
+            {
+                return (keyType, valueType);
+            }
+
+            return null;
         }
 #nullable disable
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -693,7 +693,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         break;
                     case BoundKeyValuePairElement:
                     case BoundKeyValuePairConversion:
-                        // https://github.com/dotnet/roslyn/issues/77873: Handle input type inference for key:value elements.
+                        // PROTOTYPE: Handle input type inference for key:value elements.
                         break;
                     default:
                         MakeExplicitParameterTypeInferences(binder, (BoundExpression)element, targetElementType, kind, ref useSiteInfo);
@@ -916,7 +916,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             foreach (var element in argument.Elements)
             {
-                // https://github.com/dotnet/roslyn/issues/77873: Handle output type inference for key:value elements.
+                // PROTOTYPE: Handle output type inference for key:value elements.
                 if (element is BoundExpression expression)
                 {
                     MakeOutputTypeInferences(binder, expression, targetElementType, ref useSiteInfo);

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -686,13 +686,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             foreach (var element in argument.Elements)
             {
-                if (element is BoundCollectionExpressionSpreadElement spread)
+                switch (element)
                 {
-                    MakeSpreadElementTypeInferences(spread, targetElementType, ref useSiteInfo);
-                }
-                else
-                {
-                    MakeExplicitParameterTypeInferences(binder, (BoundExpression)element, targetElementType, kind, ref useSiteInfo);
+                    case BoundCollectionExpressionSpreadElement spread:
+                        MakeSpreadElementTypeInferences(spread, targetElementType, ref useSiteInfo);
+                        break;
+                    case BoundKeyValuePairElement:
+                    case BoundKeyValuePairConversion:
+                        // https://github.com/dotnet/roslyn/issues/77873: Handle input type inference for key:value elements.
+                        break;
+                    default:
+                        MakeExplicitParameterTypeInferences(binder, (BoundExpression)element, targetElementType, kind, ref useSiteInfo);
+                        break;
                 }
             }
         }
@@ -911,6 +916,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             foreach (var element in argument.Elements)
             {
+                // https://github.com/dotnet/roslyn/issues/77873: Handle output type inference for key:value elements.
                 if (element is BoundExpression expression)
                 {
                     MakeOutputTypeInferences(binder, expression, targetElementType, ref useSiteInfo);

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -1337,7 +1337,8 @@ outerDefault:
                 return false;
             }
 
-            var collectionTypeKind = ConversionsBase.GetCollectionExpressionTypeKind(binder.Compilation, type, out elementType);
+            SyntaxNode syntax = CSharpSyntaxTree.Dummy.GetRoot();
+            var collectionTypeKind = ConversionsBase.GetCollectionExpressionTypeKind(binder, syntax, type, out elementType);
 
             switch (collectionTypeKind)
             {
@@ -1345,25 +1346,23 @@ outerDefault:
                     return false;
 
                 case CollectionExpressionTypeKind.ImplementsIEnumerable:
+                case CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer:
                 case CollectionExpressionTypeKind.CollectionBuilder:
                     {
-                        SyntaxNode syntax = CSharpSyntaxTree.Dummy.GetRoot();
-                        binder.TryGetCollectionIterationType(syntax, type, out elementType);
-
                         if (elementType.Type is null)
                         {
                             return false;
                         }
 
-                        if (collectionTypeKind == CollectionExpressionTypeKind.ImplementsIEnumerable)
+                        if (collectionTypeKind is CollectionExpressionTypeKind.ImplementsIEnumerable or CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer)
                         {
-                            if (binder.HasParamsCollectionTypeApplicableIndexerInProgress(syntax, type))
+                            if (binder.HasParamsCollectionTypeApplicableIndexerInProgress(syntax, type, out _))
                             {
                                 // We are in a cycle. Optimistically assume the type has an applicable indexer.
                                 break;
                             }
 
-                            binder = new ParamsCollectionTypeApplicableIndexerInProgress(syntax, type, binder);
+                            binder = new ParamsCollectionTypeApplicableIndexerInProgress(syntax, type, elementType, binder);
 
                             if (!binder.HasCollectionExpressionApplicableConstructor(
                                     withElement: null, syntax, type, constructor: out _, isExpanded: out _, BindingDiagnosticBag.Discarded))
@@ -1371,7 +1370,7 @@ outerDefault:
                                 return false;
                             }
 
-                            if (binder.GetCollectionExpressionApplicableIndexer(syntax, type, elementType.Type, BindingDiagnosticBag.Discarded) is null &&
+                            if (collectionTypeKind == CollectionExpressionTypeKind.ImplementsIEnumerable &&
                                 !binder.HasCollectionExpressionApplicableAddMethod(syntax, type, addMethods: out _, BindingDiagnosticBag.Discarded))
                             {
                                 return false;
@@ -3233,18 +3232,9 @@ outerDefault:
 
         private BetterResult BetterParamsCollectionType(TypeSymbol t1, TypeSymbol t2, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
-            CollectionExpressionTypeKind kind1 = ConversionsBase.GetCollectionExpressionTypeKind(Compilation, t1, out TypeWithAnnotations elementType1);
-            CollectionExpressionTypeKind kind2 = ConversionsBase.GetCollectionExpressionTypeKind(Compilation, t2, out TypeWithAnnotations elementType2);
-
-            if (kind1 is CollectionExpressionTypeKind.CollectionBuilder or CollectionExpressionTypeKind.ImplementsIEnumerable)
-            {
-                _binder.TryGetCollectionIterationType(CSharpSyntaxTree.Dummy.GetRoot(), t1, out elementType1);
-            }
-
-            if (kind2 is CollectionExpressionTypeKind.CollectionBuilder or CollectionExpressionTypeKind.ImplementsIEnumerable)
-            {
-                _binder.TryGetCollectionIterationType(CSharpSyntaxTree.Dummy.GetRoot(), t2, out elementType2);
-            }
+            var syntax = CSharpSyntaxTree.Dummy.GetRoot();
+            CollectionExpressionTypeKind kind1 = ConversionsBase.GetCollectionExpressionTypeKind(_binder, syntax, t1, out TypeWithAnnotations elementType1);
+            CollectionExpressionTypeKind kind2 = ConversionsBase.GetCollectionExpressionTypeKind(_binder, syntax, t2, out TypeWithAnnotations elementType2);
 
             return BetterCollectionExpressionConversion(
                 collectionExpressionElements: [],

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -1357,13 +1357,22 @@ outerDefault:
 
                         if (collectionTypeKind == CollectionExpressionTypeKind.ImplementsIEnumerable)
                         {
+                            if (binder.HasParamsCollectionTypeApplicableIndexerInProgress(syntax, type))
+                            {
+                                // We are in a cycle. Optimistically assume the type has an applicable indexer.
+                                break;
+                            }
+
+                            binder = new ParamsCollectionTypeApplicableIndexerInProgress(syntax, type, binder);
+
                             if (!binder.HasCollectionExpressionApplicableConstructor(
                                     withElement: null, syntax, type, constructor: out _, isExpanded: out _, BindingDiagnosticBag.Discarded))
                             {
                                 return false;
                             }
 
-                            if (!binder.HasCollectionExpressionApplicableAddMethod(syntax, type, addMethods: out _, BindingDiagnosticBag.Discarded))
+                            if (binder.GetCollectionExpressionApplicableIndexer(syntax, type, elementType.Type, BindingDiagnosticBag.Discarded) is null &&
+                                !binder.HasCollectionExpressionApplicableAddMethod(syntax, type, addMethods: out _, BindingDiagnosticBag.Discarded))
                             {
                                 return false;
                             }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1990,6 +1990,30 @@
     <Field Name="IteratorBody" Type="BoundStatement?" SkipInVisitor="true" Null="allow"/>
   </Node>
 
+  <!-- A key:value pair element within a collection expression. -->
+  <Node Name="BoundKeyValuePairElement" Base="BoundNode">
+    <!-- Key expression. -->
+    <Field Name="Key" Type="BoundExpression"/>
+    <!-- Value expression. -->
+    <Field Name="Value" Type="BoundExpression"/>
+  </Node>
+
+  <!-- A KeyValuePair<,> with key and value conversions. -->
+  <Node Name="BoundKeyValuePairConversion" Base="BoundExpression">
+    <!-- Non-null type is required for this node kind -->
+    <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
+    <!-- Expression. -->
+    <Field Name="Expression" Type="BoundExpression"/>
+    <!-- Placeholder for Expression.Key in KeyConversion. -->
+    <Field Name="KeyPlaceholder" Type="BoundValuePlaceholder" SkipInVisitor="true"/>
+    <!-- Placeholder for Expression.Value in ValueConversion. -->
+    <Field Name="ValuePlaceholder" Type="BoundValuePlaceholder" SkipInVisitor="true"/>
+    <!-- Key conversion. -->
+    <Field Name="KeyConversion" Type="BoundExpression" SkipInVisitor="true"/>
+    <!-- Value conversion. -->
+    <Field Name="ValueConversion" Type="BoundExpression" SkipInVisitor="true"/>
+  </Node>
+
   <!-- 
   Tuple literals can exist in two forms - literal and converted literal.
   This is the base node for both forms.

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1966,7 +1966,6 @@
          and will naturally be visited during all binding phases.  It is just the packaging and movement into the final
          arg that the lowering phase concerns itself with. -->
     <Field Name="CollectionBuilderElementsPlaceholder" Type="BoundCollectionBuilderElementsPlaceholder?" Null="allow" SkipInVisitor="true"/>
-    <!-- Indexer setter, if any. -->
     <Field Name="IndexerSetMethod" Type="MethodSymbol?" Null="allow"/>
     <Field Name="WasTargetTyped" Type="bool" />
     <Field Name="HasWithElement" Type="bool" />
@@ -1992,27 +1991,17 @@
     <Field Name="IteratorBody" Type="BoundStatement?" SkipInVisitor="true" Null="allow"/>
   </Node>
 
-  <!-- A key:value pair element within a collection expression. -->
   <Node Name="BoundKeyValuePairElement" Base="BoundNode">
-    <!-- Key expression. -->
     <Field Name="Key" Type="BoundExpression"/>
-    <!-- Value expression. -->
     <Field Name="Value" Type="BoundExpression"/>
   </Node>
 
-  <!-- A KeyValuePair<,> with key and value conversions. -->
   <Node Name="BoundKeyValuePairConversion" Base="BoundExpression">
-    <!-- Non-null type is required for this node kind -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
-    <!-- Expression. -->
     <Field Name="Expression" Type="BoundExpression"/>
-    <!-- Placeholder for Expression.Key in KeyConversion. -->
     <Field Name="KeyPlaceholder" Type="BoundValuePlaceholder" SkipInVisitor="true"/>
-    <!-- Placeholder for Expression.Value in ValueConversion. -->
     <Field Name="ValuePlaceholder" Type="BoundValuePlaceholder" SkipInVisitor="true"/>
-    <!-- Key conversion. -->
     <Field Name="KeyConversion" Type="BoundExpression" SkipInVisitor="true"/>
-    <!-- Value conversion. -->
     <Field Name="ValueConversion" Type="BoundExpression" SkipInVisitor="true"/>
   </Node>
 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1966,6 +1966,8 @@
          and will naturally be visited during all binding phases.  It is just the packaging and movement into the final
          arg that the lowering phase concerns itself with. -->
     <Field Name="CollectionBuilderElementsPlaceholder" Type="BoundCollectionBuilderElementsPlaceholder?" Null="allow" SkipInVisitor="true"/>
+    <!-- Indexer setter, if any. -->
+    <Field Name="IndexerSetMethod" Type="MethodSymbol?" Null="allow"/>
     <Field Name="WasTargetTyped" Type="bool" />
     <Field Name="HasWithElement" Type="bool" />
     <Field Name="UnconvertedCollectionExpression" Type="BoundUnconvertedCollectionExpression" Null="disallow" SkipInVisitor="true"/>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -8211,6 +8211,9 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="IDS_FeatureCollectionExpressionArguments" xml:space="preserve">
     <value>collection expression arguments</value>
   </data>
+  <data name="IDS_FeatureDictionaryExpressions" xml:space="preserve">
+    <value>dictionary expressions</value>
+  </data>
   <data name="ERR_CollectionArgumentsMustBeFirst" xml:space="preserve">
     <value>'with(...)' element must be the first element</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -8229,6 +8229,9 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_BadCollectionArgumentsArgCount" xml:space="preserve">
     <value>No overload for method '{0}' takes {1} 'with(...)' element arguments</value>
   </data>
+  <data name="ERR_CollectionExpressionKeyValuePairNotSupported" xml:space="preserve">
+    <value>Collection expression type '{0}' does not support key-value pair elements.</value>
+  </data>
   <data name="ERR_AmbigExtension" xml:space="preserve">
     <value>The extension resolution is ambiguous between the following members: '{0}' and '{1}'</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2486,6 +2486,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         ERR_RequiresUnsafeAttributeInSource = 9379,
 
+        ERR_CollectionExpressionKeyValuePairNotSupported = 9380,
+
         // Note: you will need to do the following after adding errors:
         //  1) Update ErrorFacts.IsBuildOnlyDiagnostic (src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs)
         //  2) Add message to CSharpResources.resx

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -2557,6 +2557,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 or ErrorCode.ERR_CollectionArgumentsMustBeEmpty
                 or ErrorCode.ERR_CollectionRefLikeElementType
                 or ErrorCode.ERR_BadCollectionArgumentsArgCount
+                or ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported
                 or ErrorCode.ERR_AmbigExtension
                 or ErrorCode.ERR_SingleInapplicableBinaryOperator
                 or ErrorCode.ERR_SingleInapplicableUnaryOperator

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -310,6 +310,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureUnsafeEvolution = MessageBase + 12859,
 
         IDS_FeatureUnions = MessageBase + 12860,
+
+        IDS_FeatureDictionaryExpressions = MessageBase + 12861,
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -493,6 +495,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case MessageID.IDS_FeatureCollectionExpressionArguments:
                 case MessageID.IDS_FeatureUnsafeEvolution: // https://github.com/dotnet/roslyn/issues/82546: keep this in preview until C# 16
                 case MessageID.IDS_FeatureUnions:
+                case MessageID.IDS_FeatureDictionaryExpressions: // semantic check
                     return LanguageVersion.Preview;
 
                 // C# 14.0 features.

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -2154,6 +2154,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
+        public override BoundNode VisitKeyValuePairElement(BoundKeyValuePairElement node)
+        {
+            VisitRvalue(node.Key);
+            VisitRvalue(node.Value);
+            return null;
+        }
+
+        public override BoundNode VisitKeyValuePairConversion(BoundKeyValuePairConversion node)
+        {
+            VisitRvalue(node.Expression);
+            return null;
+        }
+
         public override BoundNode VisitNewT(BoundNewT node)
         {
             VisitRvalue(node.InitializerExpressionOpt);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -4205,20 +4205,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             (CollectionExpressionTypeKind, TypeWithAnnotations) getCollectionDetails(BoundCollectionExpression node, TypeSymbol collectionType)
             {
-                var collectionKind = ConversionsBase.GetCollectionExpressionTypeKind(this.compilation, collectionType, out var targetElementType);
+                var collectionKind = ConversionsBase.GetCollectionExpressionTypeKind(_binder, node.Syntax, collectionType, out var targetElementType);
                 if (collectionKind is CollectionExpressionTypeKind.CollectionBuilder)
                 {
                     var createMethod = node.CollectionBuilderMethod;
                     if (createMethod is not null)
                     {
-                        var foundIterationType = _binder.TryGetCollectionIterationType((ExpressionSyntax)node.Syntax, collectionType, out targetElementType);
-                        Debug.Assert(foundIterationType);
+                        Debug.Assert(targetElementType.HasType);
                     }
                 }
-                else if (collectionKind is CollectionExpressionTypeKind.ImplementsIEnumerable)
+                else if (collectionKind is CollectionExpressionTypeKind.ImplementsIEnumerable or CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer)
                 {
-                    Debug.Assert(!targetElementType.HasType);
-                    _binder.TryGetCollectionIterationType(node.Syntax, collectionType, out targetElementType);
+                    Debug.Assert(targetElementType.HasType);
                 }
 
                 return (collectionKind, targetElementType);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -4216,7 +4216,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else if (collectionKind is CollectionExpressionTypeKind.ImplementsIEnumerable or CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer)
                 {
-                    Debug.Assert(targetElementType.HasType);
+                    Debug.Assert(targetElementType.HasType || node.HasErrors);
                 }
 
                 return (collectionKind, targetElementType);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -4119,6 +4119,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                             RemovePlaceholderReplacement(elementPlaceholder);
                         }
                         break;
+                    case BoundKeyValuePairElement keyValuePair:
+                        VisitRvalue(keyValuePair.Key);
+                        VisitRvalue(keyValuePair.Value);
+                        // https://github.com/dotnet/roslyn/issues/77875: Check nullability from conversions of key and value.
+                        break;
+                    case BoundKeyValuePairConversion keyValuePairConversion:
+                        VisitRvalue(keyValuePairConversion);
+                        // https://github.com/dotnet/roslyn/issues/77875: Check nullability from conversions of key and value.
+                        break;
                     default:
                         var elementExpr = (BoundExpression)element;
                         if (!targetElementType.HasType)
@@ -4240,6 +4249,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(node.EnumeratorInfoOpt is null);
             }
 
+            return null;
+        }
+
+        public override BoundNode? VisitKeyValuePairConversion(BoundKeyValuePairConversion node)
+        {
+            VisitRvalue(node.Expression);
+            SetUnknownResultNullability(node);
             return null;
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -4122,11 +4122,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case BoundKeyValuePairElement keyValuePair:
                         VisitRvalue(keyValuePair.Key);
                         VisitRvalue(keyValuePair.Value);
-                        // https://github.com/dotnet/roslyn/issues/77875: Check nullability from conversions of key and value.
+                        // PROTOTYPE: Check nullability from conversions of key and value.
                         break;
                     case BoundKeyValuePairConversion keyValuePairConversion:
                         VisitRvalue(keyValuePairConversion);
-                        // https://github.com/dotnet/roslyn/issues/77875: Check nullability from conversions of key and value.
+                        // PROTOTYPE: Check nullability from conversions of key and value.
                         break;
                     default:
                         var elementExpr = (BoundExpression)element;

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -6564,7 +6564,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundCollectionExpression : BoundCollectionExpressionBase
     {
-        public BoundCollectionExpression(SyntaxNode syntax, CollectionExpressionTypeKind collectionTypeKind, BoundObjectOrCollectionValuePlaceholder? placeholder, BoundExpression? collectionCreation, MethodSymbol? collectionBuilderMethod, BoundCollectionBuilderElementsPlaceholder? collectionBuilderElementsPlaceholder, bool wasTargetTyped, bool hasWithElement, BoundUnconvertedCollectionExpression unconvertedCollectionExpression, ImmutableArray<BoundNode> elements, TypeSymbol type, bool hasErrors = false)
+        public BoundCollectionExpression(SyntaxNode syntax, CollectionExpressionTypeKind collectionTypeKind, BoundObjectOrCollectionValuePlaceholder? placeholder, BoundExpression? collectionCreation, MethodSymbol? collectionBuilderMethod, BoundCollectionBuilderElementsPlaceholder? collectionBuilderElementsPlaceholder, MethodSymbol? indexerSetMethod, bool wasTargetTyped, bool hasWithElement, BoundUnconvertedCollectionExpression unconvertedCollectionExpression, ImmutableArray<BoundNode> elements, TypeSymbol type, bool hasErrors = false)
             : base(BoundKind.CollectionExpression, syntax, elements, type, hasErrors || placeholder.HasErrors() || collectionCreation.HasErrors() || collectionBuilderElementsPlaceholder.HasErrors() || unconvertedCollectionExpression.HasErrors() || elements.HasErrors())
         {
 
@@ -6577,6 +6577,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.CollectionCreation = collectionCreation;
             this.CollectionBuilderMethod = collectionBuilderMethod;
             this.CollectionBuilderElementsPlaceholder = collectionBuilderElementsPlaceholder;
+            this.IndexerSetMethod = indexerSetMethod;
             this.WasTargetTyped = wasTargetTyped;
             this.HasWithElement = hasWithElement;
             this.UnconvertedCollectionExpression = unconvertedCollectionExpression;
@@ -6592,6 +6593,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public BoundExpression? CollectionCreation { get; }
         public MethodSymbol? CollectionBuilderMethod { get; }
         public BoundCollectionBuilderElementsPlaceholder? CollectionBuilderElementsPlaceholder { get; }
+        public MethodSymbol? IndexerSetMethod { get; }
         public bool WasTargetTyped { get; }
         public bool HasWithElement { get; }
         public BoundUnconvertedCollectionExpression UnconvertedCollectionExpression { get; }
@@ -6599,11 +6601,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitCollectionExpression(this);
 
-        public BoundCollectionExpression Update(CollectionExpressionTypeKind collectionTypeKind, BoundObjectOrCollectionValuePlaceholder? placeholder, BoundExpression? collectionCreation, MethodSymbol? collectionBuilderMethod, BoundCollectionBuilderElementsPlaceholder? collectionBuilderElementsPlaceholder, bool wasTargetTyped, bool hasWithElement, BoundUnconvertedCollectionExpression unconvertedCollectionExpression, ImmutableArray<BoundNode> elements, TypeSymbol type)
+        public BoundCollectionExpression Update(CollectionExpressionTypeKind collectionTypeKind, BoundObjectOrCollectionValuePlaceholder? placeholder, BoundExpression? collectionCreation, MethodSymbol? collectionBuilderMethod, BoundCollectionBuilderElementsPlaceholder? collectionBuilderElementsPlaceholder, MethodSymbol? indexerSetMethod, bool wasTargetTyped, bool hasWithElement, BoundUnconvertedCollectionExpression unconvertedCollectionExpression, ImmutableArray<BoundNode> elements, TypeSymbol type)
         {
-            if (collectionTypeKind != this.CollectionTypeKind || placeholder != this.Placeholder || collectionCreation != this.CollectionCreation || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(collectionBuilderMethod, this.CollectionBuilderMethod) || collectionBuilderElementsPlaceholder != this.CollectionBuilderElementsPlaceholder || wasTargetTyped != this.WasTargetTyped || hasWithElement != this.HasWithElement || unconvertedCollectionExpression != this.UnconvertedCollectionExpression || elements != this.Elements || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
+            if (collectionTypeKind != this.CollectionTypeKind || placeholder != this.Placeholder || collectionCreation != this.CollectionCreation || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(collectionBuilderMethod, this.CollectionBuilderMethod) || collectionBuilderElementsPlaceholder != this.CollectionBuilderElementsPlaceholder || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(indexerSetMethod, this.IndexerSetMethod) || wasTargetTyped != this.WasTargetTyped || hasWithElement != this.HasWithElement || unconvertedCollectionExpression != this.UnconvertedCollectionExpression || elements != this.Elements || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
             {
-                var result = new BoundCollectionExpression(this.Syntax, collectionTypeKind, placeholder, collectionCreation, collectionBuilderMethod, collectionBuilderElementsPlaceholder, wasTargetTyped, hasWithElement, unconvertedCollectionExpression, elements, type, this.HasErrors);
+                var result = new BoundCollectionExpression(this.Syntax, collectionTypeKind, placeholder, collectionCreation, collectionBuilderMethod, collectionBuilderElementsPlaceholder, indexerSetMethod, wasTargetTyped, hasWithElement, unconvertedCollectionExpression, elements, type, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -12316,13 +12318,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitCollectionExpression(BoundCollectionExpression node)
         {
             MethodSymbol? collectionBuilderMethod = this.VisitMethodSymbol(node.CollectionBuilderMethod);
+            MethodSymbol? indexerSetMethod = this.VisitMethodSymbol(node.IndexerSetMethod);
             BoundObjectOrCollectionValuePlaceholder? placeholder = node.Placeholder;
             BoundExpression? collectionCreation = (BoundExpression?)this.Visit(node.CollectionCreation);
             BoundCollectionBuilderElementsPlaceholder? collectionBuilderElementsPlaceholder = node.CollectionBuilderElementsPlaceholder;
             BoundUnconvertedCollectionExpression unconvertedCollectionExpression = node.UnconvertedCollectionExpression;
             ImmutableArray<BoundNode> elements = this.VisitList(node.Elements);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.CollectionTypeKind, placeholder, collectionCreation, collectionBuilderMethod, collectionBuilderElementsPlaceholder, node.WasTargetTyped, node.HasWithElement, unconvertedCollectionExpression, elements, type);
+            return node.Update(node.CollectionTypeKind, placeholder, collectionCreation, collectionBuilderMethod, collectionBuilderElementsPlaceholder, indexerSetMethod, node.WasTargetTyped, node.HasWithElement, unconvertedCollectionExpression, elements, type);
         }
         public override BoundNode? VisitCollectionExpressionSpreadExpressionPlaceholder(BoundCollectionExpressionSpreadExpressionPlaceholder node)
         {
@@ -14646,6 +14649,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitCollectionExpression(BoundCollectionExpression node)
         {
             MethodSymbol? collectionBuilderMethod = GetUpdatedSymbol(node, node.CollectionBuilderMethod);
+            MethodSymbol? indexerSetMethod = GetUpdatedSymbol(node, node.IndexerSetMethod);
             BoundObjectOrCollectionValuePlaceholder? placeholder = node.Placeholder;
             BoundExpression? collectionCreation = (BoundExpression?)this.Visit(node.CollectionCreation);
             BoundCollectionBuilderElementsPlaceholder? collectionBuilderElementsPlaceholder = node.CollectionBuilderElementsPlaceholder;
@@ -14655,12 +14659,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol? Type) infoAndType))
             {
-                updatedNode = node.Update(node.CollectionTypeKind, placeholder, collectionCreation, collectionBuilderMethod, collectionBuilderElementsPlaceholder, node.WasTargetTyped, node.HasWithElement, unconvertedCollectionExpression, elements, infoAndType.Type!);
+                updatedNode = node.Update(node.CollectionTypeKind, placeholder, collectionCreation, collectionBuilderMethod, collectionBuilderElementsPlaceholder, indexerSetMethod, node.WasTargetTyped, node.HasWithElement, unconvertedCollectionExpression, elements, infoAndType.Type!);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(node.CollectionTypeKind, placeholder, collectionCreation, collectionBuilderMethod, collectionBuilderElementsPlaceholder, node.WasTargetTyped, node.HasWithElement, unconvertedCollectionExpression, elements, node.Type);
+                updatedNode = node.Update(node.CollectionTypeKind, placeholder, collectionCreation, collectionBuilderMethod, collectionBuilderElementsPlaceholder, indexerSetMethod, node.WasTargetTyped, node.HasWithElement, unconvertedCollectionExpression, elements, node.Type);
             }
             return updatedNode;
         }
@@ -17145,6 +17149,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             new TreeDumperNode("collectionCreation", null, new TreeDumperNode[] { Visit(node.CollectionCreation, null) }),
             new TreeDumperNode("collectionBuilderMethod", node.CollectionBuilderMethod, null),
             new TreeDumperNode("collectionBuilderElementsPlaceholder", null, new TreeDumperNode[] { Visit(node.CollectionBuilderElementsPlaceholder, null) }),
+            new TreeDumperNode("indexerSetMethod", node.IndexerSetMethod, null),
             new TreeDumperNode("wasTargetTyped", node.WasTargetTyped, null),
             new TreeDumperNode("hasWithElement", node.HasWithElement, null),
             new TreeDumperNode("unconvertedCollectionExpression", null, new TreeDumperNode[] { Visit(node.UnconvertedCollectionExpression, null) }),

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -194,6 +194,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         CollectionExpression,
         CollectionExpressionSpreadExpressionPlaceholder,
         CollectionExpressionSpreadElement,
+        KeyValuePairElement,
+        KeyValuePairConversion,
         TupleLiteral,
         ConvertedTupleLiteral,
         DynamicObjectCreationExpression,
@@ -6677,6 +6679,79 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
+    internal sealed partial class BoundKeyValuePairElement : BoundNode
+    {
+        public BoundKeyValuePairElement(SyntaxNode syntax, BoundExpression key, BoundExpression value, bool hasErrors = false)
+            : base(BoundKind.KeyValuePairElement, syntax, hasErrors || key.HasErrors() || value.HasErrors())
+        {
+
+            RoslynDebug.Assert(key is object, "Field 'key' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
+            RoslynDebug.Assert(value is object, "Field 'value' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
+
+            this.Key = key;
+            this.Value = value;
+        }
+
+        public BoundExpression Key { get; }
+        public BoundExpression Value { get; }
+
+        [DebuggerStepThrough]
+        public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitKeyValuePairElement(this);
+
+        public BoundKeyValuePairElement Update(BoundExpression key, BoundExpression value)
+        {
+            if (key != this.Key || value != this.Value)
+            {
+                var result = new BoundKeyValuePairElement(this.Syntax, key, value, this.HasErrors);
+                result.CopyAttributes(this);
+                return result;
+            }
+            return this;
+        }
+    }
+
+    internal sealed partial class BoundKeyValuePairConversion : BoundExpression
+    {
+        public BoundKeyValuePairConversion(SyntaxNode syntax, BoundExpression expression, BoundValuePlaceholder keyPlaceholder, BoundValuePlaceholder valuePlaceholder, BoundExpression keyConversion, BoundExpression valueConversion, TypeSymbol type, bool hasErrors = false)
+            : base(BoundKind.KeyValuePairConversion, syntax, type, hasErrors || expression.HasErrors() || keyPlaceholder.HasErrors() || valuePlaceholder.HasErrors() || keyConversion.HasErrors() || valueConversion.HasErrors())
+        {
+
+            RoslynDebug.Assert(expression is object, "Field 'expression' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
+            RoslynDebug.Assert(keyPlaceholder is object, "Field 'keyPlaceholder' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
+            RoslynDebug.Assert(valuePlaceholder is object, "Field 'valuePlaceholder' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
+            RoslynDebug.Assert(keyConversion is object, "Field 'keyConversion' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
+            RoslynDebug.Assert(valueConversion is object, "Field 'valueConversion' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
+            RoslynDebug.Assert(type is object, "Field 'type' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
+
+            this.Expression = expression;
+            this.KeyPlaceholder = keyPlaceholder;
+            this.ValuePlaceholder = valuePlaceholder;
+            this.KeyConversion = keyConversion;
+            this.ValueConversion = valueConversion;
+        }
+
+        public new TypeSymbol Type => base.Type!;
+        public BoundExpression Expression { get; }
+        public BoundValuePlaceholder KeyPlaceholder { get; }
+        public BoundValuePlaceholder ValuePlaceholder { get; }
+        public BoundExpression KeyConversion { get; }
+        public BoundExpression ValueConversion { get; }
+
+        [DebuggerStepThrough]
+        public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitKeyValuePairConversion(this);
+
+        public BoundKeyValuePairConversion Update(BoundExpression expression, BoundValuePlaceholder keyPlaceholder, BoundValuePlaceholder valuePlaceholder, BoundExpression keyConversion, BoundExpression valueConversion, TypeSymbol type)
+        {
+            if (expression != this.Expression || keyPlaceholder != this.KeyPlaceholder || valuePlaceholder != this.ValuePlaceholder || keyConversion != this.KeyConversion || valueConversion != this.ValueConversion || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
+            {
+                var result = new BoundKeyValuePairConversion(this.Syntax, expression, keyPlaceholder, valuePlaceholder, keyConversion, valueConversion, type, this.HasErrors);
+                result.CopyAttributes(this);
+                return result;
+            }
+            return this;
+        }
+    }
+
     internal abstract partial class BoundTupleExpression : BoundExpression
     {
         protected BoundTupleExpression(BoundKind kind, SyntaxNode syntax, ImmutableArray<BoundExpression> arguments, ImmutableArray<string?> argumentNamesOpt, ImmutableArray<bool> inferredNamesOpt, TypeSymbol? type, bool hasErrors = false)
@@ -9442,6 +9517,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return VisitCollectionExpressionSpreadExpressionPlaceholder((BoundCollectionExpressionSpreadExpressionPlaceholder)node, arg);
                 case BoundKind.CollectionExpressionSpreadElement:
                     return VisitCollectionExpressionSpreadElement((BoundCollectionExpressionSpreadElement)node, arg);
+                case BoundKind.KeyValuePairElement:
+                    return VisitKeyValuePairElement((BoundKeyValuePairElement)node, arg);
+                case BoundKind.KeyValuePairConversion:
+                    return VisitKeyValuePairConversion((BoundKeyValuePairConversion)node, arg);
                 case BoundKind.TupleLiteral:
                     return VisitTupleLiteral((BoundTupleLiteral)node, arg);
                 case BoundKind.ConvertedTupleLiteral:
@@ -9750,6 +9829,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         public virtual R VisitCollectionExpression(BoundCollectionExpression node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitCollectionExpressionSpreadExpressionPlaceholder(BoundCollectionExpressionSpreadExpressionPlaceholder node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitCollectionExpressionSpreadElement(BoundCollectionExpressionSpreadElement node, A arg) => this.DefaultVisit(node, arg);
+        public virtual R VisitKeyValuePairElement(BoundKeyValuePairElement node, A arg) => this.DefaultVisit(node, arg);
+        public virtual R VisitKeyValuePairConversion(BoundKeyValuePairConversion node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitTupleLiteral(BoundTupleLiteral node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitConvertedTupleLiteral(BoundConvertedTupleLiteral node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitDynamicObjectCreationExpression(BoundDynamicObjectCreationExpression node, A arg) => this.DefaultVisit(node, arg);
@@ -9991,6 +10072,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         public virtual BoundNode? VisitCollectionExpression(BoundCollectionExpression node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitCollectionExpressionSpreadExpressionPlaceholder(BoundCollectionExpressionSpreadExpressionPlaceholder node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitCollectionExpressionSpreadElement(BoundCollectionExpressionSpreadElement node) => this.DefaultVisit(node);
+        public virtual BoundNode? VisitKeyValuePairElement(BoundKeyValuePairElement node) => this.DefaultVisit(node);
+        public virtual BoundNode? VisitKeyValuePairConversion(BoundKeyValuePairConversion node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitTupleLiteral(BoundTupleLiteral node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitConvertedTupleLiteral(BoundConvertedTupleLiteral node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitDynamicObjectCreationExpression(BoundDynamicObjectCreationExpression node) => this.DefaultVisit(node);
@@ -10795,6 +10878,17 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitCollectionExpressionSpreadExpressionPlaceholder(BoundCollectionExpressionSpreadExpressionPlaceholder node) => null;
         public override BoundNode? VisitCollectionExpressionSpreadElement(BoundCollectionExpressionSpreadElement node)
+        {
+            this.Visit(node.Expression);
+            return null;
+        }
+        public override BoundNode? VisitKeyValuePairElement(BoundKeyValuePairElement node)
+        {
+            this.Visit(node.Key);
+            this.Visit(node.Value);
+            return null;
+        }
+        public override BoundNode? VisitKeyValuePairConversion(BoundKeyValuePairConversion node)
         {
             this.Visit(node.Expression);
             return null;
@@ -12244,6 +12338,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundValuePlaceholder? elementPlaceholder = node.ElementPlaceholder;
             BoundStatement? iteratorBody = node.IteratorBody;
             return node.Update(expression, expressionPlaceholder, conversion, node.EnumeratorInfoOpt, lengthOrCount, elementPlaceholder, iteratorBody);
+        }
+        public override BoundNode? VisitKeyValuePairElement(BoundKeyValuePairElement node)
+        {
+            BoundExpression key = (BoundExpression)this.Visit(node.Key);
+            BoundExpression value = (BoundExpression)this.Visit(node.Value);
+            return node.Update(key, value);
+        }
+        public override BoundNode? VisitKeyValuePairConversion(BoundKeyValuePairConversion node)
+        {
+            BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
+            BoundValuePlaceholder keyPlaceholder = node.KeyPlaceholder;
+            BoundValuePlaceholder valuePlaceholder = node.ValuePlaceholder;
+            BoundExpression keyConversion = node.KeyConversion;
+            BoundExpression valueConversion = node.ValueConversion;
+            TypeSymbol? type = this.VisitType(node.Type);
+            return node.Update(expression, keyPlaceholder, valuePlaceholder, keyConversion, valueConversion, type);
         }
         public override BoundNode? VisitTupleLiteral(BoundTupleLiteral node)
         {
@@ -14564,6 +14674,27 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             BoundCollectionExpressionSpreadExpressionPlaceholder updatedNode = node.Update(infoAndType.Type);
             updatedNode.TopLevelNullability = infoAndType.Info;
+            return updatedNode;
+        }
+
+        public override BoundNode? VisitKeyValuePairConversion(BoundKeyValuePairConversion node)
+        {
+            BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
+            BoundValuePlaceholder keyPlaceholder = node.KeyPlaceholder;
+            BoundValuePlaceholder valuePlaceholder = node.ValuePlaceholder;
+            BoundExpression keyConversion = node.KeyConversion;
+            BoundExpression valueConversion = node.ValueConversion;
+            BoundKeyValuePairConversion updatedNode;
+
+            if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol? Type) infoAndType))
+            {
+                updatedNode = node.Update(expression, keyPlaceholder, valuePlaceholder, keyConversion, valueConversion, infoAndType.Type!);
+                updatedNode.TopLevelNullability = infoAndType.Info;
+            }
+            else
+            {
+                updatedNode = node.Update(expression, keyPlaceholder, valuePlaceholder, keyConversion, valueConversion, node.Type);
+            }
             return updatedNode;
         }
 
@@ -17039,6 +17170,25 @@ namespace Microsoft.CodeAnalysis.CSharp
             new TreeDumperNode("lengthOrCount", null, new TreeDumperNode[] { Visit(node.LengthOrCount, null) }),
             new TreeDumperNode("elementPlaceholder", null, new TreeDumperNode[] { Visit(node.ElementPlaceholder, null) }),
             new TreeDumperNode("iteratorBody", null, new TreeDumperNode[] { Visit(node.IteratorBody, null) }),
+            new TreeDumperNode("hasErrors", node.HasErrors, null)
+        }
+        );
+        public override TreeDumperNode VisitKeyValuePairElement(BoundKeyValuePairElement node, object? arg) => new TreeDumperNode("keyValuePairElement", null, new TreeDumperNode[]
+        {
+            new TreeDumperNode("key", null, new TreeDumperNode[] { Visit(node.Key, null) }),
+            new TreeDumperNode("value", null, new TreeDumperNode[] { Visit(node.Value, null) }),
+            new TreeDumperNode("hasErrors", node.HasErrors, null)
+        }
+        );
+        public override TreeDumperNode VisitKeyValuePairConversion(BoundKeyValuePairConversion node, object? arg) => new TreeDumperNode("keyValuePairConversion", null, new TreeDumperNode[]
+        {
+            new TreeDumperNode("expression", null, new TreeDumperNode[] { Visit(node.Expression, null) }),
+            new TreeDumperNode("keyPlaceholder", null, new TreeDumperNode[] { Visit(node.KeyPlaceholder, null) }),
+            new TreeDumperNode("valuePlaceholder", null, new TreeDumperNode[] { Visit(node.ValuePlaceholder, null) }),
+            new TreeDumperNode("keyConversion", null, new TreeDumperNode[] { Visit(node.KeyConversion, null) }),
+            new TreeDumperNode("valueConversion", null, new TreeDumperNode[] { Visit(node.ValueConversion, null) }),
+            new TreeDumperNode("type", node.Type, null),
+            new TreeDumperNode("isSuppressed", node.IsSuppressed, null),
             new TreeDumperNode("hasErrors", node.HasErrors, null)
         }
         );

--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Main.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Main.Generated.cs
@@ -229,6 +229,7 @@ public partial class CSharpSyntaxVisitor<TResult>
     public virtual TResult? VisitSpreadElement(SpreadElementSyntax node) => this.DefaultVisit(node);
 
     /// <summary>Called when the visitor visits a KeyValuePairElementSyntax node.</summary>
+    [Experimental(global::Microsoft.CodeAnalysis.RoslynExperiments.PreviewLanguageFeatureApi, UrlFormat = @"https://github.com/dotnet/roslyn/issues/84112")]
     public virtual TResult? VisitKeyValuePairElement(KeyValuePairElementSyntax node) => this.DefaultVisit(node);
 
     /// <summary>Called when the visitor visits a WithElementSyntax node.</summary>
@@ -980,6 +981,7 @@ public partial class CSharpSyntaxVisitor
     public virtual void VisitSpreadElement(SpreadElementSyntax node) => this.DefaultVisit(node);
 
     /// <summary>Called when the visitor visits a KeyValuePairElementSyntax node.</summary>
+    [Experimental(global::Microsoft.CodeAnalysis.RoslynExperiments.PreviewLanguageFeatureApi, UrlFormat = @"https://github.com/dotnet/roslyn/issues/84112")]
     public virtual void VisitKeyValuePairElement(KeyValuePairElementSyntax node) => this.DefaultVisit(node);
 
     /// <summary>Called when the visitor visits a WithElementSyntax node.</summary>
@@ -1730,6 +1732,7 @@ public partial class CSharpSyntaxRewriter : CSharpSyntaxVisitor<SyntaxNode?>
     public override SyntaxNode? VisitSpreadElement(SpreadElementSyntax node)
         => node.Update(VisitToken(node.OperatorToken), (ExpressionSyntax?)Visit(node.Expression) ?? throw new ArgumentNullException("expression"));
 
+    [Experimental(global::Microsoft.CodeAnalysis.RoslynExperiments.PreviewLanguageFeatureApi, UrlFormat = @"https://github.com/dotnet/roslyn/issues/84112")]
     public override SyntaxNode? VisitKeyValuePairElement(KeyValuePairElementSyntax node)
         => node.Update((ExpressionSyntax?)Visit(node.KeyExpression) ?? throw new ArgumentNullException("keyExpression"), VisitToken(node.ColonToken), (ExpressionSyntax?)Visit(node.ValueExpression) ?? throw new ArgumentNullException("valueExpression"));
 
@@ -3458,6 +3461,7 @@ public static partial class SyntaxFactory
         => SyntaxFactory.SpreadElement(SyntaxFactory.Token(SyntaxKind.DotDotToken), expression);
 
     /// <summary>Creates a new KeyValuePairElementSyntax instance.</summary>
+    [Experimental(global::Microsoft.CodeAnalysis.RoslynExperiments.PreviewLanguageFeatureApi, UrlFormat = @"https://github.com/dotnet/roslyn/issues/84112")]
     public static KeyValuePairElementSyntax KeyValuePairElement(ExpressionSyntax keyExpression, SyntaxToken colonToken, ExpressionSyntax valueExpression)
     {
         if (keyExpression == null) throw new ArgumentNullException(nameof(keyExpression));
@@ -3467,6 +3471,7 @@ public static partial class SyntaxFactory
     }
 
     /// <summary>Creates a new KeyValuePairElementSyntax instance.</summary>
+    [Experimental(global::Microsoft.CodeAnalysis.RoslynExperiments.PreviewLanguageFeatureApi, UrlFormat = @"https://github.com/dotnet/roslyn/issues/84112")]
     public static KeyValuePairElementSyntax KeyValuePairElement(ExpressionSyntax keyExpression, ExpressionSyntax valueExpression)
         => SyntaxFactory.KeyValuePairElement(keyExpression, SyntaxFactory.Token(SyntaxKind.ColonToken), valueExpression);
 

--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Main.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Main.Generated.cs
@@ -229,7 +229,7 @@ public partial class CSharpSyntaxVisitor<TResult>
     public virtual TResult? VisitSpreadElement(SpreadElementSyntax node) => this.DefaultVisit(node);
 
     /// <summary>Called when the visitor visits a KeyValuePairElementSyntax node.</summary>
-    [Experimental(global::Microsoft.CodeAnalysis.RoslynExperiments.PreviewLanguageFeatureApi, UrlFormat = @"https://github.com/dotnet/roslyn/issues/84112")]
+    [Experimental(global::Microsoft.CodeAnalysis.RoslynExperiments.PreviewLanguageFeatureApi, UrlFormat = @"https://github.com/dotnet/roslyn/issues/84198")]
     public virtual TResult? VisitKeyValuePairElement(KeyValuePairElementSyntax node) => this.DefaultVisit(node);
 
     /// <summary>Called when the visitor visits a WithElementSyntax node.</summary>
@@ -981,7 +981,7 @@ public partial class CSharpSyntaxVisitor
     public virtual void VisitSpreadElement(SpreadElementSyntax node) => this.DefaultVisit(node);
 
     /// <summary>Called when the visitor visits a KeyValuePairElementSyntax node.</summary>
-    [Experimental(global::Microsoft.CodeAnalysis.RoslynExperiments.PreviewLanguageFeatureApi, UrlFormat = @"https://github.com/dotnet/roslyn/issues/84112")]
+    [Experimental(global::Microsoft.CodeAnalysis.RoslynExperiments.PreviewLanguageFeatureApi, UrlFormat = @"https://github.com/dotnet/roslyn/issues/84198")]
     public virtual void VisitKeyValuePairElement(KeyValuePairElementSyntax node) => this.DefaultVisit(node);
 
     /// <summary>Called when the visitor visits a WithElementSyntax node.</summary>
@@ -1732,7 +1732,7 @@ public partial class CSharpSyntaxRewriter : CSharpSyntaxVisitor<SyntaxNode?>
     public override SyntaxNode? VisitSpreadElement(SpreadElementSyntax node)
         => node.Update(VisitToken(node.OperatorToken), (ExpressionSyntax?)Visit(node.Expression) ?? throw new ArgumentNullException("expression"));
 
-    [Experimental(global::Microsoft.CodeAnalysis.RoslynExperiments.PreviewLanguageFeatureApi, UrlFormat = @"https://github.com/dotnet/roslyn/issues/84112")]
+    [Experimental(global::Microsoft.CodeAnalysis.RoslynExperiments.PreviewLanguageFeatureApi, UrlFormat = @"https://github.com/dotnet/roslyn/issues/84198")]
     public override SyntaxNode? VisitKeyValuePairElement(KeyValuePairElementSyntax node)
         => node.Update((ExpressionSyntax?)Visit(node.KeyExpression) ?? throw new ArgumentNullException("keyExpression"), VisitToken(node.ColonToken), (ExpressionSyntax?)Visit(node.ValueExpression) ?? throw new ArgumentNullException("valueExpression"));
 
@@ -3461,7 +3461,7 @@ public static partial class SyntaxFactory
         => SyntaxFactory.SpreadElement(SyntaxFactory.Token(SyntaxKind.DotDotToken), expression);
 
     /// <summary>Creates a new KeyValuePairElementSyntax instance.</summary>
-    [Experimental(global::Microsoft.CodeAnalysis.RoslynExperiments.PreviewLanguageFeatureApi, UrlFormat = @"https://github.com/dotnet/roslyn/issues/84112")]
+    [Experimental(global::Microsoft.CodeAnalysis.RoslynExperiments.PreviewLanguageFeatureApi, UrlFormat = @"https://github.com/dotnet/roslyn/issues/84198")]
     public static KeyValuePairElementSyntax KeyValuePairElement(ExpressionSyntax keyExpression, SyntaxToken colonToken, ExpressionSyntax valueExpression)
     {
         if (keyExpression == null) throw new ArgumentNullException(nameof(keyExpression));
@@ -3471,7 +3471,7 @@ public static partial class SyntaxFactory
     }
 
     /// <summary>Creates a new KeyValuePairElementSyntax instance.</summary>
-    [Experimental(global::Microsoft.CodeAnalysis.RoslynExperiments.PreviewLanguageFeatureApi, UrlFormat = @"https://github.com/dotnet/roslyn/issues/84112")]
+    [Experimental(global::Microsoft.CodeAnalysis.RoslynExperiments.PreviewLanguageFeatureApi, UrlFormat = @"https://github.com/dotnet/roslyn/issues/84198")]
     public static KeyValuePairElementSyntax KeyValuePairElement(ExpressionSyntax keyExpression, ExpressionSyntax valueExpression)
         => SyntaxFactory.KeyValuePairElement(keyExpression, SyntaxFactory.Token(SyntaxKind.ColonToken), valueExpression);
 

--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Syntax.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Syntax.Generated.cs
@@ -4279,7 +4279,7 @@ public sealed partial class SpreadElementSyntax : CollectionElementSyntax
 /// <item><description><see cref="SyntaxKind.KeyValuePairElement"/></description></item>
 /// </list>
 /// </remarks>
-[Experimental(global::Microsoft.CodeAnalysis.RoslynExperiments.PreviewLanguageFeatureApi, UrlFormat = @"https://github.com/dotnet/roslyn/issues/84112")]
+[Experimental(global::Microsoft.CodeAnalysis.RoslynExperiments.PreviewLanguageFeatureApi, UrlFormat = @"https://github.com/dotnet/roslyn/issues/84198")]
 public sealed partial class KeyValuePairElementSyntax : CollectionElementSyntax
 {
     private ExpressionSyntax? keyExpression;

--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Syntax.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Syntax.Generated.cs
@@ -4279,6 +4279,7 @@ public sealed partial class SpreadElementSyntax : CollectionElementSyntax
 /// <item><description><see cref="SyntaxKind.KeyValuePairElement"/></description></item>
 /// </list>
 /// </remarks>
+[Experimental(global::Microsoft.CodeAnalysis.RoslynExperiments.PreviewLanguageFeatureApi, UrlFormat = @"https://github.com/dotnet/roslyn/issues/84112")]
 public sealed partial class KeyValuePairElementSyntax : CollectionElementSyntax
 {
     private ExpressionSyntax? keyExpression;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
@@ -586,6 +586,48 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        private BoundExpression VisitDictionaryInterfaceCollectionExpression(BoundCollectionExpression node)
+        {
+            Debug.Assert(!_inExpressionLambda);
+            Debug.Assert(_factory.ModuleBuilderOpt is { });
+            Debug.Assert(_diagnostics.DiagnosticBag is { });
+            Debug.Assert(node.Type is NamedTypeSymbol);
+            Debug.Assert(node.CollectionCreation is BoundObjectCreationExpression);
+            Debug.Assert(node.Placeholder is { });
+
+            var interfaceType = (NamedTypeSymbol)node.Type;
+            var typeArguments = interfaceType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics;
+            var collectionType = _factory.WellKnownType(WellKnownType.System_Collections_Generic_Dictionary_KV).Construct(typeArguments);
+
+            // Dictionary<K, V> dictionary = new(args);
+            var rewrittenReceiver = VisitExpression(node.CollectionCreation);
+            var collection = PopulateDictionary(node, collectionType, rewrittenReceiver);
+
+            if ((object)interfaceType.OriginalDefinition == _compilation.GetWellKnownType(WellKnownType.System_Collections_Generic_IReadOnlyDictionary_KV))
+            {
+                // new ReadOnlyDictionary<K, V>((IDictionary<K, V>)dictionary)
+                var readOnlyDictionaryType = _factory.WellKnownType(WellKnownType.System_Collections_ObjectModel_ReadOnlyDictionary_KV).Construct(typeArguments);
+                var readOnlyDictionaryConstructor = ((MethodSymbol)_factory.WellKnownMember(WellKnownMember.System_Collections_ObjectModel_ReadOnlyDictionary_KV__ctor)).AsMember(readOnlyDictionaryType);
+                TypeSymbol readOnlyDictionaryParameterType = readOnlyDictionaryConstructor.Parameters[0].Type;
+                var readOnlyDictionaryParameterConversion = _factory.ClassifyEmitConversion(collection, readOnlyDictionaryParameterType);
+                Debug.Assert(readOnlyDictionaryParameterConversion is { IsImplicit: true, IsReference: true });
+                collection = _factory.New(
+                    readOnlyDictionaryConstructor,
+                    _factory.Convert(
+                        readOnlyDictionaryParameterType,
+                        collection,
+                        readOnlyDictionaryParameterConversion));
+            }
+
+            var resultConversion = _factory.ClassifyEmitConversion(collection, interfaceType);
+            Debug.Assert(resultConversion is { IsImplicit: true, IsReference: true });
+            return _factory.Convert(interfaceType, collection, resultConversion);
+        }
+
+        /// <summary>
+        /// Populate a dictionary from a collection expression.
+        /// The collection may or may not have a known length.
+        /// </summary>
         private BoundExpression VisitCollectionBuilderCollectionExpression(BoundCollectionExpression node)
         {
             Debug.Assert(!_inExpressionLambda);
@@ -1381,6 +1423,208 @@ namespace Microsoft.CodeAnalysis.CSharp
                 collectionType);
         }
 
+        private BoundExpression VisitImplementsIEnumerableWithIndexerCollectionExpression(BoundCollectionExpression node, NamedTypeSymbol collectionType)
+        {
+            Debug.Assert(!_inExpressionLambda);
+            Debug.Assert(node.CollectionTypeKind == CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer);
+            Debug.Assert(node.CollectionBuilderElementsPlaceholder is null);
+
+            var rewrittenReceiver = VisitExpression(node.CollectionCreation);
+            Debug.Assert(rewrittenReceiver is { });
+            return PopulateDictionary(node, collectionType, rewrittenReceiver);
+        }
+
+        private BoundExpression PopulateDictionary(BoundCollectionExpression node, NamedTypeSymbol collectionType, BoundExpression rewrittenReceiver)
+        {
+            var elements = node.Elements;
+            var localsBuilder = ArrayBuilder<LocalSymbol>.GetInstance();
+            var sideEffects = ArrayBuilder<BoundExpression>.GetInstance(elements.Length + 1);
+
+            // Create a temp for the dictionary.
+            BoundAssignmentOperator assignmentToTemp;
+            BoundLocal dictionaryTemp = _factory.StoreToTemp(rewrittenReceiver, out assignmentToTemp);
+            localsBuilder.Add(dictionaryTemp.LocalSymbol);
+            sideEffects.Add(assignmentToTemp);
+
+            var placeholder = node.Placeholder;
+            var setMethod = node.IndexerSetMethod;
+            Debug.Assert(placeholder is { });
+            Debug.Assert(setMethod is { });
+
+            AddPlaceholderReplacement(placeholder, dictionaryTemp);
+
+            foreach (var element in elements)
+            {
+                switch (element)
+                {
+                    case BoundKeyValuePairElement keyValuePairElement:
+                        {
+                            // dictionary[key] = value;
+                            VisitAndRewriteKeyValuePairElement(keyValuePairElement, out var rewrittenKey, out var rewrittenValue);
+                            sideEffects.Add(
+                                _factory.Call(
+                                    dictionaryTemp,
+                                    setMethod,
+                                    rewrittenKey,
+                                    rewrittenValue));
+                        }
+                        break;
+                    case BoundKeyValuePairConversion keyValuePairConversion:
+                        // dictionary[(TKey)element.Key] = (TValue)element.Value;
+                        assignItemFromKeyValuePairConversion(keyValuePairConversion, dictionaryTemp, setMethod, localsBuilder, sideEffects);
+                        break;
+                    case BoundExpression expressionElement:
+                        // dictionary[element.Key] = element.Value;
+                        assignItemFromExpression(expressionElement, dictionaryTemp, setMethod, localsBuilder, sideEffects);
+                        break;
+                    case BoundCollectionExpressionSpreadElement spreadElement:
+                        {
+                            var rewrittenExpression = VisitExpression(spreadElement.Expression);
+                            var rewrittenElement = MakeCollectionExpressionSpreadElement(
+                                spreadElement,
+                                rewrittenExpression,
+                                iteratorBody =>
+                                {
+                                    var localsBuilder = ArrayBuilder<LocalSymbol>.GetInstance();
+                                    var sideEffects = ArrayBuilder<BoundExpression>.GetInstance();
+                                    var expr = ((BoundExpressionStatement)iteratorBody).Expression;
+                                    switch (expr)
+                                    {
+                                        case BoundKeyValuePairConversion keyValuePairConversion:
+                                            // dictionary[(TKey)item.Key] = (TValue)item.Value;
+                                            assignItemFromKeyValuePairConversion(keyValuePairConversion, dictionaryTemp, setMethod, localsBuilder, sideEffects);
+                                            break;
+                                        case BoundExpression expressionElement:
+                                            // dictionary[element.Key] = element.Value;
+                                            assignItemFromExpression(expressionElement, dictionaryTemp, setMethod, localsBuilder, sideEffects);
+                                            break;
+                                        default:
+                                            throw ExceptionUtilities.UnexpectedValue(element);
+                                    }
+                                    var locals = localsBuilder.ToImmutableAndFree();
+                                    var statements = sideEffects.SelectAsArray(expr => (BoundStatement)new BoundExpressionStatement(expr.Syntax, expr));
+                                    sideEffects.Free();
+                                    return new BoundBlock(iteratorBody.Syntax, locals, statements);
+                                });
+                            sideEffects.Add(rewrittenElement);
+                        }
+                        break;
+                    default:
+                        throw ExceptionUtilities.UnexpectedValue(element);
+                }
+            }
+
+            RemovePlaceholderReplacement(placeholder);
+
+            return new BoundSequence(
+                node.Syntax,
+                localsBuilder.ToImmutableAndFree(),
+                sideEffects.ToImmutableAndFree(),
+                dictionaryTemp,
+                collectionType);
+
+            // dictionary[(TKey)kvp.Key] = (TValue)kvp.Value;
+            void assignItemFromKeyValuePairConversion(
+                BoundKeyValuePairConversion keyValuePairConversion,
+                BoundLocal dictionaryTemp,
+                MethodSymbol setMethod,
+                ArrayBuilder<LocalSymbol> localsBuilder,
+                ArrayBuilder<BoundExpression> sideEffects)
+            {
+                VisitAndRewriteKeyValuePairConversion(keyValuePairConversion, out var rewrittenKeyConversion, out var rewrittenValueConversion, localsBuilder, sideEffects);
+                var assignment = _factory.Call(
+                    dictionaryTemp,
+                    setMethod,
+                    rewrittenKeyConversion,
+                    rewrittenValueConversion);
+                sideEffects.Add(assignment);
+            }
+
+            // dictionary[expr.Key] = expr.Value;
+            void assignItemFromExpression(
+                BoundExpression expression,
+                BoundLocal dictionaryTemp,
+                MethodSymbol setMethod,
+                ArrayBuilder<LocalSymbol> localsBuilder,
+                ArrayBuilder<BoundExpression> sideEffects)
+            {
+                var rewrittenExpression = VisitExpression(expression);
+
+                BoundAssignmentOperator assignmentToTemp;
+                BoundLocal exprTemp = _factory.StoreToTemp(rewrittenExpression, out assignmentToTemp);
+                localsBuilder.Add(exprTemp.LocalSymbol);
+                sideEffects.Add(assignmentToTemp);
+
+                var getKey = GetKeyValuePairKeyOrValue(exprTemp, WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Key);
+                var getValue = GetKeyValuePairKeyOrValue(exprTemp, WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Value);
+                var assignment = _factory.Call(
+                    dictionaryTemp,
+                    setMethod,
+                    getKey,
+                    getValue);
+                sideEffects.Add(assignment);
+            }
+        }
+
+        private void VisitAndRewriteKeyValuePairElement(
+            BoundKeyValuePairElement keyValuePairElement,
+            out BoundExpression rewrittenKey,
+            out BoundExpression rewrittenValue)
+        {
+            rewrittenKey = VisitExpression(keyValuePairElement.Key);
+            rewrittenValue = VisitExpression(keyValuePairElement.Value);
+        }
+
+        private void VisitAndRewriteKeyValuePairConversion(
+            BoundKeyValuePairConversion keyValuePairConversion,
+            out BoundExpression rewrittenKeyConversion,
+            out BoundExpression rewrittenValueConversion,
+            ArrayBuilder<LocalSymbol> localsBuilder,
+            ArrayBuilder<BoundExpression> sideEffects)
+        {
+            var rewrittenExpression = VisitExpression(keyValuePairConversion.Expression);
+
+            BoundAssignmentOperator assignmentToTemp;
+            BoundLocal exprTemp = _factory.StoreToTemp(rewrittenExpression, out assignmentToTemp);
+            localsBuilder.Add(exprTemp.LocalSymbol);
+            sideEffects.Add(assignmentToTemp);
+
+            AddPlaceholderReplacement(keyValuePairConversion.KeyPlaceholder, GetKeyValuePairKeyOrValue(exprTemp, WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Key));
+            rewrittenKeyConversion = VisitExpression(keyValuePairConversion.KeyConversion);
+            RemovePlaceholderReplacement(keyValuePairConversion.KeyPlaceholder);
+
+            AddPlaceholderReplacement(keyValuePairConversion.ValuePlaceholder, GetKeyValuePairKeyOrValue(exprTemp, WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Value));
+            rewrittenValueConversion = VisitExpression(keyValuePairConversion.ValueConversion);
+            RemovePlaceholderReplacement(keyValuePairConversion.ValuePlaceholder);
+        }
+
+        private BoundExpression GetKeyValuePairKeyOrValue(
+            BoundExpression rewrittenExpression,
+            WellKnownMember getKeyOrValueMember)
+        {
+            Debug.Assert(getKeyOrValueMember is
+                WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Key or
+                WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Value);
+            Debug.Assert(rewrittenExpression.Type is { });
+            Debug.Assert(ConversionsBase.IsKeyValuePairType(_compilation, rewrittenExpression.Type, out _, out _));
+
+            var keyValuePairType = (NamedTypeSymbol)rewrittenExpression.Type;
+            var getMethod = _factory.WellKnownMethod(getKeyOrValueMember).AsMember(keyValuePairType);
+            return _factory.Call(rewrittenExpression, getMethod);
+        }
+
+        private BoundExpression CreateKeyValuePair(
+            BoundExpression key,
+            BoundExpression value)
+        {
+            Debug.Assert(key.Type is { });
+            Debug.Assert(value.Type is { });
+
+            var constructor = (MethodSymbol)_factory.WellKnownMember(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__ctor);
+            var type = constructor.ContainingType.Construct(key.Type, value.Type);
+            constructor = constructor.AsMember(type);
+            return _factory.New(constructor, key, value);
+        }
         private BoundExpression VisitAndRewriteCollectionElementExpression(BoundNode element, bool allowSpreadElement)
         {
             switch (element)
@@ -1395,6 +1639,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                 default:
                     throw ExceptionUtilities.UnexpectedValue(element);
             }
+        }
+
+        public override BoundNode? VisitKeyValuePairConversion(BoundKeyValuePairConversion node)
+        {
+            var localsBuilder = ArrayBuilder<LocalSymbol>.GetInstance();
+            var sideEffects = ArrayBuilder<BoundExpression>.GetInstance();
+            VisitAndRewriteKeyValuePairConversion(node, out var rewrittenKeyConversion, out var rewrittenValueConversion, localsBuilder, sideEffects);
+            var value = CreateKeyValuePair(rewrittenKeyConversion, rewrittenValueConversion);
+            Debug.Assert(value.Type is { });
+            var locals = localsBuilder.ToImmutableAndFree();
+            return new BoundSequence(
+                node.Syntax,
+                locals,
+                sideEffects.ToImmutableAndFree(),
+                value,
+                value.Type);
         }
 
         private void VisitAndRewriteCollectionExpressionElementsIntoTemporaries(
@@ -1609,265 +1869,5 @@ namespace Microsoft.CodeAnalysis.CSharp
                 result: _factory.Literal(0)); // result is unused
         }
 
-        private BoundExpression VisitImplementsIEnumerableWithIndexerCollectionExpression(BoundCollectionExpression node, NamedTypeSymbol collectionType)
-        {
-            Debug.Assert(!_inExpressionLambda);
-            Debug.Assert(node.CollectionTypeKind == CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer);
-            Debug.Assert(node.CollectionBuilderElementsPlaceholder is null);
-
-            var rewrittenReceiver = VisitExpression(node.CollectionCreation);
-            Debug.Assert(rewrittenReceiver is { });
-            return PopulateDictionary(node, collectionType, rewrittenReceiver);
-        }
-
-        private BoundExpression VisitDictionaryInterfaceCollectionExpression(BoundCollectionExpression node)
-        {
-            Debug.Assert(!_inExpressionLambda);
-            Debug.Assert(_factory.ModuleBuilderOpt is { });
-            Debug.Assert(_diagnostics.DiagnosticBag is { });
-            Debug.Assert(node.Type is NamedTypeSymbol);
-            Debug.Assert(node.CollectionCreation is BoundObjectCreationExpression);
-            Debug.Assert(node.Placeholder is { });
-
-            var interfaceType = (NamedTypeSymbol)node.Type;
-            var typeArguments = interfaceType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics;
-            var collectionType = _factory.WellKnownType(WellKnownType.System_Collections_Generic_Dictionary_KV).Construct(typeArguments);
-
-            // Dictionary<K, V> dictionary = new(args);
-            var rewrittenReceiver = VisitExpression(node.CollectionCreation);
-            var collection = PopulateDictionary(node, collectionType, rewrittenReceiver);
-
-            if ((object)interfaceType.OriginalDefinition == _compilation.GetWellKnownType(WellKnownType.System_Collections_Generic_IReadOnlyDictionary_KV))
-            {
-                // new ReadOnlyDictionary<K, V>((IDictionary<K, V>)dictionary)
-                var readOnlyDictionaryType = _factory.WellKnownType(WellKnownType.System_Collections_ObjectModel_ReadOnlyDictionary_KV).Construct(typeArguments);
-                var readOnlyDictionaryConstructor = ((MethodSymbol)_factory.WellKnownMember(WellKnownMember.System_Collections_ObjectModel_ReadOnlyDictionary_KV__ctor)).AsMember(readOnlyDictionaryType);
-                TypeSymbol readOnlyDictionaryParameterType = readOnlyDictionaryConstructor.Parameters[0].Type;
-                var readOnlyDictionaryParameterConversion = _factory.ClassifyEmitConversion(collection, readOnlyDictionaryParameterType);
-                Debug.Assert(readOnlyDictionaryParameterConversion is { IsImplicit: true, IsReference: true });
-                collection = _factory.New(
-                    readOnlyDictionaryConstructor,
-                    _factory.Convert(
-                        readOnlyDictionaryParameterType,
-                        collection,
-                        readOnlyDictionaryParameterConversion));
-            }
-
-            var resultConversion = _factory.ClassifyEmitConversion(collection, interfaceType);
-            Debug.Assert(resultConversion is { IsImplicit: true, IsReference: true });
-            return _factory.Convert(interfaceType, collection, resultConversion);
-        }
-
-        /// <summary>
-        /// Populate a dictionary from a collection expression.
-        /// The collection may or may not have a known length.
-        /// </summary>
-        private BoundExpression PopulateDictionary(BoundCollectionExpression node, NamedTypeSymbol collectionType, BoundExpression rewrittenReceiver)
-        {
-            var elements = node.Elements;
-            var localsBuilder = ArrayBuilder<LocalSymbol>.GetInstance();
-            var sideEffects = ArrayBuilder<BoundExpression>.GetInstance(elements.Length + 1);
-
-            // Create a temp for the dictionary.
-            BoundAssignmentOperator assignmentToTemp;
-            BoundLocal dictionaryTemp = _factory.StoreToTemp(rewrittenReceiver, out assignmentToTemp);
-            localsBuilder.Add(dictionaryTemp.LocalSymbol);
-            sideEffects.Add(assignmentToTemp);
-
-            var placeholder = node.Placeholder;
-            var setMethod = node.IndexerSetMethod;
-            Debug.Assert(placeholder is { });
-            Debug.Assert(setMethod is { });
-
-            AddPlaceholderReplacement(placeholder, dictionaryTemp);
-
-            foreach (var element in elements)
-            {
-                switch (element)
-                {
-                    case BoundKeyValuePairElement keyValuePairElement:
-                        {
-                            // dictionary[key] = value;
-                            VisitAndRewriteKeyValuePairElement(keyValuePairElement, out var rewrittenKey, out var rewrittenValue);
-                            sideEffects.Add(
-                                _factory.Call(
-                                    dictionaryTemp,
-                                    setMethod,
-                                    rewrittenKey,
-                                    rewrittenValue));
-                        }
-                        break;
-                    case BoundKeyValuePairConversion keyValuePairConversion:
-                        // dictionary[(TKey)element.Key] = (TValue)element.Value;
-                        assignItemFromKeyValuePairConversion(keyValuePairConversion, dictionaryTemp, setMethod, localsBuilder, sideEffects);
-                        break;
-                    case BoundExpression expressionElement:
-                        // dictionary[element.Key] = element.Value;
-                        assignItemFromExpression(expressionElement, dictionaryTemp, setMethod, localsBuilder, sideEffects);
-                        break;
-                    case BoundCollectionExpressionSpreadElement spreadElement:
-                        {
-                            var rewrittenExpression = VisitExpression(spreadElement.Expression);
-                            var rewrittenElement = MakeCollectionExpressionSpreadElement(
-                                spreadElement,
-                                rewrittenExpression,
-                                iteratorBody =>
-                                {
-                                    var localsBuilder = ArrayBuilder<LocalSymbol>.GetInstance();
-                                    var sideEffects = ArrayBuilder<BoundExpression>.GetInstance();
-                                    var expr = ((BoundExpressionStatement)iteratorBody).Expression;
-                                    switch (expr)
-                                    {
-                                        case BoundKeyValuePairConversion keyValuePairConversion:
-                                            // dictionary[(TKey)item.Key] = (TValue)item.Value;
-                                            assignItemFromKeyValuePairConversion(keyValuePairConversion, dictionaryTemp, setMethod, localsBuilder, sideEffects);
-                                            break;
-                                        case BoundExpression expressionElement:
-                                            // dictionary[element.Key] = element.Value;
-                                            assignItemFromExpression(expressionElement, dictionaryTemp, setMethod, localsBuilder, sideEffects);
-                                            break;
-                                        default:
-                                            throw ExceptionUtilities.UnexpectedValue(element);
-                                    }
-                                    var locals = localsBuilder.ToImmutableAndFree();
-                                    var statements = sideEffects.SelectAsArray(expr => (BoundStatement)new BoundExpressionStatement(expr.Syntax, expr));
-                                    sideEffects.Free();
-                                    return new BoundBlock(iteratorBody.Syntax, locals, statements);
-                                });
-                            sideEffects.Add(rewrittenElement);
-                        }
-                        break;
-                    default:
-                        throw ExceptionUtilities.UnexpectedValue(element);
-                }
-            }
-
-            RemovePlaceholderReplacement(placeholder);
-
-            return new BoundSequence(
-                node.Syntax,
-                localsBuilder.ToImmutableAndFree(),
-                sideEffects.ToImmutableAndFree(),
-                dictionaryTemp,
-                collectionType);
-
-            // dictionary[(TKey)kvp.Key] = (TValue)kvp.Value;
-            void assignItemFromKeyValuePairConversion(
-                BoundKeyValuePairConversion keyValuePairConversion,
-                BoundLocal dictionaryTemp,
-                MethodSymbol setMethod,
-                ArrayBuilder<LocalSymbol> localsBuilder,
-                ArrayBuilder<BoundExpression> sideEffects)
-            {
-                VisitAndRewriteKeyValuePairConversion(keyValuePairConversion, out var rewrittenKeyConversion, out var rewrittenValueConversion, localsBuilder, sideEffects);
-                var assignment = _factory.Call(
-                    dictionaryTemp,
-                    setMethod,
-                    rewrittenKeyConversion,
-                    rewrittenValueConversion);
-                sideEffects.Add(assignment);
-            }
-
-            // dictionary[expr.Key] = expr.Value;
-            void assignItemFromExpression(
-                BoundExpression expression,
-                BoundLocal dictionaryTemp,
-                MethodSymbol setMethod,
-                ArrayBuilder<LocalSymbol> localsBuilder,
-                ArrayBuilder<BoundExpression> sideEffects)
-            {
-                var rewrittenExpression = VisitExpression(expression);
-
-                BoundAssignmentOperator assignmentToTemp;
-                BoundLocal exprTemp = _factory.StoreToTemp(rewrittenExpression, out assignmentToTemp);
-                localsBuilder.Add(exprTemp.LocalSymbol);
-                sideEffects.Add(assignmentToTemp);
-
-                var getKey = GetKeyValuePairKeyOrValue(exprTemp, WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Key);
-                var getValue = GetKeyValuePairKeyOrValue(exprTemp, WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Value);
-                var assignment = _factory.Call(
-                    dictionaryTemp,
-                    setMethod,
-                    getKey,
-                    getValue);
-                sideEffects.Add(assignment);
-            }
-        }
-
-        private void VisitAndRewriteKeyValuePairElement(
-            BoundKeyValuePairElement keyValuePairElement,
-            out BoundExpression rewrittenKey,
-            out BoundExpression rewrittenValue)
-        {
-            rewrittenKey = VisitExpression(keyValuePairElement.Key);
-            rewrittenValue = VisitExpression(keyValuePairElement.Value);
-        }
-
-        public override BoundNode? VisitKeyValuePairConversion(BoundKeyValuePairConversion node)
-        {
-            var localsBuilder = ArrayBuilder<LocalSymbol>.GetInstance();
-            var sideEffects = ArrayBuilder<BoundExpression>.GetInstance();
-            VisitAndRewriteKeyValuePairConversion(node, out var rewrittenKeyConversion, out var rewrittenValueConversion, localsBuilder, sideEffects);
-            var value = CreateKeyValuePair(rewrittenKeyConversion, rewrittenValueConversion);
-            Debug.Assert(value.Type is { });
-            var locals = localsBuilder.ToImmutableAndFree();
-            return new BoundSequence(
-                node.Syntax,
-                locals,
-                sideEffects.ToImmutableAndFree(),
-                value,
-                value.Type);
-        }
-
-        private void VisitAndRewriteKeyValuePairConversion(
-            BoundKeyValuePairConversion keyValuePairConversion,
-            out BoundExpression rewrittenKeyConversion,
-            out BoundExpression rewrittenValueConversion,
-            ArrayBuilder<LocalSymbol> localsBuilder,
-            ArrayBuilder<BoundExpression> sideEffects)
-        {
-            var rewrittenExpression = VisitExpression(keyValuePairConversion.Expression);
-
-            BoundAssignmentOperator assignmentToTemp;
-            BoundLocal exprTemp = _factory.StoreToTemp(rewrittenExpression, out assignmentToTemp);
-            localsBuilder.Add(exprTemp.LocalSymbol);
-            sideEffects.Add(assignmentToTemp);
-
-            AddPlaceholderReplacement(keyValuePairConversion.KeyPlaceholder, GetKeyValuePairKeyOrValue(exprTemp, WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Key));
-            rewrittenKeyConversion = VisitExpression(keyValuePairConversion.KeyConversion);
-            RemovePlaceholderReplacement(keyValuePairConversion.KeyPlaceholder);
-
-            AddPlaceholderReplacement(keyValuePairConversion.ValuePlaceholder, GetKeyValuePairKeyOrValue(exprTemp, WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Value));
-            rewrittenValueConversion = VisitExpression(keyValuePairConversion.ValueConversion);
-            RemovePlaceholderReplacement(keyValuePairConversion.ValuePlaceholder);
-        }
-
-        private BoundExpression GetKeyValuePairKeyOrValue(
-            BoundExpression rewrittenExpression,
-            WellKnownMember getKeyOrValueMember)
-        {
-            Debug.Assert(getKeyOrValueMember is
-                WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Key or
-                WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Value);
-            Debug.Assert(rewrittenExpression.Type is { });
-            Debug.Assert(ConversionsBase.IsKeyValuePairType(_compilation, rewrittenExpression.Type, out _, out _));
-
-            var keyValuePairType = (NamedTypeSymbol)rewrittenExpression.Type;
-            var getMethod = _factory.WellKnownMethod(getKeyOrValueMember).AsMember(keyValuePairType);
-            return _factory.Call(rewrittenExpression, getMethod);
-        }
-
-        private BoundExpression CreateKeyValuePair(
-            BoundExpression key,
-            BoundExpression value)
-        {
-            Debug.Assert(key.Type is { });
-            Debug.Assert(value.Type is { });
-
-            var constructor = (MethodSymbol)_factory.WellKnownMember(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__ctor);
-            var type = constructor.ContainingType.Construct(key.Type, value.Type);
-            constructor = constructor.AsMember(type);
-            return _factory.New(constructor, key, value);
-        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
@@ -269,7 +269,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (collectionType is ArrayTypeSymbol arrayType)
             {
-                Debug.Assert(node.Elements.All(e => e is BoundExpression));
+                Debug.Assert(node.Elements.All(e => e is BoundExpression or BoundCollectionExpressionSpreadElement));
                 return createArray(node, arrayType, targetsReadOnlyCollection: false);
             }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
@@ -26,6 +26,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             throw ExceptionUtilities.Unreachable();
         }
 
+        public override BoundNode? VisitKeyValuePairElement(BoundKeyValuePairElement node)
+        {
+            throw ExceptionUtilities.Unreachable();
+        }
+
         private BoundExpression RewriteCollectionExpressionConversion(Conversion conversion, BoundCollectionExpression node)
         {
             Debug.Assert(conversion.Kind == ConversionKind.CollectionExpression);
@@ -76,6 +81,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                         }
                         return VisitCollectionInitializerCollectionExpression(node, node.Type);
+                    case CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer:
+                        return VisitImplementsIEnumerableWithIndexerCollectionExpression(node, (NamedTypeSymbol)node.Type);
                     case CollectionExpressionTypeKind.Array:
                     case CollectionExpressionTypeKind.Span:
                     case CollectionExpressionTypeKind.ReadOnlySpan:
@@ -260,6 +267,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (collectionType is ArrayTypeSymbol arrayType)
             {
+                Debug.Assert(node.Elements.All(e => e is BoundExpression));
                 return createArray(node, arrayType, targetsReadOnlyCollection: false);
             }
 
@@ -640,7 +648,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool asReadOnlySpan)
         {
             Debug.Assert(elements.Length > 0);
-            Debug.Assert(elements.All(e => e is BoundExpression));
+            Debug.Assert(elements.All(e => e is BoundExpression or BoundKeyValuePairConversion));
             Debug.Assert(_factory.ModuleBuilderOpt is { });
             Debug.Assert(_diagnostics.DiagnosticBag is { });
             Debug.Assert(_compilation.Assembly.RuntimeSupportsInlineArrayTypes);
@@ -657,7 +665,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     .WellKnownType(asReadOnlySpan ? WellKnownType.System_ReadOnlySpan_T : WellKnownType.System_Span_T)
                     .Construct([elementType]);
                 var constructor = spanRefConstructor.AsMember(spanType);
-                var element = VisitExpression((BoundExpression)elements[0]);
+                var element = VisitAndRewriteCollectionElementExpression((BoundExpression)elements[0], allowSpreadElement: false);
                 var temp = _factory.StoreToTemp(element, out var assignment);
                 _additionalLocals.Add(temp.LocalSymbol);
                 var call = _factory.New(constructor, arguments: [temp], argumentRefKinds: [asReadOnlySpan ? RefKindExtensions.StrictIn : RefKind.Ref]);
@@ -685,7 +693,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // ...
             for (int i = 0; i < arrayLength; i++)
             {
-                var element = VisitExpression((BoundExpression)elements[i]);
+                var element = VisitAndRewriteCollectionElementExpression((BoundExpression)elements[i], allowSpreadElement: false);
                 var call = _factory.Call(null, elementRef, inlineArrayLocal, _factory.Literal(i), useStrictArgumentRefKinds: true);
                 var assignment = new BoundAssignmentOperator(syntax, call, element, type: call.Type) { WasCompilerGenerated = true };
                 sideEffects.Add(assignment);
@@ -849,7 +857,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var initialization = new BoundArrayInitialization(
                     syntax,
                     isInferred: false,
-                    elements.SelectAsArray(static (element, rewriter) => rewriter.VisitExpression((BoundExpression)element), this));
+                    elements.SelectAsArray(static (element, rewriter) => rewriter.VisitAndRewriteCollectionElementExpression(element, allowSpreadElement: false), this));
                 return new BoundArrayCreation(
                     syntax,
                     ImmutableArray.Create<BoundExpression>(
@@ -866,7 +874,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var localsBuilder = ArrayBuilder<BoundLocal>.GetInstance();
             var sideEffects = ArrayBuilder<BoundExpression>.GetInstance();
 
-            RewriteCollectionExpressionElementsIntoTemporaries(elements, numberIncludingLastSpread, localsBuilder, sideEffects);
+            VisitAndRewriteCollectionExpressionElementsIntoTemporaries(elements, numberIncludingLastSpread, localsBuilder, sideEffects);
 
             // indexTemp is null when we can use constant compile-time indices.
             // indexTemp is non-null when we need a runtime-tracked index variable (for spread elements).
@@ -1170,7 +1178,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // we're already instantiating.  In that case, our caller has already figured out the value and just wants
             // us to add the elements to it.
             var useKnownLength = ShouldUseKnownLength(node, out var numberIncludingLastSpread) && rewrittenReceiver is null;
-            RewriteCollectionExpressionElementsIntoTemporaries(elements, numberIncludingLastSpread, localsBuilder, sideEffects);
+            VisitAndRewriteCollectionExpressionElementsIntoTemporaries(elements, numberIncludingLastSpread, localsBuilder, sideEffects);
 
             bool useOptimizations = false;
             MethodSymbol? setCount = null;
@@ -1368,15 +1376,23 @@ namespace Microsoft.CodeAnalysis.CSharp
                 collectionType);
         }
 
-        private BoundExpression RewriteCollectionExpressionElementExpression(BoundNode element)
+        private BoundExpression VisitAndRewriteCollectionElementExpression(BoundNode element, bool allowSpreadElement)
         {
-            var expression = element is BoundCollectionExpressionSpreadElement spreadElement ?
-                spreadElement.Expression :
-                (BoundExpression)element;
-            return VisitExpression(expression);
+            switch (element)
+            {
+                case BoundKeyValuePairElement keyValuePairElement:
+                    VisitAndRewriteKeyValuePairElement(keyValuePairElement, out var rewrittenKey, out var rewrittenValue);
+                    return CreateKeyValuePair(rewrittenKey, rewrittenValue);
+                case BoundExpression expression:
+                    return VisitExpression(expression);
+                case BoundCollectionExpressionSpreadElement spreadElement when allowSpreadElement:
+                    return VisitExpression(spreadElement.Expression);
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(element);
+            }
         }
 
-        private void RewriteCollectionExpressionElementsIntoTemporaries(
+        private void VisitAndRewriteCollectionExpressionElementsIntoTemporaries(
             ImmutableArray<BoundNode> elements,
             int numberIncludingLastSpread,
             ArrayBuilder<BoundLocal> locals,
@@ -1384,7 +1400,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             for (int i = 0; i < numberIncludingLastSpread; i++)
             {
-                var rewrittenExpression = RewriteCollectionExpressionElementExpression(elements[i]);
+                var rewrittenExpression = VisitAndRewriteCollectionElementExpression(elements[i], allowSpreadElement: true);
                 BoundAssignmentOperator assignmentToTemp;
                 BoundLocal temp = _factory.StoreToTemp(rewrittenExpression, out assignmentToTemp);
                 locals.Add(temp);
@@ -1406,7 +1422,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var element = elements[i];
                 var rewrittenExpression = i < numberIncludingLastSpread ?
                     rewrittenExpressions[i] :
-                    RewriteCollectionExpressionElementExpression(element);
+                    VisitAndRewriteCollectionElementExpression(element, allowSpreadElement: true);
 
                 if (element is BoundCollectionExpressionSpreadElement spreadElement)
                 {
@@ -1418,7 +1434,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         rewrittenExpression,
                         iteratorBody =>
                         {
-                            var rewrittenValue = VisitExpression(((BoundExpressionStatement)iteratorBody).Expression);
+                            var rewrittenValue = VisitAndRewriteCollectionElementExpression(((BoundExpressionStatement)iteratorBody).Expression, allowSpreadElement: false);
                             var builder = ArrayBuilder<BoundExpression>.GetInstance();
                             addElement(builder, rewrittenReceiver, rewrittenValue, false);
                             var statements = builder.SelectAsArray(expr => (BoundStatement)new BoundExpressionStatement(expr.Syntax, expr));
@@ -1586,6 +1602,267 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ImmutableArray<LocalSymbol>.Empty,
                 ImmutableArray.Create(statement),
                 result: _factory.Literal(0)); // result is unused
+        }
+
+        private BoundExpression VisitImplementsIEnumerableWithIndexerCollectionExpression(BoundCollectionExpression node, NamedTypeSymbol collectionType)
+        {
+            Debug.Assert(!_inExpressionLambda);
+            Debug.Assert(node.CollectionTypeKind == CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer);
+            Debug.Assert(node.CollectionBuilderElementsPlaceholder is null);
+
+            var rewrittenReceiver = VisitExpression(node.CollectionCreation);
+            Debug.Assert(rewrittenReceiver is { });
+            return PopulateDictionary(node, collectionType, rewrittenReceiver);
+        }
+
+        private BoundExpression VisitDictionaryInterfaceCollectionExpression(BoundCollectionExpression node)
+        {
+            Debug.Assert(!_inExpressionLambda);
+            Debug.Assert(_factory.ModuleBuilderOpt is { });
+            Debug.Assert(_diagnostics.DiagnosticBag is { });
+            Debug.Assert(node.Type is NamedTypeSymbol);
+            Debug.Assert(node.CollectionCreation is BoundObjectCreationExpression);
+            Debug.Assert(node.Placeholder is { });
+
+            var interfaceType = (NamedTypeSymbol)node.Type;
+            var typeArguments = interfaceType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics;
+            var collectionType = _factory.WellKnownType(WellKnownType.System_Collections_Generic_Dictionary_KV).Construct(typeArguments);
+
+            // Dictionary<K, V> dictionary = new(args);
+            var rewrittenReceiver = VisitExpression(node.CollectionCreation);
+            var collection = PopulateDictionary(node, collectionType, rewrittenReceiver);
+
+            if ((object)interfaceType.OriginalDefinition == _compilation.GetWellKnownType(WellKnownType.System_Collections_Generic_IReadOnlyDictionary_KV))
+            {
+                // new ReadOnlyDictionary<K, V>((IDictionary<K, V>)dictionary)
+                var readOnlyDictionaryType = _factory.WellKnownType(WellKnownType.System_Collections_ObjectModel_ReadOnlyDictionary_KV).Construct(typeArguments);
+                var readOnlyDictionaryConstructor = ((MethodSymbol)_factory.WellKnownMember(WellKnownMember.System_Collections_ObjectModel_ReadOnlyDictionary_KV__ctor)).AsMember(readOnlyDictionaryType);
+                TypeSymbol readOnlyDictionaryParameterType = readOnlyDictionaryConstructor.Parameters[0].Type;
+                var readOnlyDictionaryParameterConversion = _factory.ClassifyEmitConversion(collection, readOnlyDictionaryParameterType);
+                Debug.Assert(readOnlyDictionaryParameterConversion is { IsImplicit: true, IsReference: true });
+                collection = _factory.New(
+                    readOnlyDictionaryConstructor,
+                    _factory.Convert(
+                        readOnlyDictionaryParameterType,
+                        collection,
+                        readOnlyDictionaryParameterConversion));
+            }
+
+            var resultConversion = _factory.ClassifyEmitConversion(collection, interfaceType);
+            Debug.Assert(resultConversion is { IsImplicit: true, IsReference: true });
+            return _factory.Convert(interfaceType, collection, resultConversion);
+        }
+
+        /// <summary>
+        /// Populate a dictionary from a collection expression.
+        /// The collection may or may not have a known length.
+        /// </summary>
+        private BoundExpression PopulateDictionary(BoundCollectionExpression node, NamedTypeSymbol collectionType, BoundExpression rewrittenReceiver)
+        {
+            var elements = node.Elements;
+            var localsBuilder = ArrayBuilder<LocalSymbol>.GetInstance();
+            var sideEffects = ArrayBuilder<BoundExpression>.GetInstance(elements.Length + 1);
+
+            // Create a temp for the dictionary.
+            BoundAssignmentOperator assignmentToTemp;
+            BoundLocal dictionaryTemp = _factory.StoreToTemp(rewrittenReceiver, out assignmentToTemp);
+            localsBuilder.Add(dictionaryTemp.LocalSymbol);
+            sideEffects.Add(assignmentToTemp);
+
+            var placeholder = node.Placeholder;
+            var setMethod = node.IndexerSetMethod;
+            Debug.Assert(placeholder is { });
+            Debug.Assert(setMethod is { });
+
+            AddPlaceholderReplacement(placeholder, dictionaryTemp);
+
+            foreach (var element in elements)
+            {
+                switch (element)
+                {
+                    case BoundKeyValuePairElement keyValuePairElement:
+                        {
+                            // dictionary[key] = value;
+                            VisitAndRewriteKeyValuePairElement(keyValuePairElement, out var rewrittenKey, out var rewrittenValue);
+                            sideEffects.Add(
+                                _factory.Call(
+                                    dictionaryTemp,
+                                    setMethod,
+                                    rewrittenKey,
+                                    rewrittenValue));
+                        }
+                        break;
+                    case BoundKeyValuePairConversion keyValuePairConversion:
+                        // dictionary[(TKey)element.Key] = (TValue)element.Value;
+                        assignItemFromKeyValuePairConversion(keyValuePairConversion, dictionaryTemp, setMethod, localsBuilder, sideEffects);
+                        break;
+                    case BoundExpression expressionElement:
+                        // dictionary[element.Key] = element.Value;
+                        assignItemFromExpression(expressionElement, dictionaryTemp, setMethod, localsBuilder, sideEffects);
+                        break;
+                    case BoundCollectionExpressionSpreadElement spreadElement:
+                        {
+                            var rewrittenExpression = VisitExpression(spreadElement.Expression);
+                            var rewrittenElement = MakeCollectionExpressionSpreadElement(
+                                spreadElement,
+                                rewrittenExpression,
+                                iteratorBody =>
+                                {
+                                    var localsBuilder = ArrayBuilder<LocalSymbol>.GetInstance();
+                                    var sideEffects = ArrayBuilder<BoundExpression>.GetInstance();
+                                    var expr = ((BoundExpressionStatement)iteratorBody).Expression;
+                                    switch (expr)
+                                    {
+                                        case BoundKeyValuePairConversion keyValuePairConversion:
+                                            // dictionary[(TKey)item.Key] = (TValue)item.Value;
+                                            assignItemFromKeyValuePairConversion(keyValuePairConversion, dictionaryTemp, setMethod, localsBuilder, sideEffects);
+                                            break;
+                                        case BoundExpression expressionElement:
+                                            // dictionary[element.Key] = element.Value;
+                                            assignItemFromExpression(expressionElement, dictionaryTemp, setMethod, localsBuilder, sideEffects);
+                                            break;
+                                        default:
+                                            throw ExceptionUtilities.UnexpectedValue(element);
+                                    }
+                                    var locals = localsBuilder.ToImmutableAndFree();
+                                    var statements = sideEffects.SelectAsArray(expr => (BoundStatement)new BoundExpressionStatement(expr.Syntax, expr));
+                                    sideEffects.Free();
+                                    return new BoundBlock(iteratorBody.Syntax, locals, statements);
+                                });
+                            sideEffects.Add(rewrittenElement);
+                        }
+                        break;
+                    default:
+                        throw ExceptionUtilities.UnexpectedValue(element);
+                }
+            }
+
+            RemovePlaceholderReplacement(placeholder);
+
+            return new BoundSequence(
+                node.Syntax,
+                localsBuilder.ToImmutableAndFree(),
+                sideEffects.ToImmutableAndFree(),
+                dictionaryTemp,
+                collectionType);
+
+            // dictionary[(TKey)kvp.Key] = (TValue)kvp.Value;
+            void assignItemFromKeyValuePairConversion(
+                BoundKeyValuePairConversion keyValuePairConversion,
+                BoundLocal dictionaryTemp,
+                MethodSymbol setMethod,
+                ArrayBuilder<LocalSymbol> localsBuilder,
+                ArrayBuilder<BoundExpression> sideEffects)
+            {
+                VisitAndRewriteKeyValuePairConversion(keyValuePairConversion, out var rewrittenKeyConversion, out var rewrittenValueConversion, localsBuilder, sideEffects);
+                var assignment = _factory.Call(
+                    dictionaryTemp,
+                    setMethod,
+                    rewrittenKeyConversion,
+                    rewrittenValueConversion);
+                sideEffects.Add(assignment);
+            }
+
+            // dictionary[expr.Key] = expr.Value;
+            void assignItemFromExpression(
+                BoundExpression expression,
+                BoundLocal dictionaryTemp,
+                MethodSymbol setMethod,
+                ArrayBuilder<LocalSymbol> localsBuilder,
+                ArrayBuilder<BoundExpression> sideEffects)
+            {
+                var rewrittenExpression = VisitExpression(expression);
+
+                BoundAssignmentOperator assignmentToTemp;
+                BoundLocal exprTemp = _factory.StoreToTemp(rewrittenExpression, out assignmentToTemp);
+                localsBuilder.Add(exprTemp.LocalSymbol);
+                sideEffects.Add(assignmentToTemp);
+
+                var getKey = GetKeyValuePairKeyOrValue(exprTemp, WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Key);
+                var getValue = GetKeyValuePairKeyOrValue(exprTemp, WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Value);
+                var assignment = _factory.Call(
+                    dictionaryTemp,
+                    setMethod,
+                    getKey,
+                    getValue);
+                sideEffects.Add(assignment);
+            }
+        }
+
+        private void VisitAndRewriteKeyValuePairElement(
+            BoundKeyValuePairElement keyValuePairElement,
+            out BoundExpression rewrittenKey,
+            out BoundExpression rewrittenValue)
+        {
+            rewrittenKey = VisitExpression(keyValuePairElement.Key);
+            rewrittenValue = VisitExpression(keyValuePairElement.Value);
+        }
+
+        public override BoundNode? VisitKeyValuePairConversion(BoundKeyValuePairConversion node)
+        {
+            var localsBuilder = ArrayBuilder<LocalSymbol>.GetInstance();
+            var sideEffects = ArrayBuilder<BoundExpression>.GetInstance();
+            VisitAndRewriteKeyValuePairConversion(node, out var rewrittenKeyConversion, out var rewrittenValueConversion, localsBuilder, sideEffects);
+            var value = CreateKeyValuePair(rewrittenKeyConversion, rewrittenValueConversion);
+            Debug.Assert(value.Type is { });
+            var locals = localsBuilder.ToImmutableAndFree();
+            return new BoundSequence(
+                node.Syntax,
+                locals,
+                sideEffects.ToImmutableAndFree(),
+                value,
+                value.Type);
+        }
+
+        private void VisitAndRewriteKeyValuePairConversion(
+            BoundKeyValuePairConversion keyValuePairConversion,
+            out BoundExpression rewrittenKeyConversion,
+            out BoundExpression rewrittenValueConversion,
+            ArrayBuilder<LocalSymbol> localsBuilder,
+            ArrayBuilder<BoundExpression> sideEffects)
+        {
+            var rewrittenExpression = VisitExpression(keyValuePairConversion.Expression);
+
+            BoundAssignmentOperator assignmentToTemp;
+            BoundLocal exprTemp = _factory.StoreToTemp(rewrittenExpression, out assignmentToTemp);
+            localsBuilder.Add(exprTemp.LocalSymbol);
+            sideEffects.Add(assignmentToTemp);
+
+            AddPlaceholderReplacement(keyValuePairConversion.KeyPlaceholder, GetKeyValuePairKeyOrValue(exprTemp, WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Key));
+            rewrittenKeyConversion = VisitExpression(keyValuePairConversion.KeyConversion);
+            RemovePlaceholderReplacement(keyValuePairConversion.KeyPlaceholder);
+
+            AddPlaceholderReplacement(keyValuePairConversion.ValuePlaceholder, GetKeyValuePairKeyOrValue(exprTemp, WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Value));
+            rewrittenValueConversion = VisitExpression(keyValuePairConversion.ValueConversion);
+            RemovePlaceholderReplacement(keyValuePairConversion.ValuePlaceholder);
+        }
+
+        private BoundExpression GetKeyValuePairKeyOrValue(
+            BoundExpression rewrittenExpression,
+            WellKnownMember getKeyOrValueMember)
+        {
+            Debug.Assert(getKeyOrValueMember is
+                WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Key or
+                WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Value);
+            Debug.Assert(rewrittenExpression.Type is { });
+            Debug.Assert(ConversionsBase.IsKeyValuePairType(_compilation, rewrittenExpression.Type, out _, out _));
+
+            var keyValuePairType = (NamedTypeSymbol)rewrittenExpression.Type;
+            var getMethod = _factory.WellKnownMethod(getKeyOrValueMember).AsMember(keyValuePairType);
+            return _factory.Call(rewrittenExpression, getMethod);
+        }
+
+        private BoundExpression CreateKeyValuePair(
+            BoundExpression key,
+            BoundExpression value)
+        {
+            Debug.Assert(key.Type is { });
+            Debug.Assert(value.Type is { });
+
+            var constructor = (MethodSymbol)_factory.WellKnownMember(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__ctor);
+            var type = constructor.ContainingType.Construct(key.Type, value.Type);
+            constructor = constructor.AsMember(type);
+            return _factory.New(constructor, key, value);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
@@ -533,7 +533,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     BoundExpression fieldValue = kind switch
                     {
                         // fieldValue = e1;
-                        SynthesizedReadOnlyListKind.SingleElement => VisitAndRewriteCollectionElementExpression(elements.Single(), allowSpreadElement: false),
+                        SynthesizedReadOnlyListKind.SingleElement => VisitCollectionElementExpression(elements.Single(), allowSpreadElement: false),
                         // fieldValue = new ElementType[] { e1, ..., eN };
                         SynthesizedReadOnlyListKind.Array => createArray(node, ArrayTypeSymbol.CreateSZArray(_compilation.Assembly, elementType)),
                         // fieldValue = new List<ElementType> { e1, ..., eN };
@@ -705,7 +705,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     .WellKnownType(asReadOnlySpan ? WellKnownType.System_ReadOnlySpan_T : WellKnownType.System_Span_T)
                     .Construct([elementType]);
                 var constructor = spanRefConstructor.AsMember(spanType);
-                var element = VisitAndRewriteCollectionElementExpression(elements[0], allowSpreadElement: false);
+                var element = VisitCollectionElementExpression(elements[0], allowSpreadElement: false);
                 var temp = _factory.StoreToTemp(element, out var assignment);
                 _additionalLocals.Add(temp.LocalSymbol);
                 var call = _factory.New(constructor, arguments: [temp], argumentRefKinds: [asReadOnlySpan ? RefKindExtensions.StrictIn : RefKind.Ref]);
@@ -733,7 +733,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // ...
             for (int i = 0; i < arrayLength; i++)
             {
-                var element = VisitAndRewriteCollectionElementExpression(elements[i], allowSpreadElement: false);
+                var element = VisitCollectionElementExpression(elements[i], allowSpreadElement: false);
                 var call = _factory.Call(null, elementRef, inlineArrayLocal, _factory.Literal(i), useStrictArgumentRefKinds: true);
                 var assignment = new BoundAssignmentOperator(syntax, call, element, type: call.Type) { WasCompilerGenerated = true };
                 sideEffects.Add(assignment);
@@ -898,7 +898,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var initialization = new BoundArrayInitialization(
                     syntax,
                     isInferred: false,
-                    elements.SelectAsArray(static (element, rewriter) => rewriter.VisitAndRewriteCollectionElementExpression(element, allowSpreadElement: false), this));
+                    elements.SelectAsArray(static (element, rewriter) => rewriter.VisitCollectionElementExpression(element, allowSpreadElement: false), this));
                 return new BoundArrayCreation(
                     syntax,
                     ImmutableArray.Create<BoundExpression>(
@@ -1459,7 +1459,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case BoundKeyValuePairElement keyValuePairElement:
                         {
                             // dictionary[key] = value;
-                            VisitAndRewriteKeyValuePairElement(keyValuePairElement, out var rewrittenKey, out var rewrittenValue);
+                            VisitKeyValuePairElement(keyValuePairElement, out var rewrittenKey, out var rewrittenValue);
                             sideEffects.Add(
                                 _factory.Call(
                                     dictionaryTemp,
@@ -1530,7 +1530,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ArrayBuilder<LocalSymbol> localsBuilder,
                 ArrayBuilder<BoundExpression> sideEffects)
             {
-                VisitAndRewriteKeyValuePairConversion(keyValuePairConversion, out var rewrittenKeyConversion, out var rewrittenValueConversion, localsBuilder, sideEffects);
+                VisitKeyValuePairConversion(keyValuePairConversion, out var rewrittenKeyConversion, out var rewrittenValueConversion, localsBuilder, sideEffects);
                 var assignment = _factory.Call(
                     dictionaryTemp,
                     setMethod,
@@ -1564,7 +1564,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private void VisitAndRewriteKeyValuePairElement(
+        private void VisitKeyValuePairElement(
             BoundKeyValuePairElement keyValuePairElement,
             out BoundExpression rewrittenKey,
             out BoundExpression rewrittenValue)
@@ -1573,7 +1573,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             rewrittenValue = VisitExpression(keyValuePairElement.Value);
         }
 
-        private void VisitAndRewriteKeyValuePairConversion(
+        private void VisitKeyValuePairConversion(
             BoundKeyValuePairConversion keyValuePairConversion,
             out BoundExpression rewrittenKeyConversion,
             out BoundExpression rewrittenValueConversion,
@@ -1602,7 +1602,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(getKeyOrValueMember is
                 WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Key or
                 WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Value);
-            Debug.Assert(rewrittenExpression.Type is { });
             Debug.Assert(ConversionsBase.IsKeyValuePairType(_compilation, rewrittenExpression.Type, out _, out _));
 
             var keyValuePairType = (NamedTypeSymbol)rewrittenExpression.Type;
@@ -1623,12 +1622,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             return _factory.New(constructor, key, value);
         }
 
-        private BoundExpression VisitAndRewriteCollectionElementExpression(BoundNode element, bool allowSpreadElement)
+        private BoundExpression VisitCollectionElementExpression(BoundNode element, bool allowSpreadElement)
         {
             switch (element)
             {
                 case BoundKeyValuePairElement keyValuePairElement:
-                    VisitAndRewriteKeyValuePairElement(keyValuePairElement, out var rewrittenKey, out var rewrittenValue);
+                    VisitKeyValuePairElement(keyValuePairElement, out var rewrittenKey, out var rewrittenValue);
                     return CreateKeyValuePair(rewrittenKey, rewrittenValue);
                 case BoundExpression expression:
                     return VisitExpression(expression);
@@ -1643,7 +1642,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var localsBuilder = ArrayBuilder<LocalSymbol>.GetInstance();
             var sideEffects = ArrayBuilder<BoundExpression>.GetInstance();
-            VisitAndRewriteKeyValuePairConversion(node, out var rewrittenKeyConversion, out var rewrittenValueConversion, localsBuilder, sideEffects);
+            VisitKeyValuePairConversion(node, out var rewrittenKeyConversion, out var rewrittenValueConversion, localsBuilder, sideEffects);
             var value = CreateKeyValuePair(rewrittenKeyConversion, rewrittenValueConversion);
             Debug.Assert(value.Type is { });
             var locals = localsBuilder.ToImmutableAndFree();
@@ -1663,7 +1662,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             for (int i = 0; i < numberIncludingLastSpread; i++)
             {
-                var rewrittenExpression = VisitAndRewriteCollectionElementExpression(elements[i], allowSpreadElement: true);
+                var rewrittenExpression = VisitCollectionElementExpression(elements[i], allowSpreadElement: true);
                 BoundLocal temp = _factory.StoreToTemp(rewrittenExpression, out BoundAssignmentOperator assignmentToTemp);
                 locals.Add(temp);
                 sideEffects.Add(assignmentToTemp);
@@ -1684,7 +1683,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var element = elements[i];
                 var rewrittenExpression = i < numberIncludingLastSpread ?
                     rewrittenExpressions[i] :
-                    VisitAndRewriteCollectionElementExpression(element, allowSpreadElement: true);
+                    VisitCollectionElementExpression(element, allowSpreadElement: true);
 
                 if (element is BoundCollectionExpressionSpreadElement spreadElement)
                 {
@@ -1696,7 +1695,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         rewrittenExpression,
                         iteratorBody =>
                         {
-                            var rewrittenValue = VisitAndRewriteCollectionElementExpression(((BoundExpressionStatement)iteratorBody).Expression, allowSpreadElement: false);
+                            var rewrittenValue = VisitCollectionElementExpression(((BoundExpressionStatement)iteratorBody).Expression, allowSpreadElement: false);
                             var builder = ArrayBuilder<BoundExpression>.GetInstance();
                             addElement(builder, rewrittenReceiver, rewrittenValue, false);
                             var statements = builder.SelectAsArray(expr => (BoundStatement)new BoundExpressionStatement(expr.Syntax, expr));

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
@@ -101,6 +101,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return VisitCollectionBuilderCollectionExpression(node);
                     case CollectionExpressionTypeKind.ArrayInterface:
                         return VisitListInterfaceCollectionExpression(node);
+                    case CollectionExpressionTypeKind.DictionaryInterface:
+                        return VisitDictionaryInterfaceCollectionExpression(node);
                     default:
                         throw ExceptionUtilities.UnexpectedValue(collectionTypeKind);
                 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
@@ -624,10 +624,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return _factory.Convert(interfaceType, collection, resultConversion);
         }
 
-        /// <summary>
-        /// Populate a dictionary from a collection expression.
-        /// The collection may or may not have a known length.
-        /// </summary>
         private BoundExpression VisitCollectionBuilderCollectionExpression(BoundCollectionExpression node)
         {
             Debug.Assert(!_inExpressionLambda);
@@ -1434,6 +1430,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             return PopulateDictionary(node, collectionType, rewrittenReceiver);
         }
 
+        /// <summary>
+        /// Populate a dictionary from a collection expression.
+        /// The collection may or may not have a known length.
+        /// </summary>
         private BoundExpression PopulateDictionary(BoundCollectionExpression node, NamedTypeSymbol collectionType, BoundExpression rewrittenReceiver)
         {
             var elements = node.Elements;
@@ -1441,8 +1441,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var sideEffects = ArrayBuilder<BoundExpression>.GetInstance(elements.Length + 1);
 
             // Create a temp for the dictionary.
-            BoundAssignmentOperator assignmentToTemp;
-            BoundLocal dictionaryTemp = _factory.StoreToTemp(rewrittenReceiver, out assignmentToTemp);
+            BoundLocal dictionaryTemp = _factory.StoreToTemp(rewrittenReceiver, out BoundAssignmentOperator assignmentToTemp);
             localsBuilder.Add(dictionaryTemp.LocalSymbol);
             sideEffects.Add(assignmentToTemp);
 
@@ -1550,8 +1549,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var rewrittenExpression = VisitExpression(expression);
 
-                BoundAssignmentOperator assignmentToTemp;
-                BoundLocal exprTemp = _factory.StoreToTemp(rewrittenExpression, out assignmentToTemp);
+                BoundLocal exprTemp = _factory.StoreToTemp(rewrittenExpression, out BoundAssignmentOperator assignmentToTemp);
                 localsBuilder.Add(exprTemp.LocalSymbol);
                 sideEffects.Add(assignmentToTemp);
 
@@ -1584,8 +1582,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var rewrittenExpression = VisitExpression(keyValuePairConversion.Expression);
 
-            BoundAssignmentOperator assignmentToTemp;
-            BoundLocal exprTemp = _factory.StoreToTemp(rewrittenExpression, out assignmentToTemp);
+            BoundLocal exprTemp = _factory.StoreToTemp(rewrittenExpression, out BoundAssignmentOperator assignmentToTemp);
             localsBuilder.Add(exprTemp.LocalSymbol);
             sideEffects.Add(assignmentToTemp);
 
@@ -1625,6 +1622,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             constructor = constructor.AsMember(type);
             return _factory.New(constructor, key, value);
         }
+
         private BoundExpression VisitAndRewriteCollectionElementExpression(BoundNode element, bool allowSpreadElement)
         {
             switch (element)
@@ -1666,8 +1664,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             for (int i = 0; i < numberIncludingLastSpread; i++)
             {
                 var rewrittenExpression = VisitAndRewriteCollectionElementExpression(elements[i], allowSpreadElement: true);
-                BoundAssignmentOperator assignmentToTemp;
-                BoundLocal temp = _factory.StoreToTemp(rewrittenExpression, out assignmentToTemp);
+                BoundLocal temp = _factory.StoreToTemp(rewrittenExpression, out BoundAssignmentOperator assignmentToTemp);
                 locals.Add(temp);
                 sideEffects.Add(assignmentToTemp);
             }
@@ -1868,6 +1865,5 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ImmutableArray.Create(statement),
                 result: _factory.Literal(0)); // result is unused
         }
-
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
@@ -1498,7 +1498,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                             assignItemFromExpression(expressionElement, dictionaryTemp, setMethod, localsBuilder, sideEffects);
                                             break;
                                         default:
-                                            throw ExceptionUtilities.UnexpectedValue(element);
+                                            throw ExceptionUtilities.UnexpectedValue(expr);
                                     }
                                     var locals = localsBuilder.ToImmutableAndFree();
                                     var statements = sideEffects.SelectAsArray(expr => (BoundStatement)new BoundExpressionStatement(expr.Syntax, expr));

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CollectionExpression.cs
@@ -269,7 +269,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (collectionType is ArrayTypeSymbol arrayType)
             {
-                Debug.Assert(node.Elements.All(e => e is BoundExpression or BoundCollectionExpressionSpreadElement));
+                Debug.Assert(node.Elements.All(e => e is BoundExpression or BoundKeyValuePairElement or BoundCollectionExpressionSpreadElement));
                 return createArray(node, arrayType, targetsReadOnlyCollection: false);
             }
 
@@ -533,7 +533,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     BoundExpression fieldValue = kind switch
                     {
                         // fieldValue = e1;
-                        SynthesizedReadOnlyListKind.SingleElement => this.VisitExpression((BoundExpression)elements.Single()),
+                        SynthesizedReadOnlyListKind.SingleElement => VisitAndRewriteCollectionElementExpression(elements.Single(), allowSpreadElement: false),
                         // fieldValue = new ElementType[] { e1, ..., eN };
                         SynthesizedReadOnlyListKind.Array => createArray(node, ArrayTypeSymbol.CreateSZArray(_compilation.Assembly, elementType)),
                         // fieldValue = new List<ElementType> { e1, ..., eN };
@@ -650,7 +650,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool asReadOnlySpan)
         {
             Debug.Assert(elements.Length > 0);
-            Debug.Assert(elements.All(e => e is BoundExpression or BoundKeyValuePairConversion));
+            Debug.Assert(elements.All(e => e is BoundExpression or BoundKeyValuePairElement));
             Debug.Assert(_factory.ModuleBuilderOpt is { });
             Debug.Assert(_diagnostics.DiagnosticBag is { });
             Debug.Assert(_compilation.Assembly.RuntimeSupportsInlineArrayTypes);
@@ -667,7 +667,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     .WellKnownType(asReadOnlySpan ? WellKnownType.System_ReadOnlySpan_T : WellKnownType.System_Span_T)
                     .Construct([elementType]);
                 var constructor = spanRefConstructor.AsMember(spanType);
-                var element = VisitAndRewriteCollectionElementExpression((BoundExpression)elements[0], allowSpreadElement: false);
+                var element = VisitAndRewriteCollectionElementExpression(elements[0], allowSpreadElement: false);
                 var temp = _factory.StoreToTemp(element, out var assignment);
                 _additionalLocals.Add(temp.LocalSymbol);
                 var call = _factory.New(constructor, arguments: [temp], argumentRefKinds: [asReadOnlySpan ? RefKindExtensions.StrictIn : RefKind.Ref]);
@@ -695,7 +695,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // ...
             for (int i = 0; i < arrayLength; i++)
             {
-                var element = VisitAndRewriteCollectionElementExpression((BoundExpression)elements[i], allowSpreadElement: false);
+                var element = VisitAndRewriteCollectionElementExpression(elements[i], allowSpreadElement: false);
                 var call = _factory.Call(null, elementRef, inlineArrayLocal, _factory.Literal(i), useStrictArgumentRefKinds: true);
                 var assignment = new BoundAssignmentOperator(syntax, call, element, type: call.Type) { WasCompilerGenerated = true };
                 sideEffects.Add(assignment);
@@ -771,13 +771,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 && spreadElement.IteratorBody is BoundExpressionStatement expressionStatement)
             {
                 var spreadElementConversion = expressionStatement.Expression is BoundConversion { Conversion: var actualConversion } ? actualConversion : Conversion.Identity;
+                var spreadElementIsKeyValuePairConversion = expressionStatement.Expression is BoundKeyValuePairConversion;
                 // Allow implicit reference conversion only if we target readonly collection types like
                 // ReadOnlySpan, IEnumerable, IReadOnlyList etc. Cause otherwise user may get an array with different
                 // actual underlying array type which may lead to unexpected behavior, e.g. an exception
                 // when trying to insert an element of the base type
-                var spreadElementHasCompatibleConversion = targetsReadOnlyCollection
+                var spreadElementHasCompatibleConversion = !spreadElementIsKeyValuePairConversion && (targetsReadOnlyCollection
                     ? spreadElementConversion.Kind is ConversionKind.Identity or ConversionKind.ImplicitReference
-                    : spreadElementConversion.Kind is ConversionKind.Identity;
+                    : spreadElementConversion.Kind is ConversionKind.Identity);
                 var spreadTypeOriginalDefinition = spreadExpression.Type!.OriginalDefinition;
 
                 if (spreadElementHasCompatibleConversion
@@ -1085,7 +1086,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             // Cannot use CopyTo when spread element has non-identity conversion to target element type.
             // Could do a covariant conversion of ReadOnlySpan in future: https://github.com/dotnet/roslyn/issues/71106
-            if (spreadElement.IteratorBody is not BoundExpressionStatement expressionStatement || expressionStatement.Expression is BoundConversion { ConversionKind: not ConversionKind.Identity })
+            if (spreadElement.IteratorBody is not BoundExpressionStatement expressionStatement
+                || expressionStatement.Expression is BoundConversion { ConversionKind: not ConversionKind.Identity }
+                || expressionStatement.Expression is BoundKeyValuePairConversion)
                 return null;
 
             if (_factory.WellKnownMethod(WellKnownMember.System_Span_T__Slice_Int_Int, isOptional: true) is not { } spanSliceMethod)

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -303,6 +303,8 @@ namespace Microsoft.CodeAnalysis.Operations
                 case BoundKind.StackAllocArrayCreation:
                 case BoundKind.TypeExpression:
                 case BoundKind.TypeOrValueExpression:
+                case BoundKind.KeyValuePairElement: // https://github.com/dotnet/roslyn/issues/77872: Implement IOperation support.
+                case BoundKind.KeyValuePairConversion: // https://github.com/dotnet/roslyn/issues/77872: Implement IOperation support.
                     ConstantValue? constantValue = (boundNode as BoundExpression)?.ConstantValueOpt;
                     bool isImplicit = boundNode.WasCompilerGenerated;
 
@@ -1282,6 +1284,8 @@ namespace Microsoft.CodeAnalysis.Operations
                         return null;
                     case CollectionExpressionTypeKind.ArrayInterface:
                     case CollectionExpressionTypeKind.ImplementsIEnumerable:
+                    case CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer:
+                    case CollectionExpressionTypeKind.DictionaryInterface:
                         return (expr.CollectionCreation as BoundObjectCreationExpression)?.Constructor;
                     case CollectionExpressionTypeKind.CollectionBuilder:
                         return expr.CollectionBuilderMethod;
@@ -1332,9 +1336,13 @@ namespace Microsoft.CodeAnalysis.Operations
 
         private IOperation CreateBoundCollectionExpressionElement(BoundCollectionExpression expr, BoundNode element)
         {
-            return element is BoundCollectionExpressionSpreadElement spreadElement ?
-                CreateBoundCollectionExpressionSpreadElement(expr, spreadElement) :
-                Create(Binder.GetUnderlyingCollectionExpressionElement(expr, (BoundExpression)element, throwOnErrors: false));
+            return element switch
+            {
+                BoundCollectionExpressionSpreadElement spreadElement => CreateBoundCollectionExpressionSpreadElement(expr, spreadElement),
+                BoundKeyValuePairElement keyValuePairElement => Create(keyValuePairElement),
+                BoundKeyValuePairConversion keyValuePairConversion => Create(keyValuePairConversion),
+                _ => Create(Binder.GetUnderlyingCollectionExpressionElement(expr, (BoundExpression)element, throwOnErrors: false))
+            };
         }
 
         private ISpreadOperation CreateBoundCollectionExpressionSpreadElement(BoundCollectionExpression expr, BoundCollectionExpressionSpreadElement element)
@@ -1346,7 +1354,10 @@ namespace Microsoft.CodeAnalysis.Operations
             SyntaxNode syntax = element.Syntax;
             bool isImplicit = element.WasCompilerGenerated;
             var elementType = element.EnumeratorInfoOpt?.ElementType.GetPublicSymbol();
-            var elementConversion = BoundNode.GetConversion(iteratorItem, element.ElementPlaceholder);
+            // https://github.com/dotnet/roslyn/issues/77872: For key-value pairs, we probably need a pair of conversions rather than a single conversion.
+            var elementConversion = iteratorItem is BoundKeyValuePairConversion or BoundConversion { Operand: BoundKeyValuePairConversion } ?
+                Conversion.Identity :
+                BoundNode.GetConversion(iteratorItem, element.ElementPlaceholder);
             return new SpreadOperation(
                 collection,
                 elementType: elementType,

--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -1,19 +1,19 @@
-Microsoft.CodeAnalysis.CSharp.SyntaxKind.KeyValuePairElement = 9083 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
-Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax
-Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.ColonToken.get -> Microsoft.CodeAnalysis.SyntaxToken
-Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.KeyExpression.get -> Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax!
-Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.Update(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax! keyExpression, Microsoft.CodeAnalysis.SyntaxToken colonToken, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax! valueExpression) -> Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax!
-Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.ValueExpression.get -> Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax!
-Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.WithColonToken(Microsoft.CodeAnalysis.SyntaxToken colonToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax!
-Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.WithKeyExpression(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax! keyExpression) -> Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax!
-Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.WithValueExpression(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax! valueExpression) -> Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax!
-override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitKeyValuePairElement(Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax! node) -> Microsoft.CodeAnalysis.SyntaxNode?
-override Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.Accept(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor! visitor) -> void
-override Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.Accept<TResult>(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor<TResult>! visitor) -> TResult?
-static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.KeyValuePairElement(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax! keyExpression, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax! valueExpression) -> Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax!
-static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.KeyValuePairElement(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax! keyExpression, Microsoft.CodeAnalysis.SyntaxToken colonToken, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax! valueExpression) -> Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax!
-virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitKeyValuePairElement(Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax! node) -> void
-virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor<TResult>.VisitKeyValuePairElement(Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax! node) -> TResult?
+[RSEXPERIMENTAL006]Microsoft.CodeAnalysis.CSharp.SyntaxKind.KeyValuePairElement = 9083 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
+[RSEXPERIMENTAL006]Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax
+[RSEXPERIMENTAL006]Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.ColonToken.get -> Microsoft.CodeAnalysis.SyntaxToken
+[RSEXPERIMENTAL006]Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.KeyExpression.get -> Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax!
+[RSEXPERIMENTAL006]Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.Update(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax! keyExpression, Microsoft.CodeAnalysis.SyntaxToken colonToken, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax! valueExpression) -> Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax!
+[RSEXPERIMENTAL006]Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.ValueExpression.get -> Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax!
+[RSEXPERIMENTAL006]Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.WithColonToken(Microsoft.CodeAnalysis.SyntaxToken colonToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax!
+[RSEXPERIMENTAL006]Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.WithKeyExpression(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax! keyExpression) -> Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax!
+[RSEXPERIMENTAL006]Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.WithValueExpression(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax! valueExpression) -> Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax!
+[RSEXPERIMENTAL006]override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitKeyValuePairElement(Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax! node) -> Microsoft.CodeAnalysis.SyntaxNode?
+[RSEXPERIMENTAL006]override Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.Accept(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor! visitor) -> void
+[RSEXPERIMENTAL006]override Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax.Accept<TResult>(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor<TResult>! visitor) -> TResult?
+[RSEXPERIMENTAL006]static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.KeyValuePairElement(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax! keyExpression, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax! valueExpression) -> Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax!
+[RSEXPERIMENTAL006]static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.KeyValuePairElement(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax! keyExpression, Microsoft.CodeAnalysis.SyntaxToken colonToken, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax! valueExpression) -> Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax!
+[RSEXPERIMENTAL006]virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitKeyValuePairElement(Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax! node) -> void
+[RSEXPERIMENTAL006]virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor<TResult>.VisitKeyValuePairElement(Microsoft.CodeAnalysis.CSharp.Syntax.KeyValuePairElementSyntax! node) -> TResult?
 
 [RSEXPERIMENTAL006]Microsoft.CodeAnalysis.CSharp.SyntaxKind.WithElement = 9081 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 [RSEXPERIMENTAL006]Microsoft.CodeAnalysis.CSharp.Syntax.WithElementSyntax

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -279,6 +279,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     targetMethodKind = MethodKind.PropertyGet;
                     break;
 
+                case MemberFlags.PropertySet:
+                    targetSymbolKind = SymbolKind.Method;
+                    targetMethodKind = MethodKind.PropertySet;
+                    break;
+
                 case MemberFlags.Field:
                     targetSymbolKind = SymbolKind.Field;
                     break;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -1615,7 +1615,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             void validateParamsType(BindingDiagnosticBag diagnostics)
             {
-                var collectionTypeKind = ConversionsBase.GetCollectionExpressionTypeKind(DeclaringCompilation, Type, out TypeWithAnnotations elementTypeWithAnnotations);
+                var syntax = ParameterSyntax;
+                var binder = GetDefaultParameterValueBinder(syntax).WithContainingMemberOrLambda(ContainingSymbol); // this binder is good for our purpose
+                var collectionTypeKind = ConversionsBase.GetCollectionExpressionTypeKind(binder, syntax, Type, out TypeWithAnnotations elementTypeWithAnnotations);
 
                 var elementType = elementTypeWithAnnotations.Type;
                 switch (collectionTypeKind)
@@ -1625,12 +1627,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         return;
 
                     case CollectionExpressionTypeKind.ImplementsIEnumerable:
+                    case CollectionExpressionTypeKind.ImplementsIEnumerableWithIndexer:
                         {
-                            var syntax = ParameterSyntax;
-                            var binder = GetDefaultParameterValueBinder(syntax).WithContainingMemberOrLambda(ContainingSymbol); // this binder is good for our purpose
-
-                            binder.TryGetCollectionIterationType(syntax, Type, out elementTypeWithAnnotations);
-                            elementType = elementTypeWithAnnotations.Type;
                             if (elementType is null)
                             {
                                 reportInvalidParams(diagnostics);
@@ -1648,8 +1646,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 checkIsAtLeastAsVisible(syntax, binder, constructor, diagnostics);
                             }
 
-                            // https://github.com/dotnet/roslyn/issues/77879: Report diagnostics when GetCollectionExpressionApplicableIndexer() returns non-null?
-                            if (binder.GetCollectionExpressionApplicableIndexer(syntax, Type, elementTypeWithAnnotations.Type, BindingDiagnosticBag.Discarded) is null)
+                            if (collectionTypeKind == CollectionExpressionTypeKind.ImplementsIEnumerable)
                             {
                                 if (!binder.HasCollectionExpressionApplicableAddMethod(syntax, Type, out ImmutableArray<MethodSymbol> addMethods, diagnostics))
                                 {
@@ -1689,11 +1686,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                     case CollectionExpressionTypeKind.CollectionBuilder:
                         {
-                            var syntax = ParameterSyntax;
-                            var binder = GetDefaultParameterValueBinder(syntax).WithContainingMemberOrLambda(ContainingSymbol); // this binder is good for our purpose
-
-                            binder.TryGetCollectionIterationType(syntax, Type, out elementTypeWithAnnotations);
-                            elementType = elementTypeWithAnnotations.Type;
                             if (elementType is null)
                             {
                                 reportInvalidParams(diagnostics);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -1648,37 +1648,41 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 checkIsAtLeastAsVisible(syntax, binder, constructor, diagnostics);
                             }
 
-                            if (!binder.HasCollectionExpressionApplicableAddMethod(syntax, Type, out ImmutableArray<MethodSymbol> addMethods, diagnostics))
+                            // https://github.com/dotnet/roslyn/issues/77879: Report diagnostics when GetCollectionExpressionApplicableIndexer() returns non-null?
+                            if (binder.GetCollectionExpressionApplicableIndexer(syntax, Type, elementTypeWithAnnotations.Type, BindingDiagnosticBag.Discarded) is null)
                             {
-                                return;
-                            }
-
-                            Debug.Assert(!addMethods.IsDefaultOrEmpty);
-
-                            if (addMethods[0].IsExtensionMethod || addMethods[0].IsExtensionBlockMember()) // No need to check other methods, extensions are never mixed with instance methods
-                            {
-                                diagnostics.Add(ErrorCode.ERR_ParamsCollectionExtensionAddMethod, syntax, Type);
-                                return;
-                            }
-
-                            MethodSymbol? reportAsLessVisible = null;
-
-                            foreach (var addMethod in addMethods)
-                            {
-                                if (isAtLeastAsVisible(syntax, binder, addMethod, diagnostics))
+                                if (!binder.HasCollectionExpressionApplicableAddMethod(syntax, Type, out ImmutableArray<MethodSymbol> addMethods, diagnostics))
                                 {
-                                    reportAsLessVisible = null;
-                                    break;
+                                    return;
                                 }
-                                else
-                                {
-                                    reportAsLessVisible ??= addMethod;
-                                }
-                            }
 
-                            if (reportAsLessVisible is not null)
-                            {
-                                diagnostics.Add(ErrorCode.ERR_ParamsMemberCannotBeLessVisibleThanDeclaringMember, syntax, reportAsLessVisible, ContainingSymbol);
+                                Debug.Assert(!addMethods.IsDefaultOrEmpty);
+
+                                if (addMethods[0].IsExtensionMethod || addMethods[0].IsExtensionBlockMember()) // No need to check other methods, extensions are never mixed with instance methods
+                                {
+                                    diagnostics.Add(ErrorCode.ERR_ParamsCollectionExtensionAddMethod, syntax, Type);
+                                    return;
+                                }
+
+                                MethodSymbol? reportAsLessVisible = null;
+
+                                foreach (var addMethod in addMethods)
+                                {
+                                    if (isAtLeastAsVisible(syntax, binder, addMethod, diagnostics))
+                                    {
+                                        reportAsLessVisible = null;
+                                        break;
+                                    }
+                                    else
+                                    {
+                                        reportAsLessVisible ??= addMethod;
+                                    }
+                                }
+
+                                if (reportAsLessVisible is not null)
+                                {
+                                    diagnostics.Add(ErrorCode.ERR_ParamsMemberCannotBeLessVisibleThanDeclaringMember, syntax, reportAsLessVisible, ContainingSymbol);
+                                }
                             }
                         }
                         break;

--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -1839,7 +1839,7 @@
     </Field>
     <Field Name="Expression" Type="ExpressionSyntax" />
   </Node>
-  <Node Name="KeyValuePairElementSyntax" Base="CollectionElementSyntax" ExperimentalUrl="https://github.com/dotnet/roslyn/issues/84112">
+  <Node Name="KeyValuePairElementSyntax" Base="CollectionElementSyntax" ExperimentalUrl="https://github.com/dotnet/roslyn/issues/84198">
     <Kind Name="KeyValuePairElement"/>
     <Field Name="KeyExpression" Type="ExpressionSyntax" />
     <Field Name="ColonToken" Type="SyntaxToken">

--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -1839,7 +1839,7 @@
     </Field>
     <Field Name="Expression" Type="ExpressionSyntax" />
   </Node>
-  <Node Name="KeyValuePairElementSyntax" Base="CollectionElementSyntax">
+  <Node Name="KeyValuePairElementSyntax" Base="CollectionElementSyntax" ExperimentalUrl="https://github.com/dotnet/roslyn/issues/84112">
     <Kind Name="KeyValuePairElement"/>
     <Field Name="KeyExpression" Type="ExpressionSyntax" />
     <Field Name="ColonToken" Type="SyntaxToken">

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
@@ -945,7 +945,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         [Experimental("RSEXPERIMENTAL006", UrlFormat = "https://github.com/dotnet/roslyn/issues/82567")]
         UnionDeclaration = 9082,
 
-        [Experimental("RSEXPERIMENTAL006", UrlFormat = "https://github.com/dotnet/roslyn/issues/84112")]
+        [Experimental("RSEXPERIMENTAL006", UrlFormat = "https://github.com/dotnet/roslyn/issues/84198")]
         KeyValuePairElement = 9083,
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
@@ -945,6 +945,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         [Experimental("RSEXPERIMENTAL006", UrlFormat = "https://github.com/dotnet/roslyn/issues/82567")]
         UnionDeclaration = 9082,
 
+        [Experimental("RSEXPERIMENTAL006", UrlFormat = "https://github.com/dotnet/roslyn/issues/84112")]
         KeyValuePairElement = 9083,
     }
 }

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -2927,6 +2927,11 @@
         <target state="translated">kovariantní návratové hodnoty</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureDictionaryExpressions">
+        <source>dictionary expressions</source>
+        <target state="new">dictionary expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureDiscards">
         <source>discards</source>
         <target state="translated">discards</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -577,6 +577,11 @@
         <target state="translated">Tuto verzi {0} nelze použít s výrazy kolekce.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionKeyValuePairNotSupported">
+        <source>Collection expression type '{0}' does not support key-value pair elements.</source>
+        <target state="new">Collection expression type '{0}' does not support key-value pair elements.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionExpressionMissingAdd">
         <source>Collection expression type '{0}' must have an instance or extension method 'Add' that can be called with a single argument.</source>
         <target state="translated">Typ výrazu kolekce {0} musí mít instanci nebo metodu rozšíření Přidat, kterou lze volat jedním argumentem.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -2927,6 +2927,11 @@
         <target state="translated">Covariante Rückgaben</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureDictionaryExpressions">
+        <source>dictionary expressions</source>
+        <target state="new">dictionary expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureDiscards">
         <source>discards</source>
         <target state="translated">Ausschussvariablen</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -577,6 +577,11 @@
         <target state="translated">Diese Version von „{0}“ kann nicht mit Auflistungsausdrücken verwendet werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionKeyValuePairNotSupported">
+        <source>Collection expression type '{0}' does not support key-value pair elements.</source>
+        <target state="new">Collection expression type '{0}' does not support key-value pair elements.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionExpressionMissingAdd">
         <source>Collection expression type '{0}' must have an instance or extension method 'Add' that can be called with a single argument.</source>
         <target state="translated">Der Auflistungsausdruckstyp "{0}" muss über eine Instanz oder die Erweiterungsmethode "Add" verfügen, die mit einem einzelnen Argument aufgerufen werden kann.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -2927,6 +2927,11 @@
         <target state="translated">valores devueltos de covariante</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureDictionaryExpressions">
+        <source>dictionary expressions</source>
+        <target state="new">dictionary expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureDiscards">
         <source>discards</source>
         <target state="translated">descartes</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -577,6 +577,11 @@
         <target state="translated">Esta versión de '{0}' no se puede usar con expresiones de colección.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionKeyValuePairNotSupported">
+        <source>Collection expression type '{0}' does not support key-value pair elements.</source>
+        <target state="new">Collection expression type '{0}' does not support key-value pair elements.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionExpressionMissingAdd">
         <source>Collection expression type '{0}' must have an instance or extension method 'Add' that can be called with a single argument.</source>
         <target state="translated">El tipo de expresión de colección "{0}" debe tener una instancia o un método de extensión "Add" al que se pueda llamar con un único argumento.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -2927,6 +2927,11 @@
         <target state="translated">retours covariants</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureDictionaryExpressions">
+        <source>dictionary expressions</source>
+        <target state="new">dictionary expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureDiscards">
         <source>discards</source>
         <target state="translated">discards (éléments ignorés)</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -577,6 +577,11 @@
         <target state="translated">Cette version de « {0} » ne peut pas être utilisée avec des expressions de collection.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionKeyValuePairNotSupported">
+        <source>Collection expression type '{0}' does not support key-value pair elements.</source>
+        <target state="new">Collection expression type '{0}' does not support key-value pair elements.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionExpressionMissingAdd">
         <source>Collection expression type '{0}' must have an instance or extension method 'Add' that can be called with a single argument.</source>
         <target state="translated">Le type d’expression de collection « {0} » doit avoir une instance ou une méthode d’extension « Ajouter » qui peut être appelée avec un seul argument.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -577,6 +577,11 @@
         <target state="translated">Questa versione di '{0}' non può essere utilizzata con espressioni di raccolta.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionKeyValuePairNotSupported">
+        <source>Collection expression type '{0}' does not support key-value pair elements.</source>
+        <target state="new">Collection expression type '{0}' does not support key-value pair elements.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionExpressionMissingAdd">
         <source>Collection expression type '{0}' must have an instance or extension method 'Add' that can be called with a single argument.</source>
         <target state="translated">Il tipo di espressione della raccolta "{0}" deve avere un'istanza o un metodo di estensione "Add" da poter chiamare con un argomento singolo.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -2927,6 +2927,11 @@
         <target state="translated">tipi restituiti covarianti</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureDictionaryExpressions">
+        <source>dictionary expressions</source>
+        <target state="new">dictionary expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureDiscards">
         <source>discards</source>
         <target state="translated">rimozioni</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -577,6 +577,11 @@
         <target state="translated">このバージョンの '{0}' は、コレクション式では使用できません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionKeyValuePairNotSupported">
+        <source>Collection expression type '{0}' does not support key-value pair elements.</source>
+        <target state="new">Collection expression type '{0}' does not support key-value pair elements.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionExpressionMissingAdd">
         <source>Collection expression type '{0}' must have an instance or extension method 'Add' that can be called with a single argument.</source>
         <target state="translated">コレクション式の型 '{0}' には、1 つの引数で呼び出すことができるインスタンスメソッドまたは拡張メソッド 'Add' が必要です。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -2927,6 +2927,11 @@
         <target state="translated">covariant の戻り値</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureDictionaryExpressions">
+        <source>dictionary expressions</source>
+        <target state="new">dictionary expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureDiscards">
         <source>discards</source>
         <target state="translated">ディスカード</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -577,6 +577,11 @@
         <target state="translated">이 버전의 '{0}'은(는) 컬렉션 식과 함께 사용할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionKeyValuePairNotSupported">
+        <source>Collection expression type '{0}' does not support key-value pair elements.</source>
+        <target state="new">Collection expression type '{0}' does not support key-value pair elements.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionExpressionMissingAdd">
         <source>Collection expression type '{0}' must have an instance or extension method 'Add' that can be called with a single argument.</source>
         <target state="translated">컬렉션 식 형식 '{0}'에는 단일 인수로 호출할 수 있는 인스턴스 또는 확장 메서드 'Add'가 있어야 합니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -2927,6 +2927,11 @@
         <target state="translated">공변(covariant) 반환</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureDictionaryExpressions">
+        <source>dictionary expressions</source>
+        <target state="new">dictionary expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureDiscards">
         <source>discards</source>
         <target state="translated">무시 항목</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -577,6 +577,11 @@
         <target state="translated">Tej wersji elementu „{0}” nie można używać z wyrażeniami kolekcji.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionKeyValuePairNotSupported">
+        <source>Collection expression type '{0}' does not support key-value pair elements.</source>
+        <target state="new">Collection expression type '{0}' does not support key-value pair elements.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionExpressionMissingAdd">
         <source>Collection expression type '{0}' must have an instance or extension method 'Add' that can be called with a single argument.</source>
         <target state="translated">Typ wyrażenia kolekcji „{0}” musi mieć wystąpienie lub metodę rozszerzenia „Dodaj”, którą można wywołać z pojedynczym argumentem.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -2927,6 +2927,11 @@
         <target state="translated">zwroty kowariantne</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureDictionaryExpressions">
+        <source>dictionary expressions</source>
+        <target state="new">dictionary expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureDiscards">
         <source>discards</source>
         <target state="translated">odrzucenia</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -2927,6 +2927,11 @@
         <target state="translated">retornos de covariante</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureDictionaryExpressions">
+        <source>dictionary expressions</source>
+        <target state="new">dictionary expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureDiscards">
         <source>discards</source>
         <target state="translated">descarte</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -577,6 +577,11 @@
         <target state="translated">Esta versão de '{0}' não pode ser usada com expressões de coleção.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionKeyValuePairNotSupported">
+        <source>Collection expression type '{0}' does not support key-value pair elements.</source>
+        <target state="new">Collection expression type '{0}' does not support key-value pair elements.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionExpressionMissingAdd">
         <source>Collection expression type '{0}' must have an instance or extension method 'Add' that can be called with a single argument.</source>
         <target state="translated">O tipo de expressão de coleção '{0}' deve ter uma instância ou método de extensão 'Add' que pode ser chamado com apenas um argumento.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -577,6 +577,11 @@
         <target state="translated">Невозможно использовать эту версию "{0}" с выражениями коллекций.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionKeyValuePairNotSupported">
+        <source>Collection expression type '{0}' does not support key-value pair elements.</source>
+        <target state="new">Collection expression type '{0}' does not support key-value pair elements.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionExpressionMissingAdd">
         <source>Collection expression type '{0}' must have an instance or extension method 'Add' that can be called with a single argument.</source>
         <target state="translated">Тип выражения коллекции "{0}" должен иметь экземпляр или метод расширения "Add", который можно вызвать с помощью одного аргумента.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -2927,6 +2927,11 @@
         <target state="translated">ковариантные возвращаемые значения</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureDictionaryExpressions">
+        <source>dictionary expressions</source>
+        <target state="new">dictionary expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureDiscards">
         <source>discards</source>
         <target state="translated">пустые переменные</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -2927,6 +2927,11 @@
         <target state="translated">birlikte değişken dönüşler</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureDictionaryExpressions">
+        <source>dictionary expressions</source>
+        <target state="new">dictionary expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureDiscards">
         <source>discards</source>
         <target state="translated">atılabilir değişkenler</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -577,6 +577,11 @@
         <target state="translated">Bu '{0}' sürümü koleksiyon ifadeleri ile kullanılamaz.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionKeyValuePairNotSupported">
+        <source>Collection expression type '{0}' does not support key-value pair elements.</source>
+        <target state="new">Collection expression type '{0}' does not support key-value pair elements.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionExpressionMissingAdd">
         <source>Collection expression type '{0}' must have an instance or extension method 'Add' that can be called with a single argument.</source>
         <target state="translated">'{0}' koleksiyon ifade türünün tek bir bağımsız değişken ile çağrılabilecek bir örnek veya 'Add' genişletme yöntemi içermesi gerekir.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -2927,6 +2927,11 @@
         <target state="translated">协变返回</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureDictionaryExpressions">
+        <source>dictionary expressions</source>
+        <target state="new">dictionary expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureDiscards">
         <source>discards</source>
         <target state="translated">弃元</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -577,6 +577,11 @@
         <target state="translated">“{0}”的此版本无法与集合表达式一起使用。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionKeyValuePairNotSupported">
+        <source>Collection expression type '{0}' does not support key-value pair elements.</source>
+        <target state="new">Collection expression type '{0}' does not support key-value pair elements.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionExpressionMissingAdd">
         <source>Collection expression type '{0}' must have an instance or extension method 'Add' that can be called with a single argument.</source>
         <target state="translated">集合表达式类型“{0}”必须具有可以使用单个参数调用的实例或扩展方法 "Add"。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -2927,6 +2927,11 @@
         <target state="translated">Covariant 傳回</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureDictionaryExpressions">
+        <source>dictionary expressions</source>
+        <target state="new">dictionary expressions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureDiscards">
         <source>discards</source>
         <target state="translated">Discard</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -577,6 +577,11 @@
         <target state="translated">此版本的 '{0}' 無法與集合運算式一起使用。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionKeyValuePairNotSupported">
+        <source>Collection expression type '{0}' does not support key-value pair elements.</source>
+        <target state="new">Collection expression type '{0}' does not support key-value pair elements.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionExpressionMissingAdd">
         <source>Collection expression type '{0}' must have an instance or extension method 'Add' that can be called with a single argument.</source>
         <target state="translated">集合運算式類型 '{0}' 必須有可以使用單一引數來呼叫的執行個體或延伸模組方法 'Add'。</target>

--- a/src/Compilers/CSharp/Test/CSharp15/DictionaryExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/DictionaryExpressionTests.cs
@@ -1,0 +1,7195 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    public class DictionaryExpressionTests : CSharpTestBase
+    {
+        private static string IncludeExpectedOutput(string expectedOutput) => ExecutionConditionUtil.IsMonoOrCoreClr ? expectedOutput : null;
+
+        private const string s_collectionExtensions = """
+            using System;
+            using System.Collections;
+            using System.Linq;
+            using System.Text;
+            static partial class CollectionExtensions
+            {
+                private static void Append(StringBuilder builder, bool isFirst, object value)
+                {
+                    if (!isFirst) builder.Append(", ");
+                    if (value is IEnumerable e && value is not string)
+                    {
+                        AppendCollection(builder, e);
+                    }
+                    else
+                    {
+                        builder.Append(value is null ? "null" : value.ToString());
+                    }
+                }
+                private static void AppendCollection(StringBuilder builder, IEnumerable e)
+                {
+                    builder.Append("[");
+                    bool isFirst = true;
+                    foreach (var i in e)
+                    {
+                        Append(builder, isFirst, i);
+                        isFirst = false;
+                    }
+                    builder.Append("]");
+                }
+                internal static void Report(this object o, bool includeType = false)
+                {
+                    var builder = new StringBuilder();
+                    Append(builder, isFirst: true, o);
+                    if (includeType) Console.Write("({0}) ", GetTypeName(o.GetType()));
+                    Console.Write(builder.ToString());
+                    Console.Write(", ");
+                }
+                internal static string GetTypeName(this Type type)
+                {
+                    if (type.IsArray)
+                    {
+                        return GetTypeName(type.GetElementType()) + "[]";
+                    }
+                    string typeName = type.Name;
+                    int index = typeName.LastIndexOf('`');
+                    if (index >= 0)
+                    {
+                        typeName = typeName.Substring(0, index);
+                    }
+                    if (!type.IsGenericParameter)
+                    {
+                        if (type.DeclaringType is { } declaringType)
+                        {
+                            typeName = Concat(GetTypeName(declaringType), typeName);
+                        }
+                        else
+                        {
+                            typeName = Concat(type.Namespace, typeName);
+                        }
+                    }
+                    if (!type.IsGenericType)
+                    {
+                        return typeName;
+                    }
+                    var typeArgs = type.GetGenericArguments();
+                    return $"{typeName}<{string.Join(", ", typeArgs.Select(GetTypeName))}>";
+                }
+                private static string Concat(string container, string name)
+                {
+                    return string.IsNullOrEmpty(container) ? name : container + "." + name;
+                }
+            }
+            """;
+        private const string s_dictionaryExtensions = """
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+            using System.Text;
+            static class DictionaryExtensions
+            {
+                private static void Append(StringBuilder builder, object value)
+                {
+                    builder.Append(value is null ? "null" : value.ToString());
+                }
+                internal static void Report<K, V>(this IEnumerable<KeyValuePair<K, V>> e)
+                {
+                    e = e.OrderBy(kvp => kvp.Key);
+                    var builder = new StringBuilder();
+                    builder.Append("[");
+                    bool isFirst = true;
+                    foreach (var kvp in e)
+                    {
+                        if (!isFirst) builder.Append(", ");
+                        isFirst = false;
+                        Append(builder, kvp.Key);
+                        builder.Append(":");
+                        Append(builder, kvp.Value);
+                    }
+                    builder.Append("], ");
+                    Console.Write(builder.ToString());
+                }
+            }
+            """;
+
+        public static readonly TheoryData<LanguageVersion> LanguageVersions = new([LanguageVersion.CSharp13, LanguageVersion.Preview, LanguageVersionFacts.CSharpNext]);
+
+        [Theory]
+        [MemberData(nameof(LanguageVersions))]
+        public void LanguageVersionDiagnostics_01(LanguageVersion languageVersion)
+        {
+            string source = """
+                using System.Collections.Generic;
+                IDictionary<int, string> d = [1:"one"];
+                """;
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            if (languageVersion == LanguageVersion.CSharp13)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (2,30): error CS9174: Cannot initialize type 'IDictionary<int, string>' with a collection expression because the type is not constructible.
+                    // IDictionary<int, string> d = [1:"one"];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionTargetTypeNotConstructible, @"[1:""one""]").WithArguments("System.Collections.Generic.IDictionary<int, string>").WithLocation(2, 30),
+                    // (2,32): error CS8652: The feature 'dictionary expressions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    // IDictionary<int, string> d = [1:"one"];
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, ":").WithArguments("dictionary expressions").WithLocation(2, 32));
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics();
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(LanguageVersions))]
+        public void LanguageVersionDiagnostics_02(LanguageVersion languageVersion)
+        {
+            string source = """
+                using System.Collections.Generic;
+                IDictionary<int, string> d;
+                d = [];
+                var x = new KeyValuePair<int, string>(2, "two");
+                var y = new KeyValuePair<int, string>[] { new(3, "three") };
+                d = [x];
+                d = [..y];
+                """;
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            if (languageVersion == LanguageVersion.CSharp13)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (3,5): error CS9174: Cannot initialize type 'IDictionary<int, string>' with a collection expression because the type is not constructible.
+                    // d = [];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionTargetTypeNotConstructible, "[]").WithArguments("System.Collections.Generic.IDictionary<int, string>").WithLocation(3, 5),
+                    // (6,5): error CS9174: Cannot initialize type 'IDictionary<int, string>' with a collection expression because the type is not constructible.
+                    // d = [x];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionTargetTypeNotConstructible, "[x]").WithArguments("System.Collections.Generic.IDictionary<int, string>").WithLocation(6, 5),
+                    // (7,5): error CS9174: Cannot initialize type 'IDictionary<int, string>' with a collection expression because the type is not constructible.
+                    // d = [..y];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionTargetTypeNotConstructible, "[..y]").WithArguments("System.Collections.Generic.IDictionary<int, string>").WithLocation(7, 5));
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics();
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(LanguageVersions))]
+        public void LanguageVersionDiagnostics_03(LanguageVersion languageVersion)
+        {
+            string source = """
+                var x = [1:"one"];
+                """;
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            if (languageVersion == LanguageVersion.CSharp13)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (1,9): error CS9176: There is no target type for the collection expression.
+                    // var x = [1:"one"];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, @"[1:""one""]").WithLocation(1, 9),
+                    // (1,11): error CS8652: The feature 'dictionary expressions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    // var x = [1:"one"];
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, ":").WithArguments("dictionary expressions").WithLocation(1, 11));
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (1,9): error CS9176: There is no target type for the collection expression.
+                    // var x = [1:"one"];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionNoTargetType, @"[1:""one""]").WithLocation(1, 9));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(LanguageVersions))]
+        public void LanguageVersionDiagnostics_04(LanguageVersion languageVersion)
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Dictionary<int, string> d = [];
+                        d.Report();
+                    }
+                }
+                """;
+            // C#12 collection expressions support target types that implement IEnumerable,
+            // with no Add requirement if the collection is empty.
+            var verifier = CompileAndVerify(
+                [source, s_dictionaryExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                expectedOutput: "[], ");
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("Program.Main", """
+                {
+                  // Code size       11 (0xb)
+                  .maxstack  1
+                  IL_0000:  newobj     "System.Collections.Generic.Dictionary<int, string>..ctor()"
+                  IL_0005:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                  IL_000a:  ret
+                }
+                """);
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void LanguageVersionDiagnostics_05(
+            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext)] LanguageVersion languageVersion,
+            bool includeExtensionAdd)
+        {
+            string sourceA = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Dictionary<int, string> d = [1:"one"];
+                        d.Report();
+                    }
+                }
+                """;
+            string sourceB = """
+                using System.Collections.Generic;
+                static class Extensions
+                {
+                    internal static void Add<K, V>(this Dictionary<K, V> d, KeyValuePair<K, V> kvp)
+                    {
+                        d.Add(kvp.Key, kvp.Value);
+                    }
+                }
+                """;
+            var comp = CreateCompilation(
+                includeExtensionAdd ? [sourceA, sourceB, s_dictionaryExtensions] : [sourceA, s_dictionaryExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                options: TestOptions.ReleaseExe);
+            if (languageVersion == LanguageVersion.CSharp13 && !includeExtensionAdd)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (6,37): error CS9215: Collection expression type 'Dictionary<int, string>' must have an instance or extension method 'Add' that can be called with a single argument.
+                    //         Dictionary<int, string> d = [1:"one"];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionMissingAdd, @"[1:""one""]").WithArguments("System.Collections.Generic.Dictionary<int, string>").WithLocation(6, 37),
+                    // (6,38): error CS9500: Collection expression type 'Dictionary<int, string>' does not support key-value pair elements.
+                    //         Dictionary<int, string> d = [1:"one"];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, @"1:""one""").WithArguments("System.Collections.Generic.Dictionary<int, string>").WithLocation(6, 38),
+                    // (6,39): error CS8652: The feature 'dictionary expressions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    //         Dictionary<int, string> d = [1:"one"];
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, ":").WithArguments("dictionary expressions").WithLocation(6, 39));
+            }
+            else if (languageVersion == LanguageVersion.CSharp13)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (6,38): error CS9500: Collection expression type 'Dictionary<int, string>' does not support key-value pair elements.
+                    //         Dictionary<int, string> d = [1:"one"];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, @"1:""one""").WithArguments("System.Collections.Generic.Dictionary<int, string>").WithLocation(6, 38),
+                    // (6,39): error CS8652: The feature 'dictionary expressions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    //         Dictionary<int, string> d = [1:"one"];
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, ":").WithArguments("dictionary expressions").WithLocation(6, 39));
+            }
+            else
+            {
+                var verifier = CompileAndVerify(comp, expectedOutput: "[1:one], ");
+                verifier.VerifyDiagnostics();
+                verifier.VerifyIL("Program.Main", """
+                    {
+                      // Code size       23 (0x17)
+                      .maxstack  4
+                      IL_0000:  newobj     "System.Collections.Generic.Dictionary<int, string>..ctor()"
+                      IL_0005:  dup
+                      IL_0006:  ldc.i4.1
+                      IL_0007:  ldstr      "one"
+                      IL_000c:  callvirt   "void System.Collections.Generic.Dictionary<int, string>.this[int].set"
+                      IL_0011:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                      IL_0016:  ret
+                    }
+                    """);
+            }
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void BreakingChange_DictionaryAdd_01(
+            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext)] LanguageVersion languageVersion,
+            bool includeExtensionAdd)
+        {
+            string sourceA = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Dictionary<int, string> d;
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        var y = new KeyValuePair<int, string>[] { new(3, "three") };
+                        d = [x];
+                        d.Report();
+                        d = [..y];
+                        d.Report();
+                    }
+                }
+                """;
+            string sourceB = """
+                using System.Collections.Generic;
+                static class Extensions
+                {
+                    internal static void Add<K, V>(this Dictionary<K, V> d, KeyValuePair<K, V> kvp)
+                    {
+                        d.Add(kvp.Key, kvp.Value);
+                    }
+                }
+                """;
+            var comp = CreateCompilation(
+                includeExtensionAdd ? [sourceA, sourceB, s_dictionaryExtensions] : [sourceA, s_dictionaryExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                options: TestOptions.ReleaseExe);
+            if (languageVersion == LanguageVersion.CSharp13 && !includeExtensionAdd)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (9,13): error CS9215: Collection expression type 'Dictionary<int, string>' must have an instance or extension method 'Add' that can be called with a single argument.
+                    //         d = [x];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionMissingAdd, "[x]").WithArguments("System.Collections.Generic.Dictionary<int, string>").WithLocation(9, 13),
+                    // (11,13): error CS9215: Collection expression type 'Dictionary<int, string>' must have an instance or extension method 'Add' that can be called with a single argument.
+                    //         d = [..y];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionMissingAdd, "[..y]").WithArguments("System.Collections.Generic.Dictionary<int, string>").WithLocation(11, 13));
+                return;
+            }
+            var verifier = CompileAndVerify(comp, expectedOutput: "[2:two], [3:three], ");
+            verifier.VerifyDiagnostics();
+            if (languageVersion == LanguageVersion.CSharp13)
+            {
+                verifier.VerifyIL("Program.Main", """
+                    {
+                        // Code size       99 (0x63)
+                        .maxstack  5
+                        .locals init (System.Collections.Generic.KeyValuePair<int, string> V_0, //x
+                                    System.Collections.Generic.Dictionary<int, string> V_1,
+                                    System.Collections.Generic.KeyValuePair<int, string>[] V_2,
+                                    int V_3,
+                                    System.Collections.Generic.KeyValuePair<int, string> V_4)
+                        IL_0000:  ldloca.s   V_0
+                        IL_0002:  ldc.i4.2
+                        IL_0003:  ldstr      "two"
+                        IL_0008:  call       "System.Collections.Generic.KeyValuePair<int, string>..ctor(int, string)"
+                        IL_000d:  ldc.i4.1
+                        IL_000e:  newarr     "System.Collections.Generic.KeyValuePair<int, string>"
+                        IL_0013:  dup
+                        IL_0014:  ldc.i4.0
+                        IL_0015:  ldc.i4.3
+                        IL_0016:  ldstr      "three"
+                        IL_001b:  newobj     "System.Collections.Generic.KeyValuePair<int, string>..ctor(int, string)"
+                        IL_0020:  stelem     "System.Collections.Generic.KeyValuePair<int, string>"
+                        IL_0025:  newobj     "System.Collections.Generic.Dictionary<int, string>..ctor()"
+                        IL_002a:  dup
+                        IL_002b:  ldloc.0
+                        IL_002c:  call       "void Extensions.Add<int, string>(System.Collections.Generic.Dictionary<int, string>, System.Collections.Generic.KeyValuePair<int, string>)"
+                        IL_0031:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                        IL_0036:  newobj     "System.Collections.Generic.Dictionary<int, string>..ctor()"
+                        IL_003b:  stloc.1
+                        IL_003c:  stloc.2
+                        IL_003d:  ldc.i4.0
+                        IL_003e:  stloc.3
+                        IL_003f:  br.s       IL_0056
+                        IL_0041:  ldloc.2
+                        IL_0042:  ldloc.3
+                        IL_0043:  ldelem     "System.Collections.Generic.KeyValuePair<int, string>"
+                        IL_0048:  stloc.s    V_4
+                        IL_004a:  ldloc.1
+                        IL_004b:  ldloc.s    V_4
+                        IL_004d:  call       "void Extensions.Add<int, string>(System.Collections.Generic.Dictionary<int, string>, System.Collections.Generic.KeyValuePair<int, string>)"
+                        IL_0052:  ldloc.3
+                        IL_0053:  ldc.i4.1
+                        IL_0054:  add
+                        IL_0055:  stloc.3
+                        IL_0056:  ldloc.3
+                        IL_0057:  ldloc.2
+                        IL_0058:  ldlen
+                        IL_0059:  conv.i4
+                        IL_005a:  blt.s      IL_0041
+                        IL_005c:  ldloc.1
+                        IL_005d:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                        IL_0062:  ret
+                    }
+                    """);
+            }
+            else
+            {
+                // Using indexer rather than extension method Add() is a breaking change from C#13.
+                verifier.VerifyIL("Program.Main", """
+                    {
+                      // Code size      130 (0x82)
+                      .maxstack  5
+                      .locals init (System.Collections.Generic.KeyValuePair<int, string> V_0, //x
+                                    System.Collections.Generic.KeyValuePair<int, string> V_1,
+                                    System.Collections.Generic.Dictionary<int, string> V_2,
+                                    System.Collections.Generic.KeyValuePair<int, string>[] V_3,
+                                    int V_4)
+                      IL_0000:  ldloca.s   V_0
+                      IL_0002:  ldc.i4.2
+                      IL_0003:  ldstr      "two"
+                      IL_0008:  call       "System.Collections.Generic.KeyValuePair<int, string>..ctor(int, string)"
+                      IL_000d:  ldc.i4.1
+                      IL_000e:  newarr     "System.Collections.Generic.KeyValuePair<int, string>"
+                      IL_0013:  dup
+                      IL_0014:  ldc.i4.0
+                      IL_0015:  ldc.i4.3
+                      IL_0016:  ldstr      "three"
+                      IL_001b:  newobj     "System.Collections.Generic.KeyValuePair<int, string>..ctor(int, string)"
+                      IL_0020:  stelem     "System.Collections.Generic.KeyValuePair<int, string>"
+                      IL_0025:  newobj     "System.Collections.Generic.Dictionary<int, string>..ctor()"
+                      IL_002a:  ldloc.0
+                      IL_002b:  stloc.1
+                      IL_002c:  dup
+                      IL_002d:  ldloca.s   V_1
+                      IL_002f:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                      IL_0034:  ldloca.s   V_1
+                      IL_0036:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                      IL_003b:  callvirt   "void System.Collections.Generic.Dictionary<int, string>.this[int].set"
+                      IL_0040:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                      IL_0045:  newobj     "System.Collections.Generic.Dictionary<int, string>..ctor()"
+                      IL_004a:  stloc.2
+                      IL_004b:  stloc.3
+                      IL_004c:  ldc.i4.0
+                      IL_004d:  stloc.s    V_4
+                      IL_004f:  br.s       IL_0074
+                      IL_0051:  ldloc.3
+                      IL_0052:  ldloc.s    V_4
+                      IL_0054:  ldelem     "System.Collections.Generic.KeyValuePair<int, string>"
+                      IL_0059:  stloc.1
+                      IL_005a:  ldloc.2
+                      IL_005b:  ldloca.s   V_1
+                      IL_005d:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                      IL_0062:  ldloca.s   V_1
+                      IL_0064:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                      IL_0069:  callvirt   "void System.Collections.Generic.Dictionary<int, string>.this[int].set"
+                      IL_006e:  ldloc.s    V_4
+                      IL_0070:  ldc.i4.1
+                      IL_0071:  add
+                      IL_0072:  stloc.s    V_4
+                      IL_0074:  ldloc.s    V_4
+                      IL_0076:  ldloc.3
+                      IL_0077:  ldlen
+                      IL_0078:  conv.i4
+                      IL_0079:  blt.s      IL_0051
+                      IL_007b:  ldloc.2
+                      IL_007c:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                      IL_0081:  ret
+                    }
+                    """);
+            }
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void BreakingChange_DictionaryAdd_02(
+            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext)] LanguageVersion languageVersion,
+            bool includeAdd)
+        {
+            string sourceA = $$"""
+                using System.Collections;
+                using System.Collections.Generic;
+                struct MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    private Dictionary<K, V> _d;
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => GetDictionary().GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    public V this[K key]
+                    {
+                        get { return GetDictionary()[key]; }
+                        set { GetDictionary()[key] = value; }
+                    }
+                    {{(includeAdd ? "public void Add(KeyValuePair<K, V> kvp) { ((ICollection<KeyValuePair<K, V>>)GetDictionary()).Add(kvp); }" : "")}}
+                    private Dictionary<K, V> GetDictionary() => _d ??= new();
+                }
+                """;
+            string sourceB = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyDictionary<int, string> d;
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        var y = new KeyValuePair<int, string>[] { new(3, "three") };
+                        d = [x];
+                        d.Report();
+                        d = [..y];
+                        d.Report();
+                    }
+                }
+                """;
+            var comp = CreateCompilation(
+                [sourceA, sourceB, s_dictionaryExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                options: TestOptions.ReleaseExe);
+            if (languageVersion == LanguageVersion.CSharp13 && !includeAdd)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (9,13): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
+                    //         d = [x];
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[x]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(9, 13),
+                    // (11,13): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
+                    //         d = [..y];
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[..y]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(11, 13));
+                return;
+            }
+            var verifier = CompileAndVerify(comp, expectedOutput: "[2:two], [3:three], ");
+            verifier.VerifyDiagnostics();
+            if (languageVersion == LanguageVersion.CSharp13)
+            {
+                verifier.VerifyIL("Program.Main", """
+                    {
+                      // Code size      117 (0x75)
+                      .maxstack  5
+                      .locals init (System.Collections.Generic.KeyValuePair<int, string> V_0, //x
+                                    MyDictionary<int, string> V_1,
+                                    System.Collections.Generic.KeyValuePair<int, string>[] V_2,
+                                    int V_3,
+                                    System.Collections.Generic.KeyValuePair<int, string> V_4)
+                      IL_0000:  ldloca.s   V_0
+                      IL_0002:  ldc.i4.2
+                      IL_0003:  ldstr      "two"
+                      IL_0008:  call       "System.Collections.Generic.KeyValuePair<int, string>..ctor(int, string)"
+                      IL_000d:  ldc.i4.1
+                      IL_000e:  newarr     "System.Collections.Generic.KeyValuePair<int, string>"
+                      IL_0013:  dup
+                      IL_0014:  ldc.i4.0
+                      IL_0015:  ldc.i4.3
+                      IL_0016:  ldstr      "three"
+                      IL_001b:  newobj     "System.Collections.Generic.KeyValuePair<int, string>..ctor(int, string)"
+                      IL_0020:  stelem     "System.Collections.Generic.KeyValuePair<int, string>"
+                      IL_0025:  ldloca.s   V_1
+                      IL_0027:  initobj    "MyDictionary<int, string>"
+                      IL_002d:  ldloca.s   V_1
+                      IL_002f:  ldloc.0
+                      IL_0030:  call       "void MyDictionary<int, string>.Add(System.Collections.Generic.KeyValuePair<int, string>)"
+                      IL_0035:  ldloc.1
+                      IL_0036:  box        "MyDictionary<int, string>"
+                      IL_003b:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                      IL_0040:  ldloca.s   V_1
+                      IL_0042:  initobj    "MyDictionary<int, string>"
+                      IL_0048:  stloc.2
+                      IL_0049:  ldc.i4.0
+                      IL_004a:  stloc.3
+                      IL_004b:  br.s       IL_0063
+                      IL_004d:  ldloc.2
+                      IL_004e:  ldloc.3
+                      IL_004f:  ldelem     "System.Collections.Generic.KeyValuePair<int, string>"
+                      IL_0054:  stloc.s    V_4
+                      IL_0056:  ldloca.s   V_1
+                      IL_0058:  ldloc.s    V_4
+                      IL_005a:  call       "void MyDictionary<int, string>.Add(System.Collections.Generic.KeyValuePair<int, string>)"
+                      IL_005f:  ldloc.3
+                      IL_0060:  ldc.i4.1
+                      IL_0061:  add
+                      IL_0062:  stloc.3
+                      IL_0063:  ldloc.3
+                      IL_0064:  ldloc.2
+                      IL_0065:  ldlen
+                      IL_0066:  conv.i4
+                      IL_0067:  blt.s      IL_004d
+                      IL_0069:  ldloc.1
+                      IL_006a:  box        "MyDictionary<int, string>"
+                      IL_006f:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                      IL_0074:  ret
+                    }
+                    """);
+            }
+            else
+            {
+                // Using indexer rather than instance method Add() is a breaking change from C#13.
+                verifier.VerifyIL("Program.Main", """
+                    {
+                      // Code size      148 (0x94)
+                      .maxstack  5
+                      .locals init (System.Collections.Generic.KeyValuePair<int, string> V_0, //x
+                                    MyDictionary<int, string> V_1,
+                                    System.Collections.Generic.KeyValuePair<int, string> V_2,
+                                    System.Collections.Generic.KeyValuePair<int, string>[] V_3,
+                                    int V_4)
+                      IL_0000:  ldloca.s   V_0
+                      IL_0002:  ldc.i4.2
+                      IL_0003:  ldstr      "two"
+                      IL_0008:  call       "System.Collections.Generic.KeyValuePair<int, string>..ctor(int, string)"
+                      IL_000d:  ldc.i4.1
+                      IL_000e:  newarr     "System.Collections.Generic.KeyValuePair<int, string>"
+                      IL_0013:  dup
+                      IL_0014:  ldc.i4.0
+                      IL_0015:  ldc.i4.3
+                      IL_0016:  ldstr      "three"
+                      IL_001b:  newobj     "System.Collections.Generic.KeyValuePair<int, string>..ctor(int, string)"
+                      IL_0020:  stelem     "System.Collections.Generic.KeyValuePair<int, string>"
+                      IL_0025:  ldloca.s   V_1
+                      IL_0027:  initobj    "MyDictionary<int, string>"
+                      IL_002d:  ldloc.0
+                      IL_002e:  stloc.2
+                      IL_002f:  ldloca.s   V_1
+                      IL_0031:  ldloca.s   V_2
+                      IL_0033:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                      IL_0038:  ldloca.s   V_2
+                      IL_003a:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                      IL_003f:  call       "void MyDictionary<int, string>.this[int].set"
+                      IL_0044:  ldloc.1
+                      IL_0045:  box        "MyDictionary<int, string>"
+                      IL_004a:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                      IL_004f:  ldloca.s   V_1
+                      IL_0051:  initobj    "MyDictionary<int, string>"
+                      IL_0057:  stloc.3
+                      IL_0058:  ldc.i4.0
+                      IL_0059:  stloc.s    V_4
+                      IL_005b:  br.s       IL_0081
+                      IL_005d:  ldloc.3
+                      IL_005e:  ldloc.s    V_4
+                      IL_0060:  ldelem     "System.Collections.Generic.KeyValuePair<int, string>"
+                      IL_0065:  stloc.2
+                      IL_0066:  ldloca.s   V_1
+                      IL_0068:  ldloca.s   V_2
+                      IL_006a:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                      IL_006f:  ldloca.s   V_2
+                      IL_0071:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                      IL_0076:  call       "void MyDictionary<int, string>.this[int].set"
+                      IL_007b:  ldloc.s    V_4
+                      IL_007d:  ldc.i4.1
+                      IL_007e:  add
+                      IL_007f:  stloc.s    V_4
+                      IL_0081:  ldloc.s    V_4
+                      IL_0083:  ldloc.3
+                      IL_0084:  ldlen
+                      IL_0085:  conv.i4
+                      IL_0086:  blt.s      IL_005d
+                      IL_0088:  ldloc.1
+                      IL_0089:  box        "MyDictionary<int, string>"
+                      IL_008e:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                      IL_0093:  ret
+                    }
+                    """);
+            }
+        }
+
+        [Theory]
+        [InlineData("Dictionary")]
+        [InlineData("IDictionary")]
+        [InlineData("IReadOnlyDictionary")]
+        public void Dictionary_01(string typeName)
+        {
+            string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        F<int, string>().Report();
+                    }
+                    static {{typeName}}<K, V> F<K, V>()
+                    {
+                        return [];
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_dictionaryExtensions],
+                expectedOutput: "[], ");
+            verifier.VerifyDiagnostics();
+            if (typeName == "IReadOnlyDictionary")
+            {
+                verifier.VerifyIL("Program.F<K, V>", """
+                    {
+                      // Code size       11 (0xb)
+                      .maxstack  1
+                      IL_0000:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor()"
+                      IL_0005:  newobj     "System.Collections.ObjectModel.ReadOnlyDictionary<K, V>..ctor(System.Collections.Generic.IDictionary<K, V>)"
+                      IL_000a:  ret
+                    }
+                    """);
+            }
+            else
+            {
+                verifier.VerifyIL("Program.F<K, V>", """
+                    {
+                      // Code size        6 (0x6)
+                      .maxstack  1
+                      IL_0000:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor()"
+                      IL_0005:  ret
+                    }
+                    """);
+            }
+        }
+
+        [Theory]
+        [InlineData("Dictionary")]
+        [InlineData("IDictionary")]
+        [InlineData("IReadOnlyDictionary")]
+        public void Dictionary_02(string typeName)
+        {
+            string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        var y = new KeyValuePair<int, string>[] { new(3, "three") };
+                        F(1, "one", x, y).Report();
+                    }
+                    static {{typeName}}<K, V> F<K, V>(K k, V v, KeyValuePair<K, V> e, IEnumerable<KeyValuePair<K, V>> s)
+                    {
+                        return /*<bind>*/[k:v, e, ..s]/*</bind>*/;
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_dictionaryExtensions],
+                expectedOutput: "[1:one, 2:two, 3:three], ");
+            verifier.VerifyDiagnostics();
+            if (typeName == "IReadOnlyDictionary")
+            {
+                verifier.VerifyIL("Program.F<K, V>", """
+                    {
+                      // Code size       99 (0x63)
+                      .maxstack  3
+                      .locals init (System.Collections.Generic.Dictionary<K, V> V_0,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_1,
+                                    System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<K, V>> V_2,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_3)
+                      IL_0000:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor()"
+                      IL_0005:  stloc.0
+                      IL_0006:  ldloc.0
+                      IL_0007:  ldarg.0
+                      IL_0008:  ldarg.1
+                      IL_0009:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                      IL_000e:  ldarg.2
+                      IL_000f:  stloc.1
+                      IL_0010:  ldloc.0
+                      IL_0011:  ldloca.s   V_1
+                      IL_0013:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                      IL_0018:  ldloca.s   V_1
+                      IL_001a:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                      IL_001f:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                      IL_0024:  ldarg.3
+                      IL_0025:  callvirt   "System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<K, V>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>.GetEnumerator()"
+                      IL_002a:  stloc.2
+                      .try
+                      {
+                        IL_002b:  br.s       IL_0048
+                        IL_002d:  ldloc.2
+                        IL_002e:  callvirt   "System.Collections.Generic.KeyValuePair<K, V> System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<K, V>>.Current.get"
+                        IL_0033:  stloc.3
+                        IL_0034:  ldloc.0
+                        IL_0035:  ldloca.s   V_3
+                        IL_0037:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                        IL_003c:  ldloca.s   V_3
+                        IL_003e:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                        IL_0043:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                        IL_0048:  ldloc.2
+                        IL_0049:  callvirt   "bool System.Collections.IEnumerator.MoveNext()"
+                        IL_004e:  brtrue.s   IL_002d
+                        IL_0050:  leave.s    IL_005c
+                      }
+                      finally
+                      {
+                        IL_0052:  ldloc.2
+                        IL_0053:  brfalse.s  IL_005b
+                        IL_0055:  ldloc.2
+                        IL_0056:  callvirt   "void System.IDisposable.Dispose()"
+                        IL_005b:  endfinally
+                      }
+                      IL_005c:  ldloc.0
+                      IL_005d:  newobj     "System.Collections.ObjectModel.ReadOnlyDictionary<K, V>..ctor(System.Collections.Generic.IDictionary<K, V>)"
+                      IL_0062:  ret
+                    }
+                    """);
+            }
+            else
+            {
+                verifier.VerifyIL("Program.F<K, V>", """
+                    {
+                      // Code size       94 (0x5e)
+                      .maxstack  3
+                      .locals init (System.Collections.Generic.Dictionary<K, V> V_0,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_1,
+                                    System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<K, V>> V_2,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_3)
+                      IL_0000:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor()"
+                      IL_0005:  stloc.0
+                      IL_0006:  ldloc.0
+                      IL_0007:  ldarg.0
+                      IL_0008:  ldarg.1
+                      IL_0009:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                      IL_000e:  ldarg.2
+                      IL_000f:  stloc.1
+                      IL_0010:  ldloc.0
+                      IL_0011:  ldloca.s   V_1
+                      IL_0013:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                      IL_0018:  ldloca.s   V_1
+                      IL_001a:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                      IL_001f:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                      IL_0024:  ldarg.3
+                      IL_0025:  callvirt   "System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<K, V>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>.GetEnumerator()"
+                      IL_002a:  stloc.2
+                      .try
+                      {
+                        IL_002b:  br.s       IL_0048
+                        IL_002d:  ldloc.2
+                        IL_002e:  callvirt   "System.Collections.Generic.KeyValuePair<K, V> System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<K, V>>.Current.get"
+                        IL_0033:  stloc.3
+                        IL_0034:  ldloc.0
+                        IL_0035:  ldloca.s   V_3
+                        IL_0037:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                        IL_003c:  ldloca.s   V_3
+                        IL_003e:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                        IL_0043:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                        IL_0048:  ldloc.2
+                        IL_0049:  callvirt   "bool System.Collections.IEnumerator.MoveNext()"
+                        IL_004e:  brtrue.s   IL_002d
+                        IL_0050:  leave.s    IL_005c
+                      }
+                      finally
+                      {
+                        IL_0052:  ldloc.2
+                        IL_0053:  brfalse.s  IL_005b
+                        IL_0055:  ldloc.2
+                        IL_0056:  callvirt   "void System.IDisposable.Dispose()"
+                        IL_005b:  endfinally
+                      }
+                      IL_005c:  ldloc.0
+                      IL_005d:  ret
+                    }
+                    """);
+            }
+            var comp = (CSharpCompilation)verifier.Compilation;
+            string constructMethod = typeName == "Dictionary" ? "System.Collections.Generic.Dictionary<K, V>..ctor()" : "null";
+            VerifyOperationTreeForTest<CollectionExpressionSyntax>(comp,
+                $$"""
+                ICollectionExpressionOperation (3 elements, ConstructMethod: {{constructMethod}}) (OperationKind.CollectionExpression, Type: System.Collections.Generic.{{typeName}}<K, V>) (Syntax: '[k:v, e, ..s]')
+                  Elements(3):
+                      IOperation:  (OperationKind.None, Type: null) (Syntax: 'k:v')
+                      IParameterReferenceOperation: e (OperationKind.ParameterReference, Type: System.Collections.Generic.KeyValuePair<K, V>) (Syntax: 'e')
+                      ISpreadOperation (ElementType: System.Collections.Generic.KeyValuePair<K, V>) (OperationKind.Spread, Type: null) (Syntax: '..s')
+                        Operand:
+                          IParameterReferenceOperation: s (OperationKind.ParameterReference, Type: System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>) (Syntax: 's')
+                        ElementConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                          (Identity)
+                """);
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void Dictionary_Params(
+            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext)] LanguageVersion languageVersion,
+            [CombinatorialValues("Dictionary", "IDictionary", "IReadOnlyDictionary")] string typeName)
+        {
+            string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Params<int, string>();
+                        Three<int, string>(new(1, "one"), new(2, "two"), new(1, "three"));
+                    }
+                    static void Empty<K, V>() { Params<K, V>(); }
+                    static void Three<K, V>(KeyValuePair<K, V> x, KeyValuePair<K, V> y, KeyValuePair<K, V> z) { Params(x, y, z); }
+                    static void Params<K, V>(params {{typeName}}<K, V> args) { args.Report(); }
+                }
+                """;
+            var comp = CreateCompilation(
+                [source, s_dictionaryExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                options: TestOptions.ReleaseExe);
+            if (languageVersion == LanguageVersion.CSharp13)
+            {
+                if (typeName == "Dictionary")
+                {
+                    comp.VerifyEmitDiagnostics(
+                        // (6,9): error CS7036: There is no argument given that corresponds to the required parameter 'args' of 'Program.Params<K, V>(params Dictionary<K, V>)'
+                        //         Params<int, string>();
+                        Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "Params<int, string>").WithArguments("args", "Program.Params<K, V>(params System.Collections.Generic.Dictionary<K, V>)").WithLocation(6, 9),
+                        // (9,33): error CS7036: There is no argument given that corresponds to the required parameter 'args' of 'Program.Params<K, V>(params Dictionary<K, V>)'
+                        //     static void Empty<K, V>() { Params<K, V>(); }
+                        Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "Params<K, V>").WithArguments("args", "Program.Params<K, V>(params System.Collections.Generic.Dictionary<K, V>)").WithLocation(9, 33),
+                        // (10,97): error CS1501: No overload for method 'Params' takes 3 arguments
+                        //     static void Three<K, V>(KeyValuePair<K, V> x, KeyValuePair<K, V> y, KeyValuePair<K, V> z) { Params(x, y, z); }
+                        Diagnostic(ErrorCode.ERR_BadArgCount, "Params").WithArguments("Params", "3").WithLocation(10, 97),
+                        // (11,30): error CS9215: Collection expression type 'Dictionary<K, V>' must have an instance or extension method 'Add' that can be called with a single argument.
+                        //     static void Params<K, V>(params Dictionary<K, V> args) { args.Report(); }
+                        Diagnostic(ErrorCode.ERR_CollectionExpressionMissingAdd, "params Dictionary<K, V> args").WithArguments("System.Collections.Generic.Dictionary<K, V>").WithLocation(11, 30));
+                }
+                else
+                {
+                    comp.VerifyEmitDiagnostics(
+                        // (6,9): error CS7036: There is no argument given that corresponds to the required parameter 'args' of 'Program.Params<K, V>(params IDictionary<K, V>)'
+                        //         Params<int, string>();
+                        Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "Params<int, string>").WithArguments("args", $"Program.Params<K, V>(params System.Collections.Generic.{typeName}<K, V>)").WithLocation(6, 9),
+                        // (9,33): error CS7036: There is no argument given that corresponds to the required parameter 'args' of 'Program.Params<K, V>(params IDictionary<K, V>)'
+                        //     static void Empty<K, V>() { Params<K, V>(); }
+                        Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "Params<K, V>").WithArguments("args", $"Program.Params<K, V>(params System.Collections.Generic.{typeName}<K, V>)").WithLocation(9, 33),
+                        // (10,97): error CS1501: No overload for method 'Params' takes 3 arguments
+                        //     static void Three<K, V>(KeyValuePair<K, V> x, KeyValuePair<K, V> y, KeyValuePair<K, V> z) { Params(x, y, z); }
+                        Diagnostic(ErrorCode.ERR_BadArgCount, "Params").WithArguments("Params", "3").WithLocation(10, 97),
+                        // (11,30): error CS0225: The params parameter must have a valid collection type
+                        //     static void Params<K, V>(params IDictionary<K, V> args) { args.Report(); }
+                        Diagnostic(ErrorCode.ERR_ParamsMustBeCollection, "params").WithLocation(11, 30));
+                }
+            }
+            else
+            {
+                var verifier = CompileAndVerify(
+                    comp,
+                    expectedOutput: "[], [1:three, 2:two], ");
+                verifier.VerifyDiagnostics();
+                if (typeName == "IReadOnlyDictionary")
+                {
+                    verifier.VerifyIL("Program.Empty<K, V>", $$"""
+                        {
+                          // Code size       16 (0x10)
+                          .maxstack  1
+                          IL_0000:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor()"
+                          IL_0005:  newobj     "System.Collections.ObjectModel.ReadOnlyDictionary<K, V>..ctor(System.Collections.Generic.IDictionary<K, V>)"
+                          IL_000a:  call       "void Program.Params<K, V>(params System.Collections.Generic.IReadOnlyDictionary<K, V>)"
+                          IL_000f:  ret
+                        }
+                        """);
+                    verifier.VerifyIL("Program.Three<K, V>", $$"""
+                        {
+                          // Code size       82 (0x52)
+                          .maxstack  4
+                          .locals init (System.Collections.Generic.KeyValuePair<K, V> V_0,
+                                        System.Collections.Generic.KeyValuePair<K, V> V_1,
+                                        System.Collections.Generic.KeyValuePair<K, V> V_2)
+                          IL_0000:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor()"
+                          IL_0005:  ldarg.0
+                          IL_0006:  stloc.0
+                          IL_0007:  dup
+                          IL_0008:  ldloca.s   V_0
+                          IL_000a:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                          IL_000f:  ldloca.s   V_0
+                          IL_0011:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                          IL_0016:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                          IL_001b:  ldarg.1
+                          IL_001c:  stloc.1
+                          IL_001d:  dup
+                          IL_001e:  ldloca.s   V_1
+                          IL_0020:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                          IL_0025:  ldloca.s   V_1
+                          IL_0027:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                          IL_002c:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                          IL_0031:  ldarg.2
+                          IL_0032:  stloc.2
+                          IL_0033:  dup
+                          IL_0034:  ldloca.s   V_2
+                          IL_0036:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                          IL_003b:  ldloca.s   V_2
+                          IL_003d:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                          IL_0042:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                          IL_0047:  newobj     "System.Collections.ObjectModel.ReadOnlyDictionary<K, V>..ctor(System.Collections.Generic.IDictionary<K, V>)"
+                          IL_004c:  call       "void Program.Params<K, V>(params System.Collections.Generic.IReadOnlyDictionary<K, V>)"
+                          IL_0051:  ret
+                        }
+                        """);
+                }
+                else
+                {
+                    verifier.VerifyIL("Program.Empty<K, V>", $$"""
+                        {
+                          // Code size       11 (0xb)
+                          .maxstack  1
+                          IL_0000:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor()"
+                          IL_0005:  call       "void Program.Params<K, V>(params System.Collections.Generic.{{typeName}}<K, V>)"
+                          IL_000a:  ret
+                        }
+                        """);
+                    verifier.VerifyIL("Program.Three<K, V>", $$"""
+                        {
+                          // Code size       77 (0x4d)
+                          .maxstack  4
+                          .locals init (System.Collections.Generic.KeyValuePair<K, V> V_0,
+                                        System.Collections.Generic.KeyValuePair<K, V> V_1,
+                                        System.Collections.Generic.KeyValuePair<K, V> V_2)
+                          IL_0000:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor()"
+                          IL_0005:  ldarg.0
+                          IL_0006:  stloc.0
+                          IL_0007:  dup
+                          IL_0008:  ldloca.s   V_0
+                          IL_000a:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                          IL_000f:  ldloca.s   V_0
+                          IL_0011:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                          IL_0016:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                          IL_001b:  ldarg.1
+                          IL_001c:  stloc.1
+                          IL_001d:  dup
+                          IL_001e:  ldloca.s   V_1
+                          IL_0020:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                          IL_0025:  ldloca.s   V_1
+                          IL_0027:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                          IL_002c:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                          IL_0031:  ldarg.2
+                          IL_0032:  stloc.2
+                          IL_0033:  dup
+                          IL_0034:  ldloca.s   V_2
+                          IL_0036:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                          IL_003b:  ldloca.s   V_2
+                          IL_003d:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                          IL_0042:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                          IL_0047:  call       "void Program.Params<K, V>(params System.Collections.Generic.{{typeName}}<K, V>)"
+                          IL_004c:  ret
+                        }
+                        """);
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(LanguageVersions))]
+        public void CustomDictionary_Params(LanguageVersion languageVersion)
+        {
+            string sourceA = $$"""
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    private Dictionary<K, V> _d = new();
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => _d.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    public V this[K key]
+                    {
+                        get { return _d[key]; }
+                        set { _d[key] = value; }
+                    }
+                }
+                """;
+            string sourceB = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Params<int, string>();
+                        Three<int, string>(new(1, "one"), new(2, "two"), new(1, "three"));
+                    }
+                    static void Empty<K, V>() { Params<K, V>(); }
+                    static void Three<K, V>(KeyValuePair<K, V> x, KeyValuePair<K, V> y, KeyValuePair<K, V> z) { Params(x, y, z); }
+                    static void Params<K, V>(params MyDictionary<K, V> args) { args.Report(); }
+                }
+                """;
+            var comp = CreateCompilation(
+                [sourceA, sourceB, s_dictionaryExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                options: TestOptions.ReleaseExe);
+            if (languageVersion == LanguageVersion.CSharp13)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (6,9): error CS7036: There is no argument given that corresponds to the required parameter 'args' of 'Program.Params<K, V>(params MyDictionary<K, V>)'
+                    //         Params<int, string>();
+                    Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "Params<int, string>").WithArguments("args", "Program.Params<K, V>(params MyDictionary<K, V>)").WithLocation(6, 9),
+                    // (9,33): error CS7036: There is no argument given that corresponds to the required parameter 'args' of 'Program.Params<K, V>(params MyDictionary<K, V>)'
+                    //     static void Empty<K, V>() { Params<K, V>(); }
+                    Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "Params<K, V>").WithArguments("args", "Program.Params<K, V>(params MyDictionary<K, V>)").WithLocation(9, 33),
+                    // (10,97): error CS1501: No overload for method 'Params' takes 3 arguments
+                    //     static void Three<K, V>(KeyValuePair<K, V> x, KeyValuePair<K, V> y, KeyValuePair<K, V> z) { Params(x, y, z); }
+                    Diagnostic(ErrorCode.ERR_BadArgCount, "Params").WithArguments("Params", "3").WithLocation(10, 97),
+                    // (11,30): error CS0117: 'MyDictionary<K, V>' does not contain a definition for 'Add'
+                    //     static void Params<K, V>(params MyDictionary<K, V> args) { args.Report(); }
+                    Diagnostic(ErrorCode.ERR_NoSuchMember, "params MyDictionary<K, V> args").WithArguments("MyDictionary<K, V>", "Add").WithLocation(11, 30));
+            }
+            else
+            {
+                var verifier = CompileAndVerify(
+                    comp,
+                    expectedOutput: "[], [1:three, 2:two], ");
+                verifier.VerifyDiagnostics();
+                verifier.VerifyIL("Program.Empty<K, V>", $$"""
+                    {
+                      // Code size       11 (0xb)
+                      .maxstack  1
+                      IL_0000:  newobj     "MyDictionary<K, V>..ctor()"
+                      IL_0005:  call       "void Program.Params<K, V>(params MyDictionary<K, V>)"
+                      IL_000a:  ret
+                    }
+                    """);
+                verifier.VerifyIL("Program.Three<K, V>", $$"""
+                    {
+                      // Code size       77 (0x4d)
+                      .maxstack  4
+                      .locals init (System.Collections.Generic.KeyValuePair<K, V> V_0,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_1,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_2)
+                      IL_0000:  newobj     "MyDictionary<K, V>..ctor()"
+                      IL_0005:  ldarg.0
+                      IL_0006:  stloc.0
+                      IL_0007:  dup
+                      IL_0008:  ldloca.s   V_0
+                      IL_000a:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                      IL_000f:  ldloca.s   V_0
+                      IL_0011:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                      IL_0016:  callvirt   "void MyDictionary<K, V>.this[K].set"
+                      IL_001b:  ldarg.1
+                      IL_001c:  stloc.1
+                      IL_001d:  dup
+                      IL_001e:  ldloca.s   V_1
+                      IL_0020:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                      IL_0025:  ldloca.s   V_1
+                      IL_0027:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                      IL_002c:  callvirt   "void MyDictionary<K, V>.this[K].set"
+                      IL_0031:  ldarg.2
+                      IL_0032:  stloc.2
+                      IL_0033:  dup
+                      IL_0034:  ldloca.s   V_2
+                      IL_0036:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                      IL_003b:  ldloca.s   V_2
+                      IL_003d:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                      IL_0042:  callvirt   "void MyDictionary<K, V>.this[K].set"
+                      IL_0047:  call       "void Program.Params<K, V>(params MyDictionary<K, V>)"
+                      IL_004c:  ret
+                    }
+                    """);
+            }
+        }
+
+        [Theory]
+        [InlineData("Dictionary")]
+        [InlineData("IDictionary")]
+        [InlineData("IReadOnlyDictionary")]
+        public void Dictionary_DuplicateKeys(string typeName)
+        {
+            string source = $$"""
+                using System;
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(101, "one");
+                        var y = new KeyValuePair<int, string>(202, "two");
+                        var z = new KeyValuePair<int, string>(101, "three");
+                        Report(F1(x, y, z));
+                        Report(F1(y, z, x));
+                        Report(F1(z, x, y));
+                        Report(F2(x, y, z));
+                        Report(F2(y, z, x));
+                        Report(F2(z, x, y));
+                        Report(F3(x, y, z));
+                        Report(F3(y, z, x));
+                        Report(F3(z, x, y));
+                    }
+                    static void Report<K, V>({{typeName}}<K, V> d)
+                    {
+                        d.Report();
+                        Console.WriteLine();
+                    }
+                    static {{typeName}}<K, V> F1<K, V>(KeyValuePair<K, V> x, KeyValuePair<K, V> y, KeyValuePair<K, V> z)
+                    {
+                        return [x.Key:x.Value, y, .. new[] { z }];
+                    }
+                    static {{typeName}}<K, V> F2<K, V>(KeyValuePair<K, V> x, KeyValuePair<K, V> y, KeyValuePair<K, V> z)
+                    {
+                        return [x, .. new[] { y }, z.Key:z.Value];
+                    }
+                    static {{typeName}}<K, V> F3<K, V>(KeyValuePair<K, V> x, KeyValuePair<K, V> y, KeyValuePair<K, V> z)
+                    {
+                        return [.. new[] { x }, y.Key:y.Value, z];
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_dictionaryExtensions],
+                expectedOutput: """
+                    [101:three, 202:two], 
+                    [101:one, 202:two], 
+                    [101:one, 202:two], 
+                    [101:three, 202:two], 
+                    [101:one, 202:two], 
+                    [101:one, 202:two], 
+                    [101:three, 202:two], 
+                    [101:one, 202:two], 
+                    [101:one, 202:two], 
+                    """);
+            verifier.VerifyDiagnostics();
+        }
+
+        [Theory]
+        [InlineData("Dictionary")]
+        [InlineData("IDictionary")]
+        [InlineData("IReadOnlyDictionary")]
+        public void DictionaryNotImplementingIDictionary(string typeName)
+        {
+            string sourceA = """
+                using System.Collections.Generic;
+                namespace System
+                {
+                    public class Object { }
+                    public abstract class ValueType { }
+                    public class String { }
+                    public class Type { }
+                    public struct Void { }
+                    public struct Boolean { }
+                    public struct Int32 { }
+                    public struct Enum { }
+                    public class Attribute { }
+                    public class AttributeUsageAttribute : Attribute
+                    {
+                        public AttributeUsageAttribute(AttributeTargets t) { }
+                        public bool AllowMultiple { get; set; }
+                        public bool Inherited { get; set; }
+                    }
+                    public enum AttributeTargets { }
+                    public interface IDisposable
+                    {
+                        void Dispose();
+                    }
+                }
+                namespace System.Collections
+                {
+                    public interface IEnumerator
+                    {
+                        bool MoveNext();
+                        object Current { get; }
+                    }
+                    public interface IEnumerable
+                    {
+                        IEnumerator GetEnumerator();
+                    }
+                }
+                namespace System.Collections.Generic
+                {
+                    public interface IEnumerator<T> : IEnumerator
+                    {
+                        new T Current { get; }
+                    }
+                    public interface IEnumerable<T> : IEnumerable
+                    {
+                        new IEnumerator<T> GetEnumerator();
+                    }
+                    public interface IEqualityComparer<T>
+                    {
+                        bool Equals(T x, T y);
+                        int GetHashCode(T t);
+                    }
+                    public interface IDictionary<TKey, TValue> : IEnumerable<KeyValuePair<TKey, TValue>>
+                    {
+                    }
+                    public interface IReadOnlyDictionary<TKey, TValue> : IEnumerable<KeyValuePair<TKey, TValue>>
+                    {
+                    }
+                    public struct KeyValuePair<TKey, TValue>
+                    {
+                        public KeyValuePair(TKey key, TValue value) { }
+                        public TKey Key { get; }
+                        public TValue Value { get; }
+                    }
+                    public sealed class Dictionary<TKey, TValue> : IEnumerable<KeyValuePair<TKey, TValue>>
+                    {
+                        public Dictionary() { }
+                        public Dictionary(IEqualityComparer<TKey> comparer) { }
+                        public Dictionary(int capacity) { }
+                        public Dictionary(int capacity, IEqualityComparer<TKey> comparer) { }
+                        public TValue this[TKey key] { get { return default; } set { } }
+                        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() => null;
+                        IEnumerator IEnumerable.GetEnumerator() => null;
+                    }
+                }
+                namespace System.Collections.ObjectModel
+                {
+                    public sealed class ReadOnlyDictionary<TKey, TValue> : IReadOnlyDictionary<TKey, TValue>
+                    {
+                        public ReadOnlyDictionary(IDictionary<TKey, TValue> d) { }
+                        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() => null;
+                        IEnumerator IEnumerable.GetEnumerator() => null;
+                    }
+                }
+                namespace System.Reflection
+                {
+                    public class DefaultMemberAttribute : Attribute
+                    {
+                        public DefaultMemberAttribute(string name) { }
+                    }
+                }
+                """;
+            string sourceB = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Empty<int, string>();
+                        Many(1, "one", new KeyValuePair<int, string>(), null);
+                    }
+                    static {{typeName}}<K, V> Empty<K, V>()
+                    {
+                        return [];
+                    }
+                    static {{typeName}}<K, V> Many<K, V>(K k, V v, KeyValuePair<K, V> x, IEnumerable<KeyValuePair<K, V>> y)
+                    {
+                        return [k:v, x, ..y];
+                    }
+                }
+                """;
+            var comp = CreateEmptyCompilation(new[] { sourceA, sourceB });
+            var emitOptions = Microsoft.CodeAnalysis.Emit.EmitOptions.Default.WithRuntimeMetadataVersion("0.0.0.0");
+            if (typeName == "Dictionary")
+            {
+                comp.VerifyEmitDiagnostics(emitOptions);
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics(emitOptions,
+                    // 1.cs(11,16): error CS0029: Cannot implicitly convert type 'System.Collections.Generic.Dictionary<K, V>' to 'System.Collections.Generic.IDictionary<K, V>'
+                    //         return [];
+                    Diagnostic(ErrorCode.ERR_NoImplicitConv, "[]").WithArguments("System.Collections.Generic.Dictionary<K, V>", $"System.Collections.Generic.{typeName}<K, V>").WithLocation(11, 16),
+                    // 1.cs(15,16): error CS0029: Cannot implicitly convert type 'System.Collections.Generic.Dictionary<K, V>' to 'System.Collections.Generic.IDictionary<K, V>'
+                    //         return [k:v, x, ..y];
+                    Diagnostic(ErrorCode.ERR_NoImplicitConv, "[k:v, x, ..y]").WithArguments("System.Collections.Generic.Dictionary<K, V>", $"System.Collections.Generic.{typeName}<K, V>").WithLocation(15, 16));
+            }
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void DictionaryInterface_MissingMember(
+            [CombinatorialValues("IDictionary", "IReadOnlyDictionary")] string typeName,
+            [CombinatorialValues("k:v", "x", "..y")] string element)
+        {
+            string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static {{typeName}}<K, V> Create<K, V>(K k, V v, KeyValuePair<K, V> x, KeyValuePair<K, V>[] y)
+                    {
+                        return [{{element}}];
+                    }
+                }
+                """;
+
+            var comp = CreateCompilation(source);
+            comp.MakeTypeMissing(WellKnownType.System_Collections_Generic_List_T);
+            comp.VerifyEmitDiagnostics();
+
+            comp = CreateCompilation(source);
+            comp.MakeTypeMissing(WellKnownType.System_Collections_Generic_Dictionary_KV);
+            if (typeName == "IDictionary")
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (6,16): error CS0518: Predefined type 'System.Collections.Generic.Dictionary`2' is not defined or imported
+                    //         return [k:v];
+                    Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2").WithLocation(6, 16),
+                    // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                    //         return [k:v];
+                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 16),
+                    // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2.set_Item'
+                    //         return [k:v];
+                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", "set_Item").WithLocation(6, 16),
+                    // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                    //         return [k:v];
+                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 16),
+                    // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                    //         return [k:v];
+                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 16),
+                    // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                    //         return [k:v];
+                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 16),
+                    // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                    //         return [k:v];
+                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 16));
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (6,16): error CS0518: Predefined type 'System.Collections.Generic.Dictionary`2' is not defined or imported
+                    //         return [k:v];
+                    Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2").WithLocation(6, 16),
+                    // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                    //         return [k:v];
+                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 16),
+                    // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2.set_Item'
+                    //         return [k:v];
+                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", "set_Item").WithLocation(6, 16),
+                    // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                    //         return [k:v];
+                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 16),
+                    // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                    //         return [k:v];
+                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 16));
+            }
+
+            comp = CreateCompilation(source);
+            comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor);
+            if (typeName == "IDictionary")
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                    //         return [k:v];
+                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 16),
+                    // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                    //         return [k:v];
+                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 16),
+                    // (6,16): error CS1501: No overload for method '<signature>' takes 0 arguments
+                    //         return [k:v];
+                    Diagnostic(ErrorCode.ERR_BadArgCount, $"[{element}]").WithArguments("<signature>", "0").WithLocation(6, 16));
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                    //         return [k:v];
+                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 16),
+                    // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                    //         return [k:v];
+                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 16),
+                    // (6,16): error CS7036: There is no argument given that corresponds to the required parameter 'comparer' of 'Program.<signature>(IEqualityComparer<K>?)'
+                    //         return [k:v];
+                    Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, $"[{element}]").WithArguments("comparer", "Program.<signature>(System.Collections.Generic.IEqualityComparer<K>?)").WithLocation(6, 16));
+            }
+
+            comp = CreateCompilation(source);
+            comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_Dictionary_KV__set_Item);
+            comp.VerifyEmitDiagnostics(
+                // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2.set_Item'
+                //         return [k:v];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", "set_Item").WithLocation(6, 16));
+        }
+
+        [Theory]
+        [InlineData("IDictionary")]
+        [InlineData("IReadOnlyDictionary")]
+        public void KeyValuePair_MissingMember_DictionaryInterface(string typeName)
+        {
+            string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static {{typeName}}<int?, object> Pair(int k, string v)
+                    {
+                        return [k:v];
+                    }
+                    static {{typeName}}<int?, object> Element(KeyValuePair<int, string> e)
+                    {
+                        return [e];
+                    }
+                    static {{typeName}}<int?, object> Spread(KeyValuePair<int, string>[] s)
+                    {
+                        return [..s];
+                    }
+                }
+                """;
+
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics();
+
+            comp = CreateCompilation(source);
+            comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Key);
+            comp.VerifyEmitDiagnostics(
+                // (10,17): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
+                //         return [e];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "e").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(10, 17),
+                // (14,19): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
+                //         return [..s];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "s").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(14, 19));
+
+            comp = CreateCompilation(source);
+            comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Value);
+            comp.VerifyEmitDiagnostics(
+                // (10,17): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
+                //         return [e];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "e").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(10, 17),
+                // (14,19): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
+                //         return [..s];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "s").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(14, 19));
+        }
+
+        [Fact]
+        public void KeyValuePair_MissingMember_CustomDictionary()
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                public class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public V this[K k] { get => default; set { } }
+                }
+                """;
+            var comp = CreateCompilation(sourceA);
+            var refA = comp.EmitToImageReference();
+
+            string sourceB = """
+                using System.Collections.Generic;
+                MyDictionary<int, string> d;
+                d = [];
+                d = [1:"one"];
+                d = [new KeyValuePair<int, string>(2, "two")];
+                d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
+                """;
+
+            comp = CreateCompilation(sourceB, references: [refA]);
+            comp.VerifyEmitDiagnostics();
+
+            comp = CreateCompilation(sourceB, references: [refA]);
+            comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Key);
+            comp.VerifyEmitDiagnostics(
+                // (5,6): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
+                // d = [new KeyValuePair<int, string>(2, "two")];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"new KeyValuePair<int, string>(2, ""two"")").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(5, 6),
+                // (6,9): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
+                // d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"new KeyValuePair<int, string>[] { new(3, ""three"") }").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(6, 9));
+
+            comp = CreateCompilation(sourceB, references: [refA]);
+            comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Value);
+            comp.VerifyEmitDiagnostics(
+                // (5,6): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
+                // d = [new KeyValuePair<int, string>(2, "two")];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"new KeyValuePair<int, string>(2, ""two"")").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(5, 6),
+                // (6,9): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
+                // d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"new KeyValuePair<int, string>[] { new(3, ""three"") }").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(6, 9));
+
+            comp = CreateCompilation(sourceB, references: [refA]);
+            comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__ctor);
+            comp.VerifyEmitDiagnostics();
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void KeyValuePair_MissingMember_NonDictionary_01(
+            [CombinatorialValues(LanguageVersion.CSharp12, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
+            [CombinatorialValues("KeyValuePair<int, string>[]", "List<KeyValuePair<int, string>>")] string typeName)
+        {
+            string source = $$"""
+                using System.Collections.Generic;
+                {{typeName}} d;
+                d = [];
+                d = [new KeyValuePair<int, string>(2, "two")];
+                d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
+                """;
+
+            var parseOptions = TestOptions.Regular.WithLanguageVersion(languageVersion);
+            var comp = CreateCompilation(source, parseOptions: parseOptions);
+            comp.VerifyEmitDiagnostics();
+
+            comp = CreateCompilation(source, parseOptions: parseOptions);
+            comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Key);
+            comp.VerifyEmitDiagnostics();
+
+            comp = CreateCompilation(source, parseOptions: parseOptions);
+            comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Value);
+            comp.VerifyEmitDiagnostics();
+
+            comp = CreateCompilation(source, parseOptions: parseOptions);
+            comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__ctor);
+            comp.VerifyEmitDiagnostics();
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void KeyValuePair_MissingMember_NonDictionary_02(
+            [CombinatorialValues("KeyValuePair<int?, object>[]", "List<KeyValuePair<int?, object>>")] string typeName)
+        {
+            string source = $$"""
+                using System.Collections.Generic;
+                {{typeName}} d;
+                d = [];
+                d = [1:"one"];
+                d = [new KeyValuePair<int, string>(2, "two")];
+                d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
+                """;
+
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics();
+
+            comp = CreateCompilation(source);
+            comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Key);
+            comp.VerifyEmitDiagnostics(
+                // (5,6): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
+                // d = [new KeyValuePair<int, string>(2, "two")];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"new KeyValuePair<int, string>(2, ""two"")").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(5, 6),
+                // (6,9): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Key'
+                // d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"new KeyValuePair<int, string>[] { new(3, ""three"") }").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Key").WithLocation(6, 9));
+
+            comp = CreateCompilation(source);
+            comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__get_Value);
+            comp.VerifyEmitDiagnostics(
+                // (5,6): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
+                // d = [new KeyValuePair<int, string>(2, "two")];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"new KeyValuePair<int, string>(2, ""two"")").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(5, 6),
+                // (6,9): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2.get_Value'
+                // d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"new KeyValuePair<int, string>[] { new(3, ""three"") }").WithArguments("System.Collections.Generic.KeyValuePair`2", "get_Value").WithLocation(6, 9));
+
+            comp = CreateCompilation(source);
+            comp.MakeMemberMissing(WellKnownMember.System_Collections_Generic_KeyValuePair_KV__ctor);
+            comp.VerifyEmitDiagnostics(
+                // (4,6): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2..ctor'
+                // d = [1:"one"];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"1:""one""").WithArguments("System.Collections.Generic.KeyValuePair`2", ".ctor").WithLocation(4, 6),
+                // (5,6): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2..ctor'
+                // d = [new KeyValuePair<int, string>(2, "two")];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"new KeyValuePair<int, string>(2, ""two"")").WithArguments("System.Collections.Generic.KeyValuePair`2", ".ctor").WithLocation(5, 6),
+                // (6,9): error CS0656: Missing compiler required member 'System.Collections.Generic.KeyValuePair`2..ctor'
+                // d = [.. new KeyValuePair<int, string>[] { new(3, "three") }];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"new KeyValuePair<int, string>[] { new(3, ""three"") }").WithArguments("System.Collections.Generic.KeyValuePair`2", ".ctor").WithLocation(6, 9));
+        }
+
+        [Fact]
+        public void RefSafety_Indexer()
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Diagnostics.CodeAnalysis;
+                ref struct MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    private ref readonly K _key;
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public V this[[UnscopedRef] in K key]  { get { return default; } set { _key = ref key; } }
+                }
+                """;
+            string sourceB = """
+                class Program
+                {
+                    static MyDictionary<K, V> FromPair1<K, V>(K k, V v)
+                    {
+                        MyDictionary<K, V> d = new();
+                        d[k] = v;
+                        return d;
+                    }
+                    static MyDictionary<K, V> FromPair2<K, V>(K k, V v)
+                    {
+                        MyDictionary<K, V> d;
+                        d = [k:v];
+                        return d;
+                    }
+                    static MyDictionary<K, V> FromPair3<K, V>(K k, V v)
+                    {
+                        MyDictionary<K, V> d = [k:v];
+                        return d;
+                    }
+                    static MyDictionary<K, V> FromPair4<K, V>(ref K k, ref V v)
+                    {
+                        return [k:v];
+                    }
+                    static MyDictionary<K, V> FromPair5<K, V>(V v)
+                    {
+                        MyDictionary<K, V> d = [MakeKey<K>():v];
+                        return d;
+                    }
+                    static K MakeKey<K>() => default;
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB], targetFramework: TargetFramework.Net90);
+            comp.VerifyEmitDiagnostics(
+                // (6,9): error CS8350: This combination of arguments to 'MyDictionary<K, V>.this[in K]' is disallowed because it may expose variables referenced by parameter 'key' outside of their declaration scope
+                //         d[k] = v;
+                Diagnostic(ErrorCode.ERR_CallArgMixing, "d[k]").WithArguments("MyDictionary<K, V>.this[in K]", "key").WithLocation(6, 9),
+                // (6,11): error CS8166: Cannot return a parameter by reference 'k' because it is not a ref parameter
+                //         d[k] = v;
+                Diagnostic(ErrorCode.ERR_RefReturnParameter, "k").WithArguments("k").WithLocation(6, 11),
+                // (12,13): error CS9203: A collection expression of type 'MyDictionary<K, V>' cannot be used in this context because it may be exposed outside of the current scope.
+                //         d = [k:v];
+                Diagnostic(ErrorCode.ERR_CollectionExpressionEscape, "[k:v]").WithArguments("MyDictionary<K, V>").WithLocation(12, 13),
+                // (18,16): error CS8352: Cannot use variable 'd' in this context because it may expose referenced variables outside of their declaration scope
+                //         return d;
+                Diagnostic(ErrorCode.ERR_EscapeVariable, "d").WithArguments("d").WithLocation(18, 16),
+                // (22,16): error CS9203: A collection expression of type 'MyDictionary<K, V>' cannot be used in this context because it may be exposed outside of the current scope.
+                //         return [k:v];
+                Diagnostic(ErrorCode.ERR_CollectionExpressionEscape, "[k:v]").WithArguments("MyDictionary<K, V>").WithLocation(22, 16),
+                // (27,16): error CS8352: Cannot use variable 'd' in this context because it may expose referenced variables outside of their declaration scope
+                //         return d;
+                Diagnostic(ErrorCode.ERR_EscapeVariable, "d").WithArguments("d").WithLocation(27, 16));
+        }
+
+        [Fact]
+        public void Async()
+        {
+            string source = """
+                using System.Collections.Generic;
+                using System.Threading.Tasks;
+                class Program
+                {
+                    static async Task Main()
+                    {
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        var y = new[] { new KeyValuePair<int, string>(3, "three") };
+                        (await Create(1, "one", x, y)).Report();
+                    }
+                    static async Task<IDictionary<object, object>> Create<K, V>(K k, V v, KeyValuePair<K, V> e, IEnumerable<KeyValuePair<K, V>> s)
+                    {
+                        return [await F(k):v, k:await F(v), await F(e), .. await F(s)];
+                    }
+                    static async Task<T> F<T>(T t)
+                    {
+                        await Task.Yield();
+                        return t;
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_dictionaryExtensions],
+                expectedOutput: "[1:one, 2:two, 3:three], ");
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void KeyValuePairConversions_01()
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        F(1, "one").Report();
+                    }
+                    static IDictionary<long, object> F(int x, string y)
+                    {
+                        return /*<bind>*/[x:y]/*</bind>*/;
+                    }
+                }
+                """;
+            var comp = CreateCompilation([source, s_dictionaryExtensions], options: TestOptions.ReleaseExe);
+            var verifier = CompileAndVerify(comp, expectedOutput: "[1:one], ");
+            verifier.VerifyDiagnostics();
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var kvpElement = tree.GetRoot().DescendantNodes().OfType<KeyValuePairElementSyntax>().Single();
+            var typeInfo = model.GetTypeInfo(kvpElement.KeyExpression);
+            Assert.Equal(SpecialType.System_Int32, typeInfo.Type.SpecialType);
+            Assert.Equal(SpecialType.System_Int64, typeInfo.ConvertedType.SpecialType);
+            typeInfo = model.GetTypeInfo(kvpElement.ValueExpression);
+            Assert.Equal(SpecialType.System_String, typeInfo.Type.SpecialType);
+            Assert.Equal(SpecialType.System_Object, typeInfo.ConvertedType.SpecialType);
+
+            // https://github.com/dotnet/roslyn/issues/77872: Implement IOperation support.
+            VerifyOperationTreeForTest<CollectionExpressionSyntax>(comp,
+                """
+                ICollectionExpressionOperation (1 elements, ConstructMethod: null) (OperationKind.CollectionExpression, Type: System.Collections.Generic.IDictionary<System.Int64, System.Object>) (Syntax: '[x:y]')
+                  Elements(1):
+                      IOperation:  (OperationKind.None, Type: null) (Syntax: 'x:y')
+                """);
+        }
+
+        [Fact]
+        public void KeyValuePairExpressionConversions_01()
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>();
+                        IDictionary<object, object> d = /*<bind>*/[x]/*</bind>*/;
+                        d.Report();
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify([source, s_dictionaryExtensions], expectedOutput: "[0:null], ");
+            verifier.VerifyDiagnostics();
+
+            var comp = (CSharpCompilation)verifier.Compilation;
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var element = tree.GetRoot().DescendantNodes().OfType<ExpressionElementSyntax>().Single();
+            var typeInfo = model.GetTypeInfo(element.Expression);
+            Assert.Equal("System.Collections.Generic.KeyValuePair<System.Int32, System.String>", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal("System.Collections.Generic.KeyValuePair<System.Object, System.Object>", typeInfo.ConvertedType.ToTestDisplayString());
+
+            // https://github.com/dotnet/roslyn/issues/77872: Include IOperation support for implicit Key and Value conversions.
+            VerifyOperationTreeForTest<CollectionExpressionSyntax>(comp,
+                """
+                ICollectionExpressionOperation (1 elements, ConstructMethod: null) (OperationKind.CollectionExpression, Type: System.Collections.Generic.IDictionary<System.Object, System.Object>) (Syntax: '[x]')
+                  Elements(1):
+                      IOperation:  (OperationKind.None, Type: System.Collections.Generic.KeyValuePair<System.Object, System.Object>) (Syntax: 'x')
+                """);
+        }
+
+        [Fact]
+        public void KeyValuePairExpressionConversions_02()
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var y = new KeyValuePair<int, string>[0];
+                        IDictionary<object, object> d = /*<bind>*/[..y]/*</bind>*/;
+                        d.Report();
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify([source, s_dictionaryExtensions], expectedOutput: "[], ");
+            verifier.VerifyDiagnostics();
+
+            var comp = (CSharpCompilation)verifier.Compilation;
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var element = tree.GetRoot().DescendantNodes().OfType<SpreadElementSyntax>().Single();
+            var typeInfo = model.GetTypeInfo(element.Expression);
+            Assert.Equal("System.Collections.Generic.KeyValuePair<System.Int32, System.String>[]", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal("System.Collections.Generic.KeyValuePair<System.Int32, System.String>[]", typeInfo.ConvertedType.ToTestDisplayString());
+
+            // https://github.com/dotnet/roslyn/issues/77872: Include IOperation support for implicit Key and Value conversions.
+            VerifyOperationTreeForTest<CollectionExpressionSyntax>(comp,
+                """
+                ICollectionExpressionOperation (1 elements, ConstructMethod: null) (OperationKind.CollectionExpression, Type: System.Collections.Generic.IDictionary<System.Object, System.Object>) (Syntax: '[..y]')
+                  Elements(1):
+                      ISpreadOperation (ElementType: System.Collections.Generic.KeyValuePair<System.Int32, System.String>) (OperationKind.Spread, Type: null) (Syntax: '..y')
+                        Operand:
+                          ILocalReferenceOperation: y (OperationKind.LocalReference, Type: System.Collections.Generic.KeyValuePair<System.Int32, System.String>[]) (Syntax: 'y')
+                        ElementConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                          (Identity)
+                """);
+        }
+
+        [Fact]
+        public void KeyValuePairConversions_02()
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        var y = new KeyValuePair<int, string>[] { new(3, "three") };
+                        var d = F(x, y);
+                        d.Report();
+                    }
+                    static IDictionary<long, object> F(KeyValuePair<int, string> x, IEnumerable<KeyValuePair<int, string>> y)
+                    {
+                        return [x, ..y];
+                    }
+                }
+                """;
+            var comp = CreateCompilation([source, s_dictionaryExtensions], options: TestOptions.ReleaseExe);
+            var verifier = CompileAndVerify(comp, expectedOutput: "[2:two, 3:three], ");
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void KeyValuePairConversions_03()
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static IDictionary<int, string> F1(KeyValuePair<int?, string> x1, IEnumerable<KeyValuePair<int?, string>> y1)
+                    {
+                        return [x1, ..y1];
+                    }
+                    static IDictionary<int, string> F2(KeyValuePair<int, object> x2, IEnumerable<KeyValuePair<int, object>> y2)
+                    {
+                        return [x2, ..y2];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (6,17): error CS0029: Cannot implicitly convert type 'int?' to 'int'
+                //         return [x1, ..y1];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "x1").WithArguments("int?", "int").WithLocation(6, 17),
+                // (6,23): error CS0029: Cannot implicitly convert type 'int?' to 'int'
+                //         return [x1, ..y1];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "y1").WithArguments("int?", "int").WithLocation(6, 23),
+                // (10,17): error CS0029: Cannot implicitly convert type 'object' to 'string'
+                //         return [x2, ..y2];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "x2").WithArguments("object", "string").WithLocation(10, 17),
+                // (10,23): error CS0029: Cannot implicitly convert type 'object' to 'string'
+                //         return [x2, ..y2];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "y2").WithArguments("object", "string").WithLocation(10, 23));
+        }
+
+        [Fact]
+        public void KeyValuePairConversions_04()
+        {
+            string source = """
+                using System.Collections.Generic;
+                IDictionary<int, int> d;
+                d = [null:default];
+                d = [default:null];
+                d = [default, null];
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (3,6): error CS0037: Cannot convert null to 'int' because it is a non-nullable value type
+                // d = [null:default];
+                Diagnostic(ErrorCode.ERR_ValueCantBeNull, "null").WithArguments("int").WithLocation(3, 6),
+                // (4,14): error CS0037: Cannot convert null to 'int' because it is a non-nullable value type
+                // d = [default:null];
+                Diagnostic(ErrorCode.ERR_ValueCantBeNull, "null").WithArguments("int").WithLocation(4, 14),
+                // (5,15): error CS0037: Cannot convert null to 'KeyValuePair<int, int>' because it is a non-nullable value type
+                // d = [default, null];
+                Diagnostic(ErrorCode.ERR_ValueCantBeNull, "null").WithArguments("System.Collections.Generic.KeyValuePair<int, int>").WithLocation(5, 15));
+        }
+
+        [Fact]
+        public void KeyValuePairConversions_05()
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static IDictionary<K, V> F1<K, V>(K k) => [k];
+                    static IDictionary<K, V> F2<K, V>(IEnumerable<K> e) => [..e];
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (4,48): error CS0029: Cannot implicitly convert type 'K' to 'System.Collections.Generic.KeyValuePair<K, V>'
+                //     static IDictionary<K, V> F1<K, V>(K k) => [k];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "k").WithArguments("K", "System.Collections.Generic.KeyValuePair<K, V>").WithLocation(4, 48),
+                // (5,63): error CS0029: Cannot implicitly convert type 'K' to 'System.Collections.Generic.KeyValuePair<K, V>'
+                //     static IDictionary<K, V> F2<K, V>(IEnumerable<K> e) => [..e];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "e").WithArguments("K", "System.Collections.Generic.KeyValuePair<K, V>").WithLocation(5, 63));
+        }
+
+        [Fact]
+        public void KeyValuePairConversions_06()
+        {
+            string sourceA = """
+                using System.Collections.Generic;
+                public class MyKeyValuePair<K, V>
+                {
+                    public MyKeyValuePair(K key, V value)
+                    {
+                        Key = key;
+                        Value = value;
+                    }
+                    public readonly K Key;
+                    public readonly V Value;
+                    public override string ToString() => $"{Key}:{Value}";
+                    public static implicit operator MyKeyValuePair<K, V>(KeyValuePair<K, V> kvp) => new(kvp.Key, kvp.Value);
+                }
+                """;
+            var comp = CreateCompilation(sourceA);
+            var refA = comp.EmitToImageReference();
+
+            string sourceB1 = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        F(1, "one");
+                    }
+                    static IEnumerable<MyKeyValuePair<K, V>> F<K, V>(K k, V v)
+                    {
+                        return [k:v];
+                    }
+                }
+                """;
+            comp = CreateCompilation(sourceB1, references: [refA]);
+            comp.VerifyEmitDiagnostics(
+                // (10,17): error CS9500: Collection expression type 'IEnumerable<MyKeyValuePair<K, V>>' does not support key-value pair elements.
+                //         return [k:v];
+                Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "k:v").WithArguments("System.Collections.Generic.IEnumerable<MyKeyValuePair<K, V>>").WithLocation(10, 17));
+
+            string sourceB2 = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var e = F(new KeyValuePair<int, string>(2, "two"), new KeyValuePair<int, string>[] { new(3, "three") });
+                        e.Report();
+                    }
+                    static IEnumerable<MyKeyValuePair<K, V>> F<K, V>(KeyValuePair<K, V> x, IEnumerable<KeyValuePair<K, V>> y)
+                    {
+                        return [x, ..y];
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [sourceB2, s_collectionExtensions],
+                references: [refA],
+                expectedOutput: "[2:two, 3:three], ");
+            verifier.VerifyDiagnostics();
+        }
+
+        [Theory]
+        [InlineData(LanguageVersion.CSharp12, "IEnumerable<KeyValuePair<K, V>>")]
+        [InlineData(LanguageVersion.Preview, "IEnumerable<KeyValuePair<K, V>>")]
+        [InlineData(LanguageVersion.Preview, "IDictionary<K, V>")]
+        [InlineData(LanguageVersion.Preview, "Dictionary<K, V>")]
+        public void KeyValuePairConversions_07(LanguageVersion languageVersion, string typeName)
+        {
+            string sourceA = """
+                using System.Collections.Generic;
+                public class MyKeyValuePair<K, V>
+                {
+                    public MyKeyValuePair(K key, V value)
+                    {
+                        Key = key;
+                        Value = value;
+                    }
+                    public readonly K Key;
+                    public readonly V Value;
+                    public static implicit operator KeyValuePair<K, V>(MyKeyValuePair<K, V> kvp) => new(kvp.Key, kvp.Value);
+                }
+                """;
+            var comp = CreateCompilation(sourceA);
+            var refA = comp.EmitToImageReference();
+
+            string sourceB = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new MyKeyValuePair<int, string>(2, "two");
+                        var y = new MyKeyValuePair<int, string>[] { new(3, "three") };
+                        F(x, y).Report();
+                    }
+                    static {{typeName}} F<K, V>(MyKeyValuePair<K, V> x, IEnumerable<MyKeyValuePair<K, V>> y)
+                    {
+                        return [x, ..y];
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [sourceB, s_dictionaryExtensions],
+                references: [refA],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                expectedOutput: "[2:two, 3:three], ");
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void KeyValuePairConversions_08()
+        {
+            string sourceA = """
+                using System.Collections.Generic;
+                public class MyKeyValuePair<K, V>
+                {
+                    public MyKeyValuePair(K key, V value)
+                    {
+                        Key = key;
+                        Value = value;
+                    }
+                    public readonly K Key;
+                    public readonly V Value;
+                    public static implicit operator KeyValuePair<K, V>(MyKeyValuePair<K, V> kvp) => new(kvp.Key, kvp.Value);
+                }
+                """;
+            string sourceB = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<object, string>(1, "one");
+                        var y = new MyKeyValuePair<int, string>(2, "two");
+                        var z = new MyKeyValuePair<int, object>(3, "three");
+                        IDictionary<int, string> d;
+                        d = [x, y, z];
+                        var sx = new[] { x };
+                        var sy = new[] { y };
+                        var sz = new[] { z };
+                        d = [..sx, ..sy, ..sz];
+                    }
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB]);
+            comp.VerifyEmitDiagnostics(
+                // (10,14): error CS0029: Cannot implicitly convert type 'object' to 'int'
+                //         d = [x, y, z];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "x").WithArguments("object", "int").WithLocation(10, 14),
+                // (10,20): error CS0029: Cannot implicitly convert type 'MyKeyValuePair<int, object>' to 'KeyValuePair<int, string>'
+                //         d = [x, y, z];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "z").WithArguments("MyKeyValuePair<int, object>", "System.Collections.Generic.KeyValuePair<int, string>").WithLocation(10, 20),
+                // (14,16): error CS0029: Cannot implicitly convert type 'object' to 'int'
+                //         d = [..sx, ..sy, ..sz];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "sx").WithArguments("object", "int").WithLocation(14, 16),
+                // (14,28): error CS0029: Cannot implicitly convert type 'MyKeyValuePair<int, object>' to 'KeyValuePair<int, string>'
+                //         d = [..sx, ..sy, ..sz];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "sz").WithArguments("MyKeyValuePair<int, object>", "System.Collections.Generic.KeyValuePair<int, string>").WithLocation(14, 28));
+        }
+
+        [Fact]
+        public void KeyValuePairConversions_EvaluationOrder()
+        {
+            string source = """
+                using System;
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        var y = new[] { new KeyValuePair<int, string>(3, "three") };
+                        Create(1, "one", x, y).Report();
+                    }
+                    static IEnumerable<KeyValuePair<int?, object>> Create(int k, string v, KeyValuePair<int, string> e, KeyValuePair<int, string>[] s)
+                    {
+                        return [Identity(k):Identity(v), Identity(e), ..Identity(s)];
+                    }
+                    static T Identity<T>(T value)
+                    {
+                        Console.WriteLine(value);
+                        return value;
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_collectionExtensions],
+                expectedOutput: """
+                    1
+                    one
+                    [2, two]
+                    System.Collections.Generic.KeyValuePair`2[System.Int32,System.String][]
+                    [[1, one], [2, two], [3, three]], 
+                    """);
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("Program.Create", """
+                {
+                  // Code size      185 (0xb9)
+                  .maxstack  4
+                  .locals init (System.Collections.Generic.KeyValuePair<int?, object> V_0,
+                                System.Collections.Generic.KeyValuePair<int?, object> V_1,
+                                System.Collections.Generic.KeyValuePair<int, string>[] V_2,
+                                int V_3,
+                                System.Collections.Generic.KeyValuePair<int?, object>[] V_4,
+                                System.Collections.Generic.KeyValuePair<int, string> V_5,
+                                System.Collections.Generic.KeyValuePair<int, string>[] V_6,
+                                int V_7,
+                                System.Collections.Generic.KeyValuePair<int, string> V_8)
+                  IL_0000:  ldloca.s   V_0
+                  IL_0002:  ldarg.0
+                  IL_0003:  call       "int Program.Identity<int>(int)"
+                  IL_0008:  newobj     "int?..ctor(int)"
+                  IL_000d:  ldarg.1
+                  IL_000e:  call       "string Program.Identity<string>(string)"
+                  IL_0013:  call       "System.Collections.Generic.KeyValuePair<int?, object>..ctor(int?, object)"
+                  IL_0018:  ldarg.2
+                  IL_0019:  call       "System.Collections.Generic.KeyValuePair<int, string> Program.Identity<System.Collections.Generic.KeyValuePair<int, string>>(System.Collections.Generic.KeyValuePair<int, string>)"
+                  IL_001e:  stloc.s    V_5
+                  IL_0020:  ldloca.s   V_5
+                  IL_0022:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                  IL_0027:  newobj     "int?..ctor(int)"
+                  IL_002c:  ldloca.s   V_5
+                  IL_002e:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                  IL_0033:  newobj     "System.Collections.Generic.KeyValuePair<int?, object>..ctor(int?, object)"
+                  IL_0038:  stloc.1
+                  IL_0039:  ldarg.3
+                  IL_003a:  call       "System.Collections.Generic.KeyValuePair<int, string>[] Program.Identity<System.Collections.Generic.KeyValuePair<int, string>[]>(System.Collections.Generic.KeyValuePair<int, string>[])"
+                  IL_003f:  stloc.2
+                  IL_0040:  ldc.i4.0
+                  IL_0041:  stloc.3
+                  IL_0042:  ldc.i4.2
+                  IL_0043:  ldloc.2
+                  IL_0044:  ldlen
+                  IL_0045:  conv.i4
+                  IL_0046:  add
+                  IL_0047:  newarr     "System.Collections.Generic.KeyValuePair<int?, object>"
+                  IL_004c:  stloc.s    V_4
+                  IL_004e:  ldloc.s    V_4
+                  IL_0050:  ldloc.3
+                  IL_0051:  ldloc.0
+                  IL_0052:  stelem     "System.Collections.Generic.KeyValuePair<int?, object>"
+                  IL_0057:  ldloc.3
+                  IL_0058:  ldc.i4.1
+                  IL_0059:  add
+                  IL_005a:  stloc.3
+                  IL_005b:  ldloc.s    V_4
+                  IL_005d:  ldloc.3
+                  IL_005e:  ldloc.1
+                  IL_005f:  stelem     "System.Collections.Generic.KeyValuePair<int?, object>"
+                  IL_0064:  ldloc.3
+                  IL_0065:  ldc.i4.1
+                  IL_0066:  add
+                  IL_0067:  stloc.3
+                  IL_0068:  ldloc.2
+                  IL_0069:  stloc.s    V_6
+                  IL_006b:  ldc.i4.0
+                  IL_006c:  stloc.s    V_7
+                  IL_006e:  br.s       IL_00a9
+                  IL_0070:  ldloc.s    V_6
+                  IL_0072:  ldloc.s    V_7
+                  IL_0074:  ldelem     "System.Collections.Generic.KeyValuePair<int, string>"
+                  IL_0079:  stloc.s    V_5
+                  IL_007b:  ldloc.s    V_4
+                  IL_007d:  ldloc.3
+                  IL_007e:  ldloc.s    V_5
+                  IL_0080:  stloc.s    V_8
+                  IL_0082:  ldloca.s   V_8
+                  IL_0084:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                  IL_0089:  newobj     "int?..ctor(int)"
+                  IL_008e:  ldloca.s   V_8
+                  IL_0090:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                  IL_0095:  newobj     "System.Collections.Generic.KeyValuePair<int?, object>..ctor(int?, object)"
+                  IL_009a:  stelem     "System.Collections.Generic.KeyValuePair<int?, object>"
+                  IL_009f:  ldloc.3
+                  IL_00a0:  ldc.i4.1
+                  IL_00a1:  add
+                  IL_00a2:  stloc.3
+                  IL_00a3:  ldloc.s    V_7
+                  IL_00a5:  ldc.i4.1
+                  IL_00a6:  add
+                  IL_00a7:  stloc.s    V_7
+                  IL_00a9:  ldloc.s    V_7
+                  IL_00ab:  ldloc.s    V_6
+                  IL_00ad:  ldlen
+                  IL_00ae:  conv.i4
+                  IL_00af:  blt.s      IL_0070
+                  IL_00b1:  ldloc.s    V_4
+                  IL_00b3:  newobj     "<>z__ReadOnlyArray<System.Collections.Generic.KeyValuePair<int?, object>>..ctor(System.Collections.Generic.KeyValuePair<int?, object>[])"
+                  IL_00b8:  ret
+                }
+                """);
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void KeyValuePairConversions_KeyValueElement(
+            [CombinatorialValues(LanguageVersion.CSharp12, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
+            [CombinatorialValues(
+                "System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>",
+                "System.Collections.Generic.KeyValuePair<K, V>[]",
+                "System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<K, V>>")] string typeName)
+        {
+            string typeName1 = typeName.Replace("K, V", "int, string");
+            string typeName2 = typeName.Replace("K, V", "int?, object");
+            string sourceA = $$"""
+                class Program
+                {
+                    static void Main()
+                    {
+                        int k = 1;
+                        string v = "one";
+                        KeyValue1(k, v).Report();
+                        KeyValue2(k, v).Report();
+                    }
+                    static {{typeName1}} KeyValue1(int k, string v) =>
+                        [k:v];
+                    static {{typeName2}} KeyValue2(int k, string v) =>
+                        /*<bind>*/[k:v]/*</bind>*/;
+                }
+                """;
+            var comp = CreateCompilation(
+                [sourceA, s_collectionExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                options: TestOptions.ReleaseExe);
+            if (languageVersion == LanguageVersion.CSharp12)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (11,10): error CS9500: Collection expression type 'IEnumerable<KeyValuePair<int, string>>' does not support key-value pair elements.
+                    //         [k:v];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "k:v").WithArguments(typeName1).WithLocation(11, 10),
+                    // (11,11): error CS8652: The feature 'dictionary expressions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    //         [k:v];
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, ":").WithArguments("dictionary expressions").WithLocation(11, 11),
+                    // (13,20): error CS9500: Collection expression type 'IEnumerable<KeyValuePair<int?, object>>' does not support key-value pair elements.
+                    //         /*<bind>*/[k:v]/*</bind>*/;
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "k:v").WithArguments(typeName2).WithLocation(13, 20),
+                    // (13,21): error CS8652: The feature 'dictionary expressions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    //         /*<bind>*/[k:v]/*</bind>*/;
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, ":").WithArguments("dictionary expressions").WithLocation(13, 21));
+            }
+            else
+            {
+                var verifier = CompileAndVerify(comp, expectedOutput: "[[1, one]], [[1, one]],");
+                verifier.VerifyDiagnostics();
+                if (typeName == "System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>")
+                {
+                    verifier.VerifyIL("Program.KeyValue1", """
+                    {
+                      // Code size       13 (0xd)
+                      .maxstack  2
+                      IL_0000:  ldarg.0
+                      IL_0001:  ldarg.1
+                      IL_0002:  newobj     "System.Collections.Generic.KeyValuePair<int, string>..ctor(int, string)"
+                      IL_0007:  newobj     "<>z__ReadOnlySingleElementList<System.Collections.Generic.KeyValuePair<int, string>>..ctor(System.Collections.Generic.KeyValuePair<int, string>)"
+                      IL_000c:  ret
+                    }
+                    """);
+                    verifier.VerifyIL("Program.KeyValue2", """
+                    {
+                      // Code size       18 (0x12)
+                      .maxstack  2
+                      IL_0000:  ldarg.0
+                      IL_0001:  newobj     "int?..ctor(int)"
+                      IL_0006:  ldarg.1
+                      IL_0007:  newobj     "System.Collections.Generic.KeyValuePair<int?, object>..ctor(int?, object)"
+                      IL_000c:  newobj     "<>z__ReadOnlySingleElementList<System.Collections.Generic.KeyValuePair<int?, object>>..ctor(System.Collections.Generic.KeyValuePair<int?, object>)"
+                      IL_0011:  ret
+                    }
+                    """);
+                }
+            }
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var element = tree.GetRoot().DescendantNodes().OfType<KeyValuePairElementSyntax>().Last();
+            var typeInfo = model.GetTypeInfo(element.KeyExpression);
+            Assert.Equal("System.Int32", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal((languageVersion == LanguageVersion.CSharp12) ? "System.Int32" : "System.Int32?", typeInfo.ConvertedType.ToTestDisplayString());
+            typeInfo = model.GetTypeInfo(element.ValueExpression);
+            Assert.Equal("System.String", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal((languageVersion == LanguageVersion.CSharp12) ? "System.String" : "System.Object", typeInfo.ConvertedType.ToTestDisplayString());
+
+            string collectionTypeName = typeName.Replace("K, V", "System.Int32?, System.Object");
+            // https://github.com/dotnet/roslyn/issues/77872: Include IOperation support for implicit Key and Value conversions.
+            string expectedIOperation = (languageVersion == LanguageVersion.CSharp12) ?
+                $$"""
+                ICollectionExpressionOperation (1 elements, ConstructMethod: null) (OperationKind.CollectionExpression, Type: {{collectionTypeName}}, IsInvalid) (Syntax: '[k:v]')
+                  Elements(1):
+                      IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'k:v')
+                """ :
+                (typeName == "System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<K, V>>") ?
+                $$"""
+                ICollectionExpressionOperation (1 elements, ConstructMethod: System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<System.Int32?, System.Object>>..ctor()) (OperationKind.CollectionExpression, Type: System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<System.Int32?, System.Object>>) (Syntax: '[k:v]')
+                  Elements(1):
+                      IObjectCreationOperation (Constructor: System.Collections.Generic.KeyValuePair<System.Int32?, System.Object>..ctor(System.Int32? key, System.Object value)) (OperationKind.ObjectCreation, Type: System.Collections.Generic.KeyValuePair<System.Int32?, System.Object>, IsImplicit) (Syntax: 'k:v')
+                        Arguments(2):
+                            IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: key) (OperationKind.Argument, Type: null, IsImplicit) (Syntax: 'k')
+                              IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Int32?, IsImplicit) (Syntax: 'k')
+                                Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                                Operand:
+                                  IParameterReferenceOperation: k (OperationKind.ParameterReference, Type: System.Int32) (Syntax: 'k')
+                              InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                              OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                            IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: value) (OperationKind.Argument, Type: null, IsImplicit) (Syntax: 'v')
+                              IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 'v')
+                                Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
+                                Operand:
+                                  IParameterReferenceOperation: v (OperationKind.ParameterReference, Type: System.String) (Syntax: 'v')
+                              InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                              OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                        Initializer:
+                          null
+                """ :
+                $$"""
+                ICollectionExpressionOperation (1 elements, ConstructMethod: null) (OperationKind.CollectionExpression, Type: {{collectionTypeName}}) (Syntax: '[k:v]')
+                  Elements(1):
+                      IOperation:  (OperationKind.None, Type: null) (Syntax: 'k:v')
+                """;
+            VerifyOperationTreeForTest<CollectionExpressionSyntax>(comp, expectedIOperation);
+
+            string sourceB = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static {{typeName2}} KeyValue3(int k, string v) =>
+                        [k:v, v:k];
+                }
+                """;
+            comp = CreateCompilation(
+                sourceB,
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            if (languageVersion == LanguageVersion.CSharp12)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (5,10): error CS9500: Collection expression type 'IEnumerable<KeyValuePair<int?, object>>' does not support key-value pair elements.
+                    //         [k:v, v:k];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "k:v").WithArguments(typeName2).WithLocation(5, 10),
+                    // (5,11): error CS8652: The feature 'dictionary expressions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    //         [k:v, v:k];
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, ":").WithArguments("dictionary expressions").WithLocation(5, 11),
+                    // (5,15): error CS9500: Collection expression type 'IEnumerable<KeyValuePair<int?, object>>' does not support key-value pair elements.
+                    //         [k:v, v:k];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "v:k").WithArguments(typeName2).WithLocation(5, 15),
+                    // (5,16): error CS8652: The feature 'dictionary expressions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    //         [k:v, v:k];
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, ":").WithArguments("dictionary expressions").WithLocation(5, 16));
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (5,15): error CS0029: Cannot implicitly convert type 'string' to 'int?'
+                    //         [k:v, v:k];
+                    Diagnostic(ErrorCode.ERR_NoImplicitConv, "v").WithArguments("string", "int?").WithLocation(5, 15));
+            }
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void KeyValuePairConversions_ExpressionElement(
+            [CombinatorialValues(LanguageVersion.CSharp12, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
+            [CombinatorialValues(
+                "System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>",
+                "System.Collections.Generic.KeyValuePair<K, V>[]",
+                "System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<K, V>>")] string typeName)
+        {
+            string typeName1 = typeName.Replace("K, V", "int, string");
+            string typeName2 = typeName.Replace("K, V", "int?, object");
+            string sourceA = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        Expression1(x).Report();
+                        Expression2(x).Report();
+                    }
+                    static {{typeName1}} Expression1(KeyValuePair<int, string> e) =>
+                        [e];
+                    static {{typeName2}} Expression2(KeyValuePair<int, string> e) =>
+                        /*<bind>*/[e]/*</bind>*/;
+                }
+                """;
+            var comp = CreateCompilation(
+                [sourceA, s_collectionExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                options: TestOptions.ReleaseExe);
+            if (languageVersion == LanguageVersion.CSharp12)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (13,20): error CS0029: Cannot implicitly convert type 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                    //         /*<bind>*/[e]/*</bind>*/;
+                    Diagnostic(ErrorCode.ERR_NoImplicitConv, "e").WithArguments("System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(13, 20));
+            }
+            else
+            {
+                var verifier = CompileAndVerify(comp, expectedOutput: "[[2, two]], [[2, two]], ");
+                verifier.VerifyDiagnostics();
+                if (typeName == "System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>")
+                {
+                    verifier.VerifyIL("Program.Expression1", """
+                        {
+                          // Code size        7 (0x7)
+                          .maxstack  1
+                          IL_0000:  ldarg.0
+                          IL_0001:  newobj     "<>z__ReadOnlySingleElementList<System.Collections.Generic.KeyValuePair<int, string>>..ctor(System.Collections.Generic.KeyValuePair<int, string>)"
+                          IL_0006:  ret
+                        }
+                        """);
+                    verifier.VerifyIL("Program.Expression2", """
+                        {
+                          // Code size       32 (0x20)
+                          .maxstack  2
+                          .locals init (System.Collections.Generic.KeyValuePair<int, string> V_0)
+                          IL_0000:  ldarg.0
+                          IL_0001:  stloc.0
+                          IL_0002:  ldloca.s   V_0
+                          IL_0004:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                          IL_0009:  newobj     "int?..ctor(int)"
+                          IL_000e:  ldloca.s   V_0
+                          IL_0010:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                          IL_0015:  newobj     "System.Collections.Generic.KeyValuePair<int?, object>..ctor(int?, object)"
+                          IL_001a:  newobj     "<>z__ReadOnlySingleElementList<System.Collections.Generic.KeyValuePair<int?, object>>..ctor(System.Collections.Generic.KeyValuePair<int?, object>)"
+                          IL_001f:  ret
+                        }
+                        """);
+                }
+            }
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var element = tree.GetRoot().DescendantNodes().OfType<ExpressionElementSyntax>().Last();
+            // https://github.com/dotnet/roslyn/issues/77872: Implement GetTypeInfo() support.
+            var typeInfo = model.GetTypeInfo(element.Expression);
+            Assert.Equal("System.Collections.Generic.KeyValuePair<System.Int32, System.String>", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal((languageVersion == LanguageVersion.CSharp12) ? "System.Collections.Generic.KeyValuePair<System.Int32, System.String>" : "System.Collections.Generic.KeyValuePair<System.Int32?, System.Object>", typeInfo.ConvertedType.ToTestDisplayString());
+
+            string collectionTypeName = typeName.Replace("K, V", "System.Int32?, System.Object");
+            // https://github.com/dotnet/roslyn/issues/77872: Include IOperation support for implicit Key and Value conversions.
+            string expectedIOperation = (languageVersion == LanguageVersion.CSharp12) ?
+                $$"""
+                ICollectionExpressionOperation (1 elements, ConstructMethod: null) (OperationKind.CollectionExpression, Type: {{collectionTypeName}}, IsInvalid) (Syntax: '[e]')
+                  Elements(1):
+                      IParameterReferenceOperation: e (OperationKind.ParameterReference, Type: System.Collections.Generic.KeyValuePair<System.Int32, System.String>, IsInvalid) (Syntax: 'e')
+                """ :
+                (typeName == "System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<K, V>>") ?
+                $$"""
+                ICollectionExpressionOperation (1 elements, ConstructMethod: System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<System.Int32?, System.Object>>..ctor()) (OperationKind.CollectionExpression, Type: System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<System.Int32?, System.Object>>) (Syntax: '[e]')
+                  Elements(1):
+                      IOperation:  (OperationKind.None, Type: System.Collections.Generic.KeyValuePair<System.Int32?, System.Object>) (Syntax: 'e')
+                """ :
+                $$"""
+                ICollectionExpressionOperation (1 elements, ConstructMethod: null) (OperationKind.CollectionExpression, Type: {{collectionTypeName}}) (Syntax: '[e]')
+                  Elements(1):
+                      IOperation:  (OperationKind.None, Type: System.Collections.Generic.KeyValuePair<System.Int32?, System.Object>) (Syntax: 'e')
+                """;
+            VerifyOperationTreeForTest<CollectionExpressionSyntax>(comp, expectedIOperation);
+
+            string sourceB = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static {{typeName2}} Expression3(KeyValuePair<int, string> e1, KeyValuePair<string, int> e2) =>
+                        [e1, e2];
+                }
+                """;
+            comp = CreateCompilation(
+                sourceB,
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            if (languageVersion == LanguageVersion.CSharp12)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (5,10): error CS0029: Cannot implicitly convert type 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                    //         [e1, e2];
+                    Diagnostic(ErrorCode.ERR_NoImplicitConv, "e1").WithArguments("System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(5, 10),
+                    // (5,14): error CS0029: Cannot implicitly convert type 'System.Collections.Generic.KeyValuePair<string, int>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                    //         [e1, e2];
+                    Diagnostic(ErrorCode.ERR_NoImplicitConv, "e2").WithArguments("System.Collections.Generic.KeyValuePair<string, int>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(5, 14));
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (5,14): error CS0029: Cannot implicitly convert type 'string' to 'int?'
+                    //         [e1, e2];
+                    Diagnostic(ErrorCode.ERR_NoImplicitConv, "e2").WithArguments("string", "int?").WithLocation(5, 14));
+            }
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void KeyValuePairConversions_SpreadElement_01(
+            [CombinatorialValues(LanguageVersion.CSharp12, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
+            [CombinatorialValues(
+                "System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>",
+                "System.Collections.Generic.KeyValuePair<K, V>[]",
+                "System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<K, V>>")] string typeName)
+        {
+            string typeName1 = typeName.Replace("K, V", "int, string");
+            string typeName2 = typeName.Replace("K, V", "int?, object");
+            string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var y = new[] { new KeyValuePair<int, string>(3, "three") };
+                        Spread1(y).Report();
+                        Spread2(y).Report();
+                    }
+                    static {{typeName1}} Spread1(KeyValuePair<int, string>[] s) =>
+                        [..s];
+                    static {{typeName2}} Spread2(KeyValuePair<int, string>[] s) =>
+                        /*<bind>*/[..s]/*</bind>*/;
+                }
+                """;
+            var comp = CreateCompilation(
+                [source, s_collectionExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                options: TestOptions.ReleaseExe);
+            if (languageVersion == LanguageVersion.CSharp12)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (13,22): error CS0029: Cannot implicitly convert type 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                    //         /*<bind>*/[..s]/*</bind>*/;
+                    Diagnostic(ErrorCode.ERR_NoImplicitConv, "s").WithArguments("System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(13, 22));
+            }
+            else
+            {
+                var verifier = CompileAndVerify(comp, expectedOutput: "[[3, three]], [[3, three]], ");
+                verifier.VerifyDiagnostics();
+                if (typeName == "System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>")
+                {
+                    verifier.VerifyIL("Program.Spread1", """
+                        {
+                          // Code size       12 (0xc)
+                          .maxstack  1
+                          IL_0000:  ldarg.0
+                          IL_0001:  call       "System.Collections.Generic.KeyValuePair<int, string>[] System.Linq.Enumerable.ToArray<System.Collections.Generic.KeyValuePair<int, string>>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                          IL_0006:  newobj     "<>z__ReadOnlyArray<System.Collections.Generic.KeyValuePair<int, string>>..ctor(System.Collections.Generic.KeyValuePair<int, string>[])"
+                          IL_000b:  ret
+                        }
+                        """);
+                    verifier.VerifyIL("Program.Spread2", """
+                        {
+                          // Code size       82 (0x52)
+                          .maxstack  4
+                          .locals init (int V_0,
+                                        System.Collections.Generic.KeyValuePair<int?, object>[] V_1,
+                                        System.Collections.Generic.KeyValuePair<int, string>[] V_2,
+                                        int V_3,
+                                        System.Collections.Generic.KeyValuePair<int, string> V_4,
+                                        System.Collections.Generic.KeyValuePair<int, string> V_5)
+                          IL_0000:  ldarg.0
+                          IL_0001:  ldc.i4.0
+                          IL_0002:  stloc.0
+                          IL_0003:  dup
+                          IL_0004:  ldlen
+                          IL_0005:  conv.i4
+                          IL_0006:  newarr     "System.Collections.Generic.KeyValuePair<int?, object>"
+                          IL_000b:  stloc.1
+                          IL_000c:  stloc.2
+                          IL_000d:  ldc.i4.0
+                          IL_000e:  stloc.3
+                          IL_000f:  br.s       IL_0045
+                          IL_0011:  ldloc.2
+                          IL_0012:  ldloc.3
+                          IL_0013:  ldelem     "System.Collections.Generic.KeyValuePair<int, string>"
+                          IL_0018:  stloc.s    V_4
+                          IL_001a:  ldloc.1
+                          IL_001b:  ldloc.0
+                          IL_001c:  ldloc.s    V_4
+                          IL_001e:  stloc.s    V_5
+                          IL_0020:  ldloca.s   V_5
+                          IL_0022:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                          IL_0027:  newobj     "int?..ctor(int)"
+                          IL_002c:  ldloca.s   V_5
+                          IL_002e:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                          IL_0033:  newobj     "System.Collections.Generic.KeyValuePair<int?, object>..ctor(int?, object)"
+                          IL_0038:  stelem     "System.Collections.Generic.KeyValuePair<int?, object>"
+                          IL_003d:  ldloc.0
+                          IL_003e:  ldc.i4.1
+                          IL_003f:  add
+                          IL_0040:  stloc.0
+                          IL_0041:  ldloc.3
+                          IL_0042:  ldc.i4.1
+                          IL_0043:  add
+                          IL_0044:  stloc.3
+                          IL_0045:  ldloc.3
+                          IL_0046:  ldloc.2
+                          IL_0047:  ldlen
+                          IL_0048:  conv.i4
+                          IL_0049:  blt.s      IL_0011
+                          IL_004b:  ldloc.1
+                          IL_004c:  newobj     "<>z__ReadOnlyArray<System.Collections.Generic.KeyValuePair<int?, object>>..ctor(System.Collections.Generic.KeyValuePair<int?, object>[])"
+                          IL_0051:  ret
+                        }
+                        """);
+                }
+            }
+
+            string collectionTypeName = typeName.Replace("K, V", "System.Int32?, System.Object");
+            // https://github.com/dotnet/roslyn/issues/77872: Include IOperation support for implicit Key and Value conversions.
+            string expectedIOperation = (languageVersion == LanguageVersion.CSharp12) ?
+                $$"""
+                ICollectionExpressionOperation (1 elements, ConstructMethod: null) (OperationKind.CollectionExpression, Type: {{collectionTypeName}}, IsInvalid) (Syntax: '[..s]')
+                  Elements(1):
+                      ISpreadOperation (ElementType: System.Collections.Generic.KeyValuePair<System.Int32, System.String>) (OperationKind.Spread, Type: null, IsInvalid) (Syntax: '..s')
+                        Operand:
+                          IParameterReferenceOperation: s (OperationKind.ParameterReference, Type: System.Collections.Generic.KeyValuePair<System.Int32, System.String>[], IsInvalid) (Syntax: 's')
+                        ElementConversion: CommonConversion (Exists: False, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                          (NoConversion)
+                """ :
+                (typeName == "System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<K, V>>") ?
+                $$"""
+                ICollectionExpressionOperation (1 elements, ConstructMethod: System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<System.Int32?, System.Object>>..ctor()) (OperationKind.CollectionExpression, Type: System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<System.Int32?, System.Object>>) (Syntax: '[..s]')
+                  Elements(1):
+                      ISpreadOperation (ElementType: System.Collections.Generic.KeyValuePair<System.Int32, System.String>) (OperationKind.Spread, Type: null) (Syntax: '..s')
+                        Operand:
+                          IParameterReferenceOperation: s (OperationKind.ParameterReference, Type: System.Collections.Generic.KeyValuePair<System.Int32, System.String>[]) (Syntax: 's')
+                        ElementConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                          (Identity)
+                """ :
+                $$"""
+                ICollectionExpressionOperation (1 elements, ConstructMethod: null) (OperationKind.CollectionExpression, Type: {{collectionTypeName}}) (Syntax: '[..s]')
+                  Elements(1):
+                      ISpreadOperation (ElementType: System.Collections.Generic.KeyValuePair<System.Int32, System.String>) (OperationKind.Spread, Type: null) (Syntax: '..s')
+                        Operand:
+                          IParameterReferenceOperation: s (OperationKind.ParameterReference, Type: System.Collections.Generic.KeyValuePair<System.Int32, System.String>[]) (Syntax: 's')
+                        ElementConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                          (Identity)
+                """;
+            VerifyOperationTreeForTest<CollectionExpressionSyntax>(comp, expectedIOperation);
+
+            string sourceB = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static {{typeName2}} Spread3(KeyValuePair<int, string>[] s1, KeyValuePair<string, int>[] s2) =>
+                        [..s1, ..s2];
+                }
+                """;
+            comp = CreateCompilation(
+                sourceB,
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            if (languageVersion == LanguageVersion.CSharp12)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (5,12): error CS0029: Cannot implicitly convert type 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                    //         [..s1, ..s2];
+                    Diagnostic(ErrorCode.ERR_NoImplicitConv, "s1").WithArguments("System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(5, 12),
+                    // (5,18): error CS0029: Cannot implicitly convert type 'System.Collections.Generic.KeyValuePair<string, int>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                    //         [..s1, ..s2];
+                    Diagnostic(ErrorCode.ERR_NoImplicitConv, "s2").WithArguments("System.Collections.Generic.KeyValuePair<string, int>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(5, 18));
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (5,18): error CS0029: Cannot implicitly convert type 'string' to 'int?'
+                    //         [..s1, ..s2];
+                    Diagnostic(ErrorCode.ERR_NoImplicitConv, "s2").WithArguments("string", "int?").WithLocation(5, 18));
+            }
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void KeyValuePairConversions_SpreadElement_02(
+            [CombinatorialValues(
+                "System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>",
+                "System.Collections.Generic.KeyValuePair<K, V>[]",
+                "System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<K, V>>",
+                "System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<K, V>>",
+                "System.Collections.Immutable.ImmutableArray<KeyValuePair<K, V>>")] string typeName)
+        {
+            string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Spread<int, string, object, object>([new KeyValuePair<int, string>(3, "three")]).Report();
+                    }
+                    static KeyValuePair<KBase, VBase>[] Spread<K, V, KBase, VBase>({{typeName}} s)
+                        where K : KBase
+                        where V : VBase
+                    {
+                        return [..s];
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_collectionExtensions],
+                targetFramework: TargetFramework.Net80,
+                verify: Verification.Skipped,
+                expectedOutput: IncludeExpectedOutput("[[3, three]], "));
+            verifier.VerifyDiagnostics();
+            string expectedIL = typeName switch
+            {
+                "System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>" => """
+                    {
+                      // Code size       96 (0x60)
+                      .maxstack  3
+                      .locals init (System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<KBase, VBase>> V_0,
+                                    System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<K, V>> V_1,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_2,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_3)
+                      IL_0000:  newobj     "System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<KBase, VBase>>..ctor()"
+                      IL_0005:  stloc.0
+                      IL_0006:  ldarg.0
+                      IL_0007:  callvirt   "System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<K, V>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>.GetEnumerator()"
+                      IL_000c:  stloc.1
+                      .try
+                      {
+                        IL_000d:  br.s       IL_0045
+                        IL_000f:  ldloc.1
+                        IL_0010:  callvirt   "System.Collections.Generic.KeyValuePair<K, V> System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<K, V>>.Current.get"
+                        IL_0015:  stloc.2
+                        IL_0016:  ldloc.0
+                        IL_0017:  ldloc.2
+                        IL_0018:  stloc.3
+                        IL_0019:  ldloca.s   V_3
+                        IL_001b:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                        IL_0020:  box        "K"
+                        IL_0025:  unbox.any  "KBase"
+                        IL_002a:  ldloca.s   V_3
+                        IL_002c:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                        IL_0031:  box        "V"
+                        IL_0036:  unbox.any  "VBase"
+                        IL_003b:  newobj     "System.Collections.Generic.KeyValuePair<KBase, VBase>..ctor(KBase, VBase)"
+                        IL_0040:  callvirt   "void System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<KBase, VBase>>.Add(System.Collections.Generic.KeyValuePair<KBase, VBase>)"
+                        IL_0045:  ldloc.1
+                        IL_0046:  callvirt   "bool System.Collections.IEnumerator.MoveNext()"
+                        IL_004b:  brtrue.s   IL_000f
+                        IL_004d:  leave.s    IL_0059
+                      }
+                      finally
+                      {
+                        IL_004f:  ldloc.1
+                        IL_0050:  brfalse.s  IL_0058
+                        IL_0052:  ldloc.1
+                        IL_0053:  callvirt   "void System.IDisposable.Dispose()"
+                        IL_0058:  endfinally
+                      }
+                      IL_0059:  ldloc.0
+                      IL_005a:  callvirt   "System.Collections.Generic.KeyValuePair<KBase, VBase>[] System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<KBase, VBase>>.ToArray()"
+                      IL_005f:  ret
+                    }
+                    """,
+                "System.Collections.Generic.KeyValuePair<K, V>[]" => """
+                    {
+                      // Code size       92 (0x5c)
+                      .maxstack  4
+                      .locals init (int V_0,
+                                    System.Collections.Generic.KeyValuePair<KBase, VBase>[] V_1,
+                                    System.Collections.Generic.KeyValuePair<K, V>[] V_2,
+                                    int V_3,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_4,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_5)
+                      IL_0000:  ldarg.0
+                      IL_0001:  ldc.i4.0
+                      IL_0002:  stloc.0
+                      IL_0003:  dup
+                      IL_0004:  ldlen
+                      IL_0005:  conv.i4
+                      IL_0006:  newarr     "System.Collections.Generic.KeyValuePair<KBase, VBase>"
+                      IL_000b:  stloc.1
+                      IL_000c:  stloc.2
+                      IL_000d:  ldc.i4.0
+                      IL_000e:  stloc.3
+                      IL_000f:  br.s       IL_0054
+                      IL_0011:  ldloc.2
+                      IL_0012:  ldloc.3
+                      IL_0013:  ldelem     "System.Collections.Generic.KeyValuePair<K, V>"
+                      IL_0018:  stloc.s    V_4
+                      IL_001a:  ldloc.1
+                      IL_001b:  ldloc.0
+                      IL_001c:  ldloc.s    V_4
+                      IL_001e:  stloc.s    V_5
+                      IL_0020:  ldloca.s   V_5
+                      IL_0022:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                      IL_0027:  box        "K"
+                      IL_002c:  unbox.any  "KBase"
+                      IL_0031:  ldloca.s   V_5
+                      IL_0033:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                      IL_0038:  box        "V"
+                      IL_003d:  unbox.any  "VBase"
+                      IL_0042:  newobj     "System.Collections.Generic.KeyValuePair<KBase, VBase>..ctor(KBase, VBase)"
+                      IL_0047:  stelem     "System.Collections.Generic.KeyValuePair<KBase, VBase>"
+                      IL_004c:  ldloc.0
+                      IL_004d:  ldc.i4.1
+                      IL_004e:  add
+                      IL_004f:  stloc.0
+                      IL_0050:  ldloc.3
+                      IL_0051:  ldc.i4.1
+                      IL_0052:  add
+                      IL_0053:  stloc.3
+                      IL_0054:  ldloc.3
+                      IL_0055:  ldloc.2
+                      IL_0056:  ldlen
+                      IL_0057:  conv.i4
+                      IL_0058:  blt.s      IL_0011
+                      IL_005a:  ldloc.1
+                      IL_005b:  ret
+                    }
+                    """,
+                "System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<K, V>>" => """
+                    {
+                      // Code size      111 (0x6f)
+                      .maxstack  4
+                      .locals init (int V_0,
+                                    System.Collections.Generic.KeyValuePair<KBase, VBase>[] V_1,
+                                    System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<K, V>>.Enumerator V_2,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_3,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_4)
+                      IL_0000:  ldarg.0
+                      IL_0001:  ldc.i4.0
+                      IL_0002:  stloc.0
+                      IL_0003:  dup
+                      IL_0004:  callvirt   "int System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<K, V>>.Count.get"
+                      IL_0009:  newarr     "System.Collections.Generic.KeyValuePair<KBase, VBase>"
+                      IL_000e:  stloc.1
+                      IL_000f:  callvirt   "System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<K, V>>.Enumerator System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<K, V>>.GetEnumerator()"
+                      IL_0014:  stloc.2
+                      .try
+                      {
+                        IL_0015:  br.s       IL_0054
+                        IL_0017:  ldloca.s   V_2
+                        IL_0019:  call       "System.Collections.Generic.KeyValuePair<K, V> System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<K, V>>.Enumerator.Current.get"
+                        IL_001e:  stloc.3
+                        IL_001f:  ldloc.1
+                        IL_0020:  ldloc.0
+                        IL_0021:  ldloc.3
+                        IL_0022:  stloc.s    V_4
+                        IL_0024:  ldloca.s   V_4
+                        IL_0026:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                        IL_002b:  box        "K"
+                        IL_0030:  unbox.any  "KBase"
+                        IL_0035:  ldloca.s   V_4
+                        IL_0037:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                        IL_003c:  box        "V"
+                        IL_0041:  unbox.any  "VBase"
+                        IL_0046:  newobj     "System.Collections.Generic.KeyValuePair<KBase, VBase>..ctor(KBase, VBase)"
+                        IL_004b:  stelem     "System.Collections.Generic.KeyValuePair<KBase, VBase>"
+                        IL_0050:  ldloc.0
+                        IL_0051:  ldc.i4.1
+                        IL_0052:  add
+                        IL_0053:  stloc.0
+                        IL_0054:  ldloca.s   V_2
+                        IL_0056:  call       "bool System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<K, V>>.Enumerator.MoveNext()"
+                        IL_005b:  brtrue.s   IL_0017
+                        IL_005d:  leave.s    IL_006d
+                      }
+                      finally
+                      {
+                        IL_005f:  ldloca.s   V_2
+                        IL_0061:  constrained. "System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<K, V>>.Enumerator"
+                        IL_0067:  callvirt   "void System.IDisposable.Dispose()"
+                        IL_006c:  endfinally
+                      }
+                      IL_006d:  ldloc.1
+                      IL_006e:  ret
+                    }
+                    """,
+                "System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<K, V>>" => """
+                    {
+                      // Code size      106 (0x6a)
+                      .maxstack  4
+                      .locals init (System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<K, V>> V_0,
+                                    int V_1,
+                                    System.Collections.Generic.KeyValuePair<KBase, VBase>[] V_2,
+                                    System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<K, V>>.Enumerator V_3,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_4,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_5)
+                      IL_0000:  ldarg.0
+                      IL_0001:  stloc.0
+                      IL_0002:  ldc.i4.0
+                      IL_0003:  stloc.1
+                      IL_0004:  ldloca.s   V_0
+                      IL_0006:  call       "int System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<K, V>>.Length.get"
+                      IL_000b:  newarr     "System.Collections.Generic.KeyValuePair<KBase, VBase>"
+                      IL_0010:  stloc.2
+                      IL_0011:  ldloca.s   V_0
+                      IL_0013:  call       "System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<K, V>>.Enumerator System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<K, V>>.GetEnumerator()"
+                      IL_0018:  stloc.3
+                      IL_0019:  br.s       IL_005f
+                      IL_001b:  ldloca.s   V_3
+                      IL_001d:  call       "ref readonly System.Collections.Generic.KeyValuePair<K, V> System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<K, V>>.Enumerator.Current.get"
+                      IL_0022:  ldobj      "System.Collections.Generic.KeyValuePair<K, V>"
+                      IL_0027:  stloc.s    V_4
+                      IL_0029:  ldloc.2
+                      IL_002a:  ldloc.1
+                      IL_002b:  ldloc.s    V_4
+                      IL_002d:  stloc.s    V_5
+                      IL_002f:  ldloca.s   V_5
+                      IL_0031:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                      IL_0036:  box        "K"
+                      IL_003b:  unbox.any  "KBase"
+                      IL_0040:  ldloca.s   V_5
+                      IL_0042:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                      IL_0047:  box        "V"
+                      IL_004c:  unbox.any  "VBase"
+                      IL_0051:  newobj     "System.Collections.Generic.KeyValuePair<KBase, VBase>..ctor(KBase, VBase)"
+                      IL_0056:  stelem     "System.Collections.Generic.KeyValuePair<KBase, VBase>"
+                      IL_005b:  ldloc.1
+                      IL_005c:  ldc.i4.1
+                      IL_005d:  add
+                      IL_005e:  stloc.1
+                      IL_005f:  ldloca.s   V_3
+                      IL_0061:  call       "bool System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<K, V>>.Enumerator.MoveNext()"
+                      IL_0066:  brtrue.s   IL_001b
+                      IL_0068:  ldloc.2
+                      IL_0069:  ret
+                    }
+                    """,
+                "System.Collections.Immutable.ImmutableArray<KeyValuePair<K, V>>" => """
+                    {
+                      // Code size      101 (0x65)
+                      .maxstack  4
+                      .locals init (System.Collections.Immutable.ImmutableArray<System.Collections.Generic.KeyValuePair<K, V>> V_0,
+                                    int V_1,
+                                    System.Collections.Generic.KeyValuePair<KBase, VBase>[] V_2,
+                                    System.Collections.Immutable.ImmutableArray<System.Collections.Generic.KeyValuePair<K, V>>.Enumerator V_3,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_4,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_5)
+                      IL_0000:  ldarg.0
+                      IL_0001:  stloc.0
+                      IL_0002:  ldc.i4.0
+                      IL_0003:  stloc.1
+                      IL_0004:  ldloca.s   V_0
+                      IL_0006:  call       "int System.Collections.Immutable.ImmutableArray<System.Collections.Generic.KeyValuePair<K, V>>.Length.get"
+                      IL_000b:  newarr     "System.Collections.Generic.KeyValuePair<KBase, VBase>"
+                      IL_0010:  stloc.2
+                      IL_0011:  ldloca.s   V_0
+                      IL_0013:  call       "System.Collections.Immutable.ImmutableArray<System.Collections.Generic.KeyValuePair<K, V>>.Enumerator System.Collections.Immutable.ImmutableArray<System.Collections.Generic.KeyValuePair<K, V>>.GetEnumerator()"
+                      IL_0018:  stloc.3
+                      IL_0019:  br.s       IL_005a
+                      IL_001b:  ldloca.s   V_3
+                      IL_001d:  call       "System.Collections.Generic.KeyValuePair<K, V> System.Collections.Immutable.ImmutableArray<System.Collections.Generic.KeyValuePair<K, V>>.Enumerator.Current.get"
+                      IL_0022:  stloc.s    V_4
+                      IL_0024:  ldloc.2
+                      IL_0025:  ldloc.1
+                      IL_0026:  ldloc.s    V_4
+                      IL_0028:  stloc.s    V_5
+                      IL_002a:  ldloca.s   V_5
+                      IL_002c:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                      IL_0031:  box        "K"
+                      IL_0036:  unbox.any  "KBase"
+                      IL_003b:  ldloca.s   V_5
+                      IL_003d:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                      IL_0042:  box        "V"
+                      IL_0047:  unbox.any  "VBase"
+                      IL_004c:  newobj     "System.Collections.Generic.KeyValuePair<KBase, VBase>..ctor(KBase, VBase)"
+                      IL_0051:  stelem     "System.Collections.Generic.KeyValuePair<KBase, VBase>"
+                      IL_0056:  ldloc.1
+                      IL_0057:  ldc.i4.1
+                      IL_0058:  add
+                      IL_0059:  stloc.1
+                      IL_005a:  ldloca.s   V_3
+                      IL_005c:  call       "bool System.Collections.Immutable.ImmutableArray<System.Collections.Generic.KeyValuePair<K, V>>.Enumerator.MoveNext()"
+                      IL_0061:  brtrue.s   IL_001b
+                      IL_0063:  ldloc.2
+                      IL_0064:  ret
+                    }
+                    """,
+                _ => throw ExceptionUtilities.UnexpectedValue(typeName),
+            };
+            verifier.VerifyIL("Program.Spread<K, V, KBase, VBase>", expectedIL);
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void KeyValuePairConversions_Dictionary(
+            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
+            bool includeExtensionAdd)
+        {
+            string sourceA = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        var y = new[] { new KeyValuePair<int, string>(3, "three") };
+                        Expression(x).Report();
+                        Spread(y).Report();
+                    }
+                    static Dictionary<int?, object> Expression(KeyValuePair<int, string> e) => [e];
+                    static Dictionary<int?, object> Spread(KeyValuePair<int, string>[] s) => [..s];
+                }
+                """;
+            string sourceB = """
+                using System.Collections.Generic;
+                static class Extensions
+                {
+                    internal static void Add<K, V>(this Dictionary<K, V> d, KeyValuePair<K, V> kvp)
+                    {
+                        d.Add(kvp.Key, kvp.Value);
+                    }
+                }
+                """;
+            var comp = CreateCompilation(
+                [sourceA, includeExtensionAdd ? sourceB : "", s_collectionExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                options: TestOptions.ReleaseExe);
+            if (languageVersion == LanguageVersion.CSharp13)
+            {
+                if (includeExtensionAdd)
+                {
+                    comp.VerifyEmitDiagnostics(
+                        // (11,81): error CS0029: Cannot implicitly convert type 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                        //     static Dictionary<int?, object> Expression(KeyValuePair<int, string> e) => [e];
+                        Diagnostic(ErrorCode.ERR_NoImplicitConv, "e").WithArguments("System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(11, 81),
+                        // (12,81): error CS0029: Cannot implicitly convert type 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                        //     static Dictionary<int?, object> Spread(KeyValuePair<int, string>[] s) => [..s];
+                        Diagnostic(ErrorCode.ERR_NoImplicitConv, "s").WithArguments("System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(12, 81));
+                }
+                else
+                {
+                    comp.VerifyEmitDiagnostics(
+                        // (11,80): error CS9215: Collection expression type 'Dictionary<int?, object>' must have an instance or extension method 'Add' that can be called with a single argument.
+                        //     static Dictionary<int?, object> Expression(KeyValuePair<int, string> e) => [e];
+                        Diagnostic(ErrorCode.ERR_CollectionExpressionMissingAdd, "[e]").WithArguments("System.Collections.Generic.Dictionary<int?, object>").WithLocation(11, 80),
+                        // (11,81): error CS0029: Cannot implicitly convert type 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                        //     static Dictionary<int?, object> Expression(KeyValuePair<int, string> e) => [e];
+                        Diagnostic(ErrorCode.ERR_NoImplicitConv, "e").WithArguments("System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(11, 81),
+                        // (12,78): error CS9215: Collection expression type 'Dictionary<int?, object>' must have an instance or extension method 'Add' that can be called with a single argument.
+                        //     static Dictionary<int?, object> Spread(KeyValuePair<int, string>[] s) => [..s];
+                        Diagnostic(ErrorCode.ERR_CollectionExpressionMissingAdd, "[..s]").WithArguments("System.Collections.Generic.Dictionary<int?, object>").WithLocation(12, 78),
+                        // (12,81): error CS0029: Cannot implicitly convert type 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                        //     static Dictionary<int?, object> Spread(KeyValuePair<int, string>[] s) => [..s];
+                        Diagnostic(ErrorCode.ERR_NoImplicitConv, "s").WithArguments("System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(12, 81));
+                }
+            }
+            else
+            {
+                var verifier = CompileAndVerify(comp, expectedOutput: "[[2, two]], [[3, three]], ");
+                verifier.VerifyDiagnostics();
+                verifier.VerifyIL("Program.Expression", """
+                        {
+                          // Code size       33 (0x21)
+                          .maxstack  4
+                          .locals init (System.Collections.Generic.KeyValuePair<int, string> V_0)
+                          IL_0000:  newobj     "System.Collections.Generic.Dictionary<int?, object>..ctor()"
+                          IL_0005:  ldarg.0
+                          IL_0006:  stloc.0
+                          IL_0007:  dup
+                          IL_0008:  ldloca.s   V_0
+                          IL_000a:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                          IL_000f:  newobj     "int?..ctor(int)"
+                          IL_0014:  ldloca.s   V_0
+                          IL_0016:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                          IL_001b:  callvirt   "void System.Collections.Generic.Dictionary<int?, object>.this[int?].set"
+                          IL_0020:  ret
+                        }
+                        """);
+                verifier.VerifyIL("Program.Spread", """
+                        {
+                          // Code size       57 (0x39)
+                          .maxstack  3
+                          .locals init (System.Collections.Generic.Dictionary<int?, object> V_0,
+                                        System.Collections.Generic.KeyValuePair<int, string>[] V_1,
+                                        int V_2,
+                                        System.Collections.Generic.KeyValuePair<int, string> V_3)
+                          IL_0000:  newobj     "System.Collections.Generic.Dictionary<int?, object>..ctor()"
+                          IL_0005:  stloc.0
+                          IL_0006:  ldarg.0
+                          IL_0007:  stloc.1
+                          IL_0008:  ldc.i4.0
+                          IL_0009:  stloc.2
+                          IL_000a:  br.s       IL_0031
+                          IL_000c:  ldloc.1
+                          IL_000d:  ldloc.2
+                          IL_000e:  ldelem     "System.Collections.Generic.KeyValuePair<int, string>"
+                          IL_0013:  stloc.3
+                          IL_0014:  ldloc.0
+                          IL_0015:  ldloca.s   V_3
+                          IL_0017:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                          IL_001c:  newobj     "int?..ctor(int)"
+                          IL_0021:  ldloca.s   V_3
+                          IL_0023:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                          IL_0028:  callvirt   "void System.Collections.Generic.Dictionary<int?, object>.this[int?].set"
+                          IL_002d:  ldloc.2
+                          IL_002e:  ldc.i4.1
+                          IL_002f:  add
+                          IL_0030:  stloc.2
+                          IL_0031:  ldloc.2
+                          IL_0032:  ldloc.1
+                          IL_0033:  ldlen
+                          IL_0034:  conv.i4
+                          IL_0035:  blt.s      IL_000c
+                          IL_0037:  ldloc.0
+                          IL_0038:  ret
+                        }
+                        """);
+            }
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void KeyValuePairConversions_Params_01(
+            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
+            [CombinatorialValues(
+                "System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>",
+                "System.Collections.Generic.KeyValuePair<K, V>[]",
+                "System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<K, V>>")] string typeName)
+        {
+            string sourceA = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        Params(x);
+                        Params<int, string>(x);
+                        /*<bind>*/Params<int?, object>(x)/*</bind>*/;
+                    }
+                    static void Params<K, V>(params {{typeName}} args)
+                    {
+                        args.Report();
+                    }
+                }
+                """;
+            var comp = CreateCompilation(
+                [sourceA, s_collectionExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                options: TestOptions.ReleaseExe);
+            // https://github.com/dotnet/csharplang/blob/main/proposals/dictionary-expressions.md#support-keyvaluepair-variance-with-params: Support KeyValuePair<,> variance with params?
+            comp.VerifyEmitDiagnostics(
+                // (9,40): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                //         /*<bind>*/Params<int?, object>(x)/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("1", "System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(9, 40));
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+
+            var node = GetSyntaxNodeOfTypeForBinding<InvocationExpressionSyntax>(tree.GetRoot().DescendantNodes().ToList());
+            var expression = node.ArgumentList.Arguments[0];
+            // https://github.com/dotnet/roslyn/issues/77872: Implement GetTypeInfo() support.
+            //var typeInfo = model.GetTypeInfo(expression);
+            //Assert.Equal("System.Collections.Generic.KeyValuePair<System.Int32, System.String>", typeInfo.Type.ToTestDisplayString());
+            //Assert.Equal("System.Collections.Generic.KeyValuePair<System.Int32, System.String>", typeInfo.ConvertedType.ToTestDisplayString());
+
+            // https://github.com/dotnet/roslyn/issues/77872: Include IOperation support for implicit Key and Value conversions.
+            VerifyOperationTreeForTest<InvocationExpressionSyntax>(comp,
+                """
+                IInvalidOperation (OperationKind.Invalid, Type: System.Void, IsInvalid) (Syntax: 'Params<int?, object>(x)')
+                  Children(1):
+                      ILocalReferenceOperation: x (OperationKind.LocalReference, Type: System.Collections.Generic.KeyValuePair<System.Int32, System.String>, IsInvalid) (Syntax: 'x')
+                """);
+
+            string sourceB = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        Single(x);
+                        Single<int, string>(x);
+                        Single<int?, object>(x);
+                    }
+                    static void Single<K, V>(KeyValuePair<K, V> kvp)
+                    {
+                    }
+                }
+                """;
+            comp = CreateCompilation(
+                sourceB,
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            comp.VerifyEmitDiagnostics(
+                // (9,30): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                //         Single<int?, object>(x);
+                Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("1", "System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(9, 30));
+
+            string collectionTypeName = typeName.Replace("K, V", "int, string");
+            string sourceC = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        {{collectionTypeName}} args = [x];
+                        Params(args);
+                        Params<int, string>(args);
+                        Params<int?, object>(args);
+                    }
+                    static void Params<K, V>(params {{typeName}} args)
+                    {
+                    }
+                }
+                """;
+            comp = CreateCompilation(
+                sourceC,
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            comp.VerifyEmitDiagnostics(
+                // (10,30): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                //         Params<int?, object>(args);
+                Diagnostic(ErrorCode.ERR_BadArgType, "args").WithArguments("1", collectionTypeName, "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(10, 30));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void KeyValuePairConversions_Params_02(
+            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
+            [CombinatorialValues("ReadOnlySpan", "Span")] string typeName)
+        {
+            string source = $$"""
+                using System;
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        Params<int, string>(x);
+                        Params<int?, object>(x);
+                    }
+                    static void Params<K, V>(params {{typeName}}<KeyValuePair<K, V>> args)
+                    {
+                    }
+                }
+                """;
+            var comp = CreateCompilation(
+                source,
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (9,30): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                //         Params<int?, object>(x);
+                Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("1", "System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(9, 30));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void KeyValuePairConversions_Params_03(
+            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
+            [CombinatorialValues("IReadOnlyDictionary", "Dictionary")] string typeName)
+        {
+            string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        Params<int, string>(x);
+                        Params<int?, object>(x);
+                    }
+                    static void Params<K, V>(params {{typeName}}<K, V> args)
+                    {
+                    }
+                }
+                """;
+            var comp = CreateCompilation(
+                source,
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            if (languageVersion == LanguageVersion.CSharp13)
+            {
+                if (typeName == "Dictionary")
+                {
+                    comp.VerifyEmitDiagnostics(
+                        // (7,29): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.KeyValuePair<int, string>' to 'params System.Collections.Generic.Dictionary<int, string>'
+                        //         Params<int, string>(x);
+                        Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("1", "System.Collections.Generic.KeyValuePair<int, string>", "params System.Collections.Generic.Dictionary<int, string>").WithLocation(7, 29),
+                        // (8,30): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.KeyValuePair<int, string>' to 'params System.Collections.Generic.Dictionary<int?, object>'
+                        //         Params<int?, object>(x);
+                        Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("1", "System.Collections.Generic.KeyValuePair<int, string>", "params System.Collections.Generic.Dictionary<int?, object>").WithLocation(8, 30),
+                        // (10,30): error CS9215: Collection expression type 'Dictionary<K, V>' must have an instance or extension method 'Add' that can be called with a single argument.
+                        //     static void Params<K, V>(params Dictionary<K, V> args)
+                        Diagnostic(ErrorCode.ERR_CollectionExpressionMissingAdd, "params Dictionary<K, V> args").WithArguments("System.Collections.Generic.Dictionary<K, V>").WithLocation(10, 30));
+                }
+                else
+                {
+                    comp.VerifyEmitDiagnostics(
+                        // (7,29): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.KeyValuePair<int, string>' to 'params System.Collections.Generic.IReadOnlyDictionary<int, string>'
+                        //         Params<int, string>(x);
+                        Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("1", "System.Collections.Generic.KeyValuePair<int, string>", "params System.Collections.Generic.IReadOnlyDictionary<int, string>").WithLocation(7, 29),
+                        // (8,30): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.KeyValuePair<int, string>' to 'params System.Collections.Generic.IReadOnlyDictionary<int?, object>'
+                        //         Params<int?, object>(x);
+                        Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("1", "System.Collections.Generic.KeyValuePair<int, string>", "params System.Collections.Generic.IReadOnlyDictionary<int?, object>").WithLocation(8, 30),
+                        // (10,30): error CS0225: The params parameter must have a valid collection type
+                        //     static void Params<K, V>(params IReadOnlyDictionary<K, V> args)
+                        Diagnostic(ErrorCode.ERR_ParamsMustBeCollection, "params").WithLocation(10, 30));
+                }
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (8,30): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                    //         Params<int?, object>(x);
+                    Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("1", "System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(8, 30));
+            }
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void KeyValuePairConversions_Span(
+            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion)
+        {
+            string source = """
+                using System;
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        int k = 1;
+                        string v = "one";
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        var y = new[] { new KeyValuePair<int, string>(3, "three") };
+                        ReadOnlySpan<KeyValuePair<int, string>> c1 = [k:v, x, ..y];
+                        c1.ToArray().Report();
+                        ReadOnlySpan<KeyValuePair<int?, object>> c2 = [k:v, x, ..y];
+                        c2.ToArray().Report();
+                    }
+                }
+                """;
+            var comp = CreateCompilation(
+                [source, s_collectionExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                options: TestOptions.ReleaseExe,
+                targetFramework: TargetFramework.Net80);
+            if (languageVersion == LanguageVersion.CSharp13)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (11,55): error CS9500: Collection expression type 'ReadOnlySpan<KeyValuePair<int, string>>' does not support key-value pair elements.
+                    //         ReadOnlySpan<KeyValuePair<int, string>> c1 = [k:v, x, ..y];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "k:v").WithArguments("System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<int, string>>").WithLocation(11, 55),
+                    // (11,56): error CS8652: The feature 'dictionary expressions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    //         ReadOnlySpan<KeyValuePair<int, string>> c1 = [k:v, x, ..y];
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, ":").WithArguments("dictionary expressions").WithLocation(11, 56),
+                    // (13,56): error CS9500: Collection expression type 'ReadOnlySpan<KeyValuePair<int?, object>>' does not support key-value pair elements.
+                    //         ReadOnlySpan<KeyValuePair<int?, object>> c2 = [k:v, x, ..y];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "k:v").WithArguments("System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<int?, object>>").WithLocation(13, 56),
+                    // (13,57): error CS8652: The feature 'dictionary expressions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    //         ReadOnlySpan<KeyValuePair<int?, object>> c2 = [k:v, x, ..y];
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, ":").WithArguments("dictionary expressions").WithLocation(13, 57),
+                    // (13,61): error CS0029: Cannot implicitly convert type 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                    //         ReadOnlySpan<KeyValuePair<int?, object>> c2 = [k:v, x, ..y];
+                    Diagnostic(ErrorCode.ERR_NoImplicitConv, "x").WithArguments("System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(13, 61),
+                    // (13,66): error CS0029: Cannot implicitly convert type 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                    //         ReadOnlySpan<KeyValuePair<int?, object>> c2 = [k:v, x, ..y];
+                    Diagnostic(ErrorCode.ERR_NoImplicitConv, "y").WithArguments("System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(13, 66));
+            }
+            else
+            {
+                var verifier = CompileAndVerify(
+                    comp,
+                    verify: Verification.Skipped,
+                    expectedOutput: IncludeExpectedOutput("[[1, one], [2, two], [3, three]], [[1, one], [2, two], [3, three]], "));
+                verifier.VerifyDiagnostics();
+            }
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void KeyValuePairConversions_UseInlineArray(bool useSpan)
+        {
+            string typeName = useSpan ? "Span" : "ReadOnlySpan";
+            string source = $$"""
+                using System;
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        int k = 1;
+                        string v = "one";
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        var y = new[] { new KeyValuePair<int, string>(3, "three") };
+                        One(k, v, x);
+                        Two(k, v, x);
+                        All(y);
+                    }
+                    static void One(int k, string v, KeyValuePair<int, string> x)
+                    {
+                        Many<int?, object>([k:v]);
+                        Many<int?, object>([x]);
+                    }
+                    static void Two(int k, string v, KeyValuePair<int, string> x)
+                    {
+                        Many<int?, object>([k:v, x]);
+                    }
+                    static void All(KeyValuePair<int, string>[] y)
+                    {
+                        Many<int?, object>([..y]);
+                    }
+                    static void Many<K, V>({{typeName}}<KeyValuePair<K, V>> s)
+                    {
+                        s.ToArray().Report();
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_collectionExtensions],
+                targetFramework: TargetFramework.Net80,
+                verify: Verification.Skipped,
+                expectedOutput: IncludeExpectedOutput("[[1, one]], [[2, two]], [[1, one], [2, two]], [[3, three]], "));
+            verifier.VerifyDiagnostics();
+            string singleItemConstructor = useSpan ?
+                "System.Span<System.Collections.Generic.KeyValuePair<int?, object>>..ctor(ref System.Collections.Generic.KeyValuePair<int?, object>)" :
+                "System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<int?, object>>..ctor(ref readonly System.Collections.Generic.KeyValuePair<int?, object>)";
+            verifier.VerifyIL("Program.One", $$"""
+                {
+                  // Code size       66 (0x42)
+                  .maxstack  3
+                  .locals init (System.Collections.Generic.KeyValuePair<int?, object> V_0,
+                                System.Collections.Generic.KeyValuePair<int?, object> V_1,
+                                System.Collections.Generic.KeyValuePair<int, string> V_2)
+                  IL_0000:  ldloca.s   V_0
+                  IL_0002:  ldarg.0
+                  IL_0003:  newobj     "int?..ctor(int)"
+                  IL_0008:  ldarg.1
+                  IL_0009:  call       "System.Collections.Generic.KeyValuePair<int?, object>..ctor(int?, object)"
+                  IL_000e:  ldloca.s   V_0
+                  IL_0010:  newobj     "{{singleItemConstructor}}"
+                  IL_0015:  call       "void Program.Many<int?, object>(System.{{typeName}}<System.Collections.Generic.KeyValuePair<int?, object>>)"
+                  IL_001a:  ldarg.2
+                  IL_001b:  stloc.2
+                  IL_001c:  ldloca.s   V_2
+                  IL_001e:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                  IL_0023:  newobj     "int?..ctor(int)"
+                  IL_0028:  ldloca.s   V_2
+                  IL_002a:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                  IL_002f:  newobj     "System.Collections.Generic.KeyValuePair<int?, object>..ctor(int?, object)"
+                  IL_0034:  stloc.1
+                  IL_0035:  ldloca.s   V_1
+                  IL_0037:  newobj     "{{singleItemConstructor}}"
+                  IL_003c:  call       "void Program.Many<int?, object>(System.{{typeName}}<System.Collections.Generic.KeyValuePair<int?, object>>)"
+                  IL_0041:  ret
+                }
+                """);
+            string convertInlineArray = useSpan ?
+                "System.Span<System.Collections.Generic.KeyValuePair<int?, object>> <PrivateImplementationDetails>.InlineArrayAsSpan<<>y__InlineArray2<System.Collections.Generic.KeyValuePair<int?, object>>, System.Collections.Generic.KeyValuePair<int?, object>>(ref <>y__InlineArray2<System.Collections.Generic.KeyValuePair<int?, object>>, int)" :
+                "System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<int?, object>> <PrivateImplementationDetails>.InlineArrayAsReadOnlySpan<<>y__InlineArray2<System.Collections.Generic.KeyValuePair<int?, object>>, System.Collections.Generic.KeyValuePair<int?, object>>(in <>y__InlineArray2<System.Collections.Generic.KeyValuePair<int?, object>>, int)";
+            verifier.VerifyIL("Program.Two", $$"""
+                {
+                  // Code size       86 (0x56)
+                  .maxstack  3
+                  .locals init (<>y__InlineArray2<System.Collections.Generic.KeyValuePair<int?, object>> V_0,
+                                System.Collections.Generic.KeyValuePair<int, string> V_1)
+                  IL_0000:  ldloca.s   V_0
+                  IL_0002:  initobj    "<>y__InlineArray2<System.Collections.Generic.KeyValuePair<int?, object>>"
+                  IL_0008:  ldloca.s   V_0
+                  IL_000a:  ldc.i4.0
+                  IL_000b:  call       "ref System.Collections.Generic.KeyValuePair<int?, object> <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray2<System.Collections.Generic.KeyValuePair<int?, object>>, System.Collections.Generic.KeyValuePair<int?, object>>(ref <>y__InlineArray2<System.Collections.Generic.KeyValuePair<int?, object>>, int)"
+                  IL_0010:  ldarg.0
+                  IL_0011:  newobj     "int?..ctor(int)"
+                  IL_0016:  ldarg.1
+                  IL_0017:  newobj     "System.Collections.Generic.KeyValuePair<int?, object>..ctor(int?, object)"
+                  IL_001c:  stobj      "System.Collections.Generic.KeyValuePair<int?, object>"
+                  IL_0021:  ldloca.s   V_0
+                  IL_0023:  ldc.i4.1
+                  IL_0024:  call       "ref System.Collections.Generic.KeyValuePair<int?, object> <PrivateImplementationDetails>.InlineArrayElementRef<<>y__InlineArray2<System.Collections.Generic.KeyValuePair<int?, object>>, System.Collections.Generic.KeyValuePair<int?, object>>(ref <>y__InlineArray2<System.Collections.Generic.KeyValuePair<int?, object>>, int)"
+                  IL_0029:  ldarg.2
+                  IL_002a:  stloc.1
+                  IL_002b:  ldloca.s   V_1
+                  IL_002d:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                  IL_0032:  newobj     "int?..ctor(int)"
+                  IL_0037:  ldloca.s   V_1
+                  IL_0039:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                  IL_003e:  newobj     "System.Collections.Generic.KeyValuePair<int?, object>..ctor(int?, object)"
+                  IL_0043:  stobj      "System.Collections.Generic.KeyValuePair<int?, object>"
+                  IL_0048:  ldloca.s   V_0
+                  IL_004a:  ldc.i4.2
+                  IL_004b:  call       "{{convertInlineArray}}"
+                  IL_0050:  call       "void Program.Many<int?, object>(System.{{typeName}}<System.Collections.Generic.KeyValuePair<int?, object>>)"
+                  IL_0055:  ret
+                }
+                """);
+            verifier.VerifyIL("Program.All", $$"""
+                {
+                  // Code size       87 (0x57)
+                  .maxstack  4
+                  .locals init (int V_0,
+                                System.Collections.Generic.KeyValuePair<int?, object>[] V_1,
+                                System.Collections.Generic.KeyValuePair<int, string>[] V_2,
+                                int V_3,
+                                System.Collections.Generic.KeyValuePair<int, string> V_4,
+                                System.Collections.Generic.KeyValuePair<int, string> V_5)
+                  IL_0000:  ldarg.0
+                  IL_0001:  ldc.i4.0
+                  IL_0002:  stloc.0
+                  IL_0003:  dup
+                  IL_0004:  ldlen
+                  IL_0005:  conv.i4
+                  IL_0006:  newarr     "System.Collections.Generic.KeyValuePair<int?, object>"
+                  IL_000b:  stloc.1
+                  IL_000c:  stloc.2
+                  IL_000d:  ldc.i4.0
+                  IL_000e:  stloc.3
+                  IL_000f:  br.s       IL_0045
+                  IL_0011:  ldloc.2
+                  IL_0012:  ldloc.3
+                  IL_0013:  ldelem     "System.Collections.Generic.KeyValuePair<int, string>"
+                  IL_0018:  stloc.s    V_4
+                  IL_001a:  ldloc.1
+                  IL_001b:  ldloc.0
+                  IL_001c:  ldloc.s    V_4
+                  IL_001e:  stloc.s    V_5
+                  IL_0020:  ldloca.s   V_5
+                  IL_0022:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                  IL_0027:  newobj     "int?..ctor(int)"
+                  IL_002c:  ldloca.s   V_5
+                  IL_002e:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                  IL_0033:  newobj     "System.Collections.Generic.KeyValuePair<int?, object>..ctor(int?, object)"
+                  IL_0038:  stelem     "System.Collections.Generic.KeyValuePair<int?, object>"
+                  IL_003d:  ldloc.0
+                  IL_003e:  ldc.i4.1
+                  IL_003f:  add
+                  IL_0040:  stloc.0
+                  IL_0041:  ldloc.3
+                  IL_0042:  ldc.i4.1
+                  IL_0043:  add
+                  IL_0044:  stloc.3
+                  IL_0045:  ldloc.3
+                  IL_0046:  ldloc.2
+                  IL_0047:  ldlen
+                  IL_0048:  conv.i4
+                  IL_0049:  blt.s      IL_0011
+                  IL_004b:  ldloc.1
+                  IL_004c:  newobj     "System.{{typeName}}<System.Collections.Generic.KeyValuePair<int?, object>>..ctor(System.Collections.Generic.KeyValuePair<int?, object>[])"
+                  IL_0051:  call       "void Program.Many<int?, object>(System.{{typeName}}<System.Collections.Generic.KeyValuePair<int?, object>>)"
+                  IL_0056:  ret
+                }
+                """);
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void KeyValuePairConversions_CustomType(
+            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
+            bool useCollectionBuilder)
+        {
+            string sourceA = useCollectionBuilder ?
+                """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyBuilder), "Create")]
+                public class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _items;
+                    internal MyCollection(ReadOnlySpan<T> items) { _items = new(items.ToArray()); }
+                    public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+                public class MyBuilder
+                {
+                    public static MyCollection<T> Create<T>(ReadOnlySpan<T> items) => new(items);
+                }
+                """ :
+                """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                public class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _items;
+                    public MyCollection() { _items = new(); }
+                    public void Add(T t) { _items.Add(t); }
+                    public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+                """;
+            var comp = CreateCompilation(
+                sourceA,
+                targetFramework: TargetFramework.Net80);
+            var refA = comp.EmitToImageReference();
+
+            string sourceB1 = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        int k = 1;
+                        string v = "one";
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        var y = new[] { new KeyValuePair<int, string>(3, "three") };
+                        MyCollection<KeyValuePair<int, string>> c1;
+                        c1 = [k:v, x, ..y];
+                        c1.Report();
+                        MyCollection<KeyValuePair<int?, object>> c2;
+                        c2 = [k:v, x, ..y];
+                        c2.Report();
+                    }
+                }
+                """;
+            comp = CreateCompilation(
+                [sourceB1, s_collectionExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                options: TestOptions.ReleaseExe,
+                references: [refA],
+                targetFramework: TargetFramework.Net80);
+            if (languageVersion == LanguageVersion.CSharp13)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (11,15): error CS9500: Collection expression type 'MyCollection<KeyValuePair<int, string>>' does not support key-value pair elements.
+                    //         c1 = [k:v, x, ..y];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "k:v").WithArguments("MyCollection<System.Collections.Generic.KeyValuePair<int, string>>").WithLocation(11, 15),
+                    // (11,16): error CS8652: The feature 'dictionary expressions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    //         c1 = [k:v, x, ..y];
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, ":").WithArguments("dictionary expressions").WithLocation(11, 16),
+                    // (14,15): error CS9500: Collection expression type 'MyCollection<KeyValuePair<int?, object>>' does not support key-value pair elements.
+                    //         c2 = [k:v, x, ..y];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "k:v").WithArguments("MyCollection<System.Collections.Generic.KeyValuePair<int?, object>>").WithLocation(14, 15),
+                    // (14,16): error CS8652: The feature 'dictionary expressions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    //         c2 = [k:v, x, ..y];
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, ":").WithArguments("dictionary expressions").WithLocation(14, 16),
+                    // (14,20): error CS0029: Cannot implicitly convert type 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                    //         c2 = [k:v, x, ..y];
+                    Diagnostic(ErrorCode.ERR_NoImplicitConv, "x").WithArguments("System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(14, 20),
+                    // (14,25): error CS0029: Cannot implicitly convert type 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                    //         c2 = [k:v, x, ..y];
+                    Diagnostic(ErrorCode.ERR_NoImplicitConv, "y").WithArguments("System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(14, 25));
+            }
+            else
+            {
+                var verifier = CompileAndVerify(
+                    comp,
+                    verify: Verification.Skipped,
+                    expectedOutput: IncludeExpectedOutput("[[1, one], [2, two], [3, three]], [[1, one], [2, two], [3, three]], "));
+                verifier.VerifyDiagnostics();
+            }
+
+            string sourceB2 = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        Params(x);
+                        Params<int, string>(x);
+                        Params<int?, object>(x);
+                    }
+                    static void Params<K, V>(params MyCollection<KeyValuePair<K, V>> args)
+                    {
+                    }
+                }
+                """;
+            comp = CreateCompilation(
+                sourceB2,
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                references: [refA],
+                targetFramework: TargetFramework.Net80);
+            // https://github.com/dotnet/csharplang/blob/main/proposals/dictionary-expressions.md#support-keyvaluepair-variance-with-params: Support KeyValuePair<,> variance with params?
+            comp.VerifyEmitDiagnostics(
+                // (9,30): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                //         Params<int?, object>(x);
+                Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("1", "System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(9, 30));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void KeyValuePairConversions_AddObject(
+            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
+            bool useDynamic)
+        {
+            string parameterType = useDynamic ? "dynamic" : "object";
+            string sourceA = $$"""
+                using System.Collections;
+                using System.Collections.Generic;
+                public class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _items;
+                    public MyCollection() { _items = new(); }
+                    public void Add({{parameterType}} o) { _items.Add((T)o); }
+                    public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+                """;
+            var comp = CreateCompilation(sourceA,
+                targetFramework: TargetFramework.Net80);
+            var refA = comp.EmitToImageReference();
+
+            string sourceB1 = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        int k = 1;
+                        string v = "one";
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        var y = new[] { new KeyValuePair<int, string>(3, "three") };
+                        Many1(k, v, x, y).Report();
+                        Many2(k, v, x, y).Report();
+                    }
+                    static MyCollection<KeyValuePair<int, string>> Many1(int k1, string v1, KeyValuePair<int, string> x1, KeyValuePair<int, string>[] y1)
+                    {
+                        return [k1:v1, x1, ..y1];
+                    }
+                    static MyCollection<KeyValuePair<int?, object>> Many2(int k2, string v2, KeyValuePair<int, string> x2, KeyValuePair<int, string>[] y2)
+                    {
+                        return [k2:v2, x2, ..y2];
+                    }
+                }
+                """;
+            comp = CreateCompilation(
+                [sourceB1, s_collectionExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                references: [refA],
+                options: TestOptions.ReleaseExe,
+                targetFramework: TargetFramework.Net80);
+            if (languageVersion == LanguageVersion.CSharp13)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (15,17): error CS9500: Collection expression type 'MyCollection<KeyValuePair<int, string>>' does not support key-value pair elements.
+                    //         return [k1:v1, x1, ..y1];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "k1:v1").WithArguments("MyCollection<System.Collections.Generic.KeyValuePair<int, string>>").WithLocation(15, 17),
+                    // (15,19): error CS8652: The feature 'dictionary expressions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    //         return [k1:v1, x1, ..y1];
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, ":").WithArguments("dictionary expressions").WithLocation(15, 19),
+                    // (19,17): error CS9500: Collection expression type 'MyCollection<KeyValuePair<int?, object>>' does not support key-value pair elements.
+                    //         return [k2:v2, x2, ..y2];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "k2:v2").WithArguments("MyCollection<System.Collections.Generic.KeyValuePair<int?, object>>").WithLocation(19, 17),
+                    // (19,19): error CS8652: The feature 'dictionary expressions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    //         return [k2:v2, x2, ..y2];
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, ":").WithArguments("dictionary expressions").WithLocation(19, 19),
+                    // (19,24): error CS0029: Cannot implicitly convert type 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                    //         return [k2:v2, x2, ..y2];
+                    Diagnostic(ErrorCode.ERR_NoImplicitConv, "x2").WithArguments("System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(19, 24),
+                    // (19,30): error CS0029: Cannot implicitly convert type 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                    //         return [k2:v2, x2, ..y2];
+                    Diagnostic(ErrorCode.ERR_NoImplicitConv, "y2").WithArguments("System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(19, 30));
+            }
+            else
+            {
+                var verifier = CompileAndVerify(
+                    comp,
+                    verify: Verification.Skipped,
+                    expectedOutput: IncludeExpectedOutput("[[1, one], [2, two], [3, three]], [[1, one], [2, two], [3, three]], "));
+                verifier.VerifyDiagnostics();
+                verifier.VerifyIL("Program.Many2", $$"""
+                    {
+                      // Code size      130 (0x82)
+                      .maxstack  3
+                      .locals init (MyCollection<System.Collections.Generic.KeyValuePair<int?, object>> V_0,
+                                    System.Collections.Generic.KeyValuePair<int, string> V_1,
+                                    System.Collections.Generic.KeyValuePair<int, string>[] V_2,
+                                    int V_3,
+                                    System.Collections.Generic.KeyValuePair<int, string> V_4)
+                      IL_0000:  newobj     "MyCollection<System.Collections.Generic.KeyValuePair<int?, object>>..ctor()"
+                      IL_0005:  stloc.0
+                      IL_0006:  ldloc.0
+                      IL_0007:  ldarg.0
+                      IL_0008:  newobj     "int?..ctor(int)"
+                      IL_000d:  ldarg.1
+                      IL_000e:  newobj     "System.Collections.Generic.KeyValuePair<int?, object>..ctor(int?, object)"
+                      IL_0013:  box        "System.Collections.Generic.KeyValuePair<int?, object>"
+                      IL_0018:  callvirt   "void MyCollection<System.Collections.Generic.KeyValuePair<int?, object>>.Add({{parameterType}})"
+                      IL_001d:  ldloc.0
+                      IL_001e:  ldarg.2
+                      IL_001f:  stloc.1
+                      IL_0020:  ldloca.s   V_1
+                      IL_0022:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                      IL_0027:  newobj     "int?..ctor(int)"
+                      IL_002c:  ldloca.s   V_1
+                      IL_002e:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                      IL_0033:  newobj     "System.Collections.Generic.KeyValuePair<int?, object>..ctor(int?, object)"
+                      IL_0038:  box        "System.Collections.Generic.KeyValuePair<int?, object>"
+                      IL_003d:  callvirt   "void MyCollection<System.Collections.Generic.KeyValuePair<int?, object>>.Add({{parameterType}})"
+                      IL_0042:  ldarg.3
+                      IL_0043:  stloc.2
+                      IL_0044:  ldc.i4.0
+                      IL_0045:  stloc.3
+                      IL_0046:  br.s       IL_007a
+                      IL_0048:  ldloc.2
+                      IL_0049:  ldloc.3
+                      IL_004a:  ldelem     "System.Collections.Generic.KeyValuePair<int, string>"
+                      IL_004f:  stloc.1
+                      IL_0050:  ldloc.0
+                      IL_0051:  ldloc.1
+                      IL_0052:  stloc.s    V_4
+                      IL_0054:  ldloca.s   V_4
+                      IL_0056:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                      IL_005b:  newobj     "int?..ctor(int)"
+                      IL_0060:  ldloca.s   V_4
+                      IL_0062:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                      IL_0067:  newobj     "System.Collections.Generic.KeyValuePair<int?, object>..ctor(int?, object)"
+                      IL_006c:  box        "System.Collections.Generic.KeyValuePair<int?, object>"
+                      IL_0071:  callvirt   "void MyCollection<System.Collections.Generic.KeyValuePair<int?, object>>.Add({{parameterType}})"
+                      IL_0076:  ldloc.3
+                      IL_0077:  ldc.i4.1
+                      IL_0078:  add
+                      IL_0079:  stloc.3
+                      IL_007a:  ldloc.3
+                      IL_007b:  ldloc.2
+                      IL_007c:  ldlen
+                      IL_007d:  conv.i4
+                      IL_007e:  blt.s      IL_0048
+                      IL_0080:  ldloc.0
+                      IL_0081:  ret
+                    }
+                    """);
+            }
+
+            string sourceB2 = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        Params<int, string>();
+                        Params<int?, object>();
+                        Params<int, string>(x);
+                        Params<int?, object>(x);
+                    }
+                    static MyCollection<KeyValuePair<K, V>> Params<K, V>(params MyCollection<KeyValuePair<K, V>> args) => args;
+                }
+                """;
+            comp = CreateCompilation(
+                sourceB2,
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                references: [refA],
+                options: TestOptions.ReleaseExe,
+                targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (10,30): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                //         Params<int?, object>(x);
+                Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("1", "System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(10, 30));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void KeyValuePairConversions_AddUserDefinedConversion(
+            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion)
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                public struct MyPair<K, V>
+                {
+                    public readonly K Key;
+                    public readonly V Value;
+                    public MyPair(K key, V value) { Key = key; Value = value; }
+                    public static implicit operator MyPair<K, V>(KeyValuePair<K, V> kvp) => new(kvp.Key, kvp.Value);
+                }
+                public class MyCollection<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    private readonly List<KeyValuePair<K, V>> _items;
+                    public MyCollection() { _items = new(); }
+                    public void Add(MyPair<K, V> pair) { _items.Add(new(pair.Key, pair.Value)); }
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => _items.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+                """;
+            var comp = CreateCompilation(sourceA);
+            var refA = comp.EmitToImageReference();
+
+            string sourceB1 = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        int k = 1;
+                        string v = "one";
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        var y = new[] { new KeyValuePair<int, string>(3, "three") };
+                        Many1(k, v, x, y).Report();
+                        Many2(k, v, x, y).Report();
+                    }
+                    static MyCollection<int, string> Many1(int k1, string v1, KeyValuePair<int, string> x1, KeyValuePair<int, string>[] y1)
+                    {
+                        return [k1:v1, x1, ..y1];
+                    }
+                    static MyCollection<int?, object> Many2(int k2, string v2, KeyValuePair<int, string> x2, KeyValuePair<int, string>[] y2)
+                    {
+                        return [k2:v2, x2, ..y2];
+                    }
+                }
+                """;
+            comp = CreateCompilation(
+                [sourceB1, s_collectionExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                references: [refA],
+                options: TestOptions.ReleaseExe);
+            if (languageVersion == LanguageVersion.CSharp13)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (15,17): error CS9500: Collection expression type 'MyCollection<int, string>' does not support key-value pair elements.
+                    //         return [k1:v1, x1, ..y1];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "k1:v1").WithArguments("MyCollection<int, string>").WithLocation(15, 17),
+                    // (15,19): error CS8652: The feature 'dictionary expressions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    //         return [k1:v1, x1, ..y1];
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, ":").WithArguments("dictionary expressions").WithLocation(15, 19),
+                    // (19,17): error CS9500: Collection expression type 'MyCollection<int?, object>' does not support key-value pair elements.
+                    //         return [k2:v2, x2, ..y2];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "k2:v2").WithArguments("MyCollection<int?, object>").WithLocation(19, 17),
+                    // (19,19): error CS8652: The feature 'dictionary expressions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    //         return [k2:v2, x2, ..y2];
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, ":").WithArguments("dictionary expressions").WithLocation(19, 19),
+                    // (19,24): error CS0029: Cannot implicitly convert type 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                    //         return [k2:v2, x2, ..y2];
+                    Diagnostic(ErrorCode.ERR_NoImplicitConv, "x2").WithArguments("System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(19, 24),
+                    // (19,30): error CS0029: Cannot implicitly convert type 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                    //         return [k2:v2, x2, ..y2];
+                    Diagnostic(ErrorCode.ERR_NoImplicitConv, "y2").WithArguments("System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(19, 30));
+            }
+            else
+            {
+                var verifier = CompileAndVerify(comp, expectedOutput: "[[1, one], [2, two], [3, three]], [[1, one], [2, two], [3, three]], ");
+                verifier.VerifyDiagnostics();
+                verifier.VerifyIL("Program.Many2", """
+                    {
+                      // Code size      130 (0x82)
+                      .maxstack  3
+                      .locals init (MyCollection<int?, object> V_0,
+                                    System.Collections.Generic.KeyValuePair<int, string> V_1,
+                                    System.Collections.Generic.KeyValuePair<int, string>[] V_2,
+                                    int V_3,
+                                    System.Collections.Generic.KeyValuePair<int, string> V_4)
+                      IL_0000:  newobj     "MyCollection<int?, object>..ctor()"
+                      IL_0005:  stloc.0
+                      IL_0006:  ldloc.0
+                      IL_0007:  ldarg.0
+                      IL_0008:  newobj     "int?..ctor(int)"
+                      IL_000d:  ldarg.1
+                      IL_000e:  newobj     "System.Collections.Generic.KeyValuePair<int?, object>..ctor(int?, object)"
+                      IL_0013:  call       "MyPair<int?, object> MyPair<int?, object>.op_Implicit(System.Collections.Generic.KeyValuePair<int?, object>)"
+                      IL_0018:  callvirt   "void MyCollection<int?, object>.Add(MyPair<int?, object>)"
+                      IL_001d:  ldloc.0
+                      IL_001e:  ldarg.2
+                      IL_001f:  stloc.1
+                      IL_0020:  ldloca.s   V_1
+                      IL_0022:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                      IL_0027:  newobj     "int?..ctor(int)"
+                      IL_002c:  ldloca.s   V_1
+                      IL_002e:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                      IL_0033:  newobj     "System.Collections.Generic.KeyValuePair<int?, object>..ctor(int?, object)"
+                      IL_0038:  call       "MyPair<int?, object> MyPair<int?, object>.op_Implicit(System.Collections.Generic.KeyValuePair<int?, object>)"
+                      IL_003d:  callvirt   "void MyCollection<int?, object>.Add(MyPair<int?, object>)"
+                      IL_0042:  ldarg.3
+                      IL_0043:  stloc.2
+                      IL_0044:  ldc.i4.0
+                      IL_0045:  stloc.3
+                      IL_0046:  br.s       IL_007a
+                      IL_0048:  ldloc.2
+                      IL_0049:  ldloc.3
+                      IL_004a:  ldelem     "System.Collections.Generic.KeyValuePair<int, string>"
+                      IL_004f:  stloc.1
+                      IL_0050:  ldloc.0
+                      IL_0051:  ldloc.1
+                      IL_0052:  stloc.s    V_4
+                      IL_0054:  ldloca.s   V_4
+                      IL_0056:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                      IL_005b:  newobj     "int?..ctor(int)"
+                      IL_0060:  ldloca.s   V_4
+                      IL_0062:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                      IL_0067:  newobj     "System.Collections.Generic.KeyValuePair<int?, object>..ctor(int?, object)"
+                      IL_006c:  call       "MyPair<int?, object> MyPair<int?, object>.op_Implicit(System.Collections.Generic.KeyValuePair<int?, object>)"
+                      IL_0071:  callvirt   "void MyCollection<int?, object>.Add(MyPair<int?, object>)"
+                      IL_0076:  ldloc.3
+                      IL_0077:  ldc.i4.1
+                      IL_0078:  add
+                      IL_0079:  stloc.3
+                      IL_007a:  ldloc.3
+                      IL_007b:  ldloc.2
+                      IL_007c:  ldlen
+                      IL_007d:  conv.i4
+                      IL_007e:  blt.s      IL_0048
+                      IL_0080:  ldloc.0
+                      IL_0081:  ret
+                    }
+                    """);
+            }
+
+            string sourceB2 = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        Params<int, string>();
+                        Params<int?, object>();
+                        Params<int, string>(x);
+                        Params<int?, object>(x);
+                    }
+                    static MyCollection<K, V> Params<K, V>(params MyCollection<K, V> args) => args;
+                }
+                """;
+            comp = CreateCompilation(
+                sourceB2,
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                references: [refA],
+                options: TestOptions.ReleaseExe);
+            comp.VerifyEmitDiagnostics(
+                // (10,30): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                //         Params<int?, object>(x);
+                Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("1", "System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(10, 30));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void KeyValuePairConversions_AddOverloads(
+            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
+            bool includeAddT)
+        {
+            string sourceA = $$"""
+                using System.Collections;
+                using System.Collections.Generic;
+                public class MyCollection<T> : IEnumerable<T>
+                {
+                    private readonly List<T> _items;
+                    public MyCollection() { _items = new(); }
+                    {{(includeAddT ? "public void Add(T t) { _items.Add(t); }" : "")}}
+                    public void Add(KeyValuePair<int, string> kvp) { _items.Add((T)(object)kvp); }
+                    public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+                """;
+            var comp = CreateCompilation(sourceA);
+            var refA = comp.EmitToImageReference();
+
+            string sourceB1 = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        int k = 1;
+                        string v = "one";
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        var y = new[] { new KeyValuePair<int, string>(3, "three") };
+                        Many1(k, v, x, y).Report();
+                        Many2(k, v, x, y).Report();
+                    }
+                    static MyCollection<KeyValuePair<int, string>> Many1(int k1, string v1, KeyValuePair<int, string> x1, KeyValuePair<int, string>[] y1)
+                    {
+                        return [k1:v1, x1, ..y1];
+                    }
+                    static MyCollection<KeyValuePair<int?, object>> Many2(int k2, string v2, KeyValuePair<int, string> x2, KeyValuePair<int, string>[] y2)
+                    {
+                        return [k2:v2, x2, ..y2];
+                    }
+                }
+                """;
+            comp = CreateCompilation(
+                [sourceB1, s_collectionExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                references: [refA],
+                options: TestOptions.ReleaseExe);
+            if (languageVersion == LanguageVersion.CSharp13)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (15,17): error CS9500: Collection expression type 'MyCollection<KeyValuePair<int, string>>' does not support key-value pair elements.
+                    //         return [k1:v1, x1, ..y1];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "k1:v1").WithArguments("MyCollection<System.Collections.Generic.KeyValuePair<int, string>>").WithLocation(15, 17),
+                    // (15,19): error CS8652: The feature 'dictionary expressions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    //         return [k1:v1, x1, ..y1];
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, ":").WithArguments("dictionary expressions").WithLocation(15, 19),
+                    // (19,17): error CS9500: Collection expression type 'MyCollection<KeyValuePair<int?, object>>' does not support key-value pair elements.
+                    //         return [k2:v2, x2, ..y2];
+                    Diagnostic(ErrorCode.ERR_CollectionExpressionKeyValuePairNotSupported, "k2:v2").WithArguments("MyCollection<System.Collections.Generic.KeyValuePair<int?, object>>").WithLocation(19, 17),
+                    // (19,19): error CS8652: The feature 'dictionary expressions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                    //         return [k2:v2, x2, ..y2];
+                    Diagnostic(ErrorCode.ERR_FeatureInPreview, ":").WithArguments("dictionary expressions").WithLocation(19, 19),
+                    // (19,24): error CS0029: Cannot implicitly convert type 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                    //         return [k2:v2, x2, ..y2];
+                    Diagnostic(ErrorCode.ERR_NoImplicitConv, "x2").WithArguments("System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(19, 24),
+                    // (19,30): error CS0029: Cannot implicitly convert type 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                    //         return [k2:v2, x2, ..y2];
+                    Diagnostic(ErrorCode.ERR_NoImplicitConv, "y2").WithArguments("System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(19, 30));
+            }
+            else if (!includeAddT)
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (19,17): error CS1950: The best overloaded Add method 'MyCollection<KeyValuePair<int?, object>>.Add(KeyValuePair<int, string>)' for the collection initializer has some invalid arguments
+                    //         return [k2:v2, x2, ..y2];
+                    Diagnostic(ErrorCode.ERR_BadArgTypesForCollectionAdd, "k2:v2").WithArguments("MyCollection<System.Collections.Generic.KeyValuePair<int?, object>>.Add(System.Collections.Generic.KeyValuePair<int, string>)").WithLocation(19, 17),
+                    // (19,17): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.KeyValuePair<int?, object>' to 'System.Collections.Generic.KeyValuePair<int, string>'
+                    //         return [k2:v2, x2, ..y2];
+                    Diagnostic(ErrorCode.ERR_BadArgType, "k2:v2").WithArguments("1", "System.Collections.Generic.KeyValuePair<int?, object>", "System.Collections.Generic.KeyValuePair<int, string>").WithLocation(19, 17),
+                    // (19,24): error CS1950: The best overloaded Add method 'MyCollection<KeyValuePair<int?, object>>.Add(KeyValuePair<int, string>)' for the collection initializer has some invalid arguments
+                    //         return [k2:v2, x2, ..y2];
+                    Diagnostic(ErrorCode.ERR_BadArgTypesForCollectionAdd, "x2").WithArguments("MyCollection<System.Collections.Generic.KeyValuePair<int?, object>>.Add(System.Collections.Generic.KeyValuePair<int, string>)").WithLocation(19, 24),
+                    // (19,24): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.KeyValuePair<int?, object>' to 'System.Collections.Generic.KeyValuePair<int, string>'
+                    //         return [k2:v2, x2, ..y2];
+                    Diagnostic(ErrorCode.ERR_BadArgType, "x2").WithArguments("1", "System.Collections.Generic.KeyValuePair<int?, object>", "System.Collections.Generic.KeyValuePair<int, string>").WithLocation(19, 24),
+                    // (19,30): error CS1950: The best overloaded Add method 'MyCollection<KeyValuePair<int?, object>>.Add(KeyValuePair<int, string>)' for the collection initializer has some invalid arguments
+                    //         return [k2:v2, x2, ..y2];
+                    Diagnostic(ErrorCode.ERR_BadArgTypesForCollectionAdd, "y2").WithArguments("MyCollection<System.Collections.Generic.KeyValuePair<int?, object>>.Add(System.Collections.Generic.KeyValuePair<int, string>)").WithLocation(19, 30),
+                    // (19,30): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.KeyValuePair<int?, object>' to 'System.Collections.Generic.KeyValuePair<int, string>'
+                    //         return [k2:v2, x2, ..y2];
+                    Diagnostic(ErrorCode.ERR_BadArgType, "y2").WithArguments("1", "System.Collections.Generic.KeyValuePair<int?, object>", "System.Collections.Generic.KeyValuePair<int, string>").WithLocation(19, 30));
+            }
+            else
+            {
+                var verifier = CompileAndVerify(comp, expectedOutput: "[[1, one], [2, two], [3, three]], [[1, one], [2, two], [3, three]], ");
+                verifier.VerifyDiagnostics();
+                verifier.VerifyIL("Program.Many2", """
+                    {
+                      // Code size      115 (0x73)
+                      .maxstack  3
+                      .locals init (MyCollection<System.Collections.Generic.KeyValuePair<int?, object>> V_0,
+                                    System.Collections.Generic.KeyValuePair<int, string> V_1,
+                                    System.Collections.Generic.KeyValuePair<int, string>[] V_2,
+                                    int V_3,
+                                    System.Collections.Generic.KeyValuePair<int, string> V_4)
+                      IL_0000:  newobj     "MyCollection<System.Collections.Generic.KeyValuePair<int?, object>>..ctor()"
+                      IL_0005:  stloc.0
+                      IL_0006:  ldloc.0
+                      IL_0007:  ldarg.0
+                      IL_0008:  newobj     "int?..ctor(int)"
+                      IL_000d:  ldarg.1
+                      IL_000e:  newobj     "System.Collections.Generic.KeyValuePair<int?, object>..ctor(int?, object)"
+                      IL_0013:  callvirt   "void MyCollection<System.Collections.Generic.KeyValuePair<int?, object>>.Add(System.Collections.Generic.KeyValuePair<int?, object>)"
+                      IL_0018:  ldloc.0
+                      IL_0019:  ldarg.2
+                      IL_001a:  stloc.1
+                      IL_001b:  ldloca.s   V_1
+                      IL_001d:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                      IL_0022:  newobj     "int?..ctor(int)"
+                      IL_0027:  ldloca.s   V_1
+                      IL_0029:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                      IL_002e:  newobj     "System.Collections.Generic.KeyValuePair<int?, object>..ctor(int?, object)"
+                      IL_0033:  callvirt   "void MyCollection<System.Collections.Generic.KeyValuePair<int?, object>>.Add(System.Collections.Generic.KeyValuePair<int?, object>)"
+                      IL_0038:  ldarg.3
+                      IL_0039:  stloc.2
+                      IL_003a:  ldc.i4.0
+                      IL_003b:  stloc.3
+                      IL_003c:  br.s       IL_006b
+                      IL_003e:  ldloc.2
+                      IL_003f:  ldloc.3
+                      IL_0040:  ldelem     "System.Collections.Generic.KeyValuePair<int, string>"
+                      IL_0045:  stloc.1
+                      IL_0046:  ldloc.0
+                      IL_0047:  ldloc.1
+                      IL_0048:  stloc.s    V_4
+                      IL_004a:  ldloca.s   V_4
+                      IL_004c:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                      IL_0051:  newobj     "int?..ctor(int)"
+                      IL_0056:  ldloca.s   V_4
+                      IL_0058:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                      IL_005d:  newobj     "System.Collections.Generic.KeyValuePair<int?, object>..ctor(int?, object)"
+                      IL_0062:  callvirt   "void MyCollection<System.Collections.Generic.KeyValuePair<int?, object>>.Add(System.Collections.Generic.KeyValuePair<int?, object>)"
+                      IL_0067:  ldloc.3
+                      IL_0068:  ldc.i4.1
+                      IL_0069:  add
+                      IL_006a:  stloc.3
+                      IL_006b:  ldloc.3
+                      IL_006c:  ldloc.2
+                      IL_006d:  ldlen
+                      IL_006e:  conv.i4
+                      IL_006f:  blt.s      IL_003e
+                      IL_0071:  ldloc.0
+                      IL_0072:  ret
+                    }
+                    """);
+            }
+
+            string sourceB2 = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        Params<int, string>();
+                        Params<int?, object>();
+                        Params<int, string>(x);
+                        Params<int?, object>(x);
+                    }
+                    static MyCollection<KeyValuePair<K, V>> Params<K, V>(params MyCollection<KeyValuePair<K, V>> args) => args;
+                }
+                """;
+            comp = CreateCompilation(
+                sourceB2,
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                references: [refA],
+                options: TestOptions.ReleaseExe);
+            comp.VerifyEmitDiagnostics(
+                // (10,30): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.KeyValuePair<int, string>' to 'System.Collections.Generic.KeyValuePair<int?, object>'
+                //         Params<int?, object>(x);
+                Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("1", "System.Collections.Generic.KeyValuePair<int, string>", "System.Collections.Generic.KeyValuePair<int?, object>").WithLocation(10, 30));
+        }
+
+        [Theory]
+        [InlineData(LanguageVersion.CSharp12, "IEnumerable<KeyValuePair<int, string>>")]
+        [InlineData(LanguageVersion.Preview, "IEnumerable<KeyValuePair<int, string>>")]
+        [InlineData(LanguageVersion.Preview, "IDictionary<int, string>")]
+        [InlineData(LanguageVersion.Preview, "Dictionary<int, string>")]
+        public void KeyValuePairConversions_ConversionFromExpression(LanguageVersion languageVersion, string typeName)
+        {
+            string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        {{typeName}} c;
+                        c = [default];
+                        c.Report();
+                        c = [new()];
+                        c.Report();
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_dictionaryExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                expectedOutput: "[0:null], [0:null], ");
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void KeyValuePairConversions_NotKeyValuePair()
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static Dictionary<K, V> FromExpression<K, V>(K k) => [k];
+                    static Dictionary<K, V> FromSpread<K, V>(IEnumerable<V> e) => [..e];
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (4,59): error CS0029: Cannot implicitly convert type 'K' to 'System.Collections.Generic.KeyValuePair<K, V>'
+                //     static Dictionary<K, V> FromExpression<K, V>(K k) => [k];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "k").WithArguments("K", "System.Collections.Generic.KeyValuePair<K, V>").WithLocation(4, 59),
+                // (5,70): error CS0029: Cannot implicitly convert type 'V' to 'System.Collections.Generic.KeyValuePair<K, V>'
+                //     static Dictionary<K, V> FromSpread<K, V>(IEnumerable<V> e) => [..e];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "e").WithArguments("V", "System.Collections.Generic.KeyValuePair<K, V>").WithLocation(5, 70));
+        }
+
+        [Theory]
+        [MemberData(nameof(LanguageVersions))]
+        public void KeyValuePairConversions_Dynamic_01(LanguageVersion languageVersion)
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        KeyValuePair<string, int> x = new("two", 2);
+                        IEnumerable<object> y = [new KeyValuePair<string, int>("three", 3)];
+                        FromExpression<string, int>(x).Report();
+                        FromSpread<string, int>(y).Report();
+                    }
+                    static List<KeyValuePair<K, V>> FromExpression<K, V>(dynamic d) => [d];
+                    static List<KeyValuePair<K, V>> FromSpread<K, V>(IEnumerable<dynamic> e) => [..e];
+                }
+                """;
+            var comp = CreateCompilation(
+                [source, s_dictionaryExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                options: TestOptions.ReleaseExe,
+                targetFramework: TargetFramework.Net80);
+            if (languageVersion == LanguageVersion.CSharp13)
+            {
+                var verifier = CompileAndVerify(
+                    comp,
+                    verify: Verification.Skipped,
+                    expectedOutput: IncludeExpectedOutput("[two:2], [three:3], "));
+                verifier.VerifyDiagnostics();
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics();
+            }
+        }
+
+        [Theory]
+        [InlineData(LanguageVersion.CSharp12, "IEnumerable<KeyValuePair<K, V>>")]
+        [InlineData(LanguageVersion.Preview, "IEnumerable<KeyValuePair<K, V>>")]
+        [InlineData(LanguageVersion.Preview, "IDictionary<K, V>")]
+        [InlineData(LanguageVersion.Preview, "Dictionary<K, V>")]
+        public void KeyValuePairConversions_Dynamic_02(LanguageVersion languageVersion, string typeName)
+        {
+            string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        var y = new KeyValuePair<int, string>(3, "three");
+                        FromExpression<int, string>(x).Report();
+                        FromSpread<int, string>(new dynamic[] { y }).Report();
+                    }
+                    static {{typeName}} FromExpression<K, V>(dynamic d) => [d];
+                    static {{typeName}} FromSpread<K, V>(IEnumerable<dynamic> e) => [..e];
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_dictionaryExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                targetFramework: TargetFramework.Net80,
+                verify: Verification.Skipped,
+                expectedOutput: IncludeExpectedOutput("[2:two], [3:three], "));
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void KeyValuePairConversions_Dynamic_03()
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        FromPair1<string, int>("one", 1).Report();
+                        FromPair2<string, int>("two", 2).Report();
+                    }
+                    static Dictionary<K, V> FromPair1<K, V>(K k, dynamic d) => [k:d];
+                    static Dictionary<K, V> FromPair2<K, V>(dynamic d, V v) => [d:v];
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_dictionaryExtensions],
+                targetFramework: TargetFramework.Net80,
+                verify: Verification.Skipped,
+                expectedOutput: IncludeExpectedOutput("[one:1], [two:2], "));
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("Program.FromPair1<K, V>", """
+                {
+                  // Code size       77 (0x4d)
+                  .maxstack  6
+                  IL_0000:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor()"
+                  IL_0005:  dup
+                  IL_0006:  ldarg.0
+                  IL_0007:  ldsfld     "System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, V>> Program.<>o__1<K, V>.<>p__0"
+                  IL_000c:  brtrue.s   IL_0032
+                  IL_000e:  ldc.i4.0
+                  IL_000f:  ldtoken    "V"
+                  IL_0014:  call       "System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)"
+                  IL_0019:  ldtoken    "Program"
+                  IL_001e:  call       "System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)"
+                  IL_0023:  call       "System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)"
+                  IL_0028:  call       "System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, V>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, V>>.Create(System.Runtime.CompilerServices.CallSiteBinder)"
+                  IL_002d:  stsfld     "System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, V>> Program.<>o__1<K, V>.<>p__0"
+                  IL_0032:  ldsfld     "System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, V>> Program.<>o__1<K, V>.<>p__0"
+                  IL_0037:  ldfld      "System.Func<System.Runtime.CompilerServices.CallSite, dynamic, V> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, V>>.Target"
+                  IL_003c:  ldsfld     "System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, V>> Program.<>o__1<K, V>.<>p__0"
+                  IL_0041:  ldarg.1
+                  IL_0042:  callvirt   "V System.Func<System.Runtime.CompilerServices.CallSite, dynamic, V>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)"
+                  IL_0047:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                  IL_004c:  ret
+                }
+                """);
+            verifier.VerifyIL("Program.FromPair2<K, V>", """
+                {
+                  // Code size       77 (0x4d)
+                  .maxstack  5
+                  IL_0000:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor()"
+                  IL_0005:  dup
+                  IL_0006:  ldsfld     "System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, K>> Program.<>o__2<K, V>.<>p__0"
+                  IL_000b:  brtrue.s   IL_0031
+                  IL_000d:  ldc.i4.0
+                  IL_000e:  ldtoken    "K"
+                  IL_0013:  call       "System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)"
+                  IL_0018:  ldtoken    "Program"
+                  IL_001d:  call       "System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)"
+                  IL_0022:  call       "System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)"
+                  IL_0027:  call       "System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, K>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, K>>.Create(System.Runtime.CompilerServices.CallSiteBinder)"
+                  IL_002c:  stsfld     "System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, K>> Program.<>o__2<K, V>.<>p__0"
+                  IL_0031:  ldsfld     "System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, K>> Program.<>o__2<K, V>.<>p__0"
+                  IL_0036:  ldfld      "System.Func<System.Runtime.CompilerServices.CallSite, dynamic, K> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, K>>.Target"
+                  IL_003b:  ldsfld     "System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, K>> Program.<>o__2<K, V>.<>p__0"
+                  IL_0040:  ldarg.0
+                  IL_0041:  callvirt   "K System.Func<System.Runtime.CompilerServices.CallSite, dynamic, K>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)"
+                  IL_0046:  ldarg.1
+                  IL_0047:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                  IL_004c:  ret
+                }
+                """);
+        }
+
+        [Theory]
+        [InlineData(LanguageVersion.CSharp12, "IEnumerable<KeyValuePair<K, V>>")]
+        [InlineData(LanguageVersion.Preview, "IEnumerable<KeyValuePair<K, V>>")]
+        [InlineData(LanguageVersion.Preview, "IDictionary<K, V>")]
+        [InlineData(LanguageVersion.Preview, "Dictionary<K, V>")]
+        public void KeyValuePairConversions_Dynamic_04(LanguageVersion languageVersion, string typeName)
+        {
+            string source = $$"""
+                using System.Collections;
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var y = new[] { new KeyValuePair<int, string>(3, "three") };
+                        FromSpread1<int, string>(y);
+                        FromSpread2<int, string>(y);
+                    }
+                    static {{typeName}}
+                        FromSpread1<K, V>(dynamic e) => [..e];
+                    static {{typeName}}
+                        FromSpread2<K, V>(IEnumerable e) => [..e];
+                }
+                """;
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            comp.VerifyEmitDiagnostics(
+                // (12,44): error CS0029: Cannot implicitly convert type 'object' to 'System.Collections.Generic.KeyValuePair<K, V>'
+                //         FromSpread1<K, V>(dynamic e) => [..e];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "e").WithArguments("object", "System.Collections.Generic.KeyValuePair<K, V>").WithLocation(12, 44),
+                // (14,48): error CS0029: Cannot implicitly convert type 'object' to 'System.Collections.Generic.KeyValuePair<K, V>'
+                //         FromSpread2<K, V>(IEnumerable e) => [..e];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "e").WithArguments("object", "System.Collections.Generic.KeyValuePair<K, V>").WithLocation(14, 48));
+        }
+
+        [Fact]
+        public void KeyValuePairConversions_Dynamic_MultipleIndexers()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    private Dictionary<K, V> _d = new();
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => _d.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    public V this[K key]
+                    {
+                        get { return _d[key]; }
+                        set { Console.WriteLine("{0}, {1}, {2}, {3}", typeof(K).Name, typeof(V).Name, key, value); _d[key] = value; }
+                    }
+                    public int this[string key]
+                    {
+                        get { return (int)(object)_d[(K)(object)key]; }
+                        set { Console.WriteLine("string, int, {0}, {1}", key, value); _d[(K)(object)key] = (V)(object)value; }
+                    }
+                }
+                """;
+            string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        FromPair1A("one", 1);
+                        FromPair2A("two", 2);
+                        FromPair1B("one", 1);
+                        FromPair2B("two", 2);
+                    }
+                    static MyDictionary<object, object> FromPair1A(string k, dynamic v) => [k:v];
+                    static MyDictionary<object, object> FromPair2A(dynamic k, int v) => [k:v];
+                    static MyDictionary<object, object> FromPair1B(string k, dynamic v) { var d = new MyDictionary<object, object>(); d[k] = v; return d; }
+                    static MyDictionary<object, object> FromPair2B(dynamic k, int v) { var d = new MyDictionary<object, object>(); d[k] = v; return d; }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [sourceA, sourceB],
+                targetFramework: TargetFramework.Net80,
+                verify: Verification.Skipped,
+                expectedOutput: IncludeExpectedOutput("""
+                    Object, Object, one, 1
+                    Object, Object, two, 2
+                    string, int, one, 1
+                    string, int, two, 2
+                    """));
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void KeyValuePairConversions_MultipleIndexers_UnrelatedTypes()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    private Dictionary<K, V> _d = new();
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => _d.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    public V this[K key]
+                    {
+                        get { return _d[key]; }
+                        set { Console.WriteLine("{0}, {1}, {2}, {3}", typeof(K).Name, typeof(V).Name, key, value); _d[key] = value; }
+                    }
+                    public V this[int key]
+                    {
+                        get { return default; }
+                        set { Console.WriteLine("int, {0}, {1}, {2}", typeof(V).Name, key, value); }
+                    }
+                }
+                """;
+            string sourceB = """
+                class A
+                {
+                    public static implicit operator uint?(A a) => 1;
+                    public static implicit operator int(A a) => 2;
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        FromPair1(new A(), "one");
+                        FromPair2(new A(), "two");
+                    }
+                    static MyDictionary<uint?, object> FromPair1(A k, object v) => [k:v];
+                    static MyDictionary<uint?, object> FromPair2(A k, object v) { var d = new MyDictionary<uint?, object>(); d[k] = v; return d; }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [sourceA, sourceB],
+                verify: Verification.Skipped,
+                expectedOutput: """
+                    Nullable`1, Object, 1, one
+                    int, Object, 2, two
+                    """);
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void KeyValuePairConversions_KeyValuePairConstraint()
+        {
+            string source = """
+                using System.Collections.Generic;
+                abstract class A<T>
+                {
+                    public abstract void F<U>(U u, IEnumerable<U> e) where U : T;
+                }
+                class B<K, V> : A<KeyValuePair<K, V>>
+                {
+                    public override void F<U>(U u, IEnumerable<U> e)
+                    {
+                        Dictionary<K, V> d;
+                        d = [u];
+                        d = [..e];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (11,14): error CS0029: Cannot implicitly convert type 'U' to 'System.Collections.Generic.KeyValuePair<K, V>'
+                //         d = [u];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "u").WithArguments("U", "System.Collections.Generic.KeyValuePair<K, V>").WithLocation(11, 14),
+                // (12,16): error CS0029: Cannot implicitly convert type 'U' to 'System.Collections.Generic.KeyValuePair<K, V>'
+                //         d = [..e];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "e").WithArguments("U", "System.Collections.Generic.KeyValuePair<K, V>").WithLocation(12, 16));
+        }
+
+        [Theory]
+        [MemberData(nameof(LanguageVersions))]
+        public void KeyValuePairConversions_LanguageVersion(LanguageVersion languageVersion)
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        FromExpression(new KeyValuePair<string, int>("one", 1)).Report();
+                        FromSpread([new KeyValuePair<string, int>("two", 2)]).Report();
+                    }
+                    static KeyValuePair<K, V>[] FromExpression<K, V>(KeyValuePair<K, V> e) => [e];
+                    static KeyValuePair<K, V>[] FromSpread<K, V>(IEnumerable<KeyValuePair<K, V>> s) => [..s];
+                }
+                """;
+            var comp = CreateCompilation(
+                [source, s_dictionaryExtensions],
+                parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
+                options: TestOptions.ReleaseExe);
+            var verifier = CompileAndVerify(comp, expectedOutput: "[one:1], [two:2], ");
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("Program.FromExpression<K, V>", """
+                {
+                    // Code size       15 (0xf)
+                    .maxstack  4
+                    IL_0000:  ldc.i4.1
+                    IL_0001:  newarr     "System.Collections.Generic.KeyValuePair<K, V>"
+                    IL_0006:  dup
+                    IL_0007:  ldc.i4.0
+                    IL_0008:  ldarg.0
+                    IL_0009:  stelem     "System.Collections.Generic.KeyValuePair<K, V>"
+                    IL_000e:  ret
+                }
+                """);
+            verifier.VerifyIL("Program.FromSpread<K, V>", """
+                {
+                  // Code size        7 (0x7)
+                  .maxstack  1
+                  IL_0000:  ldarg.0
+                  IL_0001:  call       "System.Collections.Generic.KeyValuePair<K, V>[] System.Linq.Enumerable.ToArray<System.Collections.Generic.KeyValuePair<K, V>>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>)"
+                  IL_0006:  ret
+                }
+                """);
+        }
+
+        [Fact]
+        public void EvaluationOrder_01()
+        {
+            string source = """
+                using System;
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        IReadOnlyDictionary<int, string> d = [
+                            Identity(new KeyValuePair<int, string>(1, "one")),
+                            Identity(2):Identity("two"),
+                            ..Identity((KeyValuePair<int, string>[])[new(3, "three")])];
+                        d.Report();
+                    }
+                    static T Identity<T>(T value)
+                    {
+                        Console.WriteLine(value);
+                        return value;
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_dictionaryExtensions],
+                expectedOutput: """
+                    [1, one]
+                    2
+                    two
+                    System.Collections.Generic.KeyValuePair`2[System.Int32,System.String][]
+                    [1:one, 2:two, 3:three], 
+                    """);
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("Program.Main", """
+                {
+                  // Code size      150 (0x96)
+                  .maxstack  5
+                  .locals init (System.Collections.Generic.Dictionary<int, string> V_0,
+                                System.Collections.Generic.KeyValuePair<int, string> V_1,
+                                System.Collections.Generic.KeyValuePair<int, string>[] V_2,
+                                int V_3,
+                                System.Collections.Generic.KeyValuePair<int, string> V_4)
+                  IL_0000:  newobj     "System.Collections.Generic.Dictionary<int, string>..ctor()"
+                  IL_0005:  stloc.0
+                  IL_0006:  ldc.i4.1
+                  IL_0007:  ldstr      "one"
+                  IL_000c:  newobj     "System.Collections.Generic.KeyValuePair<int, string>..ctor(int, string)"
+                  IL_0011:  call       "System.Collections.Generic.KeyValuePair<int, string> Program.Identity<System.Collections.Generic.KeyValuePair<int, string>>(System.Collections.Generic.KeyValuePair<int, string>)"
+                  IL_0016:  stloc.1
+                  IL_0017:  ldloc.0
+                  IL_0018:  ldloca.s   V_1
+                  IL_001a:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                  IL_001f:  ldloca.s   V_1
+                  IL_0021:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                  IL_0026:  callvirt   "void System.Collections.Generic.Dictionary<int, string>.this[int].set"
+                  IL_002b:  ldloc.0
+                  IL_002c:  ldc.i4.2
+                  IL_002d:  call       "int Program.Identity<int>(int)"
+                  IL_0032:  ldstr      "two"
+                  IL_0037:  call       "string Program.Identity<string>(string)"
+                  IL_003c:  callvirt   "void System.Collections.Generic.Dictionary<int, string>.this[int].set"
+                  IL_0041:  ldc.i4.1
+                  IL_0042:  newarr     "System.Collections.Generic.KeyValuePair<int, string>"
+                  IL_0047:  dup
+                  IL_0048:  ldc.i4.0
+                  IL_0049:  ldc.i4.3
+                  IL_004a:  ldstr      "three"
+                  IL_004f:  newobj     "System.Collections.Generic.KeyValuePair<int, string>..ctor(int, string)"
+                  IL_0054:  stelem     "System.Collections.Generic.KeyValuePair<int, string>"
+                  IL_0059:  call       "System.Collections.Generic.KeyValuePair<int, string>[] Program.Identity<System.Collections.Generic.KeyValuePair<int, string>[]>(System.Collections.Generic.KeyValuePair<int, string>[])"
+                  IL_005e:  stloc.2
+                  IL_005f:  ldc.i4.0
+                  IL_0060:  stloc.3
+                  IL_0061:  br.s       IL_0084
+                  IL_0063:  ldloc.2
+                  IL_0064:  ldloc.3
+                  IL_0065:  ldelem     "System.Collections.Generic.KeyValuePair<int, string>"
+                  IL_006a:  stloc.s    V_4
+                  IL_006c:  ldloc.0
+                  IL_006d:  ldloca.s   V_4
+                  IL_006f:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                  IL_0074:  ldloca.s   V_4
+                  IL_0076:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                  IL_007b:  callvirt   "void System.Collections.Generic.Dictionary<int, string>.this[int].set"
+                  IL_0080:  ldloc.3
+                  IL_0081:  ldc.i4.1
+                  IL_0082:  add
+                  IL_0083:  stloc.3
+                  IL_0084:  ldloc.3
+                  IL_0085:  ldloc.2
+                  IL_0086:  ldlen
+                  IL_0087:  conv.i4
+                  IL_0088:  blt.s      IL_0063
+                  IL_008a:  ldloc.0
+                  IL_008b:  newobj     "System.Collections.ObjectModel.ReadOnlyDictionary<int, string>..ctor(System.Collections.Generic.IDictionary<int, string>)"
+                  IL_0090:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                  IL_0095:  ret
+                }
+                """);
+        }
+
+        [Fact]
+        public void EvaluationOrder_02()
+        {
+            string source = """
+                using System;
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var d = F(101, "A", 102, "B", 103, "C", true, 3);
+                        d.Report();
+                    }
+                    static IReadOnlyDictionary<K, V> F<K, V>(K k1, V v1, K k2, V v2, K k3, V v3, bool b, int i)
+                    {
+                        return [
+                            Identity(Identity(b) ? Identity(k1) : Identity(k2)) : Identity(v2),
+                            Identity(k3) : Identity(Identity(i) switch { 1 => Identity(v1), 2 => Identity(v2), _ => Identity(v3) })];
+                    }
+                    static T Identity<T>(T value)
+                    {
+                        Console.WriteLine(value);
+                        return value;
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_dictionaryExtensions],
+                expectedOutput: """
+                    True
+                    101
+                    101
+                    B
+                    103
+                    3
+                    C
+                    C
+                    [101:B, 103:C], 
+                    """);
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("Program.F<K, V>", """
+                {
+                  // Code size      124 (0x7c)
+                  .maxstack  3
+                  .locals init (System.Collections.Generic.Dictionary<K, V> V_0,
+                                K V_1,
+                                V V_2,
+                                int V_3,
+                                System.Collections.Generic.Dictionary<K, V> V_4)
+                  IL_0000:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor()"
+                  IL_0005:  stloc.s    V_4
+                  IL_0007:  ldloc.s    V_4
+                  IL_0009:  ldarg.s    V_6
+                  IL_000b:  call       "bool Program.Identity<bool>(bool)"
+                  IL_0010:  brtrue.s   IL_001a
+                  IL_0012:  ldarg.2
+                  IL_0013:  call       "K Program.Identity<K>(K)"
+                  IL_0018:  br.s       IL_0020
+                  IL_001a:  ldarg.0
+                  IL_001b:  call       "K Program.Identity<K>(K)"
+                  IL_0020:  call       "K Program.Identity<K>(K)"
+                  IL_0025:  ldarg.3
+                  IL_0026:  call       "V Program.Identity<V>(V)"
+                  IL_002b:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                  IL_0030:  ldloc.s    V_4
+                  IL_0032:  stloc.0
+                  IL_0033:  ldarg.s    V_4
+                  IL_0035:  call       "K Program.Identity<K>(K)"
+                  IL_003a:  stloc.1
+                  IL_003b:  ldarg.s    V_7
+                  IL_003d:  call       "int Program.Identity<int>(int)"
+                  IL_0042:  stloc.3
+                  IL_0043:  ldloc.3
+                  IL_0044:  ldc.i4.1
+                  IL_0045:  beq.s      IL_004d
+                  IL_0047:  ldloc.3
+                  IL_0048:  ldc.i4.2
+                  IL_0049:  beq.s      IL_0056
+                  IL_004b:  br.s       IL_005f
+                  IL_004d:  ldarg.1
+                  IL_004e:  call       "V Program.Identity<V>(V)"
+                  IL_0053:  stloc.2
+                  IL_0054:  br.s       IL_0067
+                  IL_0056:  ldarg.3
+                  IL_0057:  call       "V Program.Identity<V>(V)"
+                  IL_005c:  stloc.2
+                  IL_005d:  br.s       IL_0067
+                  IL_005f:  ldarg.s    V_5
+                  IL_0061:  call       "V Program.Identity<V>(V)"
+                  IL_0066:  stloc.2
+                  IL_0067:  ldloc.0
+                  IL_0068:  ldloc.1
+                  IL_0069:  ldloc.2
+                  IL_006a:  call       "V Program.Identity<V>(V)"
+                  IL_006f:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                  IL_0074:  ldloc.s    V_4
+                  IL_0076:  newobj     "System.Collections.ObjectModel.ReadOnlyDictionary<K, V>..ctor(System.Collections.Generic.IDictionary<K, V>)"
+                  IL_007b:  ret
+                }
+                """);
+        }
+
+        [Fact]
+        public void EvaluationOrder_03()
+        {
+            string source = """
+                using System;
+                using System.Collections.Generic;
+                class MyKeyValuePair<K, V>
+                {
+                    public MyKeyValuePair(K key, V value)
+                    {
+                        Key = key;
+                        Value = value;
+                    }
+                    public readonly K Key;
+                    public readonly V Value;
+                    public static implicit operator KeyValuePair<K, V>(MyKeyValuePair<K, V> kvp)
+                    {
+                        Console.WriteLine("conversion to MyKeyValuePair<{0}, {1}>: {2}, {3}", typeof(K).Name, typeof(V).Name, kvp.Key, kvp.Value);
+                        return new(kvp.Key, kvp.Value);
+                    }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new MyKeyValuePair<int, string>(1, "one");
+                        var y = new MyKeyValuePair<int, string>[] { new(2, "two"), new(3, "three") };
+                        F(x, y).Report();
+                    }
+                    static IDictionary<K, V> F<K, V>(MyKeyValuePair<K, V> x, IEnumerable<MyKeyValuePair<K, V>> y)
+                    {
+                        return [Identity(x), ..Identity(y)];
+                    }
+                    static T Identity<T>(T value)
+                    {
+                        Console.WriteLine(value);
+                        return value;
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_dictionaryExtensions],
+                expectedOutput: """
+                    MyKeyValuePair`2[System.Int32,System.String]
+                    conversion to MyKeyValuePair<Int32, String>: 1, one
+                    MyKeyValuePair`2[System.Int32,System.String][]
+                    conversion to MyKeyValuePair<Int32, String>: 2, two
+                    conversion to MyKeyValuePair<Int32, String>: 3, three
+                    [1:one, 2:two, 3:three],
+                    """);
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void EvaluationOrder_04()
+        {
+            string source = """
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+                class A<T>
+                {
+                    public readonly T Value;
+                    public A(T value) { Value = value; }
+                    public static implicit operator A<T>(T value)
+                    {
+                        Console.WriteLine("conversion to A<{0}>: {1}", typeof(T).Name, value);
+                        return new(value);
+                    }
+                    public override string ToString() => Value.ToString();
+                    public class Comparer : IEqualityComparer<A<T>>
+                    {
+                        public Comparer()
+                        {
+                            Console.WriteLine("new Comparer<{0}>()", typeof(T).Name);
+                        }
+                        public bool Equals(A<T> x, A<T> y) => object.Equals(x.Value, y.Value);
+                        public int GetHashCode(A<T> a) => a.Value.GetHashCode();
+                    }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(1, "one");
+                        var y = new KeyValuePair<int, string>[] { new(2, "two"), new(3, "three") };
+                        var d = F(x, y);
+                        d.Select(kvp => new KeyValuePair<int, string>(kvp.Key.Value, kvp.Value.Value)).Report();
+                    }
+                    static Dictionary<A<K>, A<V>> F<K, V>(KeyValuePair<K, V> x, IEnumerable<KeyValuePair<K, V>> y)
+                    {
+                        return [with(comparer: new A<K>.Comparer()), Identity(x), ..Identity(y)];
+                    }
+                    static T Identity<T>(T value)
+                    {
+                        Console.WriteLine(value);
+                        return value;
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_collectionExtensions],
+                expectedOutput: """
+                    new Comparer<Int32>()
+                    [1, one]
+                    conversion to A<Int32>: 1
+                    conversion to A<String>: one
+                    System.Collections.Generic.KeyValuePair`2[System.Int32,System.String][]
+                    conversion to A<Int32>: 2
+                    conversion to A<String>: two
+                    conversion to A<Int32>: 3
+                    conversion to A<String>: three
+                    [[1, one], [2, two], [3, three]], 
+                    """);
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void InferredType_ExpressionElement()
+        {
+            string source = """
+                using System.Collections.Generic;
+                IDictionary<int, string> d = [new()];
+                d.Report();
+                d = [default];
+                d.Report();
+                """;
+            var comp = CreateCompilation([source, s_dictionaryExtensions], options: TestOptions.ReleaseExe);
+            var verifier = CompileAndVerify(comp, expectedOutput: "[0:null], [0:null], ");
+            verifier.VerifyDiagnostics();
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var elements = tree.GetRoot().DescendantNodes().OfType<ExpressionElementSyntax>().ToArray();
+
+            var typeInfo = model.GetTypeInfo(elements[0].Expression);
+            Assert.Equal("System.Collections.Generic.KeyValuePair<System.Int32, System.String>", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal("System.Collections.Generic.KeyValuePair<System.Int32, System.String>", typeInfo.ConvertedType.ToTestDisplayString());
+
+            typeInfo = model.GetTypeInfo(elements[1].Expression);
+            Assert.Equal("System.Collections.Generic.KeyValuePair<System.Int32, System.String>", typeInfo.Type.ToTestDisplayString());
+            Assert.Equal("System.Collections.Generic.KeyValuePair<System.Int32, System.String>", typeInfo.ConvertedType.ToTestDisplayString());
+        }
+
+        [Fact]
+        public void InferredType_KeyValueElement_01()
+        {
+            string source = """
+                using System.Collections.Generic;
+                IDictionary<int, string> d = [default:default];
+                d.Report();
+                d = [new():null];
+                d.Report();
+                """;
+            var comp = CreateCompilation([source, s_dictionaryExtensions], options: TestOptions.ReleaseExe);
+            var verifier = CompileAndVerify(comp, expectedOutput: "[0:null], [0:null], ");
+            verifier.VerifyDiagnostics();
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var elements = tree.GetRoot().DescendantNodes().OfType<KeyValuePairElementSyntax>().ToArray();
+
+            var typeInfo = model.GetTypeInfo(elements[0].KeyExpression);
+            Assert.Equal(SpecialType.System_Int32, typeInfo.Type.SpecialType);
+            Assert.Equal(SpecialType.System_Int32, typeInfo.ConvertedType.SpecialType);
+            typeInfo = model.GetTypeInfo(elements[0].ValueExpression);
+            Assert.Equal(SpecialType.System_String, typeInfo.Type.SpecialType);
+            Assert.Equal(SpecialType.System_String, typeInfo.ConvertedType.SpecialType);
+
+            typeInfo = model.GetTypeInfo(elements[1].KeyExpression);
+            Assert.Equal(SpecialType.System_Int32, typeInfo.Type.SpecialType);
+            Assert.Equal(SpecialType.System_Int32, typeInfo.ConvertedType.SpecialType);
+            typeInfo = model.GetTypeInfo(elements[1].ValueExpression);
+            Assert.Null(typeInfo.Type);
+            Assert.Equal(SpecialType.System_String, typeInfo.ConvertedType.SpecialType);
+        }
+
+        [Fact]
+        public void InferredType_KeyValueElement_02()
+        {
+            string source = """
+                using System.Collections.Generic;
+                IDictionary<string, int> d = [null:new()];
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics();
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var elements = tree.GetRoot().DescendantNodes().OfType<KeyValuePairElementSyntax>().ToArray();
+
+            var typeInfo = model.GetTypeInfo(elements[0].KeyExpression);
+            Assert.Null(typeInfo.Type);
+            Assert.Equal(SpecialType.System_String, typeInfo.ConvertedType.SpecialType);
+            typeInfo = model.GetTypeInfo(elements[0].ValueExpression);
+            Assert.Equal(SpecialType.System_Int32, typeInfo.Type.SpecialType);
+            Assert.Equal(SpecialType.System_Int32, typeInfo.ConvertedType.SpecialType);
+        }
+
+        [Fact]
+        public void ConversionError_ExpressionElement()
+        {
+            string source = """
+                using System.Collections.Generic;
+                var x = new object();
+                IDictionary<int, int> d = [x, null];
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (3,28): error CS0029: Cannot implicitly convert type 'object' to 'System.Collections.Generic.KeyValuePair<int, int>'
+                // IDictionary<int, int> d = [x, null];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "x").WithArguments("object", "System.Collections.Generic.KeyValuePair<int, int>").WithLocation(3, 28),
+                // (3,31): error CS0037: Cannot convert null to 'KeyValuePair<int, int>' because it is a non-nullable value type
+                // IDictionary<int, int> d = [x, null];
+                Diagnostic(ErrorCode.ERR_ValueCantBeNull, "null").WithArguments("System.Collections.Generic.KeyValuePair<int, int>").WithLocation(3, 31));
+        }
+
+        [Fact]
+        public void ConversionError_KeyValueElement_01()
+        {
+            string source = """
+                using System.Collections.Generic;
+                var x = new object();
+                var y = new object();
+                IDictionary<string, int> d = [x:1, "2":y];
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (4,31): error CS0029: Cannot implicitly convert type 'object' to 'string'
+                // IDictionary<string, int> d = [x:1, "2":y];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "x").WithArguments("object", "string").WithLocation(4, 31),
+                // (4,40): error CS0029: Cannot implicitly convert type 'object' to 'int'
+                // IDictionary<string, int> d = [x:1, "2":y];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "y").WithArguments("object", "int").WithLocation(4, 40));
+        }
+
+        [Fact]
+        public void ConversionError_KeyValueElement_02()
+        {
+            string source = """
+                using System.Collections.Generic;
+                IDictionary<string, int> d;
+                d = [new():1];
+                d = ["":null];
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (3,6): error CS1729: 'string' does not contain a constructor that takes 0 arguments
+                // d = [new():1];
+                Diagnostic(ErrorCode.ERR_BadCtorArgCount, "new()").WithArguments("string", "0").WithLocation(3, 6),
+                // (4,9): error CS0037: Cannot convert null to 'int' because it is a non-nullable value type
+                // d = ["":null];
+                Diagnostic(ErrorCode.ERR_ValueCantBeNull, "null").WithArguments("int").WithLocation(4, 9));
+        }
+
+        [Fact]
+        public void ConversionError_KeyValueElement_03()
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        IDictionary<object, object> d = [P:P];
+                    }
+                    static object P { set { } }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (6,42): error CS0154: The property or indexer 'Program.P' cannot be used in this context because it lacks the get accessor
+                //         IDictionary<object, object> d = [P:P];
+                Diagnostic(ErrorCode.ERR_PropertyLacksGet, "P").WithArguments("Program.P").WithLocation(6, 42),
+                // (6,44): error CS0154: The property or indexer 'Program.P' cannot be used in this context because it lacks the get accessor
+                //         IDictionary<object, object> d = [P:P];
+                Diagnostic(ErrorCode.ERR_PropertyLacksGet, "P").WithArguments("Program.P").WithLocation(6, 44));
+        }
+
+        [Fact]
+        public void ConversionError_SpreadElement()
+        {
+            string source = """
+                using System.Collections.Generic;
+                IDictionary<string, int> d = [..new()];
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (2,33): error CS8754: There is no target type for 'new()'
+                // IDictionary<string, int> d = [..new()];
+                Diagnostic(ErrorCode.ERR_ImplicitObjectCreationNoTargetType, "new()").WithArguments("new()").WithLocation(2, 33));
+        }
+
+        [Theory]
+        [InlineData("IDictionary")]
+        [InlineData("IReadOnlyDictionary")]
+        [InlineData("Dictionary")]
+        public void TypeInference(string typeName)
+        {
+            string source = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Identity([default:default]);
+                        Identity([default:"2"]);
+                        Identity([1:default]);
+                        Identity([1:default, default:"2"]);
+                    }
+                    static {{typeName}}<K, V> Identity<K, V>({{typeName}}<K, V> d) => d;
+                }
+                """;
+            var comp = CreateCompilation(source);
+            // https://github.com/dotnet/roslyn/issues/77873: Type inference should succeed for Identity([1:default, default:"2"]);.
+            comp.VerifyEmitDiagnostics(
+                // (6,9): error CS0411: The type arguments for method 'Program.Identity<K, V>(IDictionary<K, V>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         Identity([default:default]);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Identity").WithArguments($"Program.Identity<K, V>(System.Collections.Generic.{typeName}<K, V>)").WithLocation(6, 9),
+                // (7,9): error CS0411: The type arguments for method 'Program.Identity<K, V>(IDictionary<K, V>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         Identity([default:"2"]);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Identity").WithArguments($"Program.Identity<K, V>(System.Collections.Generic.{typeName}<K, V>)").WithLocation(7, 9),
+                // (8,9): error CS0411: The type arguments for method 'Program.Identity<K, V>(IDictionary<K, V>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         Identity([1:default]);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Identity").WithArguments($"Program.Identity<K, V>(System.Collections.Generic.{typeName}<K, V>)").WithLocation(8, 9),
+                // (9,9): error CS0411: The type arguments for method 'Program.Identity<K, V>(IDictionary<K, V>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         Identity([1:default, default:"2"]);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Identity").WithArguments($"Program.Identity<K, V>(System.Collections.Generic.{typeName}<K, V>)").WithLocation(9, 9));
+        }
+
+        // Type inference should not walk into KeyValuePair<A, B> when the KeyValuePair<A, B>
+        // is substituted type for T rather than substituted for KeyValuePair<K, V>.
+        [Theory]
+        [InlineData("System.Collections.Generic.IEnumerable<T>")]
+        [InlineData("T[]")]
+        [InlineData("System.Collections.Generic.List<T>")]
+        public void TypeInference_KeyValuePairConversions(string typeName)
+        {
+            string sourceA1 = $$"""
+                class Program
+                {
+                    static void Main()
+                    {
+                        (int, string) x = (1, "one");
+                        (int?, object) y = (2, "two");
+                        Identity([x, y]);
+                        Identity([y, x]);
+                    }
+                    static {{typeName}} Identity<T>({{typeName}} c)
+                    {
+                        c.Report();
+                        return c;
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [sourceA1, s_collectionExtensions],
+                expectedOutput: "[(1, one), (2, two)], [(2, two), (1, one)], ");
+            verifier.VerifyDiagnostics();
+
+            string sourceB1 = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(1, "one");
+                        var y = new KeyValuePair<int?, object>(2, "two");
+                        Identity([x, y]);
+                        Identity([y, x]);
+                    }
+                    static {{typeName}} Identity<T>({{typeName}} c)
+                    {
+                        c.Report();
+                        return c;
+                    }
+                }
+                """;
+            var comp = CreateCompilation([sourceB1, s_collectionExtensions]);
+            comp.VerifyEmitDiagnostics(
+                // (8,9): error CS0411: The type arguments for method 'Program.Identity<T>(IEnumerable<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         Identity([x, y]);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Identity").WithArguments($"Program.Identity<T>({typeName})").WithLocation(8, 9),
+                // (9,9): error CS0411: The type arguments for method 'Program.Identity<T>(IEnumerable<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         Identity([y, x]);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Identity").WithArguments($"Program.Identity<T>({typeName})").WithLocation(9, 9));
+
+            string sourceA2 = $$"""
+                class Program
+                {
+                    static void Main()
+                    {
+                        (int, string) x = (1, "one");
+                        (int?, object) y = (2, "two");
+                        Identity(x, y);
+                        Identity(y, x);
+                    }
+                    static {{typeName}} Identity<T>(params {{typeName}} c)
+                    {
+                        c.Report();
+                        return c;
+                    }
+                }
+                """;
+            verifier = CompileAndVerify(
+                [sourceA2, s_collectionExtensions],
+                expectedOutput: "[(1, one), (2, two)], [(2, two), (1, one)], ");
+            verifier.VerifyDiagnostics();
+
+            string sourceB2 = $$"""
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(1, "one");
+                        var y = new KeyValuePair<int?, object>(2, "two");
+                        Identity(x, y);
+                        Identity(y, x);
+                    }
+                    static {{typeName}} Identity<T>(params {{typeName}} c)
+                    {
+                        c.Report();
+                        return c;
+                    }
+                }
+                """;
+            comp = CreateCompilation([sourceB2, s_collectionExtensions]);
+            comp.VerifyEmitDiagnostics(
+                // (8,9): error CS0411: The type arguments for method 'Program.Identity<T>(params IEnumerable<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         Identity(x, y);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Identity").WithArguments($"Program.Identity<T>(params {typeName})").WithLocation(8, 9),
+                // (9,9): error CS0411: The type arguments for method 'Program.Identity<T>(params IEnumerable<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         Identity(y, x);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Identity").WithArguments($"Program.Identity<T>(params {typeName})").WithLocation(9, 9));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void CustomDictionary_01([CombinatorialValues("class", "struct")] string typeKind, bool useCompilationReference)
+        {
+            string sourceA = $$"""
+                using System.Collections;
+                using System.Collections.Generic;
+                public {{typeKind}} MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    private Dictionary<K, V> _d;
+                    public MyDictionary(IEqualityComparer<K> comparer = null) { _d = new(comparer); }
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => GetDictionary().GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    public V this[K key]
+                    {
+                        get { return GetDictionary()[key]; }
+                        set { GetDictionary()[key] = value; }
+                    }
+                    private Dictionary<K, V> GetDictionary() => _d ??= new();
+                }
+                """;
+            var comp = CreateCompilation(sourceA);
+            var refA = AsReference(comp, useCompilationReference);
+
+            string sourceB = """
+                using System;
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Empty<string, int>().Report();
+                        Many(1, "one", new KeyValuePair<int, string>(2, "two"), new KeyValuePair<int, string>[] { new(3, "three") }).Report();
+                        WithComparer(StringComparer.OrdinalIgnoreCase, "ABC", 1, "ab", 2).Report();
+                    }
+                    static MyDictionary<K, V> Empty<K, V>() => [];
+                    static MyDictionary<K, V> Many<K, V>(K k, V v, KeyValuePair<K, V> e, KeyValuePair<K, V>[] s) => /*<bind>*/[with(null), k:v, e, ..s]/*</bind>*/;
+                    static MyDictionary<K, V> WithComparer<K, V>(IEqualityComparer<K> comparer, K k1, V v1, K k2, V v2) => [with(comparer), k1:v1, k2:v2];
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [sourceB, s_dictionaryExtensions],
+                references: [refA],
+                expectedOutput: "[], [1:one, 2:two, 3:three], [ab:2, ABC:1], ");
+            verifier.VerifyDiagnostics();
+            if (typeKind == "class")
+            {
+                verifier.VerifyIL("Program.Empty<K, V>", """
+                    {
+                      // Code size        7 (0x7)
+                      .maxstack  1
+                      IL_0000:  ldnull
+                      IL_0001:  newobj     "MyDictionary<K, V>..ctor(System.Collections.Generic.IEqualityComparer<K>)"
+                      IL_0006:  ret
+                    }
+                    """);
+                verifier.VerifyIL("Program.Many<K, V>", """
+                    {
+                      // Code size       84 (0x54)
+                      .maxstack  3
+                      .locals init (MyDictionary<K, V> V_0,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_1,
+                                    System.Collections.Generic.KeyValuePair<K, V>[] V_2,
+                                    int V_3,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_4)
+                      IL_0000:  ldnull
+                      IL_0001:  newobj     "MyDictionary<K, V>..ctor(System.Collections.Generic.IEqualityComparer<K>)"
+                      IL_0006:  stloc.0
+                      IL_0007:  ldloc.0
+                      IL_0008:  ldarg.0
+                      IL_0009:  ldarg.1
+                      IL_000a:  callvirt   "void MyDictionary<K, V>.this[K].set"
+                      IL_000f:  ldarg.2
+                      IL_0010:  stloc.1
+                      IL_0011:  ldloc.0
+                      IL_0012:  ldloca.s   V_1
+                      IL_0014:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                      IL_0019:  ldloca.s   V_1
+                      IL_001b:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                      IL_0020:  callvirt   "void MyDictionary<K, V>.this[K].set"
+                      IL_0025:  ldarg.3
+                      IL_0026:  stloc.2
+                      IL_0027:  ldc.i4.0
+                      IL_0028:  stloc.3
+                      IL_0029:  br.s       IL_004c
+                      IL_002b:  ldloc.2
+                      IL_002c:  ldloc.3
+                      IL_002d:  ldelem     "System.Collections.Generic.KeyValuePair<K, V>"
+                      IL_0032:  stloc.s    V_4
+                      IL_0034:  ldloc.0
+                      IL_0035:  ldloca.s   V_4
+                      IL_0037:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                      IL_003c:  ldloca.s   V_4
+                      IL_003e:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                      IL_0043:  callvirt   "void MyDictionary<K, V>.this[K].set"
+                      IL_0048:  ldloc.3
+                      IL_0049:  ldc.i4.1
+                      IL_004a:  add
+                      IL_004b:  stloc.3
+                      IL_004c:  ldloc.3
+                      IL_004d:  ldloc.2
+                      IL_004e:  ldlen
+                      IL_004f:  conv.i4
+                      IL_0050:  blt.s      IL_002b
+                      IL_0052:  ldloc.0
+                      IL_0053:  ret
+                    }
+                    """);
+                verifier.VerifyIL("Program.WithComparer<K, V>", """
+                    {
+                      // Code size       24 (0x18)
+                      .maxstack  4
+                      IL_0000:  ldarg.0
+                      IL_0001:  newobj     "MyDictionary<K, V>..ctor(System.Collections.Generic.IEqualityComparer<K>)"
+                      IL_0006:  dup
+                      IL_0007:  ldarg.1
+                      IL_0008:  ldarg.2
+                      IL_0009:  callvirt   "void MyDictionary<K, V>.this[K].set"
+                      IL_000e:  dup
+                      IL_000f:  ldarg.3
+                      IL_0010:  ldarg.s    V_4
+                      IL_0012:  callvirt   "void MyDictionary<K, V>.this[K].set"
+                      IL_0017:  ret
+                    }
+                    """);
+            }
+            else
+            {
+                verifier.VerifyIL("Program.Empty<K, V>", """
+                    {
+                      // Code size       10 (0xa)
+                      .maxstack  1
+                      .locals init (MyDictionary<K, V> V_0)
+                      IL_0000:  ldloca.s   V_0
+                      IL_0002:  initobj    "MyDictionary<K, V>"
+                      IL_0008:  ldloc.0
+                      IL_0009:  ret
+                    }
+                    """);
+                verifier.VerifyIL("Program.Many<K, V>", """
+                    {
+                      // Code size       88 (0x58)
+                      .maxstack  3
+                      .locals init (MyDictionary<K, V> V_0,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_1,
+                                    System.Collections.Generic.KeyValuePair<K, V>[] V_2,
+                                    int V_3,
+                                    System.Collections.Generic.KeyValuePair<K, V> V_4)
+                      IL_0000:  ldloca.s   V_0
+                      IL_0002:  ldnull
+                      IL_0003:  call       "MyDictionary<K, V>..ctor(System.Collections.Generic.IEqualityComparer<K>)"
+                      IL_0008:  ldloca.s   V_0
+                      IL_000a:  ldarg.0
+                      IL_000b:  ldarg.1
+                      IL_000c:  call       "void MyDictionary<K, V>.this[K].set"
+                      IL_0011:  ldarg.2
+                      IL_0012:  stloc.1
+                      IL_0013:  ldloca.s   V_0
+                      IL_0015:  ldloca.s   V_1
+                      IL_0017:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                      IL_001c:  ldloca.s   V_1
+                      IL_001e:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                      IL_0023:  call       "void MyDictionary<K, V>.this[K].set"
+                      IL_0028:  ldarg.3
+                      IL_0029:  stloc.2
+                      IL_002a:  ldc.i4.0
+                      IL_002b:  stloc.3
+                      IL_002c:  br.s       IL_0050
+                      IL_002e:  ldloc.2
+                      IL_002f:  ldloc.3
+                      IL_0030:  ldelem     "System.Collections.Generic.KeyValuePair<K, V>"
+                      IL_0035:  stloc.s    V_4
+                      IL_0037:  ldloca.s   V_0
+                      IL_0039:  ldloca.s   V_4
+                      IL_003b:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                      IL_0040:  ldloca.s   V_4
+                      IL_0042:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                      IL_0047:  call       "void MyDictionary<K, V>.this[K].set"
+                      IL_004c:  ldloc.3
+                      IL_004d:  ldc.i4.1
+                      IL_004e:  add
+                      IL_004f:  stloc.3
+                      IL_0050:  ldloc.3
+                      IL_0051:  ldloc.2
+                      IL_0052:  ldlen
+                      IL_0053:  conv.i4
+                      IL_0054:  blt.s      IL_002e
+                      IL_0056:  ldloc.0
+                      IL_0057:  ret
+                    }
+                    """);
+                verifier.VerifyIL("Program.WithComparer<K, V>", """
+                    {
+                      // Code size       29 (0x1d)
+                      .maxstack  3
+                      .locals init (MyDictionary<K, V> V_0)
+                      IL_0000:  ldloca.s   V_0
+                      IL_0002:  ldarg.0
+                      IL_0003:  call       "MyDictionary<K, V>..ctor(System.Collections.Generic.IEqualityComparer<K>)"
+                      IL_0008:  ldloca.s   V_0
+                      IL_000a:  ldarg.1
+                      IL_000b:  ldarg.2
+                      IL_000c:  call       "void MyDictionary<K, V>.this[K].set"
+                      IL_0011:  ldloca.s   V_0
+                      IL_0013:  ldarg.3
+                      IL_0014:  ldarg.s    V_4
+                      IL_0016:  call       "void MyDictionary<K, V>.this[K].set"
+                      IL_001b:  ldloc.0
+                      IL_001c:  ret
+                    }
+                    """);
+            }
+
+            comp = (CSharpCompilation)verifier.Compilation;
+            VerifyOperationTreeForTest<CollectionExpressionSyntax>(comp,
+                """
+                ICollectionExpressionOperation (3 elements, ConstructMethod: MyDictionary<K, V>..ctor([System.Collections.Generic.IEqualityComparer<K> comparer = null])) (OperationKind.CollectionExpression, Type: MyDictionary<K, V>) (Syntax: '[with(null) ... :v, e, ..s]')
+                  Elements(3):
+                      IOperation:  (OperationKind.None, Type: null) (Syntax: 'k:v')
+                      IParameterReferenceOperation: e (OperationKind.ParameterReference, Type: System.Collections.Generic.KeyValuePair<K, V>) (Syntax: 'e')
+                      ISpreadOperation (ElementType: System.Collections.Generic.KeyValuePair<K, V>) (OperationKind.Spread, Type: null) (Syntax: '..s')
+                        Operand:
+                          IParameterReferenceOperation: s (OperationKind.ParameterReference, Type: System.Collections.Generic.KeyValuePair<K, V>[]) (Syntax: 's')
+                        ElementConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                          (Identity)
+                """);
+        }
+
+        [Fact]
+        public void CustomDictionary_NoParameterlessConstructor()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    private MyDictionary() { }
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public V this[K key] { get { return default; } set { } }
+                }
+                class Program
+                {
+                    static MyDictionary<K, V> OnePair<K, V>() => [default:default];
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (12,50): error CS0122: 'MyDictionary<K, V>.MyDictionary()' is inaccessible due to its protection level
+                //     static MyDictionary<K, V> OnePair<K, V>() => [default:default];
+                Diagnostic(ErrorCode.ERR_BadAccess, "[default:default]").WithArguments("MyDictionary<K, V>.MyDictionary()").WithLocation(12, 50),
+                // (12,51): error CS8716: There is no target type for the default literal.
+                //     static MyDictionary<K, V> OnePair<K, V>() => [default:default];
+                Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(12, 51),
+                // (12,59): error CS8716: There is no target type for the default literal.
+                //     static MyDictionary<K, V> OnePair<K, V>() => [default:default];
+                Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(12, 59));
+        }
+
+        [Fact]
+        public void CustomDictionary_Params_LessAccessibleConstructor()
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                public class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    internal MyDictionary() { }
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public V this[K key] { get { return default; } set { } }
+                }
+                """;
+            string sourceB = """
+                public class Program
+                {
+                    public static void Main()
+                    {
+                        var f1 = (params MyDictionary<string, int> args) => { };
+                        static void f2<K, V>(params MyDictionary<K, V> args) { }
+                        f1();
+                        f2<string, int>();
+                    }
+                    public static void F3<K, V>(params MyDictionary<K, V> args) { }
+                    internal static void F4<K, V>(params MyDictionary<K, V> args) { }
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB]);
+            comp.VerifyEmitDiagnostics(
+                // (10,33): error CS9224: Method 'MyDictionary<K, V>.MyDictionary()' cannot be less visible than the member with params collection 'Program.F3<K, V>(params MyDictionary<K, V>)'.
+                //     public static void F3<K, V>(params MyDictionary<K, V> args) { }
+                Diagnostic(ErrorCode.ERR_ParamsMemberCannotBeLessVisibleThanDeclaringMember, "params MyDictionary<K, V> args").WithArguments("MyDictionary<K, V>.MyDictionary()", "Program.F3<K, V>(params MyDictionary<K, V>)").WithLocation(10, 33));
+        }
+
+        [Fact]
+        public void CustomDictionary_Params_ProtectedConstructor()
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                internal class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    protected MyDictionary() { }
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public V this[K key] { get { return default; } set { } }
+                }
+                """;
+            string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        var f1 = (params MyDictionary<string, int> args) => { };
+                        static void f2<K, V>(params MyDictionary<K, V> args) { }
+                        f1();
+                        f2<string, int>();
+                    }
+                    static void F3<K, V>(params MyDictionary<K, V> args) { }
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB]);
+            comp.VerifyEmitDiagnostics(
+                // (5,19): error CS0122: 'MyDictionary<string, int>.MyDictionary()' is inaccessible due to its protection level
+                //         var f1 = (params MyDictionary<string, int> args) => { };
+                Diagnostic(ErrorCode.ERR_BadAccess, "params MyDictionary<string, int> args").WithArguments("MyDictionary<string, int>.MyDictionary()").WithLocation(5, 19),
+                // (6,30): error CS0122: 'MyDictionary<K, V>.MyDictionary()' is inaccessible due to its protection level
+                //         static void f2<K, V>(params MyDictionary<K, V> args) { }
+                Diagnostic(ErrorCode.ERR_BadAccess, "params MyDictionary<K, V> args").WithArguments("MyDictionary<K, V>.MyDictionary()").WithLocation(6, 30),
+                // (7,9): error CS7036: There is no argument given that corresponds to the required parameter 'obj' of 'Action<MyDictionary<string, int>>'
+                //         f1();
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "f1").WithArguments("obj", "System.Action<MyDictionary<string, int>>").WithLocation(7, 9),
+                // (8,9): error CS7036: There is no argument given that corresponds to the required parameter 'args' of 'f2<K, V>(params MyDictionary<K, V>)'
+                //         f2<string, int>();
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "f2<string, int>").WithArguments("args", "f2<K, V>(params MyDictionary<K, V>)").WithLocation(8, 9),
+                // (10,26): error CS0122: 'MyDictionary<K, V>.MyDictionary()' is inaccessible due to its protection level
+                //     static void F3<K, V>(params MyDictionary<K, V> args) { }
+                Diagnostic(ErrorCode.ERR_BadAccess, "params MyDictionary<K, V> args").WithArguments("MyDictionary<K, V>.MyDictionary()").WithLocation(10, 26));
+        }
+
+        [Fact]
+        public void Params_Cycle_IncorrectSignature()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                public class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    public MyDictionary(params MyDictionary<K, V> args) { }
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public V this[K key, params MyDictionary<K, V> args] { get { return default; } set { } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(1, "one");
+                        F<int, string>();
+                        F(x);
+                        F<int, string>(x);
+                        F([x]);
+                        F<int, string>([2:"two"]);
+                    }
+                    static void F<K, V>(params MyDictionary<K, V> args) { }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (5,25): error CS0117: 'MyDictionary<K, V>' does not contain a definition for 'Add'
+                //     public MyDictionary(params MyDictionary<K, V> args) { }
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "params MyDictionary<K, V> args").WithArguments("MyDictionary<K, V>", "Add").WithLocation(5, 25),
+                // (8,26): error CS0117: 'MyDictionary<K, V>' does not contain a definition for 'Add'
+                //     public V this[K key, params MyDictionary<K, V> args] { get { return default; } set { } }
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "params MyDictionary<K, V> args").WithArguments("MyDictionary<K, V>", "Add").WithLocation(8, 26),
+                // (15,9): error CS7036: There is no argument given that corresponds to the required parameter 'args' of 'Program.F<K, V>(params MyDictionary<K, V>)'
+                //         F<int, string>();
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "F<int, string>").WithArguments("args", "Program.F<K, V>(params MyDictionary<K, V>)").WithLocation(15, 9),
+                // (16,9): error CS0411: The type arguments for method 'Program.F<K, V>(params MyDictionary<K, V>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         F(x);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "F").WithArguments("Program.F<K, V>(params MyDictionary<K, V>)").WithLocation(16, 9),
+                // (17,24): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.KeyValuePair<int, string>' to 'params MyDictionary<int, string>'
+                //         F<int, string>(x);
+                Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("1", "System.Collections.Generic.KeyValuePair<int, string>", "params MyDictionary<int, string>").WithLocation(17, 24),
+                // (18,11): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
+                //         F([x]);
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[x]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(18, 11),
+                // (19,24): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
+                //         F<int, string>([2:"two"]);
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, @"[2:""two""]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(19, 24),
+                // (21,25): error CS0117: 'MyDictionary<K, V>' does not contain a definition for 'Add'
+                //     static void F<K, V>(params MyDictionary<K, V> args) { }
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "params MyDictionary<K, V> args").WithArguments("MyDictionary<K, V>", "Add").WithLocation(21, 25));
+        }
+
+        [Fact]
+        public void Params_Cycle_Overloads()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                public class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    public MyDictionary(params MyDictionary<K, V> args) { }
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public V this[K key] { get { return default; } set { } }
+                    public V this[K key, params MyDictionary<K, V> args] { get { return default; } set { } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(1, "one");
+                        F<int, string>();
+                        F(x);
+                        F<int, string>(x);
+                        F([x]);
+                        F<int, string>([2:"two"]);
+                    }
+                    static void F<K, V>(params MyDictionary<K, V> args) { }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (16,9): error CS9223: Creation of params collection 'MyDictionary<int, string>' results in an infinite chain of invocation of constructor 'MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)'.
+                //         F<int, string>();
+                Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "F<int, string>()").WithArguments("MyDictionary<int, string>", "MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)").WithLocation(16, 9),
+                // (17,9): error CS9223: Creation of params collection 'MyDictionary<int, string>' results in an infinite chain of invocation of constructor 'MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)'.
+                //         F(x);
+                Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "F(x)").WithArguments("MyDictionary<int, string>", "MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)").WithLocation(17, 9),
+                // (18,9): error CS9223: Creation of params collection 'MyDictionary<int, string>' results in an infinite chain of invocation of constructor 'MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)'.
+                //         F<int, string>(x);
+                Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "F<int, string>(x)").WithArguments("MyDictionary<int, string>", "MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)").WithLocation(18, 9),
+                // (19,11): error CS9223: Creation of params collection 'MyDictionary<int, string>' results in an infinite chain of invocation of constructor 'MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)'.
+                //         F([x]);
+                Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "[x]").WithArguments("MyDictionary<int, string>", "MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)").WithLocation(19, 11),
+                // (20,24): error CS9223: Creation of params collection 'MyDictionary<int, string>' results in an infinite chain of invocation of constructor 'MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)'.
+                //         F<int, string>([2:"two"]);
+                Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, @"[2:""two""]").WithArguments("MyDictionary<int, string>", "MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)").WithLocation(20, 24));
+        }
+
+        [Fact]
+        public void Params_Cycle_ConstructorArguments()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                public class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    public MyDictionary() { }
+                    public MyDictionary(object arg, params MyDictionary<K, V> args) { }
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public V this[K key, params MyDictionary<K, V> args] { get { return default; } set { } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(1, "one");
+                        F<int, string>([with(null)]);
+                        F([with(null)], x);
+                        F<int, string>([with(null)], x);
+                        F([with(null)], [x]);
+                    }
+                    static void F<K, V>(MyDictionary<K, V> d, params MyDictionary<K, V> args) { }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (6,37): error CS0117: 'MyDictionary<K, V>' does not contain a definition for 'Add'
+                //     public MyDictionary(object arg, params MyDictionary<K, V> args) { }
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "params MyDictionary<K, V> args").WithArguments("MyDictionary<K, V>", "Add").WithLocation(6, 37),
+                // (9,26): error CS0117: 'MyDictionary<K, V>' does not contain a definition for 'Add'
+                //     public V this[K key, params MyDictionary<K, V> args] { get { return default; } set { } }
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "params MyDictionary<K, V> args").WithArguments("MyDictionary<K, V>", "Add").WithLocation(9, 26),
+                // (16,9): error CS7036: There is no argument given that corresponds to the required parameter 'args' of 'Program.F<K, V>(MyDictionary<K, V>, params MyDictionary<K, V>)'
+                //         F<int, string>([with(null)]);
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "F<int, string>").WithArguments("args", "Program.F<K, V>(MyDictionary<K, V>, params MyDictionary<K, V>)").WithLocation(16, 9),
+                // (17,9): error CS0411: The type arguments for method 'Program.F<K, V>(MyDictionary<K, V>, params MyDictionary<K, V>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         F([with(null)], x);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "F").WithArguments("Program.F<K, V>(MyDictionary<K, V>, params MyDictionary<K, V>)").WithLocation(17, 9),
+                // (18,24): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
+                //         F<int, string>([with(null)], x);
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[with(null)]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(18, 24),
+                // (18,38): error CS1503: Argument 2: cannot convert from 'System.Collections.Generic.KeyValuePair<int, string>' to 'params MyDictionary<int, string>'
+                //         F<int, string>([with(null)], x);
+                Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("2", "System.Collections.Generic.KeyValuePair<int, string>", "params MyDictionary<int, string>").WithLocation(18, 38),
+                // (19,11): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
+                //         F([with(null)], [x]);
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[with(null)]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(19, 11),
+                // (19,25): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
+                //         F([with(null)], [x]);
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[x]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(19, 25),
+                // (21,47): error CS0117: 'MyDictionary<K, V>' does not contain a definition for 'Add'
+                //     static void F<K, V>(MyDictionary<K, V> d, params MyDictionary<K, V> args) { }
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "params MyDictionary<K, V> args").WithArguments("MyDictionary<K, V>", "Add").WithLocation(21, 47));
+        }
+
+        [Theory]
+        [MemberData(nameof(LanguageVersions))]
+        public void Params_Cycle_AddAndIndexer(LanguageVersion languageVersion)
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                public class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    public MyDictionary(params MyDictionary<K, V> args) { }
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public V this[K key, params MyDictionary<K, V> args] { get { return default; } set { } }
+                    public void Add(KeyValuePair<K, V> kvp) { }
+                }
+                public static class Helpers
+                {
+                    public static void F<K, V>(params MyDictionary<K, V> args) { }
+                }
+                """;
+            var comp = CreateCompilation(sourceA, parseOptions: TestOptions.Regular13);
+            var refA = comp.EmitToImageReference();
+
+            string sourceB = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(1, "one");
+                        Helpers.F<int, string>();
+                        Helpers.F(x);
+                        Helpers.F([x]);
+                    }
+                }
+                """;
+            comp = CreateCompilation(sourceB, references: new[] { refA }, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            comp.VerifyEmitDiagnostics(
+                // (7,9): error CS9223: Creation of params collection 'MyDictionary<int, string>' results in an infinite chain of invocation of constructor 'MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)'.
+                //         Helpers.F<int, string>();
+                Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "Helpers.F<int, string>()").WithArguments("MyDictionary<int, string>", "MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)").WithLocation(7, 9),
+                // (8,9): error CS9223: Creation of params collection 'MyDictionary<int, string>' results in an infinite chain of invocation of constructor 'MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)'.
+                //         Helpers.F(x);
+                Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "Helpers.F(x)").WithArguments("MyDictionary<int, string>", "MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)").WithLocation(8, 9),
+                // (9,19): error CS9223: Creation of params collection 'MyDictionary<int, string>' results in an infinite chain of invocation of constructor 'MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)'.
+                //         Helpers.F([x]);
+                Diagnostic(ErrorCode.ERR_ParamsCollectionInfiniteChainOfConstructorCalls, "[x]").WithArguments("MyDictionary<int, string>", "MyDictionary<K, V>.MyDictionary(params MyDictionary<K, V>)").WithLocation(9, 19));
+        }
+
+        [Theory]
+        [InlineData("public V this[K key] { get { return default; } set { } }", true)]
+        [InlineData("public K this[K key] { get { return default; } set { } }", false)]
+        [InlineData("public V this[V key] { get { return default; } set { } }", false)]
+        [InlineData("public V this[K x, K y = default] { get { return default; } set { } }", false)]
+        [InlineData("public V this[K key] { get { return default; } }", false)]
+        [InlineData("public V this[K key] { set { } }", false)]
+        [InlineData("public V this[K key, object arg = null] { get { return default; } set { } }", false)]
+        [InlineData("public V this[K key, params object[] args] { get { return default; } set { } }", false)]
+        [InlineData("public V this[params K[] key] { get { return default; } set { } }", false)]
+        public void IndexerSignature_01(string indexer, bool supported)
+        {
+            string sourceA = $$"""
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    {{indexer}}
+                }
+                """;
+            string sourceB = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static MyDictionary<K, V> Empty<K, V>() => [];
+                    static MyDictionary<K, V> FromPair<K, V>(K k, V v) => [k:v];
+                    static MyDictionary<K, V> FromExpression<K, V>(KeyValuePair<K, V> e) => [e];
+                    static MyDictionary<K, V> FromSpread<K, V>(IEnumerable<KeyValuePair<K, V>> s) => [..s];
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB]);
+            if (supported)
+            {
+                comp.VerifyEmitDiagnostics();
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (5,59): error CS1061: 'MyDictionary<K, V>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<K, V>' could be found (are you missing a using directive or an assembly reference?)
+                    //     static MyDictionary<K, V> FromPair<K, V>(K k, V v) => [k:v];
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[k:v]").WithArguments("MyDictionary<K, V>", "Add").WithLocation(5, 59),
+                    // (6,77): error CS1061: 'MyDictionary<K, V>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<K, V>' could be found (are you missing a using directive or an assembly reference?)
+                    //     static MyDictionary<K, V> FromExpression<K, V>(KeyValuePair<K, V> e) => [e];
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[e]").WithArguments("MyDictionary<K, V>", "Add").WithLocation(6, 77),
+                    // (7,86): error CS1061: 'MyDictionary<K, V>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<K, V>' could be found (are you missing a using directive or an assembly reference?)
+                    //     static MyDictionary<K, V> FromSpread<K, V>(IEnumerable<KeyValuePair<K, V>> s) => [..s];
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[..s]").WithArguments("MyDictionary<K, V>", "Add").WithLocation(7, 86)); ;
+            }
+        }
+
+        [Fact]
+        public void IndexerSignature_02()
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<Ke, Ve, Ki, Vi> : IEnumerable<KeyValuePair<Ke, Ve>>
+                {
+                    public IEnumerator<KeyValuePair<Ke, Ve>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public Vi this[Ki key] { get { return default; } set { } }
+                }
+                """;
+            string sourceB = """
+                class MyDictionary1<K, V> : MyDictionary<K, V, K, V> { }
+                class MyDictionary2 : MyDictionary<string, object, string, object> { }
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyDictionary1<string, object> d1 = [default:default];
+                        MyDictionary2 d2 = [default:default];
+                        MyDictionary<string, object, string, object> d3 = [default:default];
+                        MyDictionary<string, object, object, string> d4 = [default:default];
+                    }
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB]);
+            comp.VerifyEmitDiagnostics(
+                // (10,59): error CS1061: 'MyDictionary<string, object, object, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<string, object, object, string>' could be found (are you missing a using directive or an assembly reference?)
+                //         MyDictionary<string, object, object, string> d4 = [default:default];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[default:default]").WithArguments("MyDictionary<string, object, object, string>", "Add").WithLocation(10, 59));
+        }
+
+        [Fact]
+        public void IndexerSignature_03()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary1 : IEnumerable<KeyValuePair<object, object>>
+                {
+                    public IEnumerator<KeyValuePair<object, object>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public dynamic this[dynamic key] { get { return default; } set { } }
+                }
+                class MyDictionary2 : IEnumerable<KeyValuePair<(int X, int Y), (object, object)>>
+                {
+                    public IEnumerator<KeyValuePair<(int X, int Y), (object, object)>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public (object A, object B) this[(int, int) key] { get { return default; } set { } }
+                }
+                class MyDictionary3 : IEnumerable<KeyValuePair<System.IntPtr, nuint>>
+                {
+                    public IEnumerator<KeyValuePair<System.IntPtr, nuint>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public System.UIntPtr this[nint key] { get { return default; } set { } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyDictionary1 d1 = [default:default];
+                        MyDictionary2 d2 = [default:default];
+                        MyDictionary3 d3 = [default:default];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics();
+        }
+
+        [Fact]
+        public void IndexerSignature_04()
+        {
+            string source = """
+                #nullable enable
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary1 : IEnumerable<KeyValuePair<string?, object>>
+                {
+                    public IEnumerator<KeyValuePair<string?, object>> GetEnumerator() => null!;
+                    IEnumerator IEnumerable.GetEnumerator() => null!;
+                    public object? this[string key] { get { return default!; } set { } }
+                }
+                class MyDictionary2 : IEnumerable<KeyValuePair<string, object?>>
+                {
+                    public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() => null!;
+                    IEnumerator IEnumerable.GetEnumerator() => null!;
+                    public object this[string? key] { get { return default!; } set { } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyDictionary1 d1 = [default:default];
+                        MyDictionary2 d2 = [default:default];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics();
+        }
+
+        [Fact]
+        public void IndexerSignature_MultipleIndexers()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    private Dictionary<K, V> _d = new();
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => _d.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    public int this[string key]
+                    {
+                        get { return (int)(object)_d[(K)(object)key]; }
+                        set { Console.WriteLine("string:{0}, int:{1}", key, value); _d[(K)(object)key] = (V)(object)value; }
+                    }
+                    public object this[object key]
+                    {
+                        get { return _d[(K)key]; }
+                        set { Console.WriteLine("object:{0}, object:{1}", key, value); _d[(K)key] = (V)value; }
+                    }
+                }
+                """;
+
+            string sourceB1 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyDictionary<string, object> d;
+                        d = ["one":1];
+                        d = ["two":(object)2];
+                        d = [(object)"three":(object)3];
+                    }
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB1]);
+            comp.VerifyEmitDiagnostics(
+                // (6,13): error CS1061: 'MyDictionary<string, object>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<string, object>' could be found (are you missing a using directive or an assembly reference?)
+                //         d = ["one":1];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, @"[""one"":1]").WithArguments("MyDictionary<string, object>", "Add").WithLocation(6, 13),
+                // (7,13): error CS1061: 'MyDictionary<string, object>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<string, object>' could be found (are you missing a using directive or an assembly reference?)
+                //         d = ["two":(object)2];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, @"[""two"":(object)2]").WithArguments("MyDictionary<string, object>", "Add").WithLocation(7, 13),
+                // (8,13): error CS1061: 'MyDictionary<string, object>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<string, object>' could be found (are you missing a using directive or an assembly reference?)
+                //         d = [(object)"three":(object)3];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, @"[(object)""three"":(object)3]").WithArguments("MyDictionary<string, object>", "Add").WithLocation(8, 13),
+                // (8,14): error CS0029: Cannot implicitly convert type 'object' to 'string'
+                //         d = [(object)"three":(object)3];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, @"(object)""three""").WithArguments("object", "string").WithLocation(8, 14));
+
+            string sourceB2 = """
+                class MyDictionary1 : MyDictionary<string, int> { }
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyDictionary1 d1 = ["one":1];
+                        d1.Report();
+                        MyDictionary<string, int> d2 = ["two":2];
+                        d2.Report();
+                        MyDictionary<object, object> d3 = ["three":3];
+                        d3.Report();
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [sourceA, sourceB2, s_dictionaryExtensions],
+                expectedOutput: """
+                    string:one, int:1
+                    [one:1], string:two, int:2
+                    [two:2], object:three, object:3
+                    [three:3], 
+                    """);
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void IndexerSignature_ExplicitImplementation()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                interface IMyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    V this[K key] { get; set; }
+                }
+                class MyDictionary<K, V> : IMyDictionary<K, V>
+                {
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    V IMyDictionary<K, V>.this[K key] { get { return default; } set { } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyDictionary<int, string> d = [default:default];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (17,39): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
+                //         MyDictionary<int, string> d = [default:default];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[default:default]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(17, 39));
+        }
+
+        [Fact]
+        public void IndexerSignature_Static()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public static V this[K key] { get { return default; } set { } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyDictionary<int, string> d = [default:default];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (7,21): error CS0106: The modifier 'static' is not valid for this item
+                //     public static V this[K key] { get { return default; } set { } }
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "this").WithArguments("static").WithLocation(7, 21));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("in")]
+        [InlineData("ref readonly")]
+        [InlineData("ref")]
+        [InlineData("out")]
+        public void IndexerSignature_RefParameter(string refKind)
+        {
+            string assignIfOut = refKind == "out" ? "key = default;" : "              ";
+            string source = $$"""
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    private Dictionary<K, V> _d = new();
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => _d.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    public V this[{{refKind}} K key] { get { {{assignIfOut}} return _d[key]; } set { {{assignIfOut}} _d[key] = value; } }
+                }
+                class Program
+                {
+                    static MyDictionary<K, V> Empty<K, V>() => [];
+                    static MyDictionary<K, V> FromPair<K, V>(K k, V v) => [k:v];
+                    static MyDictionary<K, V> FromExpression<K, V>(KeyValuePair<K, V> e) => [e];
+                    static MyDictionary<K, V> FromSpread<K, V>(IEnumerable<KeyValuePair<K, V>> s) => [..s];
+                    static void Main()
+                    {
+                        Empty<string, int>().Report();
+                        FromPair(1, "one").Report();
+                        FromExpression(new KeyValuePair<int, string>(2, "two")).Report();
+                        FromSpread(new KeyValuePair<int, string>[] { new(3, "three") }).Report();
+                    }
+                }
+                """;
+            var comp = CreateCompilation([source, s_dictionaryExtensions], options: TestOptions.ReleaseExe);
+            switch (refKind)
+            {
+                case "":
+                case "in":
+                    var verifier = CompileAndVerify(comp,
+                        expectedOutput: "[], [1:one], [2:two], [3:three], ");
+                    verifier.VerifyDiagnostics();
+                    break;
+                case "ref readonly":
+                    comp.VerifyEmitDiagnostics(
+                        // (13,59): error CS1061: 'MyDictionary<K, V>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<K, V>' could be found (are you missing a using directive or an assembly reference?)
+                        //     static MyDictionary<K, V> FromPair<K, V>(K k, V v) => [k:v];
+                        Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[k:v]").WithArguments("MyDictionary<K, V>", "Add").WithLocation(13, 59),
+                        // (14,77): error CS1061: 'MyDictionary<K, V>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<K, V>' could be found (are you missing a using directive or an assembly reference?)
+                        //     static MyDictionary<K, V> FromExpression<K, V>(KeyValuePair<K, V> e) => [e];
+                        Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[e]").WithArguments("MyDictionary<K, V>", "Add").WithLocation(14, 77),
+                        // (15,86): error CS1061: 'MyDictionary<K, V>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<K, V>' could be found (are you missing a using directive or an assembly reference?)
+                        //     static MyDictionary<K, V> FromSpread<K, V>(IEnumerable<KeyValuePair<K, V>> s) => [..s];
+                        Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[..s]").WithArguments("MyDictionary<K, V>", "Add").WithLocation(15, 86));
+                    break;
+                case "ref":
+                case "out":
+                    comp.VerifyEmitDiagnostics(
+                        // (8,19): error CS0631: ref and out are not valid in this context
+                        //     public V this[ref K key] { get {                return _d[key]; } set {                _d[key] = value; } }
+                        Diagnostic(ErrorCode.ERR_IllegalRefParam, refKind).WithLocation(8, 19),
+                        // (13,59): error CS1061: 'MyDictionary<K, V>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<K, V>' could be found (are you missing a using directive or an assembly reference?)
+                        //     static MyDictionary<K, V> FromPair<K, V>(K k, V v) => [k:v];
+                        Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[k:v]").WithArguments("MyDictionary<K, V>", "Add").WithLocation(13, 59),
+                        // (14,77): error CS1061: 'MyDictionary<K, V>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<K, V>' could be found (are you missing a using directive or an assembly reference?)
+                        //     static MyDictionary<K, V> FromExpression<K, V>(KeyValuePair<K, V> e) => [e];
+                        Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[e]").WithArguments("MyDictionary<K, V>", "Add").WithLocation(14, 77),
+                        // (15,86): error CS1061: 'MyDictionary<K, V>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<K, V>' could be found (are you missing a using directive or an assembly reference?)
+                        //     static MyDictionary<K, V> FromSpread<K, V>(IEnumerable<KeyValuePair<K, V>> s) => [..s];
+                        Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[..s]").WithArguments("MyDictionary<K, V>", "Add").WithLocation(15, 86));
+                    break;
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(refKind);
+            }
+        }
+
+        [Fact]
+        public void IndexerSignature_RefReturn()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary1<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public ref V this[K key] { get { throw null; } }
+                }
+                class MyDictionary2<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public ref V this[K key] { get { throw null; } set { } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyDictionary1<int, string> d1 = [default];
+                        MyDictionary2<int, string> d2 = [default];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (13,52): error CS8147: Properties which return by reference cannot have set accessors
+                //     public ref V this[K key] { get { throw null; } set { } }
+                Diagnostic(ErrorCode.ERR_RefPropertyCannotHaveSetAccessor, "set").WithLocation(13, 52),
+                // (19,41): error CS1061: 'MyDictionary1<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary1<int, string>' could be found (are you missing a using directive or an assembly reference?)
+                //         MyDictionary1<int, string> d1 = [default];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[default]").WithArguments("MyDictionary1<int, string>", "Add").WithLocation(19, 41),
+                // (20,41): error CS1061: 'MyDictionary2<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary2<int, string>' could be found (are you missing a using directive or an assembly reference?)
+                //         MyDictionary2<int, string> d2 = [default];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[default]").WithArguments("MyDictionary2<int, string>", "Add").WithLocation(20, 41));
+        }
+
+        [Fact]
+        public void IndexerSignature_Overloads_01()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    protected Dictionary<K, V> _d = new();
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => _d.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    public V this[K key, object arg = null] { get { return default; } set { } }
+                    public V this[K key] { get { return _d[key]; } set { _d[key] = value; } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyDictionary<int, string> d = [default];
+                        d.Report();
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_dictionaryExtensions],
+                expectedOutput: "[0:null], ");
+            verifier.VerifyIL("Program.Main", """
+                {
+                  // Code size       39 (0x27)
+                  .maxstack  4
+                  .locals init (System.Collections.Generic.KeyValuePair<int, string> V_0)
+                  IL_0000:  newobj     "MyDictionary<int, string>..ctor()"
+                  IL_0005:  ldloca.s   V_0
+                  IL_0007:  initobj    "System.Collections.Generic.KeyValuePair<int, string>"
+                  IL_000d:  dup
+                  IL_000e:  ldloca.s   V_0
+                  IL_0010:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                  IL_0015:  ldloca.s   V_0
+                  IL_0017:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                  IL_001c:  callvirt   "void MyDictionary<int, string>.this[int].set"
+                  IL_0021:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                  IL_0026:  ret
+                }
+                """);
+        }
+
+        [Fact]
+        public void IndexerSignature_Overloads_02()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    protected Dictionary<K, V> _d = new();
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => _d.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    public V this[K key, object arg = null] { get { return default; } set { } }
+                    public V this[K key, int arg] { get { return default; } set { } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyDictionary<int, string> d = [default];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (15,39): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
+                //         MyDictionary<int, string> d = [default];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[default]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(15, 39));
+        }
+
+        // Use indexer with expected signature, even if a better overload exists.
+        [Fact]
+        public void IndexerSignature_Overloads_BetterOverload()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V, KDerived> : IEnumerable<KeyValuePair<K, V>>
+                    where KDerived : K
+                {
+                    protected List<KeyValuePair<K, V>> _list = new();
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    public V this[KDerived key] { get { throw null; } set { throw null; } }
+                    public V this[K key] { get { throw null; } set { _list.Add(new(key, value)); } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        FromPair<object, string, int>(1, "one").Report();
+                        FromExpression<object, string, int>(new KeyValuePair<int, string>(2, "two")).Report();
+                        FromSpread<object, string, int>(new KeyValuePair<int, string>[] { new(3, "three") }).Report();
+                    }
+                    static MyDictionary<object, int, string> FromDefault() => [default];
+                    static MyDictionary<K, V, KDerived> FromPair<K, V, KDerived>(KDerived k, V v)
+                        where KDerived : K
+                    {
+                        return [k:v];
+                    }
+                    static MyDictionary<K, V, KDerived> FromExpression<K, V, KDerived>(KeyValuePair<KDerived, V> e)
+                        where KDerived : K
+                    {
+                        return [e];
+                    }
+                    static MyDictionary<K, V, KDerived> FromSpread<K, V, KDerived>(KeyValuePair<KDerived, V>[] s)
+                        where KDerived : K
+                    {
+                        return [..s];
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_dictionaryExtensions],
+                expectedOutput: "[1:one], [2:two], [3:three], ");
+            verifier.VerifyIL("Program.FromPair<K, V, KDerived>", """
+                {
+                  // Code size       24 (0x18)
+                  .maxstack  4
+                  IL_0000:  newobj     "MyDictionary<K, V, KDerived>..ctor()"
+                  IL_0005:  dup
+                  IL_0006:  ldarg.0
+                  IL_0007:  box        "KDerived"
+                  IL_000c:  unbox.any  "K"
+                  IL_0011:  ldarg.1
+                  IL_0012:  callvirt   "void MyDictionary<K, V, KDerived>.this[K].set"
+                  IL_0017:  ret
+                }
+                """);
+            verifier.VerifyIL("Program.FromExpression<K, V, KDerived>", """
+                {
+                  // Code size       38 (0x26)
+                  .maxstack  4
+                  .locals init (System.Collections.Generic.KeyValuePair<KDerived, V> V_0)
+                  IL_0000:  newobj     "MyDictionary<K, V, KDerived>..ctor()"
+                  IL_0005:  ldarg.0
+                  IL_0006:  stloc.0
+                  IL_0007:  dup
+                  IL_0008:  ldloca.s   V_0
+                  IL_000a:  call       "KDerived System.Collections.Generic.KeyValuePair<KDerived, V>.Key.get"
+                  IL_000f:  box        "KDerived"
+                  IL_0014:  unbox.any  "K"
+                  IL_0019:  ldloca.s   V_0
+                  IL_001b:  call       "V System.Collections.Generic.KeyValuePair<KDerived, V>.Value.get"
+                  IL_0020:  callvirt   "void MyDictionary<K, V, KDerived>.this[K].set"
+                  IL_0025:  ret
+                }
+                """);
+            verifier.VerifyIL("Program.FromSpread<K, V, KDerived>", """
+                {
+                  // Code size       62 (0x3e)
+                  .maxstack  3
+                  .locals init (MyDictionary<K, V, KDerived> V_0,
+                                System.Collections.Generic.KeyValuePair<KDerived, V>[] V_1,
+                                int V_2,
+                                System.Collections.Generic.KeyValuePair<KDerived, V> V_3)
+                  IL_0000:  newobj     "MyDictionary<K, V, KDerived>..ctor()"
+                  IL_0005:  stloc.0
+                  IL_0006:  ldarg.0
+                  IL_0007:  stloc.1
+                  IL_0008:  ldc.i4.0
+                  IL_0009:  stloc.2
+                  IL_000a:  br.s       IL_0036
+                  IL_000c:  ldloc.1
+                  IL_000d:  ldloc.2
+                  IL_000e:  ldelem     "System.Collections.Generic.KeyValuePair<KDerived, V>"
+                  IL_0013:  stloc.3
+                  IL_0014:  ldloc.0
+                  IL_0015:  ldloca.s   V_3
+                  IL_0017:  call       "KDerived System.Collections.Generic.KeyValuePair<KDerived, V>.Key.get"
+                  IL_001c:  box        "KDerived"
+                  IL_0021:  unbox.any  "K"
+                  IL_0026:  ldloca.s   V_3
+                  IL_0028:  call       "V System.Collections.Generic.KeyValuePair<KDerived, V>.Value.get"
+                  IL_002d:  callvirt   "void MyDictionary<K, V, KDerived>.this[K].set"
+                  IL_0032:  ldloc.2
+                  IL_0033:  ldc.i4.1
+                  IL_0034:  add
+                  IL_0035:  stloc.2
+                  IL_0036:  ldloc.2
+                  IL_0037:  ldloc.1
+                  IL_0038:  ldlen
+                  IL_0039:  conv.i4
+                  IL_003a:  blt.s      IL_000c
+                  IL_003c:  ldloc.0
+                  IL_003d:  ret
+                }
+                """);
+        }
+
+        [Fact]
+        public void IndexerSignature_Overloads_BaseAndDerived_01()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionaryBase<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    protected Dictionary<K, V> _d = new();
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => _d.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    public V this[K key, object arg = null] { get { return default; } set { } }
+                }
+                class MyDictionary<K, V> : MyDictionaryBase<K, V>
+                {
+                    public V this[K key] { get { return _d[key]; } set { _d[key] = value; } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyDictionary<int, string> d = [default];
+                        d.Report();
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_dictionaryExtensions],
+                expectedOutput: "[0:null], ");
+            verifier.VerifyIL("Program.Main", """
+                {
+                  // Code size       39 (0x27)
+                  .maxstack  4
+                  .locals init (System.Collections.Generic.KeyValuePair<int, string> V_0)
+                  IL_0000:  newobj     "MyDictionary<int, string>..ctor()"
+                  IL_0005:  ldloca.s   V_0
+                  IL_0007:  initobj    "System.Collections.Generic.KeyValuePair<int, string>"
+                  IL_000d:  dup
+                  IL_000e:  ldloca.s   V_0
+                  IL_0010:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                  IL_0015:  ldloca.s   V_0
+                  IL_0017:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                  IL_001c:  callvirt   "void MyDictionary<int, string>.this[int].set"
+                  IL_0021:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                  IL_0026:  ret
+                }
+                """);
+        }
+
+        [Fact]
+        public void IndexerSignature_Overloads_BaseAndDerived_02()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionaryBase<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    protected Dictionary<K, V> _d = new();
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => _d.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    public V this[K key] { get { return _d[key]; } set { _d[key] = value; } }
+                }
+                class MyDictionary<K, V> : MyDictionaryBase<K, V>
+                {
+                    public V this[K key, object arg = null] { get { return default; } set { } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyDictionary<int, string> d = [default];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (18,39): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
+                //         MyDictionary<int, string> d = [default];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[default]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(18, 39));
+        }
+
+        [Fact]
+        public void IndexerSignature_Overridden()
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    protected Dictionary<K, V> _d = new();
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => _d.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    public virtual V this[K key] { get { return default; } set { } }
+                }
+                class MyDictionary1<K, V> : MyDictionary<K, V>
+                {
+                    public override V this[K key] { get { return _d[key]; } }
+                }
+                class MyDictionary2<K, V> : MyDictionary<K, V>
+                {
+                    public override V this[K key] { set { _d[key] = value; } }
+                }
+                class MyDictionary3<K, V> : MyDictionary<K, V>
+                {
+                    public override V this[K key] { get { return _d[key]; } set { _d[key] = value; } }
+                }
+                """;
+            string sourceB = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyDictionary1<int, string> d1 = [default];
+                        d1.Report();
+                        MyDictionary2<int, string> d2 = [default];
+                        d2.Report();
+                        MyDictionary3<int, string> d3 = [default];
+                        d3.Report();
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [sourceA, sourceB, s_dictionaryExtensions],
+                expectedOutput: "[], [0:null], [0:null], ");
+            verifier.VerifyIL("Program.Main", """
+                {
+                  // Code size      115 (0x73)
+                  .maxstack  4
+                  .locals init (System.Collections.Generic.KeyValuePair<int, string> V_0)
+                  IL_0000:  newobj     "MyDictionary1<int, string>..ctor()"
+                  IL_0005:  ldloca.s   V_0
+                  IL_0007:  initobj    "System.Collections.Generic.KeyValuePair<int, string>"
+                  IL_000d:  dup
+                  IL_000e:  ldloca.s   V_0
+                  IL_0010:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                  IL_0015:  ldloca.s   V_0
+                  IL_0017:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                  IL_001c:  callvirt   "void MyDictionary<int, string>.this[int].set"
+                  IL_0021:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                  IL_0026:  newobj     "MyDictionary2<int, string>..ctor()"
+                  IL_002b:  ldloca.s   V_0
+                  IL_002d:  initobj    "System.Collections.Generic.KeyValuePair<int, string>"
+                  IL_0033:  dup
+                  IL_0034:  ldloca.s   V_0
+                  IL_0036:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                  IL_003b:  ldloca.s   V_0
+                  IL_003d:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                  IL_0042:  callvirt   "void MyDictionary<int, string>.this[int].set"
+                  IL_0047:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                  IL_004c:  newobj     "MyDictionary3<int, string>..ctor()"
+                  IL_0051:  ldloca.s   V_0
+                  IL_0053:  initobj    "System.Collections.Generic.KeyValuePair<int, string>"
+                  IL_0059:  dup
+                  IL_005a:  ldloca.s   V_0
+                  IL_005c:  call       "int System.Collections.Generic.KeyValuePair<int, string>.Key.get"
+                  IL_0061:  ldloca.s   V_0
+                  IL_0063:  call       "string System.Collections.Generic.KeyValuePair<int, string>.Value.get"
+                  IL_0068:  callvirt   "void MyDictionary<int, string>.this[int].set"
+                  IL_006d:  call       "void DictionaryExtensions.Report<int, string>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, string>>)"
+                  IL_0072:  ret
+                }
+                """);
+        }
+
+        [Fact]
+        public void IndexerSignature_New()
+        {
+            string sourceA = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    protected Dictionary<K, V> _d = new();
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => _d.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                    public V this[K key] { get { return default; } set { } }
+                }
+                """;
+
+            string sourceB1 = """
+                class MyDictionary1<K, V> : MyDictionary<K, V>
+                {
+                    public new V this[K key] { get { return _d[key]; } }
+                }
+                class MyDictionary2<K, V> : MyDictionary<K, V>
+                {
+                    public new V this[K key] { set { _d[key] = value; } }
+                }
+                class Program
+                {
+                    static void F<K, V>()
+                    {
+                        MyDictionary1<K, V> d1 = [default:default];
+                        MyDictionary2<K, V> d2 = [default:default];
+                    }
+                }
+                """;
+            var comp = CreateCompilation([sourceA, sourceB1]);
+            comp.VerifyEmitDiagnostics(
+                // (13,34): error CS1061: 'MyDictionary1<K, V>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary1<K, V>' could be found (are you missing a using directive or an assembly reference?)
+                //         MyDictionary1<K, V> d1 = [default:default];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[default:default]").WithArguments("MyDictionary1<K, V>", "Add").WithLocation(13, 34),
+                // (14,34): error CS1061: 'MyDictionary2<K, V>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary2<K, V>' could be found (are you missing a using directive or an assembly reference?)
+                //         MyDictionary2<K, V> d2 = [default:default];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[default:default]").WithArguments("MyDictionary2<K, V>", "Add").WithLocation(14, 34));
+
+            string sourceB2 = """
+                class MyDictionary3<K, V> : MyDictionary<K, V>
+                {
+                    public new V this[K key] { get { return _d[key]; } set { _d[key] = value; } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        F<int, string>().Report();
+                    }
+                    static MyDictionary3<K, V> F<K, V>()
+                    {
+                        return [default:default];
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [sourceA, sourceB2, s_dictionaryExtensions],
+                expectedOutput: "[0:null], ");
+            verifier.VerifyIL("Program.F<K, V>", """
+                {
+                  // Code size       30 (0x1e)
+                  .maxstack  4
+                  .locals init (K V_0,
+                                V V_1)
+                  IL_0000:  newobj     "MyDictionary3<K, V>..ctor()"
+                  IL_0005:  dup
+                  IL_0006:  ldloca.s   V_0
+                  IL_0008:  initobj    "K"
+                  IL_000e:  ldloc.0
+                  IL_000f:  ldloca.s   V_1
+                  IL_0011:  initobj    "V"
+                  IL_0017:  ldloc.1
+                  IL_0018:  callvirt   "void MyDictionary3<K, V>.this[K].set"
+                  IL_001d:  ret
+                }
+                """);
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void IndexerAccessibility_01(
+            [CombinatorialValues("", "public", "internal")] string typeAccessibility,
+            [CombinatorialValues("", "public", "internal")] string indexerAccessibility)
+        {
+            string sourceA = $$"""
+                using System.Collections;
+                using System.Collections.Generic;
+                {{typeAccessibility}} class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    {{indexerAccessibility}} V this[K key] { get { return default; } set { } }
+                }
+                """;
+            string sourceB = """
+                MyDictionary<string, object> d = [default:default];
+                """;
+            var comp = CreateCompilation([sourceA, sourceB]);
+            if (indexerAccessibility == "public")
+            {
+                comp.VerifyEmitDiagnostics();
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (1,34): error CS1061: 'MyDictionary<string, object>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<string, object>' could be found (are you missing a using directive or an assembly reference?)
+                    // MyDictionary<string, object> d = [default:default];
+                    Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[default:default]").WithArguments("MyDictionary<string, object>", "Add").WithLocation(1, 34));
+            }
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void IndexerAccessibility_02(
+            [CombinatorialValues("private", "protected")] string indexerAccessibility)
+        {
+            string sourceA = $$"""
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    {{indexerAccessibility}} V this[K key] { get { return default; } set { } }
+                }
+                """;
+            string sourceB = """
+                MyDictionary<string, object> d = [default:default];
+                """;
+            var comp = CreateCompilation([sourceA, sourceB]);
+            comp.VerifyEmitDiagnostics(
+                // (1,34): error CS1061: 'MyDictionary<string, object>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<string, object>' could be found (are you missing a using directive or an assembly reference?)
+                // MyDictionary<string, object> d = [default:default];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[default:default]").WithArguments("MyDictionary<string, object>", "Add").WithLocation(1, 34));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void IndexerAccessibility_03(
+            [CombinatorialValues("internal", "private", "protected")] string indexerAccessibility, bool modifyGetter)
+        {
+            string sourceA = $$"""
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+                {
+                    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                    public V this[K key]
+                    {
+                        {{(modifyGetter ? indexerAccessibility : "")}} get { return default; }
+                        {{(modifyGetter ? "" : indexerAccessibility)}} set { }
+                    }
+                }
+                """;
+            string sourceB = """
+                MyDictionary<string, object> d = [default:default];
+                """;
+            var comp = CreateCompilation([sourceA, sourceB]);
+            comp.VerifyEmitDiagnostics(
+                // (1,34): error CS1061: 'MyDictionary<string, object>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<string, object>' could be found (are you missing a using directive or an assembly reference?)
+                // MyDictionary<string, object> d = [default:default];
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[default:default]").WithArguments("MyDictionary<string, object>", "Add").WithLocation(1, 34));
+        }
+
+        [Fact]
+        public void IReadOnlyDictionary_01()
+        {
+            string source = """
+                using System;
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Empty<int, string>();
+                        Pair(1, "one");
+                        Many([new KeyValuePair<int, string>(3, "three")]);
+                        ParamsEmptyOrOne(new KeyValuePair<int, string>(2, "two"));
+                    }
+                    static void Empty<K, V>() { Report<K, V>([]); }
+                    static void Pair<K, V>(K k, V v) { Report<K, V>([k:v]); }
+                    static void Many<K, V>(KeyValuePair<K, V>[] s) { Report([..s]); }
+                    static void Params<K, V>(params IReadOnlyDictionary<K, V> d) { Report(d); }
+                    static void ParamsEmptyOrOne<K, V>(KeyValuePair<K, V> e)
+                    {
+                        Params<K, V>();
+                        Params(e);
+                    }
+                    static void Report<K, V>(IReadOnlyDictionary<K, V> d)
+                    {
+                        Console.Write("{0}: ", d.GetType().GetTypeName());
+                        d.Report();
+                        Console.WriteLine();
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_collectionExtensions, s_dictionaryExtensions],
+                expectedOutput: """
+                    System.Collections.ObjectModel.ReadOnlyDictionary<System.Int32, System.String>: [], 
+                    System.Collections.ObjectModel.ReadOnlyDictionary<System.Int32, System.String>: [1:one], 
+                    System.Collections.ObjectModel.ReadOnlyDictionary<System.Int32, System.String>: [3:three], 
+                    System.Collections.ObjectModel.ReadOnlyDictionary<System.Int32, System.String>: [], 
+                    System.Collections.ObjectModel.ReadOnlyDictionary<System.Int32, System.String>: [2:two],  
+                    """);
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("Program.Empty<K, V>", """
+                {
+                  // Code size       16 (0x10)
+                  .maxstack  1
+                  IL_0000:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor()"
+                  IL_0005:  newobj     "System.Collections.ObjectModel.ReadOnlyDictionary<K, V>..ctor(System.Collections.Generic.IDictionary<K, V>)"
+                  IL_000a:  call       "void Program.Report<K, V>(System.Collections.Generic.IReadOnlyDictionary<K, V>)"
+                  IL_000f:  ret
+                }
+                """);
+            verifier.VerifyIL("Program.Pair<K, V>", """
+                {
+                  // Code size       24 (0x18)
+                  .maxstack  4
+                  IL_0000:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor()"
+                  IL_0005:  dup
+                  IL_0006:  ldarg.0
+                  IL_0007:  ldarg.1
+                  IL_0008:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                  IL_000d:  newobj     "System.Collections.ObjectModel.ReadOnlyDictionary<K, V>..ctor(System.Collections.Generic.IDictionary<K, V>)"
+                  IL_0012:  call       "void Program.Report<K, V>(System.Collections.Generic.IReadOnlyDictionary<K, V>)"
+                  IL_0017:  ret
+                }
+                """);
+            verifier.VerifyIL("Program.Many<K, V>", """
+                {
+                  // Code size       62 (0x3e)
+                  .maxstack  3
+                  .locals init (System.Collections.Generic.Dictionary<K, V> V_0,
+                                System.Collections.Generic.KeyValuePair<K, V>[] V_1,
+                                int V_2,
+                                System.Collections.Generic.KeyValuePair<K, V> V_3)
+                  IL_0000:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor()"
+                  IL_0005:  stloc.0
+                  IL_0006:  ldarg.0
+                  IL_0007:  stloc.1
+                  IL_0008:  ldc.i4.0
+                  IL_0009:  stloc.2
+                  IL_000a:  br.s       IL_002c
+                  IL_000c:  ldloc.1
+                  IL_000d:  ldloc.2
+                  IL_000e:  ldelem     "System.Collections.Generic.KeyValuePair<K, V>"
+                  IL_0013:  stloc.3
+                  IL_0014:  ldloc.0
+                  IL_0015:  ldloca.s   V_3
+                  IL_0017:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                  IL_001c:  ldloca.s   V_3
+                  IL_001e:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                  IL_0023:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                  IL_0028:  ldloc.2
+                  IL_0029:  ldc.i4.1
+                  IL_002a:  add
+                  IL_002b:  stloc.2
+                  IL_002c:  ldloc.2
+                  IL_002d:  ldloc.1
+                  IL_002e:  ldlen
+                  IL_002f:  conv.i4
+                  IL_0030:  blt.s      IL_000c
+                  IL_0032:  ldloc.0
+                  IL_0033:  newobj     "System.Collections.ObjectModel.ReadOnlyDictionary<K, V>..ctor(System.Collections.Generic.IDictionary<K, V>)"
+                  IL_0038:  call       "void Program.Report<K, V>(System.Collections.Generic.IReadOnlyDictionary<K, V>)"
+                  IL_003d:  ret
+                }
+                """);
+            verifier.VerifyIL("Program.ParamsEmptyOrOne<K, V>", """
+                {
+                  // Code size       53 (0x35)
+                  .maxstack  4
+                  .locals init (System.Collections.Generic.KeyValuePair<K, V> V_0)
+                  IL_0000:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor()"
+                  IL_0005:  newobj     "System.Collections.ObjectModel.ReadOnlyDictionary<K, V>..ctor(System.Collections.Generic.IDictionary<K, V>)"
+                  IL_000a:  call       "void Program.Params<K, V>(params System.Collections.Generic.IReadOnlyDictionary<K, V>)"
+                  IL_000f:  newobj     "System.Collections.Generic.Dictionary<K, V>..ctor()"
+                  IL_0014:  ldarg.0
+                  IL_0015:  stloc.0
+                  IL_0016:  dup
+                  IL_0017:  ldloca.s   V_0
+                  IL_0019:  call       "K System.Collections.Generic.KeyValuePair<K, V>.Key.get"
+                  IL_001e:  ldloca.s   V_0
+                  IL_0020:  call       "V System.Collections.Generic.KeyValuePair<K, V>.Value.get"
+                  IL_0025:  callvirt   "void System.Collections.Generic.Dictionary<K, V>.this[K].set"
+                  IL_002a:  newobj     "System.Collections.ObjectModel.ReadOnlyDictionary<K, V>..ctor(System.Collections.Generic.IDictionary<K, V>)"
+                  IL_002f:  call       "void Program.Params<K, V>(params System.Collections.Generic.IReadOnlyDictionary<K, V>)"
+                  IL_0034:  ret
+                }
+                """);
+        }
+
+        [Fact]
+        public void IReadOnlyDictionary_02()
+        {
+            string source = """
+                using System;
+                using static System.Console;
+                using System.Collections;
+                using System.Collections.Generic;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new KeyValuePair<int, string>(2, "two");
+                        var y = new[] { new KeyValuePair<int, string>(3, "three") };
+                        ReportDictionary<int, string>([], 2, "two");
+                        ReportDictionary([1:"one", x, ..y], 2, "two");
+                    }
+                    static void ReportDictionary<K, V>(IReadOnlyDictionary<K, V> x, K k, V v)
+                    {
+                        int length = x.Count;
+                        KeyValuePair<K, V>[] a;
+                        Write("{0}: ", x.GetType().GetTypeName());
+                        ReportCollection(x, new KeyValuePair<K, V>(k, v));
+                        WriteLine("IDictionary.IsFixedSize: {0}", ((IDictionary)x).IsFixedSize);
+                        WriteLine("IDictionary.IsReadOnly: {0}", ((IDictionary)x).IsReadOnly);
+                        WriteLine("IDictionary.this[k]: {0}", Invoke(() => ((IDictionary)x)[k]));
+                        WriteLine("IDictionary.this[k] = v: {0}", Invoke(() => { ((IDictionary)x)[k] = v; }));
+                        ((IDictionary)x).Keys.Report(includeType: true);
+                        ((IDictionary)x).Values.Report(includeType: true);
+                        WriteLine("IDictionary.Add(k, v): {0}", Invoke(() => ((IDictionary)x).Add(k, v)));
+                        WriteLine("IDictionary.Clear(): {0}", Invoke(() => ((IDictionary)x).Clear()));
+                        WriteLine("IDictionary.Contains(k): {0}", Invoke(() => ((IDictionary)x).Contains(k)));
+                        Write("IDictionary.CopyTo(..., 0): ");
+                        a = new KeyValuePair<K, V>[length];
+                        ((IDictionary)x).CopyTo(a, 0);
+                        a.Report(includeType: true);
+                        WriteLine();
+                        WriteLine("IDictionary.Remove(k): {0}", Invoke(() => ((IDictionary)x).Remove(k)));
+                        WriteLine("IDictionary<K, V>.Count: {0}", ((IDictionary<K, V>)x).Count);
+                        WriteLine("IDictionary<K, V>.IsReadOnly: {0}", ((IDictionary<K, V>)x).IsReadOnly);
+                        WriteLine("IDictionary<K, V>.this[k]: {0}", Invoke(() => ((IDictionary<K, V>)x)[k]));
+                        WriteLine("IDictionary<K, V>.this[k] = v: {0}", Invoke(() => { ((IDictionary<K, V>)x)[k] = v; }));
+                        ((IDictionary<K, V>)x).Keys.Report(includeType: true);
+                        ((IDictionary<K, V>)x).Values.Report(includeType: true);
+                        WriteLine("IDictionary<K, V>.Add(k, v): {0}", Invoke(() => ((IDictionary<K, V>)x).Add(k, v)));
+                        WriteLine("IDictionary<K, V>.Clear(): {0}", Invoke(() => ((IDictionary<K, V>)x).Clear()));
+                        WriteLine("IDictionary<K, V>.ContainsKey(k): {0}", Invoke(() => ((IDictionary<K, V>)x).ContainsKey(k)));
+                        Write("IDictionary<K, V>.CopyTo(..., 0): ");
+                        a = new KeyValuePair<K, V>[length];
+                        ((IDictionary<K, V>)x).CopyTo(a, 0);
+                        a.Report(includeType: true);
+                        WriteLine();
+                        WriteLine("IDictionary<K, V>.Remove(k): {0}", Invoke(() => ((IDictionary<K, V>)x).Remove(k)));
+                        WriteLine("IDictionary<K, V>.TryGetValue(k, out v): {0}", Invoke(() => ((IDictionary<K, V>)x).TryGetValue(k, out _)));
+                        WriteLine("IReadOnlyDictionary<K, V>.Count: {0}", ((IReadOnlyDictionary<K, V>)x).Count);
+                        WriteLine("IReadOnlyDictionary<K, V>.this[k]: {0}", Invoke(() => ((IReadOnlyDictionary<K, V>)x)[k]));
+                        ((IReadOnlyDictionary<K, V>)x).Keys.Report(includeType: true);
+                        ((IReadOnlyDictionary<K, V>)x).Values.Report(includeType: true);
+                        WriteLine("IReadOnlyDictionary<K, V>.ContainsKey(k): {0}", Invoke(() => ((IReadOnlyDictionary<K, V>)x).ContainsKey(k)));
+                        WriteLine("IReadOnlyDictionary<K, V>.TryGetValue(k, out v): {0}", Invoke(() => ((IReadOnlyDictionary<K, V>)x).TryGetValue(k, out _)));
+                    }
+                    static void ReportCollection<T>(IReadOnlyCollection<T> x, T value)
+                    {
+                        int length = x.Count;
+                        T[] a;
+                        Write("IEnumerable.GetEnumerator(): ");
+                        ((IEnumerable)x).Report(includeType: true);
+                        WriteLine();
+                        WriteLine("ICollection.Count: {0}", ((ICollection)x).Count);
+                        WriteLine("ICollection.IsSynchronized: {0}", ((ICollection)x).IsSynchronized);
+                        WriteLine("ICollection.SyncRoot == (object)x: {0}", ((ICollection)x).SyncRoot == (object)x);
+                        Write("ICollection.CopyTo(..., 0): ");
+                        a = new T[length];
+                        ((ICollection)x).CopyTo(a, 0);
+                        a.Report(includeType: true);
+                        WriteLine();
+                        Write("IEnumerable<T>.GetEnumerator(): ");
+                        ((IEnumerable<T>)x).Report(includeType: true);
+                        WriteLine();
+                        WriteLine("IReadOnlyCollection<T>.Count: {0}", ((IReadOnlyCollection<T>)x).Count);
+                        WriteLine("ICollection<T>.Count: {0}", ((ICollection<T>)x).Count);
+                        WriteLine("ICollection<T>.IsReadOnly: {0}", ((ICollection<T>)x).IsReadOnly);
+                        WriteLine("ICollection<T>.Add(value): {0}", Invoke(() => ((ICollection<T>)x).Add(value)));
+                        WriteLine("ICollection<T>.Clear(): {0}", Invoke(() => ((ICollection<T>)x).Clear()));
+                        WriteLine("ICollection<T>.Contains(value): {0}", ((ICollection<T>)x).Contains(value));
+                        Write("ICollection<T>.CopyTo(..., 0): ");
+                        a = new T[length];
+                        ((ICollection<T>)x).CopyTo(a, 0);
+                        a.Report(includeType: true);
+                        WriteLine();
+                        WriteLine("ICollection<T>.Remove(value): {0}", Invoke(() => ((ICollection<T>)x).Remove(value)));
+                    }
+                    static string Invoke<T>(Func<T> f)
+                    {
+                        try
+                        {
+                            var value = f();
+                            return value is null ? "null" : value.ToString();
+                        }
+                        catch (Exception e)
+                        {
+                            return e.GetType().FullName;
+                        }
+                    }
+                    static string Invoke(Action a)
+                    {
+                        try
+                        {
+                            a();
+                            return "completed";
+                        }
+                        catch (Exception e)
+                        {
+                            return e.GetType().FullName;
+                        }
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                [source, s_collectionExtensions],
+                expectedOutput: $$"""
+                    System.Collections.ObjectModel.ReadOnlyDictionary<System.Int32, System.String>: IEnumerable.GetEnumerator(): (System.Collections.ObjectModel.ReadOnlyDictionary<System.Int32, System.String>) [], 
+                    ICollection.Count: 0
+                    ICollection.IsSynchronized: False
+                    ICollection.SyncRoot == (object)x: False
+                    ICollection.CopyTo(..., 0): (System.Collections.Generic.KeyValuePair<System.Int32, System.String>[]) [], 
+                    IEnumerable<T>.GetEnumerator(): (System.Collections.ObjectModel.ReadOnlyDictionary<System.Int32, System.String>) [], 
+                    IReadOnlyCollection<T>.Count: 0
+                    ICollection<T>.Count: 0
+                    ICollection<T>.IsReadOnly: True
+                    ICollection<T>.Add(value): System.NotSupportedException
+                    ICollection<T>.Clear(): System.NotSupportedException
+                    ICollection<T>.Contains(value): False
+                    ICollection<T>.CopyTo(..., 0): (System.Collections.Generic.KeyValuePair<System.Int32, System.String>[]) [], 
+                    ICollection<T>.Remove(value): System.NotSupportedException
+                    IDictionary.IsFixedSize: True
+                    IDictionary.IsReadOnly: True
+                    IDictionary.this[k]: {{(ExecutionConditionUtil.IsMonoOrCoreClr ? "null" : "System.Collections.Generic.KeyNotFoundException")}}
+                    IDictionary.this[k] = v: System.NotSupportedException
+                    (System.Collections.ObjectModel.ReadOnlyDictionary<TKey, TValue>.KeyCollection<System.Int32, System.String>) [], (System.Collections.ObjectModel.ReadOnlyDictionary<TKey, TValue>.ValueCollection<System.Int32, System.String>) [], IDictionary.Add(k, v): System.NotSupportedException
+                    IDictionary.Clear(): System.NotSupportedException
+                    IDictionary.Contains(k): False
+                    IDictionary.CopyTo(..., 0): (System.Collections.Generic.KeyValuePair<System.Int32, System.String>[]) [], 
+                    IDictionary.Remove(k): System.NotSupportedException
+                    IDictionary<K, V>.Count: 0
+                    IDictionary<K, V>.IsReadOnly: True
+                    IDictionary<K, V>.this[k]: System.Collections.Generic.KeyNotFoundException
+                    IDictionary<K, V>.this[k] = v: System.NotSupportedException
+                    (System.Collections.ObjectModel.ReadOnlyDictionary<TKey, TValue>.KeyCollection<System.Int32, System.String>) [], (System.Collections.ObjectModel.ReadOnlyDictionary<TKey, TValue>.ValueCollection<System.Int32, System.String>) [], IDictionary<K, V>.Add(k, v): System.NotSupportedException
+                    IDictionary<K, V>.Clear(): System.NotSupportedException
+                    IDictionary<K, V>.ContainsKey(k): False
+                    IDictionary<K, V>.CopyTo(..., 0): (System.Collections.Generic.KeyValuePair<System.Int32, System.String>[]) [], 
+                    IDictionary<K, V>.Remove(k): System.NotSupportedException
+                    IDictionary<K, V>.TryGetValue(k, out v): False
+                    IReadOnlyDictionary<K, V>.Count: 0
+                    IReadOnlyDictionary<K, V>.this[k]: System.Collections.Generic.KeyNotFoundException
+                    (System.Collections.ObjectModel.ReadOnlyDictionary<TKey, TValue>.KeyCollection<System.Int32, System.String>) [], (System.Collections.ObjectModel.ReadOnlyDictionary<TKey, TValue>.ValueCollection<System.Int32, System.String>) [], IReadOnlyDictionary<K, V>.ContainsKey(k): False
+                    IReadOnlyDictionary<K, V>.TryGetValue(k, out v): False
+                    System.Collections.ObjectModel.ReadOnlyDictionary<System.Int32, System.String>: IEnumerable.GetEnumerator(): (System.Collections.ObjectModel.ReadOnlyDictionary<System.Int32, System.String>) [[1, one], [2, two], [3, three]], 
+                    ICollection.Count: 3
+                    ICollection.IsSynchronized: False
+                    ICollection.SyncRoot == (object)x: False
+                    ICollection.CopyTo(..., 0): (System.Collections.Generic.KeyValuePair<System.Int32, System.String>[]) [[1, one], [2, two], [3, three]], 
+                    IEnumerable<T>.GetEnumerator(): (System.Collections.ObjectModel.ReadOnlyDictionary<System.Int32, System.String>) [[1, one], [2, two], [3, three]], 
+                    IReadOnlyCollection<T>.Count: 3
+                    ICollection<T>.Count: 3
+                    ICollection<T>.IsReadOnly: True
+                    ICollection<T>.Add(value): System.NotSupportedException
+                    ICollection<T>.Clear(): System.NotSupportedException
+                    ICollection<T>.Contains(value): True
+                    ICollection<T>.CopyTo(..., 0): (System.Collections.Generic.KeyValuePair<System.Int32, System.String>[]) [[1, one], [2, two], [3, three]], 
+                    ICollection<T>.Remove(value): System.NotSupportedException
+                    IDictionary.IsFixedSize: True
+                    IDictionary.IsReadOnly: True
+                    IDictionary.this[k]: two
+                    IDictionary.this[k] = v: System.NotSupportedException
+                    (System.Collections.ObjectModel.ReadOnlyDictionary<TKey, TValue>.KeyCollection<System.Int32, System.String>) [1, 2, 3], (System.Collections.ObjectModel.ReadOnlyDictionary<TKey, TValue>.ValueCollection<System.Int32, System.String>) [one, two, three], IDictionary.Add(k, v): System.NotSupportedException
+                    IDictionary.Clear(): System.NotSupportedException
+                    IDictionary.Contains(k): True
+                    IDictionary.CopyTo(..., 0): (System.Collections.Generic.KeyValuePair<System.Int32, System.String>[]) [[1, one], [2, two], [3, three]], 
+                    IDictionary.Remove(k): System.NotSupportedException
+                    IDictionary<K, V>.Count: 3
+                    IDictionary<K, V>.IsReadOnly: True
+                    IDictionary<K, V>.this[k]: two
+                    IDictionary<K, V>.this[k] = v: System.NotSupportedException
+                    (System.Collections.ObjectModel.ReadOnlyDictionary<TKey, TValue>.KeyCollection<System.Int32, System.String>) [1, 2, 3], (System.Collections.ObjectModel.ReadOnlyDictionary<TKey, TValue>.ValueCollection<System.Int32, System.String>) [one, two, three], IDictionary<K, V>.Add(k, v): System.NotSupportedException
+                    IDictionary<K, V>.Clear(): System.NotSupportedException
+                    IDictionary<K, V>.ContainsKey(k): True
+                    IDictionary<K, V>.CopyTo(..., 0): (System.Collections.Generic.KeyValuePair<System.Int32, System.String>[]) [[1, one], [2, two], [3, three]], 
+                    IDictionary<K, V>.Remove(k): System.NotSupportedException
+                    IDictionary<K, V>.TryGetValue(k, out v): True
+                    IReadOnlyDictionary<K, V>.Count: 3
+                    IReadOnlyDictionary<K, V>.this[k]: two
+                    (System.Collections.ObjectModel.ReadOnlyDictionary<TKey, TValue>.KeyCollection<System.Int32, System.String>) [1, 2, 3], (System.Collections.ObjectModel.ReadOnlyDictionary<TKey, TValue>.ValueCollection<System.Int32, System.String>) [one, two, three], IReadOnlyDictionary<K, V>.ContainsKey(k): True
+                    IReadOnlyDictionary<K, V>.TryGetValue(k, out v): True
+                    """);
+            verifier.VerifyDiagnostics();
+        }
+
+        [Theory]
+        [InlineData("Dictionary")]
+        [InlineData("IDictionary")]
+        [InlineData("IReadOnlyDictionary")]
+        public void IReadOnlyDictionary_MissingMembers(string typeName)
+        {
+            string source = $$"""
+                using System.Collections.Generic;
+                {{typeName}}<int, string> d;
+                var x = new KeyValuePair<int, string>(2, "two");
+                var y = new[] { new KeyValuePair<int, string>(3, "three") };
+                d = [];
+                d = [1:"one"];
+                d = [x, ..y];
+                """;
+
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics();
+
+            comp = CreateCompilation(source);
+            comp.MakeTypeMissing(WellKnownType.System_Collections_ObjectModel_ReadOnlyDictionary_KV);
+            if (typeName == "IReadOnlyDictionary")
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (5,5): error CS0656: Missing compiler required member 'System.Collections.ObjectModel.ReadOnlyDictionary`2..ctor'
+                    // d = [];
+                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.ObjectModel.ReadOnlyDictionary`2", ".ctor").WithLocation(5, 5),
+                    // (6,5): error CS0656: Missing compiler required member 'System.Collections.ObjectModel.ReadOnlyDictionary`2..ctor'
+                    // d = [1:"one"];
+                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[1:""one""]").WithArguments("System.Collections.ObjectModel.ReadOnlyDictionary`2", ".ctor").WithLocation(6, 5),
+                    // (7,5): error CS0656: Missing compiler required member 'System.Collections.ObjectModel.ReadOnlyDictionary`2..ctor'
+                    // d = [x, ..y];
+                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[x, ..y]").WithArguments("System.Collections.ObjectModel.ReadOnlyDictionary`2", ".ctor").WithLocation(7, 5));
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics();
+            }
+
+            comp = CreateCompilation(source);
+            comp.MakeMemberMissing(WellKnownMember.System_Collections_ObjectModel_ReadOnlyDictionary_KV__ctor);
+            if (typeName == "IReadOnlyDictionary")
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (5,5): error CS0656: Missing compiler required member 'System.Collections.ObjectModel.ReadOnlyDictionary`2..ctor'
+                    // d = [];
+                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.ObjectModel.ReadOnlyDictionary`2", ".ctor").WithLocation(5, 5),
+                    // (6,5): error CS0656: Missing compiler required member 'System.Collections.ObjectModel.ReadOnlyDictionary`2..ctor'
+                    // d = [1:"one"];
+                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"[1:""one""]").WithArguments("System.Collections.ObjectModel.ReadOnlyDictionary`2", ".ctor").WithLocation(6, 5),
+                    // (7,5): error CS0656: Missing compiler required member 'System.Collections.ObjectModel.ReadOnlyDictionary`2..ctor'
+                    // d = [x, ..y];
+                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[x, ..y]").WithArguments("System.Collections.ObjectModel.ReadOnlyDictionary`2", ".ctor").WithLocation(7, 5));
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics();
+            }
+        }
+
+        [Fact]
+        public void Lock()
+        {
+            string source = """
+                using System.Collections.Generic;
+                using System.Threading;
+                class Program
+                {
+                    static void Main()
+                    {
+                        var x = new Lock();
+                        var y = new Lock();
+                        object[] a = [x];
+                        IDictionary<object, object> d = [x:y];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net90);
+            comp.VerifyEmitDiagnostics(
+                // (9,23): warning CS9216: A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in 'lock' statement.
+                //         object[] a = [x];
+                Diagnostic(ErrorCode.WRN_ConvertingLock, "x").WithLocation(9, 23),
+                // (10,42): warning CS9216: A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in 'lock' statement.
+                //         IDictionary<object, object> d = [x:y];
+                Diagnostic(ErrorCode.WRN_ConvertingLock, "x").WithLocation(10, 42),
+                // (10,44): warning CS9216: A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in 'lock' statement.
+                //         IDictionary<object, object> d = [x:y];
+                Diagnostic(ErrorCode.WRN_ConvertingLock, "y").WithLocation(10, 44));
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/CSharp15/DictionaryExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/DictionaryExpressionTests.cs
@@ -1693,9 +1693,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 // (18,16): error CS8352: Cannot use variable 'd' in this context because it may expose referenced variables outside of their declaration scope
                 //         return d;
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "d").WithArguments("d").WithLocation(18, 16),
-                // (22,16): error CS9203: A collection expression of type 'MyDictionary<K, V>' cannot be used in this context because it may be exposed outside of the current scope.
-                //         return [k:v];
-                Diagnostic(ErrorCode.ERR_CollectionExpressionEscape, "[k:v]").WithArguments("MyDictionary<K, V>").WithLocation(22, 16),
                 // (27,16): error CS8352: Cannot use variable 'd' in this context because it may expose referenced variables outside of their declaration scope
                 //         return d;
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "d").WithArguments("d").WithLocation(27, 16));

--- a/src/Compilers/CSharp/Test/CSharp15/DictionaryExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/DictionaryExpressionTests.cs
@@ -5767,15 +5767,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 // (17,9): error CS0411: The type arguments for method 'Program.F<K, V>(MyDictionary<K, V>, params MyDictionary<K, V>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         F([with(null)], x);
                 Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "F").WithArguments("Program.F<K, V>(MyDictionary<K, V>, params MyDictionary<K, V>)").WithLocation(17, 9),
-                // (18,24): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
-                //         F<int, string>([with(null)], x);
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[with(null)]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(18, 24),
                 // (18,38): error CS1503: Argument 2: cannot convert from 'System.Collections.Generic.KeyValuePair<int, string>' to 'params MyDictionary<int, string>'
                 //         F<int, string>([with(null)], x);
                 Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("2", "System.Collections.Generic.KeyValuePair<int, string>", "params MyDictionary<int, string>").WithLocation(18, 38),
-                // (19,11): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
-                //         F([with(null)], [x]);
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[with(null)]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(19, 11),
                 // (19,25): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
                 //         F([with(null)], [x]);
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "[x]").WithArguments("MyDictionary<int, string>", "Add").WithLocation(19, 25),

--- a/src/Compilers/CSharp/Test/CSharp15/DictionaryExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/DictionaryExpressionTests.cs
@@ -5540,13 +5540,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             comp.VerifyEmitDiagnostics(
                 // (12,50): error CS0122: 'MyDictionary<K, V>.MyDictionary()' is inaccessible due to its protection level
                 //     static MyDictionary<K, V> OnePair<K, V>() => [default:default];
-                Diagnostic(ErrorCode.ERR_BadAccess, "[default:default]").WithArguments("MyDictionary<K, V>.MyDictionary()").WithLocation(12, 50),
-                // (12,51): error CS8716: There is no target type for the default literal.
-                //     static MyDictionary<K, V> OnePair<K, V>() => [default:default];
-                Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(12, 51),
-                // (12,59): error CS8716: There is no target type for the default literal.
-                //     static MyDictionary<K, V> OnePair<K, V>() => [default:default];
-                Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(12, 59));
+                Diagnostic(ErrorCode.ERR_BadAccess, "[default:default]").WithArguments("MyDictionary<K, V>.MyDictionary()").WithLocation(12, 50));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/CSharp15/DictionaryExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/DictionaryExpressionTests.cs
@@ -866,7 +866,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     """);
             }
             var comp = (CSharpCompilation)verifier.Compilation;
-            string constructMethod = typeName == "Dictionary" ? "System.Collections.Generic.Dictionary<K, V>..ctor()" : "null";
+            string constructMethod = "System.Collections.Generic.Dictionary<K, V>..ctor()";
             VerifyOperationTreeForTest<CollectionExpressionSyntax>(comp,
                 $$"""
                 ICollectionExpressionOperation (3 elements, ConstructMethod: {{constructMethod}}) (OperationKind.CollectionExpression, Type: System.Collections.Generic.{{typeName}}<K, V>) (Syntax: '[k:v, e, ..s]')
@@ -1382,21 +1382,21 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
                     //         return [k:v];
                     Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 16),
+                    // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                    //         return [k:v];
+                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 16),
+                    // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                    //         return [k:v];
+                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 16),
+                    // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                    //         return [k:v];
+                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 16),
                     // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2.set_Item'
                     //         return [k:v];
                     Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", "set_Item").WithLocation(6, 16),
-                    // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                    // (6,16): error CS1729: 'Dictionary<K, V>' does not contain a constructor that takes 0 arguments
                     //         return [k:v];
-                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 16),
-                    // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
-                    //         return [k:v];
-                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 16),
-                    // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
-                    //         return [k:v];
-                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 16),
-                    // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
-                    //         return [k:v];
-                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 16));
+                    Diagnostic(ErrorCode.ERR_BadCtorArgCount, "[").WithArguments("System.Collections.Generic.Dictionary<K, V>", "0").WithLocation(6, 16));
             }
             else
             {
@@ -1407,15 +1407,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
                     //         return [k:v];
                     Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 16),
-                    // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2.set_Item'
-                    //         return [k:v];
-                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", "set_Item").WithLocation(6, 16),
                     // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
                     //         return [k:v];
                     Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 16),
-                    // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                    // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2.set_Item'
                     //         return [k:v];
-                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 16));
+                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", "set_Item").WithLocation(6, 16),
+                    // (6,16): error CS1729: 'Dictionary<K, V>' does not contain a constructor that takes 0 arguments
+                    //         return [k:v];
+                    Diagnostic(ErrorCode.ERR_BadCtorArgCount, "[").WithArguments("System.Collections.Generic.Dictionary<K, V>", "0").WithLocation(6, 16));
             }
 
             comp = CreateCompilation(source);
@@ -1426,12 +1426,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
                     //         return [k:v];
                     Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 16),
-                    // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                    // (6,16): error CS1729: 'Dictionary<K, V>' does not contain a constructor that takes 0 arguments
                     //         return [k:v];
-                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 16),
-                    // (6,16): error CS1501: No overload for method '<signature>' takes 0 arguments
-                    //         return [k:v];
-                    Diagnostic(ErrorCode.ERR_BadArgCount, $"[{element}]").WithArguments("<signature>", "0").WithLocation(6, 16));
+                    Diagnostic(ErrorCode.ERR_BadCtorArgCount, "[").WithArguments("System.Collections.Generic.Dictionary<K, V>", "0").WithLocation(6, 16));
             }
             else
             {
@@ -1439,12 +1436,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
                     //         return [k:v];
                     Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 16),
-                    // (6,16): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                    // (6,16): error CS7036: There is no argument given that corresponds to the required parameter 'comparer' of 'Dictionary<K, V>.Dictionary(IEqualityComparer<K>)'
                     //         return [k:v];
-                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, $"[{element}]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(6, 16),
-                    // (6,16): error CS7036: There is no argument given that corresponds to the required parameter 'comparer' of 'Program.<signature>(IEqualityComparer<K>?)'
-                    //         return [k:v];
-                    Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, $"[{element}]").WithArguments("comparer", "Program.<signature>(System.Collections.Generic.IEqualityComparer<K>?)").WithLocation(6, 16));
+                    Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "[").WithArguments("comparer", "System.Collections.Generic.Dictionary<K, V>.Dictionary(System.Collections.Generic.IEqualityComparer<K>)").WithLocation(6, 16));
             }
 
             comp = CreateCompilation(source);
@@ -1772,7 +1766,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             // https://github.com/dotnet/roslyn/issues/77872: Implement IOperation support.
             VerifyOperationTreeForTest<CollectionExpressionSyntax>(comp,
                 """
-                ICollectionExpressionOperation (1 elements, ConstructMethod: null) (OperationKind.CollectionExpression, Type: System.Collections.Generic.IDictionary<System.Int64, System.Object>) (Syntax: '[x:y]')
+                ICollectionExpressionOperation (1 elements, ConstructMethod: System.Collections.Generic.Dictionary<System.Int64, System.Object>..ctor()) (OperationKind.CollectionExpression, Type: System.Collections.Generic.IDictionary<System.Int64, System.Object>) (Syntax: '[x:y]')
                   Elements(1):
                       IOperation:  (OperationKind.None, Type: null) (Syntax: 'x:y')
                 """);
@@ -1807,7 +1801,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             // https://github.com/dotnet/roslyn/issues/77872: Include IOperation support for implicit Key and Value conversions.
             VerifyOperationTreeForTest<CollectionExpressionSyntax>(comp,
                 """
-                ICollectionExpressionOperation (1 elements, ConstructMethod: null) (OperationKind.CollectionExpression, Type: System.Collections.Generic.IDictionary<System.Object, System.Object>) (Syntax: '[x]')
+                ICollectionExpressionOperation (1 elements, ConstructMethod: System.Collections.Generic.Dictionary<System.Object, System.Object>..ctor()) (OperationKind.CollectionExpression, Type: System.Collections.Generic.IDictionary<System.Object, System.Object>) (Syntax: '[x]')
                   Elements(1):
                       IOperation:  (OperationKind.None, Type: System.Collections.Generic.KeyValuePair<System.Object, System.Object>) (Syntax: 'x')
                 """);
@@ -1842,7 +1836,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             // https://github.com/dotnet/roslyn/issues/77872: Include IOperation support for implicit Key and Value conversions.
             VerifyOperationTreeForTest<CollectionExpressionSyntax>(comp,
                 """
-                ICollectionExpressionOperation (1 elements, ConstructMethod: null) (OperationKind.CollectionExpression, Type: System.Collections.Generic.IDictionary<System.Object, System.Object>) (Syntax: '[..y]')
+                ICollectionExpressionOperation (1 elements, ConstructMethod: System.Collections.Generic.Dictionary<System.Object, System.Object>..ctor()) (OperationKind.CollectionExpression, Type: System.Collections.Generic.IDictionary<System.Object, System.Object>) (Syntax: '[..y]')
                   Elements(1):
                       ISpreadOperation (ElementType: System.Collections.Generic.KeyValuePair<System.Int32, System.String>) (OperationKind.Spread, Type: null) (Syntax: '..y')
                         Operand:
@@ -5505,6 +5499,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             VerifyOperationTreeForTest<CollectionExpressionSyntax>(comp,
                 """
                 ICollectionExpressionOperation (3 elements, ConstructMethod: MyDictionary<K, V>..ctor([System.Collections.Generic.IEqualityComparer<K> comparer = null])) (OperationKind.CollectionExpression, Type: MyDictionary<K, V>) (Syntax: '[with(null) ... :v, e, ..s]')
+                  ConstructArguments(1):
+                      IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: comparer) (OperationKind.Argument, Type: null) (Syntax: 'null')
+                        IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Collections.Generic.IEqualityComparer<K>, Constant: null, IsImplicit) (Syntax: 'null')
+                          Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
+                          Operand:
+                            ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'null')
+                        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
                   Elements(3):
                       IOperation:  (OperationKind.None, Type: null) (Syntax: 'k:v')
                       IParameterReferenceOperation: e (OperationKind.ParameterReference, Type: System.Collections.Generic.KeyValuePair<K, V>) (Syntax: 'e')

--- a/src/Compilers/CSharp/Test/CSharp15/DictionaryExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/DictionaryExpressionTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             }
             """;
 
-        public static readonly TheoryData<LanguageVersion> LanguageVersions = new([LanguageVersion.CSharp13, LanguageVersion.Preview, LanguageVersionFacts.CSharpNext]);
+        public static readonly TheoryData<LanguageVersion> LanguageVersions = new([LanguageVersion.CSharp14, LanguageVersion.Preview, LanguageVersionFacts.CSharpNext]);
 
         [Theory]
         [MemberData(nameof(LanguageVersions))]
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 IDictionary<int, string> d = [1:"one"];
                 """;
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
-            if (languageVersion == LanguageVersion.CSharp13)
+            if (languageVersion == LanguageVersion.CSharp14)
             {
                 comp.VerifyEmitDiagnostics(
                     // (2,30): error CS9174: Cannot initialize type 'IDictionary<int, string>' with a collection expression because the type is not constructible.
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 d = [..y];
                 """;
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
-            if (languageVersion == LanguageVersion.CSharp13)
+            if (languageVersion == LanguageVersion.CSharp14)
             {
                 comp.VerifyEmitDiagnostics(
                     // (3,5): error CS9174: Cannot initialize type 'IDictionary<int, string>' with a collection expression because the type is not constructible.
@@ -190,7 +190,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 var x = [1:"one"];
                 """;
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
-            if (languageVersion == LanguageVersion.CSharp13)
+            if (languageVersion == LanguageVersion.CSharp14)
             {
                 comp.VerifyEmitDiagnostics(
                     // (1,9): error CS9176: There is no target type for the collection expression.
@@ -245,7 +245,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Theory]
         [CombinatorialData]
         public void LanguageVersionDiagnostics_05(
-            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext)] LanguageVersion languageVersion,
+            [CombinatorialValues(LanguageVersion.CSharp14, LanguageVersionFacts.CSharpNext)] LanguageVersion languageVersion,
             bool includeExtensionAdd)
         {
             string sourceA = """
@@ -273,7 +273,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 includeExtensionAdd ? [sourceA, sourceB, s_dictionaryExtensions] : [sourceA, s_dictionaryExtensions],
                 parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
                 options: TestOptions.ReleaseExe);
-            if (languageVersion == LanguageVersion.CSharp13 && !includeExtensionAdd)
+            if (languageVersion == LanguageVersion.CSharp14 && !includeExtensionAdd)
             {
                 comp.VerifyEmitDiagnostics(
                     // (6,37): error CS9215: Collection expression type 'Dictionary<int, string>' must have an instance or extension method 'Add' that can be called with a single argument.
@@ -286,7 +286,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     //         Dictionary<int, string> d = [1:"one"];
                     Diagnostic(ErrorCode.ERR_FeatureInPreview, ":").WithArguments("dictionary expressions").WithLocation(6, 39));
             }
-            else if (languageVersion == LanguageVersion.CSharp13)
+            else if (languageVersion == LanguageVersion.CSharp14)
             {
                 comp.VerifyEmitDiagnostics(
                     // (6,38): error CS9500: Collection expression type 'Dictionary<int, string>' does not support key-value pair elements.
@@ -319,7 +319,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Theory]
         [CombinatorialData]
         public void BreakingChange_DictionaryAdd_01(
-            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext)] LanguageVersion languageVersion,
+            [CombinatorialValues(LanguageVersion.CSharp14, LanguageVersionFacts.CSharpNext)] LanguageVersion languageVersion,
             bool includeExtensionAdd)
         {
             string sourceA = """
@@ -352,7 +352,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 includeExtensionAdd ? [sourceA, sourceB, s_dictionaryExtensions] : [sourceA, s_dictionaryExtensions],
                 parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
                 options: TestOptions.ReleaseExe);
-            if (languageVersion == LanguageVersion.CSharp13 && !includeExtensionAdd)
+            if (languageVersion == LanguageVersion.CSharp14 && !includeExtensionAdd)
             {
                 comp.VerifyEmitDiagnostics(
                     // (9,13): error CS9215: Collection expression type 'Dictionary<int, string>' must have an instance or extension method 'Add' that can be called with a single argument.
@@ -365,7 +365,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             }
             var verifier = CompileAndVerify(comp, expectedOutput: "[2:two], [3:three], ");
             verifier.VerifyDiagnostics();
-            if (languageVersion == LanguageVersion.CSharp13)
+            if (languageVersion == LanguageVersion.CSharp14)
             {
                 verifier.VerifyIL("Program.Main", """
                     {
@@ -491,7 +491,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Theory]
         [CombinatorialData]
         public void BreakingChange_DictionaryAdd_02(
-            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext)] LanguageVersion languageVersion,
+            [CombinatorialValues(LanguageVersion.CSharp14, LanguageVersionFacts.CSharpNext)] LanguageVersion languageVersion,
             bool includeAdd)
         {
             string sourceA = $$"""
@@ -531,7 +531,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 [sourceA, sourceB, s_dictionaryExtensions],
                 parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
                 options: TestOptions.ReleaseExe);
-            if (languageVersion == LanguageVersion.CSharp13 && !includeAdd)
+            if (languageVersion == LanguageVersion.CSharp14 && !includeAdd)
             {
                 comp.VerifyEmitDiagnostics(
                     // (9,13): error CS1061: 'MyDictionary<int, string>' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'MyDictionary<int, string>' could be found (are you missing a using directive or an assembly reference?)
@@ -544,7 +544,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             }
             var verifier = CompileAndVerify(comp, expectedOutput: "[2:two], [3:three], ");
             verifier.VerifyDiagnostics();
-            if (languageVersion == LanguageVersion.CSharp13)
+            if (languageVersion == LanguageVersion.CSharp14)
             {
                 verifier.VerifyIL("Program.Main", """
                     {
@@ -884,7 +884,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Theory]
         [CombinatorialData]
         public void Dictionary_Params(
-            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext)] LanguageVersion languageVersion,
+            [CombinatorialValues(LanguageVersion.CSharp14, LanguageVersionFacts.CSharpNext)] LanguageVersion languageVersion,
             [CombinatorialValues("Dictionary", "IDictionary", "IReadOnlyDictionary")] string typeName)
         {
             string source = $$"""
@@ -905,7 +905,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 [source, s_dictionaryExtensions],
                 parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
                 options: TestOptions.ReleaseExe);
-            if (languageVersion == LanguageVersion.CSharp13)
+            if (languageVersion == LanguageVersion.CSharp14)
             {
                 if (typeName == "Dictionary")
                 {
@@ -1084,7 +1084,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 [sourceA, sourceB, s_dictionaryExtensions],
                 parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
                 options: TestOptions.ReleaseExe);
-            if (languageVersion == LanguageVersion.CSharp13)
+            if (languageVersion == LanguageVersion.CSharp14)
             {
                 comp.VerifyEmitDiagnostics(
                     // (6,9): error CS7036: There is no argument given that corresponds to the required parameter 'args' of 'Program.Params<K, V>(params MyDictionary<K, V>)'
@@ -3018,7 +3018,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Theory]
         [CombinatorialData]
         public void KeyValuePairConversions_Dictionary(
-            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
+            [CombinatorialValues(LanguageVersion.CSharp14, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
             bool includeExtensionAdd)
         {
             string sourceA = """
@@ -3050,7 +3050,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 [sourceA, includeExtensionAdd ? sourceB : "", s_collectionExtensions],
                 parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
                 options: TestOptions.ReleaseExe);
-            if (languageVersion == LanguageVersion.CSharp13)
+            if (languageVersion == LanguageVersion.CSharp14)
             {
                 if (includeExtensionAdd)
                 {
@@ -3146,7 +3146,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Theory]
         [CombinatorialData]
         public void KeyValuePairConversions_Params_01(
-            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
+            [CombinatorialValues(LanguageVersion.CSharp14, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
             [CombinatorialValues(
                 "System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>",
                 "System.Collections.Generic.KeyValuePair<K, V>[]",
@@ -3251,7 +3251,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Theory]
         [CombinatorialData]
         public void KeyValuePairConversions_Params_02(
-            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
+            [CombinatorialValues(LanguageVersion.CSharp14, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
             [CombinatorialValues("ReadOnlySpan", "Span")] string typeName)
         {
             string source = $$"""
@@ -3283,7 +3283,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Theory]
         [CombinatorialData]
         public void KeyValuePairConversions_Params_03(
-            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
+            [CombinatorialValues(LanguageVersion.CSharp14, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
             [CombinatorialValues("IReadOnlyDictionary", "Dictionary")] string typeName)
         {
             string source = $$"""
@@ -3304,7 +3304,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var comp = CreateCompilation(
                 source,
                 parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
-            if (languageVersion == LanguageVersion.CSharp13)
+            if (languageVersion == LanguageVersion.CSharp14)
             {
                 if (typeName == "Dictionary")
                 {
@@ -3345,7 +3345,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Theory]
         [CombinatorialData]
         public void KeyValuePairConversions_Span(
-            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion)
+            [CombinatorialValues(LanguageVersion.CSharp14, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion)
         {
             string source = """
                 using System;
@@ -3370,7 +3370,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
                 options: TestOptions.ReleaseExe,
                 targetFramework: TargetFramework.Net80);
-            if (languageVersion == LanguageVersion.CSharp13)
+            if (languageVersion == LanguageVersion.CSharp14)
             {
                 comp.VerifyEmitDiagnostics(
                     // (11,55): error CS9500: Collection expression type 'ReadOnlySpan<KeyValuePair<int, string>>' does not support key-value pair elements.
@@ -3579,7 +3579,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Theory]
         [CombinatorialData]
         public void KeyValuePairConversions_CustomType(
-            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
+            [CombinatorialValues(LanguageVersion.CSharp14, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
             bool useCollectionBuilder)
         {
             string sourceA = useCollectionBuilder ?
@@ -3644,7 +3644,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 options: TestOptions.ReleaseExe,
                 references: [refA],
                 targetFramework: TargetFramework.Net80);
-            if (languageVersion == LanguageVersion.CSharp13)
+            if (languageVersion == LanguageVersion.CSharp14)
             {
                 comp.VerifyEmitDiagnostics(
                     // (11,15): error CS9500: Collection expression type 'MyCollection<KeyValuePair<int, string>>' does not support key-value pair elements.
@@ -3706,7 +3706,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Theory]
         [CombinatorialData]
         public void KeyValuePairConversions_AddObject(
-            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
+            [CombinatorialValues(LanguageVersion.CSharp14, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
             bool useDynamic)
         {
             string parameterType = useDynamic ? "dynamic" : "object";
@@ -3755,7 +3755,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 references: [refA],
                 options: TestOptions.ReleaseExe,
                 targetFramework: TargetFramework.Net80);
-            if (languageVersion == LanguageVersion.CSharp13)
+            if (languageVersion == LanguageVersion.CSharp14)
             {
                 comp.VerifyEmitDiagnostics(
                     // (15,17): error CS9500: Collection expression type 'MyCollection<KeyValuePair<int, string>>' does not support key-value pair elements.
@@ -3878,7 +3878,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Theory]
         [CombinatorialData]
         public void KeyValuePairConversions_AddUserDefinedConversion(
-            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion)
+            [CombinatorialValues(LanguageVersion.CSharp14, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion)
         {
             string sourceA = """
                 using System.Collections;
@@ -3930,7 +3930,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
                 references: [refA],
                 options: TestOptions.ReleaseExe);
-            if (languageVersion == LanguageVersion.CSharp13)
+            if (languageVersion == LanguageVersion.CSharp14)
             {
                 comp.VerifyEmitDiagnostics(
                     // (15,17): error CS9500: Collection expression type 'MyCollection<int, string>' does not support key-value pair elements.
@@ -4049,7 +4049,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Theory]
         [CombinatorialData]
         public void KeyValuePairConversions_AddOverloads(
-            [CombinatorialValues(LanguageVersion.CSharp13, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
+            [CombinatorialValues(LanguageVersion.CSharp14, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion,
             bool includeAddT)
         {
             string sourceA = $$"""
@@ -4096,7 +4096,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
                 references: [refA],
                 options: TestOptions.ReleaseExe);
-            if (languageVersion == LanguageVersion.CSharp13)
+            if (languageVersion == LanguageVersion.CSharp14)
             {
                 comp.VerifyEmitDiagnostics(
                     // (15,17): error CS9500: Collection expression type 'MyCollection<KeyValuePair<int, string>>' does not support key-value pair elements.
@@ -4304,7 +4304,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion),
                 options: TestOptions.ReleaseExe,
                 targetFramework: TargetFramework.Net80);
-            if (languageVersion == LanguageVersion.CSharp13)
+            if (languageVersion == LanguageVersion.CSharp14)
             {
                 var verifier = CompileAndVerify(
                     comp,

--- a/src/Compilers/CSharp/Test/CSharp15/DictionaryExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/DictionaryExpressionTests.cs
@@ -724,6 +724,42 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             }
         }
 
+        [Fact]
+        public void DictionaryInterface_UseSiteDiagnostics_TypeArgument()
+        {
+            var missingType = CreateCompilation("""
+                namespace MissingLib
+                {
+                    public class Key
+                    {
+                    }
+                }
+                """, assemblyName: "MissingLib").EmitToImageReference();
+
+            var container = CreateCompilation("""
+                public class Container
+                {
+                    public System.Collections.Generic.IDictionary<MissingLib.Key, int> Dictionary;
+                }
+                """, references: [missingType], assemblyName: "ContainerLib").EmitToImageReference();
+
+            var source = """
+                class Program
+                {
+                    static void M()
+                    {
+                        new Container().Dictionary = [];
+                    }
+                }
+                """;
+
+            var comp = CreateCompilation(source, references: [container]);
+            comp.VerifyEmitDiagnostics(
+                // (5,25): error CS0012: The type 'Key' is defined in an assembly that is not referenced. You must add a reference to assembly 'MissingLib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                //         new Container().Dictionary = [];
+                Diagnostic(ErrorCode.ERR_NoTypeDef, "Dictionary").WithArguments("MissingLib.Key", "MissingLib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(5, 25));
+        }
+
         [Theory]
         [InlineData("Dictionary")]
         [InlineData("IDictionary")]

--- a/src/Compilers/CSharp/Test/CSharp15/Microsoft.CodeAnalysis.CSharp.CSharp15.UnitTests.csproj
+++ b/src/Compilers/CSharp/Test/CSharp15/Microsoft.CodeAnalysis.CSharp.CSharp15.UnitTests.csproj
@@ -18,6 +18,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" />
     <PackageReference Include="Microsoft.DiaSymReader" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net80" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net90" />
     <PackageReference Include="Basic.Reference.Assemblies.Net100" />
   </ItemGroup>
   <Import Project="$(RepositoryEngineeringDir)targets\ILAsm.targets" />

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
@@ -9662,12 +9662,12 @@ static class Program
                 // (14,42): warning CS9193: Argument 1 should be a variable because it is passed to a 'ref readonly' parameter
                 //         MyCollection<object> x = new() { 1 };
                 Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "1").WithArguments("1").WithLocation(14, 42),
-                // (17,35): warning CS9193: Argument 1 should be a variable because it is passed to a 'ref readonly' parameter
+                // (17,37): warning CS9193: Argument 1 should be a variable because it is passed to a 'ref readonly' parameter
                 //         MyCollection<object> z = [..x, ..y, 3, v];
-                Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "..x").WithArguments("1").WithLocation(17, 35),
-                // (17,40): warning CS9193: Argument 1 should be a variable because it is passed to a 'ref readonly' parameter
+                Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "x").WithArguments("1").WithLocation(17, 37),
+                // (17,42): warning CS9193: Argument 1 should be a variable because it is passed to a 'ref readonly' parameter
                 //         MyCollection<object> z = [..x, ..y, 3, v];
-                Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "..y").WithArguments("1").WithLocation(17, 40),
+                Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "y").WithArguments("1").WithLocation(17, 42),
                 // (17,45): warning CS9193: Argument 1 should be a variable because it is passed to a 'ref readonly' parameter
                 //         MyCollection<object> z = [..x, ..y, 3, v];
                 Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "3").WithArguments("1").WithLocation(17, 45));
@@ -12890,42 +12890,42 @@ static class Program
             if (targetElementType == "int")
             {
                 comp.VerifyEmitDiagnostics(
-                    // 1.cs(10,27): error CS1503: Argument 1: cannot convert from 'object' to 'int'
-                    //         MyCollection c = [..d1, ..d2, ..e1, ..e2];
-                    Diagnostic(ErrorCode.ERR_BadArgType, "..d1").WithArguments("1", "object", "int").WithLocation(10, 27),
                     // 1.cs(10,29): error CS1950: The best overloaded Add method 'MyCollection.Add(int)' for the collection initializer has some invalid arguments
                     //         MyCollection c = [..d1, ..d2, ..e1, ..e2];
                     Diagnostic(ErrorCode.ERR_BadArgTypesForCollectionAdd, "d1").WithArguments("MyCollection.Add(int)").WithLocation(10, 29),
-                    // 1.cs(10,33): error CS1503: Argument 1: cannot convert from 'object' to 'int'
+                    // 1.cs(10,29): error CS1503: Argument 1: cannot convert from 'object' to 'int'
                     //         MyCollection c = [..d1, ..d2, ..e1, ..e2];
-                    Diagnostic(ErrorCode.ERR_BadArgType, "..d2").WithArguments("1", "object", "int").WithLocation(10, 33),
+                    Diagnostic(ErrorCode.ERR_BadArgType, "d1").WithArguments("1", "object", "int").WithLocation(10, 29),
                     // 1.cs(10,35): error CS1950: The best overloaded Add method 'MyCollection.Add(int)' for the collection initializer has some invalid arguments
                     //         MyCollection c = [..d1, ..d2, ..e1, ..e2];
                     Diagnostic(ErrorCode.ERR_BadArgTypesForCollectionAdd, "d2").WithArguments("MyCollection.Add(int)").WithLocation(10, 35),
-                    // 1.cs(10,39): error CS1503: Argument 1: cannot convert from 'object' to 'int'
+                    // 1.cs(10,35): error CS1503: Argument 1: cannot convert from 'object' to 'int'
                     //         MyCollection c = [..d1, ..d2, ..e1, ..e2];
-                    Diagnostic(ErrorCode.ERR_BadArgType, "..e1").WithArguments("1", "object", "int").WithLocation(10, 39),
+                    Diagnostic(ErrorCode.ERR_BadArgType, "d2").WithArguments("1", "object", "int").WithLocation(10, 35),
                     // 1.cs(10,41): error CS1950: The best overloaded Add method 'MyCollection.Add(int)' for the collection initializer has some invalid arguments
                     //         MyCollection c = [..d1, ..d2, ..e1, ..e2];
                     Diagnostic(ErrorCode.ERR_BadArgTypesForCollectionAdd, "e1").WithArguments("MyCollection.Add(int)").WithLocation(10, 41),
-                    // 1.cs(10,45): error CS1503: Argument 1: cannot convert from 'object' to 'int'
+                    // 1.cs(10,41): error CS1503: Argument 1: cannot convert from 'object' to 'int'
                     //         MyCollection c = [..d1, ..d2, ..e1, ..e2];
-                    Diagnostic(ErrorCode.ERR_BadArgType, "..e2").WithArguments("1", "object", "int").WithLocation(10, 45),
+                    Diagnostic(ErrorCode.ERR_BadArgType, "e1").WithArguments("1", "object", "int").WithLocation(10, 41),
                     // 1.cs(10,47): error CS1950: The best overloaded Add method 'MyCollection.Add(int)' for the collection initializer has some invalid arguments
                     //         MyCollection c = [..d1, ..d2, ..e1, ..e2];
                     Diagnostic(ErrorCode.ERR_BadArgTypesForCollectionAdd, "e2").WithArguments("MyCollection.Add(int)").WithLocation(10, 47),
-                    // 1.cs(14,14): error CS1503: Argument 1: cannot convert from 'object' to 'int'
-                    //         c = [..(dynamic)x, ..(IEnumerable)y];
-                    Diagnostic(ErrorCode.ERR_BadArgType, "..(dynamic)x").WithArguments("1", "object", "int").WithLocation(14, 14),
+                    // 1.cs(10,47): error CS1503: Argument 1: cannot convert from 'object' to 'int'
+                    //         MyCollection c = [..d1, ..d2, ..e1, ..e2];
+                    Diagnostic(ErrorCode.ERR_BadArgType, "e2").WithArguments("1", "object", "int").WithLocation(10, 47),
                     // 1.cs(14,16): error CS1950: The best overloaded Add method 'MyCollection.Add(int)' for the collection initializer has some invalid arguments
                     //         c = [..(dynamic)x, ..(IEnumerable)y];
                     Diagnostic(ErrorCode.ERR_BadArgTypesForCollectionAdd, "(dynamic)x").WithArguments("MyCollection.Add(int)").WithLocation(14, 16),
-                    // 1.cs(14,28): error CS1503: Argument 1: cannot convert from 'object' to 'int'
+                    // 1.cs(14,16): error CS1503: Argument 1: cannot convert from 'object' to 'int'
                     //         c = [..(dynamic)x, ..(IEnumerable)y];
-                    Diagnostic(ErrorCode.ERR_BadArgType, "..(IEnumerable)y").WithArguments("1", "object", "int").WithLocation(14, 28),
+                    Diagnostic(ErrorCode.ERR_BadArgType, "(dynamic)x").WithArguments("1", "object", "int").WithLocation(14, 16),
                     // 1.cs(14,30): error CS1950: The best overloaded Add method 'MyCollection.Add(int)' for the collection initializer has some invalid arguments
                     //         c = [..(dynamic)x, ..(IEnumerable)y];
-                    Diagnostic(ErrorCode.ERR_BadArgTypesForCollectionAdd, "(IEnumerable)y").WithArguments("MyCollection.Add(int)").WithLocation(14, 30));
+                    Diagnostic(ErrorCode.ERR_BadArgTypesForCollectionAdd, "(IEnumerable)y").WithArguments("MyCollection.Add(int)").WithLocation(14, 30),
+                    // 1.cs(14,30): error CS1503: Argument 1: cannot convert from 'object' to 'int'
+                    //         c = [..(dynamic)x, ..(IEnumerable)y];
+                    Diagnostic(ErrorCode.ERR_BadArgType, "(IEnumerable)y").WithArguments("1", "object", "int").WithLocation(14, 30));
             }
             else
             {
@@ -16005,9 +16005,9 @@ namespace System
                 bool m() => throw null!;
                 """;
             CreateCompilation(source).VerifyDiagnostics(
-                // (6,22): warning CS8601: Possible null reference assignment.
+                // (6,21): warning CS8601: Possible null reference assignment.
                 //     object[] b = [..(m() ? a1 : a2)];
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "m() ? a1 : a2").WithLocation(6, 22));
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "(m() ? a1 : a2)").WithLocation(6, 21));
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69447")]
@@ -29893,9 +29893,9 @@ partial class Program
                 // (5,27): error CS1503: Argument 1: cannot convert from 'int' to 'string'
                 //         return /*<bind>*/[F1(), ..F2()]/*</bind>*/;
                 Diagnostic(ErrorCode.ERR_BadArgType, "F1()").WithArguments("1", "int", "string").WithLocation(5, 27),
-                // (5,33): error CS1503: Argument 1: cannot convert from 'int' to 'string'
+                // (5,35): error CS1503: Argument 1: cannot convert from 'int' to 'string'
                 //         return /*<bind>*/[F1(), ..F2()]/*</bind>*/;
-                Diagnostic(ErrorCode.ERR_BadArgType, "..F2()").WithArguments("1", "int", "string").WithLocation(5, 33),
+                Diagnostic(ErrorCode.ERR_BadArgType, "F2()").WithArguments("1", "int", "string").WithLocation(5, 35),
                 // (5,35): error CS1950: The best overloaded Add method 'MyCollection<int>.Add(string)' for the collection initializer has some invalid arguments
                 //         return /*<bind>*/[F1(), ..F2()]/*</bind>*/;
                 Diagnostic(ErrorCode.ERR_BadArgTypesForCollectionAdd, "F2()").WithArguments("MyCollection<int>.Add(string)").WithLocation(5, 35));
@@ -29986,9 +29986,9 @@ partial class Program
                 // (5,27): error CS1503: Argument 2: cannot convert from 'int' to 'string'
                 //         return /*<bind>*/[F1(), ..F2()]/*</bind>*/;
                 Diagnostic(ErrorCode.ERR_BadArgType, "F1()").WithArguments("2", "int", "string").WithLocation(5, 27),
-                // (5,33): error CS1503: Argument 2: cannot convert from 'int' to 'string'
+                // (5,35): error CS1503: Argument 2: cannot convert from 'int' to 'string'
                 //         return /*<bind>*/[F1(), ..F2()]/*</bind>*/;
-                Diagnostic(ErrorCode.ERR_BadArgType, "..F2()").WithArguments("2", "int", "string").WithLocation(5, 33),
+                Diagnostic(ErrorCode.ERR_BadArgType, "F2()").WithArguments("2", "int", "string").WithLocation(5, 35),
                 // (5,35): error CS1950: The best overloaded Add method 'Extensions.Add<int>(MyCollection<int>, string)' for the collection initializer has some invalid arguments
                 //         return /*<bind>*/[F1(), ..F2()]/*</bind>*/;
                 Diagnostic(ErrorCode.ERR_BadArgTypesForCollectionAdd, "F2()").WithArguments("Extensions.Add<int>(MyCollection<int>, string)").WithLocation(5, 35));
@@ -30077,9 +30077,9 @@ partial class Program
                 // (5,27): error CS1503: Argument 2: cannot convert from 'int' to 'string'
                 //         return /*<bind>*/[x, ..y]/*</bind>*/;
                 Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("2", "int", "string").WithLocation(5, 27),
-                // (5,30): error CS1503: Argument 2: cannot convert from 'int' to 'string'
+                // (5,32): error CS1503: Argument 2: cannot convert from 'int' to 'string'
                 //         return /*<bind>*/[x, ..y]/*</bind>*/;
-                Diagnostic(ErrorCode.ERR_BadArgType, "..y").WithArguments("2", "int", "string").WithLocation(5, 30),
+                Diagnostic(ErrorCode.ERR_BadArgType, "y").WithArguments("2", "int", "string").WithLocation(5, 32),
                 // (5,32): error CS1950: The best overloaded Add method 'Extensions.Add<int>(MyCollection<int>, params string[])' for the collection initializer has some invalid arguments
                 //         return /*<bind>*/[x, ..y]/*</bind>*/;
                 Diagnostic(ErrorCode.ERR_BadArgTypesForCollectionAdd, "y").WithArguments("Extensions.Add<int>(MyCollection<int>, params string[])").WithLocation(5, 32));
@@ -42113,9 +42113,9 @@ partial class Program
                 // (7,33): error CS1503: Argument 1: cannot convert from 'int?' to 'string'
                 //         MyCollection<int?> z = [x, ..y];
                 Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("1", "int?", "string").WithLocation(7, 33),
-                // (7,36): error CS1503: Argument 1: cannot convert from 'int?' to 'string'
+                // (7,38): error CS1503: Argument 1: cannot convert from 'int?' to 'string'
                 //         MyCollection<int?> z = [x, ..y];
-                Diagnostic(ErrorCode.ERR_BadArgType, "..y").WithArguments("1", "int?", "string").WithLocation(7, 36),
+                Diagnostic(ErrorCode.ERR_BadArgType, "y").WithArguments("1", "int?", "string").WithLocation(7, 38),
                 // (7,38): error CS1950: The best overloaded Add method 'MyCollection<int?>.Add(string)' for the collection initializer has some invalid arguments
                 //         MyCollection<int?> z = [x, ..y];
                 Diagnostic(ErrorCode.ERR_BadArgTypesForCollectionAdd, "y").WithArguments("MyCollection<int?>.Add(string)").WithLocation(7, 38));
@@ -42363,9 +42363,9 @@ partial class Program
                 // (21,33): error CS1503: Argument 1: cannot convert from 'int' to 'R'
                 //         MyCollection<int?> z = [x, ..y, null];
                 Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("1", "int", "R").WithLocation(21, 33),
-                // (21,36): error CS1503: Argument 1: cannot convert from 'int' to 'R'
+                // (21,38): error CS1503: Argument 1: cannot convert from 'int' to 'R'
                 //         MyCollection<int?> z = [x, ..y, null];
-                Diagnostic(ErrorCode.ERR_BadArgType, "..y").WithArguments("1", "int", "R").WithLocation(21, 36),
+                Diagnostic(ErrorCode.ERR_BadArgType, "y").WithArguments("1", "int", "R").WithLocation(21, 38),
                 // (21,38): error CS1950: The best overloaded Add method 'MyCollection<int?>.Add(R)' for the collection initializer has some invalid arguments
                 //         MyCollection<int?> z = [x, ..y, null];
                 Diagnostic(ErrorCode.ERR_BadArgTypesForCollectionAdd, "y").WithArguments("MyCollection<int?>.Add(R)").WithLocation(21, 38),
@@ -42832,9 +42832,9 @@ partial class Program
                 // (7,33): error CS1503: Argument 1: cannot convert from 'int' to 'int?[]'
                 //         MyCollection<int?> z = [x, ..y];
                 Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("1", "int", "int?[]").WithLocation(7, 33),
-                // (7,36): error CS1503: Argument 1: cannot convert from 'int' to 'int?[]'
+                // (7,38): error CS1503: Argument 1: cannot convert from 'int' to 'int?[]'
                 //         MyCollection<int?> z = [x, ..y];
-                Diagnostic(ErrorCode.ERR_BadArgType, "..y").WithArguments("1", "int", "int?[]").WithLocation(7, 36),
+                Diagnostic(ErrorCode.ERR_BadArgType, "y").WithArguments("1", "int", "int?[]").WithLocation(7, 38),
                 // (7,38): error CS1950: The best overloaded Add method 'MyCollection<int?>.Add(int?[])' for the collection initializer has some invalid arguments
                 //         MyCollection<int?> z = [x, ..y];
                 Diagnostic(ErrorCode.ERR_BadArgTypesForCollectionAdd, "y").WithArguments("MyCollection<int?>.Add(int?[])").WithLocation(7, 38));
@@ -43024,9 +43024,9 @@ partial class Program
                 // (8,32): error CS1503: Argument 1: cannot convert from 'int' to 'string'
                 //         MyCollection<int> z = [x, ..y];
                 Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("1", "int", "string").WithLocation(8, 32),
-                // (8,35): error CS1503: Argument 1: cannot convert from 'int' to 'string'
+                // (8,37): error CS1503: Argument 1: cannot convert from 'int' to 'string'
                 //         MyCollection<int> z = [x, ..y];
-                Diagnostic(ErrorCode.ERR_BadArgType, "..y").WithArguments("1", "int", "string").WithLocation(8, 35),
+                Diagnostic(ErrorCode.ERR_BadArgType, "y").WithArguments("1", "int", "string").WithLocation(8, 37),
                 // (8,37): error CS1950: The best overloaded Add method 'MyCollection<int>.Add(string)' for the collection initializer has some invalid arguments
                 //         MyCollection<int> z = [x, ..y];
                 Diagnostic(ErrorCode.ERR_BadArgTypesForCollectionAdd, "y").WithArguments("MyCollection<int>.Add(string)").WithLocation(8, 37));
@@ -43141,9 +43141,9 @@ partial class Program
                 // (7,35): error CS1503: Argument 1: cannot convert from 'object' to 'string'
                 //         MyCollection<object> z = [x, ..y];
                 Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("1", "object", "string").WithLocation(7, 35),
-                // (7,38): error CS1503: Argument 1: cannot convert from 'object' to 'string'
+                // (7,40): error CS1503: Argument 1: cannot convert from 'object' to 'string'
                 //         MyCollection<object> z = [x, ..y];
-                Diagnostic(ErrorCode.ERR_BadArgType, "..y").WithArguments("1", "object", "string").WithLocation(7, 38),
+                Diagnostic(ErrorCode.ERR_BadArgType, "y").WithArguments("1", "object", "string").WithLocation(7, 40),
                 // (7,40): error CS1950: The best overloaded Add method 'MyCollection<object>.Add(string)' for the collection initializer has some invalid arguments
                 //         MyCollection<object> z = [x, ..y];
                 Diagnostic(ErrorCode.ERR_BadArgTypesForCollectionAdd, "y").WithArguments("MyCollection<object>.Add(string)").WithLocation(7, 40));
@@ -43619,9 +43619,9 @@ partial class Program
                 // (8,32): error CS1503: Argument 2: cannot convert from 'int' to 'string'
                 //         MyCollection<int> z = [x, ..y];
                 Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("2", "int", "string").WithLocation(8, 32),
-                // (8,35): error CS1503: Argument 2: cannot convert from 'int' to 'string'
+                // (8,37): error CS1503: Argument 2: cannot convert from 'int' to 'string'
                 //         MyCollection<int> z = [x, ..y];
-                Diagnostic(ErrorCode.ERR_BadArgType, "..y").WithArguments("2", "int", "string").WithLocation(8, 35),
+                Diagnostic(ErrorCode.ERR_BadArgType, "y").WithArguments("2", "int", "string").WithLocation(8, 37),
                 // (8,37): error CS1950: The best overloaded Add method 'Extensions.Add<int>(MyCollection<int>, string)' for the collection initializer has some invalid arguments
                 //         MyCollection<int> z = [x, ..y];
                 Diagnostic(ErrorCode.ERR_BadArgTypesForCollectionAdd, "y").WithArguments("Extensions.Add<int>(MyCollection<int>, string)").WithLocation(8, 37));
@@ -44718,9 +44718,9 @@ partial class Program
                 // (7,35): error CS1503: Argument 1: cannot convert from 'int' to 'void*'
                 //         MyCollection<object> z = [x, ..y];
                 Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("1", "int", "void*").WithLocation(7, 35),
-                // (7,38): error CS1503: Argument 1: cannot convert from 'int' to 'void*'
+                // (7,40): error CS1503: Argument 1: cannot convert from 'int' to 'void*'
                 //         MyCollection<object> z = [x, ..y];
-                Diagnostic(ErrorCode.ERR_BadArgType, "..y").WithArguments("1", "int", "void*").WithLocation(7, 38),
+                Diagnostic(ErrorCode.ERR_BadArgType, "y").WithArguments("1", "int", "void*").WithLocation(7, 40),
                 // (7,40): error CS1950: The best overloaded Add method 'MyCollection<object>.Add(void*)' for the collection initializer has some invalid arguments
                 //         MyCollection<object> z = [x, ..y];
                 Diagnostic(ErrorCode.ERR_BadArgTypesForCollectionAdd, "y").WithArguments("MyCollection<object>.Add(void*)").WithLocation(7, 40));
@@ -44766,9 +44766,9 @@ partial class Program
                 // (7,35): error CS1503: Argument 2: cannot convert from 'int' to 'void*'
                 //         MyCollection<object> z = [x, ..y];
                 Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("2", "int", "void*").WithLocation(7, 35),
-                // (7,38): error CS1503: Argument 2: cannot convert from 'int' to 'void*'
+                // (7,40): error CS1503: Argument 2: cannot convert from 'int' to 'void*'
                 //         MyCollection<object> z = [x, ..y];
-                Diagnostic(ErrorCode.ERR_BadArgType, "..y").WithArguments("2", "int", "void*").WithLocation(7, 38),
+                Diagnostic(ErrorCode.ERR_BadArgType, "y").WithArguments("2", "int", "void*").WithLocation(7, 40),
                 // (7,40): error CS1950: The best overloaded Add method 'Extensions1.Add<object>(MyCollection<object>, void*)' for the collection initializer has some invalid arguments
                 //         MyCollection<object> z = [x, ..y];
                 Diagnostic(ErrorCode.ERR_BadArgTypesForCollectionAdd, "y").WithArguments("Extensions1.Add<object>(MyCollection<object>, void*)").WithLocation(7, 40));

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
@@ -29610,7 +29610,7 @@ partial class Program
                 }
                 """;
 
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular13);
             comp.VerifyEmitDiagnostics(
                 // (4,52): error CS9215: Collection expression type 'Dictionary<string, object>' must have an instance or extension method 'Add' that can be called with a single argument.
                 //     Dictionary<string, object> Config => /*<bind>*/[

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
@@ -31,6 +31,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         private static string IncludeExpectedOutput(string expectedOutput) => ExecutionConditionUtil.IsMonoOrCoreClr ? expectedOutput : null;
 
+        private static CollectionExpressionTypeKind GetCollectionExpressionTypeKind(CSharpCompilation compilation, TypeSymbol type, out TypeWithAnnotations elementType)
+        {
+            var syntax = (CSharpSyntaxNode)compilation.SyntaxTrees.Last().GetRoot();
+            return ConversionsBase.GetCollectionExpressionTypeKind(compilation.GetBinder(syntax), syntax, type, out elementType);
+        }
+
         internal const string s_collectionExtensions = """
             using System;
             using System.Collections;
@@ -4988,7 +4994,7 @@ static class Program
                 Diagnostic(ErrorCode.ERR_CollectionExpressionTargetTypeNotConstructible, "[5]").WithArguments("System.Collections.Generic.ID<object, object>").WithLocation(10, 32));
 
             var collectionType = comp.GetWellKnownType(WellKnownType.System_Collections_Generic_List_T).Construct(comp.GetSpecialType(SpecialType.System_Int32));
-            Assert.Equal(CollectionExpressionTypeKind.ImplementsIEnumerable, ConversionsBase.GetCollectionExpressionTypeKind(comp, collectionType, out _));
+            Assert.Equal(CollectionExpressionTypeKind.ImplementsIEnumerable, GetCollectionExpressionTypeKind(comp, collectionType, out _));
         }
 
         [Fact]
@@ -5043,7 +5049,7 @@ static class Program
                 Diagnostic(ErrorCode.ERR_CollectionExpressionTargetTypeNotConstructible, "[2]").WithArguments("System.IEquatable<int>").WithLocation(8, 29));
 
             var collectionType = comp.GetWellKnownType(WellKnownType.System_Collections_Generic_List_T).Construct(comp.GetSpecialType(SpecialType.System_Int32));
-            Assert.Equal(CollectionExpressionTypeKind.ImplementsIEnumerable, ConversionsBase.GetCollectionExpressionTypeKind(comp, collectionType, out _));
+            Assert.Equal(CollectionExpressionTypeKind.ImplementsIEnumerable, GetCollectionExpressionTypeKind(comp, collectionType, out _));
         }
 
         [Theory, CombinatorialData]
@@ -6107,7 +6113,7 @@ static class Program
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[2]").WithArguments("System.Collections.Generic.List`1", "ToArray").WithLocation(8, 30));
 
             var listType = comp.GetWellKnownType(WellKnownType.System_Collections_Generic_List_T).Construct(comp.GetSpecialType(SpecialType.System_Int32));
-            Assert.Equal(CollectionExpressionTypeKind.None, ConversionsBase.GetCollectionExpressionTypeKind(comp, listType, out var elementType));
+            Assert.Equal(CollectionExpressionTypeKind.None, GetCollectionExpressionTypeKind(comp, listType, out var elementType));
             Assert.False(elementType.HasType);
         }
 
@@ -32530,8 +32536,8 @@ partial class Program
                 """);
 
             var collectionType = comp.GetWellKnownType(WellKnownType.System_Collections_Immutable_ImmutableArray_T).Construct(comp.GetSpecialType(SpecialType.System_Int32));
-            Assert.Equal(CollectionExpressionTypeKind.CollectionBuilder, ConversionsBase.GetCollectionExpressionTypeKind(comp, collectionType, out var elementType));
-            Assert.False(elementType.HasType);
+            Assert.Equal(CollectionExpressionTypeKind.CollectionBuilder, GetCollectionExpressionTypeKind(comp, collectionType, out var elementType));
+            Assert.Equal(SpecialType.System_Int32, elementType.Type.SpecialType);
         }
 
         [Fact]
@@ -32590,7 +32596,7 @@ partial class Program
 
             var comp = (CSharpCompilation)verifier.Compilation;
             var collectionType = comp.GetWellKnownType(WellKnownType.System_Collections_Immutable_ImmutableArray_T).Construct(comp.GetSpecialType(SpecialType.System_Int32));
-            Assert.Equal(CollectionExpressionTypeKind.CollectionBuilder, ConversionsBase.GetCollectionExpressionTypeKind(comp, collectionType, out _));
+            Assert.Equal(CollectionExpressionTypeKind.CollectionBuilder, GetCollectionExpressionTypeKind(comp, collectionType, out _));
         }
 
         [Fact]
@@ -32801,7 +32807,7 @@ partial class Program
                 Diagnostic(ErrorCode.ERR_CollectionExpressionImmutableArray, "[1, 2, 3]").WithArguments("System.Collections.Immutable.ImmutableArray<T>").WithLocation(7, 35));
 
             var collectionType = comp.GetWellKnownType(WellKnownType.System_Collections_Immutable_ImmutableArray_T).Construct(comp.GetSpecialType(SpecialType.System_Int32));
-            Assert.Equal(CollectionExpressionTypeKind.ImplementsIEnumerable, ConversionsBase.GetCollectionExpressionTypeKind(comp, collectionType, out _));
+            Assert.Equal(CollectionExpressionTypeKind.ImplementsIEnumerable, GetCollectionExpressionTypeKind(comp, collectionType, out _));
 
             // ImmutableCollectionsMarshal.AsImmutableArray is not sufficient to optimize collection expressions
             // targeting ImmutableArray<T>. ImmutableArray<T> must also have a [CollectionBuilder] attribute.
@@ -32825,7 +32831,7 @@ partial class Program
                 Diagnostic(ErrorCode.ERR_CollectionExpressionImmutableArray, "[1, 2, 3]").WithArguments("System.Collections.Immutable.ImmutableArray<T>").WithLocation(7, 35));
 
             collectionType = comp.GetWellKnownType(WellKnownType.System_Collections_Immutable_ImmutableArray_T).Construct(comp.GetSpecialType(SpecialType.System_Int32));
-            Assert.Equal(CollectionExpressionTypeKind.ImplementsIEnumerable, ConversionsBase.GetCollectionExpressionTypeKind(comp, collectionType, out _));
+            Assert.Equal(CollectionExpressionTypeKind.ImplementsIEnumerable, GetCollectionExpressionTypeKind(comp, collectionType, out _));
         }
 
         [Fact]
@@ -32860,7 +32866,7 @@ partial class Program
                 Diagnostic(ErrorCode.ERR_CollectionExpressionImmutableArray, "[1, 2, 3]").WithArguments("System.Collections.Immutable.ImmutableArray<T>").WithLocation(7, 35));
 
             var collectionType = comp.GetWellKnownType(WellKnownType.System_Collections_Immutable_ImmutableArray_T).Construct(comp.GetSpecialType(SpecialType.System_Int32));
-            Assert.Equal(CollectionExpressionTypeKind.ImplementsIEnumerable, ConversionsBase.GetCollectionExpressionTypeKind(comp, collectionType, out _));
+            Assert.Equal(CollectionExpressionTypeKind.ImplementsIEnumerable, GetCollectionExpressionTypeKind(comp, collectionType, out _));
 
             // With ImmutableCollectionsMarshal.AsImmutableArray.
             string sourceB = """
@@ -32882,7 +32888,7 @@ partial class Program
                 Diagnostic(ErrorCode.ERR_CollectionExpressionImmutableArray, "[1, 2, 3]").WithArguments("System.Collections.Immutable.ImmutableArray<T>").WithLocation(7, 35));
 
             collectionType = comp.GetWellKnownType(WellKnownType.System_Collections_Immutable_ImmutableArray_T).Construct(comp.GetSpecialType(SpecialType.System_Int32));
-            Assert.Equal(CollectionExpressionTypeKind.ImplementsIEnumerable, ConversionsBase.GetCollectionExpressionTypeKind(comp, collectionType, out _));
+            Assert.Equal(CollectionExpressionTypeKind.ImplementsIEnumerable, GetCollectionExpressionTypeKind(comp, collectionType, out _));
         }
 
         [Fact]
@@ -32914,7 +32920,7 @@ partial class Program
                 Diagnostic(ErrorCode.ERR_CollectionExpressionTargetTypeNotConstructible, "[1, 2, 3]").WithArguments("System.Collections.Immutable.ImmutableArray<int>").WithLocation(7, 35));
 
             var collectionType = comp.GetWellKnownType(WellKnownType.System_Collections_Immutable_ImmutableArray_T).Construct(comp.GetSpecialType(SpecialType.System_Int32));
-            Assert.Equal(CollectionExpressionTypeKind.None, ConversionsBase.GetCollectionExpressionTypeKind(comp, collectionType, out _));
+            Assert.Equal(CollectionExpressionTypeKind.None, GetCollectionExpressionTypeKind(comp, collectionType, out _));
 
             // With ImmutableCollectionsMarshal.AsImmutableArray.
             string sourceB = """
@@ -32936,7 +32942,7 @@ partial class Program
                 Diagnostic(ErrorCode.ERR_CollectionExpressionTargetTypeNotConstructible, "[1, 2, 3]").WithArguments("System.Collections.Immutable.ImmutableArray<int>").WithLocation(7, 35));
 
             collectionType = comp.GetWellKnownType(WellKnownType.System_Collections_Immutable_ImmutableArray_T).Construct(comp.GetSpecialType(SpecialType.System_Int32));
-            Assert.Equal(CollectionExpressionTypeKind.None, ConversionsBase.GetCollectionExpressionTypeKind(comp, collectionType, out _));
+            Assert.Equal(CollectionExpressionTypeKind.None, GetCollectionExpressionTypeKind(comp, collectionType, out _));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
@@ -11171,7 +11171,7 @@ static class Program
             CompileAndVerify(new[] { source, s_collectionExtensions }, expectedOutput: "[], ");
         }
 
-        [Fact(Skip = "PROTOTYPE: implement binding")]
+        [Fact]
         public void DictionaryElement_02()
         {
             string source = """
@@ -11182,25 +11182,15 @@ static class Program
                     {
                         Dictionary<int, int> d;
                         d = [default];
+                        d.Report();
                         d = [new KeyValuePair<int, int>(1, 2)];
+                        d.Report();
                         d = [3:4];
+                        d.Report();
                     }
                 }
                 """;
-            var comp = CreateCompilation(source);
-            comp.VerifyEmitDiagnostics(
-                // (7,13): error CS9215: Collection expression type 'Dictionary<int, int>' must have an instance or extension method 'Add' that can be called with a single argument.
-                //         d = [default];
-                Diagnostic(ErrorCode.ERR_CollectionExpressionMissingAdd, "[default]").WithArguments("System.Collections.Generic.Dictionary<int, int>").WithLocation(7, 13),
-                // (8,13): error CS9215: Collection expression type 'Dictionary<int, int>' must have an instance or extension method 'Add' that can be called with a single argument.
-                //         d = [new KeyValuePair<int, int>(1, 2)];
-                Diagnostic(ErrorCode.ERR_CollectionExpressionMissingAdd, "[new KeyValuePair<int, int>(1, 2)]").WithArguments("System.Collections.Generic.Dictionary<int, int>").WithLocation(8, 13),
-                // (9,15): error CS1003: Syntax error, ',' expected
-                //         d = [3:4];
-                Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",").WithLocation(9, 15),
-                // (9,16): error CS1003: Syntax error, ',' expected
-                //         d = [3:4];
-                Diagnostic(ErrorCode.ERR_SyntaxError, "4").WithArguments(",").WithLocation(9, 16));
+            CompileAndVerify(new[] { source, s_collectionExtensions }, expectedOutput: "[[0, 0]], [[1, 2]], [[3, 4]], ");
         }
 
         [Theory]

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests.cs
@@ -29610,7 +29610,7 @@ partial class Program
                 }
                 """;
 
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular13);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular14);
             comp.VerifyEmitDiagnostics(
                 // (4,52): error CS9215: Collection expression type 'Dictionary<string, object>' must have an instance or extension method 'Add' that can be called with a single argument.
                 //     Dictionary<string, object> Config => /*<bind>*/[

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Extra.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Extra.cs
@@ -6994,12 +6994,13 @@ public sealed class CollectionExpressionTests_WithElement_Extra : CSharpTestBase
                 }
                 """;
         var comp = CreateCompilation(source);
-        // https://github.com/dotnet/roslyn/issues/81860
-        // Handle collection arguments in flow analysis: report CS8620 for 'with(c3)'.
         comp.VerifyEmitDiagnostics(
             // (17,45): warning CS8620: Argument of type 'IEqualityComparer<K>' cannot be used for parameter 'comparer' of type 'IEqualityComparer<K?>' in 'Dictionary<K?, V>.Dictionary(IEqualityComparer<K?> comparer)' due to differences in the nullability of reference types.
             //         if (b) return new Dictionary<K?, V>(c3);
-            Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "c3").WithArguments("System.Collections.Generic.IEqualityComparer<K>", "System.Collections.Generic.IEqualityComparer<K?>", "comparer", "Dictionary<K?, V>.Dictionary(IEqualityComparer<K?> comparer)").WithLocation(17, 45));
+            Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "c3").WithArguments("System.Collections.Generic.IEqualityComparer<K>", "System.Collections.Generic.IEqualityComparer<K?>", "comparer", "Dictionary<K?, V>.Dictionary(IEqualityComparer<K?> comparer)").WithLocation(17, 45),
+            // (18,22): warning CS8620: Argument of type 'IEqualityComparer<K>' cannot be used for parameter 'comparer' of type 'IEqualityComparer<K?>' in 'Dictionary<K?, V>.Dictionary(IEqualityComparer<K?> comparer)' due to differences in the nullability of reference types.
+            //         return [with(c3)];
+            Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "c3").WithArguments("System.Collections.Generic.IEqualityComparer<K>", "System.Collections.Generic.IEqualityComparer<K?>", "comparer", "Dictionary<K?, V>.Dictionary(IEqualityComparer<K?> comparer)").WithLocation(18, 22));
     }
 
     [Theory]
@@ -7176,12 +7177,12 @@ public sealed class CollectionExpressionTests_WithElement_Extra : CSharpTestBase
         else
         {
             comp.VerifyEmitDiagnostics(
-                // (11,22): error CS1503: Argument 1: cannot convert from 'int' to 'System.Collections.Generic.IEqualityComparer<K>?'
+                // (11,22): error CS1503: Argument 1: cannot convert from 'int' to 'System.Collections.Generic.IEqualityComparer<K>'
                 //         return [with(c), k:v, x];
-                Diagnostic(ErrorCode.ERR_BadArgType, "c").WithArguments("1", "int", "System.Collections.Generic.IEqualityComparer<K>?").WithLocation(11, 22),
-                // (15,22): error CS1739: The best overload for '<signature>' does not have a parameter named 'capacity'
+                Diagnostic(ErrorCode.ERR_BadArgType, "c").WithArguments("1", "int", "System.Collections.Generic.IEqualityComparer<K>").WithLocation(11, 22),
+                // (15,22): error CS1739: The best overload for 'Dictionary' does not have a parameter named 'capacity'
                 //         return [with(capacity: c), k:v, x];
-                Diagnostic(ErrorCode.ERR_BadNamedArgument, "capacity").WithArguments("<signature>", "capacity").WithLocation(15, 22));
+                Diagnostic(ErrorCode.ERR_BadNamedArgument, "capacity").WithArguments("Dictionary", "capacity").WithLocation(15, 22));
         }
 
         string sourceC = $$"""
@@ -7316,12 +7317,12 @@ public sealed class CollectionExpressionTests_WithElement_Extra : CSharpTestBase
         else
         {
             comp.VerifyEmitDiagnostics(
-                // (11,16): error CS1501: No overload for method '<signature>' takes 2 arguments
+                // (11,17): error CS1729: 'Dictionary<K, V>' does not contain a constructor that takes 2 arguments
                 //         return [with(c, e), k:v, x];
-                Diagnostic(ErrorCode.ERR_BadArgCount, "[with(c, e), k:v, x]").WithArguments("<signature>", "2").WithLocation(11, 16),
-                // (15,22): error CS1739: The best overload for '<signature>' does not have a parameter named 'capacity'
+                Diagnostic(ErrorCode.ERR_BadCtorArgCount, "with").WithArguments("System.Collections.Generic.Dictionary<K, V>", "2").WithLocation(11, 17),
+                // (15,22): error CS1739: The best overload for 'Dictionary' does not have a parameter named 'capacity'
                 //         return [with(capacity: c, comparer: e), k:v, x];
-                Diagnostic(ErrorCode.ERR_BadNamedArgument, "capacity").WithArguments("<signature>", "capacity").WithLocation(15, 22));
+                Diagnostic(ErrorCode.ERR_BadNamedArgument, "capacity").WithArguments("Dictionary", "capacity").WithLocation(15, 22));
         }
 
         string sourceE = $$"""
@@ -7340,12 +7341,12 @@ public sealed class CollectionExpressionTests_WithElement_Extra : CSharpTestBase
                 """;
         comp = CreateCompilation(sourceE);
         comp.VerifyEmitDiagnostics(
-            // (6,22): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>' to 'System.Collections.Generic.IEqualityComparer<K>?'
+            // (6,22): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>' to 'System.Collections.Generic.IEqualityComparer<K>'
             //         return [with(c), k:v];
-            Diagnostic(ErrorCode.ERR_BadArgType, "c").WithArguments("1", "System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>", "System.Collections.Generic.IEqualityComparer<K>?").WithLocation(6, 22),
-            // (10,22): error CS1739: The best overload for '<signature>' does not have a parameter named 'collection'
+            Diagnostic(ErrorCode.ERR_BadArgType, "c").WithArguments("1", "System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<K, V>>", "System.Collections.Generic.IEqualityComparer<K>").WithLocation(6, 22),
+            // (10,22): error CS1739: The best overload for 'Dictionary' does not have a parameter named 'collection'
             //         return [with(collection: c), k:v];
-            Diagnostic(ErrorCode.ERR_BadNamedArgument, "collection").WithArguments("<signature>", "collection").WithLocation(10, 22));
+            Diagnostic(ErrorCode.ERR_BadNamedArgument, "collection").WithArguments("Dictionary", "collection").WithLocation(10, 22));
     }
 
 
@@ -7381,15 +7382,18 @@ public sealed class CollectionExpressionTests_WithElement_Extra : CSharpTestBase
                     // (10,19): error CS1503: Argument 1: cannot convert from 'int' to 'System.Collections.Generic.IEqualityComparer<K>?'
                     //         c = [with(capacity)];
                     Diagnostic(ErrorCode.ERR_BadArgType, "capacity").WithArguments("1", "int", "System.Collections.Generic.IEqualityComparer<K>?").WithLocation(10, 19),
-                    // (12,13): error CS1501: No overload for method '<signature>' takes 2 arguments
+                    // (12,14): error CS1729: 'Dictionary<K, V>' does not contain a constructor that takes 2 arguments
                     //         c = [with(capacity, comparer)];
-                    Diagnostic(ErrorCode.ERR_BadArgCount, "[with(capacity, comparer)]").WithArguments("<signature>", "2").WithLocation(12, 13));
+                    Diagnostic(ErrorCode.ERR_BadCtorArgCount, "with").WithArguments("System.Collections.Generic.Dictionary<K, V>", "2").WithLocation(12, 14));
                 break;
             case "System.Collections.Generic.IDictionary<K, V>":
                 comp.VerifyEmitDiagnostics(
-                    // (9,13): error CS0121: The call is ambiguous between the following methods or properties: 'Program.<signature>(IEqualityComparer<K>?)' and 'Program.<signature>(int)'
+                    // (9,14): error CS0121: The call is ambiguous between the following methods or properties: 'System.Collections.Generic.Dictionary<K, V>.Dictionary(System.Collections.Generic.IEqualityComparer<K>?)' and 'System.Collections.Generic.Dictionary<K, V>.Dictionary(int)'
                     //         c = [with(default)];
-                    Diagnostic(ErrorCode.ERR_AmbigCall, "[with(default)]").WithArguments("Program.<signature>(System.Collections.Generic.IEqualityComparer<K>?)", "Program.<signature>(int)").WithLocation(9, 13));
+                    Diagnostic(ErrorCode.ERR_AmbigCall, "with").WithArguments("System.Collections.Generic.Dictionary<K, V>.Dictionary(System.Collections.Generic.IEqualityComparer<K>?)", "System.Collections.Generic.Dictionary<K, V>.Dictionary(int)").WithLocation(9, 14),
+                    // (9,19): error CS8716: There is no target type for the default literal.
+                    //         c = [with(default)];
+                    Diagnostic(ErrorCode.ERR_DefaultLiteralNoTargetType, "default").WithLocation(9, 19));
                 break;
             default:
                 throw ExceptionUtilities.UnexpectedValue(typeName);
@@ -7513,9 +7517,9 @@ public sealed class CollectionExpressionTests_WithElement_Extra : CSharpTestBase
         if (interfaceType == "IReadOnlyDictionary")
         {
             comp.VerifyDiagnostics(
-                // (10,16): error CS1501: No overload for method '<signature>' takes 2 arguments
+                // (10,17): error CS1729: 'Dictionary<K, V>' does not contain a constructor that takes 2 arguments
                 //         return [with(1, c), e];
-                Diagnostic(ErrorCode.ERR_BadArgCount, "[with(1, c), e]").WithArguments("<signature>", "2").WithLocation(10, 16));
+                Diagnostic(ErrorCode.ERR_BadCtorArgCount, "with").WithArguments("System.Collections.Generic.Dictionary<K, V>", "2").WithLocation(10, 17));
         }
         else
         {
@@ -7606,15 +7610,12 @@ public sealed class CollectionExpressionTests_WithElement_Extra : CSharpTestBase
                         // (7,13): error CS0656: Missing compiler required member 'System.Collections.Generic.List`1..ctor'
                         //         c = [];
                         Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.List`1", ".ctor").WithLocation(7, 13),
-                        // (7,13): error CS7036: There is no argument given that corresponds to the required parameter 'capacity' of 'Program.<signature>(int)'
-                        //         c = [];
-                        Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "[]").WithArguments("capacity", "Program.<signature>(int)").WithLocation(7, 13),
                         // (8,13): error CS0656: Missing compiler required member 'System.Collections.Generic.List`1..ctor'
                         //         c = [with()];
                         Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with()]").WithArguments("System.Collections.Generic.List`1", ".ctor").WithLocation(8, 13),
-                        // (8,13): error CS7036: There is no argument given that corresponds to the required parameter 'capacity' of 'Program.<signature>(int)'
+                        // (8,14): error CS7036: There is no argument given that corresponds to the required parameter 'capacity' of 'List<int>.List(int)'
                         //         c = [with()];
-                        Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "[with()]").WithArguments("capacity", "Program.<signature>(int)").WithLocation(8, 13),
+                        Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "with").WithArguments("capacity", "System.Collections.Generic.List<int>.List(int)").WithLocation(8, 14),
                         // (9,13): error CS0656: Missing compiler required member 'System.Collections.Generic.List`1..ctor'
                         //         c = [with(i)];
                         Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i)]").WithArguments("System.Collections.Generic.List`1", ".ctor").WithLocation(9, 13));
@@ -7630,9 +7631,9 @@ public sealed class CollectionExpressionTests_WithElement_Extra : CSharpTestBase
                         // (9,13): error CS0656: Missing compiler required member 'System.Collections.Generic.List`1..ctor'
                         //         c = [with(i)];
                         Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i)]").WithArguments("System.Collections.Generic.List`1", ".ctor").WithLocation(9, 13),
-                        // (9,13): error CS1501: No overload for method '<signature>' takes 1 arguments
+                        // (9,14): error CS1729: 'List<int>' does not contain a constructor that takes 1 arguments
                         //         c = [with(i)];
-                        Diagnostic(ErrorCode.ERR_BadArgCount, "[with(i)]").WithArguments("<signature>", "1").WithLocation(9, 13));
+                        Diagnostic(ErrorCode.ERR_BadCtorArgCount, "with").WithArguments("System.Collections.Generic.List<int>", "1").WithLocation(9, 14));
                     break;
                 default:
                     comp.VerifyEmitDiagnostics();
@@ -7644,6 +7645,7 @@ public sealed class CollectionExpressionTests_WithElement_Extra : CSharpTestBase
             switch ((WellKnownMember)missingMember)
             {
                 case WellKnownMember.System_Collections_Generic_List_T__ctor:
+                case WellKnownMember.System_Collections_Generic_List_T__ctorInt32:
                     comp.VerifyEmitDiagnostics(
                         // (7,13): error CS0656: Missing compiler required member 'System.Collections.Generic.List`1..ctor'
                         //         c = [];
@@ -7653,13 +7655,16 @@ public sealed class CollectionExpressionTests_WithElement_Extra : CSharpTestBase
                         Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with()]").WithArguments("System.Collections.Generic.List`1", ".ctor").WithLocation(8, 13),
                         // (9,13): error CS0656: Missing compiler required member 'System.Collections.Generic.List`1..ctor'
                         //         c = [with(i)];
-                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i)]").WithArguments("System.Collections.Generic.List`1", ".ctor").WithLocation(9, 13));
+                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i)]").WithArguments("System.Collections.Generic.List`1", ".ctor").WithLocation(9, 13),
+                        // (9,14): error CS9357: 'with(...)' element for a read-only interface must be empty if present
+                        //         c = [with(i)];
+                        Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeEmpty, "with").WithLocation(9, 14));
                     break;
                 default:
                     comp.VerifyEmitDiagnostics(
-                        // (9,13): error CS1501: No overload for method '<signature>' takes 1 arguments
+                        // (9,14): error CS9357: 'with(...)' element for a read-only interface must be empty if present
                         //         c = [with(i)];
-                        Diagnostic(ErrorCode.ERR_BadArgCount, "[with(i)]").WithArguments("<signature>", "1").WithLocation(9, 13));
+                        Diagnostic(ErrorCode.ERR_CollectionArgumentsMustBeEmpty, "with").WithLocation(9, 14));
                     break;
             }
         }
@@ -7708,36 +7713,21 @@ public sealed class CollectionExpressionTests_WithElement_Extra : CSharpTestBase
                         // (7,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
                         //         c = [];
                         Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(7, 13),
-                        // (7,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        // (7,13): error CS1729: 'Dictionary<int, string>' does not contain a constructor that takes 0 arguments
                         //         c = [];
-                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(7, 13),
-                        // (7,13): error CS1501: No overload for method '<signature>' takes 0 arguments
-                        //         c = [];
-                        Diagnostic(ErrorCode.ERR_BadArgCount, "[]").WithArguments("<signature>", "0").WithLocation(7, 13),
+                        Diagnostic(ErrorCode.ERR_BadCtorArgCount, "[").WithArguments("System.Collections.Generic.Dictionary<int, string>", "0").WithLocation(7, 13),
                         // (8,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
                         //         c = [with()];
                         Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with()]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(8, 13),
-                        // (8,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        // (8,14): error CS1729: 'Dictionary<int, string>' does not contain a constructor that takes 0 arguments
                         //         c = [with()];
-                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with()]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(8, 13),
-                        // (8,13): error CS1501: No overload for method '<signature>' takes 0 arguments
-                        //         c = [with()];
-                        Diagnostic(ErrorCode.ERR_BadArgCount, "[with()]").WithArguments("<signature>", "0").WithLocation(8, 13),
-                        // (9,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
-                        //         c = [with(i)];
-                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(9, 13),
+                        Diagnostic(ErrorCode.ERR_BadCtorArgCount, "with").WithArguments("System.Collections.Generic.Dictionary<int, string>", "0").WithLocation(8, 14),
                         // (9,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
                         //         c = [with(i)];
                         Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(9, 13),
                         // (10,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
                         //         c = [with(e)];
                         Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(e)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(10, 13),
-                        // (10,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
-                        //         c = [with(e)];
-                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(e)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(10, 13),
-                        // (11,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
-                        //         c = [with(i, e)];
-                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i, e)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(11, 13),
                         // (11,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
                         //         c = [with(i, e)];
                         Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i, e)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(11, 13));
@@ -7774,9 +7764,9 @@ public sealed class CollectionExpressionTests_WithElement_Extra : CSharpTestBase
                         // (9,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
                         //         c = [with(i)];
                         Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(9, 13),
-                        // (9,19): error CS1503: Argument 1: cannot convert from 'int' to 'System.Collections.Generic.IEqualityComparer<int>?'
+                        // (9,19): error CS1503: Argument 1: cannot convert from 'int' to 'System.Collections.Generic.IEqualityComparer<int>'
                         //         c = [with(i)];
-                        Diagnostic(ErrorCode.ERR_BadArgType, "i").WithArguments("1", "int", "System.Collections.Generic.IEqualityComparer<int>?").WithLocation(9, 19),
+                        Diagnostic(ErrorCode.ERR_BadArgType, "i").WithArguments("1", "int", "System.Collections.Generic.IEqualityComparer<int>").WithLocation(9, 19),
                         // (10,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
                         //         c = [with(e)];
                         Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(e)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(10, 13),
@@ -7801,9 +7791,9 @@ public sealed class CollectionExpressionTests_WithElement_Extra : CSharpTestBase
                         // (11,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
                         //         c = [with(i, e)];
                         Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i, e)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(11, 13),
-                        // (11,13): error CS1501: No overload for method '<signature>' takes 2 arguments
+                        // (11,14): error CS1729: 'Dictionary<int, string>' does not contain a constructor that takes 2 arguments
                         //         c = [with(i, e)];
-                        Diagnostic(ErrorCode.ERR_BadArgCount, "[with(i, e)]").WithArguments("<signature>", "2").WithLocation(11, 13));
+                        Diagnostic(ErrorCode.ERR_BadCtorArgCount, "with").WithArguments("System.Collections.Generic.Dictionary<int, string>", "2").WithLocation(11, 14));
                     break;
                 default:
                     comp.VerifyEmitDiagnostics();
@@ -7819,45 +7809,30 @@ public sealed class CollectionExpressionTests_WithElement_Extra : CSharpTestBase
                         // (7,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
                         //         c = [];
                         Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(7, 13),
-                        // (7,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        // (7,13): error CS7036: There is no argument given that corresponds to the required parameter 'comparer' of 'Dictionary<int, string>.Dictionary(IEqualityComparer<int>)'
                         //         c = [];
-                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(7, 13),
-                        // (7,13): error CS7036: There is no argument given that corresponds to the required parameter 'comparer' of 'Program.<signature>(IEqualityComparer<int>?)'
-                        //         c = [];
-                        Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "[]").WithArguments("comparer", "Program.<signature>(System.Collections.Generic.IEqualityComparer<int>?)").WithLocation(7, 13),
+                        Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "[").WithArguments("comparer", "System.Collections.Generic.Dictionary<int, string>.Dictionary(System.Collections.Generic.IEqualityComparer<int>)").WithLocation(7, 13),
                         // (8,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
                         //         c = [with()];
                         Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with()]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(8, 13),
-                        // (8,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        // (8,14): error CS7036: There is no argument given that corresponds to the required parameter 'comparer' of 'Dictionary<int, string>.Dictionary(IEqualityComparer<int>)'
                         //         c = [with()];
-                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with()]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(8, 13),
-                        // (8,13): error CS7036: There is no argument given that corresponds to the required parameter 'comparer' of 'Program.<signature>(IEqualityComparer<int>?)'
-                        //         c = [with()];
-                        Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "[with()]").WithArguments("comparer", "Program.<signature>(System.Collections.Generic.IEqualityComparer<int>?)").WithLocation(8, 13),
+                        Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "with").WithArguments("comparer", "System.Collections.Generic.Dictionary<int, string>.Dictionary(System.Collections.Generic.IEqualityComparer<int>)").WithLocation(8, 14),
                         // (9,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
                         //         c = [with(i)];
                         Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(9, 13),
-                        // (9,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        // (9,19): error CS1503: Argument 1: cannot convert from 'int' to 'System.Collections.Generic.IEqualityComparer<int>'
                         //         c = [with(i)];
-                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(9, 13),
-                        // (9,19): error CS1503: Argument 1: cannot convert from 'int' to 'System.Collections.Generic.IEqualityComparer<int>?'
-                        //         c = [with(i)];
-                        Diagnostic(ErrorCode.ERR_BadArgType, "i").WithArguments("1", "int", "System.Collections.Generic.IEqualityComparer<int>?").WithLocation(9, 19),
-                        // (10,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
-                        //         c = [with(e)];
-                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(e)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(10, 13),
+                        Diagnostic(ErrorCode.ERR_BadArgType, "i").WithArguments("1", "int", "System.Collections.Generic.IEqualityComparer<int>").WithLocation(9, 19),
                         // (10,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
                         //         c = [with(e)];
                         Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(e)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(10, 13),
                         // (11,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
                         //         c = [with(i, e)];
                         Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i, e)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(11, 13),
-                        // (11,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
+                        // (11,14): error CS1729: 'Dictionary<int, string>' does not contain a constructor that takes 2 arguments
                         //         c = [with(i, e)];
-                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i, e)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(11, 13),
-                        // (11,13): error CS1501: No overload for method '<signature>' takes 2 arguments
-                        //         c = [with(i, e)];
-                        Diagnostic(ErrorCode.ERR_BadArgCount, "[with(i, e)]").WithArguments("<signature>", "2").WithLocation(11, 13));
+                        Diagnostic(ErrorCode.ERR_BadCtorArgCount, "with").WithArguments("System.Collections.Generic.Dictionary<int, string>", "2").WithLocation(11, 14));
                     break;
                 case WellKnownMember.System_Collections_Generic_Dictionary_KV__ctor_IEqualityComparer_K:
                     comp.VerifyEmitDiagnostics(
@@ -7870,30 +7845,30 @@ public sealed class CollectionExpressionTests_WithElement_Extra : CSharpTestBase
                         // (9,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
                         //         c = [with(i)];
                         Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(9, 13),
-                        // (9,13): error CS1501: No overload for method '<signature>' takes 1 arguments
+                        // (9,14): error CS1729: 'Dictionary<int, string>' does not contain a constructor that takes 1 arguments
                         //         c = [with(i)];
-                        Diagnostic(ErrorCode.ERR_BadArgCount, "[with(i)]").WithArguments("<signature>", "1").WithLocation(9, 13),
+                        Diagnostic(ErrorCode.ERR_BadCtorArgCount, "with").WithArguments("System.Collections.Generic.Dictionary<int, string>", "1").WithLocation(9, 14),
                         // (10,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
                         //         c = [with(e)];
                         Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(e)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(10, 13),
-                        // (10,13): error CS1501: No overload for method '<signature>' takes 1 arguments
+                        // (10,14): error CS1729: 'Dictionary<int, string>' does not contain a constructor that takes 1 arguments
                         //         c = [with(e)];
-                        Diagnostic(ErrorCode.ERR_BadArgCount, "[with(e)]").WithArguments("<signature>", "1").WithLocation(10, 13),
+                        Diagnostic(ErrorCode.ERR_BadCtorArgCount, "with").WithArguments("System.Collections.Generic.Dictionary<int, string>", "1").WithLocation(10, 14),
                         // (11,13): error CS0656: Missing compiler required member 'System.Collections.Generic.Dictionary`2..ctor'
                         //         c = [with(i, e)];
                         Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[with(i, e)]").WithArguments("System.Collections.Generic.Dictionary`2", ".ctor").WithLocation(11, 13),
-                        // (11,13): error CS1501: No overload for method '<signature>' takes 2 arguments
+                        // (11,14): error CS1729: 'Dictionary<int, string>' does not contain a constructor that takes 2 arguments
                         //         c = [with(i, e)];
-                        Diagnostic(ErrorCode.ERR_BadArgCount, "[with(i, e)]").WithArguments("<signature>", "2").WithLocation(11, 13));
+                        Diagnostic(ErrorCode.ERR_BadCtorArgCount, "with").WithArguments("System.Collections.Generic.Dictionary<int, string>", "2").WithLocation(11, 14));
                     break;
                 default:
                     comp.VerifyEmitDiagnostics(
-                        // (9,19): error CS1503: Argument 1: cannot convert from 'int' to 'System.Collections.Generic.IEqualityComparer<int>?'
+                        // (9,19): error CS1503: Argument 1: cannot convert from 'int' to 'System.Collections.Generic.IEqualityComparer<int>'
                         //         c = [with(i)];
-                        Diagnostic(ErrorCode.ERR_BadArgType, "i").WithArguments("1", "int", "System.Collections.Generic.IEqualityComparer<int>?").WithLocation(9, 19),
-                        // (11,13): error CS1501: No overload for method '<signature>' takes 2 arguments
+                        Diagnostic(ErrorCode.ERR_BadArgType, "i").WithArguments("1", "int", "System.Collections.Generic.IEqualityComparer<int>").WithLocation(9, 19),
+                        // (11,14): error CS1729: 'Dictionary<int, string>' does not contain a constructor that takes 2 arguments
                         //         c = [with(i, e)];
-                        Diagnostic(ErrorCode.ERR_BadArgCount, "[with(i, e)]").WithArguments("<signature>", "2").WithLocation(11, 13));
+                        Diagnostic(ErrorCode.ERR_BadCtorArgCount, "with").WithArguments("System.Collections.Generic.Dictionary<int, string>", "2").WithLocation(11, 14));
                     break;
             }
         }

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Extra.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Extra.cs
@@ -7349,7 +7349,6 @@ public sealed class CollectionExpressionTests_WithElement_Extra : CSharpTestBase
             Diagnostic(ErrorCode.ERR_BadNamedArgument, "collection").WithArguments("Dictionary", "collection").WithLocation(10, 22));
     }
 
-
     [Theory]
     [CombinatorialData]
     public void CollectionArguments_CapacityAndComparer_02(

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Extra.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/CollectionExpressionTests_WithElement_Extra.cs
@@ -6815,8 +6815,6 @@ public sealed class CollectionExpressionTests_WithElement_Extra : CSharpTestBase
             Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Identity").WithArguments("Program.Identity<T>(MyCollection<T>)").WithLocation(6, 9));
     }
 
-#if DICTIONARY_EXPRESSIONS
-
     [Fact]
     public void InterfaceTarget_ReorderedArguments()
     {
@@ -6974,7 +6972,7 @@ public sealed class CollectionExpressionTests_WithElement_Extra : CSharpTestBase
         [CombinatorialValues("IDictionary", "IReadOnlyDictionary")] string typeName)
     {
         string source = $$"""
-#nullable enable
+                #nullable enable
                 using System.Collections.Generic;
                 class Program
                 {
@@ -7900,7 +7898,6 @@ public sealed class CollectionExpressionTests_WithElement_Extra : CSharpTestBase
             }
         }
     }
-#endif
 
     [Theory]
     [CombinatorialData]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -4760,27 +4760,27 @@ class X : List<int>
                     // (8,16): error CS9203: A collection expression of type 'R' cannot be used in this context because it may be exposed outside of the current scope.
                     //         return [local, .. arr];
                     Diagnostic(ErrorCode.ERR_CollectionExpressionEscape, "[local, .. arr]").WithArguments("R").WithLocation(8, 16),
-                    // (8,24): error CS8156: An expression cannot be used in this context because it may not be passed or returned by reference
-                    //         return [local, .. arr];
-                    Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, ".. arr").WithLocation(8, 24),
                     // (8,24): error CS8350: This combination of arguments to 'R.Add(in int)' is disallowed because it may expose variables referenced by parameter 'x' outside of their declaration scope
                     //         return [local, .. arr];
                     Diagnostic(ErrorCode.ERR_CallArgMixing, ".. arr").WithArguments("R.Add(in int)", "x").WithLocation(8, 24),
+                    // (8,27): error CS8156: An expression cannot be used in this context because it may not be passed or returned by reference
+                    //         return [local, .. arr];
+                    Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "arr").WithLocation(8, 27),
                     // (13,16): error CS9203: A collection expression of type 'R' cannot be used in this context because it may be exposed outside of the current scope.
                     //         return [.. arr];
                     Diagnostic(ErrorCode.ERR_CollectionExpressionEscape, "[.. arr]").WithArguments("R").WithLocation(13, 16),
-                    // (13,17): error CS8156: An expression cannot be used in this context because it may not be passed or returned by reference
-                    //         return [.. arr];
-                    Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, ".. arr").WithLocation(13, 17),
                     // (13,17): error CS8350: This combination of arguments to 'R.Add(in int)' is disallowed because it may expose variables referenced by parameter 'x' outside of their declaration scope
                     //         return [.. arr];
                     Diagnostic(ErrorCode.ERR_CallArgMixing, ".. arr").WithArguments("R.Add(in int)", "x").WithLocation(13, 17),
-                    // (18,16): error CS8156: An expression cannot be used in this context because it may not be passed or returned by reference
-                    //         R r = [.. arr];
-                    Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, ".. arr").WithLocation(18, 16),
+                    // (13,20): error CS8156: An expression cannot be used in this context because it may not be passed or returned by reference
+                    //         return [.. arr];
+                    Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "arr").WithLocation(13, 20),
                     // (18,16): error CS8350: This combination of arguments to 'R.Add(in int)' is disallowed because it may expose variables referenced by parameter 'x' outside of their declaration scope
                     //         R r = [.. arr];
                     Diagnostic(ErrorCode.ERR_CallArgMixing, ".. arr").WithArguments("R.Add(in int)", "x").WithLocation(18, 16),
+                    // (18,19): error CS8156: An expression cannot be used in this context because it may not be passed or returned by reference
+                    //         R r = [.. arr];
+                    Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "arr").WithLocation(18, 19),
                 ]);
         }
 
@@ -4847,12 +4847,12 @@ class X : List<int>
                 }
                 """;
             CreateCompilation(source, targetFramework: TargetFramework.Net100).VerifyDiagnostics(
-                // (41,32): error CS8352: Cannot use variable '..source' in this context because it may expose referenced variables outside of their declaration scope
-                //         MyCollection result = [..source]; // 1
-                Diagnostic(ErrorCode.ERR_EscapeVariable, "..source").WithArguments("..source").WithLocation(41, 32),
                 // (41,32): error CS8350: This combination of arguments to 'MyCollection.Add(Span<int>)' is disallowed because it may expose variables referenced by parameter 'item' outside of their declaration scope
                 //         MyCollection result = [..source]; // 1
                 Diagnostic(ErrorCode.ERR_CallArgMixing, "..source").WithArguments("MyCollection.Add(System.Span<int>)", "item").WithLocation(41, 32),
+                // (41,34): error CS8352: Cannot use variable 'source' in this context because it may expose referenced variables outside of their declaration scope
+                //         MyCollection result = [..source]; // 1
+                Diagnostic(ErrorCode.ERR_EscapeVariable, "source").WithArguments("source").WithLocation(41, 34),
                 // (42,16): error CS8352: Cannot use variable 'result' in this context because it may expose referenced variables outside of their declaration scope
                 //         return result; // 2
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "result").WithArguments("result").WithLocation(42, 16));
@@ -6233,12 +6233,12 @@ class X : List<int>
                     // (8,26): error CS8350: This combination of arguments to 'R.R(ref Span<int>)' is disallowed because it may expose variables referenced by parameter 'a' outside of their declaration scope
                     //         return [with(ref heapSpan), .. arr];
                     Diagnostic(ErrorCode.ERR_CallArgMixing, "heapSpan").WithArguments("R.R(ref System.Span<int>)", "a").WithLocation(8, 26),
-                    // (8,37): error CS8156: An expression cannot be used in this context because it may not be passed or returned by reference
-                    //         return [with(ref heapSpan), .. arr];
-                    Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, ".. arr").WithLocation(8, 37),
                     // (8,37): error CS8350: This combination of arguments to 'R.Add(in int)' is disallowed because it may expose variables referenced by parameter 'i' outside of their declaration scope
                     //         return [with(ref heapSpan), .. arr];
                     Diagnostic(ErrorCode.ERR_CallArgMixing, ".. arr").WithArguments("R.Add(in int)", "i").WithLocation(8, 37),
+                    // (8,40): error CS8156: An expression cannot be used in this context because it may not be passed or returned by reference
+                    //         return [with(ref heapSpan), .. arr];
+                    Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "arr").WithLocation(8, 40),
                 ]);
         }
 

--- a/src/Compilers/Core/Portable/MemberDescriptor.cs
+++ b/src/Compilers/Core/Portable/MemberDescriptor.cs
@@ -19,13 +19,14 @@ namespace Microsoft.CodeAnalysis.RuntimeMembers
         Field = 0x02,
         Constructor = 0x04,
         PropertyGet = 0x08,
-        Property = 0x10,
+        PropertySet = 0x10,
+        Property = 0x20,
         // END Mutually exclusive Member kinds
 
-        KindMask = 0x1F,
+        KindMask = 0x3F,
 
-        Static = 0x20,
-        Virtual = 0x40, // Virtual in CLR terms, i.e. sealed should be accepted.
+        Static = 0x40,
+        Virtual = 0x80, // Virtual in CLR terms, i.e. sealed should be accepted.
     }
 
     /// <summary>

--- a/src/Compilers/Core/Portable/MemberDescriptor.cs
+++ b/src/Compilers/Core/Portable/MemberDescriptor.cs
@@ -107,6 +107,7 @@ namespace Microsoft.CodeAnalysis.RuntimeMembers
                     case MemberFlags.Constructor:
                     case MemberFlags.Method:
                     case MemberFlags.PropertyGet:
+                    case MemberFlags.PropertySet:
                     case MemberFlags.Property:
                         return Signature[0];
                     default:

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -732,6 +732,16 @@ namespace Microsoft.CodeAnalysis
 
         System_Runtime_CompilerServices_UnionAttribute__ctor,
 
+        System_Collections_Generic_Dictionary_KV__ctor,
+        System_Collections_Generic_Dictionary_KV__ctor_IEqualityComparer_K,
+        System_Collections_Generic_Dictionary_KV__ctor_Int32,
+        System_Collections_Generic_Dictionary_KV__ctor_Int32_IEqualityComparer_K,
+        System_Collections_Generic_Dictionary_KV__set_Item,
+        System_Collections_Generic_KeyValuePair_KV__ctor,
+        System_Collections_Generic_KeyValuePair_KV__get_Key,
+        System_Collections_Generic_KeyValuePair_KV__get_Value,
+        System_Collections_ObjectModel_ReadOnlyDictionary_KV__ctor,
+
         Count,
 
         // Remember to update the AllWellKnownTypeMembers tests when making changes here

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -5302,6 +5302,88 @@ namespace Microsoft.CodeAnalysis
                 0,                                                                                                          // Arity
                     0,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,                                      // Return Type
+
+                // System_Collections_Generic_Dictionary_KV__ctor
+                (byte)MemberFlags.Constructor,                                                                              // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Collections_Generic_Dictionary_KV - WellKnownType.ExtSentinel),  // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    0,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
+
+                // System_Collections_Generic_Dictionary_KV__ctor_IEqualityComparer_K
+                (byte)MemberFlags.Constructor,                                                                              // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Collections_Generic_Dictionary_KV - WellKnownType.ExtSentinel),  // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    1,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
+                    (byte)SignatureTypeCode.GenericTypeInstance,
+                        (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Collections_Generic_IEqualityComparer_T - WellKnownType.ExtSentinel),
+                        1,
+                        (byte)SignatureTypeCode.GenericTypeParameter, 0,
+
+                // System_Collections_Generic_Dictionary_KV__ctor_Int32
+                (byte)MemberFlags.Constructor,                                                                              // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Collections_Generic_Dictionary_KV - WellKnownType.ExtSentinel),  // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    1,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
+
+                // System_Collections_Generic_Dictionary_KV__ctor_Int32_IEqualityComparer_K
+                (byte)MemberFlags.Constructor,                                                                              // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Collections_Generic_Dictionary_KV - WellKnownType.ExtSentinel),  // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    2,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
+                    (byte)SignatureTypeCode.GenericTypeInstance,
+                        (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Collections_Generic_IEqualityComparer_T - WellKnownType.ExtSentinel),
+                        1,
+                        (byte)SignatureTypeCode.GenericTypeParameter, 0,
+
+                // System_Collections_Generic_Dictionary_KV__set_Item
+                (byte)MemberFlags.PropertySet,                                                                              // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Collections_Generic_Dictionary_KV - WellKnownType.ExtSentinel),  // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    2,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
+                    (byte)SignatureTypeCode.GenericTypeParameter, 0,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 1,
+
+                // System_Collections_Generic_KeyValuePair_KV__ctor
+                (byte)MemberFlags.Constructor,                                                                              // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Collections_Generic_KeyValuePair_KV - WellKnownType.ExtSentinel),  // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    2,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 0,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 1,
+
+                // System_Collections_Generic_KeyValuePair_KV__get_Key
+                (byte)MemberFlags.PropertyGet,                                                                              // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Collections_Generic_KeyValuePair_KV - WellKnownType.ExtSentinel),  // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    0,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.GenericTypeParameter, 0, // Return Type
+
+                // System_Collections_Generic_KeyValuePair_KV__get_Value
+                (byte)MemberFlags.PropertyGet,                                                                              // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Collections_Generic_KeyValuePair_KV - WellKnownType.ExtSentinel),  // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    0,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.GenericTypeParameter, 1, // Return Type
+
+                // System_Collections_ObjectModel_ReadOnlyDictionary_KV__ctor
+                (byte)MemberFlags.Constructor,                                                                              // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Collections_ObjectModel_ReadOnlyDictionary_KV - WellKnownType.ExtSentinel),  // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    1,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
+                    (byte)SignatureTypeCode.GenericTypeInstance,
+                        (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Collections_Generic_IDictionary_KV,
+                        2,
+                        (byte)SignatureTypeCode.GenericTypeParameter, 0,
+                        (byte)SignatureTypeCode.GenericTypeParameter, 1,
             };
 
             string[] allNames = new string[(int)WellKnownMember.Count]
@@ -5940,6 +6022,16 @@ namespace Microsoft.CodeAnalysis
                 "Slice",                                    // System_ReadOnlyMemory_T__Slice_Int
 
                 ".ctor",                                    // System_Runtime_CompilerServices_UnionAttribute__ctor
+
+                ".ctor",                                    // System_Collections_Generic_Dictionary_KV__ctor,
+                ".ctor",                                    // System_Collections_Generic_Dictionary_KV__ctor_IEqualityComparer_K,
+                ".ctor",                                    // System_Collections_Generic_Dictionary_KV__ctor_Int32,
+                ".ctor",                                    // System_Collections_Generic_Dictionary_KV__ctor_Int32_IEqualityComparer_K,
+                "set_Item",                                 // System_Collections_Generic_Dictionary_KV__set_Item
+                ".ctor",                                    // System_Collections_Generic_KeyValuePair_KV__ctor,
+                "get_Key",                                  // System_Collections_Generic_KeyValuePair_KV__get_Key
+                "get_Value",                                // System_Collections_Generic_KeyValuePair_KV__get_Value
+                ".ctor",                                    // System_Collections_ObjectModel_ReadOnlyDictionary_KV__ctor
             };
 
             s_descriptors = MemberDescriptor.InitializeFromStream(new System.IO.MemoryStream(initializationBytes, writable: false), allNames);

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -361,6 +361,10 @@ namespace Microsoft.CodeAnalysis
 
         System_Text_Encoding,
 
+        System_Collections_Generic_Dictionary_KV,
+        System_Collections_Generic_KeyValuePair_KV,
+        System_Collections_ObjectModel_ReadOnlyDictionary_KV,
+
         // The InlineArray types must be sequential, as we do arithmetic on them.
         System_Runtime_CompilerServices_InlineArray2,
         System_Runtime_CompilerServices_InlineArray3,
@@ -732,6 +736,10 @@ namespace Microsoft.CodeAnalysis
             "System.Linq.Expressions.DefaultExpression",
 
             "System.Text.Encoding",
+
+            "System.Collections.Generic.Dictionary`2",
+            "System.Collections.Generic.KeyValuePair`2",
+            "System.Collections.ObjectModel.ReadOnlyDictionary`2",
 
             "System.Runtime.CompilerServices.InlineArray2`1",
             "System.Runtime.CompilerServices.InlineArray3`1",

--- a/src/Compilers/VisualBasic/Portable/Symbols/WellKnownMembers.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/WellKnownMembers.vb
@@ -442,6 +442,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     targetSymbolKind = SymbolKind.Method
                     targetMethodKind = MethodKind.PropertyGet
 
+                Case MemberFlags.PropertySet
+                    targetSymbolKind = SymbolKind.Method
+                    targetMethodKind = MethodKind.PropertySet
+
                 Case MemberFlags.Field
                     targetSymbolKind = SymbolKind.Field
 


### PR DESCRIPTION
Ports dictionary expression binding from `features/dictionary-expressions-old`. A few major adaptations had to be made, including changing how overload resolution works (the old branch had a signature-only method symbol that was ditched in the final version of collection expression arguments) and the shape of the bound tree changing from the old branch. If you would find it useful, you can find the diff of the old branch vs its merge-base with `main` [here](https://github.com/333fred/roslyn/tree/dictionary-expressions-patches/patches), broken into patches for each file.

Relates to test plan https://github.com/dotnet/roslyn/issues/81860

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83983)