### PR TITLE
Reduce allocation churn in tag helper context discovery pools

### DIFF
--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultRazorTagHelperContextDiscoveryPhase.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultRazorTagHelperContextDiscoveryPhase.cs
@@ -205,14 +205,8 @@ internal sealed partial class DefaultRazorTagHelperContextDiscoveryPhase : Razor
     internal sealed class TagHelperDirectiveVisitor : DirectiveVisitor
     {
         /// <summary>
-        /// A larger pool of <see cref="TagHelperDescriptor"/> lists to handle scenarios where tag helpers
-        /// originate from a large number of assemblies.
-        /// </summary>
-        private static readonly ListPool<TagHelperDescriptor> s_pool = ListPool<TagHelperDescriptor>.Create(poolSize: 100);
-
-        /// <summary>
         /// A map from assembly name to list of <see cref="TagHelperDescriptor"/>. Lists are allocated from and returned to
-        /// <see cref="s_pool"/>.
+        /// <see cref="TagHelperCollection.TagHelperDescriptorListPool.Default"/>.
         /// </summary>
         private readonly Dictionary<string, List<TagHelperDescriptor>> _tagHelperMap = new(StringComparer.Ordinal);
 
@@ -253,7 +247,7 @@ internal sealed partial class DefaultRazorTagHelperContextDiscoveryPhase : Razor
 
                                 if (!_tagHelperMap.TryGetValue(currentAssemblyName, out currentTagHelpers))
                                 {
-                                    currentTagHelpers = s_pool.Get();
+                                    currentTagHelpers = TagHelperCollection.TagHelperDescriptorListPool.Default.Get();
                                     _tagHelperMap.Add(currentAssemblyName, currentTagHelpers);
                                 }
                             }
@@ -281,7 +275,7 @@ internal sealed partial class DefaultRazorTagHelperContextDiscoveryPhase : Razor
         {
             foreach (var (_, tagHelpers) in _tagHelperMap)
             {
-                s_pool.Return(tagHelpers);
+                TagHelperCollection.TagHelperDescriptorListPool.Default.Return(tagHelpers);
             }
 
             _tagHelperMap.Clear();
@@ -323,7 +317,7 @@ internal sealed partial class DefaultRazorTagHelperContextDiscoveryPhase : Razor
             }
 
             // We only record directives if we're visiting the source document, so no point collecting them either.
-            var contributed = IsSourceDocument ? ListPool<TagHelperDescriptor>.Default.Get() : null;
+            var contributed = IsSourceDocument ? TagHelperCollection.TagHelperDescriptorListPool.Default.Get() : null;
             switch (GetMemoryWithoutGlobalPrefix(addTagHelper.TypePattern).Span)
             {
                 case ['*']:
@@ -359,7 +353,7 @@ internal sealed partial class DefaultRazorTagHelperContextDiscoveryPhase : Razor
             if (contributed is not null)
             {
                 RecordDirectiveTagHelperContribution(node, TagHelperCollection.Create(contributed));
-                ListPool<TagHelperDescriptor>.Default.Return(contributed);
+                TagHelperCollection.TagHelperDescriptorListPool.Default.Return(contributed);
             }
         }
 
@@ -456,14 +450,14 @@ internal sealed partial class DefaultRazorTagHelperContextDiscoveryPhase : Razor
 
                 if (typeNamespace.IsEmpty)
                 {
-                    _componentsWithoutNamespace ??= ListPool<TagHelperDescriptor>.Default.Get();
+                    _componentsWithoutNamespace ??= TagHelperCollection.TagHelperDescriptorListPool.Default.Get();
                     _componentsWithoutNamespace.Add(component);
                 }
                 else
                 {
                     if (!_namespaceToComponentsMap.TryGetValue(typeNamespace, out var components))
                     {
-                        components = ListPool<TagHelperDescriptor>.Default.Get();
+                        components = TagHelperCollection.TagHelperDescriptorListPool.Default.Get();
                         _namespaceToComponentsMap.Add(typeNamespace, components);
                     }
 
@@ -484,13 +478,13 @@ internal sealed partial class DefaultRazorTagHelperContextDiscoveryPhase : Razor
         {
             if (_componentsWithoutNamespace != null)
             {
-                ListPool<TagHelperDescriptor>.Default.Return(_componentsWithoutNamespace);
+                TagHelperCollection.TagHelperDescriptorListPool.Default.Return(_componentsWithoutNamespace);
                 _componentsWithoutNamespace = null;
             }
 
             foreach (var (_, components) in _namespaceToComponentsMap)
             {
-                ListPool<TagHelperDescriptor>.Default.Return(components);
+                TagHelperCollection.TagHelperDescriptorListPool.Default.Return(components);
             }
 
             _namespaceToComponentsMap.Clear();

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelperCollection.Builder.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelperCollection.Builder.cs
@@ -4,9 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Threading;
-using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.AspNetCore.Razor.Utilities;
 
 namespace Microsoft.AspNetCore.Razor.Language;
@@ -15,21 +13,12 @@ public abstract partial class TagHelperCollection
 {
     public sealed partial class Builder : ICollection<TagHelperDescriptor>, IReadOnlyList<TagHelperDescriptor>, IDisposable
     {
-        // Create new pooled builders and sets with a larger initial capacity to limit growth.
-        private const int InitialCapacity = 256;
-
-        // Builders and sets are typically large, so allow them to stay larger when returned to their pool.
-        private const int MaximumObjectSize = 2048;
-
-        private static readonly ArrayBuilderPool<TagHelperDescriptor> s_arrayBuilderPool =
-            ArrayBuilderPool<TagHelperDescriptor>.Create(InitialCapacity, MaximumObjectSize);
-
-        private ImmutableArray<TagHelperDescriptor>.Builder _items;
+        private List<TagHelperDescriptor> _items;
         private HashSet<Checksum> _set;
 
         public Builder()
         {
-            _items = s_arrayBuilderPool.Get();
+            _items = TagHelperDescriptorListPool.Default.Get();
             _set = ChecksumSetPool.Default.Get();
         }
 
@@ -38,7 +27,7 @@ public abstract partial class TagHelperCollection
             var items = Interlocked.Exchange(ref _items, null!);
             if (items is not null)
             {
-                s_arrayBuilderPool.Return(items);
+                TagHelperDescriptorListPool.Default.Return(items);
             }
 
             var set = Interlocked.Exchange(ref _set, null!);
@@ -134,8 +123,7 @@ public abstract partial class TagHelperCollection
                 return Empty;
             }
 
-            var array = _items.ToImmutable();
-            return new SingleSegmentCollection(array.AsMemory());
+            return new SingleSegmentCollection(_items.ToArray().AsMemory());
         }
 
         public Enumerator GetEnumerator()

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelperCollection.ChecksumSetPool.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelperCollection.ChecksumSetPool.cs
@@ -15,9 +15,12 @@ public abstract partial class TagHelperCollection
         // the LOH threshold (85KB) during document compilation. With a small retention limit, the
         // set is trimmed on return and must re-grow (through multiple LOH-allocating resizes) on
         // every subsequent use. Traces have shown GBs of allocation pressure from this resize churn.
-        // A higher limit retains the grown set in the pool — trading a few MB of stable potentially LOH memory
-        // (across ~20 pool slots, most of which remain empty) for eliminating repeated resize allocations.
-        private const int MaximumObjectSize = 16384;
+        // A higher retention limit keeps the grown set in the pool, trading a few MB of stable
+        // potentially LOH memory (across ~20 pool slots, most of which remain empty) for
+        // eliminating repeated resize allocations. The initial capacity is kept smaller so that
+        // small projects don't immediately allocate LOH-sized arrays.
+        private const int InitialCapacity = 2048;
+        private const int MaximumRetainedCapacity = 16384;
 
         public static readonly ChecksumSetPool Default = new(Policy.Instance, DefaultPoolSize);
 
@@ -37,7 +40,7 @@ public abstract partial class TagHelperCollection
             public override HashSet<Checksum> Create()
             {
 #if NET
-                return new(capacity: MaximumObjectSize);
+                return new(capacity: InitialCapacity);
 #else
                 return [];
 #endif
@@ -48,10 +51,10 @@ public abstract partial class TagHelperCollection
                 var count = set.Count;
                 set.Clear();
 
-                if (count > MaximumObjectSize)
+                if (count > MaximumRetainedCapacity)
                 {
 #if NET9_0_OR_GREATER
-                    set.TrimExcess(MaximumObjectSize);
+                    set.TrimExcess(InitialCapacity);
 #else
                     set.TrimExcess();
 #endif

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelperCollection.ChecksumSetPool.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelperCollection.ChecksumSetPool.cs
@@ -11,7 +11,13 @@ public abstract partial class TagHelperCollection
 {
     private sealed class ChecksumSetPool : CustomObjectPool<HashSet<Checksum>>
     {
-        private const int MaximumObjectSize = 2048;
+        // Large projects can have thousands of tag helpers, causing the HashSet to grow well past
+        // the LOH threshold (85KB) during document compilation. With a small retention limit, the
+        // set is trimmed on return and must re-grow (through multiple LOH-allocating resizes) on
+        // every subsequent use. Traces have shown GBs of allocation pressure from this resize churn.
+        // A higher limit retains the grown set in the pool — trading a few MB of stable potentially LOH memory
+        // (across ~20 pool slots, most of which remain empty) for eliminating repeated resize allocations.
+        private const int MaximumObjectSize = 16384;
 
         public static readonly ChecksumSetPool Default = new(Policy.Instance, DefaultPoolSize);
 

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelperCollection.ChecksumSetPool.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelperCollection.ChecksumSetPool.cs
@@ -19,7 +19,9 @@ public abstract partial class TagHelperCollection
         // potentially LOH memory (across ~20 pool slots, most of which remain empty) for
         // eliminating repeated resize allocations. The initial capacity is kept smaller so that
         // small projects don't immediately allocate LOH-sized arrays.
+#if NET
         private const int InitialCapacity = 2048;
+#endif
         private const int MaximumRetainedCapacity = 16384;
 
         public static readonly ChecksumSetPool Default = new(Policy.Instance, DefaultPoolSize);

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelperCollection.TagHelperDescriptorListPool.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelperCollection.TagHelperDescriptorListPool.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.PooledObjects;
+
+namespace Microsoft.AspNetCore.Razor.Language;
+
+public abstract partial class TagHelperCollection
+{
+    /// <summary>
+    ///  A pool of <see cref="List{T}"/> instances for <see cref="TagHelperDescriptor"/>.
+    /// </summary>
+    /// <remarks>
+    ///  Large projects can have thousands of tag helpers distributed across many namespaces and
+    ///  assemblies. The directive visitors allocate lists per-namespace (or per-assembly) during
+    ///  document compilation, then return them on reset. With a small retention limit, these lists
+    ///  are trimmed on return and must re-grow on the next document — traces have shown GBs of
+    ///  allocation pressure from repeated <c>List&lt;T&gt;</c> resizing in this path. A higher
+    ///  retention limit keeps the grown lists in the pool, trading modest stable memory for
+    ///  eliminating repeated resize allocations.
+    /// </remarks>
+    internal sealed class TagHelperDescriptorListPool : CustomObjectPool<List<TagHelperDescriptor>>
+    {
+        private const int InitialCapacity = 128;
+        private const int MaximumCapacity = 2048;
+        private const int PoolSize = 128;
+
+        public static readonly TagHelperDescriptorListPool Default = new(Policy.Instance, PoolSize);
+
+        private TagHelperDescriptorListPool(PooledObjectPolicy policy, Opt<int> poolSize)
+            : base(policy, poolSize)
+        {
+        }
+
+        private sealed class Policy : PooledObjectPolicy
+        {
+            public static readonly Policy Instance = new();
+
+            public override List<TagHelperDescriptor> Create() => new(capacity: InitialCapacity);
+
+            public override bool Return(List<TagHelperDescriptor> list)
+            {
+                list.Clear();
+
+                if (list.Capacity > MaximumCapacity)
+                {
+                    list.Capacity = InitialCapacity;
+                }
+
+                return true;
+            }
+        }
+    }
+}

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelperCollection.TagHelperDescriptorListPool.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelperCollection.TagHelperDescriptorListPool.cs
@@ -45,7 +45,7 @@ public abstract partial class TagHelperCollection
 
                 if (list.Capacity > MaximumCapacity)
                 {
-                    list.Capacity = InitialCapacity;
+                    list.Capacity = MaximumCapacity;
                 }
 
                 return true;

--- a/src/Razor/src/Shared/Microsoft.AspNetCore.Razor.SharedUtilities/PooledObjects/ListPool`1.Policy.cs
+++ b/src/Razor/src/Shared/Microsoft.AspNetCore.Razor.SharedUtilities/PooledObjects/ListPool`1.Policy.cs
@@ -32,13 +32,11 @@ internal partial class ListPool<T>
 
         public override bool Return(List<T> list)
         {
-            var count = list.Count;
-
             list.Clear();
 
-            if (count > _maximumObjectSize)
+            if (list.Capacity > _maximumObjectSize)
             {
-                list.TrimExcess();
+                list.Capacity = 0;
             }
 
             return true;


### PR DESCRIPTION
An ETL trace from a very large project shows ~20 GB of allocations from repeated collection resizing in DefaultRazorTagHelperContextDiscoveryPhase. The root cause is aggressive pool trimming — collections are trimmed back to small sizes on return, forcing them to re-grow (through multiple LOH-allocating resizes) on every subsequent document compilation.

Addresses: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2987803

Changes:

 - ChecksumSetPool: Decouple initial capacity (2048, stays under LOH) from maximum retained capacity (16384). Large projects grow the HashSet once and retain it; small projects never allocate LOH-sized arrays. Previously the set was trimmed to 2048 on every return, forcing repeated LOH resize churn for large projects.
 - New TagHelperDescriptorListPool: A dedicated pool for List<TagHelperDescriptor> with InitialCapacity=128, MaximumCapacity=2048, PoolSize=128. Lists start pre-sized to avoid the 0→4→8→...→128 resize chain. Lists that grow past 2048 are trimmed back to 2048 (well below the LOH threshold for reference-type arrays).
 - TagHelperCollection.Builder: Replace ImmutableArray<TagHelperDescriptor>.Builder (via ArrayBuilderPool) with a pooled List<TagHelperDescriptor> from TagHelperDescriptorListPool. This consolidates pooling into one well-tuned pool and eliminates the ImmutableArray.Builder resize allocations seen in the trace. ToCollection() now uses ToArray().AsMemory() — same single array allocation as before.
 - Directive visitors: Both TagHelperDirectiveVisitor and ComponentDirectiveVisitor now use the shared TagHelperDescriptorListPool.Default instead of ListPool<TagHelperDescriptor>.Default.
 - ListPool<T>.Policy.Return: Now checks Capacity (not Count) and sets Capacity = 0 when oversized, matching the intent of trimming based on actual backing array size rather than item count.
 
Allocations of the HashSet<Checksum> and List<TagHelperDescriptor> showing as ~20 GB (~40% of allocations) in a trace: 
<img width="1747" height="1026" alt="image" src="https://github.com/user-attachments/assets/294b10d0-57d8-4962-ac25-3587cded1191" />

<img width="1758" height="761" alt="image" src="https://github.com/user-attachments/assets/05a54157-744f-47c2-bc67-b20b656b2c53" />


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84123)