### PR TITLE
Optimize todo-check.ps1 and have it check for merge markers

### DIFF
--- a/eng/todo-check.ps1
+++ b/eng/todo-check.ps1
@@ -89,7 +89,7 @@ $mergeMarkerExclusions = @(
   ':!src/EditorFeatures/VisualBasicTest/Classification/SyntacticClassifierTests.vb'
 )
 
-$mergeMarkers = Get-GitGrepMatches '^(<<<<<<<|>>>>>>>)' $mergeMarkerExclusions -extendedRegex
+$mergeMarkers = Get-GitGrepMatches '^(<<<<<<<|\|\|\|\|\|\||>>>>>>>)' $mergeMarkerExclusions -extendedRegex
 if ($mergeMarkers) {
   Write-Host "Found merge markers in checked-in files:"
   Write-Host $mergeMarkers

--- a/eng/todo-check.ps1
+++ b/eng/todo-check.ps1
@@ -21,13 +21,18 @@ function Get-GitGrepMatches([string] $pattern, [string[]] $pathspecs, [switch] $
   $arguments += ($pathspecs | ForEach-Object { $_.Replace('\', '/') })
 
   # A git grep exit code of 1 means no matches, not failure. Handle it below instead of letting PowerShell throw.
-  $previousNativeCommandUseErrorActionPreference = $PSNativeCommandUseErrorActionPreference
-  $PSNativeCommandUseErrorActionPreference = $false
+  $hasNativeCommandUseErrorActionPreference = Test-Path variable:PSNativeCommandUseErrorActionPreference
+  if ($hasNativeCommandUseErrorActionPreference) {
+    $previousNativeCommandUseErrorActionPreference = $PSNativeCommandUseErrorActionPreference
+    $PSNativeCommandUseErrorActionPreference = $false
+  }
   try {
     $result = & git @arguments
     $exitCode = $LASTEXITCODE
   } finally {
-    $PSNativeCommandUseErrorActionPreference = $previousNativeCommandUseErrorActionPreference
+    if ($hasNativeCommandUseErrorActionPreference) {
+      $PSNativeCommandUseErrorActionPreference = $previousNativeCommandUseErrorActionPreference
+    }
   }
 
   if ($exitCode -eq 0) {

--- a/eng/todo-check.ps1
+++ b/eng/todo-check.ps1
@@ -46,7 +46,7 @@ function Get-GitGrepMatches([string] $pattern, [string[]] $pathspecs, [switch] $
 }
 
 # Verify no PROTOTYPE marker left in main
-$prototypeExclusions = @(
+$prototypePathSpecs = @(
   '.',
   ':!eng/todo-check.ps1',
   ':!AGENTS.md',
@@ -56,7 +56,7 @@ $prototypeExclusions = @(
 
 if ($env:SYSTEM_PULLREQUEST_TARGETBRANCH -eq "main") {
   Write-Host "Checking no PROTOTYPE markers in checked-in files"
-  $prototypes = Get-GitGrepMatches 'PROTOTYPE' $prototypeExclusions
+  $prototypes = Get-GitGrepMatches 'PROTOTYPE' $prototypePathSpecs
   if ($prototypes) {
     Write-Host "Found PROTOTYPE markers in checked-in files:"
     Write-Host $prototypes
@@ -65,13 +65,13 @@ if ($env:SYSTEM_PULLREQUEST_TARGETBRANCH -eq "main") {
 }
 
 # Verify no TODO2 marker left
-$todo2Exclusions = @(
+$todo2PathSpecs = @(
   '.',
   ':!eng/todo-check.ps1',
   ':!AGENTS.md'
 )
 
-$todo2s = Get-GitGrepMatches 'TODO2' $todo2Exclusions
+$todo2s = Get-GitGrepMatches 'TODO2' $todo2PathSpecs
 if ($todo2s) {
   Write-Host "Found TODO2 markers in checked-in files:"
   Write-Host $todo2s
@@ -79,7 +79,7 @@ if ($todo2s) {
 }
 
 # Verify no merge markers left
-$mergeMarkerExclusions = @(
+$mergeMarkerPathSpecs = @(
   '.',
   ':!eng/todo-check.ps1',
   ':!src/Analyzers/CSharp/Tests/ConflictMarkerResolution/ConflictMarkerResolutionTests.cs',
@@ -89,7 +89,7 @@ $mergeMarkerExclusions = @(
   ':!src/EditorFeatures/VisualBasicTest/Classification/SyntacticClassifierTests.vb'
 )
 
-$mergeMarkers = Get-GitGrepMatches '^(<<<<<<<|\|\|\|\|\|\||>>>>>>>)' $mergeMarkerExclusions -extendedRegex
+$mergeMarkers = Get-GitGrepMatches '^(<<<<<<<|\|\|\|\|\|\||>>>>>>>)' $mergeMarkerPathSpecs -extendedRegex
 if ($mergeMarkers) {
   Write-Host "Found merge markers in checked-in files:"
   Write-Host $mergeMarkers

--- a/eng/todo-check.ps1
+++ b/eng/todo-check.ps1
@@ -2,24 +2,80 @@
   Checks that TODO and PROTOTYPE comments are not present.
 #>
 
-# Verify no PROTOTYPE marker left in main
 Set-StrictMode -version 2.0
 $ErrorActionPreference="Stop"
+
+function Get-GitGrepMatches([string] $pattern, [string[]] $pathspecs, [switch] $extendedRegex) {
+  $arguments = @(
+    'grep',
+    '-n', # Include line numbers in reported matches.
+    '-I'  # Skip binary files.
+  )
+  if ($extendedRegex) {
+    $arguments += '-E' # Treat the pattern as an extended regular expression.
+  } else {
+    $arguments += '-F' # Treat the pattern as a fixed string.
+  }
+
+  $arguments += @('-e', $pattern, '--')
+  $arguments += $pathspecs
+
+  $result = & git @arguments
+  if ($LASTEXITCODE -eq 0) {
+    return $result
+  } elseif ($LASTEXITCODE -eq 1) {
+    return @()
+  }
+
+  throw "git grep failed with exit code $LASTEXITCODE"
+}
+
+# Verify no PROTOTYPE marker left in main
+$prototypeExclusions = @(
+  '.',
+  ':!eng\todo-check.ps1',
+  ':!AGENTS.md',
+  ':!azure-pipelines.yml',
+  ':!docs\wiki\Compiler-release-process.md'
+)
+
 if ($env:SYSTEM_PULLREQUEST_TARGETBRANCH -eq "main") {
-  Write-Host "Checking no PROTOTYPE markers in source"
-  $prototypes = Get-ChildItem -Path src, eng, scripts, docs\compilers -Exclude *.dll,*.exe,*.pdb,*.xlf,todo-check.ps1 -Recurse | Select-String -Pattern 'PROTOTYPE' -CaseSensitive -SimpleMatch
+  Write-Host "Checking no PROTOTYPE markers in checked-in files"
+  $prototypes = Get-GitGrepMatches 'PROTOTYPE' $prototypeExclusions
   if ($prototypes) {
-    Write-Host "Found PROTOTYPE markers in source:"
+    Write-Host "Found PROTOTYPE markers in checked-in files:"
     Write-Host $prototypes
-    throw "PROTOTYPE markers disallowed in compiler source"
+    throw "PROTOTYPE markers disallowed in checked-in files"
   }
 }
 
 # Verify no TODO2 marker left
-$prototypes = Get-ChildItem -Path src, eng, scripts, docs\compilers -Exclude *.dll,*.exe,*.pdb,*.xlf,todo-check.ps1 -Recurse | Select-String -Pattern 'TODO2' -CaseSensitive -SimpleMatch
-if ($prototypes) {
-  Write-Host "Found TODO2 markers in source:"
-  Write-Host $prototypes
-  throw "TODO2 markers disallowed in compiler source"
+$todo2Exclusions = @(
+  '.',
+  ':!eng\todo-check.ps1'
+)
+
+$todo2s = Get-GitGrepMatches 'TODO2' $todo2Exclusions
+if ($todo2s) {
+  Write-Host "Found TODO2 markers in checked-in files:"
+  Write-Host $todo2s
+  throw "TODO2 markers disallowed in checked-in files"
 }
-  
+
+# Verify no merge markers left
+$mergeMarkerExclusions = @(
+  '.',
+  ':!eng\todo-check.ps1',
+  ':!src\Analyzers\CSharp\Tests\ConflictMarkerResolution\ConflictMarkerResolutionTests.cs',
+  ':!src\Analyzers\VisualBasic\Tests\ConflictMarkerResolution\ConflictMarkerResolutionTests.vb',
+  ':!src\Compilers\CSharp\Test\Syntax\LexicalAndXml\LexicalTests.cs',
+  ':!src\EditorFeatures\Test2\Rename\RenameTagProducerTests.vb',
+  ':!src\EditorFeatures\VisualBasicTest\Classification\SyntacticClassifierTests.vb'
+)
+
+$mergeMarkers = Get-GitGrepMatches '^(<<<<<<<|>>>>>>>)' $mergeMarkerExclusions -extendedRegex
+if ($mergeMarkers) {
+  Write-Host "Found merge markers in checked-in files:"
+  Write-Host $mergeMarkers
+  throw "Merge markers disallowed in checked-in files"
+}

--- a/eng/todo-check.ps1
+++ b/eng/todo-check.ps1
@@ -38,6 +38,7 @@ function Get-GitGrepMatches([string] $pattern, [string[]] $pathspecs, [switch] $
   if ($exitCode -eq 0) {
     return $result
   } elseif ($exitCode -eq 1) {
+    $global:LASTEXITCODE = 0
     return @()
   }
 

--- a/eng/todo-check.ps1
+++ b/eng/todo-check.ps1
@@ -20,14 +20,23 @@ function Get-GitGrepMatches([string] $pattern, [string[]] $pathspecs, [switch] $
   $arguments += @('-e', $pattern, '--')
   $arguments += ($pathspecs | ForEach-Object { $_.Replace('\', '/') })
 
-  $result = & git @arguments
-  if ($LASTEXITCODE -eq 0) {
+  # A git grep exit code of 1 means no matches, not failure. Handle it below instead of letting PowerShell throw.
+  $previousNativeCommandUseErrorActionPreference = $PSNativeCommandUseErrorActionPreference
+  $PSNativeCommandUseErrorActionPreference = $false
+  try {
+    $result = & git @arguments
+    $exitCode = $LASTEXITCODE
+  } finally {
+    $PSNativeCommandUseErrorActionPreference = $previousNativeCommandUseErrorActionPreference
+  }
+
+  if ($exitCode -eq 0) {
     return $result
-  } elseif ($LASTEXITCODE -eq 1) {
+  } elseif ($exitCode -eq 1) {
     return @()
   }
 
-  throw "git grep failed with exit code $LASTEXITCODE"
+  throw "git grep failed with exit code $exitCode"
 }
 
 # Verify no PROTOTYPE marker left in main

--- a/eng/todo-check.ps1
+++ b/eng/todo-check.ps1
@@ -52,7 +52,8 @@ if ($env:SYSTEM_PULLREQUEST_TARGETBRANCH -eq "main") {
 # Verify no TODO2 marker left
 $todo2Exclusions = @(
   '.',
-  ':!eng/todo-check.ps1'
+  ':!eng/todo-check.ps1',
+  ':!AGENTS.md'
 )
 
 $todo2s = Get-GitGrepMatches 'TODO2' $todo2Exclusions

--- a/eng/todo-check.ps1
+++ b/eng/todo-check.ps1
@@ -1,5 +1,5 @@
 <#
-  Checks that TODO and PROTOTYPE comments are not present.
+  Checks that TODO2, PROTOTYPE, and merge conflict markers are not present.
 #>
 
 Set-StrictMode -version 2.0
@@ -18,7 +18,7 @@ function Get-GitGrepMatches([string] $pattern, [string[]] $pathspecs, [switch] $
   }
 
   $arguments += @('-e', $pattern, '--')
-  $arguments += $pathspecs
+  $arguments += ($pathspecs | ForEach-Object { $_.Replace('\', '/') })
 
   $result = & git @arguments
   if ($LASTEXITCODE -eq 0) {
@@ -33,10 +33,10 @@ function Get-GitGrepMatches([string] $pattern, [string[]] $pathspecs, [switch] $
 # Verify no PROTOTYPE marker left in main
 $prototypeExclusions = @(
   '.',
-  ':!eng\todo-check.ps1',
+  ':!eng/todo-check.ps1',
   ':!AGENTS.md',
   ':!azure-pipelines.yml',
-  ':!docs\wiki\Compiler-release-process.md'
+  ':!docs/wiki/Compiler-release-process.md'
 )
 
 if ($env:SYSTEM_PULLREQUEST_TARGETBRANCH -eq "main") {
@@ -52,7 +52,7 @@ if ($env:SYSTEM_PULLREQUEST_TARGETBRANCH -eq "main") {
 # Verify no TODO2 marker left
 $todo2Exclusions = @(
   '.',
-  ':!eng\todo-check.ps1'
+  ':!eng/todo-check.ps1'
 )
 
 $todo2s = Get-GitGrepMatches 'TODO2' $todo2Exclusions
@@ -65,12 +65,12 @@ if ($todo2s) {
 # Verify no merge markers left
 $mergeMarkerExclusions = @(
   '.',
-  ':!eng\todo-check.ps1',
-  ':!src\Analyzers\CSharp\Tests\ConflictMarkerResolution\ConflictMarkerResolutionTests.cs',
-  ':!src\Analyzers\VisualBasic\Tests\ConflictMarkerResolution\ConflictMarkerResolutionTests.vb',
-  ':!src\Compilers\CSharp\Test\Syntax\LexicalAndXml\LexicalTests.cs',
-  ':!src\EditorFeatures\Test2\Rename\RenameTagProducerTests.vb',
-  ':!src\EditorFeatures\VisualBasicTest\Classification\SyntacticClassifierTests.vb'
+  ':!eng/todo-check.ps1',
+  ':!src/Analyzers/CSharp/Tests/ConflictMarkerResolution/ConflictMarkerResolutionTests.cs',
+  ':!src/Analyzers/VisualBasic/Tests/ConflictMarkerResolution/ConflictMarkerResolutionTests.vb',
+  ':!src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs',
+  ':!src/EditorFeatures/Test2/Rename/RenameTagProducerTests.vb',
+  ':!src/EditorFeatures/VisualBasicTest/Classification/SyntacticClassifierTests.vb'
 )
 
 $mergeMarkers = Get-GitGrepMatches '^(<<<<<<<|>>>>>>>)' $mergeMarkerExclusions -extendedRegex

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
@@ -27,7 +27,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
 [CompilerTrait(CompilerFeature.Extensions)]
 public partial class ExtensionTests : CompilingTestBase
 {
-    // PROTOTYPE: Canary for validating TODO/PROTOTYPE CI check.
     private static string ExpectedOutput(string output)
     {
         return ExecutionConditionUtil.IsMonoOrCoreClr ? output : null;

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
@@ -27,6 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
 [CompilerTrait(CompilerFeature.Extensions)]
 public partial class ExtensionTests : CompilingTestBase
 {
+    // PROTOTYPE: Canary for validating TODO/PROTOTYPE CI check.
     private static string ExpectedOutput(string output)
     {
         return ExecutionConditionUtil.IsMonoOrCoreClr ? output : null;

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
@@ -27,7 +27,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
 [CompilerTrait(CompilerFeature.Extensions)]
 public partial class ExtensionTests : CompilingTestBase
 {
-    // TODO2: Canary for validating TODO/PROTOTYPE CI check.
     private static string ExpectedOutput(string output)
     {
         return ExecutionConditionUtil.IsMonoOrCoreClr ? output : null;

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ExtensionTests.cs
@@ -27,6 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
 [CompilerTrait(CompilerFeature.Extensions)]
 public partial class ExtensionTests : CompilingTestBase
 {
+    // TODO2: Canary for validating TODO/PROTOTYPE CI check.
     private static string ExpectedOutput(string output)
     {
         return ExecutionConditionUtil.IsMonoOrCoreClr ? output : null;


### PR DESCRIPTION
I'd let some unresolved merge markers into the `features/extensions` branch (in [AGENTS.md](https://github.com/dotnet/roslyn/pull/84200/changes/31a0748505269226b580d962f08c95f4f20d6754)).
This change strengthens CI to catch such mistakes.

`git grep` is faster because it is aware of git-tracked files, binaries and it avoids the PowerShell pipeline/object overhead.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84204)