### PR TITLE
Fix mishandling of large embedded C# literals

### DIFF
--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests_TestMarkup.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests_TestMarkup.cs
@@ -523,4 +523,29 @@ public sealed partial class SemanticClassifierTests : AbstractCSharpClassifierTe
             String("\"\"\""),
             Punctuation.Semicolon,
             Punctuation.CloseCurly);
+
+    [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/80808")]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/83046")]
+    public Task TestLargeEmbeddedCSharp(TestHost testHost)
+    {
+        // The embedded code must be larger than SlidingTextWindow.DefaultWindowLength (4096) so that the
+        // lexer reads it in more than one chunk.  This exercises VirtualCharSequenceSourceText.CopyTo with a
+        // non-zero source index, which previously threw an IndexOutOfRangeException.
+        var comment = "// " + new string('x', 5000);
+        return TestEmbeddedCSharpAsync(
+            comment + """
+
+            class D
+            {
+            }
+            """,
+            testHost,
+            Comment(comment),
+            Keyword("class"),
+            TestCode(" "),
+            Class("D"),
+            Punctuation.OpenCurly,
+            Punctuation.CloseCurly);
+    }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/VirtualCharSequenceSourceText.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/VirtualCharSequenceSourceText.cs
@@ -30,7 +30,7 @@ internal sealed class VirtualCharSequenceSourceText : SourceText
 
     public override void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count)
     {
-        for (int i = sourceIndex, n = sourceIndex + count; i < n; i++)
-            destination[destinationIndex + i] = this[i];
+        for (var i = 0; i < count; i++)
+            destination[destinationIndex + i] = this[sourceIndex + i];
     }
 }


### PR DESCRIPTION
The index calculation VirtualCharSequenceSourceText.CopyTo was wrong.

Fixes https://github.com/dotnet/roslyn/issues/80808
Fixes https://github.com/dotnet/roslyn/issues/83046