### PR TITLE
Fix Razor breakpoint placement

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
@@ -29,11 +29,13 @@
 "ProfileSave"=dword:00000001
 "VSSettingsMigration"=dword:00000001
 
-// Provides additional Tools->Options settings not covered
-// by the settings in General.vssettings.
+// Provides the base language-service registration from
+// [ProvideLanguageService(typeof(RazorLanguageService), RazorConstants.RazorLSPContentTypeName, 110)]
+// along with additional Tools->Options settings not covered by the settings in General.vssettings.
 [$RootKey$\Languages\Language Services\Razor]
 @="{4513FA64-5B72-4B58-9D4C-1D3C81996C2C}"
 "Package"="{13b72f58-279e-49e0-a56d-296be02f0805}"
+"LangResID"=dword:0000006e
 "ShowCompletion"=dword:00000001
 "ShowBraceCompletion"=dword:00000001
 "ShowSmartIndent"=dword:00000001

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/PackageRegistration.pkgdef
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/PackageRegistration.pkgdef
@@ -31,11 +31,14 @@
 "RazorNestedFile"="HierSingleSelectionName:\.razor\."
 "CshtmlNestedFile"="HierSingleSelectionName:\.cshtml\."
 
-// The language-service registration is duplicated in Microsoft.VisualStudio.RazorExtension.Custom.pkgdef.
+// The Razor language also has a separate Languages\Language Services\Razor registration in
+// Microsoft.VisualStudio.RazorExtension.Custom.pkgdef.
 [$RootKey$\Services\{4513FA64-5B72-4B58-9D4C-1D3C81996C2C}]
 @="{13b72f58-279e-49e0-a56d-296be02f0805}"
-"Name"="Razor Language Service"
-"IsAsyncQueryable"=dword:00000001
+"Name"="RazorLanguageService"
+"IsAsyncQueryable"=dword:00000000
+"IsCacheable"=dword:00000000
+"IsFreeThreaded"=dword:00000000
 
 // [ProvideToolWindow(typeof(SyntaxVisualizerToolWindow))]
 [$RootKey$\ToolWindows\{28080d9c-0842-4155-9e7d-3b9e6d64bb29}]


### PR DESCRIPTION
Noticed today while looking at https://devdiv.visualstudio.com/DevDiv/_workitems/edit/3011927. Seems our package registration was not correct after the repo-merge, which caused our `IVsDebugInfo` implementation to not be called.

Note, this is only broken in 18.8 (for now)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84029)