### PR TITLE
[EE] Enable `using static` for non-static classes in CSharp EE

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -1104,9 +1104,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                                 // valid in the original source but unnecessary.
                                 continue; // Don't add anything for this import.
                             }
-                            else if (importRecord.Alias == null && !typeSymbol.IsStatic)
+                            else if (importRecord.Alias == null && typeSymbol.Kind != SymbolKind.NamedType)
                             {
-                                // Only static types can be directly imported.
+                                // Only named types can be directly imported.
                                 continue;
                             }
 

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -1104,9 +1104,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                                 // valid in the original source but unnecessary.
                                 continue; // Don't add anything for this import.
                             }
-                            else if (importRecord.Alias == null && typeSymbol.Kind != SymbolKind.NamedType)
+                            else if (importRecord.Alias == null && typeSymbol is not NamedTypeSymbol { IsExtension: false })
                             {
-                                // Only named types can be directly imported.
+                                // Only (non-extension) named types can be directly imported.
                                 continue;
                             }
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -5552,6 +5552,49 @@ class C
             });
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/26084")]
+        public void StaticTypeImport_Enum()
+        {
+            var source = @"
+using static ConsoleApplication1.MyEnumType;
+
+namespace ConsoleApplication1
+{
+    public enum MyEnumType
+    {
+        thing1,
+        thing2,
+    }
+
+    class Program
+    {
+        static void Main()
+        {
+            var value = thing1;
+        }
+    }
+}";
+            var compilation0 = CreateCompilation(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "ConsoleApplication1.Program.Main");
+                ResultProperties resultProperties;
+                string error;
+                var testData = new CompilationTestData();
+                context.CompileExpression("thing2", out resultProperties, out error, testData);
+                Assert.Null(error);
+                Assert.Equal(DkmClrCompilationResultFlags.ReadOnlyResult, resultProperties.Flags);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
+    @"{
+  // Code size        2 (0x2)
+  .maxstack  1
+  .locals init (ConsoleApplication1.MyEnumType V_0) //value
+  IL_0000:  ldc.i4.1
+  IL_0001:  ret
+}");
+            });
+        }
+
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1014763")]
         public void NonStateMachineTypeParameter()
         {

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/UsingDebugInfoTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/UsingDebugInfoTests.cs
@@ -617,6 +617,67 @@ namespace N
             Assert.Equal(0, imports.ExternAliases.Length);
         }
 
+        [Fact]
+        public void BadPdb_ExtensionMarkerTypeImport()
+        {
+            var source = """
+public class C
+{
+    public static void Main()
+    {
+    }
+}
+
+public static class E
+{
+    extension(int i)
+    {
+        public int P => i;
+    }
+}
+""";
+            var comp = CreateCompilation(source, parseOptions: SyntaxHelpers.PreviewParseOptions, options: TestOptions.DebugDll);
+            comp.VerifyEmitDiagnostics();
+
+            using var runtime = CreateRuntimeInstance(comp);
+            var evalContext = CreateMethodContext(runtime, "C.Main");
+            var runtimeCompContext = evalContext.CreateCompilationContext();
+            var currentFrame = (MethodSymbol)runtimeCompContext.Compilation.GlobalNamespace
+                .GetTypeMembers("C").Single()
+                .GetMembers("Main").Single();
+            var extension = runtimeCompContext.Compilation.GlobalNamespace
+                .GetTypeMembers("E").Single()
+                .GetTypeMembers().Single(t => t.IsExtension);
+            Assert.True(extension.IsExtension);
+            var importRecordGroups = ImmutableArray.Create(
+                ImmutableArray.Create(new ImportRecord(ImportTargetKind.Type, targetType: extension)));
+
+            var methodDebugInfo = new MethodDebugInfo<TypeSymbol, LocalSymbol>(
+                ImmutableArray<HoistedLocalScopeRecord>.Empty,
+                importRecordGroups,
+                ImmutableArray<ExternAliasRecord>.Empty,
+                dynamicLocalMap: null,
+                tupleLocalMap: null,
+                defaultNamespaceName: "",
+                localVariableNames: ImmutableArray<string>.Empty,
+                localConstants: ImmutableArray<LocalSymbol>.Empty,
+                reuseSpan: ILSpan.MaxValue,
+                containingDocumentName: null,
+                isPrimaryConstructor: false);
+
+            var compContext = new CompilationContext(
+                runtimeCompContext.Compilation,
+                currentFrame,
+                currentFrame,
+                locals: [],
+                inScopeHoistedLocalSlots: [],
+                methodDebugInfo);
+            var imports = compContext.NamespaceBinder.ImportChain.Single();
+            Assert.Equal(0, imports.Usings.Length); // Note: the import is dropped.
+            Assert.Equal(0, imports.UsingAliases.Count);
+            Assert.Equal(0, imports.ExternAliases.Length);
+        }
+
         #endregion Invalid PDBs
 
         #region Binder chain

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/UsingDebugInfoTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/UsingDebugInfoTests.cs
@@ -575,46 +575,6 @@ namespace N
             Assert.Equal(0, imports.ExternAliases.Length);
         }
 
-        [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1084059")]
-        public void BadPdb_NonStaticTypeImport()
-        {
-            var source = @"
-namespace N
-{
-    public class C
-    {
-        public static void Main()
-        {
-        }
-    }
-}
-";
-            var comp = CreateCompilation(source);
-            var peImage = comp.EmitToArray();
-
-            ISymUnmanagedReader symReader;
-            using (var peReader = new PEReader(peImage))
-            {
-                var metadataReader = peReader.GetMetadataReader();
-                var methodHandle = metadataReader.MethodDefinitions.Single(h => metadataReader.StringComparer.Equals(metadataReader.GetMethodDefinition(h).Name, "Main"));
-                var methodToken = metadataReader.GetToken(methodHandle);
-
-                symReader = new MockSymUnmanagedReader(new Dictionary<int, MethodDebugInfoBytes>
-                {
-                    { methodToken, new MethodDebugInfoBytes.Builder([new[] { "TSystem.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" }], suppressUsingInfo: true).AddUsingInfo(1).Build() },
-                }.ToImmutableDictionary());
-            }
-
-            var module = ModuleInstance.Create(peImage, symReader);
-            var runtime = CreateRuntimeInstance(module, new[] { MscorlibRef });
-            var evalContext = CreateMethodContext(runtime, "N.C.Main");
-            var compContext = evalContext.CreateCompilationContext();
-            var imports = compContext.NamespaceBinder.ImportChain.Single();
-            Assert.Equal(0, imports.Usings.Length); // Note: the import is dropped
-            Assert.Equal(0, imports.UsingAliases.Count);
-            Assert.Equal(0, imports.ExternAliases.Length);
-        }
-
         #endregion Invalid PDBs
 
         #region Binder chain

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/UsingDebugInfoTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/UsingDebugInfoTests.cs
@@ -575,6 +575,48 @@ namespace N
             Assert.Equal(0, imports.ExternAliases.Length);
         }
 
+        [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1084059")]
+        public void NonStaticTypeImport()
+        {
+            var source = @"
+namespace N
+{
+    public class C
+    {
+        public static void Main()
+        {
+        }
+    }
+}
+";
+            var comp = CreateCompilation(source);
+            var peImage = comp.EmitToArray();
+
+            ISymUnmanagedReader symReader;
+            using (var peReader = new PEReader(peImage))
+            {
+                var metadataReader = peReader.GetMetadataReader();
+                var methodHandle = metadataReader.MethodDefinitions.Single(h => metadataReader.StringComparer.Equals(metadataReader.GetMethodDefinition(h).Name, "Main"));
+                var methodToken = metadataReader.GetToken(methodHandle);
+
+                symReader = new MockSymUnmanagedReader(new Dictionary<int, MethodDebugInfoBytes>
+                {
+                    { methodToken, new MethodDebugInfoBytes.Builder([new[] { "TSystem.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" }], suppressUsingInfo: true).AddUsingInfo(1).Build() },
+                }.ToImmutableDictionary());
+            }
+
+            var module = ModuleInstance.Create(peImage, symReader);
+            var runtime = CreateRuntimeInstance(module, new[] { MscorlibRef });
+            var evalContext = CreateMethodContext(runtime, "N.C.Main");
+            var compContext = evalContext.CreateCompilationContext();
+            var imports = compContext.NamespaceBinder.ImportChain.Single();
+            var actualType = imports.Usings.Single().NamespaceOrType;
+            Assert.Equal(SymbolKind.NamedType, actualType.Kind);
+            Assert.Equal("System.String", actualType.ToTestDisplayString());
+            Assert.Equal(0, imports.UsingAliases.Count);
+            Assert.Equal(0, imports.ExternAliases.Length);
+        }
+
         #endregion Invalid PDBs
 
         #region Binder chain


### PR DESCRIPTION
The CSharp EE seems to be a bit out of date with C#, as it was only allowing `using static` for static classes, when `using static` is valid for named types now.

- Loosened the check in the imports builder section of `CompilationContext`
- Added test verifying the original bug is fixed
- Removed test that was verifying incorrect behavior in the EE; `using static System.String` is perfectly valid.

fix #26084
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84042)