### PR TITLE
Avoid TaskCompletionSource allocation on main-thread fast path in TaggerMainThreadManager

### DIFF
--- a/src/EditorFeatures/Core/Tagging/TaggerMainThreadManager.cs
+++ b/src/EditorFeatures/Core/Tagging/TaggerMainThreadManager.cs
@@ -69,30 +69,66 @@ internal sealed class TaggerMainThreadManager
     /// Adds the provided action to a queue that will run on the UI thread in the near future (batched with other
     /// registered actions).  If the cancellation token is triggered before the action runs, it will not be run.
     /// </summary>
-    public async ValueTask<TaggerUIData?> PerformWorkOnMainThreadAsync(Func<TaggerUIData?> action, CancellationToken cancellationToken)
+    /// <remarks>
+    /// This method is intentionally not marked <see langword="async"/>. If it were, the compiler would generate an
+    /// async state machine allocation on every call — even when we take the fast path (already on the main thread)
+    /// and never hit an <see langword="await"/>. By keeping this method synchronous and delegating to the separate
+    /// <see cref="PerformWorkOnMainThreadSlowAsync"/> only when we actually need to await, the fast path completes
+    /// with zero allocations.
+    /// </remarks>
+    public ValueTask<TaggerUIData?> PerformWorkOnMainThreadAsync(Func<TaggerUIData?> action, CancellationToken cancellationToken)
     {
-        var taskSource = new TaskCompletionSource<TaggerUIData?>();
-
         // If we're already on the main thread, just run the action directly without any delay.  This is important
         // for cases where the tagger is performing a blocking call to get tags synchronously on the UI thread (for
         // example, for determining collapsed outlining tags on document open).
         if (_threadingContext.JoinableTaskContext.IsOnMainThread)
         {
-            RunActionAndUpdateCompletionSource_NoThrow(action, taskSource, cancellationToken);
+            return new ValueTask<TaggerUIData?>(RunActionOnMainThread_NoThrow(action, cancellationToken));
         }
-        else
-        {
-            // Ensure that if the host is closing and hte queue stops running that we transition this task to the canceled state.
-            var registration = _threadingContext.DisposalToken.Register(
-                static taskSourceObj => ((TaskCompletionSource<TaggerUIData?>)taskSourceObj).TrySetCanceled(), taskSource);
 
-            _workQueue.AddWork((action, taskSource, cancellationToken));
+        return PerformWorkOnMainThreadSlowAsync(action, cancellationToken);
+    }
 
-            // Ensure that when our work is done that we let go of the registered callback.
-            _ = taskSource.Task.CompletesTrackingOperation(registration);
-        }
+    /// <summary>
+    /// Slow path for <see cref="PerformWorkOnMainThreadAsync"/> when not on the main thread.
+    /// Allocates a <see cref="TaskCompletionSource{TResult}"/> and enqueues the work for batched execution.
+    /// </summary>
+    private async ValueTask<TaggerUIData?> PerformWorkOnMainThreadSlowAsync(Func<TaggerUIData?> action, CancellationToken cancellationToken)
+    {
+        var taskSource = new TaskCompletionSource<TaggerUIData?>();
+
+        // Ensure that if the host is closing and the queue stops running that we transition this task to the canceled state.
+        var registration = _threadingContext.DisposalToken.Register(
+            static taskSourceObj => ((TaskCompletionSource<TaggerUIData?>)taskSourceObj).TrySetCanceled(), taskSource);
+
+        _workQueue.AddWork((action, taskSource, cancellationToken));
+
+        // Ensure that when our work is done that we let go of the registered callback.
+        _ = taskSource.Task.CompletesTrackingOperation(registration);
 
         return await taskSource.Task.ConfigureAwait(true);
+    }
+
+    /// <remarks>This will not ever throw.</remarks>
+    private static TaggerUIData? RunActionOnMainThread_NoThrow(
+        Func<TaggerUIData?> action,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return null;
+
+            return action();
+        }
+        catch (OperationCanceledException)
+        {
+            return null;
+        }
+        catch (Exception)
+        {
+            return null;
+        }
     }
 
     private async ValueTask ProcessWorkItemsAsync(ImmutableSegmentedList<QueueData> list, CancellationToken queueCancellationToken)

--- a/src/Tools/IdeBenchmarks/IdeBenchmarks.csproj
+++ b/src/Tools/IdeBenchmarks/IdeBenchmarks.csproj
@@ -28,7 +28,9 @@
   <PropertyGroup>
     <!-- The DiagnosticsHub package auto-injects an [assembly: Config] attribute, which conflicts
          with the existing one in Properties/AssemblyInfo.cs (MemoryDiagnoserConfig). Disable the
-         package's auto-generated config to avoid CS0579 (duplicate attribute). -->
+         package's auto-generated config to avoid CS0579 (duplicate attribute). 
+         The only downside to disabling this is that it breaks integration with the profiler agent in VS, however 
+         the benchmark itself will still function correctly and generate a diagsession at the end. -->
     <DefineConstants>$(DefineConstants);DISABLE_PROFILER_AGENT_CONFIG</DefineConstants>
   </PropertyGroup>
   <ItemGroup Label="Project References">

--- a/src/Tools/IdeBenchmarks/IdeBenchmarks.csproj
+++ b/src/Tools/IdeBenchmarks/IdeBenchmarks.csproj
@@ -23,7 +23,14 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" />
+    <PackageReference Include="Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers" />
   </ItemGroup>
+  <PropertyGroup>
+    <!-- The DiagnosticsHub package auto-injects an [assembly: Config] attribute, which conflicts
+         with the existing one in Properties/AssemblyInfo.cs (MemoryDiagnoserConfig). Disable the
+         package's auto-generated config to avoid CS0579 (duplicate attribute). -->
+    <DefineConstants>$(DefineConstants);DISABLE_PROFILER_AGENT_CONFIG</DefineConstants>
+  </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />
     <ProjectReference Include="..\..\Compilers\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.csproj" />

--- a/src/Tools/IdeBenchmarks/TaggerMainThreadManagerBenchmarks.cs
+++ b/src/Tools/IdeBenchmarks/TaggerMainThreadManagerBenchmarks.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Editor.Tagging;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.VSDiagnostics;
+using Microsoft.VisualStudio.Threading;
+
+namespace IdeBenchmarks;
+
+/// <summary>
+/// Measures the allocation overhead of <see cref="TaggerMainThreadManager.PerformWorkOnMainThreadAsync"/>
+/// when called on the main thread (the fast path exercised during normal editor tag recomputation).
+/// </summary>
+[CPUUsageDiagnoser]
+public class TaggerMainThreadManagerBenchmarks
+{
+    private TaggerMainThreadManager _manager = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // Create a JoinableTaskContext whose "main thread" is the current thread.
+        // BenchmarkDotNet runs GlobalSetup and Benchmark methods on the same thread,
+        // so IsOnMainThread will be true during benchmarks — exercising the fast path.
+#pragma warning disable VSSDK005 // Use ThreadHelper.JoinableTaskContext singleton - N/A, used for benchmark code
+        var joinableTaskContext = new JoinableTaskContext();
+#pragma warning restore VSSDK005
+        var threadingContext = new BenchmarkThreadingContext(joinableTaskContext);
+        _manager = new TaggerMainThreadManager(threadingContext, AsynchronousOperationListenerProvider.NullProvider);
+    }
+
+    [Benchmark]
+    public async ValueTask<object?> PerformWorkOnMainThread_ReturnsNull()
+    {
+        // Action returns null — simulates the case where TryAddSpansToTag returns false
+        // (e.g., during a layout pass). This is the cheapest possible call that still
+        // exercises the full PerformWorkOnMainThreadAsync code path on the main thread.
+        var result = await _manager.PerformWorkOnMainThreadAsync(static () => null, CancellationToken.None);
+        return result;
+    }
+
+    [Benchmark]
+    public async ValueTask<object?> PerformWorkOnMainThread_ReturnsValue()
+    {
+        // Action returns a value — simulates the normal success path where UI data is collected.
+        var result = await _manager.PerformWorkOnMainThreadAsync(
+            static () => (true, (Microsoft.VisualStudio.Text.SnapshotPoint?)null, default(Microsoft.CodeAnalysis.Collections.OneOrMany<Microsoft.VisualStudio.Text.SnapshotSpan>)),
+            CancellationToken.None);
+        return result;
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IThreadingContext"/> for benchmarking. The current thread becomes the "main thread".
+    /// </summary>
+    private sealed class BenchmarkThreadingContext(JoinableTaskContext joinableTaskContext) : IThreadingContext
+    {
+        public bool HasMainThread => true;
+        public JoinableTaskContext JoinableTaskContext { get; } = joinableTaskContext;
+        public JoinableTaskFactory JoinableTaskFactory { get; } = joinableTaskContext.Factory;
+        public CancellationToken DisposalToken => CancellationToken.None;
+
+        public JoinableTask RunWithShutdownBlockAsync(Func<CancellationToken, Task> func)
+            => JoinableTaskFactory.RunAsync(() => func(CancellationToken.None));
+    }
+}


### PR DESCRIPTION
Fixes #83998

## Summary

Eliminates unnecessary `TaskCompletionSource<TaggerUIData?>` allocation in `TaggerMainThreadManager.PerformWorkOnMainThreadAsync` when already on the main thread. The method previously allocated a TCS on every call, even when the action was executed synchronously and the result was immediately known.

## Changes

Split `PerformWorkOnMainThreadAsync` into a non-async fast path and an async slow path:
- **Fast path** (on main thread): Runs the action directly and returns the result as a synchronous `ValueTask` — zero heap allocations for the null-result case, 40 bytes for the value case.
- **Slow path** (off main thread): Unchanged — allocates a TCS and enqueues work for batched execution.

The method is intentionally kept non-async to avoid compiler-generated state machine allocation on the fast path.

Also adds `TaggerMainThreadManagerBenchmarks` to `src/Tools/IdeBenchmarks` and the `Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers` package reference to support `[CPUUsageDiagnoser]`.

## Benchmark results

| Method | Before Mean | After Mean | CPU Reduction | Before Alloc | After Alloc | Alloc Reduction |
|--------|------------|------------|---------------|-------------|------------|-----------------|
| ReturnsNull | 601.9 ns | 345.2 ns | -43% | 88 B | 0 B | -100% |
| ReturnsValue | 789.7 ns | 544.1 ns | -31% | 128 B | 40 B | -69% |
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/83999)