### PR TITLE
Reduce allocations during default razor intermediate node lowering phase

### DIFF
--- a/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/TestFiles/ParserTests/CSharpStatementTest/StaticUsing_Complete_Spaced.stree.txt
+++ b/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/TestFiles/ParserTests/CSharpStatementTest/StaticUsing_Complete_Spaced.stree.txt
@@ -7,7 +7,7 @@
                 CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
                     Transition;[@];
                 RazorDirectiveBody - [1..40)::39
-                    CSharpStatementLiteral - [1..40)::39 - [using   static   global::System.Console] - Gen<Import:   static   global::System.Console;> - SpanEditHandler;Accepts:AnyExceptNewline
+                    CSharpStatementLiteral - [1..40)::39 - [using   static   global::System.Console] - Gen<Import: static   global::System.Console;> - SpanEditHandler;Accepts:AnyExceptNewline
                         Keyword;[using];
                         Whitespace;[   ];
                         Keyword;[static];

--- a/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/ParserTests/CSharpStatementTest/StaticUsing_Complete_Spaced.stree.txt
+++ b/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/ParserTests/CSharpStatementTest/StaticUsing_Complete_Spaced.stree.txt
@@ -7,7 +7,7 @@
                 CSharpTransition - [0..1)::1 - Gen<None>
                     Transition;[@];
                 RazorDirectiveBody - [1..40)::39
-                    CSharpStatementLiteral - [1..40)::39 - [using   static   global::System.Console] - Gen<Import:   static   global::System.Console;>
+                    CSharpStatementLiteral - [1..40)::39 - [using   static   global::System.Console] - Gen<Import: static   global::System.Console;>
                         Keyword;[using];
                         Whitespace;[   ];
                         Keyword;[static];

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultRazorIntermediateNodeLoweringPhase.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultRazorIntermediateNodeLoweringPhase.cs
@@ -46,21 +46,27 @@ internal class DefaultRazorIntermediateNodeLoweringPhase : RazorEnginePhaseBase,
 
         documentNode.Options = codeDocument.CodeGenerationOptions;
 
+        // 1. Prioritize non-imported usings over imported ones.
+        // 2. Don't import usings that already exist in primary document.
+        // 3. Allow duplicate usings in primary document (C# warning).
+        using var _1 = ListPool<UsingReference>.GetPooledObject(out var usingReferences);
+
         // The import documents should be inserted logically before the main document.
         var imports = codeDocument.GetImportSyntaxTrees();
-        var importedUsings = !imports.IsEmpty
-            ? ImportDirectives(documentNode, builder, syntaxTree.Options, imports)
-            : [];
+        using var _2 = ListPool<UsingReference>.GetPooledObject(out var importedUsings);
+        if (!imports.IsEmpty)
+        {
+            ImportDirectives(documentNode, builder, syntaxTree.Options, imports, importedUsings);
+        }
 
         // Lower the main document, appending after the imported directives.
         //
         // We need to decide up front if this document is a "component" file. This will affect how
         // lowering behaves.
-        LoweringVisitor visitor;
         if (codeDocument.FileKind.IsComponentImport() &&
             syntaxTree.Options.AllowComponentFileKind)
         {
-            visitor = new ComponentImportFileKindVisitor(documentNode, builder, syntaxTree.Options)
+            var visitor = new ComponentImportFileKindVisitor(documentNode, builder, usingReferences, syntaxTree.Options)
             {
                 SourceDocument = syntaxTree.Source,
             };
@@ -70,7 +76,7 @@ internal class DefaultRazorIntermediateNodeLoweringPhase : RazorEnginePhaseBase,
         else if (codeDocument.FileKind.IsComponent() &&
             syntaxTree.Options.AllowComponentFileKind)
         {
-            visitor = new ComponentFileKindVisitor(documentNode, builder, syntaxTree.Options)
+            var visitor = new ComponentFileKindVisitor(documentNode, builder, usingReferences, syntaxTree.Options)
             {
                 SourceDocument = syntaxTree.Source,
             };
@@ -79,19 +85,13 @@ internal class DefaultRazorIntermediateNodeLoweringPhase : RazorEnginePhaseBase,
         }
         else
         {
-            visitor = new LegacyFileKindVisitor(documentNode, builder, syntaxTree.Options)
+            var visitor = new LegacyFileKindVisitor(documentNode, builder, usingReferences, syntaxTree.Options)
             {
                 SourceDocument = syntaxTree.Source,
             };
 
             visitor.Visit(syntaxTree.Root);
         }
-
-        // 1. Prioritize non-imported usings over imported ones.
-        // 2. Don't import usings that already exist in primary document.
-        // 3. Allow duplicate usings in primary document (C# warning).
-        using var _ = ListPool<UsingReference>.GetPooledObject(out var usingReferences);
-        usingReferences.AddRange(visitor.Usings);
 
         for (var j = importedUsings.Count - 1; j >= 0; j--)
         {
@@ -190,22 +190,21 @@ internal class DefaultRazorIntermediateNodeLoweringPhase : RazorEnginePhaseBase,
                 (category is System.Globalization.UnicodeCategory.TitlecaseLetter or System.Globalization.UnicodeCategory.OtherLetter));
     }
 
-    private static IReadOnlyList<UsingReference> ImportDirectives(
+    private static void ImportDirectives(
         DocumentIntermediateNode document,
         IntermediateNodeBuilder builder,
         RazorParserOptions options,
-        ImmutableArray<RazorSyntaxTree> imports)
+        ImmutableArray<RazorSyntaxTree> imports,
+        List<UsingReference> usings)
     {
         Debug.Assert(!imports.IsDefaultOrEmpty);
 
-        var importsVisitor = new ImportsVisitor(document, builder, options);
+        var importsVisitor = new ImportsVisitor(document, builder, usings, options);
         foreach (var import in imports)
         {
             importsVisitor.SourceDocument = import.Source;
             importsVisitor.Visit(import.Root);
         }
-
-        return importsVisitor.Usings;
     }
 
     private static void PostProcessImportedDirectives(DocumentIntermediateNode document)
@@ -318,15 +317,13 @@ internal class DefaultRazorIntermediateNodeLoweringPhase : RazorEnginePhaseBase,
         /// </summary>
         protected bool _insideUnresolvedAttribute;
 
-        public LoweringVisitor(DocumentIntermediateNode document, IntermediateNodeBuilder builder, RazorParserOptions options)
+        public LoweringVisitor(DocumentIntermediateNode document, IntermediateNodeBuilder builder, List<UsingReference> usings, RazorParserOptions options)
         {
             _document = document;
             _builder = builder;
-            _usings = new List<UsingReference>();
+            _usings = usings;
             _options = options;
         }
-
-        public IReadOnlyList<UsingReference> Usings => _usings;
 
         public RazorSourceDocument SourceDocument { get; set; }
 
@@ -400,7 +397,7 @@ internal class DefaultRazorIntermediateNodeLoweringPhase : RazorEnginePhaseBase,
                     });
                     break;
                 case AddImportChunkGenerator importChunkGenerator:
-                    var namespaceImport = importChunkGenerator.Namespace.Trim();
+                    var namespaceImport = importChunkGenerator.Namespace;
                     var namespaceSpan = BuildSourceSpanFromNode(node);
                     _usings.Add(new UsingReference(namespaceImport, namespaceSpan, importChunkGenerator.HasExplicitSemicolon));
                     break;
@@ -1039,8 +1036,8 @@ internal class DefaultRazorIntermediateNodeLoweringPhase : RazorEnginePhaseBase,
     private class LegacyFileKindVisitor : LoweringVisitor
     {
         private bool _insideUnresolvedElement;
-        public LegacyFileKindVisitor(DocumentIntermediateNode document, IntermediateNodeBuilder builder, RazorParserOptions options)
-            : base(document, builder, options)
+        public LegacyFileKindVisitor(DocumentIntermediateNode document, IntermediateNodeBuilder builder, List<UsingReference> usings, RazorParserOptions options)
+            : base(document, builder, usings, options)
         {
         }
 
@@ -1615,8 +1612,9 @@ internal class DefaultRazorIntermediateNodeLoweringPhase : RazorEnginePhaseBase,
         public ComponentFileKindVisitor(
             DocumentIntermediateNode document,
             IntermediateNodeBuilder builder,
+            List<UsingReference> usings,
             RazorParserOptions options)
-            : base(document, builder, options)
+            : base(document, builder, usings, options)
         {
         }
 
@@ -2102,8 +2100,9 @@ internal class DefaultRazorIntermediateNodeLoweringPhase : RazorEnginePhaseBase,
         public ComponentImportFileKindVisitor(
             DocumentIntermediateNode document,
             IntermediateNodeBuilder builder,
+            List<UsingReference> usings,
             RazorParserOptions options)
-            : base(document, builder, options)
+            : base(document, builder, usings, options)
         {
         }
 
@@ -2183,8 +2182,8 @@ internal class DefaultRazorIntermediateNodeLoweringPhase : RazorEnginePhaseBase,
 
     private class ImportsVisitor : LoweringVisitor
     {
-        public ImportsVisitor(DocumentIntermediateNode document, IntermediateNodeBuilder builder, RazorParserOptions options)
-            : base(document, new ImportBuilder(builder), options)
+        public ImportsVisitor(DocumentIntermediateNode document, IntermediateNodeBuilder builder, List<UsingReference> usings, RazorParserOptions options)
+            : base(document, new ImportBuilder(builder), usings, options)
         {
         }
 

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/AddImportChunkGenerator.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/AddImportChunkGenerator.cs
@@ -27,7 +27,7 @@ internal class AddImportChunkGenerator : SpanChunkGenerator
 
     public override string ToString()
     {
-        return "Import:" + Namespace + ";";
+        return "Import: " + Namespace + ";";
     }
 
     public override bool Equals(object obj)

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/CSharpCodeParser.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/CSharpCodeParser.cs
@@ -2630,7 +2630,7 @@ internal class CSharpCodeParser : TokenizerBackedParser<CSharpTokenizer>
             }
 
             chunkGenerator = new AddImportChunkGenerator(
-                usingContentBuilder.ToString(),
+                usingContentBuilder.ToStringTrimmed(),
                 parsedNamespaceBuilder.ToString(),
                 isStatic,
                 hasExplicitSemicolon);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorSyntaxFacts.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorSyntaxFacts.cs
@@ -184,7 +184,7 @@ internal static class RazorSyntaxFacts
         {
             if (child.GetChunkGenerator() is AddImportChunkGenerator usingStatement)
             {
-                @namespace = usingStatement.Namespace.Trim();
+                @namespace = usingStatement.Namespace;
                 return true;
             }
         }

--- a/src/Razor/src/Shared/Microsoft.AspNetCore.Razor.SharedUtilities/StringBuilderExtensions.cs
+++ b/src/Razor/src/Shared/Microsoft.AspNetCore.Razor.SharedUtilities/StringBuilderExtensions.cs
@@ -14,4 +14,26 @@ internal static class StringBuilderExtensions
             builder.Capacity = newCapacity;
         }
     }
+
+    /// <summary>
+    /// Returns the string contents of the <see cref="StringBuilder"/> with leading and trailing
+    /// whitespace removed, using a single allocation via <see cref="StringBuilder.ToString(int, int)"/>.
+    /// </summary>
+    public static string ToStringTrimmed(this StringBuilder builder)
+    {
+        var start = 0;
+        while (start < builder.Length && char.IsWhiteSpace(builder[start]))
+        {
+            start++;
+        }
+
+        var end = builder.Length - 1;
+        while (end >= start && char.IsWhiteSpace(builder[end]))
+        {
+            end--;
+        }
+
+        var length = end - start + 1;
+        return length > 0 ? builder.ToString(start, length) : string.Empty;
+    }
 }


### PR DESCRIPTION
Reduce allocations in DefaultRazorIntermediateNodeLoweringPhase.ImportDirectives

ETL trace from a customer ServiceCopyEnd scenario shows two allocation hotspots under ImportDirectives:

 - List<UsingReference>.AddWithResize — 196MB (0.4%)
 - String.TrimWhiteSpaceHelper — 154MB (0.3%)

Commit 1: Pool the usings list

LoweringVisitor previously allocated a new List<UsingReference> on each visit. The lists grow large, making the backing array resizes the dominant cost. Changed LoweringVisitor to accept a caller-provided list, allowing DefaultRazorIntermediateNodeLoweringPhase to pool and reuse lists across calls — eliminating both the list object allocations and the resize cost after warmup.

Commit 2: Eliminate Trim() string allocations

AddImportChunkGenerator.Namespace always contained leading/trailing whitespace from parser token concatenation, and every consumer was calling .Trim() on each access — allocating a new string every time. Added StringBuilder.ToStringTrimmed() extension that produces a trimmed string directly from the builder in a single allocation, and applied it at the parser construction site so the stored Namespace is already trimmed. Removed the now-redundant .Trim() calls at consumption sites.

*** Allocations being addressed ***
<img width="1767" height="761" alt="image" src="https://github.com/user-attachments/assets/7d55a3fc-d3d6-4f3b-b3d7-cacdac2d3004" />

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84154)