### PR TITLE
Don't warn about no additional files if the project is still loading

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/IncompatibleProjectService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/IncompatibleProjectService.cs
@@ -56,7 +56,7 @@ internal sealed class IncompatibleProjectService(IIncompatibleProjectNotifier in
                     // Additional documents may still be incomplete while the project is loading, so don't report or cache it yet.
                     break;
                 }
-            
+
                 if (ImmutableInterlocked.Update(ref _incompatibleProjectIds, static (set, id) => set.Add(id), project.Id))
                 {
                     _incompatibleProjectNotifier.NotifyMissingDocument(project, filePath);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/IncompatibleProjectService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/IncompatibleProjectService.cs
@@ -44,12 +44,6 @@ internal sealed class IncompatibleProjectService(IIncompatibleProjectNotifier in
         var filePathSpan = filePath.AsSpan();
         foreach (var project in context.Solution.Projects)
         {
-            if (!project.State.HasAllInformation)
-            {
-                // Additional documents may still be incomplete while the project is loading, so don't report or cache it yet.
-                break;
-            }
-            
             if (project.FilePath is null)
             {
                 continue;
@@ -57,6 +51,12 @@ internal sealed class IncompatibleProjectService(IIncompatibleProjectNotifier in
 
             if (filePathSpan.StartsWith(PathUtilities.GetDirectoryName(project.FilePath.AsSpan()), PathUtilities.OSSpecificPathComparison))
             {
+                if (!project.State.HasAllInformation)
+                {
+                    // Additional documents may still be incomplete while the project is loading, so don't report or cache it yet.
+                    break;
+                }
+            
                 if (ImmutableInterlocked.Update(ref _incompatibleProjectIds, static (set, id) => set.Add(id), project.Id))
                 {
                     _incompatibleProjectNotifier.NotifyMissingDocument(project, filePath);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/IncompatibleProjectService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/IncompatibleProjectService.cs
@@ -44,6 +44,12 @@ internal sealed class IncompatibleProjectService(IIncompatibleProjectNotifier in
         var filePathSpan = filePath.AsSpan();
         foreach (var project in context.Solution.Projects)
         {
+            if (!project.State.HasAllInformation)
+            {
+                // Additional documents may still be incomplete while the project is loading, so don't report or cache it yet.
+                break;
+            }
+            
             if (project.FilePath is null)
             {
                 continue;


### PR DESCRIPTION
Now that we have IVT to Roslyn, hopefully we can stop some false-negative logging from leading us (and copilot) down the garden path.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84147)