### PR TITLE
Cap Razor completion lists at 1000 items to avoid pooling issues with large JsonDocument byte[]

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionListProvider.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionListProvider.cs
@@ -2,14 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.Razor.Logging;
+using Microsoft.CodeAnalysis.Text;
+using RoslynPatternMatch = Microsoft.CodeAnalysis.PatternMatching.PatternMatch;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion;
 
@@ -41,7 +45,7 @@ internal class RazorCompletionListProvider(
             return null;
         }
 
-        return CreateAndCacheCompletionList(razorCompletionContext.CodeDocument, result, clientCapabilities);
+        return CreateAndCacheCompletionList(razorCompletionContext.CodeDocument, result, clientCapabilities, razorCompletionContext.AbsoluteIndex);
     }
 
     internal static RazorCompletionContext CreateCompletionContext(
@@ -77,9 +81,12 @@ internal class RazorCompletionListProvider(
     private RazorVSInternalCompletionList CreateAndCacheCompletionList(
         RazorCodeDocument codeDocument,
         ImmutableArray<RazorCompletionItem> razorCompletionItems,
-        VSInternalClientCapabilities clientCapabilities)
+        VSInternalClientCapabilities clientCapabilities,
+        int absoluteIndex)
     {
         var completionList = CreateLSPCompletionList(razorCompletionItems, clientCapabilities);
+
+        FilterCompletionItems(completionList, codeDocument.Source.Text, absoluteIndex);
 
         // The completion list is cached and can be retrieved via this result id to enable the resolve completion functionality.
         var filePath = codeDocument.Source.FilePath.AssumeNotNull();
@@ -319,5 +326,135 @@ internal class RazorCompletionListProvider(
         completionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
 
         return completionItem;
+    }
+
+    private static void FilterCompletionItems(
+        RazorVSInternalCompletionList completionList,
+        SourceText sourceText,
+        int absoluteIndex)
+    {
+        const int MaxRazorCompletionListSize = 1000;
+
+        // If our completion list hasn't hit the max size, we don't need to filter
+        if (completionList.Items.Length <= MaxRazorCompletionListSize)
+        {
+            return;
+        }
+
+        var filterText = GetFilterText(sourceText, absoluteIndex);
+
+        // Pattern match all items against filter text (like C# does in CompletionHandler.FilterCompletionList)
+        using var matchResults = new PooledArrayBuilder<(VSInternalCompletionItem Item, int Index, RoslynPatternMatch? Match)>(completionList.Items.Length);
+        AddMatchResults(completionList, filterText, ref matchResults.AsRef());
+
+        // Take top MaxRazorCompletionListSize items (like C# does)
+        var takeCount = Math.Min(MaxRazorCompletionListSize, matchResults.Count);
+        var preselectCount = 0;
+
+        // Count preselected items beyond takeCount (like C# does)
+        for (var i = takeCount; i < matchResults.Count; i++)
+        {
+            if (matchResults[i].Item.Preselect)
+            {
+                preselectCount++;
+            }
+        }
+
+        var result = new VSInternalCompletionItem[takeCount + preselectCount];
+
+        // Add the first takeCount items
+        for (var i = 0; i < takeCount; i++)
+        {
+            result[i] = matchResults[i].Item;
+        }
+
+        // Add preselected items beyond takeCount (like C# does)
+        if (preselectCount > 0)
+        {
+            var resultIndex = takeCount;
+            for (var i = takeCount; i < matchResults.Count; i++)
+            {
+                var matchResult = matchResults[i];
+                if (matchResult.Item.Preselect)
+                {
+                    result[resultIndex++] = matchResult.Item;
+                }
+            }
+        }
+
+        completionList.Items = result;
+        completionList.IsIncomplete = true;
+
+        return;
+
+        static string GetFilterText(SourceText sourceText, int absoluteIndex)
+        {
+            // Clamp to valid range to avoid IndexOutOfRangeException
+            var start = Math.Min(absoluteIndex, sourceText.Length);
+            while (start > 0 && IsWordCharacter(sourceText[start - 1]))
+            {
+                start--;
+            }
+
+            return (start < absoluteIndex)
+                ? sourceText.ToString(new TextSpan(start, absoluteIndex - start))
+                : string.Empty;
+
+            static bool IsWordCharacter(char ch)
+            {
+                return char.IsLetterOrDigit(ch) || ch == '_' || ch == '-' || ch == ':' || ch == '@';
+            }
+        }
+
+        static void AddMatchResults(RazorVSInternalCompletionList completionList, string filterText, ref PooledArrayBuilder<(VSInternalCompletionItem Item, int Index, RoslynPatternMatch? Match)> matchResults)
+        {
+            using var helper = string.IsNullOrEmpty(filterText) ? null : new Microsoft.CodeAnalysis.Completion.PatternMatchHelper(filterText);
+
+            for (var i = 0; i < completionList.Items.Length; i++)
+            {
+                var item = completionList.Items[i];
+
+                RoslynPatternMatch? bestMatch = null;
+                if (helper != null)
+                {
+                    var itemText = item.FilterText ?? item.Label;
+                    bestMatch = helper.GetMatch(itemText, includeMatchSpans: false, CultureInfo.CurrentCulture);
+                }
+
+                matchResults.Add((item, i, bestMatch));
+            }
+
+            // Sort by match quality, then alphabetically, then original order
+            matchResults.Sort(static (a, b) =>
+            {
+                if (a.Match.HasValue != b.Match.HasValue)
+                {
+                    // Items with matches come before items without matches
+                    return a.Match.HasValue ? -1 : 1;
+                }
+
+                if (a.Match.HasValue && b.Match.HasValue)
+                {
+                    // Both have matches - compare match quality
+                    var matchComparison = a.Match.Value.CompareTo(b.Match.Value);
+                    if (matchComparison != 0)
+                    {
+                        return matchComparison;
+                    }
+                }
+
+                // Equal match quality - sort by SortText, then Label
+                var aSortText = a.Item.SortText ?? a.Item.Label;
+                var bSortText = b.Item.SortText ?? b.Item.Label;
+                var sortComparison = string.Compare(aSortText, bSortText, StringComparison.OrdinalIgnoreCase);
+                if (sortComparison != 0)
+                {
+                    return sortComparison;
+                }
+
+                // Preserve original order for equal items
+                return a.Index.CompareTo(b.Index);
+            });
+        }
     }
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionListProvider.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionListProvider.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -331,12 +330,11 @@ internal class RazorCompletionListProvider(
     private static void FilterCompletionItems(
         RazorVSInternalCompletionList completionList,
         SourceText sourceText,
-        int absoluteIndex)
+        int absoluteIndex,
+        int maxCompletionListSize = 1000)
     {
-        const int MaxRazorCompletionListSize = 1000;
-
         // If our completion list hasn't hit the max size, we don't need to filter
-        if (completionList.Items.Length <= MaxRazorCompletionListSize)
+        if (completionList.Items.Length <= maxCompletionListSize)
         {
             return;
         }
@@ -347,8 +345,8 @@ internal class RazorCompletionListProvider(
         using var matchResults = new PooledArrayBuilder<(VSInternalCompletionItem Item, int Index, RoslynPatternMatch? Match)>(completionList.Items.Length);
         AddMatchResults(completionList, filterText, ref matchResults.AsRef());
 
-        // Take top MaxRazorCompletionListSize items (like C# does)
-        var takeCount = Math.Min(MaxRazorCompletionListSize, matchResults.Count);
+        // Take top maxCompletionListSize items (like C# does)
+        var takeCount = Math.Min(maxCompletionListSize, matchResults.Count);
         var preselectCount = 0;
 
         // Count preselected items beyond takeCount (like C# does)
@@ -390,14 +388,15 @@ internal class RazorCompletionListProvider(
         static string GetFilterText(SourceText sourceText, int absoluteIndex)
         {
             // Clamp to valid range to avoid IndexOutOfRangeException
-            var start = Math.Min(absoluteIndex, sourceText.Length);
+            var end = Math.Min(absoluteIndex, sourceText.Length);
+            var start = end;
             while (start > 0 && IsWordCharacter(sourceText[start - 1]))
             {
                 start--;
             }
 
-            return (start < absoluteIndex)
-                ? sourceText.ToString(new TextSpan(start, absoluteIndex - start))
+            return (start < end)
+                ? sourceText.ToString(new TextSpan(start, end - start))
                 : string.Empty;
 
             static bool IsWordCharacter(char ch)
@@ -443,7 +442,7 @@ internal class RazorCompletionListProvider(
                     }
                 }
 
-                // Equal match quality - sort by SortText, then Label
+                // Equal match quality - sort by SortText, or Label if there is no SortText
                 var aSortText = a.Item.SortText ?? a.Item.Label;
                 var bSortText = b.Item.SortText ?? b.Item.Label;
                 var sortComparison = string.Compare(aSortText, bSortText, StringComparison.OrdinalIgnoreCase);
@@ -456,5 +455,15 @@ internal class RazorCompletionListProvider(
                 return a.Index.CompareTo(b.Index);
             });
         }
+    }
+
+    internal readonly struct TestAccessor
+    {
+        public static void FilterCompletionItems(
+            RazorVSInternalCompletionList completionList,
+            SourceText sourceText,
+            int absoluteIndex,
+            int maxCompletionListSize = 1000)
+            => RazorCompletionListProvider.FilterCompletionItems(completionList, sourceText, absoluteIndex, maxCompletionListSize);
     }
 }

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/RazorCompletionListProviderTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/RazorCompletionListProviderTest.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.Logging;
 using Microsoft.CodeAnalysis.Razor.Tooltip;
 using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Text;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -564,5 +565,149 @@ public class RazorCompletionListProviderTest
         var razorCompletionContext = RazorCompletionListProvider.CreateCompletionContext(
             codeDocument, absoluteIndex, completionContext, completionOptions);
         return provider.GetCompletionList(razorCompletionContext, clientCapabilities);
+    }
+
+    [Fact]
+    public void FilterCompletionItems_CapsAt1000Items_ByDefault()
+    {
+        // Arrange
+        var items = new VSInternalCompletionItem[1500];
+
+        for (var i = 0; i < items.Length; i++)
+        {
+            items[i] = new VSInternalCompletionItem { Label = $"Item{i:D4}", SortText = $"Item{i:D4}" };
+        }
+
+        var completionList = new RazorVSInternalCompletionList { Items = items };
+        var sourceText = SourceText.From("<");
+
+        // Act
+        RazorCompletionListProvider.TestAccessor.FilterCompletionItems(completionList, sourceText, absoluteIndex: 1);
+
+        // Assert
+        Assert.Equal(1000, completionList.Items.Length);
+        Assert.True(completionList.IsIncomplete);
+    }
+
+    [Fact]
+    public void FilterCompletionItems_IncludesPreselectItems_BeyondCap()
+    {
+        // Arrange
+        var items = new VSInternalCompletionItem[50];
+
+        for (var i = 0; i < items.Length; i++)
+        {
+            items[i] = new VSInternalCompletionItem
+            {
+                Label = $"Item{i:D2}",
+                SortText = $"Item{i:D2}",
+                Preselect = (i >= 20 && i < 25) // Items 20-24 are preselected
+            };
+        }
+
+        var completionList = new RazorVSInternalCompletionList { Items = items };
+        var sourceText = SourceText.From("<");
+
+        // Act - cap at 10 items
+        RazorCompletionListProvider.TestAccessor.FilterCompletionItems(completionList, sourceText, absoluteIndex: 1, maxCompletionListSize: 10);
+
+        // Assert - should have 10 + 5 preselected = 15 items
+        Assert.Equal(15, completionList.Items.Length);
+        Assert.True(completionList.IsIncomplete);
+
+        // First 10 should be Items00-09
+        Assert.Equal("Item00", completionList.Items[0].Label);
+        Assert.Equal("Item09", completionList.Items[9].Label);
+
+        // Last 5 should be the preselected items
+        Assert.True(completionList.Items[10].Preselect);
+        Assert.Equal("Item20", completionList.Items[10].Label);
+        Assert.Equal("Item24", completionList.Items[14].Label);
+    }
+
+    [Fact]
+    public void FilterCompletionItems_PatternMatches_FilterText()
+    {
+        // Arrange - create 15 items, 3 items starting with each char from 'A' to 'E'
+        var items = new VSInternalCompletionItem[15];
+
+        for (var i = 0; i < items.Length; i++)
+        {
+            var letter = (char)('A' + (i % 5));
+            items[i] = new VSInternalCompletionItem
+            {
+                Label = $"{letter}Component{i:D2}",
+                SortText = $"{letter}Component{i:D2}"
+            };
+        }
+
+        var completionList = new RazorVSInternalCompletionList { Items = items };
+        var sourceText = SourceText.From("<B");
+
+        // Act - cap at 5 items, cursor after "B"
+        RazorCompletionListProvider.TestAccessor.FilterCompletionItems(completionList, sourceText, absoluteIndex: 2, maxCompletionListSize: 5);
+
+        // Assert - items starting with 'B' should come first (better pattern match)
+        Assert.Equal(5, completionList.Items.Length);
+        Assert.True(completionList.IsIncomplete);
+
+        // First 3 items should be the 'B' items (better match)
+        Assert.StartsWith("B", completionList.Items[0].Label);
+        Assert.StartsWith("B", completionList.Items[1].Label);
+        Assert.StartsWith("B", completionList.Items[2].Label);
+    }
+
+    [Fact]
+    public void FilterCompletionItems_DoesNotFilter_WhenUnderLimit()
+    {
+        // Arrange
+        var items = new VSInternalCompletionItem[500];
+
+        for (var i = 0; i < items.Length; i++)
+        {
+            items[i] = new VSInternalCompletionItem { Label = $"Item{i:D3}", SortText = $"Item{i:D3}" };
+        }
+
+        var completionList = new RazorVSInternalCompletionList { Items = items };
+        var sourceText = SourceText.From("<He");
+
+        // Act
+        RazorCompletionListProvider.TestAccessor.FilterCompletionItems(completionList, sourceText, absoluteIndex: 1);
+
+        // Assert - should not filter or set incomplete
+        Assert.Equal(500, completionList.Items.Length);
+        Assert.False(completionList.IsIncomplete);
+    }
+
+    [Fact]
+    public void FilterCompletionItems_ExtractsFilterText_FromAbsoluteIndex()
+    {
+        // Arrange
+        var items = new VSInternalCompletionItem[15];
+
+        for (var i = 0; i < items.Length; i++)
+        {
+            // Mix of items: some match "Hel", some don't
+            var prefix = i < 5 || i >= 10 ? "Hello" : "World";
+            items[i] = new VSInternalCompletionItem
+            {
+                Label = $"{prefix}{i:D2}",
+                SortText = $"{prefix}{i:D2}"
+            };
+        }
+
+        var completionList = new RazorVSInternalCompletionList { Items = items };
+        var sourceText = SourceText.From("<Hel");
+
+        // Act - cap at 8 items, cursor after "Hel"
+        RazorCompletionListProvider.TestAccessor.FilterCompletionItems(completionList, sourceText, absoluteIndex: 4, maxCompletionListSize: 8);
+
+        // Assert - should get 8 items that match "Hel" (not "World" items)
+        Assert.Equal(8, completionList.Items.Length);
+        Assert.True(completionList.IsIncomplete);
+
+        // All returned items should match "Hello" - none should be "World" items
+        Assert.All(completionList.Items, item => Assert.StartsWith("Hello", item.Label));
+        Assert.DoesNotContain(completionList.Items, item => item.Label.Contains("World"));
     }
 }


### PR DESCRIPTION
 Investigation started from customer profiles showing many 2 and 4 MB byte[] allocations from JSON-RPC serialization. The allocations were traced to JsonDocument construction in the StreamJsonRpc layer. Inspecting JsonDocument's implementation revealed it uses a pooled metadata array, allocated via System.Buffers.ArrayPool. However, ArrayPool doesn't retain arrays once they exceed its 1MB threshold (DefaultMaxArrayLength), thus these large unpooled arrays create GC pressure from repeated LOH allocations.

 At this point, we needed to find what was causing these large json rpc requests. Other large allocations in the trace during the same time period were rooted in the completion system. This led to the thought that perhaps we should support streaming completion, which we did implement. However, upon testing, we found out that the 1000 item limit Roslyn lsp completion provides actually ends up with the metadata array for JsonDocument during RPC serialization stays slightly under the ArrayPool 1 MB limit. At this point, we ditched the streaming completion changes, and realized that it was Razor completion items that were causing the problem. The customer trace in question exhibits a large amount of time spent working with tag helpers and components, leading to the conclusion that this project must have a large number of said items. As completion offers these as items in the presented list, this could end up causing very large completion lists, to the point where JsonDocument's metadata arrays exceed ArrayPool's retention threshold. A test project with 6500 components confirmed uncapped Razor completion lists were causing the LOH allocations.

 This change caps Razor completion at 1000 items, mirroring C#'s behavior (CompletionHandler.FilterCompletionList): pattern match all items against the typed text, sort by match quality, then take the top 1000 items plus any preselected items beyond that cap. This ensures relevant items appear even when thousands of alphabetically-earlier items exist (e.g. typing 'z' shows ZComponent items even when thousands of components precede it alphabetically).

 The filter text is extracted by scanning backward from the completion position for word characters (letters, digits, _, -, :, @) to support both tag helper elements and directive attributes like @onclick and @bind-Value:after. Sets IsIncomplete=true when capping occurs to enable client-side requerying as the user types.
 
 *** byte[] allocations implicating JsonDocument ***
<img width="1489" height="515" alt="image" src="https://github.com/user-attachments/assets/fc8e6144-e337-428e-b6ad-4cba5d3df4a9" />


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84194)