### PR TITLE
Fix CodeLens missing references to extension block methods

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeLens/CSharpCodeLensTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeLens/CSharpCodeLensTests.cs
@@ -446,4 +446,83 @@ public sealed class CSharpCodeLensTests : AbstractCodeLensTest
                 </Project>
             </Workspace>
             """);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84020")]
+    public Task TestExtensionBlockMethod_StaticFormCall()
+        => RunCountTest("""
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" AssemblyName="Proj1" LanguageVersion="Preview">
+                    <Document FilePath="CurrentDocument.cs"><![CDATA[
+            public static class C
+            {
+                extension(object x)
+                {
+                    {|1: void M()
+                    {
+                    }|}
+                }
+
+                static void Caller()
+                {
+                    M(new object());
+                }
+            }
+            ]]>
+                    </Document>
+                </Project>
+            </Workspace>
+            """);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84020")]
+    public Task TestExtensionBlockMethod_InstanceFormCall()
+        => RunCountTest("""
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" AssemblyName="Proj1" LanguageVersion="Preview">
+                    <Document FilePath="CurrentDocument.cs"><![CDATA[
+            public static class C
+            {
+                extension(object x)
+                {
+                    {|1: void M()
+                    {
+                    }|}
+                }
+
+                static void Caller()
+                {
+                    new object().M();
+                }
+            }
+            ]]>
+                    </Document>
+                </Project>
+            </Workspace>
+            """);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84020")]
+    public Task TestExtensionBlockMethod_MixedCalls()
+        => RunCountTest("""
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" AssemblyName="Proj1" LanguageVersion="Preview">
+                    <Document FilePath="CurrentDocument.cs"><![CDATA[
+            public static class C
+            {
+                extension(object x)
+                {
+                    {|2: void M()
+                    {
+                    }|}
+                }
+
+                static void Caller()
+                {
+                    M(new object());
+                    new object().M();
+                }
+            }
+            ]]>
+                    </Document>
+                </Project>
+            </Workspace>
+            """);
 }

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.ExtensionSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.ExtensionSymbols.vb
@@ -737,6 +737,90 @@ public static class E
         End Function
 
         <WpfTheory, CombinatorialData>
+        <WorkItem("https://github.com/dotnet/roslyn/issues/84020")>
+        Public Async Function FindReferences_ExtensionBlockMethod_UnqualifiedStaticForm(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" LanguageVersion="Preview">
+        <Document>
+public static class MyClass
+{
+    extension(object x)
+    {
+        void {|Definition:$$M|}() { }
+    }
+
+    static void M2()
+    {
+        [|M|](new object());
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData>
+        <WorkItem("https://github.com/dotnet/roslyn/issues/84020")>
+        Public Async Function FindReferences_ExtensionBlockMethod_UnqualifiedStaticForm_FromCallSite(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" LanguageVersion="Preview">
+        <Document>
+public static class MyClass
+{
+    extension(object x)
+    {
+        void {|Definition:M|}() { }
+    }
+
+    static void M2()
+    {
+        [|$$M|](new object());
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData>
+        <WorkItem("https://github.com/dotnet/roslyn/issues/84020")>
+        Public Async Function FindReferences_ExtensionBlockMethod_UnqualifiedStaticForm_WithQualifiedCall(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" LanguageVersion="Preview">
+        <Document>
+public static class MyClass
+{
+    extension(object x)
+    {
+        public void {|Definition:$$M|}() { }
+    }
+
+    static void M2()
+    {
+        [|M|](new object());
+        MyClass.[|M|](new object());
+    }
+}
+
+class Other
+{
+    void Test()
+    {
+        new object().[|M|]();
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData>
         Public Async Function FindReferences_ExtensionBlockMethod_GenericCref(kind As TestKind, host As TestHost) As Task
             Dim input =
 <Workspace>

--- a/src/Features/Core/Portable/CodeLens/CodeLensFindReferenceProgress.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensFindReferenceProgress.cs
@@ -120,6 +120,15 @@ internal sealed class CodeLensFindReferencesProgress(
         // Invocations to implicit parameterless constructors need to be included too.
         var isConstructorInvocation = _queriedSymbol.Kind == SymbolKind.NamedType &&
                                       (definition as IMethodSymbol)?.MethodKind == MethodKind.Constructor;
+
+        // Extension block methods have an implicitly declared implementation method generated on the containing
+        // type. When the method is called in static form, the call resolves to the
+        // implementation method. We should still count these references for CodeLens on the extension member.
+        var isExtensionImplementationMethod = definition is IMethodSymbol method &&
+                                              method.TryGetCorrespondingExtensionBlockMethod() != null;
+        if (isExtensionImplementationMethod)
+            return !reference.Location.IsInSource;
+
         return (isImplicitlyDeclared && !isConstructorInvocation) ||
                !reference.Location.IsInSource ||
                !definition.Locations.Any(static loc => loc.IsInSource);


### PR DESCRIPTION
Fixes #84020

CodeLens shows no references for extension block methods called in static form. FAR correctly cascades between extension members and their implementation methods, but `CodeLensFindReferenceProgress.FilterReference()` filters out the results.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84157)