### PR TITLE
Increase timeout for Correctness_Analyzers job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -597,7 +597,7 @@ stages:
 
   - job: Correctness_Analyzers
     pool: ${{ parameters.ubuntuPool }}
-    timeoutInMinutes: 35
+    timeoutInMinutes: 40
     variables:
       - template: eng/pipelines/variables-build.yml
         parameters:


### PR DESCRIPTION
We are seeing sporadic failures in this job. I _suspect_ this is because this job was always, intentionally, running close to the timeout value and once we merged razor in it pushed us even closer. This eliminated our headroom and hence now seeing the occasional failure. 

Took a look at the execution time over a number of jobs and 40m will give us enough breathing room while still guarding against big regressions in our analyzer execution time
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84064)