### PR TITLE
Reduce IntermediateNodeCollection backing List allocations

### DIFF
--- a/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Intermediate/InlineListTests.cs
+++ b/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Intermediate/InlineListTests.cs
@@ -1,0 +1,468 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Language.Intermediate;
+
+public class InlineListTests
+{
+    private static BasicIntermediateNode CreateNode(string name) => new(name);
+
+    [Fact]
+    public void Count_IsZero_WhenEmpty()
+    {
+        // Arrange
+        var collection = new IntermediateNodeCollection();
+
+        // Assert
+        Assert.Equal(0, collection.Count);
+    }
+
+    [Fact]
+    public void Add_SingleItem_StoresInline()
+    {
+        // Arrange
+        var collection = new IntermediateNodeCollection();
+        var node = CreateNode("Node1");
+
+        // Act
+        collection.Add(node);
+
+        // Assert
+        Assert.Equal(1, collection.Count);
+        Assert.Same(node, collection[0]);
+    }
+
+    [Fact]
+    public void Add_TwoItems_TransitionsToArray()
+    {
+        // Arrange
+        var collection = new IntermediateNodeCollection();
+        var node1 = CreateNode("Node1");
+        var node2 = CreateNode("Node2");
+
+        // Act
+        collection.Add(node1);
+        collection.Add(node2);
+
+        // Assert
+        Assert.Equal(2, collection.Count);
+        Assert.Same(node1, collection[0]);
+        Assert.Same(node2, collection[1]);
+    }
+
+    [Fact]
+    public void Add_MultipleItems_GrowsArray()
+    {
+        // Arrange
+        var collection = new IntermediateNodeCollection();
+        var nodes = new[]
+        {
+            CreateNode("Node1"),
+            CreateNode("Node2"),
+            CreateNode("Node3"),
+            CreateNode("Node4"),
+            CreateNode("Node5"),
+        };
+
+        // Act
+        foreach (var node in nodes)
+        {
+            collection.Add(node);
+        }
+
+        // Assert
+        Assert.Equal(5, collection.Count);
+        for (int i = 0; i < nodes.Length; i++)
+        {
+            Assert.Same(nodes[i], collection[i]);
+        }
+    }
+
+    [Theory]
+    [InlineData(0, 0)] // Empty collection, index 0
+    [InlineData(1, 1)] // Single item, index 1
+    [InlineData(1, -1)] // Single item, negative index
+    public void Indexer_Get_ThrowsForInvalidIndex(int itemCount, int invalidIndex)
+    {
+        // Arrange
+        var collection = new IntermediateNodeCollection();
+        for (int i = 0; i < itemCount; i++)
+        {
+            collection.Add(CreateNode($"Node{i}"));
+        }
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => collection[invalidIndex]);
+    }
+
+    [Fact]
+    public void Indexer_Set_UpdatesSingleItem()
+    {
+        // Arrange
+        var collection = new IntermediateNodeCollection();
+        var node1 = CreateNode("Node1");
+        var node2 = CreateNode("Node2");
+        collection.Add(node1);
+
+        // Act
+        collection[0] = node2;
+
+        // Assert
+        Assert.Same(node2, collection[0]);
+    }
+
+    [Fact]
+    public void Indexer_Set_UpdatesArrayItem()
+    {
+        // Arrange
+        var collection = new IntermediateNodeCollection();
+        collection.Add(CreateNode("Node1"));
+        collection.Add(CreateNode("Node2"));
+        collection.Add(CreateNode("Node3"));
+        var replacement = CreateNode("Replacement");
+
+        // Act
+        collection[1] = replacement;
+
+        // Assert
+        Assert.Same(replacement, collection[1]);
+    }
+
+    [Fact]
+    public void Insert_AtIndexZero_WhenEmpty()
+    {
+        // Arrange
+        var collection = new IntermediateNodeCollection();
+        var node = CreateNode("Node1");
+
+        // Act
+        collection.Insert(0, node);
+
+        // Assert
+        Assert.Equal(1, collection.Count);
+        Assert.Same(node, collection[0]);
+    }
+
+    [Fact]
+    public void Insert_AtIndexZero_BeforeSingleItem()
+    {
+        // Arrange
+        var collection = new IntermediateNodeCollection();
+        var node1 = CreateNode("Node1");
+        var node2 = CreateNode("Node2");
+        collection.Add(node1);
+
+        // Act
+        collection.Insert(0, node2);
+
+        // Assert
+        Assert.Equal(2, collection.Count);
+        Assert.Same(node2, collection[0]);
+        Assert.Same(node1, collection[1]);
+    }
+
+    [Fact]
+    public void Insert_AtIndexOne_AfterSingleItem()
+    {
+        // Arrange
+        var collection = new IntermediateNodeCollection();
+        var node1 = CreateNode("Node1");
+        var node2 = CreateNode("Node2");
+        collection.Add(node1);
+
+        // Act
+        collection.Insert(1, node2);
+
+        // Assert
+        Assert.Equal(2, collection.Count);
+        Assert.Same(node1, collection[0]);
+        Assert.Same(node2, collection[1]);
+    }
+
+    [Fact]
+    public void Insert_InMiddle_ShiftsItems()
+    {
+        // Arrange
+        var collection = new IntermediateNodeCollection();
+        var node1 = CreateNode("Node1");
+        var node2 = CreateNode("Node2");
+        var node3 = CreateNode("Node3");
+        collection.Add(node1);
+        collection.Add(node3);
+
+        // Act
+        collection.Insert(1, node2);
+
+        // Assert
+        Assert.Equal(3, collection.Count);
+        Assert.Same(node1, collection[0]);
+        Assert.Same(node2, collection[1]);
+        Assert.Same(node3, collection[2]);
+    }
+
+    [Fact]
+    public void Insert_AtEnd_AppendsItem()
+    {
+        // Arrange
+        var collection = new IntermediateNodeCollection();
+        collection.Add(CreateNode("Node1"));
+        collection.Add(CreateNode("Node2"));
+        var node3 = CreateNode("Node3");
+
+        // Act
+        collection.Insert(2, node3);
+
+        // Assert
+        Assert.Equal(3, collection.Count);
+        Assert.Same(node3, collection[2]);
+    }
+
+    [Fact]
+    public void RemoveAt_SingleItem_BecomesEmpty()
+    {
+        // Arrange
+        var collection = new IntermediateNodeCollection();
+        collection.Add(CreateNode("Node1"));
+
+        // Act
+        collection.RemoveAt(0);
+
+        // Assert
+        Assert.Equal(0, collection.Count);
+    }
+
+    [Fact]
+    public void RemoveAt_FromArray_ShiftsItems()
+    {
+        // Arrange
+        var collection = new IntermediateNodeCollection();
+        var node1 = CreateNode("Node1");
+        var node2 = CreateNode("Node2");
+        var node3 = CreateNode("Node3");
+        collection.Add(node1);
+        collection.Add(node2);
+        collection.Add(node3);
+
+        // Act
+        collection.RemoveAt(1);
+
+        // Assert
+        Assert.Equal(2, collection.Count);
+        Assert.Same(node1, collection[0]);
+        Assert.Same(node3, collection[1]);
+    }
+
+    [Fact]
+    public void RemoveAt_LastItemInArray_TransitionsToInline()
+    {
+        // Arrange
+        var collection = new IntermediateNodeCollection();
+        var node1 = CreateNode("Node1");
+        var node2 = CreateNode("Node2");
+        collection.Add(node1);
+        collection.Add(node2);
+
+        // Act
+        collection.RemoveAt(0);
+        collection.RemoveAt(0);
+
+        // Assert
+        Assert.Equal(0, collection.Count);
+    }
+
+    [Theory]
+    [InlineData(0)] // Empty collection
+    [InlineData(1)] // Single item (inline mode)
+    [InlineData(3)] // Array mode
+    public void Clear_BecomesEmpty(int initialItemCount)
+    {
+        // Arrange
+        var collection = new IntermediateNodeCollection();
+        for (int i = 0; i < initialItemCount; i++)
+        {
+            collection.Add(CreateNode($"Node{i}"));
+        }
+
+        // Act
+        collection.Clear();
+
+        // Assert
+        Assert.Equal(0, collection.Count);
+    }
+
+    [Theory]
+    [InlineData(0, -1, -1)] // Empty collection, searching for any item
+    [InlineData(1, 0, 0)] // Single item, found at index 0
+    [InlineData(1, -1, -1)] // Single item, not found
+    [InlineData(3, 1, 1)] // Array mode, found at index 1
+    [InlineData(3, -1, -1)] // Array mode, not found
+    public void IndexOf_ReturnsCorrectIndex(int collectionSize, int searchIndex, int expectedResult)
+    {
+        // Arrange
+        var collection = new IntermediateNodeCollection();
+        var nodes = new IntermediateNode[collectionSize];
+        for (int i = 0; i < collectionSize; i++)
+        {
+            nodes[i] = CreateNode($"Node{i}");
+            collection.Add(nodes[i]);
+        }
+
+        var searchNode = searchIndex >= 0 ? nodes[searchIndex] : CreateNode("NotInCollection");
+
+        // Act
+        var index = collection.IndexOf(searchNode);
+
+        // Assert
+        Assert.Equal(expectedResult, index);
+    }
+
+    [Fact]
+    public void CopyTo_WhenEmpty_DoesNothing()
+    {
+        // Arrange
+        var collection = new IntermediateNodeCollection();
+        var array = new IntermediateNode[5];
+
+        // Act
+        collection.CopyTo(array, 0);
+
+        // Assert
+        Assert.All(array, item => Assert.Null(item));
+    }
+
+    [Fact]
+    public void CopyTo_SingleItem_CopiesItem()
+    {
+        // Arrange
+        var collection = new IntermediateNodeCollection();
+        var node = CreateNode("Node1");
+        collection.Add(node);
+        var array = new IntermediateNode[5];
+
+        // Act
+        collection.CopyTo(array, 2);
+
+        // Assert
+        Assert.Null(array[0]);
+        Assert.Null(array[1]);
+        Assert.Same(node, array[2]);
+        Assert.Null(array[3]);
+        Assert.Null(array[4]);
+    }
+
+    [Fact]
+    public void CopyTo_Array_CopiesAllItems()
+    {
+        // Arrange
+        var collection = new IntermediateNodeCollection();
+        var node1 = CreateNode("Node1");
+        var node2 = CreateNode("Node2");
+        var node3 = CreateNode("Node3");
+        collection.Add(node1);
+        collection.Add(node2);
+        collection.Add(node3);
+        var array = new IntermediateNode[5];
+
+        // Act
+        collection.CopyTo(array, 1);
+
+        // Assert
+        Assert.Null(array[0]);
+        Assert.Same(node1, array[1]);
+        Assert.Same(node2, array[2]);
+        Assert.Same(node3, array[3]);
+        Assert.Null(array[4]);
+    }
+
+    [Fact]
+    public void ArrayPooling_GrowsAndReturnsArrays()
+    {
+        // Arrange
+        var collection = new IntermediateNodeCollection();
+
+        // Act - grow beyond initial capacity (4) to trigger Grow
+        for (int i = 0; i < 10; i++)
+        {
+            collection.Add(CreateNode($"Node{i}"));
+        }
+
+        // Assert - verify all items are accessible
+        Assert.Equal(10, collection.Count);
+        for (int i = 0; i < 10; i++)
+        {
+            Assert.NotNull(collection[i]);
+        }
+
+        // Act - clear should return array to pool
+        collection.Clear();
+
+        // Assert
+        Assert.Equal(0, collection.Count);
+    }
+
+    [Fact]
+    public void StressTest_ManyOperations()
+    {
+        // Arrange
+        var collection = new IntermediateNodeCollection();
+        var nodes = new IntermediateNode[100];
+        for (int i = 0; i < nodes.Length; i++)
+        {
+            nodes[i] = CreateNode($"Node{i}");
+        }
+
+        // Act - add all
+        foreach (var node in nodes)
+        {
+            collection.Add(node);
+        }
+
+        // Assert
+        Assert.Equal(100, collection.Count);
+
+        // Act - remove half
+        for (int i = 0; i < 50; i++)
+        {
+            collection.RemoveAt(0);
+        }
+
+        // Assert
+        Assert.Equal(50, collection.Count);
+
+        // Act - insert in middle
+        var insertNode = CreateNode("InsertedNode");
+        collection.Insert(25, insertNode);
+
+        // Assert
+        Assert.Equal(51, collection.Count);
+        Assert.Same(insertNode, collection[25]);
+
+        // Act - clear all
+        collection.Clear();
+
+        // Assert
+        Assert.Equal(0, collection.Count);
+    }
+
+    private class BasicIntermediateNode : IntermediateNode
+    {
+        public BasicIntermediateNode(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+
+        public override IntermediateNodeCollection Children => IntermediateNodeCollection.ReadOnly;
+
+        public override void Accept(IntermediateNodeVisitor visitor)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public override string ToString() => Name;
+    }
+}

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultRazorIntermediateNodeLoweringPhase.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultRazorIntermediateNodeLoweringPhase.cs
@@ -8,7 +8,6 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 using Microsoft.AspNetCore.Razor.Language.Components;

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/IntermediateNodeCollection.InlineList.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/IntermediateNodeCollection.InlineList.cs
@@ -1,0 +1,221 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
+
+using System;
+using System.Buffers;
+
+namespace Microsoft.AspNetCore.Razor.Language.Intermediate;
+
+public sealed partial class IntermediateNodeCollection
+{
+    /// <summary>
+    /// A list-like struct that stores a single item inline (no array allocation)
+    /// and uses <see cref="ArrayPool{T}"/> for backing storage when more than one
+    /// item is needed. On resize, the old array is returned to the pool.
+    /// </summary>
+    /// <remarks>
+    /// This struct is private to <see cref="IntermediateNodeCollection"/> and its methods
+    /// make assumptions about their inputs (e.g., valid indices, non-null items) that are
+    /// guaranteed by the collection wrapper. They do not perform defensive validation.
+    /// </remarks>
+    private struct InlineList
+    {
+        private IntermediateNode _single;
+        private IntermediateNode[] _items;
+        private int _count;
+
+        public readonly int Count => _count;
+
+        public IntermediateNode this[int index]
+        {
+            readonly get
+            {
+                if (_items != null)
+                {
+                    return _items[index];
+                }
+
+                if (index == 0 && _count == 1)
+                {
+                    return _single;
+                }
+
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+
+            set
+            {
+                if (_items != null)
+                {
+                    _items[index] = value;
+                    return;
+                }
+
+                if (index == 0 && _count == 1)
+                {
+                    _single = value;
+                    return;
+                }
+
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+        }
+
+        public void Add(IntermediateNode item)
+        {
+            if (_count == 0)
+            {
+                _single = item;
+                _count = 1;
+                return;
+            }
+
+            if (_items == null)
+            {
+                // Transition from inline to array
+                _items = ArrayPool<IntermediateNode>.Shared.Rent(4);
+                _items[0] = _single;
+                _items[1] = item;
+                _single = null;
+                _count = 2;
+                return;
+            }
+
+            if (_count == _items.Length)
+            {
+                Grow(_count + 1);
+            }
+
+            _items[_count++] = item;
+        }
+
+        public void Insert(int index, IntermediateNode item)
+        {
+            if (_count == 0 && index == 0)
+            {
+                _single = item;
+                _count = 1;
+                return;
+            }
+
+            if (_items == null)
+            {
+                // Currently have 1 item inline, need to transition to array
+                _items = ArrayPool<IntermediateNode>.Shared.Rent(4);
+                if (index == 0)
+                {
+                    _items[0] = item;
+                    _items[1] = _single;
+                }
+                else
+                {
+                    _items[0] = _single;
+                    _items[1] = item;
+                }
+
+                _single = null;
+                _count = 2;
+                return;
+            }
+
+            if (_count == _items.Length)
+            {
+                Grow(_count + 1);
+            }
+
+            if (index < _count)
+            {
+                Array.Copy(_items, index, _items, index + 1, _count - index);
+            }
+
+            _items[index] = item;
+            _count++;
+        }
+
+        public void RemoveAt(int index)
+        {
+            if (_items == null)
+            {
+                // Must be removing the single item
+                _single = null;
+                _count = 0;
+                return;
+            }
+
+            _count--;
+            if (index < _count)
+            {
+                Array.Copy(_items, index + 1, _items, index, _count - index);
+            }
+
+            _items[_count] = null;
+
+            // Transition back to inline mode when empty
+            if (_count == 0)
+            {
+                ArrayPool<IntermediateNode>.Shared.Return(_items, clearArray: true);
+                _items = null;
+            }
+        }
+
+        public void Clear()
+        {
+            if (_items != null)
+            {
+                Array.Clear(_items, 0, _count);
+                ArrayPool<IntermediateNode>.Shared.Return(_items, clearArray: false);
+                _items = null;
+            }
+            else
+            {
+                _single = null;
+            }
+
+            _count = 0;
+        }
+
+        public readonly int IndexOf(IntermediateNode item)
+        {
+            if (_items != null)
+            {
+                return Array.IndexOf(_items, item, 0, _count);
+            }
+
+            if (_count == 1 && ReferenceEquals(_single, item))
+            {
+                return 0;
+            }
+
+            return -1;
+        }
+
+        public readonly void CopyTo(IntermediateNode[] array, int arrayIndex)
+        {
+            if (_items != null)
+            {
+                Array.Copy(_items, 0, array, arrayIndex, _count);
+            }
+            else if (_count == 1)
+            {
+                array[arrayIndex] = _single;
+            }
+        }
+
+        private void Grow(int minimumRequired)
+        {
+            var newCapacity = _items.Length * 2;
+            if (newCapacity < minimumRequired)
+            {
+                newCapacity = minimumRequired;
+            }
+
+            var oldArray = _items;
+            var newArray = ArrayPool<IntermediateNode>.Shared.Rent(newCapacity);
+            Array.Copy(oldArray, newArray, _count);
+            _items = newArray;
+            ArrayPool<IntermediateNode>.Shared.Return(oldArray, clearArray: true);
+        }
+    }
+}

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/IntermediateNodeCollection.InlineList.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/IntermediateNodeCollection.InlineList.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Buffers;
+using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.Razor.Language.Intermediate;
 

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/IntermediateNodeCollection.InlineList.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/IntermediateNodeCollection.InlineList.cs
@@ -183,7 +183,7 @@ public sealed partial class IntermediateNodeCollection
                 return Array.IndexOf(_items, item, 0, _count);
             }
 
-            if (_count == 1 && ReferenceEquals(_single, item))
+            if (_count == 1 && EqualityComparer<IntermediateNode>.Default.Equals(_single, item))
             {
                 return 0;
             }

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/IntermediateNodeCollection.InlineList.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/IntermediateNodeCollection.InlineList.cs
@@ -137,27 +137,29 @@ public sealed partial class IntermediateNodeCollection
 
         public void RemoveAt(int index)
         {
-            if (_items == null)
+            if (_count == 1)
             {
-                // Must be removing the single item
+                // Removing the single item
                 _single = null;
                 _count = 0;
-                return;
             }
-
-            _count--;
-            if (index < _count)
+            else if (_count == 2)
             {
-                Array.Copy(_items, index + 1, _items, index, _count - index);
-            }
-
-            _items[_count] = null;
-
-            // Transition back to inline mode when empty
-            if (_count == 0)
-            {
+                // Transition back to single item mode when possible.
+                _single = index == 0 ? _items[1] : _items[0];
                 ArrayPool<IntermediateNode>.Shared.Return(_items, clearArray: true);
+                _count = 1;
                 _items = null;
+            }
+            else
+            {
+                _count--;
+                if (index < _count)
+                {
+                    Array.Copy(_items, index + 1, _items, index, _count - index);
+                }
+
+                _items[_count] = null;
             }
         }
 

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/IntermediateNodeCollection.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/IntermediateNodeCollection.cs
@@ -75,7 +75,7 @@ public sealed partial class IntermediateNodeCollection : IList<IntermediateNode>
 
         foreach (var item in items)
         {
-            Assumed.NotNull(item);
+            ArgHelper.ThrowIfNull(item, nameof(items));
 
             _inner.Add(item);
         }
@@ -100,7 +100,7 @@ public sealed partial class IntermediateNodeCollection : IList<IntermediateNode>
 
         foreach (var item in items)
         {
-            Assumed.NotNull(item);
+            ArgHelper.ThrowIfNull(item, nameof(items));
 
             _inner.Add(item);
         }

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/IntermediateNodeCollection.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/IntermediateNodeCollection.cs
@@ -10,20 +10,14 @@ using Microsoft.AspNetCore.Razor.PooledObjects;
 
 namespace Microsoft.AspNetCore.Razor.Language.Intermediate;
 
-public sealed class IntermediateNodeCollection : IList<IntermediateNode>, IReadOnlyList<IntermediateNode>
+public sealed partial class IntermediateNodeCollection : IList<IntermediateNode>, IReadOnlyList<IntermediateNode>
 {
-    public static readonly IntermediateNodeCollection ReadOnly = new IntermediateNodeCollection(new List<IntermediateNode>().AsReadOnly());
+    public static readonly IntermediateNodeCollection ReadOnly = new IntermediateNodeCollection();
 
-    private readonly IList<IntermediateNode> _inner;
+    private InlineList _inner;
 
     public IntermediateNodeCollection()
-        : this(new List<IntermediateNode>())
     {
-    }
-
-    private IntermediateNodeCollection(IList<IntermediateNode> inner)
-    {
-        _inner = inner;
     }
 
     public IntermediateNode this[int index]
@@ -39,6 +33,8 @@ public sealed class IntermediateNodeCollection : IList<IntermediateNode>, IReadO
         }
         set
         {
+            ThrowIfReadOnly();
+
             if (index < 0 || index >= Count)
             {
                 throw new ArgumentOutOfRangeException(nameof(index));
@@ -50,10 +46,20 @@ public sealed class IntermediateNodeCollection : IList<IntermediateNode>, IReadO
 
     public int Count => _inner.Count;
 
-    public bool IsReadOnly => _inner.IsReadOnly;
+    public bool IsReadOnly => ReferenceEquals(this, ReadOnly);
+
+    private void ThrowIfReadOnly()
+    {
+        if (IsReadOnly)
+        {
+            throw new NotSupportedException("Collection is read-only.");
+        }
+    }
 
     public void Add(IntermediateNode item)
     {
+        ThrowIfReadOnly();
+
         if (item == null)
         {
             throw new ArgumentNullException(nameof(item));
@@ -64,6 +70,8 @@ public sealed class IntermediateNodeCollection : IList<IntermediateNode>, IReadO
 
     public void AddRange(IEnumerable<IntermediateNode> items)
     {
+        ThrowIfReadOnly();
+
         if (items == null)
         {
             throw new ArgumentNullException(nameof(items));
@@ -77,6 +85,8 @@ public sealed class IntermediateNodeCollection : IList<IntermediateNode>, IReadO
 
     public void AddRange(IntermediateNodeCollection items)
     {
+        ThrowIfReadOnly();
+
         if (items == null)
         {
             throw new ArgumentNullException(nameof(items));
@@ -91,6 +101,8 @@ public sealed class IntermediateNodeCollection : IList<IntermediateNode>, IReadO
 
     internal void AddRange(in PooledArrayBuilder<IntermediateNode> items)
     {
+        ThrowIfReadOnly();
+
         foreach (var item in items)
         {
             _inner.Add(item);
@@ -99,12 +111,13 @@ public sealed class IntermediateNodeCollection : IList<IntermediateNode>, IReadO
 
     public void Clear()
     {
+        ThrowIfReadOnly();
         _inner.Clear();
     }
 
     public bool Contains(IntermediateNode item)
     {
-        return _inner.Contains(item);
+        return item != null && IndexOf(item) >= 0;
     }
 
     public void CopyTo(IntermediateNode[] array, int arrayIndex)
@@ -153,6 +166,8 @@ public sealed class IntermediateNodeCollection : IList<IntermediateNode>, IReadO
 
     public void Insert(int index, IntermediateNode item)
     {
+        ThrowIfReadOnly();
+
         if (index < 0 || index > Count)
         {
             throw new ArgumentOutOfRangeException(nameof(index));
@@ -168,16 +183,27 @@ public sealed class IntermediateNodeCollection : IList<IntermediateNode>, IReadO
 
     public bool Remove(IntermediateNode item)
     {
+        ThrowIfReadOnly();
+
         if (item == null)
         {
             throw new ArgumentNullException(nameof(item));
         }
 
-        return _inner.Remove(item);
+        var index = IndexOf(item);
+        if (index >= 0)
+        {
+            RemoveAt(index);
+            return true;
+        }
+
+        return false;
     }
 
     public void RemoveAt(int index)
     {
+        ThrowIfReadOnly();
+
         if (index < 0 || index >= Count)
         {
             throw new ArgumentOutOfRangeException(nameof(index));
@@ -188,7 +214,7 @@ public sealed class IntermediateNodeCollection : IList<IntermediateNode>, IReadO
 
     public struct Enumerator : IEnumerator<IntermediateNode>
     {
-        private readonly IList<IntermediateNode> _items;
+        private readonly IntermediateNodeCollection _items;
         private int _index;
 
         public Enumerator(IntermediateNodeCollection collection)
@@ -198,7 +224,7 @@ public sealed class IntermediateNodeCollection : IList<IntermediateNode>, IReadO
                 throw new ArgumentNullException(nameof(collection));
             }
 
-            _items = collection._inner;
+            _items = collection;
             _index = -1;
         }
 

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/IntermediateNodeCollection.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/IntermediateNodeCollection.cs
@@ -40,6 +40,11 @@ public sealed partial class IntermediateNodeCollection : IList<IntermediateNode>
                 throw new ArgumentOutOfRangeException(nameof(index));
             }
 
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
             _inner[index] = value;
         }
     }
@@ -79,6 +84,11 @@ public sealed partial class IntermediateNodeCollection : IList<IntermediateNode>
 
         foreach (var item in items)
         {
+            if (item == null)
+            {
+                throw new ArgumentNullException(nameof(item));
+            }
+
             _inner.Add(item);
         }
     }
@@ -105,6 +115,11 @@ public sealed partial class IntermediateNodeCollection : IList<IntermediateNode>
 
         foreach (var item in items)
         {
+            if (item == null)
+            {
+                throw new ArgumentNullException(nameof(item));
+            }
+
             _inner.Add(item);
         }
     }

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/IntermediateNodeCollection.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/IntermediateNodeCollection.cs
@@ -40,10 +40,7 @@ public sealed partial class IntermediateNodeCollection : IList<IntermediateNode>
                 throw new ArgumentOutOfRangeException(nameof(index));
             }
 
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
+            ArgHelper.ThrowIfNull(value, nameof(value));
 
             _inner[index] = value;
         }
@@ -65,10 +62,7 @@ public sealed partial class IntermediateNodeCollection : IList<IntermediateNode>
     {
         ThrowIfReadOnly();
 
-        if (item == null)
-        {
-            throw new ArgumentNullException(nameof(item));
-        }
+        ArgHelper.ThrowIfNull(item, nameof(item));
 
         _inner.Add(item);
     }
@@ -77,17 +71,11 @@ public sealed partial class IntermediateNodeCollection : IList<IntermediateNode>
     {
         ThrowIfReadOnly();
 
-        if (items == null)
-        {
-            throw new ArgumentNullException(nameof(items));
-        }
+        ArgHelper.ThrowIfNull(items, nameof(items));
 
         foreach (var item in items)
         {
-            if (item == null)
-            {
-                throw new ArgumentNullException(nameof(item));
-            }
+            Assumed.NotNull(item);
 
             _inner.Add(item);
         }
@@ -97,10 +85,7 @@ public sealed partial class IntermediateNodeCollection : IList<IntermediateNode>
     {
         ThrowIfReadOnly();
 
-        if (items == null)
-        {
-            throw new ArgumentNullException(nameof(items));
-        }
+        ArgHelper.ThrowIfNull(items, nameof(items));
 
         var count = items.Count;
         for (var i = 0; i < count; i++)
@@ -115,10 +100,7 @@ public sealed partial class IntermediateNodeCollection : IList<IntermediateNode>
 
         foreach (var item in items)
         {
-            if (item == null)
-            {
-                throw new ArgumentNullException(nameof(item));
-            }
+            Assumed.NotNull(item);
 
             _inner.Add(item);
         }
@@ -137,10 +119,7 @@ public sealed partial class IntermediateNodeCollection : IList<IntermediateNode>
 
     public void CopyTo(IntermediateNode[] array, int arrayIndex)
     {
-        if (array == null)
-        {
-            throw new ArgumentNullException(nameof(array));
-        }
+        ArgHelper.ThrowIfNull(array, nameof(array));
 
         if (arrayIndex < 0 || arrayIndex > array.Length)
         {
@@ -171,10 +150,7 @@ public sealed partial class IntermediateNodeCollection : IList<IntermediateNode>
 
     public int IndexOf(IntermediateNode item)
     {
-        if (item == null)
-        {
-            throw new ArgumentNullException(nameof(item));
-        }
+        ArgHelper.ThrowIfNull(item, nameof(item));
 
         return _inner.IndexOf(item);
     }
@@ -188,10 +164,7 @@ public sealed partial class IntermediateNodeCollection : IList<IntermediateNode>
             throw new ArgumentOutOfRangeException(nameof(index));
         }
 
-        if (item == null)
-        {
-            throw new ArgumentNullException(nameof(item));
-        }
+        ArgHelper.ThrowIfNull(item, nameof(item));
 
         _inner.Insert(index, item);
     }
@@ -200,10 +173,7 @@ public sealed partial class IntermediateNodeCollection : IList<IntermediateNode>
     {
         ThrowIfReadOnly();
 
-        if (item == null)
-        {
-            throw new ArgumentNullException(nameof(item));
-        }
+        ArgHelper.ThrowIfNull(item, nameof(item));
 
         var index = IndexOf(item);
         if (index >= 0)
@@ -234,10 +204,7 @@ public sealed partial class IntermediateNodeCollection : IList<IntermediateNode>
 
         public Enumerator(IntermediateNodeCollection collection)
         {
-            if (collection == null)
-            {
-                throw new ArgumentNullException(nameof(collection));
-            }
+            ArgHelper.ThrowIfNull(collection, nameof(collection));
 
             _items = collection;
             _index = -1;

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelperBinder.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelperBinder.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
-using System.Threading;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 
 namespace Microsoft.AspNetCore.Razor.Language;
@@ -36,11 +35,6 @@ internal sealed partial class TagHelperBinder
         ProcessDescriptors(tagHelpers, tagNamePrefix, out _tagNameToTagHelpersMap, out _catchAllTagHelpers);
     }
 
-    static int s_count1 = 0;
-    static List<int> s_allCounts1 = new();
-    static int s_count2 = 0;
-    static List<int> s_allCounts2 = new();
-
     private static void ProcessDescriptors(
         TagHelperCollection descriptors,
         string? tagNamePrefix,
@@ -64,10 +58,9 @@ internal sealed partial class TagHelperBinder
         // The builders are indexed using a map of "tag name" to the index of the builder in the array.
         using var _1 = SpecializedPools.GetPooledStringDictionary<int>(ignoreCase: true, out var tagNameToBuilderIndexMap);
 
-        int count1 = 0;
         foreach (var tagHelper in descriptors)
         {
-            count1 += tagHelper.TagMatchingRules.Length;
+
             foreach (var rule in tagHelper.TagMatchingRules)
             {
                 var tagName = rule.TagName;
@@ -90,15 +83,6 @@ internal sealed partial class TagHelperBinder
                 builders[builderIndex].IncreaseSize();
                 toAdd.Append((builderIndex, tagHelper));
             }
-        }
-
-        lock (s_allCounts1)
-        {
-            Interlocked.Add(ref s_count1, count1);
-            s_allCounts1.Add(count1);
-
-            Interlocked.Add(ref s_count2, tagNameToBuilderIndexMap.Count);
-            s_allCounts2.Add(tagNameToBuilderIndexMap.Count);
         }
 
         // Next, we walk through toAdd and add each descriptor to the appropriate builder.

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelperBinder.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelperBinder.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Threading;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 
 namespace Microsoft.AspNetCore.Razor.Language;
@@ -35,6 +36,11 @@ internal sealed partial class TagHelperBinder
         ProcessDescriptors(tagHelpers, tagNamePrefix, out _tagNameToTagHelpersMap, out _catchAllTagHelpers);
     }
 
+    static int s_count1 = 0;
+    static List<int> s_allCounts1 = new();
+    static int s_count2 = 0;
+    static List<int> s_allCounts2 = new();
+
     private static void ProcessDescriptors(
         TagHelperCollection descriptors,
         string? tagNamePrefix,
@@ -58,9 +64,10 @@ internal sealed partial class TagHelperBinder
         // The builders are indexed using a map of "tag name" to the index of the builder in the array.
         using var _1 = SpecializedPools.GetPooledStringDictionary<int>(ignoreCase: true, out var tagNameToBuilderIndexMap);
 
+        int count1 = 0;
         foreach (var tagHelper in descriptors)
         {
-
+            count1 += tagHelper.TagMatchingRules.Length;
             foreach (var rule in tagHelper.TagMatchingRules)
             {
                 var tagName = rule.TagName;
@@ -83,6 +90,15 @@ internal sealed partial class TagHelperBinder
                 builders[builderIndex].IncreaseSize();
                 toAdd.Append((builderIndex, tagHelper));
             }
+        }
+
+        lock (s_allCounts1)
+        {
+            Interlocked.Add(ref s_count1, count1);
+            s_allCounts1.Add(count1);
+
+            Interlocked.Add(ref s_count2, tagNameToBuilderIndexMap.Count);
+            s_allCounts2.Add(tagNameToBuilderIndexMap.Count);
         }
 
         // Next, we walk through toAdd and add each descriptor to the appropriate builder.


### PR DESCRIPTION
 IntermediateNodeCollection used IList<IntermediateNode> for backing storage, allocating a List for every collection even when most contain <= 1 items.

 Replaced with InlineList struct that stores single items inline (no heap allocation) and uses ArrayPool<IntermediateNode> for backing storage when multiple items are needed. Arrays are returned to the pool on Clear/RemoveAt transitions.

 This reduces per-collection List allocations and eliminates array allocations for the common single-item case.

From a customer trace, this should reduce the following allocations significantly (probaby by about half). It's not a complete pooling win as the IntermediateNodeCollection still need backing arrays when there is > 1 item and the collection is not disposable (about 25% of collections require > 1 item from local testing)

<img width="1504" height="1005" alt="image" src="https://github.com/user-attachments/assets/b3cabeb1-2aee-4aaf-a2c8-e8a7d4667163" />

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84165)