### PR TITLE
Use dedicated BindValueKind for left hand side of null coalescing assignment operator

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -540,9 +540,17 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             /// <summary>
             /// Expression can be the operand of an increment or decrement operation.
-            /// Same as CompoundAssignment, the distinction is really just for error reporting.
+            /// Same as CompoundAssignment, the distinction is really just for error reporting
+            /// and event handling.
             /// </summary>
             IncrementDecrement = CompoundAssignment + 1,
+
+            /// <summary>
+            /// Expression can be the operand of a null-coalescing assignment operation (??=).
+            /// Same as CompoundAssignment, the distinction is really just for error reporting
+            /// and event handling.
+            /// </summary>
+            NullCoalescingAssignment = CompoundAssignment + 2,
 
             /// <summary>
             /// Expression is a r/o reference.
@@ -3502,6 +3510,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             switch (kind)
             {
                 case BindValueKind.CompoundAssignment:
+                case BindValueKind.NullCoalescingAssignment:
                 case BindValueKind.Assignable:
                     return ErrorCode.ERR_AssgReadonlyLocal;
 
@@ -3537,6 +3546,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BindValueKind.Assignable:
                 case BindValueKind.CompoundAssignment:
                 case BindValueKind.IncrementDecrement:
+                case BindValueKind.NullCoalescingAssignment:
                     return ErrorCode.ERR_QueryRangeVariableReadOnly;
 
                 case BindValueKind.AddressOf:
@@ -3574,6 +3584,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             switch (kind)
             {
                 case BindValueKind.CompoundAssignment:
+                case BindValueKind.NullCoalescingAssignment:
                 case BindValueKind.Assignable:
                     return ErrorCode.ERR_AssgLvalueExpected;
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1848,15 +1848,16 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         private bool CheckEventValueKind(BoundEventAccess boundEvent, BindValueKind valueKind, BindingDiagnosticBag diagnostics)
         {
-            // Compound assignment (actually "event assignment") is allowed "everywhere", subject to the restrictions of
-            // accessibility, use site errors, and receiver variable-ness (for structs).
-            // Other operations are allowed only for field-like events and only where the backing field is accessible
-            // (i.e. in the declaring type) - subject to use site errors and receiver variable-ness.
-
             BoundExpression receiver = boundEvent.ReceiverOpt;
             SyntaxNode eventSyntax = GetEventName(boundEvent); //does not include receiver
             EventSymbol eventSymbol = boundEvent.EventSymbol;
 
+            // For events, we intentionally do not filter out the lower bits of BindValueKind; they specify semantic information
+            // such as being increment/decrement or null-coalescing.
+            // Compound assignment (actually "event assignment") is allowed "everywhere", subject to the restrictions of
+            // accessibility, use site errors, and receiver variable-ness (for structs).
+            // Other operations are allowed only for field-like events and only where the backing field is accessible
+            // (i.e. in the declaring type) - subject to use site errors and receiver variable-ness.
             if (valueKind == BindValueKind.CompoundAssignment)
             {
                 // NOTE: accessibility has already been checked by lookup.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 node.Left.CheckDeconstructionCompatibleArgument(diagnostics);
 
-                BoundExpression left = BindValue(node.Left, diagnostics, GetBinaryAssignmentKind(node.Kind()));
+                BoundExpression left = BindValue(node.Left, diagnostics, BindValueKind.CompoundAssignment);
                 ReportSuppressionIfNeeded(left, diagnostics);
                 BoundExpression right = BindValue(node.Right, diagnostics, BindValueKind.RValue);
                 BinaryOperatorKind kind = SyntaxKindToBinaryOperatorKind(node.Kind());
@@ -922,8 +922,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             while (syntaxNodes.Count > 0)
             {
                 BinaryExpressionSyntax syntaxNode = syntaxNodes.Pop();
-                BindValueKind bindValueKind = GetBinaryAssignmentKind(syntaxNode.Kind());
-                BoundExpression left = CheckValue(result, bindValueKind, diagnostics);
+                Debug.Assert(IsSimpleBinaryOperator(syntaxNode.Kind()));
+                BoundExpression left = CheckValue(result, BindValueKind.RValue, diagnostics);
                 BoundExpression right = BindValue(syntaxNode.Right, diagnostics, BindValueKind.RValue);
                 BoundExpression boundOp = BindSimpleBinaryOperator(syntaxNode, diagnostics, left, right, leaveUnconvertedIfInterpolatedString: true);
                 result = boundOp;
@@ -4649,30 +4649,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private static BindValueKind GetBinaryAssignmentKind(SyntaxKind kind)
-        {
-            switch (kind)
-            {
-                case SyntaxKind.SimpleAssignmentExpression:
-                    return BindValueKind.Assignable;
-                case SyntaxKind.AddAssignmentExpression:
-                case SyntaxKind.AndAssignmentExpression:
-                case SyntaxKind.DivideAssignmentExpression:
-                case SyntaxKind.ExclusiveOrAssignmentExpression:
-                case SyntaxKind.LeftShiftAssignmentExpression:
-                case SyntaxKind.ModuloAssignmentExpression:
-                case SyntaxKind.MultiplyAssignmentExpression:
-                case SyntaxKind.OrAssignmentExpression:
-                case SyntaxKind.RightShiftAssignmentExpression:
-                case SyntaxKind.UnsignedRightShiftAssignmentExpression:
-                case SyntaxKind.SubtractAssignmentExpression:
-                case SyntaxKind.CoalesceAssignmentExpression:
-                    return BindValueKind.CompoundAssignment;
-                default:
-                    return BindValueKind.RValue;
-            }
-        }
-
         private static BindValueKind GetUnaryAssignmentKind(SyntaxKind kind)
         {
             switch (kind)
@@ -5848,7 +5824,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             MessageID.IDS_FeatureCoalesceAssignmentExpression.CheckFeatureAvailability(diagnostics, node.OperatorToken);
 
-            BoundExpression leftOperand = BindValue(node.Left, diagnostics, BindValueKind.CompoundAssignment);
+            BoundExpression leftOperand = BindValue(node.Left, diagnostics, BindValueKind.NullCoalescingAssignment);
             ReportSuppressionIfNeeded(leftOperand, diagnostics);
             BoundExpression rightOperand = BindValue(node.Right, diagnostics, BindValueKind.RValue);
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenNullCoalescingAssignmentTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenNullCoalescingAssignmentTests.cs
@@ -2917,5 +2917,128 @@ struct S
 1
 1", options: TestOptions.DebugExe);
         }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/84014")]
+        public void FieldLikeEvent_01()
+        {
+            var src1 = @"
+public partial class C
+{
+    public event System.Action OnEventAction;
+
+    static void Test()
+    {
+        var x = new C();
+
+        x.OnEventAction = null;
+        x.OnEventAction ??= null;
+
+        if (x.OnEventAction == null)
+        {
+        }
+    }
+}
+";
+
+            var comp1 = CreateCompilation(src1);
+            comp1.VerifyEmitDiagnostics();
+
+            var src2 = @"
+class Program
+{
+    static void Test(C x)
+    {
+        x.OnEventAction = null;
+    }
+}
+";
+            var src3 = @"
+class Program
+{
+    static void Test(C x)
+    {
+        x.OnEventAction ??= null;
+    }
+}
+";
+            var src4 = @"
+class Program
+{
+    static void Test(C x)
+    {
+        if (x.OnEventAction == null)
+        {
+        }
+    }
+}
+";
+            var comp = CreateCompilation([src1, src2]);
+            comp.VerifyEmitDiagnostics(
+                // (6,11): error CS0070: The event 'C.OnEventAction' can only appear on the left hand side of += or -= (except when used from within the type 'C')
+                //         x.OnEventAction = null;
+                Diagnostic(ErrorCode.ERR_BadEventUsage, "OnEventAction").WithArguments("C.OnEventAction", "C").WithLocation(6, 11)
+                );
+
+            comp = CreateCompilation([src1, src3]);
+            comp.VerifyEmitDiagnostics(
+                // (6,11): error CS0070: The event 'C.OnEventAction' can only appear on the left hand side of += or -= (except when used from within the type 'C')
+                //         x.OnEventAction ??= null;
+                Diagnostic(ErrorCode.ERR_BadEventUsage, "OnEventAction").WithArguments("C.OnEventAction", "C").WithLocation(6, 11)
+                );
+
+            comp = CreateCompilation([src1, src4]);
+            comp.VerifyEmitDiagnostics(
+                // (6,15): error CS0070: The event 'C.OnEventAction' can only appear on the left hand side of += or -= (except when used from within the type 'C')
+                //         if (x.OnEventAction == null)
+                Diagnostic(ErrorCode.ERR_BadEventUsage, "OnEventAction").WithArguments("C.OnEventAction", "C").WithLocation(6, 15)
+                );
+
+            MetadataReference comp1Ref = comp1.ToMetadataReference();
+
+            comp = CreateCompilation(src2, references: [comp1Ref]);
+            comp.VerifyEmitDiagnostics(
+                // (6,11): error CS0070: The event 'C.OnEventAction' can only appear on the left hand side of += or -= (except when used from within the type 'C')
+                //         x.OnEventAction = null;
+                Diagnostic(ErrorCode.ERR_BadEventUsage, "OnEventAction").WithArguments("C.OnEventAction", "C").WithLocation(6, 11)
+                );
+
+            comp = CreateCompilation(src3, references: [comp1Ref]);
+            comp.VerifyEmitDiagnostics(
+                // (6,11): error CS0070: The event 'C.OnEventAction' can only appear on the left hand side of += or -= (except when used from within the type 'C')
+                //         x.OnEventAction ??= null;
+                Diagnostic(ErrorCode.ERR_BadEventUsage, "OnEventAction").WithArguments("C.OnEventAction", "C").WithLocation(6, 11)
+                );
+
+            comp = CreateCompilation(src4, references: [comp1Ref]);
+            comp.VerifyEmitDiagnostics(
+                // (6,15): error CS0070: The event 'C.OnEventAction' can only appear on the left hand side of += or -= (except when used from within the type 'C')
+                //         if (x.OnEventAction == null)
+                Diagnostic(ErrorCode.ERR_BadEventUsage, "OnEventAction").WithArguments("C.OnEventAction", "C").WithLocation(6, 15)
+                );
+
+            comp1Ref = comp1.EmitToImageReference();
+
+            comp = CreateCompilation(src2, references: [comp1Ref]);
+            comp.VerifyEmitDiagnostics(
+                // (6,11): error CS0079: The event 'C.OnEventAction' can only appear on the left hand side of += or -=
+                //         x.OnEventAction = null;
+                Diagnostic(ErrorCode.ERR_BadEventUsageNoField, "OnEventAction").WithArguments("C.OnEventAction").WithLocation(6, 11)
+                );
+
+            comp = CreateCompilation(src3, references: [comp1Ref]);
+            comp.VerifyEmitDiagnostics(
+                // (6,11): error CS0079: The event 'C.OnEventAction' can only appear on the left hand side of += or -=
+                //         x.OnEventAction ??= null;
+                Diagnostic(ErrorCode.ERR_BadEventUsageNoField, "OnEventAction").WithArguments("C.OnEventAction").WithLocation(6, 11)
+                );
+
+            comp = CreateCompilation(src4, references: [comp1Ref]);
+            comp.VerifyEmitDiagnostics(
+                // (6,15): error CS0079: The event 'C.OnEventAction' can only appear on the left hand side of += or -=
+                //         if (x.OnEventAction == null)
+                Diagnostic(ErrorCode.ERR_BadEventUsageNoField, "OnEventAction").WithArguments("C.OnEventAction").WithLocation(6, 15)
+                );
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenNullCoalescingAssignmentTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenNullCoalescingAssignmentTests.cs
@@ -3040,5 +3040,144 @@ class Program
                 Diagnostic(ErrorCode.ERR_BadEventUsageNoField, "OnEventAction").WithArguments("C.OnEventAction").WithLocation(6, 15)
                 );
         }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/84014")]
+        public void NotFieldLikeEvent_01()
+        {
+            var src1_0 = @"
+public partial class C
+{
+    public event System.Action OnEventAction { add { } remove { } }
+}
+";
+            var src1_1 = @"
+public partial class C
+{
+    static void Test()
+    {
+        var x = new C();
+
+#line 10
+        x.OnEventAction = null;
+        x.OnEventAction ??= null;
+
+        if (x.OnEventAction == null)
+        {
+        }
+    }
+}
+";
+
+            var comp1 = CreateCompilation([src1_0, src1_1]);
+            comp1.VerifyEmitDiagnostics(
+                // (10,11): error CS0079: The event 'C.OnEventAction' can only appear on the left hand side of += or -=
+                //         x.OnEventAction = null;
+                Diagnostic(ErrorCode.ERR_BadEventUsageNoField, "OnEventAction").WithArguments("C.OnEventAction").WithLocation(10, 11),
+                // (11,11): error CS0079: The event 'C.OnEventAction' can only appear on the left hand side of += or -=
+                //         x.OnEventAction ??= null;
+                Diagnostic(ErrorCode.ERR_BadEventUsageNoField, "OnEventAction").WithArguments("C.OnEventAction").WithLocation(11, 11),
+                // (13,15): error CS0079: The event 'C.OnEventAction' can only appear on the left hand side of += or -=
+                //         if (x.OnEventAction == null)
+                Diagnostic(ErrorCode.ERR_BadEventUsageNoField, "OnEventAction").WithArguments("C.OnEventAction").WithLocation(13, 15)
+                );
+
+            var src2 = @"
+class Program
+{
+    static void Test(C x)
+    {
+        x.OnEventAction = null;
+    }
+}
+";
+            var src3 = @"
+class Program
+{
+    static void Test(C x)
+    {
+        x.OnEventAction ??= null;
+    }
+}
+";
+            var src4 = @"
+class Program
+{
+    static void Test(C x)
+    {
+        if (x.OnEventAction == null)
+        {
+        }
+    }
+}
+";
+            var comp = CreateCompilation([src1_0, src2]);
+            comp.VerifyEmitDiagnostics(
+                // (6,11): error CS0079: The event 'C.OnEventAction' can only appear on the left hand side of += or -=
+                //         x.OnEventAction = null;
+                Diagnostic(ErrorCode.ERR_BadEventUsageNoField, "OnEventAction").WithArguments("C.OnEventAction").WithLocation(6, 11)
+                );
+
+            comp = CreateCompilation([src1_0, src3]);
+            comp.VerifyEmitDiagnostics(
+                // (6,11): error CS0079: The event 'C.OnEventAction' can only appear on the left hand side of += or -=
+                //         x.OnEventAction ??= null;
+                Diagnostic(ErrorCode.ERR_BadEventUsageNoField, "OnEventAction").WithArguments("C.OnEventAction").WithLocation(6, 11)
+                );
+
+            comp = CreateCompilation([src1_0, src4]);
+            comp.VerifyEmitDiagnostics(
+                // (6,15): error CS0079: The event 'C.OnEventAction' can only appear on the left hand side of += or -=
+                //         if (x.OnEventAction == null)
+                Diagnostic(ErrorCode.ERR_BadEventUsageNoField, "OnEventAction").WithArguments("C.OnEventAction").WithLocation(6, 15)
+                );
+
+            comp1 = CreateCompilation(src1_0);
+            MetadataReference comp1Ref = comp1.ToMetadataReference();
+
+            comp = CreateCompilation(src2, references: [comp1Ref]);
+            comp.VerifyEmitDiagnostics(
+                // (6,11): error CS0079: The event 'C.OnEventAction' can only appear on the left hand side of += or -=
+                //         x.OnEventAction = null;
+                Diagnostic(ErrorCode.ERR_BadEventUsageNoField, "OnEventAction").WithArguments("C.OnEventAction").WithLocation(6, 11)
+                );
+
+            comp = CreateCompilation(src3, references: [comp1Ref]);
+            comp.VerifyEmitDiagnostics(
+                // (6,11): error CS0079: The event 'C.OnEventAction' can only appear on the left hand side of += or -=
+                //         x.OnEventAction ??= null;
+                Diagnostic(ErrorCode.ERR_BadEventUsageNoField, "OnEventAction").WithArguments("C.OnEventAction").WithLocation(6, 11)
+                );
+
+            comp = CreateCompilation(src4, references: [comp1Ref]);
+            comp.VerifyEmitDiagnostics(
+                // (6,15): error CS0079: The event 'C.OnEventAction' can only appear on the left hand side of += or -=
+                //         if (x.OnEventAction == null)
+                Diagnostic(ErrorCode.ERR_BadEventUsageNoField, "OnEventAction").WithArguments("C.OnEventAction").WithLocation(6, 15)
+                );
+
+            comp1Ref = comp1.EmitToImageReference();
+
+            comp = CreateCompilation(src2, references: [comp1Ref]);
+            comp.VerifyEmitDiagnostics(
+                // (6,11): error CS0079: The event 'C.OnEventAction' can only appear on the left hand side of += or -=
+                //         x.OnEventAction = null;
+                Diagnostic(ErrorCode.ERR_BadEventUsageNoField, "OnEventAction").WithArguments("C.OnEventAction").WithLocation(6, 11)
+                );
+
+            comp = CreateCompilation(src3, references: [comp1Ref]);
+            comp.VerifyEmitDiagnostics(
+                // (6,11): error CS0079: The event 'C.OnEventAction' can only appear on the left hand side of += or -=
+                //         x.OnEventAction ??= null;
+                Diagnostic(ErrorCode.ERR_BadEventUsageNoField, "OnEventAction").WithArguments("C.OnEventAction").WithLocation(6, 11)
+                );
+
+            comp = CreateCompilation(src4, references: [comp1Ref]);
+            comp.VerifyEmitDiagnostics(
+                // (6,15): error CS0079: The event 'C.OnEventAction' can only appear on the left hand side of += or -=
+                //         if (x.OnEventAction == null)
+                Diagnostic(ErrorCode.ERR_BadEventUsageNoField, "OnEventAction").WithArguments("C.OnEventAction").WithLocation(6, 15)
+                );
+        }
     }
 }


### PR DESCRIPTION
Fixes #84014
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84172)