### PR TITLE
[Sonic] Minor cleanup

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Diagnostics/RazorDiagnosticHelper.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Diagnostics/RazorDiagnosticHelper.cs
@@ -1,11 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Immutable;
 using System.Globalization;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
@@ -15,21 +13,6 @@ namespace Microsoft.CodeAnalysis.Remote.Razor.Diagnostics;
 
 internal static class RazorDiagnosticHelper
 {
-    public static async Task<LspDiagnostic[]?> GetRazorDiagnosticsAsync(RemoteDocumentSnapshot documentSnapshot, CancellationToken cancellationToken)
-    {
-        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
-        var sourceText = codeDocument.Source.Text;
-        var csharpDocument = codeDocument.GetRequiredImplCSharpDocument();
-        var diagnostics = csharpDocument.Diagnostics;
-
-        if (diagnostics.Length == 0)
-        {
-            return null;
-        }
-
-        return Convert(diagnostics, sourceText, documentSnapshot);
-    }
-
     public static VSDiagnosticProjectInformation[] GetProjectInformation(RemoteDocumentSnapshot? documentSnapshot)
     {
         if (documentSnapshot is null)

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Formatting/RazorFormattingService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Formatting/RazorFormattingService.cs
@@ -81,8 +81,8 @@ internal sealed class RazorFormattingService : IRazorFormattingService
         //
         // To defeat that, we simply don't do range formatting if there are diagnostics.
 
-        // Despite what it looks like, codeDocument.GetImplCSharpDocument().Diagnostics is actually the
-        // Razor diagnostics, not the C# diagnostics 🤦‍
+        // Despite what it looks like, getting diagnostics from a CSharpDocument is actually the
+        // Razor diagnostics, not the Roslyn C# diagnostics 🤦‍
         var sourceText = codeDocument.Source.Text;
         if (range is { } span)
         {


### PR DESCRIPTION
Just a couple of small things I noticed while look for uses of `GetImplCSharpDocument()`. One unused method, and one comment.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84181)