### PR TITLE
Remove the Test_macOS_Debug job from 17.14 CI runs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -328,6 +328,33 @@ stages:
       helixApiAccessToken: $(HelixApiAccessToken)
       poolParameters: ${{ parameters.windowsPool }}
 
+- stage: Unix_Debug_CoreClr
+  dependsOn: Unix_Build
+  variables:
+  - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+    - group: DotNet-HelixApi-Access
+  jobs:
+  - template: eng/pipelines/test-unix-job.yml
+    parameters:
+      testRunName: 'Test Linux Debug'
+      jobName: Test_Linux_Debug
+      testArtifactName: Transport_Artifacts_Unix_Debug
+      configuration: Debug
+      testArguments: --testCoreClr
+      helixQueueName: $(HelixUbuntuQueueName)
+      helixApiAccessToken: $(HelixApiAccessToken)
+      poolParameters: ${{ parameters.ubuntuPool }}
+
+  - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+    - template: eng/pipelines/test-unix-job-single-machine.yml
+      parameters:
+        testRunName: 'Test Linux Debug Single Machine'
+        jobName: Test_Linux_Debug_Single_Machine
+        testArtifactName: Transport_Artifacts_Unix_Debug
+        configuration: Debug
+        testArguments: --testCoreClr
+        poolParameters: ${{ parameters.ubuntuPool }}
+
 - stage: Correctness
   dependsOn: []
   jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -328,47 +328,6 @@ stages:
       helixApiAccessToken: $(HelixApiAccessToken)
       poolParameters: ${{ parameters.windowsPool }}
 
-- stage: Unix_Debug_CoreClr
-  dependsOn: Unix_Build
-  variables:
-  - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-    - group: DotNet-HelixApi-Access
-  jobs:
-  - template: eng/pipelines/test-unix-job.yml
-    parameters:
-      testRunName: 'Test Linux Debug'
-      jobName: Test_Linux_Debug
-      testArtifactName: Transport_Artifacts_Unix_Debug
-      configuration: Debug
-      testArguments: --testCoreClr
-      helixQueueName: $(HelixUbuntuQueueName)
-      helixApiAccessToken: $(HelixApiAccessToken)
-      poolParameters: ${{ parameters.ubuntuPool }}
-
-  - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-    - template: eng/pipelines/test-unix-job-single-machine.yml
-      parameters:
-        testRunName: 'Test Linux Debug Single Machine'
-        jobName: Test_Linux_Debug_Single_Machine
-        testArtifactName: Transport_Artifacts_Unix_Debug
-        configuration: Debug
-        testArguments: --testCoreClr
-        poolParameters: ${{ parameters.ubuntuPool }}
-
-  # https://github.com/dotnet/runtime/issues/97186
-  # Disabled until runtime can track down the crash
-  - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-    - template: eng/pipelines/test-unix-job.yml
-      parameters:
-        testRunName: 'Test macOS Debug'
-        jobName: Test_macOS_Debug
-        testArtifactName: Transport_Artifacts_Unix_Debug
-        configuration: Debug
-        testArguments: --testCoreClr 
-        helixQueueName: $(HelixMacOsQueueName)
-        helixApiAccessToken: $(HelixApiAccessToken)
-        poolParameters: ${{ parameters.ubuntuPool }}
-
 - stage: Correctness
   dependsOn: []
   jobs:


### PR DESCRIPTION
Consistently failing (timing out) in this branch so we are removing since nothing we put in 17.14 affects Mac execution.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84015)