### PR TITLE
[Sonic] Support multiple C# documents in document highlight

### DIFF
--- a/src/LanguageServer/Protocol/Handler/Highlights/DocumentHighlightHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Highlights/DocumentHighlightHandler.cs
@@ -46,24 +46,19 @@ internal sealed class DocumentHighlightsHandler : ILspServiceDocumentRequestHand
         if (document == null)
             return null;
 
-        var position = ProtocolConversions.PositionToLinePosition(request.Position);
-        return await GetHighlightsAsync(_globalOptions, _highlightingService, document, position, cancellationToken).ConfigureAwait(false);
-    }
-
-    internal static async Task<DocumentHighlight[]?> GetHighlightsAsync(IGlobalOptionService globalOptions, IHighlightingService highlightingService, Document document, LinePosition linePosition, CancellationToken cancellationToken)
-    {
+        var linePosition = ProtocolConversions.PositionToLinePosition(request.Position);
         var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
         var position = await document.GetPositionFromLinePositionAsync(linePosition, cancellationToken).ConfigureAwait(false);
 
         // First check if this is a keyword that needs highlighting.
-        var keywordHighlights = await GetKeywordHighlightsAsync(highlightingService, document, text, position, cancellationToken).ConfigureAwait(false);
+        var keywordHighlights = await GetKeywordHighlightsAsync(document, text, position, cancellationToken).ConfigureAwait(false);
         if (keywordHighlights.Any())
         {
             return [.. keywordHighlights];
         }
 
         // Not a keyword, check if it is a reference that needs highlighting.
-        var referenceHighlights = await GetReferenceHighlightsAsync(globalOptions, document, text, position, cancellationToken).ConfigureAwait(false);
+        var referenceHighlights = await GetReferenceHighlightsAsync(document, text, position, cancellationToken).ConfigureAwait(false);
         if (referenceHighlights.Any())
         {
             return [.. referenceHighlights];
@@ -73,12 +68,12 @@ internal sealed class DocumentHighlightsHandler : ILspServiceDocumentRequestHand
         return [];
     }
 
-    private static async Task<ImmutableArray<DocumentHighlight>> GetKeywordHighlightsAsync(IHighlightingService highlightingService, Document document, SourceText text, int position, CancellationToken cancellationToken)
+    private async Task<ImmutableArray<DocumentHighlight>> GetKeywordHighlightsAsync(Document document, SourceText text, int position, CancellationToken cancellationToken)
     {
         var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
         var keywordSpans = new List<TextSpan>();
-        highlightingService.AddHighlights(root, position, keywordSpans, cancellationToken);
+        _highlightingService.AddHighlights(root, position, keywordSpans, cancellationToken);
 
         return keywordSpans.SelectAsArray(highlight => new DocumentHighlight
         {
@@ -87,10 +82,10 @@ internal sealed class DocumentHighlightsHandler : ILspServiceDocumentRequestHand
         });
     }
 
-    private static async Task<ImmutableArray<DocumentHighlight>> GetReferenceHighlightsAsync(IGlobalOptionService globalOptions, Document document, SourceText text, int position, CancellationToken cancellationToken)
+    private async Task<ImmutableArray<DocumentHighlight>> GetReferenceHighlightsAsync(Document document, SourceText text, int position, CancellationToken cancellationToken)
     {
         var documentHighlightService = document.GetRequiredLanguageService<IDocumentHighlightsService>();
-        var options = globalOptions.GetHighlightingOptions(document.Project.Language);
+        var options = _globalOptions.GetHighlightingOptions(document.Project.Language);
         var highlights = await documentHighlightService.GetDocumentHighlightsAsync(
             document,
             position,

--- a/src/Razor/Directory.Build.props
+++ b/src/Razor/Directory.Build.props
@@ -9,6 +9,9 @@
     <IsIntegrationTestProject>false</IsIntegrationTestProject>
     <IsIntegrationTestProject Condition="$(MSBuildProjectName.EndsWith('.IntegrationTests'))">true</IsIntegrationTestProject>
     <AddPublicApiAnalyzers Condition="'$(IsTestProject)' == 'true' OR '$(IsUnitTestProject)' == 'true' OR '$(IsIntegrationTestProject)' == 'true'">false</AddPublicApiAnalyzers>
+
+    <!-- PROTOTYPE(sonic): Uncomment to make the error list your todo list -->
+    <!--<DefineConstants>$(DefineConstants);SONICDEV</DefineConstants>-->
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeDocument.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeDocument.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -267,15 +267,24 @@ public sealed partial class RazorCodeDocument
     internal RazorCSharpDocument GetRequiredCSharpDocument(bool declarationDocument)
         => GetCSharpDocument(declarationDocument).AssumeNotNull();
 
+#if SONICDEV
+    [System.Obsolete("PROTOTYPE(sonic): Call the overload that takes a bool to prove that you thought about which document to get")]
+#endif
     internal bool TryGetImplCSharpDocument([NotNullWhen(true)] out RazorCSharpDocument? result)
     {
         result = _csharpDocument;
         return result is not null;
     }
 
+#if SONICDEV
+    [System.Obsolete("PROTOTYPE(sonic): Call the overload that takes a bool to prove that you thought about which document to get")]
+#endif
     internal RazorCSharpDocument? GetImplCSharpDocument()
         => _csharpDocument;
 
+#if SONICDEV
+    [System.Obsolete("PROTOTYPE(sonic): Call the overload that takes a bool to prove that you thought about which document to get")]
+#endif
     internal RazorCSharpDocument GetRequiredImplCSharpDocument()
         => _csharpDocument.AssumeNotNull();
 
@@ -289,6 +298,9 @@ public sealed partial class RazorCodeDocument
         return new RazorCodeDocument(Source, Imports, ParserOptions, CodeGenerationOptions, _tagHelpers, _referencedTagHelpers, _syntaxTree, _tagHelperRewrittenSyntaxTree, _importSyntaxTrees, _tagHelperContext, _documentNode, value, _declCSharpDocument, _directiveTagHelperContributions);
     }
 
+#if SONICDEV
+    [System.Obsolete("PROTOTYPE(sonic): Call the overload that takes a bool to prove that you thought about which document to get")]
+#endif
     internal RazorCSharpDocument? GetDeclCSharpDocument()
         => _declCSharpDocument;
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/IDocumentMappingServiceExtensions.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/IDocumentMappingServiceExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
@@ -90,5 +90,39 @@ internal static class IDocumentMappingServiceExtensions
         var result = service.TryMapToCSharpPositionOrNext(csharpDocument, razorIndex, out var csharpLinePosition, out csharpIndex);
         csharpPosition = result ? csharpLinePosition.ToPosition() : null;
         return result;
+    }
+
+    /// <summary>
+    /// Convenience method to map from Razor to C#, which checks both impl and decl documents
+    /// </summary>
+    /// <remarks>
+    /// A position in a Razor document could map to one of two different C# documents, but the only situation
+    /// where it would map to both, is when the resulting position in the C# document is semantically equivalent.
+    /// ie, a Razor using or namespace directive would map to both the decl and impl documents, but in either case
+    /// it ends up at a C# using or namespace directive, so it doesn't matter which one we get back.
+    ///
+    /// For all other positions in the Razor document, only one document will be mappable.
+    ///
+    /// Note that the same is NOT true in reverse: A mappable position in a C# document might be unique to either
+    /// the decl or impl document, but that would only be a coincidence. Part of the reason we emit inDeclDocument
+    /// as an out parameter is because in order to map back to Razor later, we must know which document the C# position
+    /// came from.
+    /// </remarks>
+    public static bool TryMapToCSharpDocumentLinePosition(this IDocumentMappingService service, RazorCodeDocument codeDocument, int razorIndex, out LinePosition csharpPosition, out int csharpIndex, out bool inDeclDocument)
+    {
+        inDeclDocument = false;
+        if (service.TryMapToCSharpDocumentPosition(codeDocument.GetRequiredCSharpDocument(declarationDocument: false), razorIndex, out csharpPosition, out csharpIndex))
+        {
+            return true;
+        }
+
+        inDeclDocument = true;
+        if (codeDocument.GetCSharpDocument(declarationDocument: true) is { } declDocument &&
+            service.TryMapToCSharpDocumentPosition(declDocument, razorIndex, out csharpPosition, out csharpIndex))
+        {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/IDocumentMappingServiceExtensions.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/IDocumentMappingServiceExtensions.cs
@@ -97,8 +97,8 @@ internal static class IDocumentMappingServiceExtensions
     /// </summary>
     /// <remarks>
     /// A position in a Razor document could map to one of two different C# documents, but the only situation
-    /// where it would map to both, is when the resulting position in the C# document is semantically equivalent.
-    /// ie, a Razor using or namespace directive would map to both the decl and impl documents, but in either case
+    /// where it would map to both is when the resulting position in the C# document is semantically equivalent.
+    /// i.e., a Razor using or namespace directive would map to both the decl and impl documents, but in either case
     /// it ends up at a C# using or namespace directive, so it doesn't matter which one we get back.
     ///
     /// For all other positions in the Razor document, only one document will be mappable.

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/ProjectExtensions.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/ProjectExtensions.cs
@@ -8,40 +8,12 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor;
-using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.CodeAnalysis.Razor;
 using Microsoft.NET.Sdk.Razor.SourceGenerators;
 
 namespace Microsoft.CodeAnalysis;
 
 internal static class ProjectExtensions
 {
-    /// <summary>
-    ///  Gets the available <see cref="TagHelperDescriptor">tag helpers</see> from the specified
-    ///  <see cref="Project"/> using the given <see cref="RazorProjectEngine"/>.
-    /// </summary>
-    public static async ValueTask<TagHelperCollection> GetTagHelpersAsync(
-        this Project project,
-        RazorProjectEngine projectEngine,
-        CancellationToken cancellationToken)
-    {
-        if (!projectEngine.Engine.TryGetFeature(out ITagHelperDiscoveryService? discoveryService))
-        {
-            return [];
-        }
-
-        var compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
-        if (compilation is null || !CompilationTagHelperFeature.IsValidCompilation(compilation))
-        {
-            return [];
-        }
-
-        const TagHelperDiscoveryOptions Options = TagHelperDiscoveryOptions.ExcludeHidden |
-                                                  TagHelperDiscoveryOptions.IncludeDocumentation;
-
-        return discoveryService.GetTagHelpers(compilation, Options, cancellationToken);
-    }
-
     public static Task<SourceGeneratedDocument?> TryGetCSharpDocumentForGeneratedDocumentAsync(this Project project, SourceGeneratedDocumentIdentity identity, CancellationToken cancellationToken)
     {
         Debug.Assert(identity.DocumentId.ProjectId == project.Id, "Generated document URI does not belong to this project.");
@@ -65,6 +37,9 @@ internal static class ProjectExtensions
         return generatedDocuments.SingleOrDefault(d => d.HintName == hintName);
     }
 
+#if SONICDEV
+    [System.Obsolete("PROTOTYPE(sonic): Call the overload that takes a bool to prove that you thought about which document to get")]
+#endif
     public static async Task<SourceGeneratedDocument?> TryGetSourceGeneratedDocumentForRazorDocumentAsync(this Project project, TextDocument razorDocument, CancellationToken cancellationToken)
     {
         return (await TryGetSourceGeneratedDocumentsForRazorDocumentAsync(project, razorDocument, cancellationToken).ConfigureAwait(false))?.ImplDoc;

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/RazorCodeDocumentExtensions.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/RazorCodeDocumentExtensions.cs
@@ -1,14 +1,12 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
-using Microsoft.AspNetCore.Razor.Language.Syntax;
-using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Text;
 
@@ -31,6 +29,9 @@ internal static partial class RazorCodeDocumentExtensions
     public static Syntax.SyntaxNode GetRequiredSyntaxRoot(this RazorCodeDocument codeDocument)
         => codeDocument.GetRequiredTagHelperRewrittenSyntaxTree().Root;
 
+#if SONICDEV
+    [System.Obsolete("PROTOTYPE(sonic): Call GetRequiredCSharpDocument and use the Text property on that, to prove that you thought about which document to get")]
+#endif
     public static SourceText GetCSharpSourceText(this RazorCodeDocument document)
         => document.GetRequiredImplCSharpDocument().Text;
 
@@ -49,68 +50,24 @@ internal static partial class RazorCodeDocumentExtensions
     /// </remarks>
     public static RazorCSharpDocument GetCSharpDocumentForHintName(this RazorCodeDocument document, string hintName)
     {
+        return GetCSharpDocumentForHintName(document, hintName, out _);
+    }
+
+    public static RazorCSharpDocument GetCSharpDocumentForHintName(this RazorCodeDocument document, string hintName, out bool isDeclDocument)
+    {
         if (hintName.EndsWith(".decl.g.cs", System.StringComparison.Ordinal) &&
-            document.GetDeclCSharpDocument() is { } declDocument)
+            document.GetCSharpDocument(declarationDocument: true) is { } declDocument)
         {
+            isDeclDocument = true;
             return declDocument;
         }
 
-        return document.GetRequiredImplCSharpDocument();
+        isDeclDocument = false;
+        return document.GetRequiredCSharpDocument(declarationDocument: false);
     }
 
     public static SourceText GetHtmlSourceText(this RazorCodeDocument document, CancellationToken cancellationToken)
         => GetCachedData(document).GetOrComputeHtmlDocument(cancellationToken).Text;
-
-    public static bool TryGetMinimalCSharpRange(this RazorCodeDocument codeDocument, LinePositionSpan razorRange, out LinePositionSpan csharpRange)
-    {
-        SourceSpan? minGeneratedSpan = null;
-        SourceSpan? maxGeneratedSpan = null;
-
-        var sourceText = codeDocument.Source.Text;
-        var textSpan = sourceText.GetTextSpan(razorRange);
-        var csharpDoc = codeDocument.GetRequiredImplCSharpDocument();
-
-        // We want to find the min and max C# source mapping that corresponds with our Razor range.
-        foreach (var mapping in csharpDoc.SourceMappingsSortedByOriginal)
-        {
-            var mappedTextSpan = mapping.OriginalSpan.AsTextSpan();
-
-            if (textSpan.OverlapsWith(mappedTextSpan))
-            {
-                if (minGeneratedSpan is null || mapping.GeneratedSpan.AbsoluteIndex < minGeneratedSpan.Value.AbsoluteIndex)
-                {
-                    minGeneratedSpan = mapping.GeneratedSpan;
-                }
-
-                var mappingEndIndex = mapping.GeneratedSpan.AbsoluteIndex + mapping.GeneratedSpan.Length;
-                if (maxGeneratedSpan is null || mappingEndIndex > maxGeneratedSpan.Value.AbsoluteIndex + maxGeneratedSpan.Value.Length)
-                {
-                    maxGeneratedSpan = mapping.GeneratedSpan;
-                }
-            }
-            else if (mappedTextSpan.Start > textSpan.End)
-            {
-                // This span (and all following) are after the area we're interested in
-                break;
-            }
-        }
-
-        // Create a new projected range based on our calculated min/max source spans.
-        if (minGeneratedSpan is not null && maxGeneratedSpan is not null)
-        {
-            var csharpSourceText = codeDocument.GetCSharpSourceText();
-            var startRange = csharpSourceText.GetLinePositionSpan(minGeneratedSpan.Value);
-            var endRange = csharpSourceText.GetLinePositionSpan(maxGeneratedSpan.Value);
-
-            csharpRange = new LinePositionSpan(startRange.Start, endRange.End);
-            Debug.Assert(csharpRange.Start.CompareTo(csharpRange.End) <= 0, "Range.Start should not be larger than Range.End");
-
-            return true;
-        }
-
-        csharpRange = default;
-        return false;
-    }
 
     public static bool ComponentNamespaceMatches(this RazorCodeDocument razorCodeDocument, string? fullyQualifiedNamespace)
     {

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/RazorCodeDocumentExtensions.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/RazorCodeDocumentExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentContext.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentContext.cs
@@ -78,6 +78,9 @@ internal class DocumentContext(DocumentUri uri, IDocumentSnapshot snapshot)
         }
     }
 
+#if SONICDEV
+    [System.Obsolete("PROTOTYPE(sonic): Call GetCodeDocument and get the right CSharpDocument from that, to prove that you thought about which document to get")]
+#endif
     public ValueTask<SourceText> GetCSharpSourceTextAsync(CancellationToken cancellationToken)
     {
         return TryGetCodeDocument(out var codeDocument)

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshot.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshot.cs
@@ -22,25 +22,18 @@ internal interface IDocumentSnapshot
     ValueTask<VersionStamp> GetTextVersionAsync(CancellationToken cancellationToken);
     ValueTask<RazorCodeDocument> GetGeneratedOutputAsync(CancellationToken cancellationToken);
 
+#if SONICDEV
+    [System.Obsolete("PROTOTYPE(sonic): Call the overload that takes a bool to prove that you thought about which document to get")]
+#endif
+    ValueTask<SyntaxTree> GetCSharpSyntaxTreeAsync(CancellationToken cancellationToken);
+
     /// <summary>
     ///  Gets the Roslyn syntax tree for the generated C# for this Razor document
     /// </summary>
     /// <remarks>
     ///  ⚠️ Should be used sparingly in language server scenarios.
     /// </remarks>
-    ValueTask<SyntaxTree> GetCSharpSyntaxTreeAsync(CancellationToken cancellationToken);
-
-    /// <summary>
-    /// Returns the decl-half source generated document for this Razor document, or
-    /// <see langword="null"/> when the source generator did not emit a decl half (e.g.
-    /// .cshtml files, non-component documents, or components whose primary method body is
-    /// suppressed).
-    /// </summary>
-    /// <remarks>
-    /// Implementations that do not have access to source-generator output (e.g. test
-    /// doubles) should return <see langword="null"/>.
-    /// </remarks>
-    ValueTask<SourceGeneratedDocument?> TryGetDeclGeneratedDocumentAsync(CancellationToken cancellationToken);
+    ValueTask<SyntaxTree> GetCSharpSyntaxTreeAsync(bool declarationDocument, CancellationToken cancellationToken);
 
     bool TryGetText([NotNullWhen(true)] out SourceText? result);
     bool TryGetTextVersion(out VersionStamp result);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentHighlight/RemoteDocumentHighlightService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentHighlight/RemoteDocumentHighlightService.cs
@@ -1,18 +1,23 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.PooledObjects;
+using Microsoft.CodeAnalysis.DocumentHighlighting;
 using Microsoft.CodeAnalysis.Highlighting;
-using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Protocol.DocumentHighlight;
 using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Response = Microsoft.CodeAnalysis.Razor.Remote.RemoteResponse<Microsoft.CodeAnalysis.Razor.Protocol.DocumentHighlight.RemoteDocumentHighlight[]?>;
 
@@ -60,39 +65,114 @@ internal sealed partial class RemoteDocumentHighlightService(in ServiceArgs args
             return Response.NoFurtherHandling;
         }
 
-        var csharpDocument = codeDocument.GetRequiredImplCSharpDocument();
-        if (DocumentMappingService.TryMapToCSharpDocumentPosition(csharpDocument, index, out var mappedPosition, out _))
+        if (!DocumentMappingService.TryMapToCSharpDocumentLinePosition(codeDocument, index, out _, out var csharpPosition, out var inDeclDocument))
         {
-            var generatedDocument = await context.Snapshot
-                .GetGeneratedDocumentAsync(cancellationToken)
-                .ConfigureAwait(false);
+            return Response.NoFurtherHandling;
+        }
 
-            var globalOptions = generatedDocument.Project.Solution.Services.ExportProvider.GetService<IGlobalOptionService>();
-            var highlightingService = generatedDocument.Project.Solution.Services.ExportProvider.GetService<IHighlightingService>();
-            var highlights = await DocumentHighlightsHandler.GetHighlightsAsync(
-                globalOptions,
-                highlightingService,
-                generatedDocument,
-                mappedPosition,
-                cancellationToken).ConfigureAwait(false);
+        // Roslyn keyword highlighting only supports a single C# document, and we can't make two calls to Roslyn, one for each C#
+        // document, because we would need to know a highlight location in the other document in order to know a position to ask for.
+        // Fortunately none of the (at time of writing) keyword highlighters are for scenarios that would be valid across impl and decl
+        // documents anyway.
+        var document = await context.Snapshot.GetGeneratedDocumentAsync(inDeclDocument, cancellationToken).ConfigureAwait(false);
+        var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
+        var csharpDocument = codeDocument.GetRequiredCSharpDocument(inDeclDocument);
 
-            if (highlights is not null)
-            {
-                using var results = new PooledArrayBuilder<RemoteDocumentHighlight>();
+        var keywordHighlights = await GetKeywordHighlightsAsync(document, csharpDocument, text, csharpPosition, cancellationToken).ConfigureAwait(false);
+        if (keywordHighlights.Length > 0)
+        {
+            return Response.Results(keywordHighlights);
+        }
 
-                foreach (var highlight in highlights)
-                {
-                    if (DocumentMappingService.TryMapToRazorDocumentRange(csharpDocument, highlight.Range.ToLinePositionSpan(), out var mappedRange))
-                    {
-                        highlight.Range = mappedRange.ToRange();
-                        results.Add(RemoteDocumentHighlight.FromLspDocumentHighlight(highlight));
-                    }
-                }
+        // For reference highlights, we want to make sure to get references from both documents, as the user thinks they're just one, and
+        // the results are much more useful. Fortunately Roslyn supports this, we just have to jump through a few little hoops when mapping
+        // back to Razor positions.
+        var otherDocument = await context.Snapshot.TryGetGeneratedDocumentAsync(!inDeclDocument, cancellationToken).ConfigureAwait(false);
+        var otherCSharpDocument = codeDocument.GetCSharpDocument(!inDeclDocument);
 
-                return Response.Results(results.ToArray());
-            }
+        var referenceHighlights = await GetReferenceHighlightsAsync(document, otherDocument, csharpDocument, otherCSharpDocument, csharpPosition, cancellationToken).ConfigureAwait(false);
+        if (referenceHighlights.Length > 0)
+        {
+            return Response.Results(referenceHighlights);
         }
 
         return Response.NoFurtherHandling;
+    }
+
+    // The below two methods are copied from Roslyn's DocumentHighlightHandler and modified for our needs, to map back to C# documents
+    // and to support multiple documents for reference highlights, because given a scenario like:
+    //
+    // <div>@Title</div>
+    //
+    // @code {
+    //    string Ti$$tle { get; set; }
+    // }
+    //
+    // In this scenario Roslyn only sees the two Title references as being in two separate C# documents.
+
+    private async Task<RemoteDocumentHighlight[]> GetKeywordHighlightsAsync(Document document, RazorCSharpDocument csharpDocument, SourceText text, int position, CancellationToken cancellationToken)
+    {
+        var highlightingService = document.Project.Solution.Services.ExportProvider.GetService<IHighlightingService>();
+        var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+        var keywordSpans = new List<TextSpan>();
+        highlightingService.AddHighlights(root, position, keywordSpans, cancellationToken);
+
+        using var result = new PooledArrayBuilder<RemoteDocumentHighlight>();
+        foreach (var span in keywordSpans)
+        {
+            if (DocumentMappingService.TryMapToRazorDocumentRange(csharpDocument, text.GetLinePositionSpan(span), out var mappedRange))
+            {
+                result.Add(new RemoteDocumentHighlight(mappedRange, DocumentHighlightKind.Text));
+            }
+        }
+
+        return result.ToArrayAndClear();
+    }
+
+    private async Task<RemoteDocumentHighlight[]> GetReferenceHighlightsAsync(Document document, Document? otherDocument, RazorCSharpDocument csharpDocument, RazorCSharpDocument? otherCSharpDocument, int position, CancellationToken cancellationToken)
+    {
+        var globalOptions = document.Project.Solution.Services.ExportProvider.GetService<IGlobalOptionService>();
+        var documentHighlightService = document.GetRequiredLanguageService<IDocumentHighlightsService>();
+        var options = globalOptions.GetHighlightingOptions(document.Project.Language);
+
+        var documentsToSearch = otherDocument is null
+            ? ImmutableHashSet.Create(document)
+            : [document, otherDocument];
+
+        var highlights = await documentHighlightService.GetDocumentHighlightsAsync(document, position, documentsToSearch, options, cancellationToken).ConfigureAwait(false);
+        if (highlights.IsDefaultOrEmpty)
+        {
+            return [];
+        }
+
+        using var result = new PooledArrayBuilder<RemoteDocumentHighlight>();
+        foreach (var highlight in highlights)
+        {
+            RazorCSharpDocument mappedCSharpDocument;
+            if (highlight.Document.Id == document.Id)
+            {
+                mappedCSharpDocument = csharpDocument;
+            }
+            else if (otherDocument is not null &&
+                highlight.Document.Id == otherDocument.Id)
+            {
+                mappedCSharpDocument = otherCSharpDocument.AssumeNotNull("otherCSharpDocument should not be null if otherDocument isn't");
+            }
+            else
+            {
+                continue;
+            }
+
+            foreach (var span in highlight.HighlightSpans)
+            {
+                if (DocumentMappingService.TryMapToRazorDocumentRange(mappedCSharpDocument, mappedCSharpDocument.Text.GetLinePositionSpan(span.TextSpan), out var mappedRange))
+                {
+                    result.Add(new RemoteDocumentHighlight(mappedRange, ProtocolConversions.HighlightSpanKindToDocumentHighlightKind(span.Kind)));
+                }
+            }
+        }
+
+        return result.ToArrayAndClear();
     }
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentSnapshot.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentSnapshot.cs
@@ -87,7 +87,22 @@ internal sealed class RemoteDocumentSnapshot : IDocumentSnapshot
         return snapshotManager.GetSnapshot(newDocument);
     }
 
-    public async ValueTask<SourceGeneratedDocument> GetGeneratedDocumentAsync(CancellationToken cancellationToken)
+    public async ValueTask<SourceGeneratedDocument> GetGeneratedDocumentAsync(bool declarationDocument, CancellationToken cancellationToken)
+    {
+        return declarationDocument
+            ? (await TryGetDeclGeneratedDocumentInternalAsync(cancellationToken).ConfigureAwait(false)).AssumeNotNull()
+            : await GetGeneratedDocumentInternalAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+#if SONICDEV
+    [System.Obsolete("PROTOTYPE(sonic): Call the overload that takes a bool to prove that you thought about which document to get")]
+#endif
+    public ValueTask<SourceGeneratedDocument> GetGeneratedDocumentAsync(CancellationToken cancellationToken)
+    {
+        return GetGeneratedDocumentInternalAsync(cancellationToken);
+    }
+
+    private async ValueTask<SourceGeneratedDocument> GetGeneratedDocumentInternalAsync(CancellationToken cancellationToken)
     {
         if (_generatedDocument is not null)
         {
@@ -102,7 +117,15 @@ internal sealed class RemoteDocumentSnapshot : IDocumentSnapshot
     /// Returns the decl-half generated document for this Razor document, or <see langword="null"/> when the
     /// source generator did not emit a decl-half for it. Caches the (possibly null) result.
     /// </summary>
-    public async ValueTask<SourceGeneratedDocument?> TryGetDeclGeneratedDocumentAsync(CancellationToken cancellationToken)
+#if SONICDEV
+    [System.Obsolete("PROTOTYPE(sonic): Call the overload that takes a bool to prove that you thought about which document to get")]
+#endif
+    public ValueTask<SourceGeneratedDocument?> TryGetDeclGeneratedDocumentAsync(CancellationToken cancellationToken)
+    {
+        return TryGetDeclGeneratedDocumentInternalAsync(cancellationToken);
+    }
+
+    private async ValueTask<SourceGeneratedDocument?> TryGetDeclGeneratedDocumentInternalAsync(CancellationToken cancellationToken)
     {
         if (Volatile.Read(ref _declGeneratedDocumentInitialized))
         {
@@ -116,9 +139,17 @@ internal sealed class RemoteDocumentSnapshot : IDocumentSnapshot
         return declDocument;
     }
 
+#if SONICDEV
+    [System.Obsolete("PROTOTYPE(sonic): Call the overload that takes a bool to prove that you thought about which document to get")]
+#endif
     public ValueTask<SyntaxTree> GetCSharpSyntaxTreeAsync(CancellationToken cancellationToken)
     {
-        var document = _generatedDocument;
+        return GetCSharpSyntaxTreeAsync(declarationDocument: false, cancellationToken);
+    }
+
+    public ValueTask<SyntaxTree> GetCSharpSyntaxTreeAsync(bool declarationDocument, CancellationToken cancellationToken)
+    {
+        var document = declarationDocument ? _declGeneratedDocument : _generatedDocument;
         if (document is not null &&
             document.TryGetSyntaxTree(out var tree))
         {
@@ -129,7 +160,7 @@ internal sealed class RemoteDocumentSnapshot : IDocumentSnapshot
 
         async ValueTask<SyntaxTree> GetCSharpSyntaxTreeCoreAsync(Document? document, CancellationToken cancellationToken)
         {
-            document ??= await GetGeneratedDocumentAsync(cancellationToken).ConfigureAwait(false);
+            document ??= await GetGeneratedDocumentAsync(declarationDocument, cancellationToken).ConfigureAwait(false);
 
             var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
             return tree.AssumeNotNull();

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentSnapshot.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentSnapshot.cs
@@ -87,6 +87,13 @@ internal sealed class RemoteDocumentSnapshot : IDocumentSnapshot
         return snapshotManager.GetSnapshot(newDocument);
     }
 
+    public async ValueTask<SourceGeneratedDocument?> TryGetGeneratedDocumentAsync(bool declarationDocument, CancellationToken cancellationToken)
+    {
+        return declarationDocument
+            ? await TryGetDeclGeneratedDocumentInternalAsync(cancellationToken).ConfigureAwait(false)
+            : await GetGeneratedDocumentInternalAsync(cancellationToken).ConfigureAwait(false);
+    }
+
     public async ValueTask<SourceGeneratedDocument> GetGeneratedDocumentAsync(bool declarationDocument, CancellationToken cancellationToken)
     {
         return declarationDocument

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorDocumentServiceBase.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorDocumentServiceBase.cs
@@ -45,21 +45,6 @@ internal abstract class RazorDocumentServiceBase(in ServiceArgs args) : RazorBro
         return positionInfo;
     }
 
-    protected bool TryGetDocumentPositionInfo(RazorCodeDocument codeDocument, Position position, out DocumentPositionInfo positionInfo)
-        => TryGetDocumentPositionInfo(codeDocument, position, preferCSharpOverHtml: false, out positionInfo);
-
-    protected bool TryGetDocumentPositionInfo(RazorCodeDocument codeDocument, Position position, bool preferCSharpOverHtml, out DocumentPositionInfo positionInfo)
-    {
-        if (!codeDocument.Source.Text.TryGetAbsoluteIndex(position, out var hostDocumentIndex))
-        {
-            positionInfo = default;
-            return false;
-        }
-
-        positionInfo = GetPositionInfo(codeDocument, hostDocumentIndex, preferCSharpOverHtml);
-        return true;
-    }
-
     protected ValueTask<T> RunServiceAsync<T>(
         RazorSolutionWrapper solutionInfo,
         DocumentId razorDocumentId,

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorDocumentServiceBase.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorDocumentServiceBase.cs
@@ -9,7 +9,6 @@ using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.LanguageServer;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor;

--- a/src/Razor/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestDocumentSnapshot.cs
+++ b/src/Razor/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestDocumentSnapshot.cs
@@ -48,13 +48,19 @@ internal sealed class TestDocumentSnapshot : IDocumentSnapshot
     public ValueTask<VersionStamp> GetTextVersionAsync(CancellationToken cancellationToken)
         => throw new NotImplementedException();
 
+#if SONICDEV
+    [System.Obsolete("PROTOTYPE(sonic): Call the overload that takes a bool to prove that you thought about which document to get")]
+#endif
     public ValueTask<SyntaxTree> GetCSharpSyntaxTreeAsync(CancellationToken cancellationToken)
     {
-        return new(CSharpSyntaxTree.ParseText(_codeDocument.GetCSharpSourceText(), cancellationToken: cancellationToken));
+        return GetCSharpSyntaxTreeAsync(declarationDocument: false, cancellationToken);
     }
 
-    public ValueTask<SourceGeneratedDocument?> TryGetDeclGeneratedDocumentAsync(CancellationToken cancellationToken)
-        => new(default(SourceGeneratedDocument));
+    public ValueTask<SyntaxTree> GetCSharpSyntaxTreeAsync(bool declarationDocument, CancellationToken cancellationToken)
+    {
+        var csharpDocument = _codeDocument.GetRequiredCSharpDocument(declarationDocument);
+        return new(CSharpSyntaxTree.ParseText(csharpDocument.Text, cancellationToken: cancellationToken));
+    }
 
     public bool TryGetGeneratedOutput([NotNullWhen(true)] out RazorCodeDocument? result)
     {

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentHighlightEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentHighlightEndpointTest.cs
@@ -31,7 +31,61 @@ public class CohostDocumentHighlightEndpointTest(ITestOutputHelper testOutputHel
         await VerifyDocumentHighlightsAsync(input);
     }
 
-    [Fact(Skip = "PROTOTYPE(sonic): cohosting feature not yet decl/impl split aware; see PR #83887")]
+    [Fact]
+    public async Task Keyword_Impl()
+    {
+        var input = """
+                <div></div>
+
+                @{
+                    var strings = new[] { "Hello", "World" };
+                    [|foreach|] (var str in strings)
+                    {
+                        if (str.Length == 0)
+                        {
+                            $$[|break|];
+                        }
+                    }
+                }
+
+                @code
+                {
+                    private string Title { get;set; }
+                }
+                """;
+
+        await VerifyDocumentHighlightsAsync(input);
+    }
+
+    [Fact]
+    public async Task Keyword_Decl()
+    {
+        var input = """
+                <div></div>
+
+                @{
+                    string x = "asdf";
+                }
+
+                @code
+                {
+                    void Method(string[] strings)
+                    {
+                        [|foreach|] (var str in strings)
+                        {
+                            if (str.Length == 0)
+                            {
+                                $$[|break|];
+                            }
+                        }
+                    }
+                }
+                """;
+
+        await VerifyDocumentHighlightsAsync(input);
+    }
+
+    [Fact]
     public async Task Method()
     {
         var input = """
@@ -49,7 +103,7 @@ public class CohostDocumentHighlightEndpointTest(ITestOutputHelper testOutputHel
         await VerifyDocumentHighlightsAsync(input);
     }
 
-    [Fact(Skip = "PROTOTYPE(sonic): cohosting feature not yet decl/impl split aware; see PR #83887")]
+    [Fact]
     public async Task AttributeToField()
     {
         var input = """
@@ -67,7 +121,7 @@ public class CohostDocumentHighlightEndpointTest(ITestOutputHelper testOutputHel
         await VerifyDocumentHighlightsAsync(input);
     }
 
-    [Fact(Skip = "PROTOTYPE(sonic): cohosting feature not yet decl/impl split aware; see PR #83887")]
+    [Fact]
     public async Task FieldToAttribute()
     {
         var input = """
@@ -123,7 +177,7 @@ public class CohostDocumentHighlightEndpointTest(ITestOutputHelper testOutputHel
         await VerifyDocumentHighlightsAsync(input);
     }
 
-    [Fact(Skip = "PROTOTYPE(sonic): cohosting feature not yet decl/impl split aware; see PR #83887")]
+    [Fact]
     public async Task Inject()
     {
         var input = """


### PR DESCRIPTION
I decided to give up on Code Actions, because it depended on formatting and the edit service etc. and pick something simple like Document Highlight.

And then I discovered that Document Highlight was actually broken with multiple C# documents, as the Roslyn LSP handler only ever returns highlight results from a single document, so I had to re-write more than I expected.

I have the worst luck 😁
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84009)