### PR TITLE
Allow multiple host workspaces for PdbMatchingSourceTextProvider

### DIFF
--- a/src/EditorFeatures/Core/EditAndContinue/ManagedHotReloadLanguageServiceFactory.cs
+++ b/src/EditorFeatures/Core/EditAndContinue/ManagedHotReloadLanguageServiceFactory.cs
@@ -23,7 +23,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue;
 internal sealed class ManagedHotReloadLanguageServiceFactory : IEditAndContinueSolutionProvider
 {
     private readonly EditAndContinueSessionState _sessionState;
-    private readonly PdbMatchingSourceTextProvider _sourceTextProvider;
     private readonly IActiveStatementTrackingController _activeStatementTrackingController;
     private readonly IDiagnosticsRefresher _diagnosticRefresher;
     private readonly IAsynchronousOperationListenerProvider _listenerProvider;
@@ -32,13 +31,11 @@ internal sealed class ManagedHotReloadLanguageServiceFactory : IEditAndContinueS
     [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
     public ManagedHotReloadLanguageServiceFactory(
         EditAndContinueSessionState sessionState,
-        PdbMatchingSourceTextProvider sourceTextProvider,
         IActiveStatementTrackingController activeStatementTrackingController,
         IDiagnosticsRefresher diagnosticRefresher,
         IAsynchronousOperationListenerProvider listenerProvider)
     {
         _sessionState = sessionState;
-        _sourceTextProvider = sourceTextProvider;
         _activeStatementTrackingController = activeStatementTrackingController;
         _diagnosticRefresher = diagnosticRefresher;
         _listenerProvider = listenerProvider;
@@ -54,10 +51,15 @@ internal sealed class ManagedHotReloadLanguageServiceFactory : IEditAndContinueS
     /// Host-specific solution snapshot provider. In VS this is EditorHostSolutionProvider (from MEF)
     /// </param>
     /// <param name="workspaceProvider">Host's workspace provider used by the implementation to enqueue source generator updates.</param>
+    /// <param name="sourceTextProvider">
+    /// Per-host source text provider, observing the host's <see cref="WorkspaceKind.Host"/> workspace. Owned by the caller
+    /// (the per-server hot reload stack), which is responsible for disposing it when the host/server shuts down.
+    /// </param>
     public ManagedHotReloadLanguageService Create(
         IServiceBroker serviceBroker,
         ISolutionSnapshotProvider solutionSnapshotProvider,
-        IHostWorkspaceProvider workspaceProvider)
+        IHostWorkspaceProvider workspaceProvider,
+        PdbMatchingSourceTextProvider sourceTextProvider)
     {
         var debuggerServiceProxy = new ManagedHotReloadServiceProxy(serviceBroker);
         var logReporter = new EditAndContinueLogReporter(serviceBroker, _listenerProvider);
@@ -67,7 +69,7 @@ internal sealed class ManagedHotReloadLanguageServiceFactory : IEditAndContinueS
             workspaceProvider,
             debuggerServiceProxy,
             solutionSnapshotProvider,
-            _sourceTextProvider,
+            sourceTextProvider,
             _activeStatementTrackingController,
             logReporter,
             _diagnosticRefresher);

--- a/src/EditorFeatures/Test/EditAndContinue/EditorManagedHotReloadLanguageServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditorManagedHotReloadLanguageServiceTests.cs
@@ -272,7 +272,8 @@ public sealed class EditorManagedHotReloadLanguageServiceTests : EditAndContinue
         var localFactory = localWorkspace.GetService<ManagedHotReloadLanguageServiceFactory>();
         var localBroker = localWorkspace.Services.GetRequiredService<IServiceBrokerProvider>().ServiceBroker;
         var localSnapshotProvider = localWorkspace.GetService<ISolutionSnapshotProvider>();
-        var localService = localFactory.Create(localBroker, localSnapshotProvider, localWorkspace.GetService<IHostWorkspaceProvider>(), new PdbMatchingSourceTextProvider(localWorkspace));
+        using var pdbMatchingSourceTextProvider = new PdbMatchingSourceTextProvider(localWorkspace);
+        var localService = localFactory.Create(localBroker, localSnapshotProvider, localWorkspace.GetService<IHostWorkspaceProvider>(), pdbMatchingSourceTextProvider);
 
         await localWorkspace.ChangeSolutionAsync(localWorkspace.CurrentSolution
             .AddTestProject("proj", out var projectId)
@@ -517,6 +518,7 @@ public sealed class EditorManagedHotReloadLanguageServiceTests : EditAndContinue
         var sourceFile = dir.CreateFile("test.cs").WriteAllText(source1, Encoding.UTF8);
 
         using var workspace = CreateEditorWorkspace(out var solution, out var service, out var languageService, out var sourceTextProvider);
+        using var _1 = sourceTextProvider;
 
         var projectId = ProjectId.CreateNewId();
         var documentId = DocumentId.CreateNewId(projectId);

--- a/src/EditorFeatures/Test/EditAndContinue/EditorManagedHotReloadLanguageServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditorManagedHotReloadLanguageServiceTests.cs
@@ -125,7 +125,7 @@ public sealed class EditorManagedHotReloadLanguageServiceTests : EditAndContinue
             (!string.IsNullOrWhiteSpace(d.FilePath) ? $" {d.FilePath}({d.Span.StartLine}, {d.Span.StartColumn}, {d.Span.EndLine}, {d.Span.EndColumn}):" : "") +
             $" {d.Message}";
 
-    private TestWorkspace CreateEditorWorkspace(out Solution solution, out EditAndContinueService service, out ManagedHotReloadLanguageService languageService, Type[] additionalParts = null)
+    private TestWorkspace CreateEditorWorkspace(out Solution solution, out EditAndContinueService service, out ManagedHotReloadLanguageService languageService, out PdbMatchingSourceTextProvider sourceTextProvider, Type[] additionalParts = null)
     {
         var composition = EditorTestCompositions.EditorFeatures
             .AddParts(
@@ -135,10 +135,6 @@ public sealed class EditorManagedHotReloadLanguageServiceTests : EditAndContinue
             .AddParts(additionalParts);
 
         var workspace = new TestWorkspace(composition: composition, solutionTelemetryId: s_solutionTelemetryId);
-
-        var sourceTextProvider = (PdbMatchingSourceTextProvider)workspace.ExportProvider.GetExports<IEventListener>().Single(e => e.Value is PdbMatchingSourceTextProvider).Value;
-        var listenerProvider = workspace.GetService<MockWorkspaceEventListenerProvider>();
-        listenerProvider.EventListeners = [sourceTextProvider];
 
         ((MockServiceBroker)workspace.Services.GetRequiredService<IServiceBrokerProvider>().ServiceBroker).CreateService = t => t switch
         {
@@ -151,10 +147,12 @@ public sealed class EditorManagedHotReloadLanguageServiceTests : EditAndContinue
         solution = workspace.CurrentSolution;
         service = GetEditAndContinueService(workspace);
 
+        sourceTextProvider = new PdbMatchingSourceTextProvider(workspace);
+
         var factory = workspace.GetService<ManagedHotReloadLanguageServiceFactory>();
         var serviceBroker = workspace.Services.GetRequiredService<IServiceBrokerProvider>().ServiceBroker;
         var solutionSnapshotProvider = workspace.GetService<ISolutionSnapshotProvider>();
-        languageService = factory.Create(serviceBroker, solutionSnapshotProvider, workspace.GetService<IHostWorkspaceProvider>());
+        languageService = factory.Create(serviceBroker, solutionSnapshotProvider, workspace.GetService<IHostWorkspaceProvider>(), sourceTextProvider);
         return workspace;
     }
 
@@ -274,7 +272,7 @@ public sealed class EditorManagedHotReloadLanguageServiceTests : EditAndContinue
         var localFactory = localWorkspace.GetService<ManagedHotReloadLanguageServiceFactory>();
         var localBroker = localWorkspace.Services.GetRequiredService<IServiceBrokerProvider>().ServiceBroker;
         var localSnapshotProvider = localWorkspace.GetService<ISolutionSnapshotProvider>();
-        var localService = localFactory.Create(localBroker, localSnapshotProvider, localWorkspace.GetService<IHostWorkspaceProvider>());
+        var localService = localFactory.Create(localBroker, localSnapshotProvider, localWorkspace.GetService<IHostWorkspaceProvider>(), new PdbMatchingSourceTextProvider(localWorkspace));
 
         await localWorkspace.ChangeSolutionAsync(localWorkspace.CurrentSolution
             .AddTestProject("proj", out var projectId)
@@ -518,8 +516,7 @@ public sealed class EditorManagedHotReloadLanguageServiceTests : EditAndContinue
         var dir = Temp.CreateDirectory();
         var sourceFile = dir.CreateFile("test.cs").WriteAllText(source1, Encoding.UTF8);
 
-        using var workspace = CreateEditorWorkspace(out var solution, out var service, out var languageService);
-        var sourceTextProvider = workspace.GetService<PdbMatchingSourceTextProvider>();
+        using var workspace = CreateEditorWorkspace(out var solution, out var service, out var languageService, out var sourceTextProvider);
 
         var projectId = ProjectId.CreateNewId();
         var documentId = DocumentId.CreateNewId(projectId);

--- a/src/Features/Core/Portable/EditAndContinue/PdbMatchingSourceTextProvider.cs
+++ b/src/Features/Core/Portable/EditAndContinue/PdbMatchingSourceTextProvider.cs
@@ -5,13 +5,9 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Composition;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -22,36 +18,23 @@ namespace Microsoft.CodeAnalysis.EditAndContinue;
 /// Gives us an opportunity to observe the version of the source text that matches the one used to produce the PDB. After the document is opened the content can be updated in-memory (in the editor),
 /// saved to disk and the version that matches the PDB lost.
 /// </summary>
-[ExportEventListener(WellKnownEventListeners.Workspace, WorkspaceKind.Host), Shared]
-[Export(typeof(PdbMatchingSourceTextProvider))]
-[method: ImportingConstructor]
-[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class PdbMatchingSourceTextProvider() : IEventListener, IPdbMatchingSourceTextProvider
+internal sealed class PdbMatchingSourceTextProvider : IPdbMatchingSourceTextProvider, IDisposable
 {
     private readonly object _guard = new();
 
     private bool _isActive;
     private int _baselineSolutionContentVersion;
     private readonly Dictionary<string, (DocumentState state, int solutionVersion)> _documentsWithChangedLoaderByPath = [];
-    private WorkspaceEventRegistration? _workspaceChangedDisposer;
+    private readonly WorkspaceEventRegistration _workspaceChangedDisposer;
 
-    public void StartListening(Workspace workspace)
+    public PdbMatchingSourceTextProvider(Workspace workspace)
     {
-        // TODO: Workaround for LSP tests creating two Host workspaces. https://github.com/dotnet/roslyn/issues/82917
-        if (workspace.GetType().Name == "LspTestWorkspace")
-        {
-            return;
-        }
-
-        Debug.Assert(_workspaceChangedDisposer == null);
-
         _workspaceChangedDisposer = workspace.RegisterWorkspaceChangedHandler(WorkspaceChanged);
     }
 
-    public void StopListening(Workspace workspace)
+    public void Dispose()
     {
-        _workspaceChangedDisposer?.Dispose();
-        _workspaceChangedDisposer = null;
+        _workspaceChangedDisposer.Dispose();
     }
 
     private void WorkspaceChanged(WorkspaceChangeEventArgs e)

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -46,6 +46,7 @@ internal sealed class RoslynPackage : AbstractPackage
     private ThreadSafeMenuCommandService? _menuCommandService;
     private RuleSetEventHandler? _ruleSetEventHandler;
     private SolutionEventMonitor? _solutionEventMonitor;
+    private PdbMatchingSourceTextProvider? _sourceTextProvider;
 
     internal static async ValueTask<RoslynPackage?> GetOrLoadAsync(IThreadingContext threadingContext, IAsyncServiceProvider serviceProvider, CancellationToken cancellationToken)
     {
@@ -125,14 +126,12 @@ internal sealed class RoslynPackage : AbstractPackage
         var solutionSnapshotProvider = ComponentModel.GetService<ISolutionSnapshotProvider>();
         var hostWorkspaceProvider = ComponentModel.GetService<IHostWorkspaceProvider>();
 
-        // In devenv there is a single host workspace, so a single source text provider observing it suffices.
-        // It lives for the lifetime of the process, matching the brokered service it backs.
-        var sourceTextProvider = new PdbMatchingSourceTextProvider(hostWorkspaceProvider.Workspace);
+        _sourceTextProvider = new PdbMatchingSourceTextProvider(hostWorkspaceProvider.Workspace);
         serviceBrokerContainer.Proffer(
             ManagedHotReloadLanguageServiceDescriptor.Descriptor,
             (_, _, serviceBroker, _) =>
             {
-                var service = hotReloadFactory.Create(serviceBroker, solutionSnapshotProvider, hostWorkspaceProvider, sourceTextProvider);
+                var service = hotReloadFactory.Create(serviceBroker, solutionSnapshotProvider, hostWorkspaceProvider, _sourceTextProvider);
                 return ValueTask.FromResult<object?>(service);
             });
     }
@@ -188,6 +187,8 @@ internal sealed class RoslynPackage : AbstractPackage
 
         _solutionEventMonitor?.Dispose();
         _solutionEventMonitor = null;
+        _sourceTextProvider?.Dispose();
+        _sourceTextProvider = null;
 
         base.Dispose(disposing);
     }

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -124,11 +124,15 @@ internal sealed class RoslynPackage : AbstractPackage
         var hotReloadFactory = ComponentModel.GetService<ManagedHotReloadLanguageServiceFactory>();
         var solutionSnapshotProvider = ComponentModel.GetService<ISolutionSnapshotProvider>();
         var hostWorkspaceProvider = ComponentModel.GetService<IHostWorkspaceProvider>();
+
+        // In devenv there is a single host workspace, so a single source text provider observing it suffices.
+        // It lives for the lifetime of the process, matching the brokered service it backs.
+        var sourceTextProvider = new PdbMatchingSourceTextProvider(hostWorkspaceProvider.Workspace);
         serviceBrokerContainer.Proffer(
             ManagedHotReloadLanguageServiceDescriptor.Descriptor,
             (_, _, serviceBroker, _) =>
             {
-                var service = hotReloadFactory.Create(serviceBroker, solutionSnapshotProvider, hostWorkspaceProvider);
+                var service = hotReloadFactory.Create(serviceBroker, solutionSnapshotProvider, hostWorkspaceProvider, sourceTextProvider);
                 return ValueTask.FromResult<object?>(service);
             });
     }

--- a/src/VisualStudio/DevKit/Impl/EditAndContinue/DevKitHotReloadServiceContributor.cs
+++ b/src/VisualStudio/DevKit/Impl/EditAndContinue/DevKitHotReloadServiceContributor.cs
@@ -43,8 +43,14 @@ internal sealed class DevKitHotReloadServiceContributorFactory(
 internal sealed class DevKitHotReloadServiceContributor(
     ManagedHotReloadLanguageServiceFactory factory,
     IHostWorkspaceProvider workspaceProvider,
-    SolutionSnapshotRegistry solutionSnapshotRegistry) : IServiceBrokerInitializer, ILspService
+    SolutionSnapshotRegistry solutionSnapshotRegistry) : IServiceBrokerInitializer, ILspService, IDisposable
 {
+    /// <summary>
+    /// Per-server source text provider, observing this server's host workspace. Owned (and disposed) here so that each
+    /// in-process LSP server gets its own provider bound to its own host workspace.
+    /// </summary>
+    private readonly PdbMatchingSourceTextProvider _sourceTextProvider = new(workspaceProvider.Workspace);
+
     public ImmutableDictionary<ServiceMoniker, ServiceRegistration> ServicesToRegister => new Dictionary<ServiceMoniker, ServiceRegistration>
     {
         { ManagedHotReloadLanguageServiceDescriptor.Descriptor.Moniker, new ServiceRegistration(ServiceAudience.Local, null, allowGuestClients: false) }
@@ -59,7 +65,7 @@ internal sealed class DevKitHotReloadServiceContributor(
             ManagedHotReloadLanguageServiceDescriptor.Descriptor,
             (moniker, options, innerServiceBroker, cancellationToken) =>
             {
-                var service = factory.Create(serviceBroker, solutionSnapshotProvider, workspaceProvider);
+                var service = factory.Create(serviceBroker, solutionSnapshotProvider, workspaceProvider, _sourceTextProvider);
                 return new ValueTask<object?>(service);
             });
     }
@@ -67,4 +73,7 @@ internal sealed class DevKitHotReloadServiceContributor(
     public void OnServiceBrokerInitialized(IServiceBroker serviceBroker, CancellationToken cancellationToken)
     {
     }
+
+    public void Dispose()
+        => _sourceTextProvider.Dispose();
 }


### PR DESCRIPTION
Found this while actually implementing multi-server (this started failing).  Makes PdbMatchingSourceTextProvider per server like the rest of the hot reload stack.

Also resolves https://github.com/dotnet/roslyn/issues/82917

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84094)