### PR TITLE
[Sonic] Support multiple C# documents in document highlight

### DIFF
--- a/src/LanguageServer/Protocol/Handler/Highlights/DocumentHighlightHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Highlights/DocumentHighlightHandler.cs
@@ -46,24 +46,19 @@ internal sealed class DocumentHighlightsHandler : ILspServiceDocumentRequestHand
         if (document == null)
             return null;
 
-        var position = ProtocolConversions.PositionToLinePosition(request.Position);
-        return await GetHighlightsAsync(_globalOptions, _highlightingService, document, position, cancellationToken).ConfigureAwait(false);
-    }
-
-    internal static async Task<DocumentHighlight[]?> GetHighlightsAsync(IGlobalOptionService globalOptions, IHighlightingService highlightingService, Document document, LinePosition linePosition, CancellationToken cancellationToken)
-    {
+        var linePosition = ProtocolConversions.PositionToLinePosition(request.Position);
         var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
         var position = await document.GetPositionFromLinePositionAsync(linePosition, cancellationToken).ConfigureAwait(false);
 
         // First check if this is a keyword that needs highlighting.
-        var keywordHighlights = await GetKeywordHighlightsAsync(highlightingService, document, text, position, cancellationToken).ConfigureAwait(false);
+        var keywordHighlights = await GetKeywordHighlightsAsync(document, text, position, cancellationToken).ConfigureAwait(false);
         if (keywordHighlights.Any())
         {
             return [.. keywordHighlights];
         }
 
         // Not a keyword, check if it is a reference that needs highlighting.
-        var referenceHighlights = await GetReferenceHighlightsAsync(globalOptions, document, text, position, cancellationToken).ConfigureAwait(false);
+        var referenceHighlights = await GetReferenceHighlightsAsync(document, text, position, cancellationToken).ConfigureAwait(false);
         if (referenceHighlights.Any())
         {
             return [.. referenceHighlights];
@@ -73,12 +68,12 @@ internal sealed class DocumentHighlightsHandler : ILspServiceDocumentRequestHand
         return [];
     }
 
-    private static async Task<ImmutableArray<DocumentHighlight>> GetKeywordHighlightsAsync(IHighlightingService highlightingService, Document document, SourceText text, int position, CancellationToken cancellationToken)
+    private async Task<ImmutableArray<DocumentHighlight>> GetKeywordHighlightsAsync(Document document, SourceText text, int position, CancellationToken cancellationToken)
     {
         var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
         var keywordSpans = new List<TextSpan>();
-        highlightingService.AddHighlights(root, position, keywordSpans, cancellationToken);
+        _highlightingService.AddHighlights(root, position, keywordSpans, cancellationToken);
 
         return keywordSpans.SelectAsArray(highlight => new DocumentHighlight
         {
@@ -87,10 +82,10 @@ internal sealed class DocumentHighlightsHandler : ILspServiceDocumentRequestHand
         });
     }
 
-    private static async Task<ImmutableArray<DocumentHighlight>> GetReferenceHighlightsAsync(IGlobalOptionService globalOptions, Document document, SourceText text, int position, CancellationToken cancellationToken)
+    private async Task<ImmutableArray<DocumentHighlight>> GetReferenceHighlightsAsync(Document document, SourceText text, int position, CancellationToken cancellationToken)
     {
         var documentHighlightService = document.GetRequiredLanguageService<IDocumentHighlightsService>();
-        var options = globalOptions.GetHighlightingOptions(document.Project.Language);
+        var options = _globalOptions.GetHighlightingOptions(document.Project.Language);
         var highlights = await documentHighlightService.GetDocumentHighlightsAsync(
             document,
             position,

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/IDocumentMappingServiceExtensions.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/IDocumentMappingServiceExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
@@ -90,5 +90,39 @@ internal static class IDocumentMappingServiceExtensions
         var result = service.TryMapToCSharpPositionOrNext(csharpDocument, razorIndex, out var csharpLinePosition, out csharpIndex);
         csharpPosition = result ? csharpLinePosition.ToPosition() : null;
         return result;
+    }
+
+    /// <summary>
+    /// Convenience method to map from Razor to C#, which checks both impl and decl documents
+    /// </summary>
+    /// <remarks>
+    /// A position in a Razor document could map to one of two different C# documents, but the only situation
+    /// where it would map to both, is when the resulting position in the C# document is semantically equivalent.
+    /// ie, a Razor using or namespace directive would map to both the decl and impl documents, but in either case
+    /// it ends up at a C# using or namespace directive, so it doesn't matter which one we get back.
+    ///
+    /// For all other positions in the Razor document, only one document will be mappable.
+    ///
+    /// Note that the same is NOT true in reverse: A mappable position in a C# document might be unique to either
+    /// the decl or impl document, but that would only be a coincidence. Part of the reason we emit inDeclDocument
+    /// as an out parameter is because in order to map back to Razor later, we must know which document the C# position
+    /// came from.
+    /// </remarks>
+    public static bool TryMapToCSharpDocumentLinePosition(this IDocumentMappingService service, RazorCodeDocument codeDocument, int razorIndex, out LinePosition csharpPosition, out int csharpIndex, out bool inDeclDocument)
+    {
+        inDeclDocument = false;
+        if (service.TryMapToCSharpDocumentPosition(codeDocument.GetRequiredCSharpDocument(declarationDocument: false), razorIndex, out csharpPosition, out csharpIndex))
+        {
+            return true;
+        }
+
+        inDeclDocument = true;
+        if (codeDocument.GetCSharpDocument(declarationDocument: true) is { } declDocument &&
+            service.TryMapToCSharpDocumentPosition(declDocument, razorIndex, out csharpPosition, out csharpIndex))
+        {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/IDocumentMappingServiceExtensions.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/IDocumentMappingServiceExtensions.cs
@@ -97,8 +97,8 @@ internal static class IDocumentMappingServiceExtensions
     /// </summary>
     /// <remarks>
     /// A position in a Razor document could map to one of two different C# documents, but the only situation
-    /// where it would map to both, is when the resulting position in the C# document is semantically equivalent.
-    /// ie, a Razor using or namespace directive would map to both the decl and impl documents, but in either case
+    /// where it would map to both is when the resulting position in the C# document is semantically equivalent.
+    /// i.e., a Razor using or namespace directive would map to both the decl and impl documents, but in either case
     /// it ends up at a C# using or namespace directive, so it doesn't matter which one we get back.
     ///
     /// For all other positions in the Razor document, only one document will be mappable.

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentHighlight/RemoteDocumentHighlightService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentHighlight/RemoteDocumentHighlightService.cs
@@ -1,18 +1,23 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.PooledObjects;
+using Microsoft.CodeAnalysis.DocumentHighlighting;
 using Microsoft.CodeAnalysis.Highlighting;
-using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Protocol.DocumentHighlight;
 using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Response = Microsoft.CodeAnalysis.Razor.Remote.RemoteResponse<Microsoft.CodeAnalysis.Razor.Protocol.DocumentHighlight.RemoteDocumentHighlight[]?>;
 
@@ -60,39 +65,114 @@ internal sealed partial class RemoteDocumentHighlightService(in ServiceArgs args
             return Response.NoFurtherHandling;
         }
 
-        var csharpDocument = codeDocument.GetRequiredImplCSharpDocument();
-        if (DocumentMappingService.TryMapToCSharpDocumentPosition(csharpDocument, index, out var mappedPosition, out _))
+        if (!DocumentMappingService.TryMapToCSharpDocumentLinePosition(codeDocument, index, out _, out var csharpPosition, out var inDeclDocument))
         {
-            var generatedDocument = await context.Snapshot
-                .GetGeneratedDocumentAsync(cancellationToken)
-                .ConfigureAwait(false);
+            return Response.NoFurtherHandling;
+        }
 
-            var globalOptions = generatedDocument.Project.Solution.Services.ExportProvider.GetService<IGlobalOptionService>();
-            var highlightingService = generatedDocument.Project.Solution.Services.ExportProvider.GetService<IHighlightingService>();
-            var highlights = await DocumentHighlightsHandler.GetHighlightsAsync(
-                globalOptions,
-                highlightingService,
-                generatedDocument,
-                mappedPosition,
-                cancellationToken).ConfigureAwait(false);
+        // Roslyn keyword highlighting only supports a single C# document, and we can't make two calls to Roslyn, one for each C#
+        // document, because we would need to know a highlight location in the other document in order to know a position to ask for.
+        // Fortunately none of the (at time of writing) keyword highlighters are for scenarios that would be valid across impl and decl
+        // documents anyway.
+        var document = await context.Snapshot.GetGeneratedDocumentAsync(inDeclDocument, cancellationToken).ConfigureAwait(false);
+        var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
+        var csharpDocument = codeDocument.GetRequiredCSharpDocument(inDeclDocument);
 
-            if (highlights is not null)
-            {
-                using var results = new PooledArrayBuilder<RemoteDocumentHighlight>();
+        var keywordHighlights = await GetKeywordHighlightsAsync(document, csharpDocument, text, csharpPosition, cancellationToken).ConfigureAwait(false);
+        if (keywordHighlights.Length > 0)
+        {
+            return Response.Results(keywordHighlights);
+        }
 
-                foreach (var highlight in highlights)
-                {
-                    if (DocumentMappingService.TryMapToRazorDocumentRange(csharpDocument, highlight.Range.ToLinePositionSpan(), out var mappedRange))
-                    {
-                        highlight.Range = mappedRange.ToRange();
-                        results.Add(RemoteDocumentHighlight.FromLspDocumentHighlight(highlight));
-                    }
-                }
+        // For reference highlights, we want to make sure to get references from both documents, as the user thinks they're just one, and
+        // the results are much more useful. Fortunately Roslyn supports this, we just have to jump through a few little hoops when mapping
+        // back to Razor positions.
+        var otherDocument = await context.Snapshot.TryGetGeneratedDocumentAsync(!inDeclDocument, cancellationToken).ConfigureAwait(false);
+        var otherCSharpDocument = codeDocument.GetCSharpDocument(!inDeclDocument);
 
-                return Response.Results(results.ToArray());
-            }
+        var referenceHighlights = await GetReferenceHighlightsAsync(document, otherDocument, csharpDocument, otherCSharpDocument, csharpPosition, cancellationToken).ConfigureAwait(false);
+        if (referenceHighlights.Length > 0)
+        {
+            return Response.Results(referenceHighlights);
         }
 
         return Response.NoFurtherHandling;
+    }
+
+    // The below two methods are copied from Roslyn's DocumentHighlightHandler and modified for our needs, to map back to C# documents
+    // and to support multiple documents for reference highlights, because given a scenario like:
+    //
+    // <div>@Title</div>
+    //
+    // @code {
+    //    string Ti$$tle { get; set; }
+    // }
+    //
+    // In this scenario Roslyn only sees the two Title references as being in two separate C# documents.
+
+    private async Task<RemoteDocumentHighlight[]> GetKeywordHighlightsAsync(Document document, RazorCSharpDocument csharpDocument, SourceText text, int position, CancellationToken cancellationToken)
+    {
+        var highlightingService = document.Project.Solution.Services.ExportProvider.GetService<IHighlightingService>();
+        var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+        var keywordSpans = new List<TextSpan>();
+        highlightingService.AddHighlights(root, position, keywordSpans, cancellationToken);
+
+        using var result = new PooledArrayBuilder<RemoteDocumentHighlight>();
+        foreach (var span in keywordSpans)
+        {
+            if (DocumentMappingService.TryMapToRazorDocumentRange(csharpDocument, text.GetLinePositionSpan(span), out var mappedRange))
+            {
+                result.Add(new RemoteDocumentHighlight(mappedRange, DocumentHighlightKind.Text));
+            }
+        }
+
+        return result.ToArrayAndClear();
+    }
+
+    private async Task<RemoteDocumentHighlight[]> GetReferenceHighlightsAsync(Document document, Document? otherDocument, RazorCSharpDocument csharpDocument, RazorCSharpDocument? otherCSharpDocument, int position, CancellationToken cancellationToken)
+    {
+        var globalOptions = document.Project.Solution.Services.ExportProvider.GetService<IGlobalOptionService>();
+        var documentHighlightService = document.GetRequiredLanguageService<IDocumentHighlightsService>();
+        var options = globalOptions.GetHighlightingOptions(document.Project.Language);
+
+        var documentsToSearch = otherDocument is null
+            ? ImmutableHashSet.Create(document)
+            : [document, otherDocument];
+
+        var highlights = await documentHighlightService.GetDocumentHighlightsAsync(document, position, documentsToSearch, options, cancellationToken).ConfigureAwait(false);
+        if (highlights.IsDefaultOrEmpty)
+        {
+            return [];
+        }
+
+        using var result = new PooledArrayBuilder<RemoteDocumentHighlight>();
+        foreach (var highlight in highlights)
+        {
+            RazorCSharpDocument mappedCSharpDocument;
+            if (highlight.Document.Id == document.Id)
+            {
+                mappedCSharpDocument = csharpDocument;
+            }
+            else if (otherDocument is not null &&
+                highlight.Document.Id == otherDocument.Id)
+            {
+                mappedCSharpDocument = otherCSharpDocument.AssumeNotNull("otherCSharpDocument should not be null if otherDocument isn't");
+            }
+            else
+            {
+                continue;
+            }
+
+            foreach (var span in highlight.HighlightSpans)
+            {
+                if (DocumentMappingService.TryMapToRazorDocumentRange(mappedCSharpDocument, mappedCSharpDocument.Text.GetLinePositionSpan(span.TextSpan), out var mappedRange))
+                {
+                    result.Add(new RemoteDocumentHighlight(mappedRange, ProtocolConversions.HighlightSpanKindToDocumentHighlightKind(span.Kind)));
+                }
+            }
+        }
+
+        return result.ToArrayAndClear();
     }
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentHighlight/RemoteDocumentHighlightService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentHighlight/RemoteDocumentHighlightService.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -115,7 +114,7 @@ internal sealed partial class RemoteDocumentHighlightService(in ServiceArgs args
         var highlightingService = document.Project.Solution.Services.ExportProvider.GetService<IHighlightingService>();
         var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
-        var keywordSpans = new List<TextSpan>();
+        using var _ = ListPool<TextSpan>.GetPooledObject(out var keywordSpans);
         highlightingService.AddHighlights(root, position, keywordSpans, cancellationToken);
 
         using var result = new PooledArrayBuilder<RemoteDocumentHighlight>();

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentSnapshot.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentSnapshot.cs
@@ -87,6 +87,13 @@ internal sealed class RemoteDocumentSnapshot : IDocumentSnapshot
         return snapshotManager.GetSnapshot(newDocument);
     }
 
+    public async ValueTask<SourceGeneratedDocument?> TryGetGeneratedDocumentAsync(bool declarationDocument, CancellationToken cancellationToken)
+    {
+        return declarationDocument
+            ? await TryGetDeclGeneratedDocumentInternalAsync(cancellationToken).ConfigureAwait(false)
+            : await GetGeneratedDocumentInternalAsync(cancellationToken).ConfigureAwait(false);
+    }
+
     public async ValueTask<SourceGeneratedDocument> GetGeneratedDocumentAsync(bool declarationDocument, CancellationToken cancellationToken)
     {
         return declarationDocument

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentHighlightEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentHighlightEndpointTest.cs
@@ -31,7 +31,61 @@ public class CohostDocumentHighlightEndpointTest(ITestOutputHelper testOutputHel
         await VerifyDocumentHighlightsAsync(input);
     }
 
-    [Fact(Skip = "PROTOTYPE(sonic): cohosting feature not yet decl/impl split aware; see PR #83887")]
+    [Fact]
+    public async Task Keyword_Impl()
+    {
+        var input = """
+                <div></div>
+
+                @{
+                    var strings = new[] { "Hello", "World" };
+                    [|foreach|] (var str in strings)
+                    {
+                        if (str.Length == 0)
+                        {
+                            $$[|break|];
+                        }
+                    }
+                }
+
+                @code
+                {
+                    private string Title { get;set; }
+                }
+                """;
+
+        await VerifyDocumentHighlightsAsync(input);
+    }
+
+    [Fact]
+    public async Task Keyword_Decl()
+    {
+        var input = """
+                <div></div>
+
+                @{
+                    string x = "asdf";
+                }
+
+                @code
+                {
+                    void Method(string[] strings)
+                    {
+                        [|foreach|] (var str in strings)
+                        {
+                            if (str.Length == 0)
+                            {
+                                $$[|break|];
+                            }
+                        }
+                    }
+                }
+                """;
+
+        await VerifyDocumentHighlightsAsync(input);
+    }
+
+    [Fact]
     public async Task Method()
     {
         var input = """
@@ -49,7 +103,7 @@ public class CohostDocumentHighlightEndpointTest(ITestOutputHelper testOutputHel
         await VerifyDocumentHighlightsAsync(input);
     }
 
-    [Fact(Skip = "PROTOTYPE(sonic): cohosting feature not yet decl/impl split aware; see PR #83887")]
+    [Fact]
     public async Task AttributeToField()
     {
         var input = """
@@ -67,7 +121,7 @@ public class CohostDocumentHighlightEndpointTest(ITestOutputHelper testOutputHel
         await VerifyDocumentHighlightsAsync(input);
     }
 
-    [Fact(Skip = "PROTOTYPE(sonic): cohosting feature not yet decl/impl split aware; see PR #83887")]
+    [Fact]
     public async Task FieldToAttribute()
     {
         var input = """
@@ -123,7 +177,7 @@ public class CohostDocumentHighlightEndpointTest(ITestOutputHelper testOutputHel
         await VerifyDocumentHighlightsAsync(input);
     }
 
-    [Fact(Skip = "PROTOTYPE(sonic): cohosting feature not yet decl/impl split aware; see PR #83887")]
+    [Fact]
     public async Task Inject()
     {
         var input = """

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentHighlightEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentHighlightEndpointTest.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
@@ -19,26 +20,100 @@ public class CohostDocumentHighlightEndpointTest(ITestOutputHelper testOutputHel
     public async Task Local()
     {
         var input = """
-                <div></div>
+            <div></div>
 
-                @{
-                    var $$[|myVariable|] = "Hello";
+            @{
+                var $$[|myVariable|] = "Hello";
 
-                    var length = [|myVariable|].Length;
-                }
-                """;
+                var length = [|myVariable|].Length;
+            }
+            """;
 
         await VerifyDocumentHighlightsAsync(input);
+    }
+
+    [Fact]
+    public async Task Legacy_Local()
+    {
+        var input = """
+            <div></div>
+
+            @{
+                var $$[|myVariable|] = "Hello";
+
+                var length = [|myVariable|].Length;
+            }
+            """;
+
+        await VerifyDocumentHighlightsAsync(input, fileKind: RazorFileKind.Legacy);
     }
 
     [Fact]
     public async Task Keyword_Impl()
     {
         var input = """
-                <div></div>
+            <div></div>
 
-                @{
-                    var strings = new[] { "Hello", "World" };
+            @{
+                var strings = new[] { "Hello", "World" };
+                [|foreach|] (var str in strings)
+                {
+                    if (str.Length == 0)
+                    {
+                        $$[|break|];
+                    }
+                }
+            }
+
+            @code
+            {
+                private string Title { get;set; }
+            }
+            """;
+
+        await VerifyDocumentHighlightsAsync(input);
+    }
+
+    [Fact]
+    public async Task Legacy_Keyword_Impl()
+    {
+        var input = """
+            <div></div>
+
+            @{
+                var strings = new[] { "Hello", "World" };
+                [|foreach|] (var str in strings)
+                {
+                    if (str.Length == 0)
+                    {
+                        $$[|break|];
+                    }
+                }
+            }
+
+            @functions
+            {
+                private string Title { get;set; }
+            }
+            """;
+
+        await VerifyDocumentHighlightsAsync(input, fileKind: RazorFileKind.Legacy);
+    }
+
+    [Fact]
+    public async Task Keyword_Decl()
+    {
+        var input = """
+            <div></div>
+
+            @{
+                string x = "asdf";
+            }
+
+            @code
+            {
+                void Method(string[] strings)
+                {
                     [|foreach|] (var str in strings)
                     {
                         if (str.Length == 0)
@@ -47,160 +122,268 @@ public class CohostDocumentHighlightEndpointTest(ITestOutputHelper testOutputHel
                         }
                     }
                 }
-
-                @code
-                {
-                    private string Title { get;set; }
-                }
-                """;
+            }
+            """;
 
         await VerifyDocumentHighlightsAsync(input);
     }
 
     [Fact]
-    public async Task Keyword_Decl()
+    public async Task Legacy_Keyword_Decl()
     {
         var input = """
-                <div></div>
+            <div></div>
 
-                @{
-                    string x = "asdf";
-                }
+            @{
+                string x = "asdf";
+            }
 
-                @code
+            @functions
+            {
+                void Method(string[] strings)
                 {
-                    void Method(string[] strings)
+                    [|foreach|] (var str in strings)
                     {
-                        [|foreach|] (var str in strings)
+                        if (str.Length == 0)
                         {
-                            if (str.Length == 0)
-                            {
-                                $$[|break|];
-                            }
+                            $$[|break|];
                         }
                     }
                 }
-                """;
+            }
+            """;
 
-        await VerifyDocumentHighlightsAsync(input);
+        await VerifyDocumentHighlightsAsync(input, fileKind: RazorFileKind.Legacy);
     }
 
     [Fact]
     public async Task Method()
     {
         var input = """
-                <div></div>
+            <div></div>
 
-                @code
+            @code
+            {
+                void [|Method|]()
                 {
-                    void [|Method|]()
-                    {
-                        $$[|Method|]();
-                    }
+                    $$[|Method|]();
                 }
-                """;
+            }
+            """;
 
         await VerifyDocumentHighlightsAsync(input);
+    }
+
+    [Fact]
+    public async Task Legacy_Method()
+    {
+        var input = """
+            <div></div>
+
+            @functions
+            {
+                void [|Method|]()
+                {
+                    $$[|Method|]();
+                }
+            }
+            """;
+
+        await VerifyDocumentHighlightsAsync(input, fileKind: RazorFileKind.Legacy);
     }
 
     [Fact]
     public async Task AttributeToField()
     {
         var input = """
-                <div>
-                    <div class="@$$[|_className|]">
-                    </div>
+            <div>
+                <div class="@$$[|_className|]">
                 </div>
+            </div>
 
-                @code
-                {
-                    private string [|_className|] = "hello";
-                }
-                """;
+            @code
+            {
+                private string [|_className|] = "hello";
+            }
+            """;
 
         await VerifyDocumentHighlightsAsync(input);
+    }
+
+    [Fact]
+    public async Task Legacy_AttributeToField()
+    {
+        var input = """
+            <div>
+                <div class="@$$[|_className|]">
+                </div>
+            </div>
+
+            @functions
+            {
+                private string [|_className|] = "hello";
+            }
+            """;
+
+        await VerifyDocumentHighlightsAsync(input, fileKind: RazorFileKind.Legacy);
     }
 
     [Fact]
     public async Task FieldToAttribute()
     {
         var input = """
-                <div>
-                    <div class="@[|_className|]">
-                    </div>
+            <div>
+                <div class="@[|_className|]">
                 </div>
+            </div>
 
-                @code
-                {
-                    private string $$[|_className|] = "hello";
-                }
-                """;
+            @code
+            {
+                private string $$[|_className|] = "hello";
+            }
+            """;
 
         await VerifyDocumentHighlightsAsync(input);
+    }
+
+    [Fact]
+    public async Task Legacy_FieldToAttribute()
+    {
+        var input = """
+            <div>
+                <div class="@[|_className|]">
+                </div>
+            </div>
+
+            @functions
+            {
+                private string $$[|_className|] = "hello";
+            }
+            """;
+
+        await VerifyDocumentHighlightsAsync(input, fileKind: RazorFileKind.Legacy);
     }
 
     [Fact]
     public async Task Html()
     {
         var input = """
-                <div>
-                    <di$$v class="@_className">
-                    </div>
+            <div>
+                <di$$v class="@_className">
                 </div>
+            </div>
 
-                @code
-                {
-                    private string _className = "hello";
-                }
-                """;
+            @code
+            {
+                private string _className = "hello";
+            }
+            """;
 
         await VerifyDocumentHighlightsAsync(input, htmlResponse: [new DocumentHighlight()]);
+    }
+
+    [Fact]
+    public async Task Legacy_Html()
+    {
+        var input = """
+            <div>
+                <di$$v class="@_className">
+                </div>
+            </div>
+
+            @functions
+            {
+                private string _className = "hello";
+            }
+            """;
+
+        await VerifyDocumentHighlightsAsync(input, htmlResponse: [new DocumentHighlight()], fileKind: RazorFileKind.Legacy);
     }
 
     [Fact]
     public async Task Razor()
     {
         var input = """
-                @in$$ject IDisposable Disposable
+            @in$$ject IDisposable Disposable
 
-                <div>
-                    <div class="@_className">
-                    </div>
+            <div>
+                <div class="@_className">
                 </div>
+            </div>
 
-                @code
-                {
-                    private string _className = "hello";
-                }
-                """;
+            @code
+            {
+                private string _className = "hello";
+            }
+            """;
 
         await VerifyDocumentHighlightsAsync(input);
+    }
+
+    [Fact]
+    public async Task Legacy_Razor()
+    {
+        var input = """
+            @in$$ject IDisposable Disposable
+
+            <div>
+                <div class="@_className">
+                </div>
+            </div>
+
+            @functions
+            {
+                private string _className = "hello";
+            }
+            """;
+
+        await VerifyDocumentHighlightsAsync(input, fileKind: RazorFileKind.Legacy);
     }
 
     [Fact]
     public async Task Inject()
     {
         var input = """
-                @inject [|IDis$$posable|] Disposable
+            @inject [|IDis$$posable|] Disposable
 
-                <div>
-                </div>
+            <div>
+            </div>
 
-                @code
+            @code
+            {
+                void Dispose([|IDisposable|] thingToDispose)
                 {
-                    void Dispose([|IDisposable|] thingToDispose)
-                    {
-                    }
                 }
-                """;
+            }
+            """;
 
         await VerifyDocumentHighlightsAsync(input);
     }
 
-    private async Task VerifyDocumentHighlightsAsync(string input, DocumentHighlight[]? htmlResponse = null)
+    [Fact]
+    public async Task Legacy_Inject()
+    {
+        var input = """
+            @inject [|IDis$$posable|] Disposable
+
+            <div>
+            </div>
+
+            @functions
+            {
+                void Dispose([|IDisposable|] thingToDispose)
+                {
+                }
+            }
+            """;
+
+        await VerifyDocumentHighlightsAsync(input, fileKind: RazorFileKind.Legacy);
+    }
+
+    private async Task VerifyDocumentHighlightsAsync(string input, DocumentHighlight[]? htmlResponse = null, RazorFileKind? fileKind = null)
     {
         TestFileMarkupParser.GetPositionAndSpans(input, out var source, out int cursorPosition, out ImmutableArray<TextSpan> spans);
-        var document = CreateProjectAndRazorDocument(source);
+        var document = CreateProjectAndRazorDocument(source, fileKind: fileKind);
         var inputText = await document.GetTextAsync(DisposalToken);
         var position = inputText.GetPosition(cursorPosition);
 


### PR DESCRIPTION
I decided to give up on Code Actions, because it depended on formatting and the edit service etc. and pick something simple like Document Highlight.

And then I discovered that Document Highlight was actually broken with multiple C# documents, as the Roslyn LSP handler only ever returns highlight results from a single document, so I had to re-write more than I expected.

I have the worst luck 😁
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84025)