### PR TITLE
Use cached mef compositions in language server tests when possible

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ExportProviderBuilderTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ExportProviderBuilderTests.cs
@@ -11,13 +11,15 @@ using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests;
 
-public sealed class ExportProviderBuilderTests(ITestOutputHelper testOutputHelper)
-    : AbstractLanguageServerHostTests(testOutputHelper)
+/// <summary>
+/// Use <see cref="AbstractLanguageServerMefHost"/> as we are testing the MEF composition and caching logic directly.
+/// </summary>
+public sealed class ExportProviderBuilderTests(ITestOutputHelper testOutputHelper) : AbstractLanguageServerMefHost(testOutputHelper)
 {
     [Fact]
     public async Task MefCompositionIsCached()
     {
-        await using var testServer = await CreateLanguageServerAsync(includeDevKitComponents: false);
+        await using var testServer = await CreateLanguageServerAsync(serverConfiguration: ServerConfigurationWithoutDevKit);
 
         await AssertCacheWriteWasAttemptedAsync();
 
@@ -27,12 +29,12 @@ public sealed class ExportProviderBuilderTests(ITestOutputHelper testOutputHelpe
     [Fact]
     public async Task MefCompositionIsReused()
     {
-        await using var testServer = await CreateLanguageServerAsync(includeDevKitComponents: false);
+        await using var testServer = await CreateLanguageServerAsync(serverConfiguration: ServerConfigurationWithoutDevKit);
 
         await AssertCacheWriteWasAttemptedAsync();
 
         // Second test server with the same set of assemblies.
-        await using var testServer2 = await CreateLanguageServerAsync(includeDevKitComponents: false);
+        await using var testServer2 = await CreateLanguageServerAsync(serverConfiguration: ServerConfigurationWithoutDevKit);
 
         AssertNoCacheWriteWasAttempted();
 
@@ -42,12 +44,12 @@ public sealed class ExportProviderBuilderTests(ITestOutputHelper testOutputHelpe
     [Fact]
     public async Task MultipleMefCompositionsAreCached()
     {
-        await using var testServer = await CreateLanguageServerAsync(includeDevKitComponents: false);
+        await using var testServer = await CreateLanguageServerAsync(serverConfiguration: ServerConfigurationWithoutDevKit);
 
         await AssertCacheWriteWasAttemptedAsync();
 
         // Second test server with a different set of assemblies.
-        await using var testServer2 = await CreateLanguageServerAsync(includeDevKitComponents: true);
+        await using var testServer2 = await CreateLanguageServerAsync(serverConfiguration: DefaultServerConfiguration);
 
         await AssertCacheWriteWasAttemptedAsync();
 
@@ -86,7 +88,11 @@ public sealed class ExportProviderBuilderTests(ITestOutputHelper testOutputHelpe
 
         var dllPath = GenerateDll(reservedCharacter, out var assemblyName);
 
-        await using var testServer = await TestLspServer.CreateAsync(new Roslyn.LanguageServer.Protocol.ClientCapabilities(), LoggerFactory, MefCacheDirectory.Path, includeDevKitComponents: true, [dllPath]);
+        await using var testServer = await CreateLanguageServerAsync(
+            serverConfiguration: DefaultServerConfiguration with
+            {
+                ExtensionAssemblyPaths = [dllPath]
+            });
 
         var assemblies = AppDomain.CurrentDomain.GetAssemblies();
         var assembly = Assert.Single(assemblies, a => a.GetName().Name == assemblyName);
@@ -162,7 +168,7 @@ public sealed class ExportProviderBuilderTests(ITestOutputHelper testOutputHelpe
 
     private void AssertCachedCompositionCountEquals(int expectedCount)
     {
-        var mefCompositions = Directory.EnumerateFiles(MefCacheDirectory.Path, "*.mef-composition", SearchOption.AllDirectories);
+        var mefCompositions = Directory.EnumerateFiles(MefCachedDirectory.Path, "*.mef-composition", SearchOption.AllDirectories);
 
         Assert.Equal(expectedCount, mefCompositions.Count());
     }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ExportProviderBuilderTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ExportProviderBuilderTests.cs
@@ -168,7 +168,7 @@ public sealed class ExportProviderBuilderTests(ITestOutputHelper testOutputHelpe
 
     private void AssertCachedCompositionCountEquals(int expectedCount)
     {
-        var mefCompositions = Directory.EnumerateFiles(MefCachedDirectory.Path, "*.mef-composition", SearchOption.AllDirectories);
+        var mefCompositions = Directory.EnumerateFiles(MefCacheDirectory.Path, "*.mef-composition", SearchOption.AllDirectories);
 
         Assert.Equal(expectedCount, mefCompositions.Count());
     }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/LspFileChangeWatcherTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/LspFileChangeWatcherTests.cs
@@ -29,7 +29,7 @@ public sealed class LspFileChangeWatcherTests(ITestOutputHelper testOutputHelper
     [Fact]
     public async Task LspFileWatcherNotSupportedWithoutClientSupport()
     {
-        await using var testLspServer = await TestLspServer.CreateAsync(new ClientCapabilities(), LoggerFactory, MefCacheDirectory.Path);
+        await using var testLspServer = await CreateLanguageServerAsync(new ClientCapabilities());
 
         AssertFileWatcherKind<DefaultFileChangeWatcher>(testLspServer);
     }
@@ -37,7 +37,7 @@ public sealed class LspFileChangeWatcherTests(ITestOutputHelper testOutputHelper
     [Fact]
     public async Task LspFileWatcherSupportedWithClientSupport()
     {
-        await using var testLspServer = await TestLspServer.CreateAsync(_clientCapabilitiesWithFileWatcherSupport, LoggerFactory, MefCacheDirectory.Path);
+        await using var testLspServer = await CreateLanguageServerAsync(_clientCapabilitiesWithFileWatcherSupport);
 
         AssertFileWatcherKind<LspFileChangeWatcher>(testLspServer);
     }
@@ -47,7 +47,7 @@ public sealed class LspFileChangeWatcherTests(ITestOutputHelper testOutputHelper
     {
         AsynchronousOperationListenerProvider.Enable(enable: true);
 
-        await using var testLspServer = await TestLspServer.CreateAsync(_clientCapabilitiesWithFileWatcherSupport, LoggerFactory, MefCacheDirectory.Path);
+        await using var testLspServer = await CreateLanguageServerAsync(_clientCapabilitiesWithFileWatcherSupport);
         var lspFileChangeWatcher = AssertFileWatcherKind<LspFileChangeWatcher>(testLspServer);
 
         var dynamicCapabilitiesRpcTarget = new DynamicCapabilitiesRpcTarget();
@@ -75,7 +75,7 @@ public sealed class LspFileChangeWatcherTests(ITestOutputHelper testOutputHelper
     {
         AsynchronousOperationListenerProvider.Enable(enable: true);
 
-        await using var testLspServer = await TestLspServer.CreateAsync(_clientCapabilitiesWithFileWatcherSupport, LoggerFactory, MefCacheDirectory.Path);
+        await using var testLspServer = await CreateLanguageServerAsync(_clientCapabilitiesWithFileWatcherSupport);
         var lspFileChangeWatcher = AssertFileWatcherKind<LspFileChangeWatcher>(testLspServer);
 
         var dynamicCapabilitiesRpcTarget = new DynamicCapabilitiesRpcTarget();

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/AbstractLspMiscellaneousFilesWorkspaceTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/AbstractLspMiscellaneousFilesWorkspaceTests.cs
@@ -22,11 +22,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Miscellaneous;
 public abstract class AbstractLspMiscellaneousFilesWorkspaceTests : AbstractLanguageServerProtocolTests, IDisposable
 {
     private readonly TestOutputLoggerProvider _loggerProvider;
+    private readonly ILoggerFactory _loggerFactory;
     protected readonly TempRoot TempRoot;
 
     public AbstractLspMiscellaneousFilesWorkspaceTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
     {
         _loggerProvider = new TestOutputLoggerProvider(testOutputHelper);
+        _loggerFactory = new LoggerFactory([_loggerProvider]);
         TempRoot = new();
     }
 
@@ -34,12 +36,13 @@ public abstract class AbstractLspMiscellaneousFilesWorkspaceTests : AbstractLang
     {
         TempRoot.Dispose();
         _loggerProvider.Dispose();
+        _loggerFactory.Dispose();
     }
 
     protected override ValueTask<ExportProvider> CreateExportProviderAsync()
     {
         AsynchronousOperationListenerProvider.Enable(enable: true);
-        return new(LanguageServerTestComposition.GetSharedExportProvider(AbstractLanguageServerHostTests.DefaultServerConfiguration, new LoggerFactory([_loggerProvider])));
+        return new(LanguageServerTestComposition.GetSharedExportProvider(AbstractLanguageServerHostTests.DefaultServerConfiguration, _loggerFactory));
     }
 
     private protected Workspace GetHostWorkspace(TestLspServer testLspServer)

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/AbstractLspMiscellaneousFilesWorkspaceTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/AbstractLspMiscellaneousFilesWorkspaceTests.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
+using Microsoft.CodeAnalysis.LanguageServer.Logging;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -21,16 +22,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Miscellaneous;
 public abstract class AbstractLspMiscellaneousFilesWorkspaceTests : AbstractLanguageServerProtocolTests, IDisposable
 {
     private readonly TestOutputLoggerProvider _loggerProvider;
-    private readonly ILoggerFactory _loggerFactory;
-    private readonly TempDirectory _mefCacheDirectory;
     protected readonly TempRoot TempRoot;
 
     public AbstractLspMiscellaneousFilesWorkspaceTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
     {
         _loggerProvider = new TestOutputLoggerProvider(testOutputHelper);
-        _loggerFactory = new LoggerFactory([_loggerProvider]);
         TempRoot = new();
-        _mefCacheDirectory = TempRoot.CreateDirectory();
     }
 
     public void Dispose()
@@ -39,17 +36,10 @@ public abstract class AbstractLspMiscellaneousFilesWorkspaceTests : AbstractLang
         _loggerProvider.Dispose();
     }
 
-    protected override async ValueTask<ExportProvider> CreateExportProviderAsync()
+    protected override ValueTask<ExportProvider> CreateExportProviderAsync()
     {
         AsynchronousOperationListenerProvider.Enable(enable: true);
-
-        var (exportProvider, _) = await LanguageServerTestComposition.CreateExportProviderAsync(
-            _loggerFactory,
-            includeDevKitComponents: false,
-            cacheDirectory: _mefCacheDirectory.Path,
-            extensionPaths: []);
-
-        return exportProvider;
+        return new(LanguageServerTestComposition.GetSharedExportProvider(AbstractLanguageServerHostTests.DefaultServerConfiguration, new LoggerFactory([_loggerProvider])));
     }
 
     private protected Workspace GetHostWorkspace(TestLspServer testLspServer)

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/FileBasedProgramsEntryPointDiscoveryTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/FileBasedProgramsEntryPointDiscoveryTests.cs
@@ -7,7 +7,6 @@ using Microsoft.CodeAnalysis.LanguageServer.FileBasedPrograms;
 using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
-using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.UnitTests;
@@ -26,7 +25,6 @@ public sealed class FileBasedProgramsEntryPointDiscoveryTests : AbstractLanguage
     private readonly ILoggerFactory _loggerFactory;
     private readonly TestOutputLoggerProvider _loggerProvider;
     private readonly TempRoot _tempRoot;
-    private readonly TempDirectory _mefCacheDirectory;
 
     private readonly List<string> _additionalDirectoriesToDelete = [];
 
@@ -36,20 +34,12 @@ public sealed class FileBasedProgramsEntryPointDiscoveryTests : AbstractLanguage
         _loggerProvider = new TestOutputLoggerProvider(testOutputHelper);
         _loggerFactory = new LoggerFactory([_loggerProvider]);
         _tempRoot = new();
-        _mefCacheDirectory = _tempRoot.CreateDirectory();
     }
 
-    protected override async ValueTask<ExportProvider> CreateExportProviderAsync()
+    protected override ValueTask<ExportProvider> CreateExportProviderAsync()
     {
         AsynchronousOperationListenerProvider.Enable(enable: true);
-
-        var (exportProvider, _) = await LanguageServerTestComposition.CreateExportProviderAsync(
-            _loggerFactory,
-            includeDevKitComponents: false,
-            cacheDirectory: _mefCacheDirectory.Path,
-            extensionPaths: []);
-
-        return exportProvider;
+        return new(LanguageServerTestComposition.GetSharedExportProvider(AbstractLanguageServerHostTests.DefaultServerConfiguration, new LoggerFactory([_loggerProvider])));
     }
 
     public void Dispose()

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/FileBasedProgramsEntryPointDiscoveryTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/FileBasedProgramsEntryPointDiscoveryTests.cs
@@ -39,7 +39,7 @@ public sealed class FileBasedProgramsEntryPointDiscoveryTests : AbstractLanguage
     protected override ValueTask<ExportProvider> CreateExportProviderAsync()
     {
         AsynchronousOperationListenerProvider.Enable(enable: true);
-        return new(LanguageServerTestComposition.GetSharedExportProvider(AbstractLanguageServerHostTests.DefaultServerConfiguration, new LoggerFactory([_loggerProvider])));
+        return new(LanguageServerTestComposition.GetSharedExportProvider(AbstractLanguageServerHostTests.DefaultServerConfiguration, _loggerFactory));
     }
 
     public void Dispose()

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ServerInitializationTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ServerInitializationTests.cs
@@ -3,17 +3,16 @@
 // See the LICENSE file in the project root for more information.
 
 using Roslyn.LanguageServer.Protocol;
-using Roslyn.Test.Utilities;
 using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests;
 
-public sealed class ServerInitializationTests : AbstractLanguageServerHostTests
+/// <summary>
+/// Test using <see cref="AbstractLanguageServerMefHost"/> to ensure server initialization works correctly
+/// with the real MEF export provider and composition logic. 
+/// </summary>
+public sealed class ServerInitializationTests(ITestOutputHelper testOutputHelper) : AbstractLanguageServerMefHost(testOutputHelper)
 {
-    public ServerInitializationTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
-    {
-    }
-
     [Fact]
     public async Task TestServerHandlesTextSyncRequestsAsync()
     {

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ServiceBrokerFactoryTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ServiceBrokerFactoryTests.cs
@@ -22,8 +22,12 @@ using DebuggerContracts = Microsoft.VisualStudio.Debugger.Contracts.HotReload;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests;
 
+/// <summary>
+/// These tests verify specifics around LSP service MEF lifetimes and availability, so utilize the real
+/// MEF composition via <see cref="AbstractLanguageServerMefHost"/> 
+/// </summary>
 public sealed class ServiceBrokerFactoryTests(ITestOutputHelper testOutputHelper)
-    : AbstractLanguageServerHostTests(testOutputHelper)
+    : AbstractLanguageServerMefHost(testOutputHelper)
 {
     private const string ServiceBrokerConnectMethodName = "serviceBroker/connect";
     private const string ServiceBrokerChannelName = "serviceBroker";

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/TelemetryReporterTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/TelemetryReporterTests.cs
@@ -9,21 +9,19 @@ using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests;
 
-public sealed class TelemetryReporterTests(ITestOutputHelper testOutputHelper)
-    : AbstractLanguageServerHostTests(testOutputHelper)
+/// <summary>
+/// Test using <see cref="AbstractLanguageServerMefHost"/> to ensure telemetry MEF initialization
+/// works correctly with the real MEF export provider and composition logic. 
+/// </summary>
+public sealed class TelemetryReporterTests(ITestOutputHelper testOutputHelper) : AbstractLanguageServerMefHost(testOutputHelper)
 {
-    private async Task<ITelemetryReporter> CreateReporterAsync()
+    private async Task<ITelemetryReporter> CreateReporterAsync(TestLspServer testServer)
     {
-        var (exportProvider, _) = await LanguageServerTestComposition.CreateExportProviderAsync(
-            LoggerFactory,
-            includeDevKitComponents: true,
-            MefCacheDirectory.Path,
-            []);
-
         // VS Telemetry requires this environment variable to be set.
         Environment.SetEnvironmentVariable("CommonPropertyBagPath", Path.GetTempFileName());
 
-        var reporter = exportProvider.GetExport<ITelemetryReporter>().Value;
+        var reporter = testServer.ExportProvider.GetExport<ITelemetryReporter>().Value;
+
         Assert.NotNull(reporter);
 
         // Do not set default session in tests to enable test isolation:
@@ -37,7 +35,9 @@ public sealed class TelemetryReporterTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task TestVSTelemetryLoadedIntoDefaultAlc()
     {
-        var service = await CreateReporterAsync();
+        await using var testServer = await CreateLanguageServerAsync();
+
+        var service = await CreateReporterAsync(testServer);
         var assembly = Assembly.GetAssembly(service.GetType());
         Assert.Contains(AssemblyLoadContext.Default.Assemblies, a => a == assembly);
         Assert.Contains(AssemblyLoadContext.Default.Assemblies, a => a.GetName().Name == "Microsoft.VisualStudio.Telemetry");
@@ -46,14 +46,16 @@ public sealed class TelemetryReporterTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task TestFault()
     {
-        var service = await CreateReporterAsync();
+        await using var testServer = await CreateLanguageServerAsync();
+        var service = await CreateReporterAsync(testServer);
         service.ReportFault(GetEventName(nameof(TestFault)), "test description", logLevel: 2, forceDump: false, processId: 0, new Exception());
     }
 
     [Fact]
     public async Task TestBlockLogging()
     {
-        var service = await CreateReporterAsync();
+        await using var testServer = await CreateLanguageServerAsync();
+        var service = await CreateReporterAsync(testServer);
         service.LogBlockStart(GetEventName(nameof(TestBlockLogging)), kind: 0, blockId: 0);
         service.LogBlockEnd(blockId: 0, [], CancellationToken.None);
     }
@@ -61,7 +63,8 @@ public sealed class TelemetryReporterTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task TestLog()
     {
-        var service = await CreateReporterAsync();
+        await using var testServer = await CreateLanguageServerAsync();
+        var service = await CreateReporterAsync(testServer);
         service.Log(GetEventName(nameof(TestLog)), []);
     }
 }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/AbstractLanguageServerHostTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/AbstractLanguageServerHostTests.cs
@@ -11,25 +11,56 @@ using System.IO.Pipelines;
 using Roslyn.LanguageServer.Protocol;
 using StreamJsonRpc;
 using Xunit.Abstractions;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.LanguageServer.Services;
+using Microsoft.CodeAnalysis.LanguageServer.Logging;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests;
 
+[UseExportProvider]
 public abstract class AbstractLanguageServerHostTests : IDisposable
 {
     protected ILoggerFactory LoggerFactory { get; }
     protected TempRoot TempRoot { get; }
-    protected TempDirectory MefCacheDirectory { get; }
+
+    internal static ServerConfiguration DefaultServerConfiguration => new(
+        LaunchDebugger: false,
+        LogConfiguration: new LogConfiguration(LogLevel.Trace),
+        TelemetryLevel: null,
+        SessionId: null,
+        ExtensionAssemblyPaths: Array.Empty<string>(),
+        DevKitDependencyPath: TestPaths.GetDevKitExtensionPath(),
+        CSharpDesignTimePath: null,
+        ExtensionLogDirectory: string.Empty,
+        ServerPipeName: null,
+        UseStdIo: false,
+        AutoLoadProjects: null,
+        SourceGeneratorExecutionPreference: SourceGeneratorExecutionPreference.Balanced,
+        ClientProcessId: null);
+
+    internal static ServerConfiguration ServerConfigurationWithoutDevKit => DefaultServerConfiguration with { DevKitDependencyPath = null };
+
+    private protected virtual Task<ExportProvider> CreateExportProviderAsync(
+        ServerConfiguration serverConfiguration,
+        ILoggerFactory loggerFactory,
+        ExtensionAssemblyManager extensionManager,
+        IAssemblyLoader assemblyLoader)
+    {
+        var provider = LanguageServerTestComposition.GetSharedExportProvider(serverConfiguration, loggerFactory);
+        return Task.FromResult(provider);
+    }
 
     protected AbstractLanguageServerHostTests(ITestOutputHelper testOutputHelper)
     {
         LoggerFactory = new LoggerFactory([new TestOutputLoggerProvider(testOutputHelper)]);
         TempRoot = new();
-        MefCacheDirectory = TempRoot.CreateDirectory();
     }
 
-    protected Task<TestLspServer> CreateLanguageServerAsync(bool includeDevKitComponents = true)
+    private protected Task<TestLspServer> CreateLanguageServerAsync(
+        ClientCapabilities? clientCapabilities = null,
+        ServerConfiguration? serverConfiguration = null)
     {
-        return TestLspServer.CreateAsync(new ClientCapabilities(), LoggerFactory, MefCacheDirectory.Path, includeDevKitComponents);
+        return TestLspServer.CreateAsync(clientCapabilities ?? new ClientCapabilities(), LoggerFactory, serverConfiguration ?? DefaultServerConfiguration, this);
     }
 
     public void Dispose()
@@ -44,11 +75,18 @@ public abstract class AbstractLanguageServerHostTests : IDisposable
         private readonly Pipe _clientToServerPipe;
         private readonly Pipe _serverToClientPipe;
 
-        internal static async Task<TestLspServer> CreateAsync(ClientCapabilities clientCapabilities, ILoggerFactory loggerFactory, string cacheDirectory, bool includeDevKitComponents = true, string[]? extensionPaths = null)
+        internal static async Task<TestLspServer> CreateAsync(
+            ClientCapabilities clientCapabilities,
+            ILoggerFactory loggerFactory,
+            ServerConfiguration serverConfiguration,
+            AbstractLanguageServerHostTests hostTests)
         {
-            var (exportProvider, assemblyLoader) = await LanguageServerTestComposition.CreateExportProviderAsync(
-                loggerFactory, includeDevKitComponents, cacheDirectory, extensionPaths);
+            var extensionManager = ExtensionAssemblyManager.Create(serverConfiguration, loggerFactory);
+            var assemblyLoader = new CustomExportAssemblyLoader(extensionManager, loggerFactory);
+
+            var exportProvider = await hostTests.CreateExportProviderAsync(serverConfiguration, loggerFactory, extensionManager, assemblyLoader);
             var testLspServer = new TestLspServer(exportProvider, loggerFactory, assemblyLoader);
+
             var initializeResponse = await testLspServer.ExecuteRequestAsync<InitializeParams, InitializeResult>(Methods.InitializeName, new InitializeParams { Capabilities = clientCapabilities }, CancellationToken.None);
             Assert.NotNull(initializeResponse?.Capabilities);
             testLspServer.ServerCapabilities = initializeResponse.Capabilities;

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/AbstractLanguageServerMefHost.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/AbstractLanguageServerMefHost.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.Composition;
+using Xunit.Abstractions;
+using Microsoft.CodeAnalysis.LanguageServer.Services;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests;
+
+/// <summary>
+/// Implementation of <see cref="AbstractLanguageServerHostTests"/> that uses the real MEF export provider and composition logic.
+/// Only use this when testing components directly related to MEF composition and caching.  Otherwise prefer using <see cref="AbstractLanguageServerHostTests"/>
+/// to benefit from the shared, cached test MEF composition (faster execution).
+/// </summary>
+public abstract class AbstractLanguageServerMefHost : AbstractLanguageServerHostTests
+{
+    protected readonly TempDirectory MefCachedDirectory;
+
+    protected AbstractLanguageServerMefHost(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+    {
+        MefCachedDirectory = TempRoot.CreateDirectory();
+    }
+
+    private protected override Task<ExportProvider> CreateExportProviderAsync(
+        ServerConfiguration serverConfiguration,
+        ILoggerFactory loggerFactory,
+        ExtensionAssemblyManager extensionManager,
+        IAssemblyLoader assemblyLoader)
+    {
+        return LanguageServerTestComposition.CreateLanguageServerExportProviderAsync(serverConfiguration, loggerFactory, extensionManager, assemblyLoader, MefCachedDirectory.Path);
+    }
+}

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/AbstractLanguageServerMefHost.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/AbstractLanguageServerMefHost.cs
@@ -17,11 +17,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests;
 /// </summary>
 public abstract class AbstractLanguageServerMefHost : AbstractLanguageServerHostTests
 {
-    protected readonly TempDirectory MefCachedDirectory;
+    protected readonly TempDirectory MefCacheDirectory;
 
     protected AbstractLanguageServerMefHost(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
     {
-        MefCachedDirectory = TempRoot.CreateDirectory();
+        MefCacheDirectory = TempRoot.CreateDirectory();
     }
 
     private protected override Task<ExportProvider> CreateExportProviderAsync(
@@ -30,6 +30,6 @@ public abstract class AbstractLanguageServerMefHost : AbstractLanguageServerHost
         ExtensionAssemblyManager extensionManager,
         IAssemblyLoader assemblyLoader)
     {
-        return LanguageServerTestComposition.CreateLanguageServerExportProviderAsync(serverConfiguration, loggerFactory, extensionManager, assemblyLoader, MefCachedDirectory.Path);
+        return LanguageServerTestComposition.CreateLanguageServerExportProviderAsync(serverConfiguration, loggerFactory, extensionManager, assemblyLoader, MefCacheDirectory.Path);
     }
 }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/LanguageServerTestComposition.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/LanguageServerTestComposition.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.CodeAnalysis.Host;
+using System.Reflection;
+using Microsoft.CodeAnalysis.LanguageServer.Logging;
 using Microsoft.CodeAnalysis.LanguageServer.Services;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.Composition;
 
@@ -11,31 +13,41 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests;
 
 internal sealed class LanguageServerTestComposition
 {
-    public static async Task<(ExportProvider exportProvider, IAssemblyLoader assemblyLoader)> CreateExportProviderAsync(
+    public static Task<ExportProvider> CreateLanguageServerExportProviderAsync(
+        ServerConfiguration serverConfiguration,
         ILoggerFactory loggerFactory,
-        bool includeDevKitComponents,
-        string cacheDirectory,
-        string[]? extensionPaths)
+        ExtensionAssemblyManager extensionManager,
+        IAssemblyLoader assemblyLoader,
+        string cacheDirectory)
     {
-        var devKitDependencyPath = includeDevKitComponents ? TestPaths.GetDevKitExtensionPath() : null;
-        var serverConfiguration = new ServerConfiguration(LaunchDebugger: false,
-            LogConfiguration: new LogConfiguration(LogLevel.Trace),
-            TelemetryLevel: null,
-            SessionId: null,
-            ExtensionAssemblyPaths: extensionPaths ?? [],
-            DevKitDependencyPath: devKitDependencyPath,
-            CSharpDesignTimePath: null,
-            ExtensionLogDirectory: string.Empty,
-            ServerPipeName: null,
-            UseStdIo: false,
-            AutoLoadProjects: null,
-            SourceGeneratorExecutionPreference: SourceGeneratorExecutionPreference.Balanced,
-            ClientProcessId: null);
-        var extensionManager = ExtensionAssemblyManager.Create(serverConfiguration, loggerFactory);
-        var assemblyLoader = new CustomExportAssemblyLoader(extensionManager, loggerFactory);
+        return LanguageServerExportProviderBuilder.CreateExportProviderAsync(TestPaths.GetLanguageServerDirectory(), extensionManager, assemblyLoader, serverConfiguration, cacheDirectory, loggerFactory, CancellationToken.None);
+    }
 
-        var exportProvider = await LanguageServerExportProviderBuilder.CreateExportProviderAsync(TestPaths.GetLanguageServerDirectory(), extensionManager, assemblyLoader, devKitDependencyPath, cacheDirectory, loggerFactory, CancellationToken.None);
-        exportProvider.GetExportedValue<ServerConfigurationFactory>().InitializeConfiguration(serverConfiguration);
-        return (exportProvider, assemblyLoader);
+    public static ExportProvider GetSharedExportProvider(ServerConfiguration serverConfiguration, ILoggerFactory loggerFactory)
+    {
+        Contract.ThrowIfTrue(serverConfiguration.ExtensionAssemblyPaths.Any(), "Tests that require extension assemblies should use AbstractLanguageServerMefHost instead");
+        var exportProvider = serverConfiguration.DevKitDependencyPath != null
+            ? s_devKit.ExportProviderFactory.CreateExportProvider()
+            : s_languageServer.ExportProviderFactory.CreateExportProvider();
+
+        LanguageServerExportProviderBuilder.TestAccessor.InitializeManualExports(exportProvider, new ExtensionAssemblyManager([], [], []), loggerFactory, serverConfiguration);
+        return exportProvider;
+    }
+
+    private static readonly TestComposition s_languageServer = CreateBaseComposition();
+    private static readonly TestComposition s_devKit = CreateDevKitComposition();
+
+    private static TestComposition CreateBaseComposition()
+    {
+        var languageServerDirectory = TestPaths.GetLanguageServerDirectory();
+        var languageServerDlls = LanguageServerExportProviderBuilder.TestAccessor.FilterFiles(languageServerDirectory);
+
+        return TestComposition.Empty.AddAssemblies(languageServerDlls.Select(Assembly.LoadFrom));
+    }
+
+    private static TestComposition CreateDevKitComposition()
+    {
+        var devKitDirectory = TestPaths.GetDevKitExtensionPath();
+        return s_languageServer.AddAssemblies(Assembly.LoadFrom(devKitDirectory));
     }
 }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/LanguageServerTestComposition.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/LanguageServerTestComposition.cs
@@ -40,7 +40,7 @@ internal sealed class LanguageServerTestComposition
     private static TestComposition CreateBaseComposition()
     {
         var languageServerDirectory = TestPaths.GetLanguageServerDirectory();
-        var languageServerDlls = LanguageServerExportProviderBuilder.TestAccessor.FilterFiles(languageServerDirectory);
+        var languageServerDlls = LanguageServerExportProviderBuilder.TestAccessor.FindMefAssemblies(languageServerDirectory);
 
         return TestComposition.Empty.AddAssemblies(languageServerDlls.Select(Assembly.LoadFrom));
     }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/VirtualProjectXmlProviderTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/VirtualProjectXmlProviderTests.cs
@@ -5,7 +5,6 @@
 using System.Text;
 using Microsoft.CodeAnalysis.LanguageServer.FileBasedPrograms;
 using Microsoft.Extensions.Logging;
-using Roslyn.Test.Utilities;
 using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests;
@@ -18,16 +17,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests;
 /// - Thorough behavioral testing.
 /// - Testing of more intricate behaviors which are subject to change.
 /// </summary>
-public sealed class VirtualProjectXmlProviderTests : AbstractLanguageServerHostTests
+public sealed class VirtualProjectXmlProviderTests(ITestOutputHelper testOutputHelper) : AbstractLanguageServerHostTests(testOutputHelper)
 {
-    public VirtualProjectXmlProviderTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
-    {
-    }
-
     private async Task<VirtualProjectXmlProvider> GetProjectXmlProviderAsync()
     {
-        var (exportProvider, _) = await LanguageServerTestComposition.CreateExportProviderAsync(
-            LoggerFactory, includeDevKitComponents: false, MefCacheDirectory.Path, extensionPaths: null);
+        var exportProvider = LanguageServerTestComposition.GetSharedExportProvider(DefaultServerConfiguration, LoggerFactory);
         return exportProvider.GetExportedValue<VirtualProjectXmlProvider>();
     }
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/WorkspaceProjectFactoryServiceTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/WorkspaceProjectFactoryServiceTests.cs
@@ -17,7 +17,7 @@ public sealed class WorkspaceProjectFactoryServiceTests(ITestOutputHelper testOu
     public async Task CreateProjectAndBatch()
     {
         var loggerFactory = new LoggerFactory();
-        await using var testLspServer = await CreateLanguageServerAsync(includeDevKitComponents: false);
+        await using var testLspServer = await CreateLanguageServerAsync(serverConfiguration: ServerConfigurationWithoutDevKit);
 
         var workspaceFactory = testLspServer.GetRequiredLspService<LanguageServerWorkspaceFactory>();
         var serviceBrokerFactory = testLspServer.GetRequiredLspService<ServiceBrokerFactory>();

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServerExportProviderBuilder.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServerExportProviderBuilder.cs
@@ -64,9 +64,6 @@ internal sealed class LanguageServerExportProviderBuilder : ExportProviderBuilde
         // a partial catalog that will surely blow up later.
         assemblyPathsBuilder.AddRange(FindMefAssemblies(baseDirectory));
 
-        // The Razor extension ships with Roslyn and so needs to be in our MEF composition
-        assemblyPathsBuilder.Add(Path.Combine(baseDirectory, "Microsoft.VisualStudioCode.RazorExtension.dll"));
-
         // DevKit assemblies are not shipped in the main language server folder
         // and not included in ExtensionAssemblyPaths (they get loaded into the default ALC).
         // So manually add them to the MEF catalog here.

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServerExportProviderBuilder.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServerExportProviderBuilder.cs
@@ -20,7 +20,13 @@ internal sealed class LanguageServerExportProviderBuilder : ExportProviderBuilde
     // For testing purposes, track the last cache write task.
     private static Task? s_cacheWriteTask_forTestingPurposesOnly;
 
-    private static readonly FrozenSet<string> s_dllsToExcludeFromMef = FrozenSet.ToFrozenSet(
+    private static readonly FrozenSet<string> s_dllsToIncludeInMef = FrozenSet.ToFrozenSet(
+    [
+        // The Razor extension ships with Roslyn and so needs to be in our MEF composition.
+        "Microsoft.VisualStudioCode.RazorExtension.dll",
+    ], StringComparer.OrdinalIgnoreCase);
+
+    internal static readonly FrozenSet<string> s_dllsToExcludeFromMef = FrozenSet.ToFrozenSet(
     [
         // These DLLs are part of Razor, but should only be in their MEF composition not ours
         "Microsoft.CodeAnalysis.Razor.Workspaces.dll",
@@ -46,7 +52,7 @@ internal sealed class LanguageServerExportProviderBuilder : ExportProviderBuilde
         string baseDirectory,
         ExtensionAssemblyManager extensionManager,
         IAssemblyLoader assemblyLoader,
-        string? devKitDependencyPath,
+        ServerConfiguration serverConfiguration,
         string cacheDirectory,
         ILoggerFactory loggerFactory,
         CancellationToken cancellationToken)
@@ -56,8 +62,7 @@ internal sealed class LanguageServerExportProviderBuilder : ExportProviderBuilde
 
         // Don't catch IO exceptions as it's better to fail to build the catalog than give back
         // a partial catalog that will surely blow up later.
-        assemblyPathsBuilder.AddRange(FilterFiles(baseDirectory, "Microsoft.CodeAnalysis*.dll"));
-        assemblyPathsBuilder.AddRange(FilterFiles(baseDirectory, "Microsoft.ServiceHub*.dll"));
+        assemblyPathsBuilder.AddRange(FilterFiles(baseDirectory));
 
         // The Razor extension ships with Roslyn and so needs to be in our MEF composition
         assemblyPathsBuilder.Add(Path.Combine(baseDirectory, "Microsoft.VisualStudioCode.RazorExtension.dll"));
@@ -65,8 +70,8 @@ internal sealed class LanguageServerExportProviderBuilder : ExportProviderBuilde
         // DevKit assemblies are not shipped in the main language server folder
         // and not included in ExtensionAssemblyPaths (they get loaded into the default ALC).
         // So manually add them to the MEF catalog here.
-        if (devKitDependencyPath != null)
-            assemblyPathsBuilder.Add(devKitDependencyPath);
+        if (serverConfiguration.DevKitDependencyPath != null)
+            assemblyPathsBuilder.Add(serverConfiguration.DevKitDependencyPath);
 
         // Add the extension assemblies to the MEF catalog.
         assemblyPathsBuilder.AddRange(extensionManager.ExtensionAssemblyPaths);
@@ -80,21 +85,35 @@ internal sealed class LanguageServerExportProviderBuilder : ExportProviderBuilde
             loggerFactory);
         var exportProvider = await builder.CreateExportProviderAsync(cancellationToken);
 
-        // Also add the ExtensionAssemblyManager so it will be available for the rest of the composition.
-        exportProvider.GetExportedValue<ExtensionAssemblyManagerMefProvider>().SetMefExtensionAssemblyManager(extensionManager);
-
-        // Immediately set the logger factory, so that way it'll be available for the rest of the composition
-        exportProvider.GetExportedValue<ServerLoggerFactory>().SetFactory(loggerFactory);
+        InitializeManualExports(exportProvider, extensionManager, loggerFactory, serverConfiguration);
 
         return exportProvider;
     }
 
-    private static IEnumerable<string> FilterFiles(string baseDirectory, string filter)
+    private static void InitializeManualExports(
+        ExportProvider exportProvider,
+        ExtensionAssemblyManager extensionManager,
+        ILoggerFactory loggerFactory,
+        ServerConfiguration serverConfiguration)
     {
-        foreach (var file in Directory.EnumerateFiles(baseDirectory, filter))
+        // Initialize exports that require manual setup.
+        exportProvider.GetExportedValue<ExtensionAssemblyManagerMefProvider>().SetMefExtensionAssemblyManager(extensionManager);
+        exportProvider.GetExportedValue<ServerLoggerFactory>().SetFactory(loggerFactory);
+        exportProvider.GetExportedValue<ServerConfigurationFactory>().InitializeConfiguration(serverConfiguration);
+    }
+
+    private static IEnumerable<string> FilterFiles(string baseDirectory)
+    {
+        foreach (var file in Directory.EnumerateFiles(baseDirectory, "*.dll"))
         {
-            if (!s_dllsToExcludeFromMef.Contains(Path.GetFileName(file)))
+            var fileName = Path.GetFileName(file);
+            if ((fileName.StartsWith("Microsoft.CodeAnalysis", StringComparison.OrdinalIgnoreCase) ||
+                 fileName.StartsWith("Microsoft.ServiceHub", StringComparison.OrdinalIgnoreCase) ||
+                 s_dllsToIncludeInMef.Contains(fileName)) &&
+                !s_dllsToExcludeFromMef.Contains(fileName))
+            {
                 yield return file;
+            }
         }
     }
 
@@ -139,5 +158,11 @@ internal sealed class LanguageServerExportProviderBuilder : ExportProviderBuilde
 #pragma warning disable VSTHRD200 // Use "Async" suffix for async methods
         public static Task? GetCacheWriteTask() => s_cacheWriteTask_forTestingPurposesOnly;
 #pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
+
+        public static ImmutableArray<string> FilterFiles(string baseDirectory)
+            => LanguageServerExportProviderBuilder.FilterFiles(baseDirectory).ToImmutableArray();
+
+        public static void InitializeManualExports(ExportProvider exportProvider, ExtensionAssemblyManager extensionManager, ILoggerFactory loggerFactory, ServerConfiguration serverConfiguration)
+            => LanguageServerExportProviderBuilder.InitializeManualExports(exportProvider, extensionManager, loggerFactory, serverConfiguration);
     }
 }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServerExportProviderBuilder.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServerExportProviderBuilder.cs
@@ -62,7 +62,7 @@ internal sealed class LanguageServerExportProviderBuilder : ExportProviderBuilde
 
         // Don't catch IO exceptions as it's better to fail to build the catalog than give back
         // a partial catalog that will surely blow up later.
-        assemblyPathsBuilder.AddRange(FilterFiles(baseDirectory));
+        assemblyPathsBuilder.AddRange(FindMefAssemblies(baseDirectory));
 
         // The Razor extension ships with Roslyn and so needs to be in our MEF composition
         assemblyPathsBuilder.Add(Path.Combine(baseDirectory, "Microsoft.VisualStudioCode.RazorExtension.dll"));
@@ -102,7 +102,7 @@ internal sealed class LanguageServerExportProviderBuilder : ExportProviderBuilde
         exportProvider.GetExportedValue<ServerConfigurationFactory>().InitializeConfiguration(serverConfiguration);
     }
 
-    private static IEnumerable<string> FilterFiles(string baseDirectory)
+    private static IEnumerable<string> FindMefAssemblies(string baseDirectory)
     {
         foreach (var file in Directory.EnumerateFiles(baseDirectory, "*.dll"))
         {
@@ -159,8 +159,8 @@ internal sealed class LanguageServerExportProviderBuilder : ExportProviderBuilde
         public static Task? GetCacheWriteTask() => s_cacheWriteTask_forTestingPurposesOnly;
 #pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
 
-        public static ImmutableArray<string> FilterFiles(string baseDirectory)
-            => LanguageServerExportProviderBuilder.FilterFiles(baseDirectory).ToImmutableArray();
+        public static ImmutableArray<string> FindMefAssemblies(string baseDirectory)
+            => LanguageServerExportProviderBuilder.FindMefAssemblies(baseDirectory).ToImmutableArray();
 
         public static void InitializeManualExports(ExportProvider exportProvider, ExtensionAssemblyManager extensionManager, ILoggerFactory loggerFactory, ServerConfiguration serverConfiguration)
             => LanguageServerExportProviderBuilder.InitializeManualExports(exportProvider, extensionManager, loggerFactory, serverConfiguration);

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
@@ -97,7 +97,7 @@ static async Task RunAsync(ServerConfiguration serverConfiguration, Cancellation
 
     var cacheDirectory = Path.Combine(Path.GetDirectoryName(typeof(Program).Assembly.Location)!, "cache");
 
-    using var exportProvider = await LanguageServerExportProviderBuilder.CreateExportProviderAsync(AppContext.BaseDirectory, extensionManager, assemblyLoader, serverConfiguration.DevKitDependencyPath, cacheDirectory, loggerFactory, cancellationToken);
+    using var exportProvider = await LanguageServerExportProviderBuilder.CreateExportProviderAsync(AppContext.BaseDirectory, extensionManager, assemblyLoader, serverConfiguration, cacheDirectory, loggerFactory, cancellationToken);
 
     var globalOptionService = exportProvider.GetExportedValue<Microsoft.CodeAnalysis.Options.IGlobalOptionService>();
     globalOptionService.SetGlobalOption(WorkspaceConfigurationOptionsStorage.SourceGeneratorExecution, serverConfiguration.SourceGeneratorExecutionPreference);
@@ -108,9 +108,6 @@ static async Task RunAsync(ServerConfiguration serverConfiguration, Cancellation
     {
         Directory.CreateDirectory(serverConfiguration.ExtensionLogDirectory);
     }
-
-    // Initialize the server configuration MEF exported value.
-    exportProvider.GetExportedValue<ServerConfigurationFactory>().InitializeConfiguration(serverConfiguration);
 
     // Initialize the fault handler if it's available
     var telemetryReporter = exportProvider.GetExports<ITelemetryReporter>().SingleOrDefault()?.Value;


### PR DESCRIPTION
Currently, all tests in LanguageServer.UnitTests create new MEF compositions on each test run.  This has two problems:
1.  It's slow
2.  There is a bug in the runtime that causes MEF discovery to crash in Linux CI - the more tests that run MEF discovery, the more likely we are to hit it.

In some cases however, we do need to actually test the language server MEF creation (and caching) - but not all tests need to do that. 

This PR adds the ability for most tests to use a single cached MEF composition, while allowing others to opt-in to full MEF creation.  This should improve the speed of test execution, as well as reduce the chances that we hit the runtime bug in MEF discovery.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84083)