### PR TITLE
Document cache contents as a trusted compilation input

### DIFF
--- a/docs/compilers/Design/compiler-output-cache-experiment.md
+++ b/docs/compilers/Design/compiler-output-cache-experiment.md
@@ -17,7 +17,7 @@ The current implementation is intentionally scoped as an experiment:
 
 ## Security
 
-The cache folder is an input to the compilation. When a cache hit occurs, the cached outputs are restored and used as the result of the compilation, so the contents of the cache directly affect what the build produces. Users of this feature must add appropriate access controls to the cache folder to ensure it is trusted to the same degree as any other compilation input, such as source files, references, and analyzers. A cache folder that can be written to by untrusted parties should be treated as an untrusted input.
+The contents of the cache folder are an input to the compilation. When a cache hit occurs, the cached outputs (and their associated metadata) are restored and used as the result of the compilation, so what is stored in the cache directly affects what the build produces. Users of this feature must add appropriate access controls to the cache folder to ensure its contents are trusted to the same degree as any other compilation input, such as source files, references, and analyzers. A cache whose contents can be written or modified by untrusted parties should be treated as an untrusted input.
 
 ## Goals
 

--- a/docs/compilers/Design/compiler-output-cache-experiment.md
+++ b/docs/compilers/Design/compiler-output-cache-experiment.md
@@ -15,6 +15,10 @@ The current implementation is intentionally scoped as an experiment:
 - it is primarily designed for repeated local or CI builds that produce identical outputs
 - it is expected to evolve as we learn more about correctness, diagnostics, and operational behavior
 
+## Security
+
+The cache folder is an input to the compilation. When a cache hit occurs, the cached outputs are restored and used as the result of the compilation, so the contents of the cache directly affect what the build produces. Users of this feature must add appropriate access controls to the cache folder to ensure it is trusted to the same degree as any other compilation input, such as source files, references, and analyzers. A cache folder that can be written to by untrusted parties should be treated as an untrusted input.
+
 ## Goals
 
 The experiment has four primary goals:


### PR DESCRIPTION
Adds a Security section to the compiler output cache experiment doc clarifying that the cache contents (and associated metadata) are an input to the compilation. Users of the feature need to add appropriate access controls to the cache folder so its contents are trusted to the same degree as any other compilation input (source files, references, analyzers). A cache writable by untrusted parties should be treated as an untrusted input.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84114)