### PR TITLE
Support extension blocks in script submissions

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
@@ -224,7 +224,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // 1. visit the type
-            if (symbol.IsExtension && (SourceNamedTypeSymbol)symbol.ContainingType is { } containingType)
+            // SourceMemberContainerTypeSymbol is a SourceNamedTypeSymbol for a normal static class, or an ImplicitNamedTypeSymbol when the extension block is declared at script top-level.
+            if (symbol.IsExtension && (SourceMemberContainerTypeSymbol)symbol.ContainingType is { } containingType)
             {
                 // We've been asked to generate the docs for a given extension block. We'll produce the merged docs for the merged blocks.
                 ImmutableArray<SourceNamedTypeSymbol> extensions = containingType.GetExtensionGroupingInfo().GetMergedExtensions((SourceNamedTypeSymbol)symbol);
@@ -254,13 +255,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (sawExtension)
                 {
-                    appendContainedExtensions((SourceNamedTypeSymbol)symbol);
+                    appendContainedExtensions((SourceMemberContainerTypeSymbol)symbol);
                 }
             }
 
             return;
 
-            void appendContainedExtensions(SourceNamedTypeSymbol containingType)
+            void appendContainedExtensions(SourceMemberContainerTypeSymbol containingType)
             {
                 Debug.Assert(!_isForSingleSymbol);
                 ExtensionGroupingInfo extensionGroupingInfo = containingType.GetExtensionGroupingInfo();

--- a/src/Compilers/CSharp/Portable/Declarations/DeclarationTreeBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/DeclarationTreeBuilder.cs
@@ -289,7 +289,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            //Script class is not static and contains no extensions.
+            //Script class is not static. It can still act as the container for extension methods and extension blocks declared at script top level.
             SingleTypeDeclaration.TypeDeclarationFlags declFlags = SingleTypeDeclaration.TypeDeclarationFlags.None;
             var membernames = GetNonTypeMemberNames(compilationUnit, ((Syntax.InternalSyntax.CompilationUnitSyntax)(compilationUnit.Green)).Members, ref declFlags);
             rootChildren.Add(

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -417,7 +417,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             PooledHashSet<MethodSymbol>? implementationsToShadow = null;
 
-            if (this.IsClassType() && IsStatic && !IsGenericType)
+            if ((this.IsClassType() && IsStatic && !IsGenericType) || this.IsScriptClass)
             {
                 doGetExtensionMembers(members, name, alternativeName, arity, options, ref implementationsToShadow, fieldsBeingBound);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -3995,7 +3995,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     AddSynthesizedTypeMembersIfNecessary(builder, declaredMembersAndInitializers, diagnostics);
                     AddSynthesizedConstructorsIfNecessary(builder, declaredMembersAndInitializers, diagnostics);
 
-                    if (TypeKind == TypeKind.Class) // Tracked by https://github.com/dotnet/roslyn/issues/78827 : MQ, Consider tightening this check to only top-level non-generic static classes, however optimizing for error scenarios is usually not a goal.
+                    if (TypeKind is TypeKind.Class or TypeKind.Submission) // Tracked by https://github.com/dotnet/roslyn/issues/78827 : MQ, Consider tightening this check to only top-level non-generic static classes, however optimizing for error scenarios is usually not a goal. TypeKind.Submission covers extension blocks declared at the top level of an interactive.
                     {
                         AddSynthesizedExtensionImplementationsIfNecessary(builder, declaredMembersAndInitializers);
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -2093,8 +2093,10 @@ next:;
 
             if (IsExtension && ContainingType?.IsExtension != true)
             {
-                // If the containing type is an extension, we'll have already reported an error
-                if (ContainingType is null || !ContainingType.IsStatic || ContainingType.Arity != 0 || ContainingType.ContainingType is not null)
+                // If the containing type is an extension, we'll have already reported an error.
+                // A script/submission class is a valid extension container even though it is not static. It is always non-generic and top-level.
+                if ((ContainingType is null || !ContainingType.IsStatic || ContainingType.Arity != 0 || ContainingType.ContainingType is not null)
+                    && ContainingType?.IsScriptClass != true)
                 {
                     var syntax = (ExtensionBlockDeclarationSyntax)this.GetNonNullSyntaxNode();
                     diagnostics.Add(ErrorCode.ERR_BadExtensionContainingType, syntax.Keyword);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ScriptSemanticsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ScriptSemanticsTests.cs
@@ -1125,6 +1125,51 @@ goto Label;");
         }
 
         [Fact]
+        [CompilerTrait(CompilerFeature.Extensions)]
+        public void DefineExtensionBlock_TopLevel()
+        {
+            var references = new[] { NetFramework.SystemCore };
+            var parseOptions = TestOptions.Script.WithLanguageVersion(LanguageVersion.CSharp14);
+
+            // No error for an extension block declared at the top level of a submission, and its members (both static and instance) 
+            // are usable within the same submission. The non-static script class acts as the container.
+            var s0 = CreateSubmission(@"
+extension(string s)
+{
+    public static string Hello => ""Hello!"";
+    public bool IsEmpty => s.Length == 0;
+}
+string h = string.Hello;
+bool e = """".IsEmpty;
+", references, parseOptions: parseOptions);
+            s0.VerifyDiagnostics();
+
+            // Members declared in one submission are usable in a later submission that chains onto it.
+            var s1 = CreateSubmission(@"
+string h = string.Hello;
+bool e = """".IsEmpty;
+", references, parseOptions: parseOptions, previous: s0);
+            s1.VerifyDiagnostics();
+        }
+
+        [Fact]
+        [CompilerTrait(CompilerFeature.Extensions)]
+        public void DefineExtensionBlock_NestedInInstanceClassStillIllegal()
+        {
+            var parseOptions = TestOptions.Script.WithLanguageVersion(LanguageVersion.CSharp14);
+
+            // The script-class relaxation only applies to the script class itself. An extension block nested inside an 
+            // explicit (non-static) class at script top level remains illegal.
+            var s0 = CreateSubmission(
+                "class C { extension(string) { public static string Hello => \"Hello!\"; } }",
+                parseOptions: parseOptions);
+            s0.VerifyDiagnostics(
+                // (1,11): error CS9283: Extensions must be declared in a top-level, non-generic, static class
+                // class C { extension(string) { public static string Hello => "Hello!"; } }
+                Diagnostic(ErrorCode.ERR_BadExtensionContainingType, "extension").WithLocation(1, 11));
+        }
+
+        [Fact]
         [WorkItem(13590, "https://github.com/dotnet/roslyn/issues/13590")]
         public void FixedBuffer_01()
         {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ExtensionsParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ExtensionsParsingTests.cs
@@ -1895,6 +1895,41 @@ extension(object) { }
     }
 
     [Fact]
+    public void TopLevel_Script()
+    {
+        // At script top level, `extension(...)` parses as an extension block (a type declaration),
+        // not as an expression statement invoking a method named `extension`.
+        var src = """
+extension(object) { }
+""";
+        UsingTree(src, TestOptions.Script.WithLanguageVersion(LanguageVersion.CSharp14));
+
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ExtensionBlockDeclaration);
+            {
+                N(SyntaxKind.ExtensionKeyword);
+                N(SyntaxKind.ParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.ObjectKeyword);
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+    }
+
+    [Fact]
     public void InNestedType()
     {
         var src = """

--- a/src/Scripting/CSharpTest/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest/InteractiveSessionTests.cs
@@ -1010,6 +1010,33 @@ fruit.Skip(1).Where(s => s.Length > 4).Count()", options).Result;
         }
 
         [Fact]
+        public void ExtensionBlock()
+        {
+            // An extension block declared at script top level is usable later in the same script.
+            var result = CSharpScript.EvaluateAsync<string>(@"
+extension(string)
+{
+    public static string Hello => ""Hello!"";
+}
+string.Hello").Result;
+
+            Assert.Equal("Hello!", result);
+        }
+
+        [Fact]
+        public void ExtensionBlock_AcrossSubmissions()
+        {
+            // An extension block declared in one submission is usable in a later submission.
+            var result = CSharpScript.Create(@"
+extension(string s)
+{
+    public bool IsEmpty => s.Length == 0;
+}").ContinueWith<bool>("\"\".IsEmpty").EvaluateAsync().Result;
+
+            Assert.True(result);
+        }
+
+        [Fact]
         public void ImplicitlyTypedFields()
         {
             var result = CSharpScript.EvaluateAsync<object[]>(@"


### PR DESCRIPTION
This PR adds support for extension blocks to Roslyn Scripting.

Previously, Roslyn Scripting submissions supported extension methods, but not extension blocks. e.g. this is a valid roslyn scripting submission:

```csharp
public static string Greet(this string name) => $"Hello {name}!";

"Joe".Greet() // works, returns "Hello Joe!"
```

But extension blocks did not work:

```csharp
extension(string name)
{
    public string Greet() => $"Hello {name}!";
}

// error CS9283: Extensions must be declared in a top-level, non-generic, static class
```

C# extension blocks were only allowed inside a top-level, non-generic, static class. This PR allows the script/submission class to be a valid extension-block container.

There are two main changes (both in commit 5351f65153ea53bcfc628617f076a29343b5c513):

1. `SourceNamedTypeSymbol`: don't report ERR_BadExtensionContainingType when the container is the script class.
2. `NamedTypeSymbol.GetAllExtensionMembers`: enumerate extension members when the container is the script class, so member lookup finds them.

There were also two follow-up changes:

1. Commit b8e30f432f3f92f5542509d2da3d3ebc4682280c - the documentation comment compiler had some casting that needed to be loosened; it was casting the extension's containing type to SourceNamedTypeSymbol, which threw InvalidCastException for a script class. Easily resolved, the script class is an ImplicitNamedTypeSymbol, which shares the base class SourceMemberContainerTypeSymbol base, so use that base instead.
2. Commit 285b9fe4c8c9da4d39175d96018029addf1d4d5c - required for members to execute across submissions. Extension implementation methods were only added for TypeKind.Class; needed to add `TypeKind.Submission`

The parser already recognized `extension(...)` as a type declaration at script top level, so no parser changes are needed.

I fully understand if some sort of design approval is required for this change. Hopefully because scripting already supports extension methods, the decision to support extension blocks follows from that.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84177)