### PR TITLE
Fix ArrayBuilder<SyntaxNode> pool leak in ComputeDeclarationAnalysisData

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -2576,7 +2576,16 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             bool isPartialDeclAnalysis = analysisScope.FilterSpanOpt.HasValue && !analysisScope.ContainsSpan(topmostNodeForAnalysis.FullSpan);
             var data = new DeclarationAnalysisData(declaringReferenceSyntax, topmostNodeForAnalysis, declarationInfos, isPartialDeclAnalysis);
-            AddSyntaxNodesToAnalyze(topmostNodeForAnalysis, symbol, declarationInfos, semanticModel, data.DescendantNodesToAnalyze, cancellationToken);
+            try
+            {
+                AddSyntaxNodesToAnalyze(topmostNodeForAnalysis, symbol, declarationInfos, semanticModel, data.DescendantNodesToAnalyze, cancellationToken);
+            }
+            catch
+            {
+                data.Free();
+                throw;
+            }
+
             return data;
         }
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -2569,10 +2569,21 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             cancellationToken.ThrowIfCancellationRequested();
 
             var builder = ArrayBuilder<DeclarationInfo>.GetInstance();
-            SyntaxNode declaringReferenceSyntax = declaration.GetSyntax(cancellationToken);
-            SyntaxNode topmostNodeForAnalysis = semanticModel.GetTopmostNodeForDiagnosticAnalysis(symbol, declaringReferenceSyntax);
-            ComputeDeclarationsInNode(semanticModel, symbol, declaringReferenceSyntax, topmostNodeForAnalysis, builder, cancellationToken);
-            ImmutableArray<DeclarationInfo> declarationInfos = builder.ToImmutableAndFree();
+            SyntaxNode declaringReferenceSyntax;
+            SyntaxNode topmostNodeForAnalysis;
+            ImmutableArray<DeclarationInfo> declarationInfos;
+            try
+            {
+                declaringReferenceSyntax = declaration.GetSyntax(cancellationToken);
+                topmostNodeForAnalysis = semanticModel.GetTopmostNodeForDiagnosticAnalysis(symbol, declaringReferenceSyntax);
+                ComputeDeclarationsInNode(semanticModel, symbol, declaringReferenceSyntax, topmostNodeForAnalysis, builder, cancellationToken);
+                declarationInfos = builder.ToImmutableAndFree();
+            }
+            catch
+            {
+                builder.Free();
+                throw;
+            }
 
             bool isPartialDeclAnalysis = analysisScope.FilterSpanOpt.HasValue && !analysisScope.ContainsSpan(topmostNodeForAnalysis.FullSpan);
             var data = new DeclarationAnalysisData(declaringReferenceSyntax, topmostNodeForAnalysis, declarationInfos, isPartialDeclAnalysis);


### PR DESCRIPTION
When concurrent worker tasks process different symbols, a standard cancellation can leak the DescendantNodesToAnalyze ArrayBuilder. Worker A processes a method symbol whose analyzer callback cancels the token. Concurrently, Worker B is inside ComputeDeclarationAnalysisData for a different symbol, has already allocated the DeclarationAnalysisData (which allocates ArrayBuilder<SyntaxNode> in its field initializer), and then hits cancellationToken.ThrowIfCancellationRequested() inside AddSyntaxNodesToAnalyze. The exception propagates without freeing the ArrayBuilder.

Fix by wrapping AddSyntaxNodesToAnalyze in a try/catch that calls data.Free() before rethrowing.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84046)