### PR TITLE
Don't assume documents being saved are documents

### DIFF
--- a/src/LanguageServer/Protocol/Handler/DocumentChanges/DidSaveHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/DocumentChanges/DidSaveHandler.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -25,7 +25,7 @@ internal class DidSaveHandler() : ILspServiceNotificationHandler<DidSaveTextDocu
 
     public async Task HandleNotificationAsync(DidSaveTextDocumentParams request, RequestContext context, CancellationToken cancellationToken)
     {
-        var document = context.GetRequiredDocument();
+        var document = context.GetRequiredTextDocument();
         var workspace = document.Project.Solution.Workspace;
         context.TraceDebug($"RefreshSourceGenerators for {document.Project.Id.DebugName}");
 

--- a/src/LanguageServer/ProtocolUnitTests/Workspaces/SourceGeneratedDocumentTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Workspaces/SourceGeneratedDocumentTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -528,6 +529,71 @@ public sealed class SourceGeneratedDocumentTests(ITestOutputHelper testOutputHel
         var didSaveParams = new LSP.DidSaveTextDocumentParams
         {
             TextDocument = new LSP.TextDocumentIdentifier { DocumentUri = documentUri },
+        };
+
+        // The didSave should now trigger generators to run in balanced mode.  In automatic mode it will also trigger but we will already have the updated text.
+        await testLspServer.ExecuteRequestAsync<LSP.DidSaveTextDocumentParams, object>(LSP.Methods.TextDocumentDidSaveName, didSaveParams, CancellationToken.None);
+        await testLspServer.WaitForSourceGeneratorsAsync();
+
+        var thirdResult = await testLspServer.GetSourceGeneratedDocumentTextAsync(sourceGeneratorDocumentUri);
+        Assert.NotNull(thirdResult);
+        Assert.Equal("// callCount: 1", thirdResult.Text);
+    }
+
+    [Theory, CombinatorialData]
+    internal async Task TestSaveAdditionalDocumentRefreshesSourceGenerators(bool mutatingLspWorkspace, SourceGeneratorExecutionPreference sourceGeneratorExecution)
+    {
+        await using var testLspServer = await CreateTestLspServerAsync(string.Empty, mutatingLspWorkspace);
+
+        var project = testLspServer.GetCurrentSolution().Projects.First();
+        var projectDirectory = Path.GetDirectoryName(project.FilePath);
+        Contract.ThrowIfNull(projectDirectory);
+        var additionalDocument = project.AddAdditionalDocument(
+            name: "additional.txt",
+            text: SourceText.From(string.Empty),
+            filePath: Path.Combine(projectDirectory, "additional.txt"));
+        Assert.True(testLspServer.TestWorkspace.TryApplyChanges(additionalDocument.Project.Solution));
+
+        additionalDocument = testLspServer.GetCurrentSolution().Projects.First().AdditionalDocuments.Single();
+        var additionalDocumentUri = additionalDocument.GetURI();
+
+        var configService = testLspServer.TestWorkspace.ExportProvider.GetExportedValue<TestWorkspaceConfigurationService>();
+        configService.Options = new WorkspaceConfigurationOptions(SourceGeneratorExecution: sourceGeneratorExecution);
+
+        var callCount = 0;
+        var generatorReference = await AddGeneratorAsync(new CallbackGenerator(() => ("hintName.cs", "// callCount: " + callCount++)), testLspServer.TestWorkspace);
+
+        var sourceGeneratedDocuments = await testLspServer.GetCurrentSolution().Projects.Single().GetSourceGeneratedDocumentsAsync();
+        var sourceGeneratedDocumentIdentity = sourceGeneratedDocuments.Single().Identity;
+        var sourceGeneratorDocumentUri = SourceGeneratedDocumentUri.Create(sourceGeneratedDocumentIdentity);
+
+        var result = await testLspServer.GetSourceGeneratedDocumentTextAsync(sourceGeneratorDocumentUri);
+
+        Assert.NotNull(result);
+        Assert.Equal("// callCount: 0", result.Text);
+
+        await testLspServer.OpenDocumentAsync(additionalDocumentUri);
+
+        // Modify the additional document in the workspace.
+        // In automatic mode this should trigger generators to re-run.
+        // In balanced mode generators should not re-run.
+        testLspServer.TestWorkspace.ChangeAdditionalDocument(additionalDocument.Id, SourceText.From("new text"));
+        await testLspServer.WaitForSourceGeneratorsAsync();
+
+        var secondResult = await testLspServer.GetSourceGeneratedDocumentTextAsync(sourceGeneratorDocumentUri);
+        Assert.NotNull(secondResult);
+        if (sourceGeneratorExecution == SourceGeneratorExecutionPreference.Automatic)
+        {
+            Assert.Equal("// callCount: 1", secondResult.Text);
+        }
+        else
+        {
+            Assert.Equal("// callCount: 0", secondResult.Text);
+        }
+
+        var didSaveParams = new LSP.DidSaveTextDocumentParams
+        {
+            TextDocument = new LSP.TextDocumentIdentifier { DocumentUri = additionalDocumentUri },
         };
 
         // The didSave should now trigger generators to run in balanced mode.  In automatic mode it will also trigger but we will already have the updated text.


### PR DESCRIPTION
Fixes this error that appears in the service hub logs every time someone saves a Razor document. All other text sync handlers already use `TextDocument`

```
06/16/2026 11:38:59 AUS Eastern Standard Time: Error : 1 :[devenv:2004] Unexpected exception: System.InvalidOperationException: Attempted to retrieve a Document but a TextDocument was found instead.
   at Microsoft.CodeAnalysis.LanguageServer.Handler.RequestContext.get_Document()
   at Microsoft.CodeAnalysis.LanguageServer.Handler.RequestContext.GetRequiredDocument()
   at Microsoft.CodeAnalysis.LanguageServer.Handler.DocumentChanges.DidSaveHandler.<HandleNotificationAsync>d__6.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.CommonLanguageServerProtocol.Framework.QueueItem`1.<StartRequestAsync>d__17`2.MoveNext()
```

The exception itself has no user impact (other than cost of throwing and logging), it's just a common occurrence in logs and copilot will often see it and think it's found some signal or smoking gun, which hampers investigations.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84146)