### PR TITLE
[LSP] Enable file renaming on class rename by default

### DIFF
--- a/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -550,6 +550,37 @@ internal static partial class ProtocolConversions
         return documentEdits;
     }
 
+    /// <summary>
+    /// Detects documents that were renamed (name changed) between <paramref name="oldSolution"/> and <paramref name="newSolution"/>
+    /// and returns the corresponding <see cref="RenameFile"/> operations for the LSP <c>WorkspaceEdit</c>.
+    /// </summary>
+    public static RenameFile[] GetDocumentRenames(Solution oldSolution, Solution newSolution)
+    {
+        var solutionChanges = newSolution.GetChanges(oldSolution);
+
+        using var _ = ArrayBuilder<RenameFile>.GetInstance(out var renameFiles);
+
+        foreach (var projectChange in solutionChanges.GetProjectChanges())
+        {
+            foreach (var documentId in projectChange.GetChangedDocuments(onlyGetDocumentsWithTextChanges: false))
+            {
+                var oldDocument = oldSolution.GetRequiredDocument(documentId);
+                var newDocument = newSolution.GetRequiredDocument(documentId);
+
+                if (oldDocument.Name != newDocument.Name)
+                {
+                    renameFiles.Add(new RenameFile
+                    {
+                        OldDocumentUri = oldDocument.GetURI(),
+                        NewDocumentUri = newDocument.GetUriForRenamedDocument()
+                    });
+                }
+            }
+        }
+
+        return renameFiles.ToArray();
+    }
+
     public static Task<LSP.Location?> TextSpanToLocationAsync(
         TextDocument document,
         TextSpan textSpan,

--- a/src/LanguageServer/Protocol/Handler/Rename/RenameHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Rename/RenameHandler.cs
@@ -4,10 +4,10 @@
 
 using System;
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Rename;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -49,7 +49,7 @@ internal sealed class RenameHandler() : ILspServiceDocumentRequestHandler<LSP.Re
             RenameOverloads: false,
             RenameInStrings: false,
             RenameInComments: false,
-            RenameFile: false);
+            RenameFile: true);
 
         var renameLocationSet = await Renamer.FindRenameLocationsAsync(
             oldSolution,
@@ -76,6 +76,20 @@ internal sealed class RenameHandler() : ILspServiceDocumentRequestHandler<LSP.Re
 
         var documentEdits = await ProtocolConversions.ChangedDocumentsToTextDocumentEditsAsync(renamedSolution, oldSolution, cancellationToken).ConfigureAwait(false);
 
-        return new WorkspaceEdit { DocumentChanges = documentEdits };
+        // Detect document renames and add RenameFile operations
+        var renameFiles = ProtocolConversions.GetDocumentRenames(oldSolution, renamedSolution);
+
+        if (renameFiles.Length == 0)
+            return new WorkspaceEdit { DocumentChanges = documentEdits };
+
+        using var _ = ArrayBuilder<LSP.SumType<LSP.TextDocumentEdit, LSP.CreateFile, LSP.RenameFile, LSP.DeleteFile>>.GetInstance(out var allChanges);
+
+        foreach (var edit in documentEdits)
+            allChanges.Add(edit);
+
+        foreach (var rename in renameFiles)
+            allChanges.Add(rename);
+
+        return new WorkspaceEdit { DocumentChanges = allChanges.ToArray() };
     }
 }


### PR DESCRIPTION
The Roslyn LSP server's textDocument/rename handler hardcodes RenameFile: false

In the Visual Studio editor layer, file rename during symbol rename is enabled by default                                                                                                                                                                
                                                                                                                                                                                
This change enables RenameFile: true in the LSP handler and adds RenameFile resource operations to the returned WorkspaceEdit
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84107)