### PR TITLE
SourceMemberMethodSymbol.IsMetadataVirtual should force complete declaring type when queried by a different module

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
@@ -382,7 +382,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             // Metadata Spec (II.14.6):
             //   Delegates shall be declared sealed.
             //   The Invoke method shall be virtual.
-            if (!method.IsStatic && method.IsMetadataVirtual() && !method.ContainingType.IsDelegateType() && !receiver.SuppressVirtualCalls)
+            if (!method.IsStatic && method.IsMetadataVirtual(this._module.SourceModule) && !method.ContainingType.IsDelegateType() && !receiver.SuppressVirtualCalls)
             {
                 // NOTE: method.IsMetadataVirtual -> receiver != null
                 _builder.EmitOpCode(ILOpCode.Dup);

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -1865,7 +1865,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     // In some cases CanUseCallOnRefTypeReceiver returns true which means that 
                     // null check is unnecessary and we can use "call"
                     if (receiver.SuppressVirtualCalls ||
-                        (!method.IsMetadataVirtual() && CanUseCallOnRefTypeReceiver(receiver)))
+                        (!method.IsMetadataVirtual(this._module.SourceModule) && CanUseCallOnRefTypeReceiver(receiver)))
                     {
                         callKind = CallKind.Call;
                     }
@@ -1884,7 +1884,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                         addressKind = IsReadOnlyCall(method, methodContainingType) ?
                                                                         AddressKind.ReadOnly :
                                                                         AddressKind.Writeable;
-                        if (MayUseCallForStructMethod(method))
+                        if (MayUseCallForStructMethod(this._module.SourceModule, method))
                         {
                             // NOTE: this should be either a method which overrides some abstract method or 
                             //       does not override anything (with few exceptions, see MayUseCallForStructMethod); 
@@ -1905,7 +1905,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
                         // When calling a method that is virtual in metadata on a struct receiver,
                         // we use a constrained virtual call. If possible, it will skip boxing.
-                        if (method.IsMetadataVirtual())
+                        if (method.IsMetadataVirtual(this._module.SourceModule))
                         {
                             // For readonly value type receivers, we only need readonly access since
                             // readonly structs guarantee non-mutation for all their methods, and the
@@ -2326,11 +2326,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         /// It basically checks if the method overrides any other and method's defining type
         /// is not a 'special' or 'special-by-ref' type. 
         /// </summary>
-        internal static bool MayUseCallForStructMethod(MethodSymbol method)
+        internal static bool MayUseCallForStructMethod(ModuleSymbol context, MethodSymbol method)
         {
             Debug.Assert(method.ContainingType.IsVerifierValue(), "this is not a value type");
 
-            if (!method.IsMetadataVirtual() || method.IsStatic)
+            if (method.IsStatic || !method.IsMetadataVirtual(context))
             {
                 return true;
             }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/MethodSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/MethodSymbolAdapter.cs
@@ -433,7 +433,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 CheckDefinitionInvariant();
-                return AdaptedMethodSymbol.IsMetadataNewSlot();
+                return AdaptedMethodSymbol.IsMetadataNewSlot(AdaptedSymbol.ContainingModule); // Use in context of other module is not expected. See 'CheckDefinitionInvariant' above.
             }
         }
 
@@ -502,7 +502,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 CheckDefinitionInvariant();
-                return AdaptedMethodSymbol.IsMetadataVirtual();
+                return AdaptedMethodSymbol.IsMetadataVirtual(AdaptedSymbol.ContainingModule); // Use in context of other module is not expected. See 'CheckDefinitionInvariant' above.
             }
         }
 
@@ -618,7 +618,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return (accessibility == Accessibility.Private ||
                         accessibility == Accessibility.ProtectedAndInternal ||
                         accessibility == Accessibility.Internal)
-                       && this.IsMetadataVirtual() && !this.IsMetadataFinal;
+                       && this.IsMetadataVirtual(ContainingModule) && !this.IsMetadataFinal; // Use in context of other module is not expected. See 'CheckDefinitionInvariant' above.
             }
         }
 
@@ -647,7 +647,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// requirements.
         /// NOTE: Not ignoring changes can only result in a value that is more true.
         /// </summary>
-        internal abstract bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false);
+        /// <param name="context">See <see cref="IsMetadataVirtual(ModuleSymbol?, bool)"/></param>
+        /// <param name="ignoreInterfaceImplementationChanges">See summary.</param>
+#nullable enable
+        internal abstract bool IsMetadataNewSlot(ModuleSymbol? context, bool ignoreInterfaceImplementationChanges = false);
+#nullable disable
 
         internal virtual bool HasRuntimeSpecialName
         {
@@ -667,7 +671,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 Debug.Assert(this.MethodKind != MethodKind.Destructor);
 
                 return this.IsSealed ||
-                    (this.IsMetadataVirtual() &&
+                    (this.IsMetadataVirtual(this.ContainingModule) &&
                      !(this.IsVirtual || this.IsOverride || this.IsAbstract || this.MethodKind == MethodKind.Destructor));
             }
         }
@@ -676,26 +680,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// This method indicates whether or not the runtime will regard the method
         /// as virtual (as indicated by the presence of the "virtual" modifier in the
         /// signature).
-        /// WARN WARN WARN: We won't have a final value for this until declaration
+        /// WARN WARN WARN:
+        /// When called in <paramref name="context"/> of the declaring module we won't have a final value for this until declaration
         /// diagnostics have been computed for all <see cref="SourceMemberContainerTypeSymbol"/>s, so pass
-        /// option: <see cref="IsMetadataVirtualOption.IgnoreInterfaceImplementationChanges"/> if you need a value sooner
+        /// 'true' for <paramref name="ignoreInterfaceImplementationChanges"/> if you need a value sooner
         /// and aren't concerned about tweaks made to satisfy interface implementation 
         /// requirements.
         /// NOTE: Not ignoring changes can only result in a value that is more true.
-        ///
-        /// Use IsMetadataVirtualOption.ForceCompleteIfNeeded in DEBUG/assertion code
-        /// to get the final value.
         /// </summary>
-        internal abstract bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None);
-
-        internal enum IsMetadataVirtualOption
-        {
-            None = 0,
-            IgnoreInterfaceImplementationChanges,
-#if DEBUG
-            ForceCompleteIfNeeded
-#endif
-        }
+        /// <param name="context">
+        /// Module "asking" the question. For example, when "asking" the question during emit,
+        /// the module that is being emitted. Etc.
+        /// This is needed to determine whether we should force compute the final value.
+        /// Fine to pass null if <paramref name="ignoreInterfaceImplementationChanges"/> is 'true'.
+        /// </param>
+        /// <param name="ignoreInterfaceImplementationChanges">See summary.</param>
+#nullable enable
+        internal abstract bool IsMetadataVirtual(ModuleSymbol? context, bool ignoreInterfaceImplementationChanges = false);
+#nullable disable
 
         internal virtual bool ReturnValueIsMarshalledExplicitly
         {

--- a/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedMethod.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedMethod.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.Emit;
 using Cci = Microsoft.Cci;
@@ -91,7 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
         {
             get
             {
-                return UnderlyingMethod.AdaptedMethodSymbol.IsMetadataNewSlot();
+                return UnderlyingMethod.AdaptedMethodSymbol.IsMetadataNewSlot(TypeManager.ModuleBeingBuilt.SourceModule);
             }
         }
 
@@ -123,7 +124,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
         {
             get
             {
-                return UnderlyingMethod.AdaptedMethodSymbol.IsMetadataFinal;
+                bool isMetadataFinal = UnderlyingMethod.AdaptedMethodSymbol.IsMetadataFinal;
+
+                Debug.Assert(!isMetadataFinal);
+                return isMetadataFinal;
             }
         }
 
@@ -139,7 +143,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
         {
             get
             {
-                return UnderlyingMethod.AdaptedMethodSymbol.IsMetadataVirtual();
+                return UnderlyingMethod.AdaptedMethodSymbol.IsMetadataVirtual(TypeManager.ModuleBeingBuilt.SourceModule);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorFinallyMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorFinallyMethodSymbol.cs
@@ -49,12 +49,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
+        internal override bool IsMetadataNewSlot(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
             return false;
         }
 
-        internal override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None)
+        internal override bool IsMetadataVirtual(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
             return false;
         }

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -100,17 +100,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var rewrittenArguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
             var rewrittenType = this.VisitType(node.Type);
 
-#if DEBUG
-            // Calling IsMetadataVirtual with intent of getting a fully accurate result requires the symbol to be fully completed first
-            Debug.Assert(rewrittenMethodSymbol.IsMetadataVirtual(MethodSymbol.IsMetadataVirtualOption.ForceCompleteIfNeeded)
-                == node.Method.IsMetadataVirtual(MethodSymbol.IsMetadataVirtualOption.ForceCompleteIfNeeded));
-#endif
-
             // If the original receiver was a base access and it was rewritten, 
             // change the method to point to the wrapper method
-            if (BaseReferenceInReceiverWasRewritten(node.ReceiverOpt, rewrittenReceiver) && node.Method.IsMetadataVirtual())
+            if (BaseReferenceInReceiverWasRewritten(node.ReceiverOpt, rewrittenReceiver))
             {
-                rewrittenMethodSymbol = GetMethodWrapperForBaseNonVirtualCall(rewrittenMethodSymbol, node.Syntax);
+                if (node.Method.IsMetadataVirtual(CompilationState.Compilation.SourceModule))
+                {
+                    Debug.Assert(rewrittenMethodSymbol.IsMetadataVirtual(CompilationState.Compilation.SourceModule));
+                    rewrittenMethodSymbol = GetMethodWrapperForBaseNonVirtualCall(rewrittenMethodSymbol, node.Syntax);
+                }
+                else
+                {
+                    Debug.Assert(!rewrittenMethodSymbol.IsMetadataVirtual(CompilationState.Compilation.SourceModule));
+                }
             }
 
             return node.Update(
@@ -341,7 +343,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             // if the original receiver was BoundKind.BaseReference (i.e. from a method group)
             // and the receiver is overridden, change the method to point to a wrapper method
-            if (BaseReferenceInReceiverWasRewritten(originalArgument, rewrittenArgument) && method!.IsMetadataVirtual())
+            if (BaseReferenceInReceiverWasRewritten(originalArgument, rewrittenArgument) && method!.IsMetadataVirtual(CompilationState.Compilation.SourceModule))
             {
                 method = GetMethodWrapperForBaseNonVirtualCall(method, originalArgument.Syntax);
             }

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -1437,7 +1437,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // in special circumstances. These circumstances are exactly the checks performed by
             // MayUseCallForStructMethod (which is also used by the emitter when determining
             // whether or not to call a method with a value type receiver directly).
-            if (!method.ContainingType.IsValueType || !Microsoft.CodeAnalysis.CSharp.CodeGen.CodeGenerator.MayUseCallForStructMethod(method))
+            if (!method.ContainingType.IsValueType || !Microsoft.CodeAnalysis.CSharp.CodeGen.CodeGenerator.MayUseCallForStructMethod(this.CompilationState.Compilation.SourceModule, method))
             {
                 method = method.GetConstructedLeastOverriddenMethod(this.CompilationState.Type, requireSameReturnType: true);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.ConstructorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.ConstructorSymbol.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 get { return false; }
             }
 
-            internal sealed override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None)
+            internal sealed override bool IsMetadataVirtual(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.EqualsMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.EqualsMethodSymbol.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 get { return true; }
             }
 
-            internal sealed override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None)
+            internal sealed override bool IsMetadataVirtual(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
             {
                 return true;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.GetHashCodeMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.GetHashCodeMethodSymbol.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 get { return true; }
             }
 
-            internal sealed override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None)
+            internal sealed override bool IsMetadataVirtual(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
             {
                 return true;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.PropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.PropertyAccessorSymbol.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 get { return false; }
             }
 
-            internal sealed override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None)
+            internal sealed override bool IsMetadataVirtual(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.SynthesizedMethodBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.SynthesizedMethodBase.cs
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 get { return _name; }
             }
 
-            internal sealed override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
+            internal sealed override bool IsMetadataNewSlot(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.ToStringMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.ToStringMethodSymbol.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 get { return true; }
             }
 
-            internal sealed override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None)
+            internal sealed override bool IsMetadataVirtual(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
             {
                 return true;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorMethodSymbol.cs
@@ -215,12 +215,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal sealed override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
+        internal sealed override bool IsMetadataNewSlot(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
             return false;
         }
 
-        internal sealed override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None)
+        internal sealed override bool IsMetadataVirtual(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
             return false;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Extensions/SourceExtensionImplementationMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Extensions/SourceExtensionImplementationMethodSymbol.cs
@@ -49,9 +49,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public sealed override bool IsAbstract => false;
         public sealed override bool IsSealed => false;
 
-        internal sealed override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None) => false;
+        internal sealed override bool IsMetadataVirtual(ModuleSymbol? context, bool ignoreInterfaceImplementationChanges = false) => false;
         internal sealed override bool IsMetadataFinal => false;
-        internal sealed override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false) => false;
+        internal sealed override bool IsMetadataNewSlot(ModuleSymbol? context, bool ignoreInterfaceImplementationChanges = false) => false;
 
         internal sealed override bool IsAccessCheckedOnOverride => false;
 

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerMethodSymbol.cs
@@ -846,8 +846,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override ImmutableHashSet<string> ReturnNotNullIfParameterNotNull => ImmutableHashSet<string>.Empty;
         public override FlowAnalysisAnnotations FlowAnalysisAnnotations => FlowAnalysisAnnotations.None;
         internal sealed override ThreeState RuntimeAsyncMethodGenerationAttributeSetting => throw ExceptionUtilities.Unreachable();
-        internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false) => false;
-        internal override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None) => false;
+        internal override bool IsMetadataNewSlot(ModuleSymbol? context, bool ignoreInterfaceImplementationChanges = false) => false;
+        internal override bool IsMetadataVirtual(ModuleSymbol? context, bool ignoreInterfaceImplementationChanges = false) => false;
         internal sealed override UnmanagedCallersOnlyAttributeData? GetUnmanagedCallersOnlyAttributeData(bool forceComplete) => null;
         internal sealed override bool HasSpecialNameAttribute => throw ExceptionUtilities.Unreachable();
 

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
@@ -615,9 +615,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         public override bool IsStatic => HasFlag(MethodAttributes.Static);
 
-        internal override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None) => HasFlag(MethodAttributes.Virtual);
+        internal override bool IsMetadataVirtual(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false) => IsMetadataVirtual();
+        internal bool IsMetadataVirtual() => HasFlag(MethodAttributes.Virtual);
 
-        internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false) => HasFlag(MethodAttributes.NewSlot);
+        internal override bool IsMetadataNewSlot(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false) => IsMetadataNewSlot();
+        internal bool IsMetadataNewSlot() => HasFlag(MethodAttributes.NewSlot);
 
         internal override bool IsMetadataFinal => HasFlag(MethodAttributes.Final);
 

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -1226,7 +1226,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         bool IMethodSymbolInternal.IsAccessCheckedOnOverride => IsAccessCheckedOnOverride;
         bool IMethodSymbolInternal.IsExternal => IsExternal;
         bool IMethodSymbolInternal.IsHiddenBySignature => !HidesBaseMethodsByName;
-        bool IMethodSymbolInternal.IsMetadataNewSlot => IsMetadataNewSlot();
+        bool IMethodSymbolInternal.IsMetadataNewSlotIgnoringInterfaceImplementationChanges => IsMetadataNewSlot(context: null, ignoreInterfaceImplementationChanges: true);
         bool IMethodSymbolInternal.IsPlatformInvoke => GetDllImportData() != null;
         bool IMethodSymbolInternal.HasRuntimeSpecialName => HasRuntimeSpecialName;
         bool IMethodSymbolInternal.IsMetadataFinal => IsSealed;

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
@@ -40,10 +40,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             // Note: Flipping the metadata-virtual bit on a method can't change it from not-a-runtime-finalize
             // to runtime-finalizer (since it will also be marked newslot), so it is safe to use
-            // IsMetadataVirtualIgnoringInterfaceImplementationChanges.  This also has the advantage of making
+            // IsMetadataVirtual(ignoreInterfaceImplementationChanges: true). This also has the advantage of making
             // this method safe to call before declaration diagnostics have been computed.
             if ((object)method == null || method.Name != WellKnownMemberNames.DestructorName ||
-                method.ParameterCount != 0 || method.Arity != 0 || !method.IsMetadataVirtual(MethodSymbol.IsMetadataVirtualOption.IgnoreInterfaceImplementationChanges))
+                method.ParameterCount != 0 || method.Arity != 0 || !method.IsMetadataVirtual(context: null, ignoreInterfaceImplementationChanges: true))
             {
                 return false;
             }
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     return true;
                 }
-                else if (method.IsMetadataNewSlot(ignoreInterfaceImplementationChanges: true))
+                else if (method.IsMetadataNewSlot(context: null, ignoreInterfaceImplementationChanges: true))
                 {
                     // If the method isn't a runtime override, then it can't be a finalizer.
                     return false;

--- a/src/Compilers/CSharp/Portable/Symbols/OverriddenOrHiddenMembersHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/OverriddenOrHiddenMembersHelpers.cs
@@ -1016,10 +1016,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // be computed, then it is important for us to pass ignoreInterfaceImplementationChanges: true
             // (see MethodSymbol.IsMetadataVirtual for details).
             // Since we are only concerned with overrides (of class methods), interface implementations can be ignored.
-            const MethodSymbol.IsMetadataVirtualOption ignoreInterfaceImplementationChanges = MethodSymbol.IsMetadataVirtualOption.IgnoreInterfaceImplementationChanges;
-
             wasAmbiguous = false;
-            if (!method.IsMetadataVirtual(ignoreInterfaceImplementationChanges) || method.IsStatic)
+            if (!method.IsMetadataVirtual(context: null, ignoreInterfaceImplementationChanges: true) || method.IsStatic)
             {
                 return null;
             }
@@ -1038,7 +1036,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         MethodSymbol overridden = (MethodSymbol)otherMember;
 
                         // NOTE: The runtime doesn't consider non-virtual methods during override resolution.
-                        if (overridden.IsMetadataVirtual(ignoreInterfaceImplementationChanges))
+                        if (overridden.IsMetadataVirtual(context: null, ignoreInterfaceImplementationChanges: true))
                         {
                             if (candidate is { })
                             {

--- a/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
@@ -419,12 +419,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return true; }
         }
 
-        internal sealed override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
+        internal sealed override bool IsMetadataNewSlot(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
             return false;
         }
 
-        internal sealed override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None)
+        internal sealed override bool IsMetadataVirtual(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
             return false;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyMethodSymbol.cs
@@ -162,9 +162,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override ModuleSymbol ContainingModule { get { throw ExceptionUtilities.Unreachable(); } }
 
-        internal sealed override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false) { throw ExceptionUtilities.Unreachable(); }
+        internal sealed override bool IsMetadataNewSlot(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false) { throw ExceptionUtilities.Unreachable(); }
 
-        internal sealed override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None) { throw ExceptionUtilities.Unreachable(); }
+        internal sealed override bool IsMetadataVirtual(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false) { throw ExceptionUtilities.Unreachable(); }
 
         internal override bool IsMetadataFinal
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -114,12 +114,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _isAsync; }
         }
 
-        internal sealed override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
+        internal sealed override bool IsMetadataNewSlot(ModuleSymbol? context, bool ignoreInterfaceImplementationChanges = false)
         {
             return false;
         }
 
-        internal sealed override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None)
+        internal sealed override bool IsMetadataVirtual(ModuleSymbol? context, bool ignoreInterfaceImplementationChanges = false)
         {
             return false;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -427,9 +427,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override bool IsInitOnly => false;
 
-        internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false) => false;
+        internal override bool IsMetadataNewSlot(ModuleSymbol? context, bool ignoreInterfaceImplementationChanges = false) => false;
 
-        internal override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None) => false;
+        internal override bool IsMetadataVirtual(ModuleSymbol? context, bool ignoreInterfaceImplementationChanges = false) => false;
 
         internal override int CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDestructorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDestructorSymbol.cs
@@ -161,7 +161,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return OneOrMany.Create(default(SyntaxList<AttributeListSyntax>));
         }
 
-        internal sealed override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None)
+        internal sealed override bool IsMetadataVirtual(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
             return true;
         }
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal sealed override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
+        internal sealed override bool IsMetadataNewSlot(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
             return (object)this.ContainingType.BaseTypeNoUseSiteDiagnostics == null;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -1910,7 +1910,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             needSynthesizedImplementation = false;
                         }
                     }
-                    else if (implementingMethod.IsMetadataVirtual(MethodSymbol.IsMetadataVirtualOption.IgnoreInterfaceImplementationChanges))
+                    else if (implementingMethod.IsMetadataVirtual(null, ignoreInterfaceImplementationChanges: true))
                     {
                         // If the signatures match and the implementation method is definitely virtual, then we're set.
                         needSynthesizedImplementation = false;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -567,8 +567,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        // TODO (tomat): sealed
-        internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
+#nullable enable
+        internal override bool IsMetadataNewSlot(ModuleSymbol? context, bool ignoreInterfaceImplementationChanges = false)
         {
             if (IsExplicitInterfaceImplementation && _containingType.IsInterface)
             {
@@ -582,21 +582,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // in NamedTypeSymbolAdapter.cs).
             return this.IsOverride ?
                 this.RequiresExplicitOverride(out _) :
-                !this.IsStatic && this.IsMetadataVirtual(ignoreInterfaceImplementationChanges ? IsMetadataVirtualOption.IgnoreInterfaceImplementationChanges : IsMetadataVirtualOption.None);
+                !this.IsStatic && this.IsMetadataVirtual(context, ignoreInterfaceImplementationChanges);
         }
 
-        // TODO (tomat): sealed?
-        internal override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None)
+        internal override bool IsMetadataVirtual(ModuleSymbol? context, bool ignoreInterfaceImplementationChanges = false)
         {
-#if DEBUG
-            if (option == IsMetadataVirtualOption.ForceCompleteIfNeeded && !this.flags.IsMetadataVirtualLocked)
+            Debug.Assert(context is not null || ignoreInterfaceImplementationChanges);
+
+            if (!ignoreInterfaceImplementationChanges && context != (object)ContainingModule)
             {
                 this.ContainingSymbol.ForceComplete(locationOpt: null, filter: null, cancellationToken: CancellationToken.None);
             }
-#endif
 
-            return this.flags.IsMetadataVirtual(ignoreInterfaceImplementationChanges: option == IsMetadataVirtualOption.IgnoreInterfaceImplementationChanges);
+            return this.flags.IsMetadataVirtual(ignoreInterfaceImplementationChanges);
         }
+#nullable disable
 
         internal void EnsureMetadataVirtual()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedDelegateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedDelegateSymbol.cs
@@ -75,12 +75,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return WellKnownMemberNames.DelegateInvokeName; }
         }
 
-        internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
+        internal override bool IsMetadataNewSlot(ModuleSymbol? context, bool ignoreInterfaceImplementationChanges = false)
         {
             return true;
         }
 
-        internal override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None)
+        internal override bool IsMetadataVirtual(ModuleSymbol? context, bool ignoreInterfaceImplementationChanges = false)
         {
             return true;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributePropertySymbol.cs
@@ -9,12 +9,12 @@ using Microsoft.Cci;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols;
 
-internal sealed class SynthesizedPropertySymbol : PropertySymbol
+internal sealed class SynthesizedEmbeddedAttributePropertySymbol : PropertySymbol
 {
     private readonly string _name;
     private readonly SynthesizedFieldSymbol _backingField;
 
-    public SynthesizedPropertySymbol(string name, SynthesizedFieldSymbol backingField)
+    public SynthesizedEmbeddedAttributePropertySymbol(string name, SynthesizedFieldSymbol backingField)
     {
         _name = name;
         _backingField = backingField;
@@ -50,9 +50,9 @@ internal sealed class SynthesizedPropertySymbol : PropertySymbol
     internal override ObsoleteAttributeData? ObsoleteAttributeData => null;
     internal override int TryGetOverloadResolutionPriority() => 0;
 
-    private sealed partial class GetAccessorMethodSymbol(SynthesizedPropertySymbol property) : SynthesizedMethodSymbol
+    private sealed partial class GetAccessorMethodSymbol(SynthesizedEmbeddedAttributePropertySymbol property) : SynthesizedMethodSymbol
     {
-        private readonly SynthesizedPropertySymbol _property = property;
+        private readonly SynthesizedEmbeddedAttributePropertySymbol _property = property;
 
         public override string Name => $"get_{_property.Name}";
         internal override bool HasSpecialName => true;
@@ -113,7 +113,7 @@ internal sealed class SynthesizedPropertySymbol : PropertySymbol
         public override DllImportData? GetDllImportData() => null;
         internal override ImmutableArray<string> GetAppliedConditionalSymbols() => [];
         internal override IEnumerable<SecurityAttribute>? GetSecurityInformation() => null;
-        internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false) => false;
-        internal override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None) => false;
+        internal override bool IsMetadataNewSlot(ModuleSymbol? context, bool ignoreInterfaceImplementationChanges = false) => false;
+        internal override bool IsMetadataVirtual(ModuleSymbol? context, bool ignoreInterfaceImplementationChanges = false) => false;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedExtensionMarkerNameAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedExtensionMarkerNameAttributeSymbol.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         private readonly ImmutableArray<MethodSymbol> _constructors;
         private readonly SynthesizedFieldSymbol _nameField;
-        private readonly SynthesizedPropertySymbol _nameProperty;
+        private readonly SynthesizedEmbeddedAttributePropertySymbol _nameProperty;
 
         private const string PropertyName = "Name";
         private const string FieldName = "<Name>k__BackingField";
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(FieldName == GeneratedNames.MakeBackingFieldName(PropertyName));
 
             _nameField = new SynthesizedFieldSymbol(this, systemStringType, FieldName, isReadOnly: true);
-            _nameProperty = new SynthesizedPropertySymbol(PropertyName, _nameField);
+            _nameProperty = new SynthesizedEmbeddedAttributePropertySymbol(PropertyName, _nameField);
             _constructors = [new SynthesizedEmbeddedAttributeConstructorWithBodySymbol(this, getConstructorParameters, getConstructorBody)];
 
             // Ensure we never get out of sync with the description

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedMemorySafetyRulesAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedMemorySafetyRulesAttributeSymbol.cs
@@ -52,7 +52,7 @@ internal sealed class SynthesizedEmbeddedMemorySafetyRulesAttributeSymbol : Synt
 
         _properties =
         [
-            new SynthesizedPropertySymbol(PropertyName, field),
+            new SynthesizedEmbeddedAttributePropertySymbol(PropertyName, field),
         ];
 
         _constructors =

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
@@ -228,12 +228,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal sealed override bool IsInitOnly => false;
 
-        internal sealed override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
+        internal sealed override bool IsMetadataNewSlot(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
             return false;
         }
 
-        internal sealed override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None)
+        internal sealed override bool IsMetadataVirtual(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
             return false;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedGlobalMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedGlobalMethodSymbol.cs
@@ -290,12 +290,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return false; }
         }
 
-        internal sealed override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
+        internal sealed override bool IsMetadataNewSlot(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
             return false;
         }
 
-        internal sealed override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None)
+        internal sealed override bool IsMetadataVirtual(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
             return false;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedImplementationMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedImplementationMethod.cs
@@ -223,7 +223,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _interfaceMethod.RequiresSecurityObject; }
         }
 
-        internal sealed override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None)
+        internal sealed override bool IsMetadataVirtual(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
             return !IsStatic;
         }
@@ -236,7 +236,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal sealed override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
+        internal sealed override bool IsMetadataNewSlot(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
             return !IsStatic;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInstanceConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInstanceConstructor.cs
@@ -235,12 +235,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return false; }
         }
 
-        internal sealed override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
+        internal sealed override bool IsMetadataNewSlot(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
             return false;
         }
 
-        internal sealed override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None)
+        internal sealed override bool IsMetadataVirtual(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
             return false;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInteractiveInitializerMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInteractiveInitializerMethod.cs
@@ -220,12 +220,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             throw ExceptionUtilities.Unreachable();
         }
 
-        internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
+        internal override bool IsMetadataNewSlot(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
             return false;
         }
 
-        internal override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None)
+        internal override bool IsMetadataVirtual(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
             return false;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedIntrinsicOperatorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedIntrinsicOperatorSymbol.cs
@@ -93,12 +93,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return null;
         }
 
-        internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
+        internal override bool IsMetadataNewSlot(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
             return false;
         }
 
-        internal override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None)
+        internal override bool IsMetadataVirtual(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
             return false;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSealedPropertyAccessor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSealedPropertyAccessor.cs
@@ -307,7 +307,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal sealed override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None)
+        internal sealed override bool IsMetadataVirtual(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
             return true;
         }
@@ -320,7 +320,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal sealed override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
+        internal sealed override bool IsMetadataNewSlot(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
             return false;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedStaticConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedStaticConstructor.cs
@@ -311,12 +311,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal sealed override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
+        internal sealed override bool IsMetadataNewSlot(ModuleSymbol? context, bool ignoreInterfaceImplementationChanges = false)
         {
             return false;
         }
 
-        internal sealed override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None)
+        internal sealed override bool IsMetadataVirtual(ModuleSymbol? context, bool ignoreInterfaceImplementationChanges = false)
         {
             return false;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedMethodSymbol.cs
@@ -182,9 +182,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override CallerUnsafeMode CallerUnsafeMode => UnderlyingMethod.CallerUnsafeMode;
 
-        internal override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None)
+        internal override bool IsMetadataVirtual(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
-            return UnderlyingMethod.IsMetadataVirtual(option);
+            return UnderlyingMethod.IsMetadataVirtual(context, ignoreInterfaceImplementationChanges);
         }
 
         internal override bool IsMetadataFinal
@@ -195,9 +195,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
+        internal override bool IsMetadataNewSlot(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
-            return UnderlyingMethod.IsMetadataNewSlot(ignoreInterfaceImplementationChanges);
+            return UnderlyingMethod.IsMetadataNewSlot(context, ignoreInterfaceImplementationChanges);
         }
 
         internal override bool RequiresSecurityObject

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CovariantReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CovariantReturnTests.cs
@@ -262,13 +262,13 @@ namespace System.Runtime.CompilerServices
             {
                 Assert.True(method.IsOverride);
                 Assert.False(method.IsVirtual);
-                Assert.True(method.IsMetadataVirtual(MethodSymbol.IsMetadataVirtualOption.IgnoreInterfaceImplementationChanges));
+                Assert.True(method.IsMetadataVirtual(context: null, ignoreInterfaceImplementationChanges: true));
                 var isCovariant = !method.ReturnType.Equals(overriddenMethod.ReturnType, TypeCompareKind.AllIgnoreOptions);
                 var checkMetadata = hasReturnConversion(method.ReturnType, overriddenMethod.ReturnType);
                 if (checkMetadata)
                 {
                     requiresMethodimpl = isCovariant | requiresMethodimpl;
-                    Assert.Equal(requiresMethodimpl, method.IsMetadataNewSlot(ignoreInterfaceImplementationChanges: true));
+                    Assert.Equal(requiresMethodimpl, method.IsMetadataNewSlot(context: null, ignoreInterfaceImplementationChanges: true));
                     Assert.Equal(requiresMethodimpl, method.RequiresExplicitOverride(out _));
                     if (method.OriginalDefinition is PEMethodSymbol originalMethod &&
                         comp.GetSpecialTypeMember(SpecialMember.System_Runtime_CompilerServices_PreserveBaseOverridesAttribute__ctor) is MethodSymbol attrConstructor)
@@ -308,7 +308,7 @@ namespace System.Runtime.CompilerServices
                     if (checkMetadata)
                     {
                         requiresMethodimpl = isCovariant | requiresMethodimpl;
-                        Assert.Equal(requiresMethodimpl, getMethod.IsMetadataNewSlot(ignoreInterfaceImplementationChanges: true));
+                        Assert.Equal(requiresMethodimpl, getMethod.IsMetadataNewSlot(context: null, ignoreInterfaceImplementationChanges: true));
                         Assert.Equal(requiresMethodimpl, getMethod.RequiresExplicitOverride(out _)); // implies the presence of a methodimpl
                         if (getMethod.OriginalDefinition is PEMethodSymbol originalMethod &&
                             comp.GetSpecialTypeMember(SpecialMember.System_Runtime_CompilerServices_PreserveBaseOverridesAttribute__ctor) is MethodSymbol attrConstructor)
@@ -319,7 +319,7 @@ namespace System.Runtime.CompilerServices
                 }
                 if (property.SetMethod is MethodSymbol setMethod && overriddenProperty.SetMethod is MethodSymbol overriddenSetMethod)
                 {
-                    Assert.False(setMethod.IsMetadataNewSlot(ignoreInterfaceImplementationChanges: true));
+                    Assert.False(setMethod.IsMetadataNewSlot(context: null, ignoreInterfaceImplementationChanges: true));
                     Assert.False(setMethod.RequiresExplicitOverride(out _));
                     Assert.Equal(!isCovariant, overriddenSetMethod.Equals(setMethod.GetOverriddenMember(), TypeCompareKind.AllIgnoreOptions));
                 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/CompletionTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/CompletionTests.cs
@@ -179,5 +179,37 @@ class A {
         {
             return unchecked((bits & (sbyte)(bits - 1)) == 0);
         }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/83978")]
+        public void Repro_IsMetadataVirtualLocked_Assertion()
+        {
+            var source1 = """
+                public struct U : I1
+                {
+                    public object Value => throw null!;
+                }
+
+                public interface I1
+                {
+                    object Value { get; }
+                }
+                """;
+
+            var source2 = """
+                class Program
+                {
+                    object M1(U u)
+                    {
+                        return u.Value;
+                    }
+                }
+                """;
+
+            var comp0 = CreateCompilation(source1);
+            var comp = CreateCompilation(source2, references: [comp0.ToMetadataReference()]);
+            comp.VerifyEmitDiagnostics();
+            comp0.VerifyEmitDiagnostics();
+        }
     }
 }

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DeletedPEMethodDefinition.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DeletedPEMethodDefinition.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Emit.EditAndContinue
             => _oldMethod.IsHiddenBySignature;
 
         public bool IsNewSlot
-            => _oldMethod.IsMetadataNewSlot;
+            => _oldMethod.IsMetadataNewSlotIgnoringInterfaceImplementationChanges;
 
         public bool IsPlatformInvoke
             => _oldMethod.IsPlatformInvoke;

--- a/src/Compilers/Core/Portable/Symbols/IMethodSymbolInternal.cs
+++ b/src/Compilers/Core/Portable/Symbols/IMethodSymbolInternal.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Symbols
         bool IsAccessCheckedOnOverride { get; }
         bool IsExternal { get; }
         bool IsHiddenBySignature { get; }
-        bool IsMetadataNewSlot { get; }
+        bool IsMetadataNewSlotIgnoringInterfaceImplementationChanges { get; }
         bool IsPlatformInvoke { get; }
         bool IsMetadataFinal { get; }
         bool HasSpecialName { get; }

--- a/src/Compilers/Test/Utilities/CSharp/Extensions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/Extensions.cs
@@ -631,6 +631,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(propertyOrEvent.IsExtern, accessor.IsExtern);
             Assert.Equal(propertyOrEvent.IsStatic, accessor.IsStatic);
         }
+
+        internal static bool IsMetadataNewSlot(this MethodSymbol method)
+        {
+            return method.IsMetadataNewSlot(context: method.ContainingModule);
+        }
+
+        internal static bool IsMetadataVirtual(this MethodSymbol method)
+        {
+            return method.IsMetadataVirtual(context: method.ContainingModule);
+        }
     }
 }
 

--- a/src/Compilers/Test/Utilities/CSharp/FunctionPointerUtilities.cs
+++ b/src/Compilers/Test/Utilities/CSharp/FunctionPointerUtilities.cs
@@ -78,10 +78,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 Assert.False(symbol.HasDeclarativeSecurity);
                 Assert.False(symbol.RequiresSecurityObject);
                 Assert.False(symbol.IsDeclaredReadOnly);
-                Assert.False(symbol.IsMetadataNewSlot(true));
-                Assert.False(symbol.IsMetadataNewSlot(false));
-                Assert.False(symbol.IsMetadataVirtual(MethodSymbol.IsMetadataVirtualOption.IgnoreInterfaceImplementationChanges));
-                Assert.False(symbol.IsMetadataVirtual(MethodSymbol.IsMetadataVirtualOption.None));
+                Assert.False(symbol.IsMetadataNewSlot(context: null, ignoreInterfaceImplementationChanges: true));
+                Assert.False(symbol.IsMetadataNewSlot(context: symbol.ContainingModule));
+                Assert.False(symbol.IsMetadataVirtual(context: null, ignoreInterfaceImplementationChanges: true));
+                Assert.False(symbol.IsMetadataVirtual(context: symbol.ContainingModule));
 
                 Assert.Equal(symbol.IsVararg, symbol.CallingConvention.IsCallingConvention(CallingConvention.ExtraArguments));
 

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_XmlLiterals.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_XmlLiterals.vb
@@ -1988,7 +1988,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End Get
             End Property
 
-            Friend Overrides Function IsMetadataNewSlot(Optional ignoreInterfaceImplementationChanges As Boolean = False) As Boolean
+            Friend Overrides Function IsMetadataNewSlot() As Boolean
                 Return False
             End Function
 

--- a/src/Compilers/VisualBasic/Portable/Emit/MethodSymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/MethodSymbolAdapter.vb
@@ -520,14 +520,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' This method indicates whether or not the runtime will regard the method
         ''' as newslot (as indicated by the presence of the "newslot" modifier in the
         ''' signature).
-        ''' WARN WARN WARN: We won't have a final value for this until declaration
-        ''' diagnostics have been computed for all <see cref="SourceMemberContainerTypeSymbol"/>s,
-        ''' so pass ignoringInterfaceImplementationChanges: True if you need a value sooner
-        ''' and aren't concerned about tweaks made to satisfy interface implementation 
-        ''' requirements.
-        ''' NOTE: Not ignoring changes can only result in a value that is more true.
         ''' </summary>
-        Friend Overridable Function IsMetadataNewSlot(Optional ignoreInterfaceImplementationChanges As Boolean = False) As Boolean
+        Friend Overridable Function IsMetadataNewSlot() As Boolean
             If Me.IsOverrides Then
                 Return OverrideHidingHelper.RequiresExplicitOverride(Me)
             Else
@@ -535,7 +529,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End If
         End Function
 
-        Private ReadOnly Property IMethodSymbolInternal_IsMetadataNewSlot As Boolean Implements IMethodSymbolInternal.IsMetadataNewSlot
+        Private ReadOnly Property IMethodSymbolInternal_IsMetadataNewSlotIgnoringInterfaceImplementationChanges As Boolean Implements IMethodSymbolInternal.IsMetadataNewSlotIgnoringInterfaceImplementationChanges
             Get
                 Return IsMetadataNewSlot()
             End Get

--- a/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaFrameConstructor.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaFrameConstructor.vb
@@ -42,7 +42,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
-        Friend Overrides Function IsMetadataNewSlot(Optional ignoreInterfaceImplementationChanges As Boolean = False) As Boolean
+        Friend Overrides Function IsMetadataNewSlot() As Boolean
             Return False
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/SynthesizedLambdaMethod.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/SynthesizedLambdaMethod.vb
@@ -182,7 +182,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
-        Friend Overrides Function IsMetadataNewSlot(Optional ignoreInterfaceImplementationChanges As Boolean = False) As Boolean
+        Friend Overrides Function IsMetadataNewSlot() As Boolean
             Return False
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/MethodToClassRewriter/MethodToClassRewriter.MyBaseMyClassWrapper.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/MethodToClassRewriter/MethodToClassRewriter.MyBaseMyClassWrapper.vb
@@ -305,7 +305,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End Get
             End Property
 
-            Friend Overrides Function IsMetadataNewSlot(Optional ignoreInterfaceImplementationChanges As Boolean = False) As Boolean
+            Friend Overrides Function IsMetadataNewSlot() As Boolean
                 Return False
             End Function
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/SynthesizedStateMachineMethod.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/SynthesizedStateMachineMethod.vb
@@ -148,7 +148,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
-        Friend Overrides Function IsMetadataNewSlot(Optional ignoreInterfaceImplementationChanges As Boolean = False) As Boolean
+        Friend Overrides Function IsMetadataNewSlot() As Boolean
             Return True
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/ErrorMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ErrorMethodSymbol.vb
@@ -254,7 +254,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend Overrides Function IsMetadataNewSlot(Optional ignoreInterfaceImplementationChanges As Boolean = False) As Boolean
+        Friend Overrides Function IsMetadataNewSlot() As Boolean
             Return False
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEMethodSymbol.vb
@@ -726,7 +726,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             Return _containingType.ContainingPEModule.Module.GetDllImportData(Me._handle)
         End Function
 
-        Friend Overrides Function IsMetadataNewSlot(Optional ignoreInterfaceImplementationChanges As Boolean = False) As Boolean
+        Friend Overrides Function IsMetadataNewSlot() As Boolean
             Return (_flags And MethodAttributes.NewSlot) <> 0
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/ReducedExtensionMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ReducedExtensionMethodSymbol.vb
@@ -652,7 +652,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend Overrides Function IsMetadataNewSlot(Optional ignoreInterfaceImplementationChanges As Boolean = False) As Boolean
+        Friend Overrides Function IsMetadataNewSlot() As Boolean
             Return False
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingMethodSymbol.vb
@@ -315,8 +315,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
             Return _underlyingMethod.GetDllImportData()
         End Function
 
-        Friend Overrides Function IsMetadataNewSlot(Optional ignoreInterfaceImplementationChanges As Boolean = False) As Boolean
-            Return _underlyingMethod.IsMetadataNewSlot(ignoreInterfaceImplementationChanges)
+        Friend Overrides Function IsMetadataNewSlot() As Boolean
+            Return _underlyingMethod.IsMetadataNewSlot()
         End Function
 
         Friend Overrides ReadOnly Property ReturnValueIsMarshalledExplicitly As Boolean

--- a/src/Compilers/VisualBasic/Portable/Symbols/SignatureOnlyMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SignatureOnlyMethodSymbol.vb
@@ -301,7 +301,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Throw ExceptionUtilities.Unreachable
         End Function
 
-        Friend Overrides Function IsMetadataNewSlot(Optional ignoreInterfaceImplementationChanges As Boolean = False) As Boolean
+        Friend Overrides Function IsMetadataNewSlot() As Boolean
             Throw ExceptionUtilities.Unreachable
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/LambdaSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/LambdaSymbol.vb
@@ -339,7 +339,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend Overrides Function IsMetadataNewSlot(Optional ignoreInterfaceImplementationChanges As Boolean = False) As Boolean
+        Friend Overrides Function IsMetadataNewSlot() As Boolean
             Return False
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol_ComClass.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol_ComClass.vb
@@ -1383,7 +1383,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     Return ImmutableArray(Of VisualBasicAttributeData).Empty
                 End Function
 
-                Friend NotOverridable Overrides Function IsMetadataNewSlot(Optional ignoreInterfaceImplementationChanges As Boolean = False) As Boolean
+                Friend NotOverridable Overrides Function IsMetadataNewSlot() As Boolean
                     Return True
                 End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SynthesizedEntryPointSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SynthesizedEntryPointSymbol.vb
@@ -172,7 +172,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend Overrides Function IsMetadataNewSlot(Optional ignoreInterfaceImplementationChanges As Boolean = False) As Boolean
+        Friend Overrides Function IsMetadataNewSlot() As Boolean
             Return False
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/SubstitutedMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SubstitutedMethodSymbol.vb
@@ -341,8 +341,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend NotOverridable Overrides Function IsMetadataNewSlot(Optional ignoreInterfaceImplementationChanges As Boolean = False) As Boolean
-            Return OriginalDefinition.IsMetadataNewSlot(ignoreInterfaceImplementationChanges)
+        Friend NotOverridable Overrides Function IsMetadataNewSlot() As Boolean
+            Return OriginalDefinition.IsMetadataNewSlot()
         End Function
 
         Friend NotOverridable Overrides Function TryGetMeParameter(<Out> ByRef meParameter As ParameterSymbol) As Boolean

--- a/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedIntrinsicOperatorSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedIntrinsicOperatorSymbol.vb
@@ -171,7 +171,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend Overrides Function IsMetadataNewSlot(Optional ignoreInterfaceImplementationChanges As Boolean = False) As Boolean
+        Friend Overrides Function IsMetadataNewSlot() As Boolean
             Return False
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Wrapped/WrappedMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Wrapped/WrappedMethodSymbol.vb
@@ -249,8 +249,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend Overrides Function IsMetadataNewSlot(Optional ignoreInterfaceImplementationChanges As Boolean = False) As Boolean
-            Return Me.UnderlyingMethod.IsMetadataNewSlot(ignoreInterfaceImplementationChanges)
+        Friend Overrides Function IsMetadataNewSlot() As Boolean
+            Return Me.UnderlyingMethod.IsMetadataNewSlot()
         End Function
 
         Public Overrides Function GetDllImportData() As DllImportData

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
@@ -216,12 +216,12 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             return SynthesizedParameterSymbol.Create(this, sourceParameter.TypeWithAnnotations, ordinal, sourceParameter.RefKind, name, ScopedKind.None, refCustomModifiers: sourceParameter.RefCustomModifiers);
         }
 
-        internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
+        internal override bool IsMetadataNewSlot(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
             return false;
         }
 
-        internal override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None)
+        internal override bool IsMetadataVirtual(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
             return false;
         }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderMethodSymbol.cs
@@ -262,12 +262,12 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             }
         }
 
-        internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
+        internal override bool IsMetadataNewSlot(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
             return false;
         }
 
-        internal override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None)
+        internal override bool IsMetadataVirtual(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
             return false;
         }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/SynthesizedContextMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/SynthesizedContextMethodSymbol.cs
@@ -207,12 +207,12 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             }
         }
 
-        internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
+        internal override bool IsMetadataNewSlot(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
             throw ExceptionUtilities.Unreachable();
         }
 
-        internal override bool IsMetadataVirtual(IsMetadataVirtualOption option = IsMetadataVirtualOption.None)
+        internal override bool IsMetadataVirtual(ModuleSymbol context, bool ignoreInterfaceImplementationChanges = false)
         {
             throw ExceptionUtilities.Unreachable();
         }


### PR DESCRIPTION
Fixes #83978
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84013)