### PR TITLE
DefaultFileChangeWatcher fixes - share/fix leaks/assert

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/AbstractLspMiscellaneousFilesWorkspaceTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/AbstractLspMiscellaneousFilesWorkspaceTests.cs
@@ -25,18 +25,42 @@ public abstract class AbstractLspMiscellaneousFilesWorkspaceTests : AbstractLang
     private readonly ILoggerFactory _loggerFactory;
     protected readonly TempRoot TempRoot;
 
+    /// <summary>
+    /// Projects created via <see cref="AddDocumentAsync"/>. These are created directly against the host project factory
+    /// (bypassing the project loader that would normally dispose them on shutdown), so the test owns their lifetime and
+    /// must remove them on teardown to release the file watches they hold.
+    /// </summary>
+    private readonly List<ProjectSystemProject> _projectsToRemoveOnDispose = [];
+
+    /// <summary>
+    /// Snapshot of the file watches active before this test ran. Used to verify that the server releases every file
+    /// watch it created once it shuts down (see <see cref="FileWatcherReleaseTracker"/>).
+    /// </summary>
+    private readonly FileWatcherReleaseTracker _fileWatcherReleaseTracker;
+
     public AbstractLspMiscellaneousFilesWorkspaceTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
     {
         _loggerProvider = new TestOutputLoggerProvider(testOutputHelper);
         _loggerFactory = new LoggerFactory([_loggerProvider]);
         TempRoot = new();
+        _fileWatcherReleaseTracker = FileWatcherReleaseTracker.Capture();
     }
 
     public void Dispose()
     {
+        // Projects created via AddDocumentAsync are created directly against the host project factory and bypass the
+        // project loader, so nothing else removes them. Remove them now (while the host workspace is still alive) to
+        // release the file watches they hold, mirroring what LoadedProject.Dispose does for loader-managed projects.
+        foreach (var project in _projectsToRemoveOnDispose)
+            project.RemoveFromWorkspace();
+
         TempRoot.Dispose();
         _loggerProvider.Dispose();
         _loggerFactory.Dispose();
+
+        // The test's server(s) are disposed by the test body (via 'await using'), which releases their file watches on
+        // shutdown. Verify that actually happened so a watch-leaking test fails here rather than leaking into a later test.
+        _fileWatcherReleaseTracker.AssertWatchesReleased();
     }
 
     protected override ValueTask<ExportProvider> CreateExportProviderAsync()
@@ -62,6 +86,9 @@ public abstract class AbstractLspMiscellaneousFilesWorkspaceTests : AbstractLang
             workspaceFactory.ProjectSystemHostInfo);
 
         project.AddSourceFile(filePath);
+
+        // The test owns this project's lifetime; track it so it is removed (releasing its file watches) on teardown.
+        _projectsToRemoveOnDispose.Add(project);
 
         return workspaceFactory.HostWorkspace.CurrentSolution.GetRequiredProject(project.Id).Documents.Single();
     }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/AbstractLanguageServerHostTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/AbstractLanguageServerHostTests.cs
@@ -23,6 +23,12 @@ public abstract class AbstractLanguageServerHostTests : IDisposable
     protected ILoggerFactory LoggerFactory { get; }
     protected TempRoot TempRoot { get; }
 
+    /// <summary>
+    /// Snapshot of the file watches active before this test ran. Used to verify that the server releases every file
+    /// watch it created once it shuts down (see <see cref="FileWatcherReleaseTracker"/>).
+    /// </summary>
+    private readonly FileWatcherReleaseTracker _fileWatcherReleaseTracker;
+
     internal static ServerConfiguration DefaultServerConfiguration => new(
         LaunchDebugger: false,
         LogConfiguration: new LogConfiguration(LogLevel.Trace),
@@ -54,6 +60,7 @@ public abstract class AbstractLanguageServerHostTests : IDisposable
     {
         LoggerFactory = new LoggerFactory([new TestOutputLoggerProvider(testOutputHelper)]);
         TempRoot = new();
+        _fileWatcherReleaseTracker = FileWatcherReleaseTracker.Capture();
     }
 
     private protected Task<TestLspServer> CreateLanguageServerAsync(
@@ -66,6 +73,10 @@ public abstract class AbstractLanguageServerHostTests : IDisposable
     public void Dispose()
     {
         TempRoot.Dispose();
+
+        // The test's server(s) are disposed by the test body (via 'await using'), which releases their file watches on
+        // shutdown. Verify that actually happened so a watch-leaking test fails here rather than leaking into a later test.
+        _fileWatcherReleaseTracker.AssertWatchesReleased();
     }
 
     protected sealed class TestLspServer : ILspClient, IAsyncDisposable

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/FileWatcherReleaseTracker.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/FileWatcherReleaseTracker.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.FileWatching;
+using Microsoft.CodeAnalysis.ProjectSystem;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests;
+
+/// <summary>
+/// Captures the file watches active in the process-wide <see cref="DefaultFileChangeWatcher"/> (shared by every
+/// server via <see cref="DelegatingFileChangeWatcher"/>) so a test can later assert that any watches created after the
+/// snapshot were released. This is used to catch tests that leak file watches by failing to dispose a server (and
+/// hence its projects) on shutdown.
+/// </summary>
+/// <remarks>
+/// Tests in this assembly run sequentially (see <c>eng/config/xunit.runner.json</c>), so the shared watcher is only
+/// mutated by one test at a time. Capturing a baseline at test construction and comparing against it on teardown means
+/// only the test that actually leaked a watch fails, rather than some arbitrary later test that happens to inspect the
+/// shared watcher. Watches are tracked by context identity rather than by directory path so the comparison is unaffected
+/// by watcher consolidation or by an earlier leaked watch happening to cover the same directory.
+/// </remarks>
+internal readonly struct FileWatcherReleaseTracker
+{
+    private readonly ImmutableHashSet<IFileChangeContext> _baselineContexts;
+
+    private FileWatcherReleaseTracker(ImmutableHashSet<IFileChangeContext> baselineContexts)
+    {
+        _baselineContexts = baselineContexts;
+    }
+
+    /// <summary>
+    /// Snapshots the file watches currently active. Capture this before creating a server so that
+    /// <see cref="AssertWatchesReleased"/> only considers watches created (and expected to be released) afterwards.
+    /// </summary>
+    public static FileWatcherReleaseTracker Capture()
+        => new(GetActiveContexts());
+
+    /// <summary>
+    /// Asserts that every file watch created since <see cref="Capture"/> has been released. Call this after all servers
+    /// created by the test have shut down (for example, from the test class's dispose method).
+    /// </summary>
+    public void AssertWatchesReleased()
+    {
+        var leakedContexts = GetActiveContexts().Except(_baselineContexts);
+        if (leakedContexts.IsEmpty)
+            return;
+
+        var watcher = DelegatingFileChangeWatcher.TestAccessor.SharedDefaultFileChangeWatcher;
+        var watchedDirectories = DefaultFileChangeWatcher.TestAccessor.GetWatchedDirectories(watcher).Select(static d => d.path);
+
+        Assert.Fail($"""
+            The language server did not release all of its file watches on shutdown ({leakedContexts.Count} file watch context(s) leaked).
+            This usually indicates the test left a server (or one of its projects) undisposed. Currently watched directories:
+            {string.Join(Environment.NewLine, watchedDirectories)}
+            """);
+    }
+
+    private static ImmutableHashSet<IFileChangeContext> GetActiveContexts()
+    {
+        var watcher = DelegatingFileChangeWatcher.TestAccessor.SharedDefaultFileChangeWatcher;
+        return [.. DefaultFileChangeWatcher.TestAccessor.GetActiveContexts(watcher)];
+    }
+}

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/DefaultFileChangeWatcher.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/DefaultFileChangeWatcher.cs
@@ -491,5 +491,31 @@ internal sealed partial class DefaultFileChangeWatcher : IFileChangeWatcher
                     AddWatchedDirectoryPaths(child);
             }
         }
+
+        /// <summary>
+        /// Returns the distinct set of <see cref="FileChangeContext"/>s that currently hold one or more file watches.
+        /// A context is referenced in the tree from when it acquires its first watch until it is disposed, so this can
+        /// be used to detect file watches that were never released (for example, when a server fails to dispose its
+        /// projects on shutdown). Tracking contexts by identity (rather than watched directory paths) keeps the result
+        /// stable even when the watcher consolidates watches or different contexts watch the same directory.
+        /// </summary>
+        public static IReadOnlyCollection<IFileChangeContext> GetActiveContexts(DefaultFileChangeWatcher watcher)
+        {
+            var contexts = new HashSet<IFileChangeContext>(ReferenceEqualityComparer.Instance);
+
+            foreach (var root in watcher._roots.Values)
+                AddActiveContexts(root);
+
+            return contexts;
+
+            void AddActiveContexts(DirectoryNode node)
+            {
+                foreach (var context in node.ActiveContexts)
+                    contexts.Add(context);
+
+                foreach (var child in node.Children.Values)
+                    AddActiveContexts(child);
+            }
+        }
     }
 }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/DelegatingFileChangeWatcher.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/DelegatingFileChangeWatcher.cs
@@ -26,6 +26,15 @@ internal sealed class DelegatingFileChangeWatcher(
     IAsynchronousOperationListenerProvider asynchronousOperationListenerProvider)
     : IFileChangeWatcher, ILspService
 {
+    /// <summary>
+    /// Share a single default file change watcher across all server instances to ensure they respect the platform limits and consolidate.
+    /// As servers are created and disposed, they will add / remove files/directories from this shared watcher.
+    /// 
+    /// On non-Windows platforms, the number of inotify handles is limited, so we'll want to be more aggressive with reducing it.
+    /// TODO: we could read the inotify limit and set this dynamically, since some newer kernels have a higher default.
+    /// </summary>
+    private static readonly Lazy<DefaultFileChangeWatcher> _defaultFileChangeWatcher = new(() => new DefaultFileChangeWatcher(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 10_000 : 50));
+
     private readonly Lazy<IFileChangeWatcher> _underlyingFileWatcher = new(() =>
         {
             if (LspFileChangeWatcher.TryCreate(lspServices, asynchronousOperationListenerProvider, out var lspFileChangeWatcher))
@@ -33,9 +42,7 @@ internal sealed class DelegatingFileChangeWatcher(
 
             loggerFactory.CreateLogger<DelegatingFileChangeWatcher>().LogWarning("We are unable to use LSP file watching; falling back to our in-process watcher.");
 
-            // On non-Windows platforms, the number of inotify handles is limited, so we'll want to be more aggressive with reducing it.
-            // TODO: we could read the inotify limit and set this dynamically, since some newer kernels have a higher default.
-            return new DefaultFileChangeWatcher(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 10_000 : 50);
+            return _defaultFileChangeWatcher.Value;
         });
 
     public IFileChangeContext CreateContext(ImmutableArray<WatchedDirectory> watchedDirectories)
@@ -49,5 +56,11 @@ internal sealed class DelegatingFileChangeWatcher(
     internal readonly struct TestAccessor(DelegatingFileChangeWatcher instance)
     {
         internal IFileChangeWatcher UnderlyingFileWatcher => instance._underlyingFileWatcher.Value;
+
+        /// <summary>
+        /// The single <see cref="DefaultFileChangeWatcher"/> shared by every <see cref="DelegatingFileChangeWatcher"/>
+        /// instance. Tests can inspect this to verify that servers release their file watches when they shut down.
+        /// </summary>
+        internal static DefaultFileChangeWatcher SharedDefaultFileChangeWatcher => _defaultFileChangeWatcher.Value;
     }
 }


### PR DESCRIPTION
Three changes:
1.  Share a single DefaultFileChangeWatcher so consolidation works across servers
2.  Track all file watches in LSP host tests and assert they were properly disposed at the end of every test
3.  Fix file watcher leak in lsp misc tests where a project was manually added, but never disposed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84143)