### PR TITLE
Reduce lsp server allocations by ~70% during load of already restored projects

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -144,7 +144,7 @@
       Language Server
     -->
     <PackageVersion Include="Microsoft.VisualStudio.LanguageServer.Client.Implementation" Version="17.10.72-preview" />
-    <PackageVersion Include="NuGet.ProjectModel" Version="6.8.0-rc.112" />
+    <PackageVersion Include="NuGet.ProjectModel" Version="6.14.0" />
     <PackageVersion Include="Microsoft.TestPlatform.TranslationLayer" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="$(MicrosoftNETTestSdkVersion)" />
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectDependencyHelper.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectDependencyHelper.cs
@@ -3,8 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.Extensions.Logging;
 using NuGet.ProjectModel;
 using NuGet.Versioning;
@@ -75,7 +77,7 @@ internal static class ProjectDependencyHelper
 
     /// <summary>
     /// Uses the <c>project.nuget.cache</c> file NuGet writes next to <paramref name="projectAssetsPath"/> to
-    /// confirm—without parsing the (potentially large) <c>project.assets.json</c>—that the last restore is still
+    /// confirm without parsing the (potentially large) <c>project.assets.json</c> that the last restore is still
     /// applicable to the project we're loading. The cache must be valid (<see cref="CacheFile.IsValid"/> verifies
     /// the format version matches the NuGet library we build against, the last restore succeeded, and a dependency
     /// graph hash was recorded) and the packages that restore produced
@@ -103,16 +105,13 @@ internal static class ProjectDependencyHelper
             return false;
         }
 
-        CacheFile cacheFile;
-        try
+        var cacheFile = IOUtilities.PerformIO<CacheFile?>(() =>
         {
             using var stream = File.OpenRead(cachePath);
+            return CacheFileFormat.Read(stream, NuGet.Common.NullLogger.Instance, cachePath);
+        });
 
-            // CacheFileFormat.Read handles malformed content internally (returning an invalid cache), so we
-            // only need to guard against failures opening the file itself.
-            cacheFile = CacheFileFormat.Read(stream, NuGet.Common.NullLogger.Instance, cachePath);
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        if (cacheFile is null)
         {
             return false;
         }
@@ -151,9 +150,9 @@ internal static class ProjectDependencyHelper
     /// <c>{packagesFolder}/{id}/{version}/{id}.{version}.nupkg.sha512</c>, so the package id and resolved version
     /// are the two directories that contain the file. Returns <see langword="null"/> if no package could be parsed.
     /// </summary>
-    private static Dictionary<string, ImmutableArray<NuGetVersion>>? TryCreateRestoredPackagesMap(IList<string> expectedPackageFilePaths)
+    private static Dictionary<string, OneOrMany<NuGetVersion>>? TryCreateRestoredPackagesMap(IList<string> expectedPackageFilePaths)
     {
-        var versionsById = new Dictionary<string, List<NuGetVersion>>(StringComparer.OrdinalIgnoreCase);
+        var versionsById = new Dictionary<string, OneOrMany<NuGetVersion>>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var filePath in expectedPackageFilePaths)
         {
@@ -172,28 +171,15 @@ internal static class ProjectDependencyHelper
 
             if (!versionsById.TryGetValue(id, out var versions))
             {
-                versions = new List<NuGetVersion>(capacity: 1);
-                versionsById.Add(id, versions);
+                versionsById.Add(id, OneOrMany.Create(version));
             }
-
-            if (!versions.Contains(version))
+            else if (!versions.Contains(version))
             {
-                versions.Add(version);
+                versionsById[id] = versions.Add(version);
             }
         }
 
-        if (versionsById.Count == 0)
-        {
-            return null;
-        }
-
-        var map = new Dictionary<string, ImmutableArray<NuGetVersion>>(versionsById.Count, StringComparer.OrdinalIgnoreCase);
-        foreach (var (id, versions) in versionsById)
-        {
-            map.Add(id, versions.ToImmutableArray());
-        }
-
-        return map;
+        return versionsById.Count == 0 ? null : versionsById;
     }
 
     /// <summary>
@@ -202,7 +188,7 @@ internal static class ProjectDependencyHelper
     /// reference is resolved when its name is present and at least one restored version satisfies the requested
     /// version range.
     /// </summary>
-    private static bool IsPackageReferenceResolved(PackageReferenceItem reference, IReadOnlyDictionary<string, ImmutableArray<NuGetVersion>> restoredPackages)
+    private static bool IsPackageReferenceResolved(PackageReferenceItem reference, IReadOnlyDictionary<string, OneOrMany<NuGetVersion>> restoredPackages)
     {
         if (!restoredPackages.TryGetValue(reference.Name, out var versions))
         {
@@ -255,12 +241,12 @@ internal static class ProjectDependencyHelper
 
         return false;
 
-        static ImmutableDictionary<string, ImmutableArray<NuGetVersion>> CreateProjectAssetsMap(LockFile lockFile)
+        static ImmutableDictionary<string, OneOrMany<NuGetVersion>> CreateProjectAssetsMap(LockFile lockFile)
         {
             // Create a map of package names to all versions in the lock file.
             var map = lockFile.Libraries
                 .GroupBy(l => l.Name, l => l.Version, StringComparer.OrdinalIgnoreCase)
-                .ToImmutableDictionary(g => g.Key, g => g.ToImmutableArray(), StringComparer.OrdinalIgnoreCase);
+                .ToImmutableDictionary(g => g.Key, g => OneOrMany.Create(g.ToImmutableArray()), StringComparer.OrdinalIgnoreCase);
 
             return map;
         }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectDependencyHelper.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectDependencyHelper.cs
@@ -14,6 +14,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
 
 internal static class ProjectDependencyHelper
 {
+    private const string NuGetCacheFileName = "project.nuget.cache";
+
     internal static bool NeedsRestore(ProjectFileInfo newProjectFileInfo, ProjectFileInfo? previousProjectFileInfo, ILogger logger)
     {
         if (previousProjectFileInfo is null)
@@ -60,6 +62,171 @@ internal static class ProjectDependencyHelper
             return false;
         }
 
+        // Fast path: consult the 'project.nuget.cache' file NuGet writes next to the assets file. If it
+        // confirms the last restore still accounts for every package reference the project declares, we can
+        // skip parsing the (potentially large) project.assets.json entirely.
+        if (TryConfirmRestoreUpToDateFromNuGetCache(projectFileInfo, projectAssetsPath))
+        {
+            return false;
+        }
+
+        return CheckAssetsFileForUnresolvedReferences(projectFileInfo, projectAssetsPath, logger);
+    }
+
+    /// <summary>
+    /// Uses the <c>project.nuget.cache</c> file NuGet writes next to <paramref name="projectAssetsPath"/> to
+    /// confirm—without parsing the (potentially large) <c>project.assets.json</c>—that the last restore is still
+    /// applicable to the project we're loading. The cache must be valid (<see cref="CacheFile.IsValid"/> verifies
+    /// the format version matches the NuGet library we build against, the last restore succeeded, and a dependency
+    /// graph hash was recorded) and the packages that restore produced
+    /// (<see cref="CacheFile.ExpectedPackageFilePaths"/>) must satisfy every package reference the project currently
+    /// declares. The latter check catches a project whose package set changed since the last restore—for example a
+    /// package added directly to the project or via a shared <c>Directory.Packages.props</c>—in which case the
+    /// previously restored assets no longer reflect the project and we can't claim it's up to date.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> only when the cache proves the restore is current for every package reference the
+    /// project declares; otherwise <see langword="false"/> (the cache is missing, invalid, or doesn't account for
+    /// all of the project's package references), in which case the caller should inspect the assets file directly.
+    /// </returns>
+    /// <remarks>
+    /// This intentionally does not reproduce NuGet's dependency-graph-hash comparison, which needs the current
+    /// restore dependency graph that is not available here. Instead it confirms the restored package set covers the
+    /// project's declared references and otherwise defers to the precise assets-file check, so it can only ever
+    /// accelerate the up-to-date case and never report a stale restore as current.
+    /// </remarks>
+    private static bool TryConfirmRestoreUpToDateFromNuGetCache(ProjectFileInfo projectFileInfo, string projectAssetsPath)
+    {
+        var cachePath = Path.Combine(Path.GetDirectoryName(projectAssetsPath)!, NuGetCacheFileName);
+        if (!File.Exists(cachePath))
+        {
+            return false;
+        }
+
+        CacheFile cacheFile;
+        try
+        {
+            using var stream = File.OpenRead(cachePath);
+
+            // CacheFileFormat.Read handles malformed content internally (returning an invalid cache), so we
+            // only need to guard against failures opening the file itself.
+            cacheFile = CacheFileFormat.Read(stream, NuGet.Common.NullLogger.Instance, cachePath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return false;
+        }
+
+        // IsValid checks Version == CacheFile.CurrentVersion (the format version this NuGet build understands),
+        // Success, and that a dependency graph hash was recorded.
+        if (!cacheFile.IsValid || cacheFile.ExpectedPackageFilePaths is not { Count: > 0 })
+        {
+            return false;
+        }
+
+        // Reconstruct the set of packages the last restore produced and confirm every package reference the
+        // project currently declares is present with a satisfying version. If a reference isn't accounted for,
+        // the project changed since the restore (or the cache is otherwise incomplete), so we can't confirm it's
+        // up to date and defer to the assets-file check.
+        var restoredPackages = TryCreateRestoredPackagesMap(cacheFile.ExpectedPackageFilePaths);
+        if (restoredPackages is null)
+        {
+            return false;
+        }
+
+        foreach (var reference in projectFileInfo.PackageReferences)
+        {
+            if (!IsPackageReferenceResolved(reference, restoredPackages))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Builds a map of package id to the versions present in the restore, derived from the
+    /// <see cref="CacheFile.ExpectedPackageFilePaths"/>. Each entry looks like
+    /// <c>{packagesFolder}/{id}/{version}/{id}.{version}.nupkg.sha512</c>, so the package id and resolved version
+    /// are the two directories that contain the file. Returns <see langword="null"/> if no package could be parsed.
+    /// </summary>
+    private static Dictionary<string, ImmutableArray<NuGetVersion>>? TryCreateRestoredPackagesMap(IList<string> expectedPackageFilePaths)
+    {
+        var versionsById = new Dictionary<string, List<NuGetVersion>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var filePath in expectedPackageFilePaths)
+        {
+            var versionDirectory = Path.GetDirectoryName(filePath);
+            var idDirectory = Path.GetDirectoryName(versionDirectory);
+            if (string.IsNullOrEmpty(versionDirectory) || string.IsNullOrEmpty(idDirectory))
+            {
+                continue;
+            }
+
+            var id = Path.GetFileName(idDirectory);
+            if (string.IsNullOrEmpty(id) || !NuGetVersion.TryParse(Path.GetFileName(versionDirectory), out var version))
+            {
+                continue;
+            }
+
+            if (!versionsById.TryGetValue(id, out var versions))
+            {
+                versions = new List<NuGetVersion>(capacity: 1);
+                versionsById.Add(id, versions);
+            }
+
+            if (!versions.Contains(version))
+            {
+                versions.Add(version);
+            }
+        }
+
+        if (versionsById.Count == 0)
+        {
+            return null;
+        }
+
+        var map = new Dictionary<string, ImmutableArray<NuGetVersion>>(versionsById.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (var (id, versions) in versionsById)
+        {
+            map.Add(id, versions.ToImmutableArray());
+        }
+
+        return map;
+    }
+
+    /// <summary>
+    /// Determines whether <paramref name="reference"/> is satisfied by a restored package in
+    /// <paramref name="restoredPackages"/> (a map of package id to the versions present in the restore). A
+    /// reference is resolved when its name is present and at least one restored version satisfies the requested
+    /// version range.
+    /// </summary>
+    private static bool IsPackageReferenceResolved(PackageReferenceItem reference, IReadOnlyDictionary<string, ImmutableArray<NuGetVersion>> restoredPackages)
+    {
+        if (!restoredPackages.TryGetValue(reference.Name, out var versions))
+        {
+            // The package name isn't in the restore at all.
+            return false;
+        }
+
+        var requestedVersionRange = VersionRange.TryParse(reference.VersionRange, out var versionRange)
+            ? versionRange
+            : VersionRange.All;
+
+        foreach (var version in versions)
+        {
+            if (requestedVersionRange.Satisfies(version))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool CheckAssetsFileForUnresolvedReferences(ProjectFileInfo projectFileInfo, string projectAssetsPath, ILogger logger)
+    {
         // Iterate the project's package references and check if there is a package with the same name
         // and acceptable version in the lock file.
 
@@ -71,21 +238,8 @@ internal static class ProjectDependencyHelper
 
         foreach (var reference in projectFileInfo.PackageReferences)
         {
-            if (!projectAssetsMap.TryGetValue(reference.Name, out var projectAssetsVersions))
+            if (!IsPackageReferenceResolved(reference, projectAssetsMap))
             {
-                // If the package name isn't in the lock file then it's unresolved.
-                unresolved.Add(reference);
-                continue;
-            }
-
-            var requestedVersionRange = VersionRange.TryParse(reference.VersionRange, out var versionRange)
-                ? versionRange
-                : VersionRange.All;
-
-            var projectAssetsHasVersion = projectAssetsVersions.Any(projectAssetsVersion => SatisfiesVersion(requestedVersionRange, projectAssetsVersion));
-            if (!projectAssetsHasVersion)
-            {
-                // If the package name is in the lock file but none of the versions satisfy the requested version range then it's unresolved.
                 unresolved.Add(reference);
             }
         }
@@ -109,11 +263,6 @@ internal static class ProjectDependencyHelper
                 .ToImmutableDictionary(g => g.Key, g => g.ToImmutableArray(), StringComparer.OrdinalIgnoreCase);
 
             return map;
-        }
-
-        static bool SatisfiesVersion(VersionRange requestedVersionRange, NuGetVersion projectAssetsVersion)
-        {
-            return requestedVersionRange.Satisfies(projectAssetsVersion);
         }
     }
 


### PR DESCRIPTION
Reduces total allocations in the language server process for loading an already restored Roslyn.slnx by ~70% (650 MB):
| Metric | Before | After | Δ |
|---|--:|--:|--:|
| Load allocations | 1,956.6 MB | **649.4 MB** | **−66.8%** |
| GCs (gen2) | 33 (13) | 16 (9) | −17 |
| Newtonsoft assets-parse frames | 30 (~800 MB) | **0** | eliminated |

The allocations in the baseline were caused by the nuget API using Newtonsoft to parse the `project.assets.json`, for every project.  We did this to determine if the project had been restored (all `PackageReference` items in the project present in the `project.assets.json`).

This change has two parts

#### Update nuget API package
The latest nuget API package uses STJ and reduces the allocations to about ~200 MB (from ~650 MB) by itself.

#### Use `project.nuget.cache`
We reduce allocations even further by reading the `project.nuget.cache` to find the `ExpectedPackageFilePaths` and verify it contains the `PackageReference` items.  This avoids reading the much larger `project.assets.json` file.  However it is not as robust as it requires parsing the package Id and version from the file path.  So on misses, we fall back to the previous `project.assets.json` check.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84205)