### PR TITLE
Fix Razor source generator crash on misplaced preprocessor directive in disabled text

### DIFF
--- a/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentPreprocessorDirectiveTest/MisplacedEndingDirective_01/TestComponent.diagnostics.txt
+++ b/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentPreprocessorDirectiveTest/MisplacedEndingDirective_01/TestComponent.diagnostics.txt
@@ -1,2 +1,2 @@
 ﻿x:\dir\subdir\Test\TestComponent.razor(1,2): Error RZ1006: The code block is missing a closing "}" character.  Make sure you have a matching "}" character for all the "{" characters within this block, and that none of the "}" characters are being interpreted as markup.
-(4,4): Warning RZ1044: Possible C# preprocessor directive is misplaced. C# preprocessor directives must be at the start of the line, except for whitespace.
+x:\dir\subdir\Test\TestComponent.razor(4,4): Warning RZ1044: Possible C# preprocessor directive is misplaced. C# preprocessor directives must be at the start of the line, except for whitespace.

--- a/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentPreprocessorDirectiveTest/MisplacedEndingDirective_02/TestComponent.diagnostics.txt
+++ b/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentPreprocessorDirectiveTest/MisplacedEndingDirective_02/TestComponent.diagnostics.txt
@@ -1,2 +1,2 @@
 ﻿x:\dir\subdir\Test\TestComponent.razor(1,2): Error RZ1006: The code block is missing a closing "}" character.  Make sure you have a matching "}" character for all the "{" characters within this block, and that none of the "}" characters are being interpreted as markup.
-(4,9): Warning RZ1044: Possible C# preprocessor directive is misplaced. C# preprocessor directives must be at the start of the line, except for whitespace.
+x:\dir\subdir\Test\TestComponent.razor(4,9): Warning RZ1044: Possible C# preprocessor directive is misplaced. C# preprocessor directives must be at the start of the line, except for whitespace.

--- a/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentPreprocessorDirectiveTest/MisplacedEndingDirective_03/TestComponent.diagnostics.txt
+++ b/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentPreprocessorDirectiveTest/MisplacedEndingDirective_03/TestComponent.diagnostics.txt
@@ -1,2 +1,2 @@
 ﻿x:\dir\subdir\Test\TestComponent.razor(1,2): Error RZ1006: The code block is missing a closing "}" character.  Make sure you have a matching "}" character for all the "{" characters within this block, and that none of the "}" characters are being interpreted as markup.
-(5,12): Warning RZ1044: Possible C# preprocessor directive is misplaced. C# preprocessor directives must be at the start of the line, except for whitespace.
+x:\dir\subdir\Test\TestComponent.razor(5,12): Warning RZ1044: Possible C# preprocessor directive is misplaced. C# preprocessor directives must be at the start of the line, except for whitespace.

--- a/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentPreprocessorDirectiveTest/MisplacedEndingDirective_04/TestComponent.diagnostics.txt
+++ b/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentPreprocessorDirectiveTest/MisplacedEndingDirective_04/TestComponent.diagnostics.txt
@@ -1,2 +1,2 @@
 ﻿x:\dir\subdir\Test\TestComponent.razor(1,2): Error RZ1006: The code block is missing a closing "}" character.  Make sure you have a matching "}" character for all the "{" characters within this block, and that none of the "}" characters are being interpreted as markup.
-(5,12): Warning RZ1044: Possible C# preprocessor directive is misplaced. C# preprocessor directives must be at the start of the line, except for whitespace.
+x:\dir\subdir\Test\TestComponent.razor(5,12): Warning RZ1044: Possible C# preprocessor directive is misplaced. C# preprocessor directives must be at the start of the line, except for whitespace.

--- a/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentPreprocessorDirectiveTest/MisplacedEndingDirective_05/TestComponent.diagnostics.txt
+++ b/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentPreprocessorDirectiveTest/MisplacedEndingDirective_05/TestComponent.diagnostics.txt
@@ -1,2 +1,2 @@
 ﻿x:\dir\subdir\Test\TestComponent.razor(1,2): Error RZ1006: The code block is missing a closing "}" character.  Make sure you have a matching "}" character for all the "{" characters within this block, and that none of the "}" characters are being interpreted as markup.
-(5,6): Warning RZ1044: Possible C# preprocessor directive is misplaced. C# preprocessor directives must be at the start of the line, except for whitespace.
+x:\dir\subdir\Test\TestComponent.razor(5,6): Warning RZ1044: Possible C# preprocessor directive is misplaced. C# preprocessor directives must be at the start of the line, except for whitespace.

--- a/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentPreprocessorDirectiveTest/MisplacedEndingDirective_06/TestComponent.diagnostics.txt
+++ b/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentPreprocessorDirectiveTest/MisplacedEndingDirective_06/TestComponent.diagnostics.txt
@@ -1,1 +1,1 @@
-﻿(4,4): Warning RZ1044: Possible C# preprocessor directive is misplaced. C# preprocessor directives must be at the start of the line, except for whitespace.
+﻿x:\dir\subdir\Test\TestComponent.razor(4,4): Warning RZ1044: Possible C# preprocessor directive is misplaced. C# preprocessor directives must be at the start of the line, except for whitespace.

--- a/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentPreprocessorDirectiveTest/MisplacedEndingDirective_07/TestComponent.diagnostics.txt
+++ b/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentPreprocessorDirectiveTest/MisplacedEndingDirective_07/TestComponent.diagnostics.txt
@@ -1,1 +1,1 @@
-﻿(4,9): Warning RZ1044: Possible C# preprocessor directive is misplaced. C# preprocessor directives must be at the start of the line, except for whitespace.
+﻿x:\dir\subdir\Test\TestComponent.razor(4,9): Warning RZ1044: Possible C# preprocessor directive is misplaced. C# preprocessor directives must be at the start of the line, except for whitespace.

--- a/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentPreprocessorDirectiveTest/MisplacedEndingDirective_08/TestComponent.diagnostics.txt
+++ b/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentPreprocessorDirectiveTest/MisplacedEndingDirective_08/TestComponent.diagnostics.txt
@@ -1,1 +1,1 @@
-﻿(5,12): Warning RZ1044: Possible C# preprocessor directive is misplaced. C# preprocessor directives must be at the start of the line, except for whitespace.
+﻿x:\dir\subdir\Test\TestComponent.razor(5,12): Warning RZ1044: Possible C# preprocessor directive is misplaced. C# preprocessor directives must be at the start of the line, except for whitespace.

--- a/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentPreprocessorDirectiveTest/MisplacedEndingDirective_09/TestComponent.diagnostics.txt
+++ b/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentPreprocessorDirectiveTest/MisplacedEndingDirective_09/TestComponent.diagnostics.txt
@@ -1,1 +1,1 @@
-﻿(5,12): Warning RZ1044: Possible C# preprocessor directive is misplaced. C# preprocessor directives must be at the start of the line, except for whitespace.
+﻿x:\dir\subdir\Test\TestComponent.razor(5,12): Warning RZ1044: Possible C# preprocessor directive is misplaced. C# preprocessor directives must be at the start of the line, except for whitespace.

--- a/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentPreprocessorDirectiveTest/MisplacedEndingDirective_10/TestComponent.diagnostics.txt
+++ b/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentPreprocessorDirectiveTest/MisplacedEndingDirective_10/TestComponent.diagnostics.txt
@@ -1,1 +1,1 @@
-﻿(5,6): Warning RZ1044: Possible C# preprocessor directive is misplaced. C# preprocessor directives must be at the start of the line, except for whitespace.
+﻿x:\dir\subdir\Test\TestComponent.razor(5,6): Warning RZ1044: Possible C# preprocessor directive is misplaced. C# preprocessor directives must be at the start of the line, except for whitespace.

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/RoslynCSharpTokenizer.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/RoslynCSharpTokenizer.cs
@@ -588,6 +588,7 @@ internal sealed class RoslynCSharpTokenizer : CSharpTokenizer
                                     CurrentErrors.Add(
                                         RazorDiagnosticFactory.CreateParsing_PossibleMisplacedPreprocessorDirective(
                                             new SourceSpan(
+                                                filePath: CurrentStart.FilePath,
                                                 absoluteIndex: start,
                                                 lineIndex: linePosition.Line,
                                                 characterIndex: linePosition.Character,
@@ -601,6 +602,7 @@ internal sealed class RoslynCSharpTokenizer : CSharpTokenizer
                                     CurrentErrors.Add(
                                         RazorDiagnosticFactory.CreateParsing_PossibleMisplacedPreprocessorDirective(
                                             new SourceSpan(
+                                                filePath: CurrentStart.FilePath,
                                                 absoluteIndex: start,
                                                 lineIndex: linePosition.Line,
                                                 characterIndex: linePosition.Character,

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/Diagnostics/RazorDiagnostics.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/Diagnostics/RazorDiagnostics.cs
@@ -107,9 +107,9 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             var span = razorDiagnostic.Span;
 
             Location location;
-            if (span == SourceSpan.Undefined)
+            if (span == SourceSpan.Undefined || span.FilePath is null)
             {
-                // TextSpan.Empty
+                // Location.Create requires a non-null file path; fall back to Location.None when the span lacks one.
                 location = Location.None;
             }
             else

--- a/src/Razor/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.UnitTests/RazorSourceGeneratorTests.cs
+++ b/src/Razor/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.UnitTests/RazorSourceGeneratorTests.cs
@@ -3191,5 +3191,35 @@ namespace MyApp
             // TagHelpersFromCompilation re-runs when compilation changes but output is unchanged
             mainRun.VerifyIncrementalSteps("TagHelpersFromCompilation", IncrementalStepRunReason.Unchanged);
         }
+
+        [Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/3016708")]
+        public async Task SourceGenerator_MisplacedPreprocessorDirectiveInDisabledText_DoesNotCrash()
+        {
+            // A misplaced '#endif' inside a false '#if' block's disabled text reports RZ1044. The
+            // diagnostic must carry a file path so the source generator can map it to a Location.
+            var parseOptions = CSharpParseOptions.Default.WithFeatures([new("use-roslyn-tokenizer", "true")]);
+
+            var project = CreateTestProject(new()
+            {
+                ["Pages/Index.razor"] = """
+                    @code {
+                    #if DEBUG
+                    x #endif
+                    #endif
+                    }
+                    """,
+            }, cSharpParseOptions: parseOptions);
+
+            var compilation = await project.GetCompilationAsync();
+            var driver = await GetDriverAsync(project);
+
+            var result = RunGenerator(compilation!, ref driver);
+
+            var diagnostic = Assert.Single(result.Diagnostics);
+            Assert.Equal("RZ1044", diagnostic.Id);
+            Assert.NotEqual(Location.None, diagnostic.Location);
+            Assert.Equal("Pages/Index.razor", diagnostic.Location.GetLineSpan().Path);
+            Assert.Single(result.GeneratedSources);
+        }
     }
 }

--- a/src/Razor/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/IntegrationTestBase.cs
+++ b/src/Razor/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/IntegrationTestBase.cs
@@ -419,7 +419,7 @@ public abstract class IntegrationTestBase
             File.WriteAllText(baselineFullPath, csharpDocument.Text.ToString(), _baselineEncoding);
 
             var baselineDiagnosticsFullPath = Path.Combine(TestProjectRoot, baselineDiagnosticsFileName);
-            var lines = csharpDocument.Diagnostics.Select(RazorDiagnosticSerializer.Serialize).ToArray();
+            var lines = csharpDocument.Diagnostics.Select(RazorDiagnosticSerializer.SerializeAssertingFilePath).ToArray();
             if (lines.Any())
             {
                 File.WriteAllLines(baselineDiagnosticsFullPath, lines, _baselineEncoding);
@@ -451,7 +451,7 @@ public abstract class IntegrationTestBase
             baselineDiagnostics = diagnosticsFile.ReadAllText();
         }
 
-        var actualDiagnostics = string.Concat(csharpDocument.Diagnostics.Select(d => NormalizeNewLines(RazorDiagnosticSerializer.Serialize(d)) + "\r\n"));
+        var actualDiagnostics = string.Concat(csharpDocument.Diagnostics.Select(d => NormalizeNewLines(RazorDiagnosticSerializer.SerializeAssertingFilePath(d)) + "\r\n"));
         Assert.Equal(baselineDiagnostics, actualDiagnostics);
     }
 

--- a/src/Razor/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/RazorBaselineIntegrationTestBase.cs
+++ b/src/Razor/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/RazorBaselineIntegrationTestBase.cs
@@ -88,7 +88,7 @@ public abstract class RazorBaselineIntegrationTestBase : RazorIntegrationTestBas
             WriteBaseline(actualCode, baselineFullPath);
 
             var baselineDiagnosticsFullPath = Path.Combine(TestProjectRoot, baselineDiagnosticsFilePath);
-            var lines = document.Diagnostics.Select(RazorDiagnosticSerializer.Serialize).ToArray();
+            var lines = document.Diagnostics.Select(RazorDiagnosticSerializer.SerializeAssertingFilePath).ToArray();
             if (lines.Any())
             {
                 WriteBaseline(lines, baselineDiagnosticsFullPath);
@@ -128,7 +128,7 @@ public abstract class RazorBaselineIntegrationTestBase : RazorIntegrationTestBas
             baselineDiagnostics = diagnosticsFile.ReadAllText();
         }
 
-        var actualDiagnostics = string.Concat(document.Diagnostics.Select(d => RazorDiagnosticSerializer.Serialize(d) + "\r\n"));
+        var actualDiagnostics = string.Concat(document.Diagnostics.Select(d => RazorDiagnosticSerializer.SerializeAssertingFilePath(d) + "\r\n"));
         Assert.Equal(baselineDiagnostics, actualDiagnostics);
 
         var baselineMappings = string.Empty;

--- a/src/Razor/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/RazorDiagnosticSerializer.cs
+++ b/src/Razor/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/RazorDiagnosticSerializer.cs
@@ -3,12 +3,31 @@
 
 #nullable disable
 
+using System.Diagnostics;
+
 namespace Microsoft.AspNetCore.Razor.Language;
 
 public static class RazorDiagnosticSerializer
 {
     public static string Serialize(RazorDiagnostic diagnostic)
     {
+        return diagnostic.ToString();
+    }
+
+    /// <summary>
+    /// Serializes a diagnostic that originates from a source document with a known file path,
+    /// asserting that any diagnostic with a real source location carries that path. A located
+    /// span with a null path can crash consumers that build a concrete location from it (e.g. the
+    /// source generator's <c>Location.Create</c>); the unspecified ("zero") location may omit it.
+    /// </summary>
+    public static string SerializeAssertingFilePath(RazorDiagnostic diagnostic)
+    {
+        var span = diagnostic.Span;
+
+        Debug.Assert(
+            span.FilePath is not null || (span.LineIndex < 0 && span.CharacterIndex < 0),
+            $"Diagnostic '{diagnostic.Id}' has source location ({span.LineIndex + 1},{span.CharacterIndex + 1}) but no file path.");
+
         return diagnostic.ToString();
     }
 }


### PR DESCRIPTION
When disabled text (e.g. an inactive `#if` block) contains an `#endif` or `#else` that is not at the start of a line, the Razor C# tokenizer reports `RZ1044` ("Possible C# preprocessor directive is misplaced") with a span that has no file path.

`RazorDiagnostics.AsDiagnostic` passes that null path to `Location.Create`, which throws `ArgumentNullException`.

## Fix

- Populate the diagnostic span's file path from the current source location in
  `RoslynCSharpTokenizer`.
- Guard `RazorDiagnostics.AsDiagnostic` against a null file path, falling back
  to `Location.None`.

Fixes [AB#3016708](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/3016708).
