### PR TITLE
Fix Razor allowed child validation in code blocks

### DIFF
--- a/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorIntermediateNodeLoweringPhaseIntegrationTest.cs
+++ b/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorIntermediateNodeLoweringPhaseIntegrationTest.cs
@@ -5,6 +5,7 @@ using System;
 using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
+using Roslyn.Test.Utilities;
 using Xunit;
 using static Microsoft.AspNetCore.Razor.Language.Intermediate.IntermediateNodeAssert;
 
@@ -315,6 +316,74 @@ public class DefaultRazorIntermediateNodeLoweringPhaseIntegrationTest : RazorPro
                 c1 => Html(Environment.NewLine, c1)));
     }
 
+    [Fact, WorkItem("https://github.com/microsoft/vscode-dotnettools/issues/3210")]
+    public void Lower_TagHelperWithAllowedChildren_AllowsChildTagHelpersInsideCSharpBlock()
+    {
+        // Arrange
+        var contactListTagHelper = CreateTagHelperDescriptorWithAllowedChild(
+            tagName: "my-contact-list",
+            typeName: "ContactListTagHelper",
+            assemblyName: "TestAssembly",
+            allowedChildTag: "my-contact");
+
+        var contactTagHelper = CreateTagHelperDescriptor(
+            tagName: "my-contact",
+            typeName: "ContactTagHelper",
+            assemblyName: "TestAssembly");
+
+        var codeDocument = ProjectEngine.CreateCodeDocument(
+            """
+            @addTagHelper *, TestAssembly
+            <my-contact-list>
+                @foreach (var contact in Model)
+                {
+                    <my-contact></my-contact>
+                }
+            </my-contact-list>
+            """,
+            [contactListTagHelper, contactTagHelper]);
+
+        var processor = CreateCodeDocumentProcessor(codeDocument);
+
+        // Act
+        var documentNode = processor.GetDocumentNode();
+
+        // Assert
+        Assert.Empty(documentNode.GetAllDiagnostics());
+    }
+
+    [Fact]
+    public void Lower_TagHelperWithAllowedChildren_ReportsInvalidChildInsideCSharpBlock()
+    {
+        // Arrange
+        var contactListTagHelper = CreateTagHelperDescriptorWithAllowedChild(
+            tagName: "my-contact-list",
+            typeName: "ContactListTagHelper",
+            assemblyName: "TestAssembly",
+            allowedChildTag: "my-contact");
+
+        var codeDocument = ProjectEngine.CreateCodeDocument(
+            """
+            @addTagHelper *, TestAssembly
+            <my-contact-list>
+                @foreach (var contact in Model)
+                {
+                    <div></div>
+                }
+            </my-contact-list>
+            """,
+            [contactListTagHelper]);
+
+        var processor = CreateCodeDocumentProcessor(codeDocument);
+
+        // Act
+        var documentNode = processor.GetDocumentNode();
+
+        // Assert
+        var diagnostic = Assert.Single(documentNode.GetAllDiagnostics());
+        Assert.Equal("RZ2009", diagnostic.Id);
+    }
+
     [Fact]
     public void Lower_TagHelpersWithBoundAttribute()
     {
@@ -475,6 +544,20 @@ public class DefaultRazorIntermediateNodeLoweringPhaseIntegrationTest : RazorPro
         }
 
         builder.TagMatchingRuleDescriptor(ruleBuilder => ruleBuilder.RequireTagName(tagName));
+
+        return builder.Build();
+    }
+
+    private static TagHelperDescriptor CreateTagHelperDescriptorWithAllowedChild(
+        string tagName,
+        string typeName,
+        string assemblyName,
+        string allowedChildTag)
+    {
+        var builder = TagHelperDescriptorBuilder.CreateTagHelper(typeName, assemblyName);
+        builder.SetTypeName(typeName, typeNamespace: null, typeNameIdentifier: null);
+        builder.TagMatchingRuleDescriptor(ruleBuilder => ruleBuilder.RequireTagName(tagName));
+        builder.AllowChildTag(allowedChildTag);
 
         return builder.Build();
     }

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultTagHelperResolutionPhase.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultTagHelperResolutionPhase.cs
@@ -493,7 +493,17 @@ internal partial class DefaultTagHelperResolutionPhase : RazorEnginePhaseBase
         var allowedChildrenString = string.Join(", ", allowedNames.ToArray());
         var parentTagName = tagHelperNode.TagName;
 
-        foreach (var child in bodyNode.Children)
+        ValidateAllowedChildren(parentTagName, bodyNode.Children, in allowedNames, allowedChildrenString, prefix);
+    }
+
+    private static void ValidateAllowedChildren(
+        string parentTagName,
+        IntermediateNodeCollection children,
+        in PooledArrayBuilder<string> allowedNames,
+        string allowedChildrenString,
+        string prefix)
+    {
+        foreach (var child in children)
         {
             if (child is TagHelperIntermediateNode childTagHelper)
             {
@@ -534,11 +544,16 @@ internal partial class DefaultTagHelperResolutionPhase : RazorEnginePhaseBase
                     }
                 }
             }
-            else if (child is CSharpExpressionIntermediateNode or CSharpCodeIntermediateNode)
+            else if (child is CSharpExpressionIntermediateNode)
             {
                 child.AddDiagnostic(
                     RazorDiagnosticFactory.CreateTagHelper_CannotHaveNonTagContent(
                         child.Source ?? SourceSpan.Undefined, parentTagName, allowedChildrenString));
+            }
+            else if (child is CSharpCodeIntermediateNode or MarkupBlockIntermediateNode)
+            {
+                // Razor blocks can contain markup children, so validate their children instead of the block itself.
+                ValidateAllowedChildren(parentTagName, child.Children, in allowedNames, allowedChildrenString, prefix);
             }
         }
     }

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultTagHelperResolutionPhase.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultTagHelperResolutionPhase.cs
@@ -550,9 +550,9 @@ internal partial class DefaultTagHelperResolutionPhase : RazorEnginePhaseBase
                     RazorDiagnosticFactory.CreateTagHelper_CannotHaveNonTagContent(
                         child.Source ?? SourceSpan.Undefined, parentTagName, allowedChildrenString));
             }
-            else if (child is CSharpCodeIntermediateNode or MarkupBlockIntermediateNode)
+            else if (child is CSharpCodeIntermediateNode)
             {
-                // Razor blocks can contain markup children, so validate their children instead of the block itself.
+                // Razor code blocks can contain markup children, so validate their children instead of the block itself.
                 ValidateAllowedChildren(parentTagName, child.Children, in allowedNames, allowedChildrenString, prefix);
             }
         }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-dotnettools/issues/3210.

Razor tag helper allowed-children validation now treats Razor code/markup blocks as transparent containers, so allowed child tag helpers inside blocks like `@foreach` don't produce false RZ2009 diagnostics while invalid nested tags are still reported.

Validation:
- `dotnet test src\Razor\src\Compiler\Microsoft.AspNetCore.Razor.Language\test\Microsoft.AspNetCore.Razor.Language.UnitTests.csproj --filter "FullyQualifiedName~DefaultRazorIntermediateNodeLoweringPhaseIntegrationTest" --no-restore --verbosity minimal`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84116)