### PR TITLE
Fix frontmatter syntax in Compiler.instructions.md

### DIFF
--- a/.github/instructions/Compiler.instructions.md
+++ b/.github/instructions/Compiler.instructions.md
@@ -1,8 +1,8 @@
-# Roslyn Compiler Instructions for AI Coding Agents
-
 ---
 applyTo: "src/{Compilers,Dependencies,ExpressionEvaluator,Tools}/**/*.{cs,vb}"
 ---
+
+# Roslyn Compiler Instructions for AI Coding Agents
 
 ## Architecture Overview
 


### PR DESCRIPTION
The frontmatter YAML should be at the top of the file, otherwise I don't think it has any effect.