### PR TITLE
Restore solution as a whole on auto-load instead of per-project

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.ProcessHost.UnitTests/Utilities/AbstractLanguageServerClientTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.ProcessHost.UnitTests/Utilities/AbstractLanguageServerClientTests.cs
@@ -176,7 +176,6 @@ public abstract partial class AbstractLanguageServerClientTests(ITestOutputHelpe
             private readonly object _gate = new();
             private readonly List<WorkDoneProgress> _progressReports = [];
             private readonly TaskCompletionSource<WorkDoneProgressEnd> _endSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
-            private readonly List<(Func<WorkDoneProgress, bool> Predicate, TaskCompletionSource<WorkDoneProgress> Source)> _reportWaiters = [];
 
             public string Token { get; } = token;
             public WorkDoneProgressCreateParams CreateParams { get; } = createParams;
@@ -194,35 +193,11 @@ public abstract partial class AbstractLanguageServerClientTests(ITestOutputHelpe
 
                     if (progress is WorkDoneProgressEnd end)
                         _endSource.TrySetResult(end);
-
-                    foreach (var (predicate, source) in _reportWaiters)
-                    {
-                        if (predicate(progress))
-                            source.TrySetResult(progress);
-                    }
                 }
             }
 
             public Task<WorkDoneProgressEnd> WaitForEndAsync()
                 => _endSource.Task;
-
-            /// <summary>
-            /// Waits for a progress report matching <paramref name="predicate"/> to be reported. Returns immediately if a
-            /// matching report has already been observed. Useful for asserting on progress that is reported before some
-            /// long-running (or never-completing) work, without having to wait for the work to finish.
-            /// </summary>
-            public Task<WorkDoneProgress> WaitForReportAsync(Func<WorkDoneProgress, bool> predicate)
-            {
-                lock (_gate)
-                {
-                    if (_progressReports.FirstOrDefault(predicate) is { } existing)
-                        return Task.FromResult(existing);
-
-                    var source = new TaskCompletionSource<WorkDoneProgress>(TaskCreationOptions.RunContinuationsAsynchronously);
-                    _reportWaiters.Add((predicate, source));
-                    return source.Task;
-                }
-            }
 
             public ImmutableArray<WorkDoneProgress> GetProgressReports()
             {

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.ProcessHost.UnitTests/Utilities/AbstractLanguageServerClientTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.ProcessHost.UnitTests/Utilities/AbstractLanguageServerClientTests.cs
@@ -176,6 +176,7 @@ public abstract partial class AbstractLanguageServerClientTests(ITestOutputHelpe
             private readonly object _gate = new();
             private readonly List<WorkDoneProgress> _progressReports = [];
             private readonly TaskCompletionSource<WorkDoneProgressEnd> _endSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly List<(Func<WorkDoneProgress, bool> Predicate, TaskCompletionSource<WorkDoneProgress> Source)> _reportWaiters = [];
 
             public string Token { get; } = token;
             public WorkDoneProgressCreateParams CreateParams { get; } = createParams;
@@ -193,11 +194,35 @@ public abstract partial class AbstractLanguageServerClientTests(ITestOutputHelpe
 
                     if (progress is WorkDoneProgressEnd end)
                         _endSource.TrySetResult(end);
+
+                    foreach (var (predicate, source) in _reportWaiters)
+                    {
+                        if (predicate(progress))
+                            source.TrySetResult(progress);
+                    }
                 }
             }
 
             public Task<WorkDoneProgressEnd> WaitForEndAsync()
                 => _endSource.Task;
+
+            /// <summary>
+            /// Waits for a progress report matching <paramref name="predicate"/> to be reported. Returns immediately if a
+            /// matching report has already been observed. Useful for asserting on progress that is reported before some
+            /// long-running (or never-completing) work, without having to wait for the work to finish.
+            /// </summary>
+            public Task<WorkDoneProgress> WaitForReportAsync(Func<WorkDoneProgress, bool> predicate)
+            {
+                lock (_gate)
+                {
+                    if (_progressReports.FirstOrDefault(predicate) is { } existing)
+                        return Task.FromResult(existing);
+
+                    var source = new TaskCompletionSource<WorkDoneProgress>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    _reportWaiters.Add((predicate, source));
+                    return source.Task;
+                }
+            }
 
             public ImmutableArray<WorkDoneProgress> GetProgressReports()
             {

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.ProcessHost.UnitTests/Workspaces/AutoLoadProjectsTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.ProcessHost.UnitTests/Workspaces/AutoLoadProjectsTests.cs
@@ -133,6 +133,30 @@ public sealed class AutoLoadProjectsTests(ITestOutputHelper testOutputHelper) : 
         await AssertAutoLoadCompletedAsync(testLspServer, GetLoadingProjectsMessage(projectCount: 1), GetLoadedProjectsMessage(projectCount: 1));
     }
 
+    [Fact]
+    public async Task RestoresSolutionInsteadOfIndividualProjectsWhenSolutionLoaded()
+    {
+        // Note: intentionally not pre-restoring the workspace so that loading the solution triggers an automatic restore.
+        var workspaceContent = LspWorkspaceContent.Empty
+            .WithFile("App/App.csproj", ProjectContent)
+            .WithFile("Nested/Nested.csproj", ProjectContent)
+            .WithFile("App.sln", CreateSolutionFile("App/App.csproj", "Nested/Nested.csproj"));
+
+        await using var testLspServer = await CreateAutoLoadLanguageServerAsync(workspaceContent);
+
+        // The single solution file at the root is auto-loaded, which triggers a restore of the unrestored projects.
+        // Verify that the restore runs against the solution as a whole (a single "Restoring App.sln" stage) rather than
+        // restoring each contained project individually (which would report a "Restoring <project>.csproj" stage per project).
+        var restoreUnit = await testLspServer.WorkDoneProgress.WaitForWorkDoneProgressCreation(LanguageServerResources.Restore);
+
+        // Assert on the restore stage as soon as it is reported (before the restore process completes) so the test does
+        // not depend on the dotnet restore process exiting.
+        var restoreStage = await restoreUnit.WaitForReportAsync(static progress => progress is WorkDoneProgressReport);
+
+        var expectedStage = string.Format(LanguageServerResources.Restoring_0, "App.sln");
+        Assert.Equal(expectedStage, ((WorkDoneProgressReport)restoreStage).Message);
+    }
+
     private Task<TestLspClient> CreateAutoLoadLanguageServerAsync(LspWorkspaceContent workspaceContent)
         => CreateLanguageServerAsync(
             workspaceContent,

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.ProcessHost.UnitTests/Workspaces/AutoLoadProjectsTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.ProcessHost.UnitTests/Workspaces/AutoLoadProjectsTests.cs
@@ -145,16 +145,19 @@ public sealed class AutoLoadProjectsTests(ITestOutputHelper testOutputHelper) : 
         await using var testLspServer = await CreateAutoLoadLanguageServerAsync(workspaceContent);
 
         // The single solution file at the root is auto-loaded, which triggers a restore of the unrestored projects.
-        // Verify that the restore runs against the solution as a whole (a single "Restoring App.sln" stage) rather than
-        // restoring each contained project individually (which would report a "Restoring <project>.csproj" stage per project).
         var restoreUnit = await testLspServer.WorkDoneProgress.WaitForWorkDoneProgressCreation(LanguageServerResources.Restore);
+        await restoreUnit.WaitForEndAsync();
 
-        // Assert on the restore stage as soon as it is reported (before the restore process completes) so the test does
-        // not depend on the dotnet restore process exiting.
-        var restoreStage = await restoreUnit.WaitForReportAsync(static progress => progress is WorkDoneProgressReport);
+        // Verify that the restore ran against the solution as a whole (a single "Restoring App.sln" stage) rather than
+        // restoring each contained project individually (which would report a "Restoring <project>.csproj" stage per project).
+        var restoreStages = restoreUnit.GetProgressReports()
+            .OfType<WorkDoneProgressReport>()
+            .Select(report => report.Message)
+            .Distinct()
+            .ToArray();
 
         var expectedStage = string.Format(LanguageServerResources.Restoring_0, "App.sln");
-        Assert.Equal(expectedStage, ((WorkDoneProgressReport)restoreStage).Message);
+        Assert.Equal(expectedStage, Assert.Single(restoreStages));
     }
 
     private Task<TestLspClient> CreateAutoLoadLanguageServerAsync(LspWorkspaceContent workspaceContent)

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
@@ -101,6 +101,7 @@ internal abstract class LanguageServerProjectLoader : IDisposable
         // Don't overload the machine, so leave some CPU cores open. This was chosen without much supporting evidence, other than that it's still pretty close to max.
         => Math.Max(Environment.ProcessorCount / 2, 1);
 
+    /// <summary>
     /// Maps the set of project file paths that were determined to need a NuGet restore to the set of paths that restore
     /// should actually be invoked on. The base implementation restores each project individually. Derived loaders may
     /// override this to coalesce the work, e.g. restoring an entire solution at once instead of restoring each contained

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
@@ -104,10 +104,11 @@ internal abstract class LanguageServerProjectLoader : IDisposable
     /// Maps the set of project file paths that were determined to need a NuGet restore to the set of paths that restore
     /// should actually be invoked on. The base implementation restores each project individually. Derived loaders may
     /// override this to coalesce the work, e.g. restoring an entire solution at once instead of restoring each contained
-    /// project one at a time.
+    /// project one at a time. This is invoked at restore time (rather than cached) so overrides can consult current,
+    /// possibly-changed state such as the on-disk contents of the open solution.
     /// </summary>
-    protected virtual ImmutableArray<string> GetPathsToRestore(ImmutableArray<string> projectsThatNeedRestore)
-        => projectsThatNeedRestore;
+    protected virtual ValueTask<ImmutableArray<string>> GetPathsToRestoreAsync(ImmutableArray<string> projectsThatNeedRestore, CancellationToken cancellationToken)
+        => new(projectsThatNeedRestore);
 
     protected LanguageServerProjectLoader(
         ILspServices lspServices,
@@ -220,7 +221,7 @@ internal abstract class LanguageServerProjectLoader : IDisposable
 
             if (GlobalOptionService.GetOption(LanguageServerProjectSystemOptionsStorage.EnableAutomaticRestore) && projectsThatNeedRestore.Any())
             {
-                var pathsToRestore = GetPathsToRestore(projectsThatNeedRestore);
+                var pathsToRestore = await GetPathsToRestoreAsync(projectsThatNeedRestore, cancellationToken);
 
                 // This request blocks to ensure we aren't trying to run a design time build at the same time as a restore.
                 await ProjectDependencyHelper.RestoreProjectsAsync(_workDoneProgressManager, pathsToRestore, EnableProgressReporting, _dotnetCliHelper, _logger, cancellationToken);

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
@@ -101,6 +101,14 @@ internal abstract class LanguageServerProjectLoader : IDisposable
         // Don't overload the machine, so leave some CPU cores open. This was chosen without much supporting evidence, other than that it's still pretty close to max.
         => Math.Max(Environment.ProcessorCount / 2, 1);
 
+    /// Maps the set of project file paths that were determined to need a NuGet restore to the set of paths that restore
+    /// should actually be invoked on. The base implementation restores each project individually. Derived loaders may
+    /// override this to coalesce the work, e.g. restoring an entire solution at once instead of restoring each contained
+    /// project one at a time.
+    /// </summary>
+    protected virtual ImmutableArray<string> GetPathsToRestore(ImmutableArray<string> projectsThatNeedRestore)
+        => projectsThatNeedRestore;
+
     protected LanguageServerProjectLoader(
         ILspServices lspServices,
         IGlobalOptionService globalOptionService,
@@ -212,8 +220,10 @@ internal abstract class LanguageServerProjectLoader : IDisposable
 
             if (GlobalOptionService.GetOption(LanguageServerProjectSystemOptionsStorage.EnableAutomaticRestore) && projectsThatNeedRestore.Any())
             {
+                var pathsToRestore = GetPathsToRestore(projectsThatNeedRestore);
+
                 // This request blocks to ensure we aren't trying to run a design time build at the same time as a restore.
-                await ProjectDependencyHelper.RestoreProjectsAsync(_workDoneProgressManager, projectsThatNeedRestore, EnableProgressReporting, _dotnetCliHelper, _logger, cancellationToken);
+                await ProjectDependencyHelper.RestoreProjectsAsync(_workDoneProgressManager, pathsToRestore, EnableProgressReporting, _dotnetCliHelper, _logger, cancellationToken);
             }
         }
         finally

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
@@ -76,16 +76,55 @@ internal sealed class LanguageServerProjectSystem : LanguageServerProjectLoader,
     /// than restoring each contained project individually. A single solution-level restore is significantly faster than
     /// running <c>dotnet restore</c> once per project, which matters most for large, completely unrestored solutions.
     /// </summary>
-    protected override ImmutableArray<string> GetPathsToRestore(ImmutableArray<string> projectsThatNeedRestore)
+    /// <remarks>
+    /// A solution-level restore only covers the projects contained in the solution. It is possible for a project to be
+    /// loaded into this project system without being part of the open solution (for example, a project opened on its own
+    /// via <see cref="OpenProjectsAsync"/>). Such projects are not covered by the solution restore, so they are still
+    /// restored individually alongside the solution. The solution's project set is re-read from disk here (rather than
+    /// cached) so that edits to the solution file are always reflected in the restore scope.
+    /// </remarks>
+    protected override async ValueTask<ImmutableArray<string>> GetPathsToRestoreAsync(ImmutableArray<string> projectsThatNeedRestore, CancellationToken cancellationToken)
     {
         var solutionPath = _hostProjectFactory.SolutionPath;
-        if (solutionPath is not null)
+
+        // If no solution is open, restore each project individually.
+        if (solutionPath is null)
+            return projectsThatNeedRestore;
+
+        // Re-read the solution's current project set so a solution-level restore only collapses projects that are
+        // actually part of the solution as it exists on disk right now (the set can change if the solution file is
+        // edited between restores).
+        ImmutableHashSet<string> solutionProjectPaths;
+        try
         {
-            _logger.LogInformation("Restoring solution '{SolutionPath}' instead of {ProjectCount} individual project(s).", solutionPath, projectsThatNeedRestore.Length);
-            return [solutionPath];
+            var (_, projects) = await SolutionFileReader.ReadSolutionFileAsync(solutionPath, DiagnosticReportingMode.Throw, cancellationToken);
+            solutionProjectPaths = projects.Select(static p => p.ProjectPath).ToImmutableHashSet(PathUtilities.Comparer);
+        }
+        catch (Exception e) when (e is not OperationCanceledException)
+        {
+            // If the solution can't be read (for example it was edited into an invalid state), fall back to restoring
+            // each project individually rather than failing the restore entirely.
+            _logger.LogWarning(e, "Unable to read solution '{SolutionPath}' to determine restore scope; restoring {ProjectCount} project(s) individually.", solutionPath, projectsThatNeedRestore.Length);
+            return projectsThatNeedRestore;
         }
 
-        return projectsThatNeedRestore;
+        // Separate out any projects that need a restore but are not part of the open solution. Those are not covered by
+        // a solution-level restore, so they must still be restored on their own.
+        var projectsNotInSolution = projectsThatNeedRestore.WhereAsArray(
+            static (path, solutionProjectPaths) => !solutionProjectPaths.Contains(path), solutionProjectPaths);
+
+        // If none of the projects that need a restore are actually part of the solution, restore them individually
+        // rather than kicking off a solution restore that would not cover any of them.
+        if (projectsNotInSolution.Length == projectsThatNeedRestore.Length)
+            return projectsThatNeedRestore;
+
+        if (projectsNotInSolution.IsEmpty)
+            _logger.LogInformation("Restoring solution '{SolutionPath}' instead of {ProjectCount} individual project(s).", solutionPath, projectsThatNeedRestore.Length);
+        else
+            _logger.LogInformation("Restoring solution '{SolutionPath}' for its projects, plus {ProjectCount} project(s) not contained in the solution.", solutionPath, projectsNotInSolution.Length);
+
+        // Restore the solution as a whole (covering all of its projects), plus any projects outside the solution.
+        return [solutionPath, .. projectsNotInSolution];
     }
 
     public async Task OpenSolutionAsync(string solutionFilePath, IProgress<LSP.WorkDoneProgress>? progressReporter = null)

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
@@ -71,6 +71,23 @@ internal sealed class LanguageServerProjectSystem : LanguageServerProjectLoader,
         _projectFileExtensionRegistry = new ProjectFileExtensionRegistry(new DiagnosticReporter(workspace));
     }
 
+    /// <summary>
+    /// When a solution has been opened (either explicitly or via auto-load), restore the solution as a whole rather
+    /// than restoring each contained project individually. A single solution-level restore is significantly faster than
+    /// running <c>dotnet restore</c> once per project, which matters most for large, completely unrestored solutions.
+    /// </summary>
+    protected override ImmutableArray<string> GetPathsToRestore(ImmutableArray<string> projectsThatNeedRestore)
+    {
+        var solutionPath = _hostProjectFactory.SolutionPath;
+        if (solutionPath is not null)
+        {
+            _logger.LogInformation("Restoring solution '{SolutionPath}' instead of {ProjectCount} individual project(s).", solutionPath, projectsThatNeedRestore.Length);
+            return [solutionPath];
+        }
+
+        return projectsThatNeedRestore;
+    }
+
     public async Task OpenSolutionAsync(string solutionFilePath, IProgress<LSP.WorkDoneProgress>? progressReporter = null)
     {
         _logger.LogInformation(string.Format(LanguageServerResources.Loading_0, solutionFilePath));


### PR DESCRIPTION
When the standalone language server loads a solution (explicitly or via auto-load), restore the solution in a single `dotnet restore <solution>` rather than restoring each contained project individually. A solution-level restore is significantly faster for large, completely unrestored solutions.

Adds a virtual GetPathsToRestore hook on the base project loader and overrides it in LanguageServerProjectSystem to return the solution path when a solution is open. Includes an AutoLoadProjectsTests integration test.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84202)