### PR TITLE
Batch legacy C# project option defaults to avoid per-option workspace applies

### DIFF
--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.cs
@@ -68,8 +68,15 @@ internal sealed partial class CSharpProjectShim : AbstractLegacyProject, ICodeMo
         this.ProjectCodeModel = componentModel.GetService<IProjectCodeModelFactory>().CreateProjectCodeModel(ProjectSystemProject.Id, this);
         this.ProjectSystemProjectOptionsProcessor = new OptionsProcessor(this.ProjectSystemProject, Workspace.Services.SolutionServices);
 
-        // Ensure the default options are set up
-        ResetAllOptions();
+        // Ensure the default options are set up. Each option assignment in ResetAllOptions can
+        // trigger a synchronous apply of the project to the workspace, and each such apply blocks
+        // the calling (UI) thread on the project system's apply lock. Batching them so the whole
+        // set of defaults is applied as a single workspace update avoids those repeated synchronous
+        // applies during project creation.
+        using (ProjectSystemProject.CreateBatchScope())
+        {
+            ResetAllOptions();
+        }
     }
 
     public override void Disconnect()


### PR DESCRIPTION
## Summary

The legacy `CSharpProjectShim` constructor calls `ResetAllOptions()` to seed a new project's default compiler options. Each option assignment flows through `OptionsProcessor` indexer set -> `UpdateProjectForNewHostValues` -> `UpdateProjectOptions_NoLock`, which re-applies several `ProjectSystemProject` properties (`AssemblyName`, `CompilationOptions`, `ParseOptions`, `CompilationOutputAssemblyFilePath`, `GeneratedFilesOutputDirectory`, `ChecksumAlgorithm`).

Every one of those property setters opens its **own** batch scope (`ChangeProjectProperty` -> `CreateBatchScope`). With no outer batch around `ResetAllOptions()`, each of the ~7 default options triggers a separate synchronous workspace apply. Each apply:

- blocks the calling (UI) thread on `ProjectSystemProjectFactory`'s apply semaphore (`_gate.DisposableWait()`), and
- fans out a synchronous `SetCurrentSolution` (workspace-changed event handlers run inline).

During solution open / new-project creation this can serialize badly against concurrent work (e.g. OOP `RemoteHostClient` / ServiceHub creation) and has been observed hanging legacy C# project creation under load.

## Change

Wrap `ResetAllOptions()` in a single `ProjectSystemProject.CreateBatchScope()`. While an outer batch scope is active, the per-property inner batch disposes are no-ops (`OnBatchScopeDisposedMaybeAsync` returns early while `_activeBatchScopes > 0`), so the defaults are applied to the workspace as **one** change at the outer scope's dispose instead of ~7. This collapses the repeated synchronous UI-thread applies during project creation.

This mirrors how modern project-system loads (and the VB shim's option setup) already wrap bulk setup in a single batch scope.

## Risk

Minimal and self-contained: one method, behavior-preserving (the same options are set; only the number of workspace applies changes). VB shim needs no change -- it has no construction-time `ResetAllOptions` equivalent and already batches its option setup.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84160)