### PR TITLE
Replace string.Compare == 0 patterns with Equals/StartsWith calls

### DIFF
--- a/src/Analyzers/Core/Analyzers/FileHeaders/AbstractFileHeaderDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/FileHeaders/AbstractFileHeaderDiagnosticAnalyzer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.IO;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -94,7 +95,7 @@ internal abstract class AbstractFileHeaderDiagnosticAnalyzer : AbstractBuiltInCo
         // compare line by line, ignoring leading and trailing whitespace on each line.
         for (var i = 0; i < reformattedCopyrightTextParts.Length; i++)
         {
-            if (reformattedCopyrightTextParts[i].Trim() != fileHeaderCopyrightTextParts[i].Trim())
+            if (!string.Equals(reformattedCopyrightTextParts[i].Trim(), fileHeaderCopyrightTextParts[i].Trim(), StringComparison.Ordinal))
             {
                 return false;
             }

--- a/src/Analyzers/Core/Analyzers/FileHeaders/AbstractFileHeaderDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/FileHeaders/AbstractFileHeaderDiagnosticAnalyzer.cs
@@ -94,7 +94,7 @@ internal abstract class AbstractFileHeaderDiagnosticAnalyzer : AbstractBuiltInCo
         // compare line by line, ignoring leading and trailing whitespace on each line.
         for (var i = 0; i < reformattedCopyrightTextParts.Length; i++)
         {
-            if (string.CompareOrdinal(reformattedCopyrightTextParts[i].Trim(), fileHeaderCopyrightTextParts[i].Trim()) != 0)
+            if (reformattedCopyrightTextParts[i].Trim() != fileHeaderCopyrightTextParts[i].Trim())
             {
                 return false;
             }

--- a/src/Analyzers/VisualBasic/CodeFixes/Iterator/VisualBasicConvertToIteratorCodeFixProvider.vb
+++ b/src/Analyzers/VisualBasic/CodeFixes/Iterator/VisualBasicConvertToIteratorCodeFixProvider.vb
@@ -48,7 +48,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.Iterator
             End If
 
             ' Check identifier text is 'Yield'
-            If String.Compare(identifier.Identifier.Text, "Yield", StringComparison.OrdinalIgnoreCase) <> 0 Then
+            If Not String.Equals(identifier.Identifier.Text, "Yield", StringComparison.OrdinalIgnoreCase) Then
                 Return Nothing
             End If
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
@@ -302,7 +302,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 string leftName = leftNoNames ? null : leftNames[i];
                 string rightName = rightNoNames ? null : rightNames[i];
 
-                if (leftName == rightName)
+                if (string.Equals(leftName, rightName, StringComparison.Ordinal))
                 {
                     continue;
                 }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
@@ -302,8 +302,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 string leftName = leftNoNames ? null : leftNames[i];
                 string rightName = rightNoNames ? null : rightNames[i];
 
-                bool different = string.CompareOrdinal(rightName, leftName) != 0;
-                if (!different)
+                if (leftName == rightName)
                 {
                     continue;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -798,7 +798,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             NoLocation.Singleton);
                     }
                 }
-                else if (String.Compare(_compilation.Options.CryptoKeyContainer, assemblyKeyContainerAttributeSetting, StringComparison.OrdinalIgnoreCase) != 0)
+                else if (!string.Equals(_compilation.Options.CryptoKeyContainer, assemblyKeyContainerAttributeSetting, StringComparison.OrdinalIgnoreCase))
                 {
                     // Native compiler reports a warning in this case, notifying the user that attribute value from source is ignored,
                     // but it doesn't drop the attribute during emit. That might be fine if we produce an assembly because we actually sign it with correct
@@ -845,7 +845,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             NoLocation.Singleton);
                     }
                 }
-                else if (String.Compare(_compilation.Options.CryptoKeyFile, assemblyKeyFileAttributeSetting, StringComparison.OrdinalIgnoreCase) != 0)
+                else if (!string.Equals(_compilation.Options.CryptoKeyFile, assemblyKeyFileAttributeSetting, StringComparison.OrdinalIgnoreCase))
                 {
                     // Comment in similar section for CryptoKeyContainer is applicable here as well.
                     if (_compilation.Options.OutputKind == OutputKind.NetModule)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
@@ -440,7 +440,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             foreach (var p in currentParameters)
             {
-                if (string.CompareOrdinal(p.Name, name) == 0)
+                if (p.Name == name)
                 {
                     return false;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -440,7 +441,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             foreach (var p in currentParameters)
             {
-                if (p.Name == name)
+                if (string.Equals(p.Name, name, StringComparison.Ordinal))
                 {
                     return false;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -294,7 +294,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var sourceName = sourceNames[i];
                 var wasInferred = noInferredNames ? false : inferredNames[i];
 
-                if (sourceName != null && !wasInferred && (allMissing || destinationNames[i] != sourceName))
+                if (sourceName != null && !wasInferred && (allMissing || !string.Equals(destinationNames[i], sourceName, StringComparison.Ordinal)))
                 {
                     diagnostics.Add(ErrorCode.WRN_TupleLiteralNameMismatch, literal.Arguments[i].Syntax.Parent!.Location, sourceName, destination);
                 }
@@ -863,7 +863,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             else
             {
                 Debug.Assert(names1.Length == names2.Length);
-                mergedNames = names1.ZipAsArray(names2, (n1, n2) => n1 == n2 ? n1 : null);
+                mergedNames = names1.ZipAsArray(names2, (n1, n2) => string.Equals(n1, n2, StringComparison.Ordinal) ? n1 : null);
 
                 if (mergedNames.All(n => n is null))
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -294,7 +294,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var sourceName = sourceNames[i];
                 var wasInferred = noInferredNames ? false : inferredNames[i];
 
-                if (sourceName != null && !wasInferred && (allMissing || string.CompareOrdinal(destinationNames[i], sourceName) != 0))
+                if (sourceName != null && !wasInferred && (allMissing || destinationNames[i] != sourceName))
                 {
                     diagnostics.Add(ErrorCode.WRN_TupleLiteralNameMismatch, literal.Arguments[i].Syntax.Parent!.Location, sourceName, destination);
                 }
@@ -863,7 +863,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             else
             {
                 Debug.Assert(names1.Length == names2.Length);
-                mergedNames = names1.ZipAsArray(names2, (n1, n2) => string.CompareOrdinal(n1, n2) == 0 ? n1 : null);
+                mergedNames = names1.ZipAsArray(names2, (n1, n2) => n1 == n2 ? n1 : null);
 
                 if (mergedNames.All(n => n is null))
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1906,7 +1906,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             var name = @namespace.Name;
-            return (name.Length == length) && (string.Compare(name, 0, namespaceName, offset, length, comparison) == 0);
+            return name.AsSpan().Equals(namespaceName.AsSpan(offset, length), comparison);
         }
 
         internal static bool IsNonGenericTaskType(this TypeSymbol type, CSharpCompilation compilation)

--- a/src/Compilers/Core/MSBuildTask/CanonicalError.cs
+++ b/src/Compilers/Core/MSBuildTask/CanonicalError.cs
@@ -312,11 +312,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             parsedMessage.subcategory = match.Groups["SUBCATEGORY"].Value.Trim();
 
             // Next, see if category is something that is recognized.
-            if (0 == String.Compare(category, "error", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(category, "error", StringComparison.OrdinalIgnoreCase))
             {
                 parsedMessage.category = Parts.Category.Error;
             }
-            else if (0 == String.Compare(category, "warning", StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(category, "warning", StringComparison.OrdinalIgnoreCase))
             {
                 parsedMessage.category = Parts.Category.Warning;
             }

--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -409,7 +409,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
                         // The alias called "global" is special.  It means that we don't
                         // give it an alias on the command-line.
-                        if (string.Compare("global", trimmedAlias, StringComparison.OrdinalIgnoreCase) == 0)
+                        if (string.Equals("global", trimmedAlias, StringComparison.OrdinalIgnoreCase))
                         {
                             appendGlobalReference(reference.ItemSpec);
                         }

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -856,11 +856,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 {
                     throw new ArgumentException(e.Message, "Sources");
                 }
-                if (string.Compare(TargetType, "library", StringComparison.OrdinalIgnoreCase) == 0)
+                if (string.Equals(TargetType, "library", StringComparison.OrdinalIgnoreCase))
                 {
                     OutputAssembly.ItemSpec += ".dll";
                 }
-                else if (string.Compare(TargetType, "module", StringComparison.OrdinalIgnoreCase) == 0)
+                else if (string.Equals(TargetType, "module", StringComparison.OrdinalIgnoreCase))
                 {
                     OutputAssembly.ItemSpec += ".netmodule";
                 }
@@ -1057,7 +1057,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             if (_store[nameof(DebugType)] != null)
             {
                 // If debugtype is none then only show debug- else use the debug type and the debugsymbols as is.
-                if (string.Compare((string?)_store[nameof(DebugType)], "none", StringComparison.OrdinalIgnoreCase) == 0)
+                if (string.Equals((string?)_store[nameof(DebugType)], "none", StringComparison.OrdinalIgnoreCase))
                 {
                     _store[nameof(DebugType)] = null;
                     _store[nameof(EmitDebugInformation)] = false;

--- a/src/Compilers/Core/MSBuildTask/Utilities.cs
+++ b/src/Compilers/Core/MSBuildTask/Utilities.cs
@@ -91,24 +91,24 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// such as "on", "!false", "yes"
         /// </summary>
         private static bool ValidBooleanTrue(string parameterValue) =>
-            String.Compare(parameterValue, "true", StringComparison.OrdinalIgnoreCase) == 0 ||
-            String.Compare(parameterValue, "on", StringComparison.OrdinalIgnoreCase) == 0 ||
-            String.Compare(parameterValue, "yes", StringComparison.OrdinalIgnoreCase) == 0 ||
-            String.Compare(parameterValue, "!false", StringComparison.OrdinalIgnoreCase) == 0 ||
-            String.Compare(parameterValue, "!off", StringComparison.OrdinalIgnoreCase) == 0 ||
-            String.Compare(parameterValue, "!no", StringComparison.OrdinalIgnoreCase) == 0;
+            string.Equals(parameterValue, "true", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(parameterValue, "on", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(parameterValue, "yes", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(parameterValue, "!false", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(parameterValue, "!off", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(parameterValue, "!no", StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
         /// Returns true if the string represents a valid MSBuild boolean false value,
         /// such as "!on" "off" "no" "!true"
         /// </summary>
         private static bool ValidBooleanFalse(string parameterValue) =>
-            String.Compare(parameterValue, "false", StringComparison.OrdinalIgnoreCase) == 0 ||
-            String.Compare(parameterValue, "off", StringComparison.OrdinalIgnoreCase) == 0 ||
-            String.Compare(parameterValue, "no", StringComparison.OrdinalIgnoreCase) == 0 ||
-            String.Compare(parameterValue, "!true", StringComparison.OrdinalIgnoreCase) == 0 ||
-            String.Compare(parameterValue, "!on", StringComparison.OrdinalIgnoreCase) == 0 ||
-            String.Compare(parameterValue, "!yes", StringComparison.OrdinalIgnoreCase) == 0;
+            string.Equals(parameterValue, "false", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(parameterValue, "off", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(parameterValue, "no", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(parameterValue, "!true", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(parameterValue, "!on", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(parameterValue, "!yes", StringComparison.OrdinalIgnoreCase);
 
         internal static string GetFullPathNoThrow(string path)
         {

--- a/src/Compilers/Core/MSBuildTask/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Vbc.cs
@@ -969,7 +969,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 // However, we explicitly allow two values (mostly for parity with C#):
                 // Null is supported because it means that option should be omitted, and compiler default used - obviously always valid.
                 // Explicitly specified name of current locale is also supported, since it is effectively a no-op.
-                if (!string.IsNullOrEmpty(PreferredUILang) && !string.Equals(PreferredUILang, System.Globalization.CultureInfo.CurrentUICulture.Name, StringComparison.OrdinalIgnoreCase))
+                if (!String.IsNullOrEmpty(PreferredUILang) && !String.Equals(PreferredUILang, System.Globalization.CultureInfo.CurrentUICulture.Name, StringComparison.OrdinalIgnoreCase))
                 {
                     CheckHostObjectSupport(param = nameof(PreferredUILang), resultFromHostObjectSetOperation: false);
                 }

--- a/src/Compilers/Core/MSBuildTask/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Vbc.cs
@@ -352,8 +352,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     string twoLetterPrefix = originalBaseAddress.Substring(0, 2);
 
                     if (
-                         (0 == String.Compare(twoLetterPrefix, "0x", StringComparison.OrdinalIgnoreCase)) ||
-                         (0 == String.Compare(twoLetterPrefix, "&h", StringComparison.OrdinalIgnoreCase))
+                         string.Equals(twoLetterPrefix, "0x", StringComparison.OrdinalIgnoreCase) ||
+                         string.Equals(twoLetterPrefix, "&h", StringComparison.OrdinalIgnoreCase)
                        )
                     {
                         // The incoming string is already in hex format ... we just need to
@@ -459,22 +459,22 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             commandLine.AppendSwitchIfNotNull("/preferreduilang:", this.PreferredUILang);
             commandLine.AppendPlusOrMinusSwitch("/highentropyva", this._store, "HighEntropyVA");
 
-            if (0 == String.Compare(this.VBRuntimePath, this.VBRuntime, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(this.VBRuntimePath, this.VBRuntime, StringComparison.OrdinalIgnoreCase))
             {
                 commandLine.AppendSwitchIfNotNull("/vbruntime:", this.VBRuntimePath);
             }
             else if (this.VBRuntime != null)
             {
                 string vbRuntimeSwitch = this.VBRuntime;
-                if (0 == String.Compare(vbRuntimeSwitch, "EMBED", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(vbRuntimeSwitch, "EMBED", StringComparison.OrdinalIgnoreCase))
                 {
                     commandLine.AppendSwitch("/vbruntime*");
                 }
-                else if (0 == String.Compare(vbRuntimeSwitch, "NONE", StringComparison.OrdinalIgnoreCase))
+                else if (string.Equals(vbRuntimeSwitch, "NONE", StringComparison.OrdinalIgnoreCase))
                 {
                     commandLine.AppendSwitch("/vbruntime-");
                 }
-                else if (0 == String.Compare(vbRuntimeSwitch, "DEFAULT", StringComparison.OrdinalIgnoreCase))
+                else if (string.Equals(vbRuntimeSwitch, "DEFAULT", StringComparison.OrdinalIgnoreCase))
                 {
                     commandLine.AppendSwitch("/vbruntime+");
                 }
@@ -489,8 +489,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                    (this.Verbosity != null) &&
 
                    (
-                      (0 == String.Compare(this.Verbosity, "quiet", StringComparison.OrdinalIgnoreCase)) ||
-                      (0 == String.Compare(this.Verbosity, "verbose", StringComparison.OrdinalIgnoreCase))
+                      string.Equals(this.Verbosity, "quiet", StringComparison.OrdinalIgnoreCase) ||
+                      string.Equals(this.Verbosity, "verbose", StringComparison.OrdinalIgnoreCase)
                    )
                 )
             {
@@ -511,7 +511,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             commandLine.AppendSwitchIfNotNull("/win32resource:", this.Win32Resource);
 
             // Special case for "Sub Main" (See VSWhidbey 381254)
-            if (0 != String.Compare("Sub Main", this.MainEntryPoint, StringComparison.OrdinalIgnoreCase))
+            if (!string.Equals("Sub Main", this.MainEntryPoint, StringComparison.OrdinalIgnoreCase))
             {
                 commandLine.AppendSwitchIfNotNull("/main:", this.MainEntryPoint);
             }
@@ -616,9 +616,9 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             // Validate that the "Verbosity" parameter is one of "quiet", "normal", or "verbose".
             if (this.Verbosity != null)
             {
-                if ((0 != String.Compare(Verbosity, "normal", StringComparison.OrdinalIgnoreCase)) &&
-                    (0 != String.Compare(Verbosity, "quiet", StringComparison.OrdinalIgnoreCase)) &&
-                    (0 != String.Compare(Verbosity, "verbose", StringComparison.OrdinalIgnoreCase)))
+                if (!string.Equals(Verbosity, "normal", StringComparison.OrdinalIgnoreCase) &&
+                    !string.Equals(Verbosity, "quiet", StringComparison.OrdinalIgnoreCase) &&
+                    !string.Equals(Verbosity, "verbose", StringComparison.OrdinalIgnoreCase))
                 {
                     Log.LogErrorWithCodeFromResources("Vbc_EnumParameterHasInvalidValue", "Verbosity", this.Verbosity, "Quiet, Normal, Verbose");
                     return false;
@@ -969,7 +969,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 // However, we explicitly allow two values (mostly for parity with C#):
                 // Null is supported because it means that option should be omitted, and compiler default used - obviously always valid.
                 // Explicitly specified name of current locale is also supported, since it is effectively a no-op.
-                if (!String.IsNullOrEmpty(PreferredUILang) && !String.Equals(PreferredUILang, System.Globalization.CultureInfo.CurrentUICulture.Name, StringComparison.OrdinalIgnoreCase))
+                if (!string.IsNullOrEmpty(PreferredUILang) && !string.Equals(PreferredUILang, System.Globalization.CultureInfo.CurrentUICulture.Name, StringComparison.OrdinalIgnoreCase))
                 {
                     CheckHostObjectSupport(param = nameof(PreferredUILang), resultFromHostObjectSetOperation: false);
                 }

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonAttributeData.cs
@@ -123,9 +123,8 @@ namespace Microsoft.CodeAnalysis
                     }
 
                     string name = container.Name;
-                    int nameLength = name.Length;
-                    index -= nameLength;
-                    if (index < 0 || string.Compare(namespaceName, index, name, 0, nameLength, options) != 0)
+                    index -= name.Length;
+                    if (index < 0 || !namespaceName.AsSpan(index).StartsWith(name.AsSpan(), options))
                     {
                         return false;
                     }

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
@@ -1301,7 +1301,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                             NoLocation.Singleton,
                             diagnostics)
 
-                    ElseIf String.Compare(_compilation.Options.CryptoKeyContainer, assemblyKeyContainerAttributeSetting, StringComparison.OrdinalIgnoreCase) <> 0 Then
+                    ElseIf Not String.Equals(_compilation.Options.CryptoKeyContainer, assemblyKeyContainerAttributeSetting, StringComparison.OrdinalIgnoreCase) Then
                         ' If we are building a .NET module, things get more complicated. In particular, we don't sign the module, we emit an attribute with the key 
                         ' information, which will be used to sign an assembly once the module is linked into it. If there is already an attribute like that in source,
                         ' native compiler emits both of them, synthetic attribute is emitted after the one from source. Incidentally, ALink picks the last attribute
@@ -1326,7 +1326,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                             NoLocation.Singleton,
                             diagnostics)
 
-                    ElseIf String.Compare(_compilation.Options.CryptoKeyFile, assemblyKeyFileAttributeSetting, StringComparison.OrdinalIgnoreCase) <> 0 Then
+                    ElseIf Not String.Equals(_compilation.Options.CryptoKeyFile, assemblyKeyFileAttributeSetting, StringComparison.OrdinalIgnoreCase) Then
                         ' Comment in similar section for CryptoKeyContainer is applicable here as well.
                         diagnostics.Add(ERRID.ERR_CmdOptionConflictsSource, NoLocation.Singleton, AttributeDescription.AssemblyKeyFileAttribute.FullName, "CryptoKeyFile")
                     End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamespaceSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamespaceSymbol.vb
@@ -414,7 +414,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ' VS can display errors and warnings separately in the IDE, so it may be ok to flood the users with
             ' these warnings.
             If Not reportedNamespaceMismatch AndAlso
-                String.Compare(node.Identifier.ValueText, Me.Name, StringComparison.Ordinal) <> 0 Then
+                Not String.Equals(node.Identifier.ValueText, Me.Name, StringComparison.Ordinal) Then
                 ' all namespace names from the declarations match following the VB identifier comparison rules,
                 ' so we just need to check when they are not matching using case sensitive comparison.
 
@@ -461,7 +461,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim path = Nothing
 
             For Each declaration In _declaration.Declarations
-                If String.Compare(Me.Name, declaration.Name, StringComparison.Ordinal) = 0 Then
+                If String.Equals(Me.Name, declaration.Name, StringComparison.Ordinal) Then
                     If declaration.IsPartOfRootNamespace Then
                         'path = StringConstants.ProjectSettingLocationName
                         path = New LocalizableErrorArgument(ERRID.IDS_ProjectSettingsLocationName)

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
@@ -1275,7 +1275,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End If
 
             Dim name = [namespace].Name
-            Return name.AsSpan().Equals(namespaceName.AsSpan(offset, length), comparison)
+            Return (name.Length = length) AndAlso (String.Compare(name, 0, namespaceName, offset, length, comparison) = 0)
         End Function
 
         <Extension>

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
@@ -1275,7 +1275,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End If
 
             Dim name = [namespace].Name
-            Return (name.Length = length) AndAlso (String.Compare(name, 0, namespaceName, offset, length, comparison) = 0)
+            Return name.AsSpan().Equals(namespaceName.AsSpan(offset, length), comparison)
         End Function
 
         <Extension>

--- a/src/EditorFeatures/Core/DocumentationComments/AbstractDocumentationCommentCommandHandler.cs
+++ b/src/EditorFeatures/Core/DocumentationComments/AbstractDocumentationCommentCommandHandler.cs
@@ -391,6 +391,6 @@ internal abstract class AbstractDocumentationCommentCommandHandler :
             return false;
         }
 
-        return string.CompareOrdinal(lineText, lineOffset, ExteriorTriviaText, 0, ExteriorTriviaText.Length) == 0;
+        return lineText.AsSpan(lineOffset).StartsWith(ExteriorTriviaText.AsSpan(), StringComparison.Ordinal);
     }
 }

--- a/src/Features/CSharp/Portable/SyncedSource/FileBasedPrograms/MSBuildUtilities.cs
+++ b/src/Features/CSharp/Portable/SyncedSource/FileBasedPrograms/MSBuildUtilities.cs
@@ -46,12 +46,12 @@ namespace Microsoft.DotNet.FileBasedPrograms
         /// </summary>
         private static bool ValidBooleanTrue(string? parameterValue)
         {
-            return (string.Equals(parameterValue, "true", StringComparison.OrdinalIgnoreCase) ||
-                    string.Equals(parameterValue, "on", StringComparison.OrdinalIgnoreCase) ||
-                    string.Equals(parameterValue, "yes", StringComparison.OrdinalIgnoreCase) ||
-                    string.Equals(parameterValue, "!false", StringComparison.OrdinalIgnoreCase) ||
-                    string.Equals(parameterValue, "!off", StringComparison.OrdinalIgnoreCase) ||
-                    string.Equals(parameterValue, "!no", StringComparison.OrdinalIgnoreCase));
+            return ((string.Compare(parameterValue, "true", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (string.Compare(parameterValue, "on", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (string.Compare(parameterValue, "yes", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (string.Compare(parameterValue, "!false", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (string.Compare(parameterValue, "!off", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (string.Compare(parameterValue, "!no", StringComparison.OrdinalIgnoreCase) == 0));
         }
 
         /// <summary>
@@ -60,12 +60,12 @@ namespace Microsoft.DotNet.FileBasedPrograms
         /// </summary>
         private static bool ValidBooleanFalse(string? parameterValue)
         {
-            return ((string.Equals(parameterValue, "false", StringComparison.OrdinalIgnoreCase)) ||
-                    (string.Equals(parameterValue, "off", StringComparison.OrdinalIgnoreCase)) ||
-                    (string.Equals(parameterValue, "no", StringComparison.OrdinalIgnoreCase)) ||
-                    (string.Equals(parameterValue, "!true", StringComparison.OrdinalIgnoreCase)) ||
-                    (string.Equals(parameterValue, "!on", StringComparison.OrdinalIgnoreCase)) ||
-                    (string.Equals(parameterValue, "!yes", StringComparison.OrdinalIgnoreCase)));
+            return ((string.Compare(parameterValue, "false", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (string.Compare(parameterValue, "off", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (string.Compare(parameterValue, "no", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (string.Compare(parameterValue, "!true", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (string.Compare(parameterValue, "!on", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (string.Compare(parameterValue, "!yes", StringComparison.OrdinalIgnoreCase) == 0));
         }
     }
 }

--- a/src/Features/CSharp/Portable/SyncedSource/FileBasedPrograms/MSBuildUtilities.cs
+++ b/src/Features/CSharp/Portable/SyncedSource/FileBasedPrograms/MSBuildUtilities.cs
@@ -46,12 +46,12 @@ namespace Microsoft.DotNet.FileBasedPrograms
         /// </summary>
         private static bool ValidBooleanTrue(string? parameterValue)
         {
-            return ((string.Compare(parameterValue, "true", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (string.Compare(parameterValue, "on", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (string.Compare(parameterValue, "yes", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (string.Compare(parameterValue, "!false", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (string.Compare(parameterValue, "!off", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (string.Compare(parameterValue, "!no", StringComparison.OrdinalIgnoreCase) == 0));
+            return (string.Equals(parameterValue, "true", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(parameterValue, "on", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(parameterValue, "yes", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(parameterValue, "!false", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(parameterValue, "!off", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(parameterValue, "!no", StringComparison.OrdinalIgnoreCase));
         }
 
         /// <summary>
@@ -60,12 +60,12 @@ namespace Microsoft.DotNet.FileBasedPrograms
         /// </summary>
         private static bool ValidBooleanFalse(string? parameterValue)
         {
-            return ((string.Compare(parameterValue, "false", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (string.Compare(parameterValue, "off", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (string.Compare(parameterValue, "no", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (string.Compare(parameterValue, "!true", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (string.Compare(parameterValue, "!on", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (string.Compare(parameterValue, "!yes", StringComparison.OrdinalIgnoreCase) == 0));
+            return ((string.Equals(parameterValue, "false", StringComparison.OrdinalIgnoreCase)) ||
+                    (string.Equals(parameterValue, "off", StringComparison.OrdinalIgnoreCase)) ||
+                    (string.Equals(parameterValue, "no", StringComparison.OrdinalIgnoreCase)) ||
+                    (string.Equals(parameterValue, "!true", StringComparison.OrdinalIgnoreCase)) ||
+                    (string.Equals(parameterValue, "!on", StringComparison.OrdinalIgnoreCase)) ||
+                    (string.Equals(parameterValue, "!yes", StringComparison.OrdinalIgnoreCase)));
         }
     }
 }

--- a/src/Features/Core/Portable/TaskList/AbstractTaskListService.cs
+++ b/src/Features/Core/Portable/TaskList/AbstractTaskListService.cs
@@ -91,9 +91,7 @@ internal abstract class AbstractTaskListService : ITaskListService
         foreach (var commentDescriptor in descriptors)
         {
             var token = commentDescriptor.Text;
-            if (string.Compare(
-                    normalized, index, token, indexB: 0,
-                    length: token.Length, comparisonType: StringComparison.OrdinalIgnoreCase) != 0)
+            if (!normalized.AsSpan(index).StartsWith(token.AsSpan(), StringComparison.OrdinalIgnoreCase))
             {
                 continue;
             }

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/VirtualRazorProjectFileSystem.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/VirtualRazorProjectFileSystem.cs
@@ -106,7 +106,7 @@ internal class VirtualRazorProjectFileSystem : RazorProjectFileSystem
                 // path, filePath -> /Views/Home/Index.cshtml
                 // directory.Path -> /Views/Home/
                 // We only need to match the file name portion since we've already matched the directory segment.
-                if (string.Compare(path, directoryLength, filePath, directoryLength, path.Length - directoryLength, StringComparison.OrdinalIgnoreCase) == 0)
+                if (path.AsSpan(directoryLength).Equals(filePath.AsSpan(directoryLength), StringComparison.OrdinalIgnoreCase))
                 {
                     return file.ProjectItem;
                 }
@@ -173,9 +173,8 @@ internal class VirtualRazorProjectFileSystem : RazorProjectFileSystem
                 var currentDirectory = parentDirectory.Directories[i];
                 var directoryPath = currentDirectory.Path;
                 var startIndex = parentDirectory.Path.Length;
-                var directoryNameLength = directoryPath.Length - startIndex;
 
-                if (string.Compare(path, startIndex, directoryPath, startIndex, directoryNameLength, StringComparison.OrdinalIgnoreCase) == 0)
+                if (path.AsSpan(startIndex).StartsWith(directoryPath.AsSpan(startIndex), StringComparison.OrdinalIgnoreCase))
                 {
                     return currentDirectory;
                 }

--- a/src/Tools/CompilerGeneratorTools/Source/BoundTreeGenerator/BoundNodeClassWriter.cs
+++ b/src/Tools/CompilerGeneratorTools/Source/BoundTreeGenerator/BoundNodeClassWriter.cs
@@ -727,7 +727,7 @@ namespace BoundTreeGenerator
 
         private static bool HasValidate(TreeType node)
         {
-            return node.HasValidate != null && string.Compare(node.HasValidate, "true", true) == 0;
+            return node.HasValidate != null && string.Equals(node.HasValidate, "true", StringComparison.OrdinalIgnoreCase);
         }
 
         private IEnumerable<TreeType> TypeAndBaseTypes(TreeType node)
@@ -1847,33 +1847,33 @@ namespace BoundTreeGenerator
 
         private static bool IsNew(Field f)
         {
-            return string.Compare(f.New, "true", true) == 0;
+            return string.Equals(f.New, "true", StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool IsPropertyOverrides(Field f)
         {
-            return string.Compare(f.PropertyOverrides, "true", true) == 0;
+            return string.Equals(f.PropertyOverrides, "true", StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool SkipInVisitor(Field f)
         {
-            return string.Compare(f.SkipInVisitor, "true", true) == 0
+            return string.Equals(f.SkipInVisitor, "true", StringComparison.OrdinalIgnoreCase)
                 || VisitFieldOnlyInNullabilityRewriter(f);
         }
 
         private static bool VisitFieldOnlyInNullabilityRewriter(Field f)
         {
-            return string.Compare(f.SkipInVisitor, "ExceptNullabilityRewriter", true) == 0;
+            return string.Equals(f.SkipInVisitor, "ExceptNullabilityRewriter", StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool SkipInNullabilityRewriter(Node n)
         {
-            return string.Compare(n.SkipInNullabilityRewriter, "true", true) == 0;
+            return string.Equals(n.SkipInNullabilityRewriter, "true", StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool SkipInNullabilityRewriter(Field f)
         {
-            return string.Compare(f.SkipInNullabilityRewriter, "true", ignoreCase: true) == 0;
+            return string.Equals(f.SkipInNullabilityRewriter, "true", StringComparison.OrdinalIgnoreCase);
         }
 
         private string ToCamelCase(string name)

--- a/src/Tools/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/AbstractFileWriter.cs
+++ b/src/Tools/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/AbstractFileWriter.cs
@@ -229,7 +229,7 @@ namespace CSharpSyntaxGenerator
 
         protected static bool IsRoot(Node n)
         {
-            return n.Root != null && string.Compare(n.Root, "true", true) == 0;
+            return n.Root != null && string.Equals(n.Root, "true", StringComparison.OrdinalIgnoreCase);
         }
 
         protected bool IsNode(string typeName)
@@ -244,7 +244,7 @@ namespace CSharpSyntaxGenerator
             => _typeMap.TryGetValue(typeName, out var node) ? node : null;
 
         private static bool IsTrue(string val)
-            => val != null && string.Compare(val, "true", true) == 0;
+            => val != null && string.Equals(val, "true", StringComparison.OrdinalIgnoreCase);
 
         protected static bool IsOptional(Field f)
             => IsTrue(f.Optional);
@@ -260,7 +260,7 @@ namespace CSharpSyntaxGenerator
 
         protected static bool HasErrors(Node n)
         {
-            return n.Errors == null || string.Compare(n.Errors, "true", true) == 0;
+            return n.Errors == null || string.Equals(n.Errors, "true", StringComparison.OrdinalIgnoreCase);
         }
 
         protected static string CamelCase(string name)

--- a/src/Tools/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/SourceWriter.cs
+++ b/src/Tools/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/SourceWriter.cs
@@ -1114,7 +1114,7 @@ namespace CSharpSyntaxGenerator
 
         private static bool HasValidate(TreeType node)
         {
-            return node.HasValidate != null && string.Compare(node.HasValidate, "true", ignoreCase: true) == 0;
+            return node.HasValidate != null && string.Equals(node.HasValidate, "true", StringComparison.OrdinalIgnoreCase);
         }
 
         private string GetRedFieldType(Field field)
@@ -1441,7 +1441,7 @@ namespace CSharpSyntaxGenerator
             foreach (var node in nodes)
             {
                 this.WriteRedFactory(node);
-                bool skipConvenienceFactories = node.SkipConvenienceFactories != null && string.Compare(node.SkipConvenienceFactories, "true", true) == 0;
+                bool skipConvenienceFactories = node.SkipConvenienceFactories != null && string.Equals(node.SkipConvenienceFactories, "true", StringComparison.OrdinalIgnoreCase);
                 if (!skipConvenienceFactories)
                 {
                     this.WriteRedFactoryWithNoAutoCreatableTokens(node);

--- a/src/Tools/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/XML/ParseTreeDescription.vb
+++ b/src/Tools/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/XML/ParseTreeDescription.vb
@@ -349,7 +349,7 @@ Public Class ParseNodeStructure
     Public Function DerivesFrom(baseClassName As String) As Boolean
         Dim nodeStructure As ParseNodeStructure = Me
         While nodeStructure IsNot Nothing
-            If String.Compare(nodeStructure.Name, baseClassName, True) = 0 Then
+            If String.Equals(nodeStructure.Name, baseClassName, StringComparison.OrdinalIgnoreCase) Then
                 Return True
             End If
             nodeStructure = nodeStructure.ParentStructure

--- a/src/VisualStudio/Core/Def/ProjectSystem/SdkAnalyzerAssemblyRedirector.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/SdkAnalyzerAssemblyRedirector.cs
@@ -186,7 +186,8 @@ internal class SdkAnalyzerAssemblyRedirectorCore : IAnalyzerAssemblyRedirector
                 return false;
             }
 
-            return version1.AsSpan(0, secondDotIndex + 1).Equals(version2.AsSpan(0, secondDotIndex + 1), StringComparison.OrdinalIgnoreCase);
+            var prefixLength = secondDotIndex + 1;
+            return version2.Length >= prefixLength && version1.AsSpan(0, prefixLength).Equals(version2.AsSpan(0, prefixLength), StringComparison.OrdinalIgnoreCase);
         }
     }
 

--- a/src/VisualStudio/Core/Def/ProjectSystem/SdkAnalyzerAssemblyRedirector.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/SdkAnalyzerAssemblyRedirector.cs
@@ -186,7 +186,7 @@ internal class SdkAnalyzerAssemblyRedirectorCore : IAnalyzerAssemblyRedirector
                 return false;
             }
 
-            return 0 == string.Compare(version1, 0, version2, 0, secondDotIndex + 1, StringComparison.OrdinalIgnoreCase);
+            return version1.AsSpan(0, secondDotIndex + 1).Equals(version2.AsSpan(0, secondDotIndex + 1), StringComparison.OrdinalIgnoreCase);
         }
     }
 

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -801,7 +801,7 @@ internal abstract partial class VisualStudioWorkspaceImpl : VisualStudioWorkspac
         foreach (var folder in folders)
         {
             var items = GetAllItems(project.ProjectItems);
-            var folderItem = items.FirstOrDefault(p => StringComparer.OrdinalIgnoreCase.Compare(p.Name, folder) == 0);
+            var folderItem = items.FirstOrDefault(p => StringComparer.OrdinalIgnoreCase.Equals(p.Name, folder));
             if (folderItem == null || folderItem.Kind != EnvDTE.Constants.vsProjectItemKindPhysicalFile)
             {
                 yield return folder;

--- a/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
+++ b/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
@@ -949,15 +949,15 @@ internal sealed class CSharpRenameConflictLanguageService() : AbstractRenameRewr
     {
         // Handle renaming of symbols used for foreach
         var implicitReferencesMightConflict = renameSymbol.Kind == SymbolKind.Property &&
-                                            string.Compare(renameSymbol.Name, "Current", StringComparison.OrdinalIgnoreCase) == 0;
+                                            string.Equals(renameSymbol.Name, "Current", StringComparison.OrdinalIgnoreCase);
 
         implicitReferencesMightConflict =
             implicitReferencesMightConflict ||
                 (renameSymbol.Kind == SymbolKind.Method &&
-                    (string.Compare(renameSymbol.Name, WellKnownMemberNames.MoveNextMethodName, StringComparison.OrdinalIgnoreCase) == 0 ||
-                    string.Compare(renameSymbol.Name, WellKnownMemberNames.GetEnumeratorMethodName, StringComparison.OrdinalIgnoreCase) == 0 ||
-                    string.Compare(renameSymbol.Name, WellKnownMemberNames.GetAwaiter, StringComparison.OrdinalIgnoreCase) == 0 ||
-                    string.Compare(renameSymbol.Name, WellKnownMemberNames.DeconstructMethodName, StringComparison.OrdinalIgnoreCase) == 0));
+                    (string.Equals(renameSymbol.Name, WellKnownMemberNames.MoveNextMethodName, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(renameSymbol.Name, WellKnownMemberNames.GetEnumeratorMethodName, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(renameSymbol.Name, WellKnownMemberNames.GetAwaiter, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(renameSymbol.Name, WellKnownMemberNames.DeconstructMethodName, StringComparison.OrdinalIgnoreCase)));
 
         // TODO: handle Dispose for using statement and Add methods for collection initializers.
 

--- a/src/Workspaces/Core/Desktop/Workspace/Host/Mef/MefV1HostServices.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/Host/Mef/MefV1HostServices.cs
@@ -122,8 +122,8 @@ public class MefV1HostServices : HostServices, IMefHostExportProvider
 
         public bool Equals(ExportKey other)
         {
-            return string.Compare(this.ExtensionTypeName, other.ExtensionTypeName, StringComparison.OrdinalIgnoreCase) == 0
-                && string.Compare(this.MetadataTypeName, other.MetadataTypeName, StringComparison.OrdinalIgnoreCase) == 0;
+            return string.Equals(this.ExtensionTypeName, other.ExtensionTypeName, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(this.MetadataTypeName, other.MetadataTypeName, StringComparison.OrdinalIgnoreCase);
         }
 
         public override bool Equals(object? obj)

--- a/src/Workspaces/Core/Portable/Rename/IRenameRewriterLanguageService.cs
+++ b/src/Workspaces/Core/Portable/Rename/IRenameRewriterLanguageService.cs
@@ -139,7 +139,7 @@ internal abstract class AbstractRenameRewriterLanguageService : IRenameRewriterL
             var prop = (IPropertySymbol)symbol;
 
             var conflictingParameter = prop.Parameters.FirstOrDefault(
-                param => string.Compare(param.Name, newPropertyName, StringComparison.OrdinalIgnoreCase) == 0);
+                param => string.Equals(param.Name, newPropertyName, StringComparison.OrdinalIgnoreCase));
 
             if (conflictingParameter != null)
             {

--- a/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.ReferenceProcessing.cs
+++ b/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.ReferenceProcessing.cs
@@ -65,7 +65,7 @@ internal sealed partial class SymbolicRenameLocations
             // Visual Basic and VB's identifiers are case insensitive. 
             // Do not cascade to symbols that are defined only in metadata.
             if (referencedSymbol.Kind == originalSymbol.Kind &&
-                string.Compare(TrimNameToAfterLastDot(referencedSymbol.Name), TrimNameToAfterLastDot(originalSymbol.Name), StringComparison.OrdinalIgnoreCase) == 0 &&
+                string.Equals(TrimNameToAfterLastDot(referencedSymbol.Name), TrimNameToAfterLastDot(originalSymbol.Name), StringComparison.OrdinalIgnoreCase) &&
                 referencedSymbol.Locations.Any(static loc => loc.IsInSource))
             {
                 return true;

--- a/src/Workspaces/MSBuild/BuildHost/MSBuild/ProjectFile/ProjectFile.cs
+++ b/src/Workspaces/MSBuild/BuildHost/MSBuild/ProjectFile/ProjectFile.cs
@@ -131,12 +131,12 @@ internal sealed class ProjectFile(
         var fileName = Path.GetFileNameWithoutExtension(filePath);
 
         // check for short name match
-        item = references.FirstOrDefault(it => string.Compare(it.EvaluatedInclude, shortAssemblyName, StringComparison.OrdinalIgnoreCase) == 0);
+        item = references.FirstOrDefault(it => string.Equals(it.EvaluatedInclude, shortAssemblyName, StringComparison.OrdinalIgnoreCase));
         if (item is not null)
             return item;
 
         // check for full name match
-        item = references.FirstOrDefault(it => string.Compare(it.EvaluatedInclude, fullAssemblyName, StringComparison.OrdinalIgnoreCase) == 0);
+        item = references.FirstOrDefault(it => string.Equals(it.EvaluatedInclude, fullAssemblyName, StringComparison.OrdinalIgnoreCase));
         if (item is not null)
             return item;
 
@@ -216,7 +216,7 @@ internal sealed class ProjectFile(
                                    || PathUtilities.PathsEqual(it.EvaluatedInclude, projectFilePath));
 
         // try to find by project name
-        item ??= references.First(it => string.Compare(projectName, it.GetMetadataValue(MetadataNames.Name), StringComparison.OrdinalIgnoreCase) == 0);
+        item ??= references.First(it => string.Equals(projectName, it.GetMetadataValue(MetadataNames.Name), StringComparison.OrdinalIgnoreCase));
 
         return item;
     }

--- a/src/Workspaces/Remote/Core/VisualStudioMefHostServices.cs
+++ b/src/Workspaces/Remote/Core/VisualStudioMefHostServices.cs
@@ -82,8 +82,8 @@ internal sealed class VisualStudioMefHostServices : HostServices, IMefHostExport
         }
 
         public bool Equals(ExportKey other)
-            => string.Compare(ExtensionTypeName, other.ExtensionTypeName, StringComparison.OrdinalIgnoreCase) == 0 &&
-               string.Compare(MetadataTypeName, other.MetadataTypeName, StringComparison.OrdinalIgnoreCase) == 0;
+            => string.Equals(ExtensionTypeName, other.ExtensionTypeName, StringComparison.OrdinalIgnoreCase) &&
+               string.Equals(MetadataTypeName, other.MetadataTypeName, StringComparison.OrdinalIgnoreCase);
 
         public override bool Equals(object? obj)
             => obj is ExportKey key && Equals(key);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Extensions/ExpressionSyntaxExtensions.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Extensions/ExpressionSyntaxExtensions.vb
@@ -46,7 +46,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                 Return False
             End If
 
-            If String.Compare(identifierName.Identifier.ToString(), "New", StringComparison.OrdinalIgnoreCase) <> 0 Then
+            If Not String.Equals(identifierName.Identifier.ToString(), "New", StringComparison.OrdinalIgnoreCase) Then
                 Return False
             End If
 

--- a/src/Workspaces/VisualBasic/Portable/Simplification/Simplifiers/NameSimplifier.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/Simplifiers/NameSimplifier.vb
@@ -361,7 +361,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification.Simplifiers
                 ' When the replacement is an Alias we don't want the "Attribute" Suffix to be removed because this will result in symbol change
                 Dim aliasSymbol = semanticModel.GetAliasInfo(name, cancellationToken)
                 If aliasSymbol IsNot Nothing AndAlso
-                   String.Compare(aliasSymbol.Name, identifierToken.ValueText, StringComparison.OrdinalIgnoreCase) = 0 Then
+                   String.Equals(aliasSymbol.Name, identifierToken.ValueText, StringComparison.OrdinalIgnoreCase) Then
                     Return False
                 End If
 


### PR DESCRIPTION
More readable and also cheaper, especially if the JIT can see that one of the values is a constant.
Same idea as https://github.com/dotnet/runtime/pull/124566 in runtime
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84036)