### PR TITLE
EnC session tracker cleanup

### DIFF
--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueService.cs
@@ -17,13 +17,12 @@ using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.Extensions;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue;
 
 /// <summary>
 /// Implements core of Edit and Continue orchestration: management of edit sessions and connecting EnC related services.
-/// In VS this service should only by instantiated in OOP and accessed remotely via <see cref="IRemoteEditAndContinueService"/>.
+/// In VS, this service should only be instantiated in OOP and accessed remotely via <see cref="IRemoteEditAndContinueService"/>.
 /// The service is used directly only by dotnet-watch and for testing.
 /// </summary>
 internal sealed class EditAndContinueService : IEditAndContinueService

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueService.cs
@@ -23,6 +23,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue;
 
 /// <summary>
 /// Implements core of Edit and Continue orchestration: management of edit sessions and connecting EnC related services.
+/// In VS this service should only by instantiated in OOP and accessed remotely via <see cref="IRemoteEditAndContinueService"/>.
+/// The service is used directly only by dotnet-watch and for testing.
 /// </summary>
 internal sealed class EditAndContinueService : IEditAndContinueService
 {

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueService.cs
@@ -29,31 +29,18 @@ internal sealed class EditAndContinueService : IEditAndContinueService
     [ExportWorkspaceServiceFactory(typeof(IEditAndContinueWorkspaceService)), Shared]
     [method: ImportingConstructor]
     [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    internal sealed class WorkspaceServiceFactory(
-        [Import(AllowDefault = true)] IEditAndContinueSessionTracker? sessionTracker = null) : IWorkspaceServiceFactory
+    internal sealed class WorkspaceServiceFactory() : IWorkspaceServiceFactory
     {
         public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
             => new WorkspaceService(
                 // The host may optionally provide a log reporter (e.g. to forward EnC logs to the debugger's hot reload
                 // logger). When not available the service logs to file only.
-                new EditAndContinueService(workspaceServices.GetService<IEditAndContinueLogReporter>()),
-                sessionTracker ?? VoidSessionTracker.Instance);
+                new EditAndContinueService(workspaceServices.GetService<IEditAndContinueLogReporter>()));
     }
 
-    internal sealed class WorkspaceService(
-        IEditAndContinueService service,
-        IEditAndContinueSessionTracker sessionTracker) : IEditAndContinueWorkspaceService
+    internal sealed class WorkspaceService(IEditAndContinueService service) : IEditAndContinueWorkspaceService
     {
         public IEditAndContinueService Service { get; } = service;
-        public IEditAndContinueSessionTracker SessionTracker { get; } = sessionTracker;
-    }
-
-    internal sealed class VoidSessionTracker : IEditAndContinueSessionTracker
-    {
-        public static readonly VoidSessionTracker Instance = new();
-
-        public bool IsSessionActive => false;
-        public ImmutableArray<DiagnosticData> ApplyChangesDiagnostics => [];
     }
 
     private static readonly string? s_logDir = GetLogDirectory();

--- a/src/Features/Core/Portable/EditAndContinue/IEditAndContinueService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/IEditAndContinueService.cs
@@ -13,7 +13,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue;
 internal interface IEditAndContinueWorkspaceService : IWorkspaceService
 {
     IEditAndContinueService Service { get; }
-    IEditAndContinueSessionTracker SessionTracker { get; }
 }
 
 internal interface IEditAndContinueService

--- a/src/Features/TestUtilities/EditAndContinue/MockEditAndContinueService.cs
+++ b/src/Features/TestUtilities/EditAndContinue/MockEditAndContinueService.cs
@@ -16,13 +16,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests;
 [ExportWorkspaceServiceFactory(typeof(IEditAndContinueWorkspaceService), ServiceLayer.Test), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class MockEditAndContinueServiceFactory(
-    [Import(AllowDefault = true)] IEditAndContinueSessionTracker? sessionTracker = null) : IWorkspaceServiceFactory
+internal sealed class MockEditAndContinueServiceFactory() : IWorkspaceServiceFactory
 {
     public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
-        => new EditAndContinueService.WorkspaceService(
-            new MockEditAndContinueService(),
-            sessionTracker ?? EditAndContinueService.VoidSessionTracker.Instance);
+        => new EditAndContinueService.WorkspaceService(new MockEditAndContinueService());
 }
 
 internal sealed class MockEditAndContinueService() : IEditAndContinueService

--- a/src/LanguageServer/Protocol/Features/EditAndContinue/EditAndContinueDiagnosticSource_OpenDocument.cs
+++ b/src/LanguageServer/Protocol/Features/EditAndContinue/EditAndContinueDiagnosticSource_OpenDocument.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -13,24 +13,23 @@ namespace Microsoft.CodeAnalysis.EditAndContinue;
 
 internal static partial class EditAndContinueDiagnosticSource
 {
-    private sealed class OpenDocumentSource(Document document) : AbstractDocumentDiagnosticSource<Document>(document)
+    private sealed class OpenDocumentSource(Document document, IEditAndContinueSessionTracker sessionTracker) : AbstractDocumentDiagnosticSource<Document>(document)
     {
         public override Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(RequestContext context, CancellationToken cancellationToken)
-            => GetDiagnosticsAsync(Document, cancellationToken);
+            => GetDiagnosticsAsync(Document, sessionTracker, cancellationToken);
 
-        public static async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(Document document, CancellationToken cancellationToken)
+        public static async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(Document document, IEditAndContinueSessionTracker sessionTracker, CancellationToken cancellationToken)
         {
             var solution = document.Project.Solution;
             var services = solution.Services;
 
             // Do not report EnC diagnostics for a non-host workspace, or if Hot Reload/EnC session is not active.
-            if (solution.WorkspaceKind != WorkspaceKind.Host ||
-                services.GetService<IEditAndContinueWorkspaceService>()?.SessionTracker is not { IsSessionActive: true } sessionStateTracker)
+            if (solution.WorkspaceKind != WorkspaceKind.Host || !sessionTracker.IsSessionActive)
             {
                 return [];
             }
 
-            var applyDiagnostics = sessionStateTracker.ApplyChangesDiagnostics.WhereAsArray(static (data, id) => data.DocumentId == id, document.Id);
+            var applyDiagnostics = sessionTracker.ApplyChangesDiagnostics.WhereAsArray(static (data, id) => data.DocumentId == id, document.Id);
 
             var proxy = new RemoteEditAndContinueServiceProxy(services);
             var spanLocator = services.GetService<IActiveStatementSpanLocator>();
@@ -45,9 +44,9 @@ internal static partial class EditAndContinueDiagnosticSource
         }
     }
 
-    public static IDiagnosticSource CreateOpenDocumentSource(Document document)
-        => new OpenDocumentSource(document);
+    public static IDiagnosticSource CreateOpenDocumentSource(Document document, IEditAndContinueSessionTracker encSessionTracker)
+        => new OpenDocumentSource(document, encSessionTracker);
 
-    internal static Task<ImmutableArray<DiagnosticData>> GetDocumentDiagnosticsAsync(Document document, CancellationToken cancellationToken)
-        => OpenDocumentSource.GetDiagnosticsAsync(document, cancellationToken);
+    internal static Task<ImmutableArray<DiagnosticData>> GetDocumentDiagnosticsAsync(Document document, IEditAndContinueSessionTracker encSessionTracker, CancellationToken cancellationToken)
+        => OpenDocumentSource.GetDiagnosticsAsync(document, encSessionTracker, cancellationToken);
 }

--- a/src/LanguageServer/Protocol/Features/EditAndContinue/EditAndContinueDiagnosticSource_Workspace.cs
+++ b/src/LanguageServer/Protocol/Features/EditAndContinue/EditAndContinueDiagnosticSource_Workspace.cs
@@ -31,18 +31,17 @@ internal static partial class EditAndContinueDiagnosticSource
             => diagnostics;
     }
 
-    public static async ValueTask<ImmutableArray<IDiagnosticSource>> CreateWorkspaceDiagnosticSourcesAsync(Solution solution, Func<Document, bool> isDocumentOpen, CancellationToken cancellationToken)
+    public static async ValueTask<ImmutableArray<IDiagnosticSource>> CreateWorkspaceDiagnosticSourcesAsync(Solution solution, IEditAndContinueSessionTracker sessionTracker, Func<Document, bool> isDocumentOpen, CancellationToken cancellationToken)
     {
         // Do not report EnC diagnostics for a non-host workspace, or if Hot Reload/EnC session is not active.
-        if (solution.WorkspaceKind != WorkspaceKind.Host ||
-            solution.Services.GetService<IEditAndContinueWorkspaceService>()?.SessionTracker is not { IsSessionActive: true } sessionStateTracker)
+        if (solution.WorkspaceKind != WorkspaceKind.Host || !sessionTracker.IsSessionActive)
         {
             return [];
         }
 
         using var _ = ArrayBuilder<IDiagnosticSource>.GetInstance(out var sources);
 
-        var applyDiagnostics = sessionStateTracker.ApplyChangesDiagnostics;
+        var applyDiagnostics = sessionTracker.ApplyChangesDiagnostics;
 
         var dataByDocument = from data in applyDiagnostics
                              where data.DocumentId != null

--- a/src/LanguageServer/Protocol/Handler/EditAndContinue/DocumentEditAndContinueDiagnosticSourceProvider.cs
+++ b/src/LanguageServer/Protocol/Handler/EditAndContinue/DocumentEditAndContinueDiagnosticSourceProvider.cs
@@ -16,7 +16,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics;
 [Export(typeof(IDiagnosticSourceProvider)), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class DocumentEditAndContinueDiagnosticSourceProvider() : IDiagnosticSourceProvider
+internal sealed class DocumentEditAndContinueDiagnosticSourceProvider(
+    [Import(AllowDefault = true)] IEditAndContinueSessionTracker? sessionTracker = null) : IDiagnosticSourceProvider
 {
     public bool IsDocument => true;
     public string Name => PullDiagnosticCategories.EditAndContinue;
@@ -24,7 +25,5 @@ internal sealed class DocumentEditAndContinueDiagnosticSourceProvider() : IDiagn
     public bool IsEnabled(ClientCapabilities capabilities) => true;
 
     public async ValueTask<ImmutableArray<IDiagnosticSource>> CreateDiagnosticSourcesAsync(RequestContext context, CancellationToken cancellationToken)
-    {
-        return [EditAndContinueDiagnosticSource.CreateOpenDocumentSource(context.GetRequiredDocument())];
-    }
+        => sessionTracker is null ? [] : [EditAndContinueDiagnosticSource.CreateOpenDocumentSource(context.GetRequiredDocument(), sessionTracker)];
 }

--- a/src/LanguageServer/Protocol/Handler/EditAndContinue/DocumentEditAndContinueDiagnosticSourceProvider.cs
+++ b/src/LanguageServer/Protocol/Handler/EditAndContinue/DocumentEditAndContinueDiagnosticSourceProvider.cs
@@ -16,8 +16,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics;
 [Export(typeof(IDiagnosticSourceProvider)), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class DocumentEditAndContinueDiagnosticSourceProvider(
-    [Import(AllowDefault = true)] IEditAndContinueSessionTracker? sessionTracker = null) : IDiagnosticSourceProvider
+internal sealed class DocumentEditAndContinueDiagnosticSourceProvider(IEditAndContinueSessionTracker sessionTracker) : IDiagnosticSourceProvider
 {
     public bool IsDocument => true;
     public string Name => PullDiagnosticCategories.EditAndContinue;
@@ -25,5 +24,5 @@ internal sealed class DocumentEditAndContinueDiagnosticSourceProvider(
     public bool IsEnabled(ClientCapabilities capabilities) => true;
 
     public async ValueTask<ImmutableArray<IDiagnosticSource>> CreateDiagnosticSourcesAsync(RequestContext context, CancellationToken cancellationToken)
-        => sessionTracker is null ? [] : [EditAndContinueDiagnosticSource.CreateOpenDocumentSource(context.GetRequiredDocument(), sessionTracker)];
+        => [EditAndContinueDiagnosticSource.CreateOpenDocumentSource(context.GetRequiredDocument(), sessionTracker)];
 }

--- a/src/LanguageServer/Protocol/Handler/EditAndContinue/WorkspaceEditAndContinueDiagnosticSourceProvider.cs
+++ b/src/LanguageServer/Protocol/Handler/EditAndContinue/WorkspaceEditAndContinueDiagnosticSourceProvider.cs
@@ -16,8 +16,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics;
 [Export(typeof(IDiagnosticSourceProvider)), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class WorkspaceEditAndContinueDiagnosticSourceProvider(
-    [Import(AllowDefault = true)] IEditAndContinueSessionTracker? sessionTracker) : IDiagnosticSourceProvider
+internal sealed class WorkspaceEditAndContinueDiagnosticSourceProvider(IEditAndContinueSessionTracker sessionTracker) : IDiagnosticSourceProvider
 {
     public bool IsDocument => false;
     public string Name => PullDiagnosticCategories.EditAndContinue;
@@ -27,11 +26,6 @@ internal sealed class WorkspaceEditAndContinueDiagnosticSourceProvider(
     public ValueTask<ImmutableArray<IDiagnosticSource>> CreateDiagnosticSourcesAsync(RequestContext context, CancellationToken cancellationToken)
     {
         Contract.ThrowIfNull(context.Solution);
-        if (sessionTracker == null)
-        {
-            return new([]);
-        }
-
         return EditAndContinueDiagnosticSource.CreateWorkspaceDiagnosticSourcesAsync(context.Solution, sessionTracker, document => context.IsTracking(document.GetURI()), cancellationToken);
     }
 }

--- a/src/LanguageServer/Protocol/Handler/EditAndContinue/WorkspaceEditAndContinueDiagnosticSourceProvider.cs
+++ b/src/LanguageServer/Protocol/Handler/EditAndContinue/WorkspaceEditAndContinueDiagnosticSourceProvider.cs
@@ -16,7 +16,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics;
 [Export(typeof(IDiagnosticSourceProvider)), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class WorkspaceEditAndContinueDiagnosticSourceProvider() : IDiagnosticSourceProvider
+internal sealed class WorkspaceEditAndContinueDiagnosticSourceProvider(
+    [Import(AllowDefault = true)] IEditAndContinueSessionTracker? sessionTracker) : IDiagnosticSourceProvider
 {
     public bool IsDocument => false;
     public string Name => PullDiagnosticCategories.EditAndContinue;
@@ -26,6 +27,11 @@ internal sealed class WorkspaceEditAndContinueDiagnosticSourceProvider() : IDiag
     public ValueTask<ImmutableArray<IDiagnosticSource>> CreateDiagnosticSourcesAsync(RequestContext context, CancellationToken cancellationToken)
     {
         Contract.ThrowIfNull(context.Solution);
-        return EditAndContinueDiagnosticSource.CreateWorkspaceDiagnosticSourcesAsync(context.Solution, document => context.IsTracking(document.GetURI()), cancellationToken);
+        if (sessionTracker == null)
+        {
+            return new([]);
+        }
+
+        return EditAndContinueDiagnosticSource.CreateWorkspaceDiagnosticSourcesAsync(context.Solution, sessionTracker, document => context.IsTracking(document.GetURI()), cancellationToken);
     }
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Diagnostics/CohostDocumentPullDiagnosticsEndpointBase.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Diagnostics/CohostDocumentPullDiagnosticsEndpointBase.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Threading;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Cohost;
 using Microsoft.CodeAnalysis.Razor.Logging;
@@ -22,7 +23,8 @@ internal abstract class CohostDocumentPullDiagnosticsEndpointBase<TRequest, TRes
     IHtmlRequestInvoker requestInvoker,
     IClientCapabilitiesService clientCapabilitiesService,
     ITelemetryReporter telemetryReporter,
-    ILogger logger)
+    ILogger logger,
+    IEditAndContinueSessionTracker? encSessionTracker)
     : AbstractCohostDocumentEndpoint<TRequest, TResponse>(incompatibleProjectService)
     where TRequest : notnull
 {
@@ -31,6 +33,7 @@ internal abstract class CohostDocumentPullDiagnosticsEndpointBase<TRequest, TRes
     private readonly IClientCapabilitiesService _clientCapabilitiesService = clientCapabilitiesService;
     private readonly ITelemetryReporter _telemetryReporter = telemetryReporter;
     private readonly ILogger _logger = logger;
+    private readonly IEditAndContinueSessionTracker? _encSessionTracker = encSessionTracker;
 
     protected override bool MutatesSolutionState => false;
 
@@ -115,7 +118,7 @@ internal abstract class CohostDocumentPullDiagnosticsEndpointBase<TRequest, TRes
 
         using var _ = _telemetryReporter.TrackLspRequest(LspMethodName, "Razor.ExternalAccess", TelemetryThresholds.DiagnosticsSubLSPTelemetryThreshold, correletionId);
         var supportsVisualStudioExtensions = _clientCapabilitiesService.ClientCapabilities.SupportsVisualStudioExtensions;
-        var diagnostics = await CohostDocumentPullDiagnosticsHelpers.GetDocumentDiagnosticsAsync(generatedDocument, supportsVisualStudioExtensions, cancellationToken).ConfigureAwait(false);
+        var diagnostics = await CohostDocumentPullDiagnosticsHelpers.GetDocumentDiagnosticsAsync(generatedDocument, _encSessionTracker, supportsVisualStudioExtensions, cancellationToken).ConfigureAwait(false);
         return [.. diagnostics];
     }
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Diagnostics/CohostDocumentPullDiagnosticsEndpointBase.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Diagnostics/CohostDocumentPullDiagnosticsEndpointBase.cs
@@ -24,7 +24,7 @@ internal abstract class CohostDocumentPullDiagnosticsEndpointBase<TRequest, TRes
     IClientCapabilitiesService clientCapabilitiesService,
     ITelemetryReporter telemetryReporter,
     ILogger logger,
-    IEditAndContinueSessionTracker? encSessionTracker)
+    IEditAndContinueSessionTracker encSessionTracker)
     : AbstractCohostDocumentEndpoint<TRequest, TResponse>(incompatibleProjectService)
     where TRequest : notnull
 {
@@ -33,7 +33,7 @@ internal abstract class CohostDocumentPullDiagnosticsEndpointBase<TRequest, TRes
     private readonly IClientCapabilitiesService _clientCapabilitiesService = clientCapabilitiesService;
     private readonly ITelemetryReporter _telemetryReporter = telemetryReporter;
     private readonly ILogger _logger = logger;
-    private readonly IEditAndContinueSessionTracker? _encSessionTracker = encSessionTracker;
+    private readonly IEditAndContinueSessionTracker _encSessionTracker = encSessionTracker;
 
     protected override bool MutatesSolutionState => false;
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Diagnostics/CohostDocumentPullDiagnosticsHelpers.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Diagnostics/CohostDocumentPullDiagnosticsHelpers.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 
 internal static class CohostDocumentPullDiagnosticsHelpers
 {
-    public static async Task<ImmutableArray<LspDiagnostic>> GetDocumentDiagnosticsAsync(Document document, bool supportsVisualStudioExtensions, CancellationToken cancellationToken)
+    public static async Task<ImmutableArray<LspDiagnostic>> GetDocumentDiagnosticsAsync(Document document, IEditAndContinueSessionTracker? encSessionTracker, bool supportsVisualStudioExtensions, CancellationToken cancellationToken)
     {
         var solutionServices = document.Project.Solution.Services;
         var globalOptionsService = solutionServices.ExportProvider.GetService<IGlobalOptionService>();
@@ -24,7 +24,9 @@ internal static class CohostDocumentPullDiagnosticsHelpers
         var diagnostics = await diagnosticAnalyzerService.GetDiagnosticsForSpanAsync(
             document, range: null, DiagnosticKind.All, cancellationToken).ConfigureAwait(false);
 
-        var encDiagnostics = await EditAndContinueDiagnosticSource.GetDocumentDiagnosticsAsync(document, cancellationToken).ConfigureAwait(false);
+        var encDiagnostics = encSessionTracker != null
+            ? await EditAndContinueDiagnosticSource.GetDocumentDiagnosticsAsync(document, encSessionTracker, cancellationToken).ConfigureAwait(false)
+            : [];
 
         return ConvertDiagnostics(document, supportsVisualStudioExtensions, globalOptionsService, [.. diagnostics, .. encDiagnostics]);
     }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Diagnostics/CohostDocumentPullDiagnosticsHelpers.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Diagnostics/CohostDocumentPullDiagnosticsHelpers.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 
 internal static class CohostDocumentPullDiagnosticsHelpers
 {
-    public static async Task<ImmutableArray<LspDiagnostic>> GetDocumentDiagnosticsAsync(Document document, IEditAndContinueSessionTracker? encSessionTracker, bool supportsVisualStudioExtensions, CancellationToken cancellationToken)
+    public static async Task<ImmutableArray<LspDiagnostic>> GetDocumentDiagnosticsAsync(Document document, IEditAndContinueSessionTracker encSessionTracker, bool supportsVisualStudioExtensions, CancellationToken cancellationToken)
     {
         var solutionServices = document.Project.Solution.Services;
         var globalOptionsService = solutionServices.ExportProvider.GetService<IGlobalOptionService>();
@@ -24,10 +24,7 @@ internal static class CohostDocumentPullDiagnosticsHelpers
         var diagnostics = await diagnosticAnalyzerService.GetDiagnosticsForSpanAsync(
             document, range: null, DiagnosticKind.All, cancellationToken).ConfigureAwait(false);
 
-        var encDiagnostics = encSessionTracker != null
-            ? await EditAndContinueDiagnosticSource.GetDocumentDiagnosticsAsync(document, encSessionTracker, cancellationToken).ConfigureAwait(false)
-            : [];
-
+        var encDiagnostics = await EditAndContinueDiagnosticSource.GetDocumentDiagnosticsAsync(document, encSessionTracker, cancellationToken).ConfigureAwait(false);
         return ConvertDiagnostics(document, supportsVisualStudioExtensions, globalOptionsService, [.. diagnostics, .. encDiagnostics]);
     }
 

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostDocumentPullDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostDocumentPullDiagnosticsEndpoint.cs
@@ -29,6 +29,7 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 [Export(typeof(IDynamicRegistrationProvider))]
 [ExportRazorStatelessLspService(typeof(CohostDocumentPullDiagnosticsEndpoint))]
 [method: ImportingConstructor]
+#pragma warning restore RS0030 // Do not use banned APIs
 internal sealed class CohostDocumentPullDiagnosticsEndpoint(
     IIncompatibleProjectService incompatibleProjectService,
     IRemoteServiceInvoker remoteServiceInvoker,
@@ -36,8 +37,7 @@ internal sealed class CohostDocumentPullDiagnosticsEndpoint(
     IClientCapabilitiesService clientCapabilitiesService,
     ITelemetryReporter telemetryReporter,
     ILoggerFactory loggerFactory,
-    [Import(AllowDefault = true)] IEditAndContinueSessionTracker? encSessionTracker)
-#pragma warning restore RS0030 // Do not use banned APIs
+    IEditAndContinueSessionTracker encSessionTracker)
     : CohostDocumentPullDiagnosticsEndpointBase<VSInternalDocumentDiagnosticsParams, VSInternalDiagnosticReport[]>(
         incompatibleProjectService,
         remoteServiceInvoker,

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostDocumentPullDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostDocumentPullDiagnosticsEndpoint.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
@@ -28,21 +29,24 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 [Export(typeof(IDynamicRegistrationProvider))]
 [ExportRazorStatelessLspService(typeof(CohostDocumentPullDiagnosticsEndpoint))]
 [method: ImportingConstructor]
-#pragma warning restore RS0030 // Do not use banned APIs
 internal sealed class CohostDocumentPullDiagnosticsEndpoint(
     IIncompatibleProjectService incompatibleProjectService,
     IRemoteServiceInvoker remoteServiceInvoker,
     IHtmlRequestInvoker requestInvoker,
     IClientCapabilitiesService clientCapabilitiesService,
     ITelemetryReporter telemetryReporter,
-    ILoggerFactory loggerFactory)
+    ILoggerFactory loggerFactory,
+    [Import(AllowDefault = true)] IEditAndContinueSessionTracker? encSessionTracker)
+#pragma warning restore RS0030 // Do not use banned APIs
     : CohostDocumentPullDiagnosticsEndpointBase<VSInternalDocumentDiagnosticsParams, VSInternalDiagnosticReport[]>(
         incompatibleProjectService,
         remoteServiceInvoker,
         requestInvoker,
         clientCapabilitiesService,
         telemetryReporter,
-        loggerFactory.GetOrCreateLogger<CohostDocumentPullDiagnosticsEndpoint>()), IDynamicRegistrationProvider
+        loggerFactory.GetOrCreateLogger<CohostDocumentPullDiagnosticsEndpoint>(),
+        encSessionTracker),
+      IDynamicRegistrationProvider
 {
     private readonly IRemoteServiceInvoker _remoteServiceInvoker = remoteServiceInvoker;
     private readonly IClientCapabilitiesService _clientCapabilitiesService = clientCapabilitiesService;

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/OrganizeUsingsCommand.cs
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/OrganizeUsingsCommand.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.Razor;
 [method: ImportingConstructor]
 internal sealed class OrganizeUsingsCommand(
     IRemoteServiceInvoker remoteServiceInvoker,
-    [Import(AllowDefault = true)] IEditAndContinueSessionTracker? encSessionTracker) : IInterceptedCommand
+    IEditAndContinueSessionTracker encSessionTracker) : IInterceptedCommand
 {
     // Roslyn C# command group (guidCSharpGrpId) — used for "Remove and Sort Usings"
     private static readonly Guid s_cSharpGroupGuid = new("5d7e7f65-a63f-46ee-84f1-990b2cab23f9");

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/OrganizeUsingsCommand.cs
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/OrganizeUsingsCommand.cs
@@ -7,6 +7,7 @@ using System.ComponentModel.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
@@ -15,7 +16,9 @@ namespace Microsoft.VisualStudio.Razor;
 
 [Export(typeof(IInterceptedCommand))]
 [method: ImportingConstructor]
-internal sealed class OrganizeUsingsCommand(IRemoteServiceInvoker remoteServiceInvoker) : IInterceptedCommand
+internal sealed class OrganizeUsingsCommand(
+    IRemoteServiceInvoker remoteServiceInvoker,
+    [Import(AllowDefault = true)] IEditAndContinueSessionTracker? encSessionTracker) : IInterceptedCommand
 {
     // Roslyn C# command group (guidCSharpGrpId) — used for "Remove and Sort Usings"
     private static readonly Guid s_cSharpGroupGuid = new("5d7e7f65-a63f-46ee-84f1-990b2cab23f9");
@@ -68,7 +71,7 @@ internal sealed class OrganizeUsingsCommand(IRemoteServiceInvoker remoteServiceI
         }
 
         // C# diagnostics
-        var csharpDiagnostics = await CohostDocumentPullDiagnosticsHelpers.GetDocumentDiagnosticsAsync(generatedDocument, supportsVisualStudioExtensions: true, cancellationToken).ConfigureAwait(false);
+        var csharpDiagnostics = await CohostDocumentPullDiagnosticsHelpers.GetDocumentDiagnosticsAsync(generatedDocument, encSessionTracker, supportsVisualStudioExtensions: true, cancellationToken).ConfigureAwait(false);
 
         // Razor diagnostics (to filter and hydrate cache)
         await _remoteServiceInvoker.TryInvokeAsync<IRemoteDiagnosticsService, ImmutableArray<LspDiagnostic>>(

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Endpoints/DocumentPullDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Endpoints/DocumentPullDiagnosticsEndpoint.cs
@@ -32,7 +32,7 @@ internal sealed class DocumentPullDiagnosticsEndpoint(
     IClientCapabilitiesService clientCapabilitiesService,
     ITelemetryReporter telemetryReporter,
     ILoggerFactory loggerFactory,
-    [Import(AllowDefault = true)] IEditAndContinueSessionTracker? sessionTracker)
+    IEditAndContinueSessionTracker encSessionTracker)
     : CohostDocumentPullDiagnosticsEndpointBase<DocumentDiagnosticParams, FullDocumentDiagnosticReport?>(
         incompatibleProjectService,
         remoteServiceInvoker,
@@ -40,7 +40,7 @@ internal sealed class DocumentPullDiagnosticsEndpoint(
         clientCapabilitiesService,
         telemetryReporter,
         loggerFactory.GetOrCreateLogger<DocumentPullDiagnosticsEndpoint>(),
-        sessionTracker),
+        encSessionTracker),
       IDynamicRegistrationProvider
 {
     protected override string LspMethodName => Methods.TextDocumentDiagnosticName;

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Endpoints/DocumentPullDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Endpoints/DocumentPullDiagnosticsEndpoint.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.CodeAnalysis.Razor.Telemetry;
+using Microsoft.CodeAnalysis.EditAndContinue;
 
 namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 
@@ -30,14 +31,17 @@ internal sealed class DocumentPullDiagnosticsEndpoint(
     IHtmlRequestInvoker requestInvoker,
     IClientCapabilitiesService clientCapabilitiesService,
     ITelemetryReporter telemetryReporter,
-    ILoggerFactory loggerFactory)
+    ILoggerFactory loggerFactory,
+    [Import(AllowDefault = true)] IEditAndContinueSessionTracker? sessionTracker)
     : CohostDocumentPullDiagnosticsEndpointBase<DocumentDiagnosticParams, FullDocumentDiagnosticReport?>(
         incompatibleProjectService,
         remoteServiceInvoker,
         requestInvoker,
         clientCapabilitiesService,
         telemetryReporter,
-        loggerFactory.GetOrCreateLogger<DocumentPullDiagnosticsEndpoint>()), IDynamicRegistrationProvider
+        loggerFactory.GetOrCreateLogger<DocumentPullDiagnosticsEndpoint>(),
+        sessionTracker),
+      IDynamicRegistrationProvider
 {
     protected override string LspMethodName => Methods.TextDocumentDiagnosticName;
     protected override bool SupportsHtmlDiagnostics => false;

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests.projitems
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests.projitems
@@ -83,5 +83,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)RazorDocumentMappingServiceTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SemanticTokens\CohostSemanticTokensLegendServiceTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ThrowingSnippetResolveProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)VoidSessionTracker.cs" />
   </ItemGroup>
 </Project>

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/VoidSessionTracker.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/VoidSessionTracker.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.EditAndContinue;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+internal sealed class VoidSessionTracker : IEditAndContinueSessionTracker
+{
+    public static readonly VoidSessionTracker Instance = new();
+
+    public bool IsSessionActive => false;
+    public ImmutableArray<DiagnosticData> ApplyChangesDiagnostics => [];
+}

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostDocumentPullDiagnosticsTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostDocumentPullDiagnosticsTest.cs
@@ -635,7 +635,7 @@ public partial class CohostDocumentPullDiagnosticsTest
         ILoggerFactory loggerFactory,
         CancellationToken cancellationToken)
     {
-        var endpoint = new CohostDocumentPullDiagnosticsEndpoint(incompatibleProjectService, remoteServiceInvoker, requestInvoker, clientCapabilitiesService, NoOpTelemetryReporter.Instance, loggerFactory);
+        var endpoint = new CohostDocumentPullDiagnosticsEndpoint(incompatibleProjectService, remoteServiceInvoker, requestInvoker, clientCapabilitiesService, NoOpTelemetryReporter.Instance, loggerFactory, encSessionTracker: null);
 
         var result = taskListRequest
             ? await endpoint.GetTestAccessor().HandleTaskListItemRequestAsync(document, cancellationToken)

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostDocumentPullDiagnosticsTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostDocumentPullDiagnosticsTest.cs
@@ -635,7 +635,7 @@ public partial class CohostDocumentPullDiagnosticsTest
         ILoggerFactory loggerFactory,
         CancellationToken cancellationToken)
     {
-        var endpoint = new CohostDocumentPullDiagnosticsEndpoint(incompatibleProjectService, remoteServiceInvoker, requestInvoker, clientCapabilitiesService, NoOpTelemetryReporter.Instance, loggerFactory, encSessionTracker: null);
+        var endpoint = new CohostDocumentPullDiagnosticsEndpoint(incompatibleProjectService, remoteServiceInvoker, requestInvoker, clientCapabilitiesService, NoOpTelemetryReporter.Instance, loggerFactory, VoidSessionTracker.Instance);
 
         var result = taskListRequest
             ? await endpoint.GetTestAccessor().HandleTaskListItemRequestAsync(document, cancellationToken)

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/OrganizeUsingsCommandTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/OrganizeUsingsCommandTest.cs
@@ -620,7 +620,7 @@ public class OrganizeUsingsCommandTest(ITestOutputHelper testOutputHelper) : Coh
     {
         var document = CreateProjectAndRazorDocument(input.Text, fileKind: fileKind, additionalFiles: additionalFiles);
 
-        var command = new OrganizeUsingsCommand(RemoteServiceInvoker, encSessionTracker: null);
+        var command = new OrganizeUsingsCommand(RemoteServiceInvoker, VoidSessionTracker.Instance);
         var accessor = command.GetTestAccessor();
 
         Assert.True(accessor.QueryRemoveAndSortUsings());
@@ -637,7 +637,7 @@ public class OrganizeUsingsCommandTest(ITestOutputHelper testOutputHelper) : Coh
     {
         var document = CreateProjectAndRazorDocument(input.Text, fileKind: fileKind, additionalFiles: additionalFiles);
 
-        var command = new OrganizeUsingsCommand(RemoteServiceInvoker, encSessionTracker: null);
+        var command = new OrganizeUsingsCommand(RemoteServiceInvoker, VoidSessionTracker.Instance);
         var accessor = command.GetTestAccessor();
 
         Assert.True(accessor.QuerySortUsings());

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/OrganizeUsingsCommandTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/OrganizeUsingsCommandTest.cs
@@ -620,7 +620,7 @@ public class OrganizeUsingsCommandTest(ITestOutputHelper testOutputHelper) : Coh
     {
         var document = CreateProjectAndRazorDocument(input.Text, fileKind: fileKind, additionalFiles: additionalFiles);
 
-        var command = new OrganizeUsingsCommand(RemoteServiceInvoker);
+        var command = new OrganizeUsingsCommand(RemoteServiceInvoker, encSessionTracker: null);
         var accessor = command.GetTestAccessor();
 
         Assert.True(accessor.QueryRemoveAndSortUsings());
@@ -637,7 +637,7 @@ public class OrganizeUsingsCommandTest(ITestOutputHelper testOutputHelper) : Coh
     {
         var document = CreateProjectAndRazorDocument(input.Text, fileKind: fileKind, additionalFiles: additionalFiles);
 
-        var command = new OrganizeUsingsCommand(RemoteServiceInvoker);
+        var command = new OrganizeUsingsCommand(RemoteServiceInvoker, encSessionTracker: null);
         var accessor = command.GetTestAccessor();
 
         Assert.True(accessor.QuerySortUsings());

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudioCode.RazorExtension.UnitTests/Endpoints/CohostDocumentPullDiagnosticsTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudioCode.RazorExtension.UnitTests/Endpoints/CohostDocumentPullDiagnosticsTest.cs
@@ -96,7 +96,7 @@ public partial class CohostDocumentPullDiagnosticsTest
     {
         Assert.False(taskListRequest, "Not supported.");
 
-        var endpoint = new DocumentPullDiagnosticsEndpoint(incompatibleProjectService, remoteServiceInvoker, requestInvoker, clientCapabilitiesService, NoOpTelemetryReporter.Instance, loggerFactory, sessionTracker: null);
+        var endpoint = new DocumentPullDiagnosticsEndpoint(incompatibleProjectService, remoteServiceInvoker, requestInvoker, clientCapabilitiesService, NoOpTelemetryReporter.Instance, loggerFactory, VoidSessionTracker.Instance);
 
         return endpoint.GetTestAccessor().HandleRequestAsync(document, cancellationToken);
     }

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudioCode.RazorExtension.UnitTests/Endpoints/CohostDocumentPullDiagnosticsTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudioCode.RazorExtension.UnitTests/Endpoints/CohostDocumentPullDiagnosticsTest.cs
@@ -96,7 +96,7 @@ public partial class CohostDocumentPullDiagnosticsTest
     {
         Assert.False(taskListRequest, "Not supported.");
 
-        var endpoint = new DocumentPullDiagnosticsEndpoint(incompatibleProjectService, remoteServiceInvoker, requestInvoker, clientCapabilitiesService, NoOpTelemetryReporter.Instance, loggerFactory);
+        var endpoint = new DocumentPullDiagnosticsEndpoint(incompatibleProjectService, remoteServiceInvoker, requestInvoker, clientCapabilitiesService, NoOpTelemetryReporter.Instance, loggerFactory, sessionTracker: null);
 
         return endpoint.GetTestAccessor().HandleRequestAsync(document, cancellationToken);
     }


### PR DESCRIPTION
In VS, `IEditAndContinueService` should only by instantiated in OOP and accessed remotely via `IRemoteEditAndContinueService`.
The service is used directly only by dotnet-watch and for testing.