### PR TITLE
Fix multiline lambda formatting in non-directive attributes

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPass.CSharpDocumentGenerator.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPass.CSharpDocumentGenerator.cs
@@ -378,6 +378,19 @@ internal partial class CSharpFormattingPass
                 // any indentation we want to add to line up attribute content, otherwise we'd end up pushing that content to
                 // the right repeatedly.
                 var attributeIndentationWidth = (htmlIndentLevel * _tabSize) + additionalIndentation.GetValueOrDefault();
+
+                // For lambda attributes like `OnClick=@(() => ...)`, Roslyn already contributes the
+                // lambda-body indentation on wrapped lines. If we keep applying the full attribute
+                // indentation baseline to those continuation lines, every format pass shifts the block
+                // body one level to the right.
+                if (expressionStartsBlockLambda &&
+                    attributeNode is MarkupAttributeBlockSyntax or MarkupTagHelperAttributeSyntax &&
+                    _currentLine.LineNumber > nodeStartLine &&
+                    htmlIndentLevel > 0)
+                {
+                    htmlIndentLevel--;
+                }
+
                 if (attributeIndentationWidth <= 0)
                 {
                     // Attributes don't affect indentation here, so the user's indentation is all we need.

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Formatting/DocumentFormattingTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Formatting/DocumentFormattingTest.cs
@@ -11132,6 +11132,736 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
     }
 
     [Fact]
+    public async Task MultilineLambdaExplicitExpressionInAttribute_DoesNotShiftRight()
+    {
+        var code = """
+            @if (inChatMember)
+            {
+                <div class="foo"
+                     style=@(() =>
+                     {
+                         Foo();
+                         Bar();
+                     }) title="bar"></div>
+            }
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: """
+                @if (inChatMember)
+                {
+                <div class="foo"
+                     style=@(() =>
+                     {
+                     Foo();
+                     Bar();
+                     }) title="bar"></div>
+                }
+                """,
+            expected: code,
+            fileKind: RazorFileKind.Component,
+            csharpSyntaxFormattingOptions: GetNewLineBeforeBraceInLambdaExpressionOptions(newLineBeforeBraceInLambda: true));
+    }
+
+    [Fact]
+    public async Task MultilineLambdaExplicitExpressionInAttribute_DoesNotShiftRight_IndentByOne()
+    {
+        var code = """
+            @if (inChatMember)
+            {
+                <div class="foo"
+                    style=@(() =>
+                    {
+                        Foo();
+                        Bar();
+                    }) title="bar"></div>
+            }
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: """
+                @if (inChatMember)
+                {
+                <div class="foo"
+                     style=@(() =>
+                     {
+                     Foo();
+                     Bar();
+                     }) title="bar"></div>
+                }
+                """,
+            expected: code,
+            fileKind: RazorFileKind.Component,
+            csharpSyntaxFormattingOptions: GetNewLineBeforeBraceInLambdaExpressionOptions(newLineBeforeBraceInLambda: true),
+            attributeIndentStyle: AttributeIndentStyle.IndentByOne);
+    }
+
+    [Fact]
+    public async Task MultilineLambdaExplicitExpressionInAttribute_DoesNotShiftRight_IndentByTwo()
+    {
+        var code = """
+            @if (inChatMember)
+            {
+                <div class="foo"
+                        style=@(() =>
+                        {
+                            Foo();
+                            Bar();
+                        }) title="bar"></div>
+            }
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: """
+                @if (inChatMember)
+                {
+                <div class="foo"
+                     style=@(() =>
+                     {
+                     Foo();
+                     Bar();
+                     }) title="bar"></div>
+                }
+                """,
+            expected: code,
+            fileKind: RazorFileKind.Component,
+            csharpSyntaxFormattingOptions: GetNewLineBeforeBraceInLambdaExpressionOptions(newLineBeforeBraceInLambda: true),
+            attributeIndentStyle: AttributeIndentStyle.IndentByTwo);
+    }
+
+    [Fact]
+    public async Task MultilineLambdaQuotedExplicitExpressionInAttribute_DoesNotShiftRight()
+    {
+        var code = """
+            @if (inChatMember)
+            {
+                <div class="foo"
+                     style="@(() =>
+                     {
+                         Foo();
+                         Bar();
+                     })" title="bar"></div>
+            }
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: """
+                @if (inChatMember)
+                {
+                <div class="foo"
+                     style="@(() =>
+                         {
+                             Foo();
+                             Bar();
+                         })" title="bar"></div>
+                }
+                """,
+            expected: code,
+            fileKind: RazorFileKind.Component,
+            csharpSyntaxFormattingOptions: GetNewLineBeforeBraceInLambdaExpressionOptions(newLineBeforeBraceInLambda: true));
+    }
+
+    [Fact]
+    public async Task MultilineLambdaQuotedExplicitExpressionInAttribute_DoesNotShiftRight_IndentByOne()
+    {
+        var code = """
+            @if (inChatMember)
+            {
+                <div class="foo"
+                    style="@(() =>
+                    {
+                        Foo();
+                        Bar();
+                    })" title="bar"></div>
+            }
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: """
+                @if (inChatMember)
+                {
+                <div class="foo"
+                     style="@(() =>
+                        {
+                            Foo();
+                            Bar();
+                        })" title="bar"></div>
+                }
+                """,
+            expected: code,
+            fileKind: RazorFileKind.Component,
+            csharpSyntaxFormattingOptions: GetNewLineBeforeBraceInLambdaExpressionOptions(newLineBeforeBraceInLambda: true),
+            attributeIndentStyle: AttributeIndentStyle.IndentByOne);
+    }
+
+    [Fact]
+    public async Task MultilineLambdaQuotedExplicitExpressionInAttribute_DoesNotShiftRight_IndentByTwo()
+    {
+        var code = """
+            @if (inChatMember)
+            {
+                <div class="foo"
+                        style="@(() =>
+                        {
+                            Foo();
+                            Bar();
+                        })" title="bar"></div>
+            }
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: """
+                @if (inChatMember)
+                {
+                <div class="foo"
+                     style="@(() =>
+                            {
+                                Foo();
+                                Bar();
+                            })" title="bar"></div>
+                }
+                """,
+            expected: code,
+            fileKind: RazorFileKind.Component,
+            csharpSyntaxFormattingOptions: GetNewLineBeforeBraceInLambdaExpressionOptions(newLineBeforeBraceInLambda: true),
+            attributeIndentStyle: AttributeIndentStyle.IndentByTwo);
+    }
+
+    [Fact]
+    public async Task MultilineLambdaQuotedImplicitExpressionInComponentAttribute_DoesNotShiftRight()
+    {
+        var code = """
+            @if (inChatMember)
+            {
+                <CheckBoxButton ImageContentSource="foo"
+                                OnClick="() =>
+                                {
+                                    Foo();
+                                    Bar();
+                                }" ImgSize=24 />
+            }
+
+            @code {
+                private bool inChatMember = true;
+
+                private void Foo()
+                {
+                }
+
+                private void Bar()
+                {
+                }
+            }
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: $$"""
+                @if (inChatMember)
+                {
+                <CheckBoxButton ImageContentSource="foo"
+                                OnClick="() =>
+                                    {
+                                        Foo();
+                                        Bar();
+                                    }" ImgSize=24 />
+                }
+
+                @code {
+                    private bool inChatMember = true;
+
+                    private void Foo()
+                    {
+                    }
+
+                    private void Bar()
+                    {
+                    }
+                }
+                """,
+            expected: code,
+            fileKind: RazorFileKind.Component,
+            csharpSyntaxFormattingOptions: GetNewLineBeforeBraceInLambdaExpressionOptions(newLineBeforeBraceInLambda: true),
+            additionalFiles: GetCheckBoxButtonComponentFiles());
+    }
+
+    [Fact]
+    public async Task MultilineLambdaQuotedImplicitExpressionInComponentAttribute_DoesNotShiftRight_IndentByOne()
+    {
+        var code = """
+            @if (inChatMember)
+            {
+                <CheckBoxButton ImageContentSource="foo"
+                    OnClick="() =>
+                    {
+                        Foo();
+                        Bar();
+                    }" ImgSize=24 />
+            }
+
+            @code {
+                private bool inChatMember = true;
+
+                private void Foo()
+                {
+                }
+
+                private void Bar()
+                {
+                }
+            }
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: """
+                @if (inChatMember)
+                {
+                <CheckBoxButton ImageContentSource="foo"
+                                OnClick="() =>
+                        {
+                            Foo();
+                            Bar();
+                        }" ImgSize=24 />
+                }
+                
+                @code {
+                    private bool inChatMember = true;
+                
+                    private void Foo()
+                    {
+                    }
+                
+                    private void Bar()
+                    {
+                    }
+                }
+                """,
+            expected: code,
+            fileKind: RazorFileKind.Component,
+            csharpSyntaxFormattingOptions: GetNewLineBeforeBraceInLambdaExpressionOptions(newLineBeforeBraceInLambda: true),
+            attributeIndentStyle: AttributeIndentStyle.IndentByOne,
+            additionalFiles: GetCheckBoxButtonComponentFiles());
+    }
+
+    [Fact]
+    public async Task MultilineLambdaQuotedImplicitExpressionInComponentAttribute_DoesNotShiftRight_IndentByTwo()
+    {
+        var code = """
+            @if (inChatMember)
+            {
+                <CheckBoxButton ImageContentSource="foo"
+                        OnClick="() =>
+                        {
+                            Foo();
+                            Bar();
+                        }" ImgSize=24 />
+            }
+
+            @code {
+                private bool inChatMember = true;
+
+                private void Foo()
+                {
+                }
+
+                private void Bar()
+                {
+                }
+            }
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: """
+                @if (inChatMember)
+                {
+                <CheckBoxButton ImageContentSource="foo"
+                                OnClick="() =>
+                            {
+                                Foo();
+                                Bar();
+                            }" ImgSize=24 />
+                }
+                
+                @code {
+                    private bool inChatMember = true;
+                
+                    private void Foo()
+                    {
+                    }
+                
+                    private void Bar()
+                    {
+                    }
+                }
+                """,
+            expected: code,
+            fileKind: RazorFileKind.Component,
+            csharpSyntaxFormattingOptions: GetNewLineBeforeBraceInLambdaExpressionOptions(newLineBeforeBraceInLambda: true),
+            attributeIndentStyle: AttributeIndentStyle.IndentByTwo,
+            additionalFiles: GetCheckBoxButtonComponentFiles());
+    }
+
+    [Fact]
+    public async Task MultilineLambdaExplicitExpressionInComponentAttribute_DoesNotShiftRight()
+    {
+        var code = """
+            @if (inChatMember)
+            {
+                <CheckBoxButton ImageContentSource="foo"
+                                OnClick=@(() =>
+                                {
+                                    Foo();
+                                    Bar();
+                                }) ImgSize=24 />
+            }
+
+            @code {
+                private bool inChatMember = true;
+
+                private void Foo()
+                {
+                }
+
+                private void Bar()
+                {
+                }
+            }
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: """
+                @if (inChatMember)
+                {
+                <CheckBoxButton ImageContentSource="foo"
+                                OnClick=@(() =>
+                                {
+                                Foo();
+                                Bar();
+                                }) ImgSize=24 />
+                }
+                
+                @code {
+                    private bool inChatMember = true;
+                
+                    private void Foo()
+                    {
+                    }
+                
+                    private void Bar()
+                    {
+                    }
+                }
+                """,
+            expected: code,
+            fileKind: RazorFileKind.Component,
+            csharpSyntaxFormattingOptions: GetNewLineBeforeBraceInLambdaExpressionOptions(newLineBeforeBraceInLambda: true),
+            additionalFiles: GetCheckBoxButtonComponentFiles());
+    }
+
+    [Fact]
+    public async Task MultilineLambdaExplicitExpressionInComponentAttribute_DoesNotShiftRight_IndentByOne()
+    {
+        var code = """
+            @if (inChatMember)
+            {
+                <CheckBoxButton ImageContentSource="foo"
+                    OnClick=@(() =>
+                    {
+                        Foo();
+                        Bar();
+                    }) ImgSize=24 />
+            }
+
+            @code {
+                private bool inChatMember = true;
+
+                private void Foo()
+                {
+                }
+
+                private void Bar()
+                {
+                }
+            }
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: """
+                @if (inChatMember)
+                {
+                <CheckBoxButton ImageContentSource="foo"
+                                OnClick=@(() =>
+                                {
+                                Foo();
+                                Bar();
+                                }) ImgSize=24 />
+                }
+                
+                @code {
+                    private bool inChatMember = true;
+                
+                    private void Foo()
+                    {
+                    }
+                
+                    private void Bar()
+                    {
+                    }
+                }
+                """,
+            expected: code,
+            fileKind: RazorFileKind.Component,
+            csharpSyntaxFormattingOptions: GetNewLineBeforeBraceInLambdaExpressionOptions(newLineBeforeBraceInLambda: true),
+            attributeIndentStyle: AttributeIndentStyle.IndentByOne,
+            additionalFiles: GetCheckBoxButtonComponentFiles());
+    }
+
+    [Fact]
+    public async Task MultilineLambdaExplicitExpressionInComponentAttribute_DoesNotShiftRight_IndentByTwo()
+    {
+        var code = """
+            @if (inChatMember)
+            {
+                <CheckBoxButton ImageContentSource="foo"
+                        OnClick=@(() =>
+                        {
+                            Foo();
+                            Bar();
+                        }) ImgSize=24 />
+            }
+
+            @code {
+                private bool inChatMember = true;
+
+                private void Foo()
+                {
+                }
+
+                private void Bar()
+                {
+                }
+            }
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: """
+                @if (inChatMember)
+                {
+                <CheckBoxButton ImageContentSource="foo"
+                                OnClick=@(() =>
+                                {
+                                Foo();
+                                Bar();
+                                }) ImgSize=24 />
+                }
+                
+                @code {
+                    private bool inChatMember = true;
+                
+                    private void Foo()
+                    {
+                    }
+                
+                    private void Bar()
+                    {
+                    }
+                }
+                """,
+            expected: code,
+            fileKind: RazorFileKind.Component,
+            csharpSyntaxFormattingOptions: GetNewLineBeforeBraceInLambdaExpressionOptions(newLineBeforeBraceInLambda: true),
+            attributeIndentStyle: AttributeIndentStyle.IndentByTwo,
+            additionalFiles: GetCheckBoxButtonComponentFiles());
+    }
+
+    [Fact]
+    public async Task MultilineLambdaQuotedExplicitExpressionInComponentAttribute_DoesNotShiftRight()
+    {
+        var code = """
+            @if (inChatMember)
+            {
+                <CheckBoxButton ImageContentSource="foo"
+                                OnClick="@(() =>
+                                {
+                                    Foo();
+                                    Bar();
+                                })" ImgSize=24 />
+            }
+
+            @code {
+                private bool inChatMember = true;
+
+                private void Foo()
+                {
+                }
+
+                private void Bar()
+                {
+                }
+            }
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: $$"""
+                @if (inChatMember)
+                {
+                <CheckBoxButton ImageContentSource="foo"
+                                OnClick="@(() =>
+                                    {
+                                        Foo();
+                                        Bar();
+                                    })" ImgSize=24 />
+                }
+
+                @code {
+                    private bool inChatMember = true;
+
+                    private void Foo()
+                    {
+                    }
+
+                    private void Bar()
+                    {
+                    }
+                }
+                """,
+            expected: code,
+            fileKind: RazorFileKind.Component,
+            csharpSyntaxFormattingOptions: GetNewLineBeforeBraceInLambdaExpressionOptions(newLineBeforeBraceInLambda: true),
+            additionalFiles: GetCheckBoxButtonComponentFiles());
+    }
+
+    [Fact]
+    public async Task MultilineLambdaQuotedExplicitExpressionInComponentAttribute_DoesNotShiftRight_IndentByOne()
+    {
+        var code = """
+            @if (inChatMember)
+            {
+                <CheckBoxButton ImageContentSource="foo"
+                    OnClick="@(() =>
+                    {
+                        Foo();
+                        Bar();
+                    })" ImgSize=24 />
+            }
+
+            @code {
+                private bool inChatMember = true;
+
+                private void Foo()
+                {
+                }
+
+                private void Bar()
+                {
+                }
+            }
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: """
+                @if (inChatMember)
+                {
+                <CheckBoxButton ImageContentSource="foo"
+                                OnClick="@(() =>
+                        {
+                            Foo();
+                            Bar();
+                        })" ImgSize=24 />
+                }
+                
+                @code {
+                    private bool inChatMember = true;
+                
+                    private void Foo()
+                    {
+                    }
+                
+                    private void Bar()
+                    {
+                    }
+                }
+                """,
+            expected: code,
+            fileKind: RazorFileKind.Component,
+            csharpSyntaxFormattingOptions: GetNewLineBeforeBraceInLambdaExpressionOptions(newLineBeforeBraceInLambda: true),
+            attributeIndentStyle: AttributeIndentStyle.IndentByOne,
+            additionalFiles: GetCheckBoxButtonComponentFiles());
+    }
+
+    [Fact]
+    public async Task MultilineLambdaQuotedExplicitExpressionInComponentAttribute_DoesNotShiftRight_IndentByTwo()
+    {
+        var code = """
+            @if (inChatMember)
+            {
+                <CheckBoxButton ImageContentSource="foo"
+                        OnClick="@(() =>
+                        {
+                            Foo();
+                            Bar();
+                        })" ImgSize=24 />
+            }
+
+            @code {
+                private bool inChatMember = true;
+
+                private void Foo()
+                {
+                }
+
+                private void Bar()
+                {
+                }
+            }
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: """
+                @if (inChatMember)
+                {
+                <CheckBoxButton ImageContentSource="foo"
+                                OnClick="@(() =>
+                            {
+                                Foo();
+                                Bar();
+                            })" ImgSize=24 />
+                }
+                
+                @code {
+                    private bool inChatMember = true;
+                
+                    private void Foo()
+                    {
+                    }
+                
+                    private void Bar()
+                    {
+                    }
+                }
+                """,
+            expected: code,
+            fileKind: RazorFileKind.Component,
+            csharpSyntaxFormattingOptions: GetNewLineBeforeBraceInLambdaExpressionOptions(newLineBeforeBraceInLambda: true),
+            attributeIndentStyle: AttributeIndentStyle.IndentByTwo,
+            additionalFiles: GetCheckBoxButtonComponentFiles());
+    }
+
+    [Fact]
     [WorkItem("https://github.com/dotnet/razor/issues/13064")]
     public async Task RenderFragment_Multiline_ComponentAttributesWithExplicitExpression_IndentByOne()
     {
@@ -13616,6 +14346,20 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
                 </div>
                 """);
     }
+
+    private (string fileName, string contents)[] GetCheckBoxButtonComponentFiles()
+        =>
+        [
+            (FilePath("CheckBoxButton.razor"), """
+                @using Microsoft.AspNetCore.Components
+
+                @code {
+                    [Parameter] public string? ImageContentSource { get; set; }
+                    [Parameter] public EventCallback OnClick { get; set; }
+                    [Parameter] public int ImgSize { get; set; }
+                }
+                """)
+        ];
 
     private static CSharpSyntaxFormattingOptions GetNewLineBeforeBraceInLambdaExpressionOptions(bool newLineBeforeBraceInLambda)
         => CSharpSyntaxFormattingOptions.Default with

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Formatting/DocumentFormattingTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Formatting/DocumentFormattingTest.cs
@@ -11132,6 +11132,7 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
     }
 
     [Fact]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/84105")]
     public async Task MultilineLambdaExplicitExpressionInAttribute_DoesNotShiftRight()
     {
         var code = """
@@ -11165,6 +11166,7 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
     }
 
     [Fact]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/84105")]
     public async Task MultilineLambdaExplicitExpressionInAttribute_DoesNotShiftRight_IndentByOne()
     {
         var code = """
@@ -11199,6 +11201,7 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
     }
 
     [Fact]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/84105")]
     public async Task MultilineLambdaExplicitExpressionInAttribute_DoesNotShiftRight_IndentByTwo()
     {
         var code = """
@@ -11233,6 +11236,7 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
     }
 
     [Fact]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/84105")]
     public async Task MultilineLambdaQuotedExplicitExpressionInAttribute_DoesNotShiftRight()
     {
         var code = """
@@ -11266,6 +11270,7 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
     }
 
     [Fact]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/84105")]
     public async Task MultilineLambdaQuotedExplicitExpressionInAttribute_DoesNotShiftRight_IndentByOne()
     {
         var code = """
@@ -11300,6 +11305,7 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
     }
 
     [Fact]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/84105")]
     public async Task MultilineLambdaQuotedExplicitExpressionInAttribute_DoesNotShiftRight_IndentByTwo()
     {
         var code = """
@@ -11334,6 +11340,7 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
     }
 
     [Fact]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/84105")]
     public async Task MultilineLambdaQuotedImplicitExpressionInComponentAttribute_DoesNotShiftRight()
     {
         var code = """
@@ -11392,6 +11399,7 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
     }
 
     [Fact]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/84105")]
     public async Task MultilineLambdaQuotedImplicitExpressionInComponentAttribute_DoesNotShiftRight_IndentByOne()
     {
         var code = """
@@ -11451,6 +11459,7 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
     }
 
     [Fact]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/84105")]
     public async Task MultilineLambdaQuotedImplicitExpressionInComponentAttribute_DoesNotShiftRight_IndentByTwo()
     {
         var code = """
@@ -11510,6 +11519,7 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
     }
 
     [Fact]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/84105")]
     public async Task MultilineLambdaExplicitExpressionInComponentAttribute_DoesNotShiftRight()
     {
         var code = """
@@ -11568,6 +11578,7 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
     }
 
     [Fact]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/84105")]
     public async Task MultilineLambdaExplicitExpressionInComponentAttribute_DoesNotShiftRight_IndentByOne()
     {
         var code = """
@@ -11627,6 +11638,7 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
     }
 
     [Fact]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/84105")]
     public async Task MultilineLambdaExplicitExpressionInComponentAttribute_DoesNotShiftRight_IndentByTwo()
     {
         var code = """
@@ -11686,6 +11698,7 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
     }
 
     [Fact]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/84105")]
     public async Task MultilineLambdaQuotedExplicitExpressionInComponentAttribute_DoesNotShiftRight()
     {
         var code = """
@@ -11744,6 +11757,7 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
     }
 
     [Fact]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/84105")]
     public async Task MultilineLambdaQuotedExplicitExpressionInComponentAttribute_DoesNotShiftRight_IndentByOne()
     {
         var code = """
@@ -11803,6 +11817,7 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
     }
 
     [Fact]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/84105")]
     public async Task MultilineLambdaQuotedExplicitExpressionInComponentAttribute_DoesNotShiftRight_IndentByTwo()
     {
         var code = """


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/84105

Seems like previous lambda fixes weren't enough, and only dealt with directive attributes (ie `@onclick`). Also I didn't realise people wouldn't use double quotes in their attributes like this, but I guess there is no accounting for good taste.

The fix is super simple, and I added a bunch of tests to hopefully cover everything, but basically its the combinations of regular attributes and component attributes, each attribute indent style, and the three forms of multiple attribute values that can be written: `"() => ..."`, `"@(() => ...)"` and `@(() => ...)`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84121)