### PR TITLE
Limit x86 test partitions to 2 assemblies to prevent OOM

### DIFF
--- a/src/Tools/RunTests/AssemblyScheduler.cs
+++ b/src/Tools/RunTests/AssemblyScheduler.cs
@@ -24,8 +24,17 @@ namespace RunTests
         /// </summary>
         private const int TargetWorkItemCount = 25;
 
+        /// <summary>
+        /// The maximum number of assemblies that can be included in a single work item when
+        /// running on x86. The x86 test host has a ~2GB virtual address space limit and loading
+        /// too many test assemblies (along with their reference assembly dependencies) into a
+        /// single process causes OOM failures.
+        /// </summary>
+        private const int MaxAssembliesPerWorkItemX86 = 2;
+
         public static ImmutableArray<HelixWorkItem> Schedule(
             IEnumerable<string> assemblyFilePaths,
+            string platform,
             Dictionary<string, (TimeSpan Duration, int TestTheoryInstances)>? testHistory)
         {
             var orderedTypeInfos = assemblyFilePaths.ToImmutableSortedDictionary(x => x, GetTypeInfoList);
@@ -37,13 +46,17 @@ namespace RunTests
                 ConsoleUtil.WriteLine($"\tAssembly: {Path.GetFileName(kvp.Key)}, Test Type Count: {typeCount}, Test Count: {testCount}");
             }
 
+            var maxAssembliesPerWorkItem = string.Equals(platform, "x86", StringComparison.OrdinalIgnoreCase)
+                ? MaxAssembliesPerWorkItemX86
+                : (int?)null;
+
             if (testHistory is null)
             {
                 ConsoleUtil.Warning($"Could not look up test history - partitioning based on test count instead");
-                return ScheduleByCount(orderedTypeInfos);
+                return ScheduleByCount(orderedTypeInfos, maxAssembliesPerWorkItem);
             }
 
-            return ScheduleByTime(orderedTypeInfos, testHistory);
+            return ScheduleByTime(orderedTypeInfos, testHistory, maxAssembliesPerWorkItem);
         }
 
         /// <summary>
@@ -51,14 +64,16 @@ namespace RunTests
         /// Used as a fallback when test history is unavailable.
         /// </summary>
         private static ImmutableArray<HelixWorkItem> ScheduleByCount(
-            ImmutableSortedDictionary<string, ImmutableArray<TypeInfo>> orderedTypeInfos)
+            ImmutableSortedDictionary<string, ImmutableArray<TypeInfo>> orderedTypeInfos,
+            int? maxAssembliesPerWorkItem)
         {
             var totalTestCount = orderedTypeInfos.Values.Sum(types => types.Sum(t => t.Tests.Length));
             var testsPerWorkItem = Math.Max(1, totalTestCount / TargetWorkItemCount);
             var workItems = BuildWorkItems(
                 orderedTypeInfos,
                 getWeightFunc: static test => 1,
-                limit: testsPerWorkItem);
+                limit: testsPerWorkItem,
+                maxAssembliesPerWorkItem);
 
             LogWorkItems(workItems);
             return workItems;
@@ -70,7 +85,8 @@ namespace RunTests
         /// </summary>
         private static ImmutableArray<HelixWorkItem> ScheduleByTime(
             ImmutableSortedDictionary<string, ImmutableArray<TypeInfo>> orderedTypeInfos,
-            Dictionary<string, (TimeSpan Duration, int TestTheoryInstances)> testHistory)
+            Dictionary<string, (TimeSpan Duration, int TestTheoryInstances)> testHistory,
+            int? maxAssembliesPerWorkItem)
         {
             LogLongTests(testHistory);
 
@@ -84,7 +100,8 @@ namespace RunTests
             var workItems = BuildWorkItems(
                 orderedTypeInfos,
                 getWeightFunc: static test => test.ExecutionTime.TotalSeconds,
-                limit: HelixTestRunner.WorkItemScheduleTime.TotalSeconds);
+                limit: HelixTestRunner.WorkItemScheduleTime.TotalSeconds,
+                maxAssembliesPerWorkItem);
             LogWorkItems(workItems);
             return workItems;
         }
@@ -195,12 +212,14 @@ namespace RunTests
         private static ImmutableArray<HelixWorkItem> BuildWorkItems<TWeight>(
             ImmutableSortedDictionary<string, ImmutableArray<TypeInfo>> typeInfos,
             Func<TestMethodInfo, TWeight> getWeightFunc,
-            TWeight limit)
+            TWeight limit,
+            int? maxAssembliesPerWorkItem)
             where TWeight : struct, INumber<TWeight>
         {
             var workItems = new List<HelixWorkItem>();
             var currentWeight = TWeight.Zero;
             var currentFilters = new List<(string AssemblyFilePath, TestMethodInfo TestMethodInfo)>();
+            var currentAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             foreach (var (assemblyFilePath, types) in typeInfos)
             {
@@ -208,6 +227,16 @@ namespace RunTests
                 {
                     AddWorkItem(types.SelectMany(x => x.Tests).Select(x => (assemblyFilePath, x)));
                     continue;
+                }
+
+                // If adding a new assembly would exceed the per-work-item assembly limit,
+                // flush the current work item first. This prevents OOM in x86 test hosts
+                // where loading too many assemblies exhausts the 2GB address space.
+                if (maxAssembliesPerWorkItem is int max &&
+                    !currentAssemblies.Contains(assemblyFilePath) &&
+                    currentAssemblies.Count >= max)
+                {
+                    MaybeAddCurrentWorkItem();
                 }
 
                 foreach (var type in types)
@@ -234,6 +263,7 @@ namespace RunTests
                         }
 
                         currentFilters.Add((assemblyFilePath, test));
+                        currentAssemblies.Add(assemblyFilePath);
                     }
                 }
             }
@@ -248,6 +278,7 @@ namespace RunTests
                     AddWorkItem(currentFilters);
                     currentFilters.Clear();
                     currentWeight = TWeight.Zero;
+                    currentAssemblies.Clear();
                 }
             }
 

--- a/src/Tools/RunTests/HelixTestRunner.cs
+++ b/src/Tools/RunTests/HelixTestRunner.cs
@@ -322,7 +322,7 @@ internal sealed partial class HelixTestRunner
 
         // Retrieve test runtimes from azure devops historical data.
         var testHistory = await TestHistoryManager.GetTestHistoryAsync(options, cancellationToken);
-        var helixWorkItems = AssemblyScheduler.Schedule(assemblies.Select(x => x.AssemblyPath), testHistory);
+        var helixWorkItems = AssemblyScheduler.Schedule(assemblies.Select(x => x.AssemblyPath), platform, testHistory);
         var timeout = testHistory is null ? WorkItemExecutionTimeout * 2 : WorkItemExecutionTimeout;
         var helixProjectFileContent = GetHelixProjectFileContent(
             helixWorkItems,


### PR DESCRIPTION
The x86 Helix test host (testhost.net472.x86) has a ~2GB virtual address space limit. When the AssemblyScheduler partitions tests by time, it can merge tests from many assemblies into a single work item. For x86 this causes the test host process to OOM as it loads too many test assemblies and their reference assembly dependencies (115MB of Basic.Reference.Assemblies alone) into a 32-bit process.

Measurements from running vstest.console.exe with 8 VB test DLLs on x86 showed the following memory profile:

| Configuration                        | Peak WS  | Peak VM  | Result    |
|--------------------------------------|----------|----------|-----------|
| 1 DLL, no filter, x86                | 203 MB   | -        | OK        |
| 2 DLLs + 2MB filter, x86             | 692 MB   | 1,085 MB | OK        |
| 2 DLLs (heaviest), no filter, x86    | 881 MB   | 1,371 MB | OK        |
| 5 DLLs, no filter, x86               | 1,620 MB | 2,404 MB | OK barely |
| 8 DLLs + 1MB filter (7.7K tests) x86 | 1,414 MB | 2,186 MB | OK        |
| 8 DLLs + 2MB filter (15K tests), x86 | 2,259 MB | 3,400 MB | OOM       |
| 8 DLLs + 2MB filter, x64             | 1,434 MB | -        | OK        |

Even the two heaviest assemblies (Emit at 23MB and Semantic at 18MB) together peaked at only 881MB on x86, well within the 2GB limit. Limiting x86 partitions to 2 assemblies per work item keeps memory usage safely under the address space ceiling while still running all tests.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84184)