### PR TITLE
Remove unneeded logging

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/FileWatchedPortableExecutableReferenceFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/FileWatchedPortableExecutableReferenceFactory.cs
@@ -35,18 +35,7 @@ internal sealed class FileWatchedReferenceFactory<TReference>
     /// the file reference will actually be a file reference or it'll be a converted project reference.
     /// </summary>
     private readonly Dictionary<string, (IWatchedFile Token, int RefCount)> _referenceFileWatchingTokens = [];
-
-    /// <summary>
-    /// Stores the caller for a previous disposal of a reference produced by this class, to track down a double-dispose
-    /// issue.
-    /// </summary>
-    /// <remarks>
-    /// This can be removed once https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1843611 is fixed.
-    /// </remarks>
-    private readonly ConditionalWeakTable<TReference, string> _previousDisposalLocations = new();
-
     private readonly AsyncBatchingWorkQueue<string> _workQueue;
-
     private readonly Func<string, CancellationToken, Task> _callback;
 
     public FileWatchedReferenceFactory(
@@ -130,23 +119,12 @@ internal sealed class FileWatchedReferenceFactory<TReference>
     /// 0, the file watcher will be stopped. This is *not* safe to attempt to call multiple times for the same project
     /// and reference (e.g. in applying workspace updates)
     /// </summary>
-    public void StopWatchingReference(string fullFilePath, TReference? referenceToTrack, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = 0)
+    public void StopWatchingReference(string fullFilePath)
     {
         lock (_gate)
         {
             if (!_referenceFileWatchingTokens.TryGetValue(fullFilePath, out var watchedFileReference))
-            {
-                if (referenceToTrack != null)
-                {
-                    // We're attempting to stop watching a file that we never started watching. This is a bug.
-                    var existingDisposalStackTrace = _previousDisposalLocations.TryGetValue(referenceToTrack, out var previousDisposalLocation);
-                    throw new ArgumentException("The reference was already disposed at " + previousDisposalLocation);
-                }
-                else
-                {
-                    throw new ArgumentException("Attempting to stop watching a file that we never started watching. This is a bug.");
-                }
-            }
+                throw new ArgumentException("Attempting to stop watching a file that we never started watching. This is a bug.");
 
             var newRefCount = watchedFileReference.RefCount - 1;
             Contract.ThrowIfFalse(newRefCount >= 0, "Ref count cannot be negative");
@@ -155,14 +133,6 @@ internal sealed class FileWatchedReferenceFactory<TReference>
                 // No one else is watching this file, so stop watching it and remove from our map.
                 watchedFileReference.Token.Dispose();
                 _referenceFileWatchingTokens.Remove(fullFilePath);
-
-                if (referenceToTrack != null)
-                {
-                    var disposalLocation = callerFilePath + ", line " + callerLineNumber;
-
-                    _previousDisposalLocations.Remove(referenceToTrack);
-                    _previousDisposalLocations.Add(referenceToTrack, disposalLocation);
-                }
             }
             else
             {

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
@@ -1264,10 +1264,10 @@ internal sealed partial class ProjectSystemProject
         Contract.ThrowIfNull(remainingAnalyzerReferences);
 
         foreach (var reference in remainingMetadataReferences.OfType<PortableExecutableReference>())
-            _projectSystemProjectFactory.FileWatchedPortableExecutableReferenceFactory.StopWatchingReference(reference.FilePath!);
+            _projectSystemProjectFactory.PortableExecutableReferenceFileChangeTracker.StopWatchingReference(reference.FilePath!);
 
         foreach (var reference in remainingAnalyzerReferences)
-            _projectSystemProjectFactory.FileWatchedAnalyzerReferenceFactory.StopWatchingReference(reference.FullPath!);
+            _projectSystemProjectFactory.AnalyzerReferenceFileChangeTracker.StopWatchingReference(reference.FullPath!);
     }
 
     public void ReorderSourceFiles(ImmutableArray<string> filePaths)

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
@@ -1264,10 +1264,10 @@ internal sealed partial class ProjectSystemProject
         Contract.ThrowIfNull(remainingAnalyzerReferences);
 
         foreach (var reference in remainingMetadataReferences.OfType<PortableExecutableReference>())
-            _projectSystemProjectFactory.FileWatchedPortableExecutableReferenceFactory.StopWatchingReference(reference.FilePath!, referenceToTrack: reference);
+            _projectSystemProjectFactory.FileWatchedPortableExecutableReferenceFactory.StopWatchingReference(reference.FilePath!);
 
         foreach (var reference in remainingAnalyzerReferences)
-            _projectSystemProjectFactory.FileWatchedAnalyzerReferenceFactory.StopWatchingReference(reference.FullPath!, referenceToTrack: reference);
+            _projectSystemProjectFactory.FileWatchedAnalyzerReferenceFactory.StopWatchingReference(reference.FullPath!);
     }
 
     public void ReorderSourceFiles(ImmutableArray<string> filePaths)

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
@@ -438,7 +438,7 @@ internal sealed partial class ProjectSystemProjectFactory
 
         // Remove file watchers for any references we're no longer watching.
         foreach (var reference in projectUpdateState.RemovedMetadataReferences)
-            FileWatchedPortableExecutableReferenceFactory.StopWatchingReference(reference.FilePath!, referenceToTrack: reference);
+            FileWatchedPortableExecutableReferenceFactory.StopWatchingReference(reference.FilePath!);
 
         // Add file watchers for any analyzers we are now watching.
         foreach (var referenceFullPath in projectUpdateState.AddedAnalyzerReferences)
@@ -446,7 +446,7 @@ internal sealed partial class ProjectSystemProjectFactory
 
         // Remove file watchers for any analyzers we're no longer watching.
         foreach (var referenceFullPath in projectUpdateState.RemovedAnalyzerReferences)
-            FileWatchedAnalyzerReferenceFactory.StopWatchingReference(referenceFullPath, referenceToTrack: null);
+            FileWatchedAnalyzerReferenceFactory.StopWatchingReference(referenceFullPath);
 
         // Clear the state from the this update in preparation for the next.
         projectUpdateState = projectUpdateState.ClearIncrementalState();

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
@@ -43,8 +43,8 @@ internal sealed partial class ProjectSystemProjectFactory
     public IAsynchronousOperationListener WorkspaceListener { get; }
     public IFileChangeWatcher FileChangeWatcher { get; }
 
-    public FileWatchedReferenceFactory<PortableExecutableReference> FileWatchedPortableExecutableReferenceFactory { get; }
-    public FileWatchedReferenceFactory<AnalyzerReference> FileWatchedAnalyzerReferenceFactory { get; }
+    public ReferenceFileChangeTracker PortableExecutableReferenceFileChangeTracker { get; }
+    public ReferenceFileChangeTracker AnalyzerReferenceFileChangeTracker { get; }
 
     public SolutionServices SolutionServices => this.Workspace.Services.SolutionServices;
 
@@ -90,8 +90,8 @@ internal sealed partial class ProjectSystemProjectFactory
 
         WorkspaceListener = this.SolutionServices.GetRequiredService<IWorkspaceAsynchronousOperationListenerProvider>().GetListener();
 
-        FileWatchedPortableExecutableReferenceFactory = new(fileChangeWatcher, WorkspaceListener, this.StartRefreshingMetadataReferencesForFileAsync, cancellationToken);
-        FileWatchedAnalyzerReferenceFactory = new(fileChangeWatcher, WorkspaceListener, this.StartRefreshingAnalyzerReferenceForFileAsync, cancellationToken);
+        PortableExecutableReferenceFileChangeTracker = new(fileChangeWatcher, WorkspaceListener, this.StartRefreshingMetadataReferencesForFileAsync, cancellationToken);
+        AnalyzerReferenceFileChangeTracker = new(fileChangeWatcher, WorkspaceListener, this.StartRefreshingAnalyzerReferenceForFileAsync, cancellationToken);
     }
 
     public FileTextLoader CreateFileTextLoader(string fullPath)
@@ -434,19 +434,19 @@ internal sealed partial class ProjectSystemProjectFactory
 
         // Add file watchers for any references we are now watching.
         foreach (var reference in projectUpdateState.AddedMetadataReferences)
-            FileWatchedPortableExecutableReferenceFactory.StartWatchingReference(reference.FilePath!);
+            PortableExecutableReferenceFileChangeTracker.StartWatchingReference(reference.FilePath!);
 
         // Remove file watchers for any references we're no longer watching.
         foreach (var reference in projectUpdateState.RemovedMetadataReferences)
-            FileWatchedPortableExecutableReferenceFactory.StopWatchingReference(reference.FilePath!);
+            PortableExecutableReferenceFileChangeTracker.StopWatchingReference(reference.FilePath!);
 
         // Add file watchers for any analyzers we are now watching.
         foreach (var referenceFullPath in projectUpdateState.AddedAnalyzerReferences)
-            FileWatchedAnalyzerReferenceFactory.StartWatchingReference(referenceFullPath);
+            AnalyzerReferenceFileChangeTracker.StartWatchingReference(referenceFullPath);
 
         // Remove file watchers for any analyzers we're no longer watching.
         foreach (var referenceFullPath in projectUpdateState.RemovedAnalyzerReferences)
-            FileWatchedAnalyzerReferenceFactory.StopWatchingReference(referenceFullPath);
+            AnalyzerReferenceFileChangeTracker.StopWatchingReference(referenceFullPath);
 
         // Clear the state from the this update in preparation for the next.
         projectUpdateState = projectUpdateState.ClearIncrementalState();

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ReferenceFileChangeTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ReferenceFileChangeTracker.cs
@@ -18,8 +18,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ProjectSystem;
 
-internal sealed class FileWatchedReferenceFactory<TReference>
-    where TReference : class
+internal sealed class ReferenceFileChangeTracker
 {
     private readonly object _gate = new();
 
@@ -38,7 +37,7 @@ internal sealed class FileWatchedReferenceFactory<TReference>
     private readonly AsyncBatchingWorkQueue<string> _workQueue;
     private readonly Func<string, CancellationToken, Task> _callback;
 
-    public FileWatchedReferenceFactory(
+    public ReferenceFileChangeTracker(
         IFileChangeWatcher fileChangeWatcher,
         IAsynchronousOperationListener asyncListener,
         Func<string, CancellationToken, Task> callback,
@@ -96,7 +95,7 @@ internal sealed class FileWatchedReferenceFactory<TReference>
     }
 
     /// <summary>
-    /// Starts watching a particular <typeparamref name="TReference"/> for changes to the file. If this is already being
+    /// Starts watching a particular reference for changes to the file. If this is already being
     /// watched , the reference count will be incremented. This is *not* safe to attempt to call multiple times for the
     /// same project and reference (e.g. in applying workspace updates)
     /// </summary>
@@ -115,7 +114,7 @@ internal sealed class FileWatchedReferenceFactory<TReference>
     }
 
     /// <summary>
-    /// Decrements the reference count for the given <typeparamref name="TReference"/>. When the reference count reaches
+    /// Decrements the reference count for the given reference. When the reference count reaches
     /// 0, the file watcher will be stopped. This is *not* safe to attempt to call multiple times for the same project
     /// and reference (e.g. in applying workspace updates)
     /// </summary>


### PR DESCRIPTION
The underlying bug has been fixed, so there's no need to keep this around. In practice the logging wasn't really useful.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84023)