### PR TITLE
Fix design-time-builds from out-of-proc nodes returning empty data

### DIFF
--- a/src/Workspaces/MSBuild/BuildHost/Build/ProjectBuildManager.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Build/ProjectBuildManager.cs
@@ -292,7 +292,13 @@ internal sealed class ProjectBuildManager : IDisposable
             }
         }
 
-        var buildRequestData = new MSB.Execution.BuildRequestData(projectInstance, [.. targets]);
+        // Since we are doing parallel builds where the build may happen in another MSBuild node, we need to pass
+        // ProvideProjectStateAfterBuild to get that state back when we're done.
+        var buildRequestData = new MSB.Execution.BuildRequestData(
+            projectInstance,
+            [.. targets],
+            hostServices: null,
+            flags: MSB.Execution.BuildRequestDataFlags.ProvideProjectStateAfterBuild);
 
         var result = await BuildAsync(buildRequestData, log, cancellationToken).ConfigureAwait(false);
 
@@ -304,7 +310,7 @@ internal sealed class ProjectBuildManager : IDisposable
             }
         }
 
-        return projectInstance;
+        return result.ProjectStateAfterBuild ?? projectInstance;
     }
 
     private async Task<MSB.Execution.BuildResult> BuildAsync(MSB.Execution.BuildRequestData requestData, DiagnosticLog log, CancellationToken cancellationToken)

--- a/src/Workspaces/MSBuild/BuildHost/MSBuild/ProjectFile/ProjectInstanceReader.cs
+++ b/src/Workspaces/MSBuild/BuildHost/MSBuild/ProjectFile/ProjectInstanceReader.cs
@@ -17,6 +17,7 @@ internal readonly struct ProjectInstanceReader
     public readonly MSB.Evaluation.Project? Project;
     public readonly MSB.Execution.ProjectInstance _projectInstance;
 
+    private readonly string _projectFullPath;
     private readonly string _projectDirectory;
 
     public string Language { get; }
@@ -31,11 +32,14 @@ internal readonly struct ProjectInstanceReader
         _commandLineProvider = commandLineReader;
         _projectInstance = projectInstance;
         Project = project;
-        _projectDirectory = PathUtilities.EnsureTrailingSeparator(PathUtilities.GetDirectoryName(_projectInstance.FullPath));
-    }
 
-    public string FilePath
-        => _projectInstance.FullPath;
+        // The ProjectInstance we get from BuildResult.ProjectStateAfterBuild returns a limited ProjectInstance that
+        // only has MSBuild properties and items available; in this case the ProjectInstance.FullPath will be an empty string.
+        // Since in the out-of-process build case we will still have the project evaluation, we can get the full path from there.
+        _projectFullPath = Project?.FullPath ?? _projectInstance.FullPath;
+        Contract.ThrowIfTrue(string.IsNullOrEmpty(_projectFullPath));
+        _projectDirectory = PathUtilities.EnsureTrailingSeparator(PathUtilities.GetDirectoryName(_projectFullPath));
+    }
 
     public ProjectFileInfo CreateProjectFileInfo()
     {
@@ -117,7 +121,7 @@ internal readonly struct ProjectInstanceReader
         return new ProjectFileInfo()
         {
             Language = Language,
-            FilePath = _projectInstance.FullPath,
+            FilePath = _projectFullPath,
             OutputFilePath = outputFilePath,
             OutputRefFilePath = outputRefFilePath,
             GeneratedFilesOutputDirectory = generatedFilesOutputDirectory,

--- a/src/Workspaces/MSBuild/Test/NetCoreTests.cs
+++ b/src/Workspaces/MSBuild/Test/NetCoreTests.cs
@@ -146,6 +146,55 @@ public sealed class NetCoreTests : MSBuildWorkspaceTestBase
     [ConditionalFact(typeof(DotNetSdkMSBuildInstalled))]
     [Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
     [Trait(Traits.Feature, Traits.Features.NetCore)]
+    // TODO: Delete this test once parallel project loading is supported directly in MSBuildWorkspace, at which point the
+    // existing MSBuildWorkspace tests will exercise this path.
+    public async Task TestLoadMultipleProjectsInParallelProducesConsistentResults()
+    {
+        CreateFiles(GetNetCoreAppAndTwoLibrariesFiles());
+
+        var projectFilePaths = new[]
+        {
+            GetSolutionFileName(@"Project\Project.csproj"),
+            GetSolutionFileName(@"Library1\Library1.csproj"),
+            GetSolutionFileName(@"Library2\Library2.csproj"),
+        };
+
+        DotNetRestore(@"Project\Project.csproj");
+        DotNetRestore(@"Library2\Library2.csproj");
+
+        for (var iteration = 0; iteration < 5; iteration++)
+        {
+            // Use a fresh build host (and therefore a fresh ProjectBuildManager) each iteration, mirroring how the LSP
+            // creates a build host process manager per reload. Force more than one node so that MSBuild is free to
+            // schedule the concurrent builds onto out-of-proc worker nodes.
+            await using var buildHostProcessManager = new BuildHostProcessManager(
+                knownCommandLineParserLanguages: [LanguageNames.CSharp],
+                maxNodeCount: 4);
+
+            var loadTasks = projectFilePaths.Select(async projectFilePath =>
+            {
+                var buildHost = await buildHostProcessManager.GetBuildHostAsync(BuildHostProcessKind.NetCore, CancellationToken.None);
+                var projectFile = await buildHost.LoadProjectFileAsync(projectFilePath, LanguageNames.CSharp, CancellationToken.None);
+                return (await projectFile.GetProjectFileInfosAsync(CancellationToken.None)).Single();
+            });
+
+            var projectFileInfos = await Task.WhenAll(loadTasks);
+
+            foreach (var projectFileInfo in projectFileInfos)
+            {
+                // Every project resolves framework references, so a successful design-time build must produce command
+                // line args containing at least one /reference. An empty set means the build's outputs were lost.
+                Assert.True(
+                    projectFileInfo.CommandLineArgs.Any(arg => arg.StartsWith("/reference:", StringComparison.OrdinalIgnoreCase)),
+                    $"Iteration {iteration}: project '{projectFileInfo.FilePath}' was loaded without any metadata references. " +
+                    $"Command line args: [{string.Join(", ", projectFileInfo.CommandLineArgs)}]");
+            }
+        }
+    }
+
+    [ConditionalFact(typeof(DotNetSdkMSBuildInstalled))]
+    [Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
+    [Trait(Traits.Feature, Traits.Features.NetCore)]
     public async Task TestOpenProjectTwice_NetCoreAppAndLibrary()
     {
         CreateFiles(GetNetCoreAppAndLibraryFiles());


### PR DESCRIPTION
ProjectInstances behave a bit differently in this case, which was causing issues.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84096)