### PR TITLE
Fix a number of helix issues

### DIFF
--- a/src/Tools/RunTests/AssemblyScheduler.cs
+++ b/src/Tools/RunTests/AssemblyScheduler.cs
@@ -20,9 +20,9 @@ namespace RunTests
     {
 
         /// <summary>
-        /// If we were unable to find the test execution history, we fall back to partitioning by just method count.
+        /// The target number of work items to create when partitioning by test count.
         /// </summary>
-        private static readonly int s_maxMethodCount = 500;
+        private const int TargetWorkItemCount = 25;
 
         public static ImmutableArray<HelixWorkItem> Schedule(
             IEnumerable<string> assemblyFilePaths,
@@ -41,10 +41,12 @@ namespace RunTests
             {
                 // We didn't have any test history from azure devops, just partition by test count.
                 ConsoleUtil.Warning($"Could not look up test history - partitioning based on test count instead");
+                var totalTestCount = orderedTypeInfos.Values.Sum(types => types.Sum(t => t.Tests.Length));
+                var testsPerWorkItem = Math.Max(1, totalTestCount / TargetWorkItemCount);
                 var workItemsByMethodCount = BuildWorkItems(
                     orderedTypeInfos,
                     getWeightFunc: static test => 1,
-                    limit: s_maxMethodCount);
+                    limit: testsPerWorkItem);
 
                 LogWorkItems(workItemsByMethodCount);
                 return workItemsByMethodCount;

--- a/src/Tools/RunTests/AssemblyScheduler.cs
+++ b/src/Tools/RunTests/AssemblyScheduler.cs
@@ -39,19 +39,39 @@ namespace RunTests
 
             if (testHistory is null)
             {
-                // We didn't have any test history from azure devops, just partition by test count.
                 ConsoleUtil.Warning($"Could not look up test history - partitioning based on test count instead");
-                var totalTestCount = orderedTypeInfos.Values.Sum(types => types.Sum(t => t.Tests.Length));
-                var testsPerWorkItem = Math.Max(1, totalTestCount / TargetWorkItemCount);
-                var workItemsByMethodCount = BuildWorkItems(
-                    orderedTypeInfos,
-                    getWeightFunc: static test => 1,
-                    limit: testsPerWorkItem);
-
-                LogWorkItems(workItemsByMethodCount);
-                return workItemsByMethodCount;
+                return ScheduleByCount(orderedTypeInfos);
             }
 
+            return ScheduleByTime(orderedTypeInfos, testHistory);
+        }
+
+        /// <summary>
+        /// Partition tests evenly by count into a target number of work items.
+        /// Used as a fallback when test history is unavailable.
+        /// </summary>
+        private static ImmutableArray<HelixWorkItem> ScheduleByCount(
+            ImmutableSortedDictionary<string, ImmutableArray<TypeInfo>> orderedTypeInfos)
+        {
+            var totalTestCount = orderedTypeInfos.Values.Sum(types => types.Sum(t => t.Tests.Length));
+            var testsPerWorkItem = Math.Max(1, totalTestCount / TargetWorkItemCount);
+            var workItems = BuildWorkItems(
+                orderedTypeInfos,
+                getWeightFunc: static test => 1,
+                limit: testsPerWorkItem);
+
+            LogWorkItems(workItems);
+            return workItems;
+        }
+
+        /// <summary>
+        /// Partition tests by historical execution time with the goal of each work item
+        /// running under the time limit.
+        /// </summary>
+        private static ImmutableArray<HelixWorkItem> ScheduleByTime(
+            ImmutableSortedDictionary<string, ImmutableArray<TypeInfo>> orderedTypeInfos,
+            Dictionary<string, (TimeSpan Duration, int TestTheoryInstances)> testHistory)
+        {
             LogLongTests(testHistory);
 
             // Now for our current set of test methods we got from the assemblies we built, match them to tests from our test run history

--- a/src/Tools/RunTests/AssemblyScheduler.cs
+++ b/src/Tools/RunTests/AssemblyScheduler.cs
@@ -26,7 +26,7 @@ namespace RunTests
 
         public static ImmutableArray<HelixWorkItem> Schedule(
             IEnumerable<string> assemblyFilePaths,
-            ImmutableDictionary<string, (TimeSpan Duration, int TestTheoryInstances)> testHistory)
+            Dictionary<string, (TimeSpan Duration, int TestTheoryInstances)>? testHistory)
         {
             var orderedTypeInfos = assemblyFilePaths.ToImmutableSortedDictionary(x => x, GetTypeInfoList);
             ConsoleUtil.WriteLine($"Scheduling {orderedTypeInfos.Count} assemblies");
@@ -37,7 +37,7 @@ namespace RunTests
                 ConsoleUtil.WriteLine($"\tAssembly: {Path.GetFileName(kvp.Key)}, Test Type Count: {typeCount}, Test Count: {testCount}");
             }
 
-            if (testHistory.IsEmpty)
+            if (testHistory is null)
             {
                 // We didn't have any test history from azure devops, just partition by test count.
                 ConsoleUtil.Warning($"Could not look up test history - partitioning based on test count instead");
@@ -67,7 +67,7 @@ namespace RunTests
             return workItems;
         }
 
-        private static void LogLongTests(ImmutableDictionary<string, (TimeSpan Duration, int TestTheoryInstances)> testHistory)
+        private static void LogLongTests(Dictionary<string, (TimeSpan Duration, int TestTheoryInstances)> testHistory)
         {
             var longTests = testHistory
                 .Where(kvp => kvp.Value.Duration > HelixTestRunner.WorkItemScheduleTime)
@@ -85,7 +85,7 @@ namespace RunTests
 
         private static ImmutableSortedDictionary<string, ImmutableArray<TypeInfo>> UpdateTestsWithExecutionTimes(
             ImmutableSortedDictionary<string, ImmutableArray<TypeInfo>> assemblyTypes,
-            ImmutableDictionary<string, (TimeSpan Duration, int TestTheoryInstances)> testHistory)
+            Dictionary<string, (TimeSpan Duration, int TestTheoryInstances)> testHistory)
         {
             // In xUnit v2, the ExecutionTimer in TestInvoker does NOT include IAsyncLifetime
             // .InitializeAsync() or .DisposeAsync() in DurationInMs. Test base classes that

--- a/src/Tools/RunTests/HelixTestRunner.cs
+++ b/src/Tools/RunTests/HelixTestRunner.cs
@@ -323,6 +323,7 @@ internal sealed partial class HelixTestRunner
         // Retrieve test runtimes from azure devops historical data.
         var testHistory = await TestHistoryManager.GetTestHistoryAsync(options, cancellationToken);
         var helixWorkItems = AssemblyScheduler.Schedule(assemblies.Select(x => x.AssemblyPath), testHistory);
+        var timeout = testHistory is null ? WorkItemExecutionTimeout * 2 : WorkItemExecutionTimeout;
         var helixProjectFileContent = GetHelixProjectFileContent(
             helixWorkItems,
             testOS,
@@ -330,7 +331,8 @@ internal sealed partial class HelixTestRunner
             platform,
             options.HelixQueueName,
             options.ArtifactsDirectory,
-            payloadsDir);
+            payloadsDir,
+            timeout);
 
         var helixFilePath = Path.Combine(options.ArtifactsDirectory, "helix.proj");
         File.WriteAllText(helixFilePath, helixProjectFileContent);
@@ -419,7 +421,8 @@ internal sealed partial class HelixTestRunner
         string platform,
         string helixQueueName,
         string artifactsDir,
-        string payloadsDir)
+        string payloadsDir,
+        TimeSpan timeout)
     {
         // Setup the environment variables that are required for the helix project.
         //
@@ -464,7 +467,7 @@ internal sealed partial class HelixTestRunner
 
         foreach (var helixWorkItem in helixWorkItems)
         {
-            AppendHelixWorkItemProject(builder, helixWorkItem, platform, artifactsDir, payloadsDir, testOS);
+            AppendHelixWorkItemProject(builder, helixWorkItem, platform, artifactsDir, payloadsDir, testOS, timeout);
         }
 
         builder.AppendLine("""
@@ -490,7 +493,8 @@ internal sealed partial class HelixTestRunner
             string platform,
             string artifactsDir,
             string payloadsDir,
-            TestOS testOS)
+            TestOS testOS,
+            TimeSpan timeout)
         {
             var isUnix = testOS != TestOS.Windows;
 
@@ -538,7 +542,7 @@ internal sealed partial class HelixTestRunner
                         <PayloadDirectory>{workItemPayloadDir}</PayloadDirectory>
                         <Command>{commandPrefix}{commandFileName}</Command>
                         <PostCommands>{commandPrefix}{postCommandFileName}</PostCommands>
-                        <Timeout>{WorkItemExecutionTimeout:hh\:mm\:ss}</Timeout>
+                        <Timeout>{timeout:hh\:mm\:ss}</Timeout>
                         <ExpectedExecutionTime>{helixWorkItem.EstimatedExecutionTime}</ExpectedExecutionTime>
                     </HelixWorkItem>
                 """);

--- a/src/Tools/RunTests/HelixTestRunner.cs
+++ b/src/Tools/RunTests/HelixTestRunner.cs
@@ -52,13 +52,10 @@ internal sealed partial class HelixTestRunner
     internal static TimeSpan AsyncLifetimeInstanceOverhead { get; } = TimeSpan.FromMilliseconds(700);
 
     /// <summary>
-    /// This is the amount of time we will wait for a helix work item to complete before we consider it a severe error
-    /// and cancel the helix job entirely.
+    /// This is the maximum time a Helix work item is allowed to execute. This value is passed to Helix
+    /// as the work item timeout. We also monitor work items against this value and report warnings when
+    /// it is exceeded.
     /// </summary>
-    /// <remarks>
-    /// The only lever that vstest provides is for timeout on an individual test, not the entire test run. We need a guard
-    /// against the helix job executing for the entire AzDO job time (currently set at six hours).
-    /// </remarks>
     internal static TimeSpan WorkItemExecutionTimeout { get; } = WorkItemScheduleTime * 3;
 
     /// <summary>
@@ -135,7 +132,7 @@ internal sealed partial class HelixTestRunner
         try
         {
             await WaitForAllWorkItemsRunningAsync(helixApi, helixJobId, processWaitTask, cancellationToken);
-            await WaitForWorkItemsToCompleteOrTimeoutAsync(helixApi, helixJobId, helixCancellationToken, testResultsDirectory, processWaitTask, cancellationToken);
+            await WaitForHelixJob(helixApi, helixJobId, testResultsDirectory, processWaitTask, cancellationToken);
             await process.WaitForExitAsync(cancellationToken);
             return process.ExitCode;
         }
@@ -188,8 +185,9 @@ internal sealed partial class HelixTestRunner
             } while (true);
         }
 
-        static async Task WaitForWorkItemsToCompleteOrTimeoutAsync(HelixApi helixApi, string helixJobId, string helixCancellationToken, string testResultsDirectory, Task processWaitTask, CancellationToken cancellationToken)
+        static async Task WaitForHelixJob(HelixApi helixApi, string helixJobId, string testResultsDirectory, Task processWaitTask, CancellationToken cancellationToken)
         {
+            var reportedTimeouts = new HashSet<string>();
             do
             {
                 var delayTask = Task.Delay(HelixPollTime, cancellationToken);
@@ -217,9 +215,9 @@ internal sealed partial class HelixTestRunner
                             continue;
                         }
 
-                        if (HasTimedOut(details))
+                        if (HasTimedOut(details) && reportedTimeouts.Add(workItem.Name))
                         {
-                            ConsoleUtil.Error($"Helix Job {helixJobId} Work item {workItem.Name} has been in state {details.State} for more than {WorkItemExecutionTimeout}. Timing out the job.");
+                            ConsoleUtil.Warning($"Helix Job {helixJobId} Work item {workItem.Name} has been in state {details.State} for more than {WorkItemExecutionTimeout}.");
                             timedOutWorkItems.Add(workItem.Name);
                         }
                     }
@@ -227,8 +225,6 @@ internal sealed partial class HelixTestRunner
                     if (timedOutWorkItems.Count > 0)
                     {
                         WriteSyntheticTimeoutResults(testResultsDirectory, helixJobId, timedOutWorkItems);
-                        await helixApi.CancelJobAsync(helixJobId, helixCancellationToken, cancellationToken);
-                        throw new Exception($"One or more work items in Helix job {helixJobId} have timed out. Timing out the entire job.");
                     }
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException and not TimeoutException)
@@ -542,7 +538,7 @@ internal sealed partial class HelixTestRunner
                         <PayloadDirectory>{workItemPayloadDir}</PayloadDirectory>
                         <Command>{commandPrefix}{commandFileName}</Command>
                         <PostCommands>{commandPrefix}{postCommandFileName}</PostCommands>
-                        <Timeout>01:00:00</Timeout>
+                        <Timeout>{WorkItemExecutionTimeout:hh\:mm\:ss}</Timeout>
                         <ExpectedExecutionTime>{helixWorkItem.EstimatedExecutionTime}</ExpectedExecutionTime>
                     </HelixWorkItem>
                 """);

--- a/src/Tools/RunTests/TestHistoryManager.cs
+++ b/src/Tools/RunTests/TestHistoryManager.cs
@@ -29,7 +29,7 @@ internal class TestHistoryManager
     /// In xUnit v2, DurationInMs does NOT include IAsyncLifetime.InitializeAsync or DisposeAsync time.
     /// The caller is responsible for adjusting the duration based on the HasAsyncLifetime flag from test discovery.
     /// </summary>
-    public static async Task<ImmutableDictionary<string, (TimeSpan Duration, int TestTheoryInstances)>> GetTestHistoryAsync(Options options, CancellationToken cancellationToken)
+    public static async Task<Dictionary<string, (TimeSpan Duration, int TestTheoryInstances)>?> GetTestHistoryAsync(Options options, CancellationToken cancellationToken)
     {
         // Access token that has permissions to lookup test history.  This typically comes from the pipeline.
         var accessToken = options.AccessToken ?? GetEnvironmentVariable("SYSTEM_ACCESSTOKEN");
@@ -54,7 +54,7 @@ internal class TestHistoryManager
         if (string.IsNullOrEmpty(accessToken) || string.IsNullOrEmpty(projectUri) || string.IsNullOrEmpty(phaseName) || string.IsNullOrEmpty(targetBranch) || !int.TryParse(pipelineDefinitionIdStr, out var pipelineDefinitionId))
         {
             ConsoleUtil.Warning($"Missing required options to lookup test history, projectUri={projectUri}, phaseName={phaseName}, targetBranchName={targetBranch}, pipelineDefinitionId={pipelineDefinitionIdStr}");
-            return ImmutableDictionary<string, (TimeSpan Duration, int TestTheoryInstances)>.Empty;
+            return null;
         }
 
         using var azdoClient = AzdoClient.Create(projectUri, accessToken);
@@ -76,7 +76,7 @@ internal class TestHistoryManager
         {
             // If this is a new branch we may not have any historical data for it.
             ConsoleUtil.Warning($"Unable to get the last successful build for definition {pipelineDefinitionId} in {projectUri} and branch {targetBranch}");
-            return ImmutableDictionary<string, (TimeSpan Duration, int TestTheoryInstances)>.Empty;
+            return null;
         }
 
         var runForThisStage = await GetRunForStageAsync(azdoClient, lastSuccessfulBuild, phaseName, cancellationToken);
@@ -84,7 +84,7 @@ internal class TestHistoryManager
         {
             // If this is a new stage, historical runs will not have any data for it.
             ConsoleUtil.Warning($"Unable to get a run with name {phaseName} from build {lastSuccessfulBuild.Url}.");
-            return ImmutableDictionary<string, (TimeSpan Duration, int TestTheoryInstances)>.Empty;
+            return null;
         }
 
         ConsoleUtil.WriteLine($"Looking up test execution data for build {lastSuccessfulBuild.Id} on branch {targetBranch} and stage {phaseName}");
@@ -138,9 +138,15 @@ internal class TestHistoryManager
             Logger.Log($"Found {duplicateCount} duplicate tests in run {runForThisStage.Name}.");
         }
 
+        if (testInfos.Count == 0)
+        {
+            ConsoleUtil.Warning($"Retrieved zero test results from build {lastSuccessfulBuild.Id} and stage {phaseName}, falling back to count based scheduling");
+            return null;
+        }
+
         var totalTestRuntime = TimeSpan.FromMilliseconds(testInfos.Values.Sum(t => t.Duration.TotalMilliseconds));
         ConsoleUtil.WriteLine($"Retrieved {testInfos.Keys.Count} tests from AzureDevops in {timer.Elapsed}.  Total runtime of all tests is {totalTestRuntime}");
-        return testInfos.ToImmutableDictionary();
+        return testInfos;
     }
 
     private static string? GetEnvironmentVariable(string envVarName)


### PR DESCRIPTION
Consider reviewing commit by commit.  Changes

 1. Return nullable from `GetTestHistoryAsync`: Changed the return type to `Dictionary<...>?` where `null` explicitly indicates that test history is unavailable (error or zero results), triggering count-based fallback scheduling.
 2. Move timeout enforcement to Helix: The `<Timeout>` value in the Helix project file now uses `WorkItemExecutionTimeout` so Helix enforces timeouts natively. RunTests continues to monitor and write synthetic timeout test results for reporting, but no longer cancels the job itself.
 3. Target fixed work item count: Count-based partitioning now targets 25 work items by dividing total tests evenly, rather than using a fixed 500-tests-per-partition limit. This keeps work item count predictable regardless of total test count. This should significantly reduce burden on helix queues
 4. Refactor Schedule into `ScheduleByCount` and `ScheduleByTime`: Extracted the two scheduling strategies into separate methods for clarity.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84039)