### PR TITLE
Fix signature help selecting wrong overload for multiple type parameter extension methods

### DIFF
--- a/src/EditorFeatures/CSharpTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.cs
@@ -2405,4 +2405,42 @@ public sealed class InvocationExpressionSignatureHelpProviderTests : AbstractCSh
             public interface IResourceBuilder<T> where T : IResource { }
             """, [new SignatureHelpTestItem($"({CSharpFeaturesResources.extension}) IResourceBuilder<C> IResourceBuilder<C>.WithServiceBinding<C>(int containerPort, [int? hostPort = null], [string? scheme = null], [string? name = null], [string? env = null])", currentParameterIndex: 0)],
             sourceCodeKind: SourceCodeKind.Regular);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84055")]
+    public async Task PickCorrectOverload_MoreSpecificExtensionMethod()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            using System.Collections.Immutable;
+            using System.Linq;
+
+            class Program
+            {
+                static void Main()
+                {
+                    var a1 = ImmutableArray.Create(1, 2, 3);
+                    var a2 = ImmutableArray.Create(1, 2, 3);
+                    [|a1.SequenceEqual(a2$$|]);
+                }
+            }
+            """;
+        var markup = string.Format("""
+            <Workspace>
+                <Project Language="C#" CommonReferencesNetCoreApp="true">
+                    <Document FilePath="SourceDocument">
+            {0}
+                    </Document>
+                </Project>
+            </Workspace>
+            """, System.Security.SecurityElement.Escape(source));
+
+        await VerifyItemWithReferenceWorkerAsync(markup, [
+            new SignatureHelpTestItem($"({CSharpFeaturesResources.extension}) bool IEnumerable<int>.SequenceEqual<int>(IEnumerable<int> second)", currentParameterIndex: 0),
+            new SignatureHelpTestItem($"({CSharpFeaturesResources.extension}) bool IEnumerable<int>.SequenceEqual<int>(IEnumerable<int> second, IEqualityComparer<int>? comparer)", currentParameterIndex: 0),
+            new SignatureHelpTestItem($"({CSharpFeaturesResources.extension}) bool ImmutableArray<int>.SequenceEqual<TDerived, int>(IEnumerable<TDerived> items, [IEqualityComparer<int>? comparer = null])", currentParameterIndex: 0),
+            new SignatureHelpTestItem($"({CSharpFeaturesResources.extension}) bool ImmutableArray<int>.SequenceEqual<int, int>(ImmutableArray<int> items, [IEqualityComparer<int>? comparer = null])", currentParameterIndex: 0, isSelected: true),
+            new SignatureHelpTestItem($"({CSharpFeaturesResources.extension}) bool ImmutableArray<int>.SequenceEqual<TDerived, int>(ImmutableArray<TDerived> items, Func<int, int, bool> predicate)", currentParameterIndex: 0)],
+            hideAdvancedMembers: false);
+    }
 }

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.cs
@@ -2425,15 +2425,15 @@ public sealed class InvocationExpressionSignatureHelpProviderTests : AbstractCSh
                 }
             }
             """;
-        var markup = string.Format("""
+        var markup = $$"""
             <Workspace>
                 <Project Language="C#" CommonReferencesNetCoreApp="true">
-                    <Document FilePath="SourceDocument">
-            {0}
-                    </Document>
+                    <Document FilePath="SourceDocument"><![CDATA[
+            {{source}}
+                    ]]></Document>
                 </Project>
             </Workspace>
-            """, System.Security.SecurityElement.Escape(source));
+            """;
 
         await VerifyItemWithReferenceWorkerAsync(markup, [
             new SignatureHelpTestItem($"({CSharpFeaturesResources.extension}) bool IEnumerable<int>.SequenceEqual<int>(IEnumerable<int> second)", currentParameterIndex: 0),

--- a/src/Features/CSharp/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider.cs
@@ -94,7 +94,7 @@ internal partial class InvocationExpressionSignatureHelpProviderBase : AbstractO
 
         // if the symbol could be bound, replace that item in the symbol list
         if (currentSymbol?.IsGenericMethod == true)
-            methods = methods.SelectAsArray(m => Equals(currentSymbol.OriginalDefinition, m) ? currentSymbol : m);
+            methods = methods.SelectAsArray(m => Equals(currentSymbol.OriginalDefinition, m.OriginalDefinition) ? currentSymbol : m);
 
         // present items and select
         var (items, selectedItem) = await GetMethodGroupItemsAndSelectionAsync(


### PR DESCRIPTION
Fixes #84055

When signature help resolves the current overload for reduced extension methods with multiple type parameters, the comparison `Equals(currentSymbol.OriginalDefinition, m)` fails because `m` is partially constructed, so use the `OriginalDefinition` instead.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84089)