### PR TITLE
Include nullable annotations in quick-info tooltip for delegates

### DIFF
--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -798,6 +798,23 @@ public sealed class SemanticQuickInfoSourceTests : AbstractSemanticQuickInfoSour
             """,
             MainDescription("delegate void MyHandler(object? sender, string e)"));
 
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84010")]
+    public Task TestNullableSynthesizedDelegateWithNullableParameter()
+        => TestWithOptionsAsync(TestOptions.Regular,
+            """
+            #nullable enable
+
+            class C
+            {
+                void M()
+                {
+                    $$var v = (ref object? sender) => sender?.ToString();
+                }
+            }
+            """,
+            MainDescription("delegate string <anonymous delegate>(ref object? arg)?"),
+            AnonymousTypes(""));
+
     [Fact]
     public Task TestTypeParameter()
         => TestAsync(

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -783,6 +783,21 @@ public sealed class SemanticQuickInfoSourceTests : AbstractSemanticQuickInfoSour
             @"event $$EventHandler e;",
             MainDescription("delegate void System.EventHandler(object sender, System.EventArgs e)"));
 
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84010")]
+    public Task TestDelegateWithNullableParameter()
+        => TestAsync(
+            """
+            #nullable enable
+
+            delegate void MyHandler(object? sender, string e);
+
+            class C
+            {
+                $$MyHandler handler;
+            }
+            """,
+            MainDescription("delegate void MyHandler(object? sender, string e)"));
+
     [Fact]
     public Task TestTypeParameter()
         => TestAsync(

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
@@ -557,22 +557,28 @@ internal abstract partial class AbstractSymbolDisplayService
             {
                 var style = s_descriptionStyle.WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes | SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier);
 
-                // Under the covers anonymous delegates are represented with generic types.  However, we don't want
-                // to see the unbound form of that generic.  We want to see the fully instantiated signature.
-                var displayParts = symbol.IsAnonymousDelegateType()
+                // Under the covers anonymous delegates are represented with generic types. However, we don't want
+                // to see the unbound form of that generic. We want to see the fully instantiated signature.
+                var isAnonymousDelegate = symbol.IsAnonymousDelegateType();
+                var displayParts = isAnonymousDelegate
                     ? symbol.ToDisplayParts(style)
                     : symbol.OriginalDefinition.ToDisplayParts(style);
 
                 AddToGroup(SymbolDescriptionGroups.MainDescription, WrapConstraints(symbol, displayParts));
+
+                // For non-anonymous delegates, we display OriginalDefinition which won't carry nullable
+                // annotation, so we need to add '?' separately.
+                if (!isAnonymousDelegate && symbol.NullableAnnotation == NullableAnnotation.Annotated)
+                    AddToGroup(SymbolDescriptionGroups.MainDescription, new SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, null, "?"));
             }
             else
             {
                 AddToGroup(SymbolDescriptionGroups.MainDescription,
                     WrapConstraints(symbol.OriginalDefinition, symbol.OriginalDefinition.ToDisplayParts(s_descriptionStyle)));
-            }
 
-            if (symbol.NullableAnnotation == NullableAnnotation.Annotated)
-                AddToGroup(SymbolDescriptionGroups.MainDescription, new SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, null, "?"));
+                if (symbol.NullableAnnotation == NullableAnnotation.Annotated)
+                    AddToGroup(SymbolDescriptionGroups.MainDescription, new SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, null, "?"));
+            }
 
             if (!symbol.IsUnboundGenericType &&
                 !TypeArgumentsAndParametersAreSame(symbol) &&

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
@@ -555,7 +555,7 @@ internal abstract partial class AbstractSymbolDisplayService
 
             if (symbol.TypeKind == TypeKind.Delegate)
             {
-                var style = s_descriptionStyle.WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
+                var style = s_descriptionStyle.WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes | SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier);
 
                 // Under the covers anonymous delegates are represented with generic types.  However, we don't want
                 // to see the unbound form of that generic.  We want to see the fully instantiated signature.


### PR DESCRIPTION
Fixes #84010
Delegate tooltips  were not showing nullable annotations  because the `SymbolDisplayFormat` used for delegates was missing `IncludeNullableReferenceTypeModifier`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84195)