### PR TITLE
Add imports for child namespace references when moving types

### DIFF
--- a/src/EditorFeatures/CSharpTest/MoveToNamespace/MoveToNamespaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/MoveToNamespace/MoveToNamespaceTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1554,5 +1554,70 @@ public sealed class MoveToNamespaceTests : AbstractMoveToNamespaceTests
             expectedSymbolChanges: new Dictionary<string, string>()
             {
                 {"A.MyClass", "B.MyClass" }
+            });
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/50672")]
+    public Task MoveToNamespace_MoveType_AddsImportForChildNamespaceReference()
+        => TestMoveToNamespaceAsync(
+            """
+            using System;
+
+            namespace Tests
+            {
+                internal class Foo[||]
+                {
+                    public static int Do(Inner.Data d) => 42;
+                }
+            }
+
+            namespace Tests
+            {
+                namespace Inner
+                {
+                    public class App
+                    {
+                        static void Main()
+                        {
+                            Console.WriteLine(Foo.Do(new Data()));
+                        }
+                    }
+
+                    public class Data { }
+                }
+            }
+            """,
+            expectedMarkup: """
+            using System;
+            using Something.Else;
+            using Tests.Inner;
+
+            namespace {|Warning:Something.Else|}
+            {
+                internal class Foo
+                {
+                    public static int Do(Data d) => 42;
+                }
+            }
+
+            namespace Tests
+            {
+                namespace Inner
+                {
+                    public class App
+                    {
+                        static void Main()
+                        {
+                            Console.WriteLine(Foo.Do(new Data()));
+                        }
+                    }
+
+                    public class Data { }
+                }
+            }
+            """,
+            targetNamespace: "Something.Else",
+            expectedSymbolChanges: new Dictionary<string, string>()
+            {
+                { "Tests.Foo", "Something.Else.Foo" }
             });
 }

--- a/src/EditorFeatures/CSharpTest/MoveToNamespace/MoveToNamespaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/MoveToNamespace/MoveToNamespaceTests.cs
@@ -1564,7 +1564,7 @@ public sealed class MoveToNamespaceTests : AbstractMoveToNamespaceTests
 
             namespace Tests
             {
-                internal class Foo[||]
+                internal class Goo[||]
                 {
                     public static int Do(Inner.Data d) => 42;
                 }
@@ -1578,7 +1578,7 @@ public sealed class MoveToNamespaceTests : AbstractMoveToNamespaceTests
                     {
                         static void Main()
                         {
-                            Console.WriteLine(Foo.Do(new Data()));
+                            Console.WriteLine(Goo.Do(new Data()));
                         }
                     }
 
@@ -1593,7 +1593,7 @@ public sealed class MoveToNamespaceTests : AbstractMoveToNamespaceTests
 
             namespace {|Warning:Something.Else|}
             {
-                internal class Foo
+                internal class Goo
                 {
                     public static int Do(Data d) => 42;
                 }
@@ -1607,7 +1607,7 @@ public sealed class MoveToNamespaceTests : AbstractMoveToNamespaceTests
                     {
                         static void Main()
                         {
-                            Console.WriteLine(Foo.Do(new Data()));
+                            Console.WriteLine(Goo.Do(new Data()));
                         }
                     }
 
@@ -1618,6 +1618,6 @@ public sealed class MoveToNamespaceTests : AbstractMoveToNamespaceTests
             targetNamespace: "Something.Else",
             expectedSymbolChanges: new Dictionary<string, string>()
             {
-                { "Tests.Foo", "Something.Else.Foo" }
+                { "Tests.Goo", "Something.Else.Goo" }
             });
 }

--- a/src/Features/CSharp/Portable/CodeRefactorings/SyncNamespace/CSharpChangeNamespaceService.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/SyncNamespace/CSharpChangeNamespaceService.cs
@@ -87,6 +87,9 @@ internal sealed class CSharpChangeNamespaceService() :
         throw ExceptionUtilities.Unreachable();
     }
 
+    protected override SimpleNameSyntax? GetRightmostName(NameSyntax name)
+        => name.GetRightmostName();
+
     protected override SyntaxList<MemberDeclarationSyntax> GetMemberDeclarationsInContainer(SyntaxNode container)
     {
         if (container is BaseNamespaceDeclarationSyntax namespaceDecl)

--- a/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
@@ -493,15 +493,19 @@ internal abstract partial class AbstractChangeNamespaceService<
             : root.ReplaceNodes(replacements.Keys, (original, _) => replacements[original]);
     }
 
-    private static async Task<ImmutableArray<string>> GetChildNamespaceImportsAsync(
-        Document document,
+    /// <summary>
+    /// Enumerates the distinct "highest" name nodes within <paramref name="container"/> whose bound symbol lives in a
+    /// namespace strictly nested under <paramref name="oldNamespaceSymbol"/> (the namespace the declaration is moving
+    /// out of). These are the references that may need an import and/or simplification once the declaration moves,
+    /// since a name that used to bind through the old namespace can become over- or under-qualified afterwards.
+    /// </summary>
+    private static IEnumerable<(SyntaxNode highestName, ISymbol symbol, INamespaceSymbol containingNamespace)> EnumerateChildNamespaceReferences(
+        SemanticModel semanticModel,
         SyntaxNode container,
         INamespaceSymbol oldNamespaceSymbol,
         CancellationToken cancellationToken)
     {
-        var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-        using var _1 = PooledHashSet<SyntaxNode>.GetInstance(out var processedNames);
-        using var _2 = PooledHashSet<string>.GetInstance(out var imports);
+        using var _ = PooledHashSet<SyntaxNode>.GetInstance(out var processedNames);
 
         foreach (var node in container.DescendantNodes())
         {
@@ -514,8 +518,7 @@ internal abstract partial class AbstractChangeNamespaceService<
 
             var nameForBinding = highestName as TNameSyntax ?? nameSyntax;
             var symbolInfo = semanticModel.GetSymbolInfo(nameForBinding, cancellationToken);
-            var symbol = symbolInfo.Symbol
-                ?? symbolInfo.CandidateSymbols.FirstOrDefault()
+            var symbol = symbolInfo.GetAnySymbol()
                 ?? semanticModel.GetTypeInfo(nameForBinding, cancellationToken).Type;
             if (symbol?.ContainingNamespace is not { IsGlobalNamespace: false } containingNamespace ||
                 !IsTransitivelyContainedWithin(containingNamespace, oldNamespaceSymbol))
@@ -523,6 +526,22 @@ internal abstract partial class AbstractChangeNamespaceService<
                 continue;
             }
 
+            yield return (highestName, symbol, containingNamespace);
+        }
+    }
+
+    private static async Task<ImmutableArray<string>> GetChildNamespaceImportsAsync(
+        Document document,
+        SyntaxNode container,
+        INamespaceSymbol oldNamespaceSymbol,
+        CancellationToken cancellationToken)
+    {
+        var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        using var _ = PooledHashSet<string>.GetInstance(out var imports);
+
+        foreach (var (_, _, containingNamespace) in EnumerateChildNamespaceReferences(
+            semanticModel, container, oldNamespaceSymbol, cancellationToken))
+        {
             imports.Add(containingNamespace.ToDisplayString());
         }
 
@@ -820,29 +839,11 @@ internal abstract partial class AbstractChangeNamespaceService<
         if (container is not null && oldNamespaceSymbol is not null)
         {
             var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            using var _1 = PooledHashSet<SyntaxNode>.GetInstance(out var processedNames);
-            using var _2 = PooledDictionary<SyntaxNode, SyntaxNode>.GetInstance(out var replacements);
+            using var _1 = PooledDictionary<SyntaxNode, SyntaxNode>.GetInstance(out var replacements);
 
-            foreach (var node in container.DescendantNodes())
+            foreach (var (highestName, symbol, _) in EnumerateChildNamespaceReferences(
+                semanticModel, container, oldNamespaceSymbol, cancellationToken))
             {
-                if (node is not TNameSyntax nameSyntax)
-                    continue;
-
-                var highestName = GetHighestNameOrCref(nameSyntax);
-                if (!processedNames.Add(highestName))
-                    continue;
-
-                var nameForBinding = highestName as TNameSyntax ?? nameSyntax;
-                var symbolInfo = semanticModel.GetSymbolInfo(nameForBinding, cancellationToken);
-                var symbol = symbolInfo.Symbol
-                    ?? symbolInfo.CandidateSymbols.FirstOrDefault()
-                    ?? semanticModel.GetTypeInfo(nameForBinding, cancellationToken).Type;
-                if (symbol?.ContainingNamespace is not { IsGlobalNamespace: false } containingNamespace ||
-                    !IsTransitivelyContainedWithin(containingNamespace, oldNamespaceSymbol))
-                {
-                    continue;
-                }
-
                 if (highestName is TNameSyntax highestNameSyntax)
                 {
                     var rightmostSimpleName = GetRightmostName(highestNameSyntax);

--- a/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
@@ -399,6 +399,133 @@ internal abstract partial class AbstractChangeNamespaceService<
         return builder.ToImmutableAndFree();
     }
 
+    private static INamespaceSymbol? GetNamespaceSymbol(Compilation compilation, string? @namespace)
+    {
+        if (string.IsNullOrEmpty(@namespace))
+            return null;
+
+        var current = compilation.GlobalNamespace;
+        foreach (var part in GetNamespaceParts(@namespace))
+        {
+            current = current.GetNamespaceMembers().FirstOrDefault(member => member.Name == part);
+            if (current is null)
+                return null;
+        }
+
+        return current;
+    }
+
+    private static bool IsStrictChildNamespace(INamespaceSymbol namespaceSymbol, INamespaceSymbol oldNamespaceSymbol)
+    {
+        for (var current = namespaceSymbol.ContainingNamespace; !current.IsGlobalNamespace; current = current.ContainingNamespace)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current, oldNamespaceSymbol))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static SyntaxNode GetHighestNameOrCref(TNameSyntax name)
+    {
+        while (name.Parent is TNameSyntax parentName)
+            name = parentName;
+
+        return name.Parent is TCrefSyntax ? name.Parent : name;
+    }
+
+    private static TSimpleNameSyntax? GetRightmostSimpleName(TNameSyntax name)
+        => name.DescendantNodesAndSelf().OfType<TSimpleNameSyntax>().LastOrDefault();
+
+    private static SyntaxNode SimplifyChildNamespaceQualifiedNames(
+        SyntaxNode root,
+        ISyntaxFactsService syntaxFacts,
+        ImmutableArray<ImmutableArray<string>> relativeChildNamespaceParts)
+    {
+        if (relativeChildNamespaceParts.Length == 0)
+            return root;
+
+        using var _1 = PooledHashSet<SyntaxNode>.GetInstance(out var processedNames);
+        using var _2 = PooledDictionary<SyntaxNode, SyntaxNode>.GetInstance(out var replacements);
+
+        foreach (var node in root.DescendantNodes())
+        {
+            if (node is not TNameSyntax nameSyntax)
+                continue;
+
+            if (nameSyntax.Parent is TNameSyntax)
+                continue;
+
+            if (!processedNames.Add(nameSyntax))
+                continue;
+
+            var simpleNames = nameSyntax.DescendantNodesAndSelf().OfType<TSimpleNameSyntax>().ToImmutableArray();
+            foreach (var relativeChildNamespace in relativeChildNamespaceParts)
+            {
+                if (simpleNames.Length <= relativeChildNamespace.Length)
+                    continue;
+
+                var prefixMatches = true;
+                for (var i = 0; i < relativeChildNamespace.Length; i++)
+                {
+                    if (syntaxFacts.GetIdentifierOfSimpleName(simpleNames[i]).ValueText != relativeChildNamespace[i])
+                    {
+                        prefixMatches = false;
+                        break;
+                    }
+                }
+
+                if (!prefixMatches)
+                    continue;
+
+                replacements[nameSyntax] = simpleNames[^1]
+                    .WithTriviaFrom(nameSyntax)
+                    .WithAdditionalAnnotations(Simplifier.Annotation);
+                break;
+            }
+        }
+
+        return replacements.Count == 0
+            ? root
+            : root.ReplaceNodes(replacements.Keys, (original, _) => replacements[original]);
+    }
+
+    private static async Task<ImmutableArray<string>> GetChildNamespaceImportsAsync(
+        Document document,
+        SyntaxNode container,
+        INamespaceSymbol oldNamespaceSymbol,
+        CancellationToken cancellationToken)
+    {
+        var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        using var _1 = PooledHashSet<SyntaxNode>.GetInstance(out var processedNames);
+        using var _2 = PooledHashSet<string>.GetInstance(out var imports);
+
+        foreach (var node in container.DescendantNodes())
+        {
+            if (node is not TNameSyntax nameSyntax)
+                continue;
+
+            var highestName = GetHighestNameOrCref(nameSyntax);
+            if (!processedNames.Add(highestName))
+                continue;
+
+            var nameForBinding = highestName as TNameSyntax ?? nameSyntax;
+            var symbolInfo = semanticModel.GetSymbolInfo(nameForBinding, cancellationToken);
+            var symbol = symbolInfo.Symbol
+                ?? symbolInfo.CandidateSymbols.FirstOrDefault()
+                ?? semanticModel.GetTypeInfo(nameForBinding, cancellationToken).Type;
+            if (symbol?.ContainingNamespace is not { IsGlobalNamespace: false } containingNamespace ||
+                !IsStrictChildNamespace(containingNamespace, oldNamespaceSymbol))
+            {
+                continue;
+            }
+
+            imports.Add(containingNamespace.ToDisplayString());
+        }
+
+        return [.. imports];
+    }
+
     private static ImmutableArray<SyntaxNode> CreateImports(Document document, ImmutableArray<string> names, bool withFormatterAnnotation)
     {
         var generator = SyntaxGenerator.GetGenerator(document);
@@ -581,6 +708,20 @@ internal abstract partial class AbstractChangeNamespaceService<
         var oldNamespaceParts = GetNamespaceParts(oldNamespace);
         var newNamespaceParts = GetNamespaceParts(newNamespace);
 
+        var compilation = await document.Project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
+        var oldNamespaceSymbol = GetNamespaceSymbol(compilation, oldNamespace);
+        var rootBeforeImports = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        var containerBeforeImports = rootBeforeImports.GetAnnotatedNodes(ContainerAnnotation).Single();
+        var childNamespaceImports = oldNamespaceSymbol is null
+            ? []
+            : await GetChildNamespaceImportsAsync(document, containerBeforeImports, oldNamespaceSymbol, cancellationToken).ConfigureAwait(false);
+        var relativeChildNamespaceParts = childNamespaceImports
+            .Select(importName => GetNamespaceParts(importName))
+            .Where(parts => parts.Length > oldNamespaceParts.Length && parts.Take(oldNamespaceParts.Length).SequenceEqual(oldNamespaceParts))
+            .Select(parts => parts.Skip(oldNamespaceParts.Length).ToImmutableArray())
+            .Where(parts => parts.Length > 0)
+            .ToImmutableArray();
+
         if (refLocations.Count > 0)
         {
             (document, containersToAddImports) = await FixReferencesAsync(
@@ -599,7 +740,10 @@ internal abstract partial class AbstractChangeNamespaceService<
         // namespace). Include the new namespace in case there are multiple namespace declarations in the declaring
         // document. They may need a using statement added to correctly keep references to the type inside it's new
         // namespace
-        var namesToImport = GetAllNamespaceImportsForDeclaringDocument(oldNamespace, newNamespace);
+        using var _1 = PooledHashSet<string>.GetInstance(out var namesToImportBuilder);
+        namesToImportBuilder.AddRange(GetAllNamespaceImportsForDeclaringDocument(oldNamespace, newNamespace));
+        namesToImportBuilder.AddRange(childNamespaceImports);
+        var namesToImport = namesToImportBuilder.ToImmutableArray();
 
         var documentOptions = await document.GetCodeCleanupOptionsAsync(cancellationToken).ConfigureAwait(false);
 
@@ -612,6 +756,19 @@ internal abstract partial class AbstractChangeNamespaceService<
             cancellationToken).ConfigureAwait(false);
 
         var root = await documentWithAddedImports.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        var containerAfterImports = root.GetAnnotatedNodes(ContainerAnnotation).Single();
+        var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
+
+        root = await AddSimplifierAnnotationToPotentialReferencesAsync(
+            documentWithAddedImports,
+            root,
+            syntaxFacts,
+            containerAfterImports,
+            oldNamespaceSymbol,
+            allNamespaceNameParts: null,
+            cancellationToken).ConfigureAwait(false);
+
+        documentWithAddedImports = documentWithAddedImports.WithSyntaxRoot(root);
 
         root = ChangeNamespaceDeclaration((TCompilationUnitSyntax)root, oldNamespaceParts, newNamespaceParts);
 
@@ -623,29 +780,99 @@ internal abstract partial class AbstractChangeNamespaceService<
         // Need to invoke formatter explicitly since we are doing the diff merge ourselves.
         var services = documentWithAddedImports.Project.Solution.Services;
         root = Formatter.Format(root, Formatter.Annotation, services, documentOptions.FormattingOptions, cancellationToken);
+        root = SimplifyChildNamespaceQualifiedNames(root, syntaxFacts, relativeChildNamespaceParts);
 
         using var _ = PooledHashSet<string>.GetInstance(out var allNamespaceNameParts);
         allNamespaceNameParts.AddRange(oldNamespaceParts);
         allNamespaceNameParts.AddRange(newNamespaceParts);
+        foreach (var childNamespaceImport in childNamespaceImports)
+        {
+            allNamespaceNameParts.AddRange(GetNamespaceParts(childNamespaceImport));
+        }
 
-        var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
-        root = AddSimplifierAnnotationToPotentialReferences(syntaxFacts, root, allNamespaceNameParts);
+        root = await AddSimplifierAnnotationToPotentialReferencesAsync(
+            documentWithAddedImports,
+            root,
+            syntaxFacts,
+            container: null,
+            oldNamespaceSymbol: null,
+            allNamespaceNameParts,
+            cancellationToken).ConfigureAwait(false);
 
         var formattedDocument = documentWithAddedImports.WithSyntaxRoot(root);
+        formattedDocument = await ImportAdder.AddImportsFromSymbolAnnotationAsync(
+            formattedDocument, documentOptions.AddImportOptions, cancellationToken).ConfigureAwait(false);
         return await SimplifyTypeNamesAsync(formattedDocument, documentOptions, cancellationToken).ConfigureAwait(false);
     }
 
-    private static SyntaxNode AddSimplifierAnnotationToPotentialReferences(
-        ISyntaxFactsService syntaxFacts, SyntaxNode root, HashSet<string> allNamespaceNameParts)
+    private static async Task<SyntaxNode> AddSimplifierAnnotationToPotentialReferencesAsync(
+        Document document,
+        SyntaxNode root,
+        ISyntaxFactsService syntaxFacts,
+        SyntaxNode? container,
+        INamespaceSymbol? oldNamespaceSymbol,
+        HashSet<string>? allNamespaceNameParts,
+        CancellationToken cancellationToken)
     {
+        if (container is not null && oldNamespaceSymbol is not null)
+        {
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            using var _1 = PooledHashSet<SyntaxNode>.GetInstance(out var processedNames);
+            using var _2 = PooledDictionary<SyntaxNode, SyntaxNode>.GetInstance(out var replacements);
+
+            foreach (var node in container.DescendantNodes())
+            {
+                if (node is not TNameSyntax nameSyntax)
+                    continue;
+
+                var highestName = GetHighestNameOrCref(nameSyntax);
+                if (!processedNames.Add(highestName))
+                    continue;
+
+                var nameForBinding = highestName as TNameSyntax ?? nameSyntax;
+                var symbolInfo = semanticModel.GetSymbolInfo(nameForBinding, cancellationToken);
+                var symbol = symbolInfo.Symbol
+                    ?? symbolInfo.CandidateSymbols.FirstOrDefault()
+                    ?? semanticModel.GetTypeInfo(nameForBinding, cancellationToken).Type;
+                if (symbol?.ContainingNamespace is not { IsGlobalNamespace: false } containingNamespace ||
+                    !IsStrictChildNamespace(containingNamespace, oldNamespaceSymbol))
+                {
+                    continue;
+                }
+
+                if (highestName is TNameSyntax highestNameSyntax)
+                {
+                    var rightmostSimpleName = GetRightmostSimpleName(highestNameSyntax);
+                    if (rightmostSimpleName is not null && !ReferenceEquals(rightmostSimpleName, highestNameSyntax))
+                    {
+                        replacements[highestName] = rightmostSimpleName
+                            .WithTriviaFrom(highestName)
+                            .WithAdditionalAnnotations(Simplifier.Annotation);
+                        continue;
+                    }
+                }
+
+                var expanded = await Simplifier.ExpandAsync(
+                    highestName, document, cancellationToken: cancellationToken).ConfigureAwait(false);
+                replacements[highestName] = expanded.WithAdditionalAnnotations(
+                    Simplifier.Annotation,
+                    Simplifier.AddImportsAnnotation,
+                    SymbolAnnotation.Create(symbol));
+            }
+
+            if (replacements.Count > 0)
+            {
+                root = root.ReplaceNodes(
+                    replacements.Keys,
+                    (original, _) => replacements[original]);
+            }
+        }
+
+        if (allNamespaceNameParts is null)
+            return root;
+
         // Find all identifiers in this tree that use at least one of the namespace names of either the old or new
         // namespace.  Mark those as needing potential complexification/simplification to preserve meaning.
-        //
-        // Note: we could go further here and actually bind these nodes to make sure they are actually references
-        // to one of the namespaces in question.  But that doesn't seem super necessary as the chance that these names
-        // are actually to something else *and* they would reduce without issue seems very low.  This can be revisited
-        // if we get feedback on this.
-
         using var _ = PooledHashSet<SyntaxNode>.GetInstance(out var namesToUpdate);
         foreach (var descendent in root.DescendantNodes(descendIntoTrivia: true))
         {
@@ -659,14 +886,6 @@ internal abstract partial class AbstractChangeNamespaceService<
         return root.ReplaceNodes(
             namesToUpdate,
             (_, current) => current.WithAdditionalAnnotations(Simplifier.Annotation));
-
-        static SyntaxNode GetHighestNameOrCref(TNameSyntax name)
-        {
-            while (name.Parent is TNameSyntax parentName)
-                name = parentName;
-
-            return name.Parent is TCrefSyntax ? name.Parent : name;
-        }
     }
 
     private static async Task<Document> FixReferencingDocumentAsync(

--- a/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
@@ -95,6 +95,8 @@ internal abstract partial class AbstractChangeNamespaceService<
 
     protected abstract string GetDeclaredNamespace(SyntaxNode container);
 
+    protected abstract TSimpleNameSyntax? GetRightmostName(TNameSyntax name);
+
     /// <summary>
     /// Decide if we can change the namespace for provided <paramref name="container"/> based on the criteria listed for 
     /// <see cref="IChangeNamespaceService.CanChangeNamespaceAsync(Document, SyntaxNode, CancellationToken)"/>
@@ -399,7 +401,7 @@ internal abstract partial class AbstractChangeNamespaceService<
         return builder.ToImmutableAndFree();
     }
 
-    private static INamespaceSymbol? GetNamespaceSymbol(Compilation compilation, string? @namespace)
+    private static INamespaceSymbol? TryGetNamespaceSymbol(Compilation compilation, string? @namespace)
     {
         if (string.IsNullOrEmpty(@namespace))
             return null;
@@ -415,11 +417,11 @@ internal abstract partial class AbstractChangeNamespaceService<
         return current;
     }
 
-    private static bool IsStrictChildNamespace(INamespaceSymbol namespaceSymbol, INamespaceSymbol oldNamespaceSymbol)
+    private static bool IsTransitivelyContainedWithin(INamespaceSymbol namespaceSymbol, INamespaceSymbol containingNamespaceSymbol)
     {
         for (var current = namespaceSymbol.ContainingNamespace; !current.IsGlobalNamespace; current = current.ContainingNamespace)
         {
-            if (SymbolEqualityComparer.Default.Equals(current, oldNamespaceSymbol))
+            if (SymbolEqualityComparer.Default.Equals(current, containingNamespaceSymbol))
                 return true;
         }
 
@@ -434,9 +436,6 @@ internal abstract partial class AbstractChangeNamespaceService<
         return name.Parent is TCrefSyntax ? name.Parent : name;
     }
 
-    private static TSimpleNameSyntax? GetRightmostSimpleName(TNameSyntax name)
-        => name.DescendantNodesAndSelf().OfType<TSimpleNameSyntax>().LastOrDefault();
-
     private static SyntaxNode SimplifyChildNamespaceQualifiedNames(
         SyntaxNode root,
         ISyntaxFactsService syntaxFacts,
@@ -445,6 +444,10 @@ internal abstract partial class AbstractChangeNamespaceService<
         if (relativeChildNamespaceParts.Length == 0)
             return root;
 
+        // After moving the declaration out of its original namespace, a reference that used to bind through the
+        // declaration's namespace can become over-qualified. For example, `Inner.Data` in namespace `Tests` should
+        // become `Data` once we add `using Tests.Inner;`. The simplifier will not infer that rewrite by itself here,
+        // so trim names that start with one of the imported child namespace paths and let normal simplification finish.
         using var _1 = PooledHashSet<SyntaxNode>.GetInstance(out var processedNames);
         using var _2 = PooledDictionary<SyntaxNode, SyntaxNode>.GetInstance(out var replacements);
 
@@ -515,7 +518,7 @@ internal abstract partial class AbstractChangeNamespaceService<
                 ?? symbolInfo.CandidateSymbols.FirstOrDefault()
                 ?? semanticModel.GetTypeInfo(nameForBinding, cancellationToken).Type;
             if (symbol?.ContainingNamespace is not { IsGlobalNamespace: false } containingNamespace ||
-                !IsStrictChildNamespace(containingNamespace, oldNamespaceSymbol))
+                !IsTransitivelyContainedWithin(containingNamespace, oldNamespaceSymbol))
             {
                 continue;
             }
@@ -709,7 +712,7 @@ internal abstract partial class AbstractChangeNamespaceService<
         var newNamespaceParts = GetNamespaceParts(newNamespace);
 
         var compilation = await document.Project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
-        var oldNamespaceSymbol = GetNamespaceSymbol(compilation, oldNamespace);
+        var oldNamespaceSymbol = TryGetNamespaceSymbol(compilation, oldNamespace);
         var rootBeforeImports = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
         var containerBeforeImports = rootBeforeImports.GetAnnotatedNodes(ContainerAnnotation).Single();
         var childNamespaceImports = oldNamespaceSymbol is null
@@ -805,7 +808,7 @@ internal abstract partial class AbstractChangeNamespaceService<
         return await SimplifyTypeNamesAsync(formattedDocument, documentOptions, cancellationToken).ConfigureAwait(false);
     }
 
-    private static async Task<SyntaxNode> AddSimplifierAnnotationToPotentialReferencesAsync(
+    private async Task<SyntaxNode> AddSimplifierAnnotationToPotentialReferencesAsync(
         Document document,
         SyntaxNode root,
         ISyntaxFactsService syntaxFacts,
@@ -835,14 +838,14 @@ internal abstract partial class AbstractChangeNamespaceService<
                     ?? symbolInfo.CandidateSymbols.FirstOrDefault()
                     ?? semanticModel.GetTypeInfo(nameForBinding, cancellationToken).Type;
                 if (symbol?.ContainingNamespace is not { IsGlobalNamespace: false } containingNamespace ||
-                    !IsStrictChildNamespace(containingNamespace, oldNamespaceSymbol))
+                    !IsTransitivelyContainedWithin(containingNamespace, oldNamespaceSymbol))
                 {
                     continue;
                 }
 
                 if (highestName is TNameSyntax highestNameSyntax)
                 {
-                    var rightmostSimpleName = GetRightmostSimpleName(highestNameSyntax);
+                    var rightmostSimpleName = GetRightmostName(highestNameSyntax);
                     if (rightmostSimpleName is not null && !ReferenceEquals(rightmostSimpleName, highestNameSyntax))
                     {
                         replacements[highestName] = rightmostSimpleName

--- a/src/Features/VisualBasic/Portable/CodeRefactorings/SyncNamespace/VisualBasicChangeNamespaceService.vb
+++ b/src/Features/VisualBasic/Portable/CodeRefactorings/SyncNamespace/VisualBasicChangeNamespaceService.vb
@@ -10,6 +10,7 @@ Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.LanguageService
 Imports Microsoft.CodeAnalysis.Simplification
 Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.CodeAnalysis.VisualBasic.Extensions
 Imports Microsoft.CodeAnalysis.VisualBasic.Simplification
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -89,6 +90,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ChangeNamespace
         ' This is only reachable when called from a VB service, which is not implemented yet.
         Protected Overrides Function GetDeclaredNamespace(container As SyntaxNode) As String
             Throw ExceptionUtilities.Unreachable
+        End Function
+
+        Protected Overrides Function GetRightmostName(name As NameSyntax) As SimpleNameSyntax
+            Return name.GetRightmostName()
         End Function
 
         Private Shared Function CreateNamespaceAsQualifiedName(namespaceParts As ImmutableArray(Of String), index As Integer) As NameSyntax


### PR DESCRIPTION
## Summary

Fixes Move to Namespace leaving partially qualified references broken when a moved type references a child namespace of its original namespace.

## Problem

When `Foo` in namespace `Tests` references `Inner.Data` (meaning `Tests.Inner.Data`), moving `Foo` to `Something.Else` fails to compile because `Inner` is no longer in scope.

Expected: add `using Tests.Inner;` and simplify to `Data`.

## Fix

In `FixDeclarationDocumentAsync`, scan the moving container for references whose containing namespace is a child of the old namespace and add the required imports before simplification.

## Testing

- Added `MoveToNamespace_MoveType_AddsImportForChildNamespaceReference` test for #50672
- `Microsoft.CodeAnalysis.CSharp.Features` builds cleanly

Fixes #50672
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84132)