### PR TITLE
Fix file watching leaks for shared server

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/FileBasedProgramsWorkspaceTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/FileBasedProgramsWorkspaceTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.LanguageServer.FileBasedPrograms;
 using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
+using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.FileWatching;
 using Microsoft.CodeAnalysis.LanguageServer.UnitTests.Miscellaneous;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.ProjectSystem;
@@ -495,6 +496,40 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
     {
         _ = await GetRequiredLspWorkspaceAndDocumentAsync(looseFileUri, testLspServer).ConfigureAwait(false);
         await testLspServer.TestWorkspace.GetService<AsynchronousOperationListenerProvider>().GetWaiter(FeatureAttribute.Workspace).ExpeditedWaitAsync();
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestFileWatchesReleasedOnServerShutdown(bool mutatingLspWorkspace)
+    {
+        // Regression test ensuring the project loader disposes the projects (and hence their file watches) it created
+        // when the server shuts down. Each file watch holds an operating system handle (e.g. an inotify instance on
+        // Linux); leaking them across server restarts eventually exhausts the per-user limit.
+        var tempDir = TempRoot.CreateDirectory();
+        var sourceText = """
+            #:sdk Microsoft.NET.Sdk
+            Console.WriteLine("Hello World!");
+            """;
+        var sourceFile = tempDir.CreateFile("SomeFile.cs").WriteAllText(sourceText);
+        var looseFileUri = ProtocolConversions.CreateAbsoluteDocumentUri(sourceFile.Path);
+
+        DefaultFileChangeWatcher watcher;
+
+        await using (var testLspServer = await CreateTestLspServerAsync(string.Empty, mutatingLspWorkspace, new InitializationOptions { ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer }))
+        {
+            await testLspServer.OpenDocumentAsync(looseFileUri, sourceText).ConfigureAwait(false);
+            await WaitForProjectLoad(looseFileUri, testLspServer);
+
+            // Loading the file-based program project should have created file watches on the in-process watcher.
+            var fileChangeWatcher = testLspServer.GetRequiredLspService<IFileChangeWatcher>();
+            var delegatingWatcher = Assert.IsType<DelegatingFileChangeWatcher>(fileChangeWatcher);
+            watcher = Assert.IsType<DefaultFileChangeWatcher>(delegatingWatcher.GetTestAccessor().UnderlyingFileWatcher);
+
+            Assert.NotEmpty(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
+        }
+
+        // Once the server has shut down, the project loader must have disposed its loaded projects and the workspace
+        // factory must have disposed its reference trackers, releasing every file watch.
+        Assert.Empty(DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher));
     }
 
     [Theory, CombinatorialData]

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/FileBasedProgramsProjectSystem.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/FileBasedProgramsProjectSystem.cs
@@ -24,7 +24,7 @@ using Roslyn.Utilities;
 namespace Microsoft.CodeAnalysis.LanguageServer.FileBasedPrograms;
 
 /// <summary>Handles loading both miscellaneous files and file-based program projects.</summary>
-internal sealed class FileBasedProgramsProjectSystem : LanguageServerProjectLoader, ILspMiscellaneousFilesWorkspaceProvider, IDisposable
+internal sealed class FileBasedProgramsProjectSystem : LanguageServerProjectLoader, ILspMiscellaneousFilesWorkspaceProvider
 {
     private readonly ILspServices _lspServices;
     private readonly ILogger<FileBasedProgramsProjectSystem> _logger;
@@ -57,9 +57,10 @@ internal sealed class FileBasedProgramsProjectSystem : LanguageServerProjectLoad
         globalOptionService.AddOptionChangedHandler(this, OnGlobalOptionChanged);
     }
 
-    public void Dispose()
+    public override void Dispose()
     {
         GlobalOptionService.RemoveOptionChangedHandler(this, OnGlobalOptionChanged);
+        base.Dispose();
     }
 
     private void OnGlobalOptionChanged(object sender, object target, OptionChangedEventArgs args)

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
@@ -240,10 +240,10 @@ internal abstract class LanguageServerProjectLoader : IDisposable
         var projectPath = projectToLoad.Path;
 
         // Before doing any work, check if the project has already been unloaded
-        // or if the loader itself has been disposed (indicating the server is shutting down).
         using (await _gate.DisposableWaitAsync(cancellationToken))
         {
-            if (_isDisposed || !_loadedProjects.ContainsKey(projectPath))
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!_loadedProjects.ContainsKey(projectPath))
             {
                 return null;
             }
@@ -291,6 +291,7 @@ internal abstract class LanguageServerProjectLoader : IDisposable
 
             using (await _gate.DisposableWaitAsync(cancellationToken))
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 if (!_loadedProjects.TryGetValue(projectPath, out var currentLoadState))
                 {
                     // Project was unloaded. Do not proceed with reloading it.

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
@@ -22,7 +22,7 @@ using LSP = Roslyn.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
 
-internal abstract class LanguageServerProjectLoader
+internal abstract class LanguageServerProjectLoader : IDisposable
 {
     private static readonly string s_razorDesignTimePath = Path.Combine(AppContext.BaseDirectory, "Targets", "Microsoft.NET.Sdk.Razor.DesignTime.targets");
 
@@ -504,6 +504,31 @@ internal abstract class LanguageServerProjectLoader
                 var removed = await TryUnloadProject_NoLockAsync(key);
                 Contract.ThrowIfFalse(removed); // We obtained lock before enumerating, how was this already removed?
             }
+        }
+    }
+
+    /// <summary>
+    /// Disposes all loaded projects when the server is shutting down. Each <see cref="LoadedProject"/> owns the file
+    /// watches (e.g. inotify instances on Linux) it created, so they must be disposed here to avoid leaking those
+    /// operating system handles across server restarts.
+    /// </summary>
+    public virtual void Dispose()
+    {
+        using (_gate.DisposableWait(CancellationToken.None))
+        {
+            foreach (var (_, loadState) in _loadedProjects)
+            {
+                // Disposing a LoadedProject unloads it, releasing its file watches and removing it from the workspace.
+                // Primordial projects don't own any file watches; their placeholder projects are torn down along with
+                // the workspace, so there's nothing to release for them here.
+                if (loadState is ProjectLoadState.LoadedTargets(var loadedProjectTargets))
+                {
+                    foreach (var loadedProject in loadedProjectTargets)
+                        loadedProject.Dispose();
+                }
+            }
+
+            _loadedProjects.Clear();
         }
     }
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
@@ -27,6 +27,7 @@ internal abstract class LanguageServerProjectLoader : IDisposable
     private static readonly string s_razorDesignTimePath = Path.Combine(AppContext.BaseDirectory, "Targets", "Microsoft.NET.Sdk.Razor.DesignTime.targets");
 
     private readonly AsyncBatchingWorkQueue<ProjectToLoad> _projectsToReload;
+    private bool _isDisposed;
 
     protected readonly LanguageServerWorkspaceFactory _workspaceFactory;
     private readonly ProjectTargetFrameworkManager _projectTargetFrameworkManager;
@@ -238,10 +239,11 @@ internal abstract class LanguageServerProjectLoader : IDisposable
         BuildHostProcessKind? preferredBuildHostKindThatWeDidNotGet = null;
         var projectPath = projectToLoad.Path;
 
-        // Before doing any work, check if the project has already been unloaded.
+        // Before doing any work, check if the project has already been unloaded
+        // or if the loader itself has been disposed (indicating the server is shutting down).
         using (await _gate.DisposableWaitAsync(cancellationToken))
         {
-            if (!_loadedProjects.ContainsKey(projectPath))
+            if (_isDisposed || !_loadedProjects.ContainsKey(projectPath))
             {
                 return null;
             }
@@ -433,6 +435,8 @@ internal abstract class LanguageServerProjectLoader : IDisposable
     {
         using (await _gate.DisposableWaitAsync(CancellationToken.None))
         {
+            Contract.ThrowIfTrue(_isDisposed, "Project loader is already disposed");
+
             if (_loadedProjects.TryGetValue(projectPath, out var existingState))
             {
                 // Note: this generally only happens if we fall through to the "add to misc workspace" path,
@@ -480,6 +484,8 @@ internal abstract class LanguageServerProjectLoader : IDisposable
     {
         using (await _gate.DisposableWaitAsync(CancellationToken.None))
         {
+            Contract.ThrowIfTrue(_isDisposed, "Project loader is already disposed");
+
             // If project has already begun loading, no need to do any further work.
             if (_loadedProjects.ContainsKey(projectPath))
             {
@@ -507,15 +513,16 @@ internal abstract class LanguageServerProjectLoader : IDisposable
         }
     }
 
-    /// <summary>
-    /// Disposes all loaded projects when the server is shutting down. Each <see cref="LoadedProject"/> owns the file
-    /// watches (e.g. inotify instances on Linux) it created, so they must be disposed here to avoid leaking those
-    /// operating system handles across server restarts.
-    /// </summary>
     public virtual void Dispose()
     {
         using (_gate.DisposableWait(CancellationToken.None))
         {
+            if (_isDisposed)
+                return;
+
+            _isDisposed = true;
+            _projectsToReload.Dispose();
+
             foreach (var (_, loadState) in _loadedProjects)
             {
                 // Disposing a LoadedProject unloads it, releasing its file watches and removing it from the workspace.

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerWorkspaceFactory.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerWorkspaceFactory.cs
@@ -82,8 +82,6 @@ internal sealed class LanguageServerWorkspaceFactory : ILspService, IHostWorkspa
 
     public void Dispose()
     {
-        // Dispose the project factories so they release the reference-directory file watches (e.g. inotify instances
-        // on Linux) they created. This factory is an LSP service, so it is disposed when the LSP server shuts down.
         HostProjectFactory.Dispose();
         MiscellaneousFilesWorkspaceProjectFactory.Dispose();
     }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerWorkspaceFactory.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerWorkspaceFactory.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
 /// <see cref="LspServices"/> instance by <see cref="LanguageServerWorkspaceFactoryServiceFactory"/> and
 /// disposed when the LSP server shuts down.
 /// </summary>
-internal sealed class LanguageServerWorkspaceFactory : ILspService, IHostWorkspaceProvider
+internal sealed class LanguageServerWorkspaceFactory : ILspService, IHostWorkspaceProvider, IDisposable
 {
     private readonly ILogger _logger;
     private readonly ImmutableArray<string> _solutionLevelAnalyzerPaths;
@@ -79,6 +79,14 @@ internal sealed class LanguageServerWorkspaceFactory : ILspService, IHostWorkspa
     public ProjectSystemHostInfo ProjectSystemHostInfo { get; }
 
     Workspace IHostWorkspaceProvider.Workspace => HostWorkspace;
+
+    public void Dispose()
+    {
+        // Dispose the project factories so they release the reference-directory file watches (e.g. inotify instances
+        // on Linux) they created. This factory is an LSP service, so it is disposed when the LSP server shuts down.
+        HostProjectFactory.Dispose();
+        MiscellaneousFilesWorkspaceProjectFactory.Dispose();
+    }
 
     private ImmutableArray<AnalyzerFileReference> CreateSolutionLevelAnalyzerReferences(IAnalyzerAssemblyLoaderProvider loaderProvider)
     {

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
@@ -136,6 +136,8 @@ internal sealed class LoadedProject : IDisposable
     {
         _sourceFileCreatedOrDeletedChangeContext?.Dispose();
         _projectFileChangeContext?.Dispose();
+        _mostRecentProjectAssetsFileWatcher?.Dispose();
+        _assetsFileChangeContext.Dispose();
         _optionsProcessor.Dispose();
         _projectSystemProject.RemoveFromWorkspace();
     }

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
@@ -21,7 +21,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 
-internal sealed partial class ProjectSystemProjectFactory
+internal sealed partial class ProjectSystemProjectFactory : IDisposable
 {
     /// <summary>
     /// The main gate to synchronize updates to this solution.
@@ -96,6 +96,15 @@ internal sealed partial class ProjectSystemProjectFactory
 
     public FileTextLoader CreateFileTextLoader(string fullPath)
         => new WorkspaceFileTextLoader(this.SolutionServices, fullPath, defaultEncoding: null);
+
+    public void Dispose()
+    {
+        // Releases the file watches (e.g. inotify instances on Linux) created to watch metadata and analyzer
+        // reference directories. Hosts that keep this factory alive for the lifetime of the process (such as Visual
+        // Studio) never dispose it; the LSP server disposes it when the server shuts down.
+        PortableExecutableReferenceFileChangeTracker.Dispose();
+        AnalyzerReferenceFileChangeTracker.Dispose();
+    }
 
     public async Task<ProjectSystemProject> CreateAndAddToWorkspaceAsync(string projectSystemName, string language, ProjectSystemProjectCreationInfo creationInfo, ProjectSystemHostInfo hostInfo, CancellationToken cancellationToken = default)
     {

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
@@ -99,9 +99,6 @@ internal sealed partial class ProjectSystemProjectFactory : IDisposable
 
     public void Dispose()
     {
-        // Releases the file watches (e.g. inotify instances on Linux) created to watch metadata and analyzer
-        // reference directories. Hosts that keep this factory alive for the lifetime of the process (such as Visual
-        // Studio) never dispose it; the LSP server disposes it when the server shuts down.
         PortableExecutableReferenceFileChangeTracker.Dispose();
         AnalyzerReferenceFileChangeTracker.Dispose();
     }

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ReferenceFileChangeTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ReferenceFileChangeTracker.cs
@@ -36,6 +36,7 @@ internal sealed class ReferenceFileChangeTracker : IDisposable
     private readonly Dictionary<string, (IWatchedFile Token, int RefCount)> _referenceFileWatchingTokens = [];
     private readonly AsyncBatchingWorkQueue<string> _workQueue;
     private readonly Func<string, CancellationToken, Task> _callback;
+    private bool _isDisposed;
 
     public ReferenceFileChangeTracker(
         IFileChangeWatcher fileChangeWatcher,
@@ -103,6 +104,9 @@ internal sealed class ReferenceFileChangeTracker : IDisposable
     {
         lock (_gate)
         {
+            if (_isDisposed)
+                return;
+
             var (token, count) = _referenceFileWatchingTokens.GetOrAdd(fullFilePath, _ =>
             {
                 var fileToken = _fileReferenceChangeContext.Value.EnqueueWatchingFile(fullFilePath);
@@ -122,6 +126,9 @@ internal sealed class ReferenceFileChangeTracker : IDisposable
     {
         lock (_gate)
         {
+            if (_isDisposed)
+                return;
+
             if (!_referenceFileWatchingTokens.TryGetValue(fullFilePath, out var watchedFileReference))
                 throw new ArgumentException("Attempting to stop watching a file that we never started watching. This is a bug.");
 
@@ -155,18 +162,28 @@ internal sealed class ReferenceFileChangeTracker : IDisposable
     private async ValueTask ProcessWorkAsync(ImmutableSegmentedList<string> list, CancellationToken cancellationToken)
     {
         foreach (var filePath in list)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
             await _callback(filePath, cancellationToken).ConfigureAwait(false);
+        }
     }
 
-    /// <summary>
-    /// Releases the file watches created by this tracker. Disposing the underlying <see cref="IFileChangeContext"/>
-    /// releases both the directory watch on the reference directories and any per-file watches created via
-    /// <see cref="StartWatchingReference"/>. This is used when the owning workspace is torn down (e.g. on LSP server
-    /// shutdown) so we don't leak operating system file watch handles (such as inotify instances on Linux).
-    /// </summary>
     public void Dispose()
     {
-        if (_fileReferenceChangeContext.IsValueCreated)
-            _fileReferenceChangeContext.Value.Dispose();
+        IFileChangeContext? fileReferenceChangeContext = null;
+
+        lock (_gate)
+        {
+            if (_isDisposed)
+                return;
+
+            _workQueue.Dispose();
+            _isDisposed = true;
+
+            if (_fileReferenceChangeContext.IsValueCreated)
+                fileReferenceChangeContext = _fileReferenceChangeContext.Value;
+        }
+
+        fileReferenceChangeContext?.Dispose();
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ReferenceFileChangeTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ReferenceFileChangeTracker.cs
@@ -170,8 +170,6 @@ internal sealed class ReferenceFileChangeTracker : IDisposable
 
     public void Dispose()
     {
-        IFileChangeContext? fileReferenceChangeContext = null;
-
         lock (_gate)
         {
             if (_isDisposed)
@@ -181,9 +179,7 @@ internal sealed class ReferenceFileChangeTracker : IDisposable
             _isDisposed = true;
 
             if (_fileReferenceChangeContext.IsValueCreated)
-                fileReferenceChangeContext = _fileReferenceChangeContext.Value;
+                _fileReferenceChangeContext.Value.Dispose();
         }
-
-        fileReferenceChangeContext?.Dispose();
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ReferenceFileChangeTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ReferenceFileChangeTracker.cs
@@ -18,7 +18,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ProjectSystem;
 
-internal sealed class ReferenceFileChangeTracker
+internal sealed class ReferenceFileChangeTracker : IDisposable
 {
     private readonly object _gate = new();
 
@@ -156,5 +156,17 @@ internal sealed class ReferenceFileChangeTracker
     {
         foreach (var filePath in list)
             await _callback(filePath, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Releases the file watches created by this tracker. Disposing the underlying <see cref="IFileChangeContext"/>
+    /// releases both the directory watch on the reference directories and any per-file watches created via
+    /// <see cref="StartWatchingReference"/>. This is used when the owning workspace is torn down (e.g. on LSP server
+    /// shutdown) so we don't leak operating system file watch handles (such as inotify instances on Linux).
+    /// </summary>
+    public void Dispose()
+    {
+        if (_fileReferenceChangeContext.IsValueCreated)
+            _fileReferenceChangeContext.Value.Dispose();
     }
 }


### PR DESCRIPTION
discovered this while working on logging changes - Linux CI hit inotify instance limits.  I'm not 100% certain why the tests didn't leak watchers before - potentially it was related to there previously being a singleton DefaultFileChangeWatcher that was able to consolidate watchers across tests (so leaked, but less badly?).  I made that back into a singleton in https://github.com/dotnet/roslyn/pull/84001

However regardless - on server shutdown we need to dispose of the watchers associated with the loaded projects that we're also disposing of.  So this change ensures that happens.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84049)