### PR TITLE
Use MEF services in VS Code cohost tests

### DIFF
--- a/src/Razor/src/Razor/test/Microsoft.VisualStudioCode.RazorExtension.UnitTests/CohostEndpointTestBase.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudioCode.RazorExtension.UnitTests/CohostEndpointTestBase.cs
@@ -39,13 +39,13 @@ public abstract class CohostEndpointTestBase(ITestOutputHelper testOutputHelper)
 
         InProcServiceFactory.TestAccessor.SetExportProvider(OOPExportProvider);
 
-        var workspaceProvider = new VSCodeWorkspaceProvider();
+        // Make sure we've hooked up our workspace to the workspace provider
+        var workspaceProvider = LocalExportProvider.GetExportedValue<VSCodeWorkspaceProvider>();
         workspaceProvider.SetWorkspace(LocalWorkspace);
 
-        _remoteServiceInvoker = new VSCodeRemoteServiceInvoker(workspaceProvider, LoggerFactory);
-        AddDisposable(_remoteServiceInvoker);
-
-        _filePathService = new VSCodeFilePathService();
+        // Grab a few things from the local MEF composition, for convenience
+        _remoteServiceInvoker = (VSCodeRemoteServiceInvoker)LocalExportProvider.GetExportedValue<IRemoteServiceInvoker>();
+        _filePathService = (VSCodeFilePathService)LocalExportProvider.GetExportedValue<IFilePathService>();
 
         _semanticTokensLegendService = new CohostSemanticTokensLegendService(new TestClientCapabilitiesService(new VSInternalClientCapabilities() { SupportsVisualStudioExtensions = false }));
     }

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudioCode.RazorExtension.UnitTests/CohostEndpointTestBase.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudioCode.RazorExtension.UnitTests/CohostEndpointTestBase.cs
@@ -13,7 +13,6 @@ using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.CodeAnalysis.Razor.SemanticTokens;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Settings;
-using Microsoft.CodeAnalysis.Remote.Razor;
 using Microsoft.VisualStudioCode.RazorExtension.Configuration;
 using Microsoft.VisualStudioCode.RazorExtension.Services;
 using Xunit.Abstractions;
@@ -22,7 +21,7 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 
 public abstract class CohostEndpointTestBase(ITestOutputHelper testOutputHelper) : CohostTestBase(testOutputHelper)
 {
-    private VSCodeRemoteServiceInvoker? _remoteServiceInvoker;
+    private IRemoteServiceInvoker? _remoteServiceInvoker;
     private IFilePathService? _filePathService;
     private ISemanticTokensLegendService? _semanticTokensLegendService;
 
@@ -44,8 +43,8 @@ public abstract class CohostEndpointTestBase(ITestOutputHelper testOutputHelper)
         workspaceProvider.SetWorkspace(LocalWorkspace);
 
         // Grab a few things from the local MEF composition, for convenience
-        _remoteServiceInvoker = (VSCodeRemoteServiceInvoker)LocalExportProvider.GetExportedValue<IRemoteServiceInvoker>();
-        _filePathService = (VSCodeFilePathService)LocalExportProvider.GetExportedValue<IFilePathService>();
+        _remoteServiceInvoker = LocalExportProvider.GetExportedValue<IRemoteServiceInvoker>();
+        _filePathService = LocalExportProvider.GetExportedValue<IFilePathService>();
 
         _semanticTokensLegendService = new CohostSemanticTokensLegendService(new TestClientCapabilitiesService(new VSInternalClientCapabilities() { SupportsVisualStudioExtensions = false }));
     }


### PR DESCRIPTION
Follow up to https://github.com/dotnet/roslyn/pull/83971 to further bolster the VS Code tests, after a copilot code review comment on that PR found an inconsistency.

Essentially, since the VS Code tests use the real product services for the most part, and not test equivalents, and now that all of our types are in the local MEF composition, we can use the "real" MEF instances instead of manually constructing our own. This makes for better test foundation in future, even if none of the current tests run into issues. eg, in the VS Code side the tests could all be changed to stop manually constructing the endpoints, and just use MEF, or potentially even a real LSP request to a server.

That's a future time if/when we get rid of the shared projects though.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83986)