### PR TITLE
Exclude all root `.md` files from CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,7 @@ pr:
       - azure-pipelines-integration-scouting.yml
       - azure-pipelines-official.yml
       - azure-pipelines-pr-validation.yml
-      - *.md
+      - '*.md'
 
 variables:
   # This value is conditionally overriden by the variable group DotNet-HelixApi-Access.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,9 +34,7 @@ pr:
       - azure-pipelines-integration-scouting.yml
       - azure-pipelines-official.yml
       - azure-pipelines-pr-validation.yml
-      - CODE-OF-CONDUCT.md
-      - CONTRIBUTING.md
-      - README.md
+      - *.md
 
 variables:
   # This value is conditionally overriden by the variable group DotNet-HelixApi-Access.


### PR DESCRIPTION
For example, the new `AGENTS.md` file is currently not excluded, running CI unnecessarily when updating it.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84074)