### PR TITLE
File-based apps: force using a single msbuild node for design-time builds

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/FileBasedProgramsWorkspaceTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/FileBasedProgramsWorkspaceTests.cs
@@ -25,12 +25,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.FileBasedPrograms;
 
 public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutputHelper) : AbstractLspMiscellaneousFilesWorkspaceTests(testOutputHelper)
 {
-    /// <summary>
-    /// .NET SDK version used at runtime for tests. Note: right now this matches the repo-level SDK requirement.
-    /// In the near future we are going to experiment with ways for these tests to acquire
-    /// </summary>
-    private const string SdkVersion = "10.0.108";
-
     [Theory, CombinatorialData]
     public async Task TestFileBasedProgram_Simple(bool mutatingLspWorkspace)
     {
@@ -548,16 +542,22 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
     private TempDirectory CreateTempDirectoryWithGlobalJson()
     {
         var tempDirectory = TempRoot.CreateDirectory();
-        var globalJsonContent = $$"""
+
+        string? globalJsonPath = null;
+        for (var path = AppContext.BaseDirectory; path != null; path = Path.GetDirectoryName(path))
+        {
+            var candidatePath = Path.Combine(path, "global.json");
+            if (File.Exists(candidatePath))
             {
-                "sdk": {
-                    "version": "{{SdkVersion}}",
-                    "allowPrerelease": true,
-                    "rollForward": "patch"
-                }
+                globalJsonPath = candidatePath;
+                break;
             }
-            """;
-        tempDirectory.CreateFile("global.json").WriteAllText(globalJsonContent);
+        }
+
+        if (globalJsonPath is null)
+            throw new InvalidOperationException($"The test was unable to find a global.json in the current directory tree: {AppContext.BaseDirectory}. This is likely a build authoring or deployment error.");
+
+        File.Copy(sourceFileName: globalJsonPath, destFileName: Path.Combine(tempDirectory.Path, "global.json"));
         return tempDirectory;
     }
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/FileBasedProgramsWorkspaceTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/FileBasedProgramsWorkspaceTests.cs
@@ -25,6 +25,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.FileBasedPrograms;
 
 public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutputHelper) : AbstractLspMiscellaneousFilesWorkspaceTests(testOutputHelper)
 {
+    /// <summary>
+    /// .NET SDK version used at runtime for tests. Note: right now this matches the repo-level SDK requirement.
+    /// In the near future we are going to experiment with ways for these tests to acquire
+    /// </summary>
+    private const string SdkVersion = "10.0.108";
 
     [Theory, CombinatorialData]
     public async Task TestFileBasedProgram_Simple(bool mutatingLspWorkspace)
@@ -33,7 +38,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
         await using var testLspServer = await CreateTestLspServerAsync(string.Empty, mutatingLspWorkspace, new InitializationOptions { ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer });
 
         Assert.Null(await GetMiscellaneousDocumentAsync(testLspServer));
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
         var sourceText = """
             #:sdk Microsoft.NET.Sdk
             Console.WriteLine("Hello World!");
@@ -70,7 +75,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
         await using var testLspServer = await CreateTestLspServerAsync(string.Empty, mutatingLspWorkspace, new InitializationOptions { ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer });
 
         Assert.Null(await GetMiscellaneousDocumentAsync(testLspServer));
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
         var sourceText = """
             #:sdk Microsoft.Net.Sdk
             class C { }
@@ -92,7 +97,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
         await using var testLspServer = await CreateTestLspServerAsync(string.Empty, mutatingLspWorkspace, new InitializationOptions { ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer });
 
         Assert.Null(await GetMiscellaneousDocumentAsync(testLspServer));
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
         var sourceText = """
             #!/usr/bin/env dotnet
             #:sdk Microsoft.NET.Sdk
@@ -127,7 +132,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
     public async Task TestMultipleFileBasedPrograms_WithWorkspaceDiscovery(bool mutatingLspWorkspace)
     {
         // Test discovering and loading several file-based apps in a single batch.
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
 
         var app1Text = """
             #!/usr/bin/env dotnet
@@ -178,7 +183,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
         await using var testLspServer = await CreateTestLspServerAsync(string.Empty, mutatingLspWorkspace, new InitializationOptions { ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer });
 
         Assert.Null(await GetMiscellaneousDocumentAsync(testLspServer));
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
         var sourceText = """
             #:property TargetFrameworks=net8.0;net10.0
             Console.WriteLine("Hello World!");
@@ -204,7 +209,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
         await using var testLspServer = await CreateTestLspServerAsync(string.Empty, mutatingLspWorkspace, new InitializationOptions { ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer });
 
         Assert.Null(await GetMiscellaneousDocumentAsync(testLspServer));
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
         var sourceText = """
             #:sdk Microsoft.NET.Sdk
             Console.WriteLine("Hello World!");
@@ -232,7 +237,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
         await using var testLspServer = await CreateTestLspServerAsync(string.Empty, mutatingLspWorkspace, new InitializationOptions { ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer });
 
         Assert.Null(await GetMiscellaneousDocumentAsync(testLspServer));
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
         var sourceText = """
             #:sdk Microsoft.NET.Sdk
             Console.WriteLine("Hello World!");
@@ -265,7 +270,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
         });
 
         Assert.Null(await GetMiscellaneousDocumentAsync(testLspServer));
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
         var sourceText = """
             #:sdk Microsoft.NET.Sdk
             Console.WriteLine("Hello World!");
@@ -367,7 +372,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
         await using var testLspServer = await CreateTestLspServerAsync(string.Empty, mutatingLspWorkspace, new InitializationOptions { ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer });
         Assert.Null(await GetMiscellaneousDocumentAsync(testLspServer));
 
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
         var initialText = """
             class C { }
             """;
@@ -503,7 +508,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
         await using var testLspServer = await CreateTestLspServerAsync(string.Empty, mutatingLspWorkspace, new InitializationOptions { ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer });
 
         Assert.Null(await GetMiscellaneousDocumentAsync(testLspServer));
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
         var sourceText = """
             #:sdk Microsoft.NET.Sdk
             Console.WriteLine("Hello World!");
@@ -540,6 +545,22 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
         Assert.Empty(syntaxTree.GetDiagnostics(CancellationToken.None));
     }
 
+    private TempDirectory CreateTempDirectoryWithGlobalJson()
+    {
+        var tempDirectory = TempRoot.CreateDirectory();
+        var globalJsonContent = $$"""
+            {
+                "sdk": {
+                    "version": "{{SdkVersion}}",
+                    "allowPrerelease": true,
+                    "rollForward": "patch"
+                }
+            }
+            """;
+        tempDirectory.CreateFile("global.json").WriteAllText(globalJsonContent);
+        return tempDirectory;
+    }
+
     private async ValueTask WaitForProjectLoad(DocumentUri looseFileUri, TestLspServer testLspServer)
     {
         _ = await GetRequiredLspWorkspaceAndDocumentAsync(looseFileUri, testLspServer).ConfigureAwait(false);
@@ -552,7 +573,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
         // Regression test ensuring the project loader disposes the projects (and hence their file watches) it created
         // when the server shuts down. Each file watch holds an operating system handle (e.g. an inotify instance on
         // Linux); leaking them across server restarts eventually exhausts the per-user limit.
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
         var sourceText = """
             #:sdk Microsoft.NET.Sdk
             Console.WriteLine("Hello World!");
@@ -587,7 +608,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
         await using var testLspServer = await CreateTestLspServerAsync(string.Empty, mutatingLspWorkspace, new InitializationOptions { ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer });
 
         Assert.Null(await GetMiscellaneousDocumentAsync(testLspServer));
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
         var sourceText = """
             #:sdk Microsoft.NET.Sdk
             Console.WriteLine("Hello World!");
@@ -628,7 +649,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
         await using var testLspServer = await CreateTestLspServerAsync(string.Empty, mutatingLspWorkspace, new InitializationOptions { ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer });
 
         Assert.Null(await GetMiscellaneousDocumentAsync(testLspServer));
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
         var sourceText = """
             Console.WriteLine("Hello World!");
             """;
@@ -713,7 +734,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
         await using var testLspServer = await CreateTestLspServerAsync(string.Empty, mutatingLspWorkspace, new InitializationOptions { ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer });
         Assert.Null(await GetMiscellaneousDocumentAsync(testLspServer));
 
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
         var initialText = """
             Console.WriteLine("Hello World!");
             """;
@@ -766,7 +787,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
     [ConditionalTheory(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83192"), CombinatorialData]
     public async Task TestFileStopsBeingFileBasedProgramWhenDirectivesDeleted(bool mutatingLspWorkspace)
     {
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
         var appCsText = """
             #!/usr/bin/env dotnet
             Console.WriteLine("Hello World!");
@@ -880,7 +901,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
     public async Task TestMultiFile_Simulated_01(bool mutatingLspWorkspace)
     {
         // Use a Directory.Build.props in the same directory to simulate an '#:include' directive.
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
         var dbPropsText = """
             <Project>
                 <ItemGroup>
@@ -936,7 +957,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
     public async Task TestMultiFile_Simulated_02(bool mutatingLspWorkspace)
     {
         // Reference the same non-entry-point file in both an `#:include` and `<Compile Include=...` of an ordinary project
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
         var dbPropsText = """
             <Project>
                 <ItemGroup>
@@ -1005,7 +1026,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
         // When the primary file (with `#:` + top-level statements) is opened,
         // the secondary file moves from misc workspace to the primary file's project.
         // Directory.Build.props simulates the `#:include` directive.
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
         var dbPropsText = """
             <Project>
                 <ItemGroup>
@@ -1067,7 +1088,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
         // When the primary file (with `#:` + top-level statements) is opened,
         // the secondary file moves from misc workspace to the primary file's project.
         // Directory.Build.props simulates the `#:include` directive.
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
         var dbPropsText = """
             <Project>
                 <ItemGroup>
@@ -1127,7 +1148,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
     {
         // Error scenario: open a file-based app entry point document,
         // then load a project which contains the same document.
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
         var appCsText = """
             #:property A=B
             Console.WriteLine("Hello");
@@ -1191,7 +1212,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
     {
         // Error scenario: load a project which contains a file-based app entry point,
         // then open the file-based app entry point.
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
         var appCsText = """
             #:property A=B
             Console.WriteLine("Hello");
@@ -1241,7 +1262,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
     public async Task TestCsprojInCone_01(bool mutatingLspWorkspace)
     {
         // in-cone: csproj in a containing directory (one level of nesting)
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
         var csprojFile = tempDir.CreateFile("Project.csproj");
 
         var srcDir = tempDir.CreateDirectory("src");
@@ -1302,7 +1323,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
     public async Task TestCsprojInCone_02(bool mutatingLspWorkspace)
     {
         // in-cone: csproj in same directory
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
         var csprojFile = tempDir.CreateFile("Project.csproj");
 
         var fileText = """
@@ -1330,7 +1351,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
     public async Task TestCsprojInCone_03(bool mutatingLspWorkspace)
     {
         // in-cone: csproj in a nested containing directory
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
         var csprojFile = tempDir.CreateFile("Project.csproj");
 
         var src1Dir = tempDir.CreateDirectory("src1");
@@ -1360,7 +1381,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
     public async Task TestCsprojInCone_04(bool mutatingLspWorkspace)
     {
         // not-in-cone: csproj in a sibling directory
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
 
         var src1Dir = tempDir.CreateDirectory("src");
         var csprojFile = src1Dir.CreateFile("Project.csproj");
@@ -1423,7 +1444,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
     public async Task TestCsprojInCone_05(bool mutatingLspWorkspace)
     {
         // not-in-cone: csproj in a child directory
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
         var fileText = """
             Console.WriteLine("Hello World");
             """;
@@ -1453,7 +1474,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
     {
         // not-in-cone: csproj in a parent directory above a workspace directory.
         // even though the csproj file is "in-cone" in the file system, it's not within the workspace folder, so we act as if it's not-in-cone.
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
         var csprojFile = tempDir.CreateFile("Project.csproj");
 
         var src1Dir = tempDir.CreateDirectory("src1");
@@ -1488,7 +1509,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
     {
         // in-cone: Test an edge case where multiple workspace folders are in-cone with each other.
         // The csproj-in-cone check may do unnecessary work in this case, but, observable behavior must be correct
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
         var csprojFile = tempDir.CreateFile("Project.csproj");
 
         var src1Dir = tempDir.CreateDirectory("src1");
@@ -1521,7 +1542,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
     public async Task TestCsprojInCone_08(bool mutatingLspWorkspace)
     {
         // not-in-cone: No workspace folder is opened at all. Therefore no search is done for a csproj in cone.
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
         var csprojFile = tempDir.CreateFile("Project.csproj");
 
         var fileText = """
@@ -1546,7 +1567,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
     {
         // not-in-cone: A workspace folder is open, but a .cs file outside that folder was opened.
         // No search is done for a .csproj-in-cone.
-        var tempDir = TempRoot.CreateDirectory();
+        var tempDir = CreateTempDirectoryWithGlobalJson();
         var src1Dir = tempDir.CreateDirectory("src1");
         var src2Dir = tempDir.CreateDirectory("src2");
         var csprojFile = src2Dir.CreateFile("Project.csproj");

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/FileBasedProgramsWorkspaceTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/FileBasedProgramsWorkspaceTests.cs
@@ -124,6 +124,54 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
     }
 
     [Theory, CombinatorialData]
+    public async Task TestMultipleFileBasedPrograms_WithWorkspaceDiscovery(bool mutatingLspWorkspace)
+    {
+        // Test discovering and loading several file-based apps in a single batch.
+        var tempDir = TempRoot.CreateDirectory();
+
+        var app1Text = """
+            #!/usr/bin/env dotnet
+            Console.WriteLine("app1");
+            """;
+        var app1File = tempDir.CreateFile("app1.cs").WriteAllText(app1Text);
+
+        var app2Text = """
+            #!/usr/bin/env dotnet
+            Console.WriteLine("app2");
+            """;
+        var app2File = tempDir.CreateFile("app2.cs").WriteAllText(app2Text);
+
+        var app3Text = """
+            #!/usr/bin/env dotnet
+            Console.WriteLine("app3");
+            """;
+        var app3File = tempDir.CreateFile("app3.cs").WriteAllText(app3Text);
+
+        await using var testLspServer = await CreateTestLspServerAsync(string.Empty, mutatingLspWorkspace, new InitializationOptions
+        {
+            ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer,
+            WorkspaceFolders = [new() { DocumentUri = CreateAbsoluteDocumentUri(tempDir.Path), Name = "workspace" }],
+            OptionUpdater = options => options.SetGlobalOption(FileBasedAppsOptionsStorage.EnableAutomaticDiscovery, false),
+        });
+
+        // Enable discovery and find all FBAs at once — they are queued and loaded in a single batch.
+        var globalOptions = testLspServer.TestWorkspace.ExportProvider.GetExportedValue<IGlobalOptionService>();
+        globalOptions.SetGlobalOption(FileBasedAppsOptionsStorage.EnableAutomaticDiscovery, true);
+        var discovery = testLspServer.GetRequiredLspService<FileBasedProgramsEntryPointDiscovery>();
+        await discovery.FindAndLoadEntryPointsAsync();
+        await testLspServer.TestWorkspace.GetService<AsynchronousOperationListenerProvider>().GetWaiter(FeatureAttribute.Workspace).ExpeditedWaitAsync();
+
+        // Verify all FBAs loaded successfully in the host workspace.
+        foreach (var file in new[] { app1File, app2File, app3File })
+        {
+            var uri = ProtocolConversions.CreateAbsoluteDocumentUri(file.Path);
+            var (workspace, document) = await GetRequiredLspWorkspaceAndDocumentAsync(uri, testLspServer).ConfigureAwait(false);
+            Assert.Equal(WorkspaceKind.Host, workspace.Kind);
+            Assert.True(document.Project.State.HasAllInformation, $"HasAllInformation was false for {file.Path}");
+        }
+    }
+
+    [Theory, CombinatorialData]
     public async Task TestFileBasedProgram_Multitargeting(bool mutatingLspWorkspace)
     {
         // Load a file-based app which multitargets via `#:property TargetFrameworks`.

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/FileBasedProgramsProjectSystem.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/FileBasedProgramsProjectSystem.cs
@@ -32,6 +32,12 @@ internal sealed class FileBasedProgramsProjectSystem : LanguageServerProjectLoad
     private readonly CanonicalMiscellaneousFilesProjectProvider _canonicalProjectProvider;
     private readonly DotnetCliHelper _dotnetCliHelper;
 
+    /// <summary>
+    /// Virtual (in-memory) projects don't exist on disk, so MSBuild worker nodes
+    /// can't re-evaluate them. Force single-node builds to keep everything in-process.
+    /// </summary>
+    protected override int MaxNodeCount => 1;
+
     public FileBasedProgramsProjectSystem(
         ILspServices lspServices,
         VirtualProjectXmlProvider projectXmlProvider,

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/FileBasedProgramsProjectSystem.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/FileBasedProgramsProjectSystem.cs
@@ -344,12 +344,10 @@ internal sealed class FileBasedProgramsProjectSystem : LanguageServerProjectLoad
         Contract.ThrowIfFalse(documentKind is LooseDocumentKind.FileBasedApp);
 
         var content = await _projectXmlProvider.GetVirtualProjectContentAsync(documentPath, _dotnetCliHelper, _logger, cancellationToken);
-        if (content is not var (virtualProjectContent, diagnostics))
+        if (content is not var (virtualProjectContent, virtualProjectPath, diagnostics))
         {
-            // https://github.com/dotnet/roslyn/issues/78618: falling back to this until dotnet run-api is more widely available
-            _logger.LogInformation($"Failed to obtain virtual project for '{documentPath}' using dotnet run-api. Falling back to directly creating the virtual project.");
-            virtualProjectContent = VirtualProjectXmlProvider.MakeVirtualProjectContent_DirectFallback(documentPath);
-            diagnostics = [];
+            _logger.LogError("Failed to obtain virtual project for '{documentPath}' using dotnet run-api.", documentPath);
+            return null;
         }
 
         foreach (var diagnostic in diagnostics)
@@ -357,9 +355,7 @@ internal sealed class FileBasedProgramsProjectSystem : LanguageServerProjectLoad
             _logger.LogError($"{diagnostic.Location.Path}{diagnostic.Location.Span.Start}: {diagnostic.Message}");
         }
 
-        // When loading a virtual project, the path to the on-disk source file is not used. Instead the path is adjusted to end with .csproj.
-        // This is necessary in order to get msbuild to apply the standard c# props/targets to the project.
-        var virtualProjectPath = VirtualProjectXmlProvider.GetVirtualProjectPath(documentPath);
+        virtualProjectPath ??= VirtualProjectXmlProvider.GetFallbackVirtualProjectPath(documentPath);
         const BuildHostProcessKind buildHostKind = BuildHostProcessKind.NetCore;
         var buildHost = await buildHostProcessManager.GetBuildHostAsync(buildHostKind, virtualProjectPath, dotnetPath: null, cancellationToken);
         var loadedFile = await buildHost.LoadProjectAsync(virtualProjectPath, virtualProjectContent, languageName: LanguageNames.CSharp, cancellationToken);

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/RunApiModels.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/RunApiModels.cs
@@ -40,6 +40,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.FileBasedPrograms
         public sealed class Project : RunApiOutput
         {
             public required string Content { get; init; }
+            public string? ProjectPath { get; init; }
             public required ImmutableArray<SimpleDiagnostic> Diagnostics { get; init; }
         }
     }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/VirtualProjectXmlProvider.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/VirtualProjectXmlProvider.cs
@@ -94,9 +94,13 @@ internal class VirtualProjectXmlProvider()
         }
     }
 
-    // See https://github.com/dotnet/sdk/blob/2d9fb6f7c32303c6ec359f429dee62a23e2d867c/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs#L102-L105
+    /// <summary>
+    /// From a C# document path, get the virtual project path to pass to MSBuild. Used only for the scenario where run-api doesn't give us a VirtualProjectPath.
+    /// Note: "Older" logic is used here, because, it's presumed that if run-api isn't giving us a path, it is using the older version of the logic.
+    /// See also https://github.com/dotnet/sdk/pull/53182
+    /// </summary>
     internal static string GetFallbackVirtualProjectPath(string documentFilePath)
-        => documentFilePath + ".csproj";
+        => Path.ChangeExtension(documentFilePath, ".csproj");
 
     #region Temporary copy of subset of dotnet run-api behavior
     // See https://github.com/dotnet/sdk/blob/b5dbc69cc28676ac6ea615654c8016a11b75e747/src/Cli/Microsoft.DotNet.Cli.Utils/Sha256Hasher.cs#L10

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/VirtualProjectXmlProvider.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/VirtualProjectXmlProvider.cs
@@ -6,7 +6,6 @@ using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
-using System.Security;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -27,7 +26,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.FileBasedPrograms;
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
 internal class VirtualProjectXmlProvider()
 {
-    internal async Task<(string VirtualProjectXml, ImmutableArray<SimpleDiagnostic> Diagnostics)?> GetVirtualProjectContentAsync(
+    internal async Task<(string VirtualProjectXml, string? VirtualProjectPath, ImmutableArray<SimpleDiagnostic> Diagnostics)?> GetVirtualProjectContentAsync(
         string documentFilePath,
         DotnetCliHelper dotnetCliHelper,
         ILogger logger,
@@ -78,7 +77,7 @@ internal class VirtualProjectXmlProvider()
 
             if (response is RunApiOutput.Project project)
             {
-                return (project.Content, project.Diagnostics);
+                return (project.Content, project.ProjectPath, project.Diagnostics);
             }
 
             throw ExceptionUtilities.UnexpectedValue(response);
@@ -95,15 +94,11 @@ internal class VirtualProjectXmlProvider()
         }
     }
 
-    /// <summary>
-    /// Adjusts a path to a file-based program for use in passing the virtual project to msbuild.
-    /// (msbuild needs the path to end in .csproj to recognize as a C# project and apply all the standard props/targets to it.)
-    /// </summary>
-    [return: NotNullIfNotNull(nameof(documentFilePath))]
-    internal static string? GetVirtualProjectPath(string? documentFilePath)
-        => Path.ChangeExtension(documentFilePath, ".csproj");
+    // See https://github.com/dotnet/sdk/blob/2d9fb6f7c32303c6ec359f429dee62a23e2d867c/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs#L102-L105
+    internal static string GetFallbackVirtualProjectPath(string documentFilePath)
+        => documentFilePath + ".csproj";
 
-    #region Temporary copy of subset of dotnet run-api behavior for fallback: https://github.com/dotnet/roslyn/issues/78618
+    #region Temporary copy of subset of dotnet run-api behavior
     // See https://github.com/dotnet/sdk/blob/b5dbc69cc28676ac6ea615654c8016a11b75e747/src/Cli/Microsoft.DotNet.Cli.Utils/Sha256Hasher.cs#L10
     private static class Sha256Hasher
     {
@@ -154,68 +149,4 @@ internal class VirtualProjectXmlProvider()
     }
 
     #endregion
-
-    // https://github.com/dotnet/roslyn/issues/78618: falling back to this until dotnet run-api is more widely available
-    internal static string MakeVirtualProjectContent_DirectFallback(string documentFilePath)
-    {
-        Contract.ThrowIfFalse(PathUtilities.IsAbsolute(documentFilePath));
-        var artifactsPath = GetArtifactsPath(documentFilePath);
-
-        var targetFramework = Environment.GetEnvironmentVariable("DOTNET_RUN_FILE_TFM") ?? "net$(BundledNETCoreAppTargetFrameworkVersion)";
-
-        var virtualProjectXml = $"""
-            <Project>
-              <PropertyGroup>
-                <BaseIntermediateOutputPath>{SecurityElement.Escape(artifactsPath)}\obj\</BaseIntermediateOutputPath>
-                <BaseOutputPath>{SecurityElement.Escape(artifactsPath)}\bin\</BaseOutputPath>
-              </PropertyGroup>
-              <!-- We need to explicitly import Sdk props/targets so we can override the targets below. -->
-              <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
-              <PropertyGroup>
-                <OutputType>Exe</OutputType>
-                <TargetFramework>{SecurityElement.Escape(targetFramework)}</TargetFramework>
-                <ImplicitUsings>enable</ImplicitUsings>
-                <Nullable>enable</Nullable>
-              </PropertyGroup>
-              <PropertyGroup>
-                <EnableDefaultItems>false</EnableDefaultItems>
-              </PropertyGroup>
-              <PropertyGroup>
-                <LangVersion>preview</LangVersion>
-              </PropertyGroup>
-              <PropertyGroup>
-                <Features>$(Features);FileBasedProgram</Features>
-              </PropertyGroup>
-              <ItemGroup>
-                <Compile Include="{SecurityElement.Escape(documentFilePath)}" />
-              </ItemGroup>
-              <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
-              <!--
-                Override targets which don't work with project files that are not present on disk.
-                See https://github.com/NuGet/Home/issues/14148.
-              -->
-              <Target Name="_FilterRestoreGraphProjectInputItems"
-                      DependsOnTargets="_LoadRestoreGraphEntryPoints"
-                      Returns="@(FilteredRestoreGraphProjectInputItems)">
-                <ItemGroup>
-                  <FilteredRestoreGraphProjectInputItems Include="@(RestoreGraphProjectInputItems)" />
-                </ItemGroup>
-              </Target>
-              <Target Name="_GetAllRestoreProjectPathItems"
-                      DependsOnTargets="_FilterRestoreGraphProjectInputItems"
-                      Returns="@(_RestoreProjectPathItems)">
-                <ItemGroup>
-                  <_RestoreProjectPathItems Include="@(FilteredRestoreGraphProjectInputItems)" />
-                </ItemGroup>
-              </Target>
-              <Target Name="_GenerateRestoreGraph"
-                      DependsOnTargets="_FilterRestoreGraphProjectInputItems;_GetAllRestoreProjectPathItems;_GenerateRestoreGraphProjectEntry;_GenerateProjectRestoreGraph"
-                      Returns="@(_RestoreGraphEntry)">
-                <!-- Output from dependency _GenerateRestoreGraphProjectEntry and _GenerateProjectRestoreGraph -->
-              </Target>
-            </Project>
-            """;
-
-        return virtualProjectXml;
-    }
 }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
@@ -94,6 +94,13 @@ internal abstract class LanguageServerProjectLoader : IDisposable
     /// </summary>
     protected virtual bool EnableProgressReporting => true;
 
+    /// <summary>
+    /// The max MSBuild node count to use for design-time builds.
+    /// </summary>
+    protected virtual int MaxNodeCount
+        // Don't overload the machine, so leave some CPU cores open. This chosen without much support evidence, other than it's still pretty close to max.
+        => Math.Max(Environment.ProcessorCount / 2, 1);
+
     protected LanguageServerProjectLoader(
         ILspServices lspServices,
         IGlobalOptionService globalOptionService,
@@ -176,7 +183,7 @@ internal abstract class LanguageServerProjectLoader : IDisposable
                 knownCommandLineParserLanguages: _workspaceFactory.HostWorkspace.Services.SolutionServices.GetSupportedLanguages<ICommandLineParserService>(),
                 globalMSBuildProperties: AdditionalProperties,
                 binaryLogPathProvider: _binLogPathProvider,
-                maxNodeCount: Math.Max(Environment.ProcessorCount / 2, 1), // Don't overload the machine, so leave some CPU cores open. This chosen without much support evidence, other than it's still pretty close to max.
+                maxNodeCount: MaxNodeCount,
                 loggerFactory: LoggerFactory))
             {
                 var toastErrorReporter = new ToastErrorReporter(_clientLanguageServerManager);

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
@@ -98,7 +98,7 @@ internal abstract class LanguageServerProjectLoader : IDisposable
     /// The max MSBuild node count to use for design-time builds.
     /// </summary>
     protected virtual int MaxNodeCount
-        // Don't overload the machine, so leave some CPU cores open. This chosen without much support evidence, other than it's still pretty close to max.
+        // Don't overload the machine, so leave some CPU cores open. This was chosen without much supporting evidence, other than that it's still pretty close to max.
         => Math.Max(Environment.ProcessorCount / 2, 1);
 
     protected LanguageServerProjectLoader(


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode-dotnettools/issues/3102

Aspire apphost files such as https://github.com/DamianEdwards/runfile/blob/ref/flat/apphost.cs tended to particularly fail to design-time build. The evaluation would fail with a message like: `The project file could not be loaded. Could not find file 'c:\Users\rikki\src\damian-fba-samples\flat\apphost.csproj'.`

I found that the issue didn't repro when copying just one file to a new folder and opening that in vscode. This pointed me to thinking that batching of design-time builds was going wrong here somehow.

I tried forcing using a single node for design time builds here and the full folder scenario started to succeed. This is borne out in the new unit test. If you try deleting the override of MaxNodeCount, it will fail.

2 parts to the change:
1) Stop falling back to prebaked xml when run-api fails. This tends to mask other problems and cause confusion. All cases where we invoke run-api are now expected to only work with an SDK sufficiently new to have run-api. i.e. there's no supported scenario involving .NET 8 SDK which involves calling `dotnet run-api`. We're also now consuming the ProjectPath given back to us by newer versions of run-api and ensuring our fallback (which is valid since not all run-apis will produce it), looks similar to what run-api does, to try and reduce confusion going forward.
2) Force single-node DTBs for file-based apps as described above.

There is still a need to check the original scenario listed in https://github.com/microsoft/vscode-dotnettools/issues/3102 and any other similar ones, to ensure that there aren't other bugs also causing DTBs of these files to fail.

I also don't know why Aspire apphost files seem to be blamed particularly for these failures. It feels like any multi-file setup could start failing with this--maybe there's something about apphost files that causes msbuild to tend to want to farm them out to another node. I'm unsure.

It's possible that some of this change will be obviated by @jjonescz's work to put the virtual project creation logic deeper into the BuildHost. I'm uncertain. Re-enabling multi-node in the future would be ideal, so, we should keep an eye on it.