### PR TITLE
[Sonic] Create a way to do sonic tooling development and keep some kind of sanity

### DIFF
--- a/src/Razor/Directory.Build.props
+++ b/src/Razor/Directory.Build.props
@@ -9,6 +9,9 @@
     <IsIntegrationTestProject>false</IsIntegrationTestProject>
     <IsIntegrationTestProject Condition="$(MSBuildProjectName.EndsWith('.IntegrationTests'))">true</IsIntegrationTestProject>
     <AddPublicApiAnalyzers Condition="'$(IsTestProject)' == 'true' OR '$(IsUnitTestProject)' == 'true' OR '$(IsIntegrationTestProject)' == 'true'">false</AddPublicApiAnalyzers>
+
+    <!-- PROTOTYPE(sonic): Uncomment to make the error list your todo list -->
+    <!--<DefineConstants>$(DefineConstants);SONICDEV</DefineConstants>-->
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeDocument.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeDocument.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -267,15 +267,24 @@ public sealed partial class RazorCodeDocument
     internal RazorCSharpDocument GetRequiredCSharpDocument(bool declarationDocument)
         => GetCSharpDocument(declarationDocument).AssumeNotNull();
 
+#if SONICDEV
+    [System.Obsolete("PROTOTYPE(sonic): Call the overload that takes a bool to prove that you thought about which document to get")]
+#endif
     internal bool TryGetImplCSharpDocument([NotNullWhen(true)] out RazorCSharpDocument? result)
     {
         result = _csharpDocument;
         return result is not null;
     }
 
+#if SONICDEV
+    [System.Obsolete("PROTOTYPE(sonic): Call the overload that takes a bool to prove that you thought about which document to get")]
+#endif
     internal RazorCSharpDocument? GetImplCSharpDocument()
         => _csharpDocument;
 
+#if SONICDEV
+    [System.Obsolete("PROTOTYPE(sonic): Call the overload that takes a bool to prove that you thought about which document to get")]
+#endif
     internal RazorCSharpDocument GetRequiredImplCSharpDocument()
         => _csharpDocument.AssumeNotNull();
 
@@ -289,6 +298,9 @@ public sealed partial class RazorCodeDocument
         return new RazorCodeDocument(Source, Imports, ParserOptions, CodeGenerationOptions, _tagHelpers, _referencedTagHelpers, _syntaxTree, _tagHelperRewrittenSyntaxTree, _importSyntaxTrees, _tagHelperContext, _documentNode, value, _declCSharpDocument, _directiveTagHelperContributions);
     }
 
+#if SONICDEV
+    [System.Obsolete("PROTOTYPE(sonic): Call the overload that takes a bool to prove that you thought about which document to get")]
+#endif
     internal RazorCSharpDocument? GetDeclCSharpDocument()
         => _declCSharpDocument;
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/ProjectExtensions.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/ProjectExtensions.cs
@@ -8,40 +8,12 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor;
-using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.CodeAnalysis.Razor;
 using Microsoft.NET.Sdk.Razor.SourceGenerators;
 
 namespace Microsoft.CodeAnalysis;
 
 internal static class ProjectExtensions
 {
-    /// <summary>
-    ///  Gets the available <see cref="TagHelperDescriptor">tag helpers</see> from the specified
-    ///  <see cref="Project"/> using the given <see cref="RazorProjectEngine"/>.
-    /// </summary>
-    public static async ValueTask<TagHelperCollection> GetTagHelpersAsync(
-        this Project project,
-        RazorProjectEngine projectEngine,
-        CancellationToken cancellationToken)
-    {
-        if (!projectEngine.Engine.TryGetFeature(out ITagHelperDiscoveryService? discoveryService))
-        {
-            return [];
-        }
-
-        var compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
-        if (compilation is null || !CompilationTagHelperFeature.IsValidCompilation(compilation))
-        {
-            return [];
-        }
-
-        const TagHelperDiscoveryOptions Options = TagHelperDiscoveryOptions.ExcludeHidden |
-                                                  TagHelperDiscoveryOptions.IncludeDocumentation;
-
-        return discoveryService.GetTagHelpers(compilation, Options, cancellationToken);
-    }
-
     public static Task<SourceGeneratedDocument?> TryGetCSharpDocumentForGeneratedDocumentAsync(this Project project, SourceGeneratedDocumentIdentity identity, CancellationToken cancellationToken)
     {
         Debug.Assert(identity.DocumentId.ProjectId == project.Id, "Generated document URI does not belong to this project.");
@@ -65,6 +37,9 @@ internal static class ProjectExtensions
         return generatedDocuments.SingleOrDefault(d => d.HintName == hintName);
     }
 
+#if SONICDEV
+    [System.Obsolete("PROTOTYPE(sonic): Call the overload that takes a bool to prove that you thought about which document to get")]
+#endif
     public static async Task<SourceGeneratedDocument?> TryGetSourceGeneratedDocumentForRazorDocumentAsync(this Project project, TextDocument razorDocument, CancellationToken cancellationToken)
     {
         return (await TryGetSourceGeneratedDocumentsForRazorDocumentAsync(project, razorDocument, cancellationToken).ConfigureAwait(false))?.ImplDoc;

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/RazorCodeDocumentExtensions.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/RazorCodeDocumentExtensions.cs
@@ -1,14 +1,12 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
-using Microsoft.AspNetCore.Razor.Language.Syntax;
-using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Text;
 
@@ -31,6 +29,9 @@ internal static partial class RazorCodeDocumentExtensions
     public static Syntax.SyntaxNode GetRequiredSyntaxRoot(this RazorCodeDocument codeDocument)
         => codeDocument.GetRequiredTagHelperRewrittenSyntaxTree().Root;
 
+#if SONICDEV
+    [System.Obsolete("PROTOTYPE(sonic): Call GetRequiredCSharpDocument and use the Text property on that, to prove that you thought about which document to get")]
+#endif
     public static SourceText GetCSharpSourceText(this RazorCodeDocument document)
         => document.GetRequiredImplCSharpDocument().Text;
 
@@ -49,68 +50,24 @@ internal static partial class RazorCodeDocumentExtensions
     /// </remarks>
     public static RazorCSharpDocument GetCSharpDocumentForHintName(this RazorCodeDocument document, string hintName)
     {
+        return GetCSharpDocumentForHintName(document, hintName, out _);
+    }
+
+    public static RazorCSharpDocument GetCSharpDocumentForHintName(this RazorCodeDocument document, string hintName, out bool isDeclDocument)
+    {
         if (hintName.EndsWith(".decl.g.cs", System.StringComparison.Ordinal) &&
-            document.GetDeclCSharpDocument() is { } declDocument)
+            document.GetCSharpDocument(declarationDocument: true) is { } declDocument)
         {
+            isDeclDocument = true;
             return declDocument;
         }
 
-        return document.GetRequiredImplCSharpDocument();
+        isDeclDocument = false;
+        return document.GetRequiredCSharpDocument(declarationDocument: false);
     }
 
     public static SourceText GetHtmlSourceText(this RazorCodeDocument document, CancellationToken cancellationToken)
         => GetCachedData(document).GetOrComputeHtmlDocument(cancellationToken).Text;
-
-    public static bool TryGetMinimalCSharpRange(this RazorCodeDocument codeDocument, LinePositionSpan razorRange, out LinePositionSpan csharpRange)
-    {
-        SourceSpan? minGeneratedSpan = null;
-        SourceSpan? maxGeneratedSpan = null;
-
-        var sourceText = codeDocument.Source.Text;
-        var textSpan = sourceText.GetTextSpan(razorRange);
-        var csharpDoc = codeDocument.GetRequiredImplCSharpDocument();
-
-        // We want to find the min and max C# source mapping that corresponds with our Razor range.
-        foreach (var mapping in csharpDoc.SourceMappingsSortedByOriginal)
-        {
-            var mappedTextSpan = mapping.OriginalSpan.AsTextSpan();
-
-            if (textSpan.OverlapsWith(mappedTextSpan))
-            {
-                if (minGeneratedSpan is null || mapping.GeneratedSpan.AbsoluteIndex < minGeneratedSpan.Value.AbsoluteIndex)
-                {
-                    minGeneratedSpan = mapping.GeneratedSpan;
-                }
-
-                var mappingEndIndex = mapping.GeneratedSpan.AbsoluteIndex + mapping.GeneratedSpan.Length;
-                if (maxGeneratedSpan is null || mappingEndIndex > maxGeneratedSpan.Value.AbsoluteIndex + maxGeneratedSpan.Value.Length)
-                {
-                    maxGeneratedSpan = mapping.GeneratedSpan;
-                }
-            }
-            else if (mappedTextSpan.Start > textSpan.End)
-            {
-                // This span (and all following) are after the area we're interested in
-                break;
-            }
-        }
-
-        // Create a new projected range based on our calculated min/max source spans.
-        if (minGeneratedSpan is not null && maxGeneratedSpan is not null)
-        {
-            var csharpSourceText = codeDocument.GetCSharpSourceText();
-            var startRange = csharpSourceText.GetLinePositionSpan(minGeneratedSpan.Value);
-            var endRange = csharpSourceText.GetLinePositionSpan(maxGeneratedSpan.Value);
-
-            csharpRange = new LinePositionSpan(startRange.Start, endRange.End);
-            Debug.Assert(csharpRange.Start.CompareTo(csharpRange.End) <= 0, "Range.Start should not be larger than Range.End");
-
-            return true;
-        }
-
-        csharpRange = default;
-        return false;
-    }
 
     public static bool ComponentNamespaceMatches(this RazorCodeDocument razorCodeDocument, string? fullyQualifiedNamespace)
     {

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/RazorCodeDocumentExtensions.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/RazorCodeDocumentExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentContext.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentContext.cs
@@ -78,6 +78,9 @@ internal class DocumentContext(DocumentUri uri, IDocumentSnapshot snapshot)
         }
     }
 
+#if SONICDEV
+    [System.Obsolete("PROTOTYPE(sonic): Call GetCodeDocument and get the right CSharpDocument from that, to prove that you thought about which document to get")]
+#endif
     public ValueTask<SourceText> GetCSharpSourceTextAsync(CancellationToken cancellationToken)
     {
         return TryGetCodeDocument(out var codeDocument)

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshot.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshot.cs
@@ -22,25 +22,18 @@ internal interface IDocumentSnapshot
     ValueTask<VersionStamp> GetTextVersionAsync(CancellationToken cancellationToken);
     ValueTask<RazorCodeDocument> GetGeneratedOutputAsync(CancellationToken cancellationToken);
 
+#if SONICDEV
+    [System.Obsolete("PROTOTYPE(sonic): Call the overload that takes a bool to prove that you thought about which document to get")]
+#endif
+    ValueTask<SyntaxTree> GetCSharpSyntaxTreeAsync(CancellationToken cancellationToken);
+
     /// <summary>
     ///  Gets the Roslyn syntax tree for the generated C# for this Razor document
     /// </summary>
     /// <remarks>
     ///  ⚠️ Should be used sparingly in language server scenarios.
     /// </remarks>
-    ValueTask<SyntaxTree> GetCSharpSyntaxTreeAsync(CancellationToken cancellationToken);
-
-    /// <summary>
-    /// Returns the decl-half source generated document for this Razor document, or
-    /// <see langword="null"/> when the source generator did not emit a decl half (e.g.
-    /// .cshtml files, non-component documents, or components whose primary method body is
-    /// suppressed).
-    /// </summary>
-    /// <remarks>
-    /// Implementations that do not have access to source-generator output (e.g. test
-    /// doubles) should return <see langword="null"/>.
-    /// </remarks>
-    ValueTask<SourceGeneratedDocument?> TryGetDeclGeneratedDocumentAsync(CancellationToken cancellationToken);
+    ValueTask<SyntaxTree> GetCSharpSyntaxTreeAsync(bool declarationDocument, CancellationToken cancellationToken);
 
     bool TryGetText([NotNullWhen(true)] out SourceText? result);
     bool TryGetTextVersion(out VersionStamp result);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentSnapshot.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentSnapshot.cs
@@ -87,7 +87,22 @@ internal sealed class RemoteDocumentSnapshot : IDocumentSnapshot
         return snapshotManager.GetSnapshot(newDocument);
     }
 
-    public async ValueTask<SourceGeneratedDocument> GetGeneratedDocumentAsync(CancellationToken cancellationToken)
+    public async ValueTask<SourceGeneratedDocument> GetGeneratedDocumentAsync(bool declarationDocument, CancellationToken cancellationToken)
+    {
+        return declarationDocument
+            ? (await TryGetDeclGeneratedDocumentInternalAsync(cancellationToken).ConfigureAwait(false)).AssumeNotNull()
+            : await GetGeneratedDocumentInternalAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+#if SONICDEV
+    [System.Obsolete("PROTOTYPE(sonic): Call the overload that takes a bool to prove that you thought about which document to get")]
+#endif
+    public ValueTask<SourceGeneratedDocument> GetGeneratedDocumentAsync(CancellationToken cancellationToken)
+    {
+        return GetGeneratedDocumentInternalAsync(cancellationToken);
+    }
+
+    private async ValueTask<SourceGeneratedDocument> GetGeneratedDocumentInternalAsync(CancellationToken cancellationToken)
     {
         if (_generatedDocument is not null)
         {
@@ -102,7 +117,15 @@ internal sealed class RemoteDocumentSnapshot : IDocumentSnapshot
     /// Returns the decl-half generated document for this Razor document, or <see langword="null"/> when the
     /// source generator did not emit a decl-half for it. Caches the (possibly null) result.
     /// </summary>
-    public async ValueTask<SourceGeneratedDocument?> TryGetDeclGeneratedDocumentAsync(CancellationToken cancellationToken)
+#if SONICDEV
+    [System.Obsolete("PROTOTYPE(sonic): Call the overload that takes a bool to prove that you thought about which document to get")]
+#endif
+    public ValueTask<SourceGeneratedDocument?> TryGetDeclGeneratedDocumentAsync(CancellationToken cancellationToken)
+    {
+        return TryGetDeclGeneratedDocumentInternalAsync(cancellationToken);
+    }
+
+    private async ValueTask<SourceGeneratedDocument?> TryGetDeclGeneratedDocumentInternalAsync(CancellationToken cancellationToken)
     {
         if (Volatile.Read(ref _declGeneratedDocumentInitialized))
         {
@@ -116,9 +139,17 @@ internal sealed class RemoteDocumentSnapshot : IDocumentSnapshot
         return declDocument;
     }
 
+#if SONICDEV
+    [System.Obsolete("PROTOTYPE(sonic): Call the overload that takes a bool to prove that you thought about which document to get")]
+#endif
     public ValueTask<SyntaxTree> GetCSharpSyntaxTreeAsync(CancellationToken cancellationToken)
     {
-        var document = _generatedDocument;
+        return GetCSharpSyntaxTreeAsync(declarationDocument: false, cancellationToken);
+    }
+
+    public ValueTask<SyntaxTree> GetCSharpSyntaxTreeAsync(bool declarationDocument, CancellationToken cancellationToken)
+    {
+        var document = declarationDocument ? _declGeneratedDocument : _generatedDocument;
         if (document is not null &&
             document.TryGetSyntaxTree(out var tree))
         {
@@ -129,7 +160,7 @@ internal sealed class RemoteDocumentSnapshot : IDocumentSnapshot
 
         async ValueTask<SyntaxTree> GetCSharpSyntaxTreeCoreAsync(Document? document, CancellationToken cancellationToken)
         {
-            document ??= await GetGeneratedDocumentAsync(cancellationToken).ConfigureAwait(false);
+            document ??= await GetGeneratedDocumentAsync(declarationDocument, cancellationToken).ConfigureAwait(false);
 
             var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
             return tree.AssumeNotNull();

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorDocumentServiceBase.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorDocumentServiceBase.cs
@@ -45,21 +45,6 @@ internal abstract class RazorDocumentServiceBase(in ServiceArgs args) : RazorBro
         return positionInfo;
     }
 
-    protected bool TryGetDocumentPositionInfo(RazorCodeDocument codeDocument, Position position, out DocumentPositionInfo positionInfo)
-        => TryGetDocumentPositionInfo(codeDocument, position, preferCSharpOverHtml: false, out positionInfo);
-
-    protected bool TryGetDocumentPositionInfo(RazorCodeDocument codeDocument, Position position, bool preferCSharpOverHtml, out DocumentPositionInfo positionInfo)
-    {
-        if (!codeDocument.Source.Text.TryGetAbsoluteIndex(position, out var hostDocumentIndex))
-        {
-            positionInfo = default;
-            return false;
-        }
-
-        positionInfo = GetPositionInfo(codeDocument, hostDocumentIndex, preferCSharpOverHtml);
-        return true;
-    }
-
     protected ValueTask<T> RunServiceAsync<T>(
         RazorSolutionWrapper solutionInfo,
         DocumentId razorDocumentId,

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorDocumentServiceBase.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorDocumentServiceBase.cs
@@ -9,7 +9,6 @@ using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.LanguageServer;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor;

--- a/src/Razor/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestDocumentSnapshot.cs
+++ b/src/Razor/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestDocumentSnapshot.cs
@@ -48,13 +48,19 @@ internal sealed class TestDocumentSnapshot : IDocumentSnapshot
     public ValueTask<VersionStamp> GetTextVersionAsync(CancellationToken cancellationToken)
         => throw new NotImplementedException();
 
+#if SONICDEV
+    [System.Obsolete("PROTOTYPE(sonic): Call the overload that takes a bool to prove that you thought about which document to get")]
+#endif
     public ValueTask<SyntaxTree> GetCSharpSyntaxTreeAsync(CancellationToken cancellationToken)
     {
-        return new(CSharpSyntaxTree.ParseText(_codeDocument.GetCSharpSourceText(), cancellationToken: cancellationToken));
+        return GetCSharpSyntaxTreeAsync(declarationDocument: false, cancellationToken);
     }
 
-    public ValueTask<SourceGeneratedDocument?> TryGetDeclGeneratedDocumentAsync(CancellationToken cancellationToken)
-        => new(default(SourceGeneratedDocument));
+    public ValueTask<SyntaxTree> GetCSharpSyntaxTreeAsync(bool declarationDocument, CancellationToken cancellationToken)
+    {
+        var csharpDocument = _codeDocument.GetRequiredCSharpDocument(declarationDocument);
+        return new(CSharpSyntaxTree.ParseText(csharpDocument.Text, cancellationToken: cancellationToken));
+    }
 
     public bool TryGetGeneratedOutput([NotNullWhen(true)] out RazorCodeDocument? result)
     {


### PR DESCRIPTION
This is my best bet at how to make Sonic Tooling dev approachable. It has no impact on CI builds, we'll have to remove it before merging to main (if I understand how PROTOTYPE comments work properly), but by setting a local define, I get a nice todo list from the error list about what needs to be fixed.

I also found a few methods that had no callers when I was making these changes, so I removed them. Less surface area to worry about is good.

As part of de-obsoleting everything at the end of the work, I'm open to removing the methods that take booleans, and switching to the document specific methods, or keeping both sets. Certainly, the boolean option is proving useful in porting other features.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84008)