### PR TITLE
Ensure TrivialTemporaryStorageService doesn't root text

### DIFF
--- a/src/Workspaces/Core/Portable/TemporaryStorage/TrivialTemporaryStorageService.cs
+++ b/src/Workspaces/Core/Portable/TemporaryStorage/TrivialTemporaryStorageService.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
@@ -59,24 +60,31 @@ internal sealed class TrivialTemporaryStorageService : ITemporaryStorageServiceI
 
     private sealed class TextStorage : ITemporaryStorageTextHandle
     {
-        private readonly SourceText _sourceText;
+        private readonly string _content;
+        private readonly Encoding? _encoding;
+        private readonly SourceHashAlgorithm _checksumAlgorithm;
 
         public TemporaryStorageIdentifier Identifier { get; }
 
         public TextStorage(SourceText sourceText)
         {
-            _sourceText = sourceText;
-            Identifier = new TemporaryStorageIdentifier(Guid.NewGuid().ToString(), 0, _sourceText.Length);
+            // Rather than holding onto the SourceText, just hold onto the underlying content;
+            // this better matches the real implementation where creating temporary storage for text does
+            // not root the underlying text objects.
+            _content = sourceText.ToString();
+            _encoding = sourceText.Encoding;
+            _checksumAlgorithm = sourceText.ChecksumAlgorithm;
+            Identifier = new TemporaryStorageIdentifier(Guid.NewGuid().ToString(), 0, _content.Length);
         }
 
         public SourceText ReadFromTemporaryStorage(CancellationToken cancellationToken)
         {
-            return _sourceText;
+            return SourceText.From(_content, _encoding, _checksumAlgorithm);
         }
 
         public async Task<SourceText> ReadFromTemporaryStorageAsync(CancellationToken cancellationToken)
         {
-            return _sourceText;
+            return SourceText.From(_content, _encoding, _checksumAlgorithm);
         }
     }
 }

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -3554,7 +3554,7 @@ public sealed class SolutionTests : TestBase
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83118")]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/83118")]
     public void TestGetRecoveredTextAsync()
     {
         var pid = ProjectId.CreateNewId();
@@ -3700,7 +3700,7 @@ public sealed class SolutionTests : TestBase
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    [Fact(Skip = "https://github.com/dotnet/roslyn/issues/13433")]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/13433")]
     public void TestGetTextDoesNotKeepTextAlive()
     {
         var pid = ProjectId.CreateNewId();
@@ -3731,7 +3731,7 @@ public sealed class SolutionTests : TestBase
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    [Fact(Skip = "https://github.com/dotnet/roslyn/issues/13433")]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/13433")]
     public void TestGetTextAsyncDoesNotKeepTextAlive()
     {
         var pid = ProjectId.CreateNewId();


### PR DESCRIPTION
The real implementation of TemporaryStorageService doesn't root a SourceText when temporary storage is created around a SourceText. The Trivial implementation was, which breaks some tests on non-Windows where we don't use the real service. This makes the behavior match a bit better so the tests can be unskipped.

Fixes https://github.com/dotnet/roslyn/issues/83118
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84180)