### PR TITLE
Adjust decision Dag reachability based on nullable analysis when reporting unhandled `null` values in a switch expression

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/PatternExplainer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/PatternExplainer.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 switch (n)
                 {
                     case BoundEvaluationDecisionDagNode e:
-                        distanceInfo = (Math.Max(reachabilityInfo?.Contains(new NullableWalker.DecisionDagReachabilityInfo(e, true)) == false ? infinity : 0, distance(e.Next)), e.Next);
+                        distanceInfo = (Math.Max(reachabilityInfo?.Contains(new NullableWalker.DecisionDagReachabilityInfo(e, whenTrueBranch: true)) == false ? infinity : 0, distance(e.Next)), e.Next);
                         break;
                     case BoundTestDecisionDagNode { Test: BoundDagNonNullTest } t when !nullPaths:
                         distanceInfo = (1 + distance(t.WhenTrue), t.WhenTrue);
@@ -69,13 +69,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                         distanceInfo = (1 + distance(t.WhenFalse), t.WhenFalse);
                         break;
                     case BoundTestDecisionDagNode t:
-                        var trueDist1 = Math.Max(reachabilityInfo?.Contains(new NullableWalker.DecisionDagReachabilityInfo(t, true)) == false ? infinity : 0, distance(t.WhenTrue));
-                        var falseDist1 = Math.Max(reachabilityInfo?.Contains(new NullableWalker.DecisionDagReachabilityInfo(t, false)) == false ? infinity : 0, distance(t.WhenFalse));
+                        var trueDist1 = Math.Max(reachabilityInfo?.Contains(new NullableWalker.DecisionDagReachabilityInfo(t, whenTrueBranch: true)) == false ? infinity : 0, distance(t.WhenTrue));
+                        var falseDist1 = Math.Max(reachabilityInfo?.Contains(new NullableWalker.DecisionDagReachabilityInfo(t, whenTrueBranch: false)) == false ? infinity : 0, distance(t.WhenFalse));
                         distanceInfo = (trueDist1 <= falseDist1) ? (1 + trueDist1, t.WhenTrue) : (1 + falseDist1, t.WhenFalse);
                         break;
                     case BoundWhenDecisionDagNode w:
-                        var trueDist2 = Math.Max(reachabilityInfo?.Contains(new NullableWalker.DecisionDagReachabilityInfo(w, true)) == false ? infinity : 0, distance(w.WhenTrue));
-                        var falseDist2 = Math.Max(reachabilityInfo?.Contains(new NullableWalker.DecisionDagReachabilityInfo(w, false)) == false ? infinity : 0, distance(w.WhenFalse));
+                        var trueDist2 = Math.Max(reachabilityInfo?.Contains(new NullableWalker.DecisionDagReachabilityInfo(w, whenTrueBranch: true)) == false ? infinity : 0, distance(w.WhenTrue));
+                        var falseDist2 = Math.Max(reachabilityInfo?.Contains(new NullableWalker.DecisionDagReachabilityInfo(w, whenTrueBranch: false)) == false ? infinity : 0, distance(w.WhenFalse));
                         // add nodeCount to the distance if we need to flag that the path requires failure of a when clause
                         distanceInfo = (trueDist2 <= falseDist2) ? (1 + trueDist2, w.WhenTrue) : (1 + (falseDist2 < nodeCount ? nodeCount : 0) + falseDist2, w.WhenFalse);
                         break;

--- a/src/Compilers/CSharp/Portable/Binder/PatternExplainer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/PatternExplainer.cs
@@ -32,8 +32,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundDecisionDagNode> nodes,
             BoundDecisionDagNode node,
             bool nullPaths,
+            HashSet<NullableWalker.DecisionDagReachabilityInfo> reachabilityInfo,
             out bool requiresFalseWhenClause)
         {
+            Debug.Assert(nullPaths == (reachabilityInfo is not null));
+
             // compute the distance from each node to the endpoint.
             var dist = PooledDictionary<BoundDecisionDagNode, (int distance, BoundDecisionDagNode next)>.GetInstance();
             int nodeCount = nodes.Length;
@@ -51,20 +54,39 @@ namespace Microsoft.CodeAnalysis.CSharp
             for (int i = nodeCount - 1; i >= 0; i--)
             {
                 var n = nodes[i];
-                dist.Add(n, n switch
+
+                (int distance, BoundDecisionDagNode next) distanceInfo;
+
+                switch (n)
                 {
-                    BoundEvaluationDecisionDagNode e => (distance(e.Next), e.Next),
-                    BoundTestDecisionDagNode { Test: BoundDagNonNullTest } t when !nullPaths => (1 + distance(t.WhenTrue), t.WhenTrue),
-                    BoundTestDecisionDagNode { Test: BoundDagExplicitNullTest } t when !nullPaths => (1 + distance(t.WhenFalse), t.WhenFalse),
-                    BoundTestDecisionDagNode t when distance(t.WhenTrue) is var trueDist1 && distance(t.WhenFalse) is var falseDist1 =>
-                        (trueDist1 <= falseDist1) ? (1 + trueDist1, t.WhenTrue) : (1 + falseDist1, t.WhenFalse),
-                    BoundWhenDecisionDagNode w when distance(w.WhenTrue) is var trueDist2 && distance(w.WhenFalse) is var falseDist2 =>
+                    case BoundEvaluationDecisionDagNode e:
+                        distanceInfo = (Math.Max(reachabilityInfo?.Contains(new NullableWalker.DecisionDagReachabilityInfo(e, true)) == false ? infinity : 0, distance(e.Next)), e.Next);
+                        break;
+                    case BoundTestDecisionDagNode { Test: BoundDagNonNullTest } t when !nullPaths:
+                        distanceInfo = (1 + distance(t.WhenTrue), t.WhenTrue);
+                        break;
+                    case BoundTestDecisionDagNode { Test: BoundDagExplicitNullTest } t when !nullPaths:
+                        distanceInfo = (1 + distance(t.WhenFalse), t.WhenFalse);
+                        break;
+                    case BoundTestDecisionDagNode t:
+                        var trueDist1 = Math.Max(reachabilityInfo?.Contains(new NullableWalker.DecisionDagReachabilityInfo(t, true)) == false ? infinity : 0, distance(t.WhenTrue));
+                        var falseDist1 = Math.Max(reachabilityInfo?.Contains(new NullableWalker.DecisionDagReachabilityInfo(t, false)) == false ? infinity : 0, distance(t.WhenFalse));
+                        distanceInfo = (trueDist1 <= falseDist1) ? (1 + trueDist1, t.WhenTrue) : (1 + falseDist1, t.WhenFalse);
+                        break;
+                    case BoundWhenDecisionDagNode w:
+                        var trueDist2 = Math.Max(reachabilityInfo?.Contains(new NullableWalker.DecisionDagReachabilityInfo(w, true)) == false ? infinity : 0, distance(w.WhenTrue));
+                        var falseDist2 = Math.Max(reachabilityInfo?.Contains(new NullableWalker.DecisionDagReachabilityInfo(w, false)) == false ? infinity : 0, distance(w.WhenFalse));
                         // add nodeCount to the distance if we need to flag that the path requires failure of a when clause
-                        (trueDist2 <= falseDist2) ? (1 + trueDist2, w.WhenTrue) : (1 + (falseDist2 < nodeCount ? nodeCount : 0) + falseDist2, w.WhenFalse),
+                        distanceInfo = (trueDist2 <= falseDist2) ? (1 + trueDist2, w.WhenTrue) : (1 + (falseDist2 < nodeCount ? nodeCount : 0) + falseDist2, w.WhenFalse);
+                        break;
                     // treat the endpoint as distance 1.
                     // treat other nodes as not on the path to the endpoint
-                    _ => ((n == node) ? 1 : infinity, null),
-                });
+                    default:
+                        distanceInfo = ((n == node) ? 1 : infinity, null);
+                        break;
+                }
+
+                dist.Add(n, distanceInfo);
             }
 
             // trace a path from the root node to the node of interest
@@ -222,10 +244,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundDecisionDagNode> nodes,
             BoundDecisionDagNode targetNode,
             bool nullPaths,
+            HashSet<NullableWalker.DecisionDagReachabilityInfo> reachabilityInfo,
             out bool requiresFalseWhenClause,
             out bool unnamedEnumValue)
         {
 #if DEBUG
+            Debug.Assert(nullPaths == (reachabilityInfo is not null));
+
             // Exercise enumeration of all paths to node
             VisitPathsToNode(nodes[0], targetNode, nullPaths: true, handler: (currentPathToNode, currentRequiresFalseWhenClause) => true);
             VisitPathsToNode(nodes[0], targetNode, nullPaths: false, handler: (currentPathToNode, currentRequiresFalseWhenClause) => true);
@@ -234,7 +259,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             unnamedEnumValue = false;
 
             // Compute the path to the node, excluding the node itself.
-            var shortestPathToNode = ShortestPathToNode(nodes, targetNode, nullPaths, out requiresFalseWhenClause);
+            var shortestPathToNode = ShortestPathToNode(nodes, targetNode, nullPaths, reachabilityInfo, out requiresFalseWhenClause);
             gatherConstraintsAndEvaluations(binder, targetNode, shortestPathToNode, out var constraints, out var evaluations);
 
             try

--- a/src/Compilers/CSharp/Portable/Binder/PatternExplainer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/PatternExplainer.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 switch (n)
                 {
                     case BoundEvaluationDecisionDagNode e:
-                        distanceInfo = (Math.Max(reachabilityInfo?.Contains(new NullableWalker.DecisionDagReachabilityInfo(e, whenTrueBranch: true)) == false ? infinity : 0, distance(e.Next)), e.Next);
+                        distanceInfo = (Math.Max(reachabilityInfo?.Contains(new NullableWalker.DecisionDagReachabilityInfo(e, whenTrue: true)) == false ? infinity : 0, distance(e.Next)), e.Next);
                         break;
                     case BoundTestDecisionDagNode { Test: BoundDagNonNullTest } t when !nullPaths:
                         distanceInfo = (1 + distance(t.WhenTrue), t.WhenTrue);
@@ -69,13 +69,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                         distanceInfo = (1 + distance(t.WhenFalse), t.WhenFalse);
                         break;
                     case BoundTestDecisionDagNode t:
-                        var trueDist1 = Math.Max(reachabilityInfo?.Contains(new NullableWalker.DecisionDagReachabilityInfo(t, whenTrueBranch: true)) == false ? infinity : 0, distance(t.WhenTrue));
-                        var falseDist1 = Math.Max(reachabilityInfo?.Contains(new NullableWalker.DecisionDagReachabilityInfo(t, whenTrueBranch: false)) == false ? infinity : 0, distance(t.WhenFalse));
+                        var trueDist1 = Math.Max(reachabilityInfo?.Contains(new NullableWalker.DecisionDagReachabilityInfo(t, whenTrue: true)) == false ? infinity : 0, distance(t.WhenTrue));
+                        var falseDist1 = Math.Max(reachabilityInfo?.Contains(new NullableWalker.DecisionDagReachabilityInfo(t, whenTrue: false)) == false ? infinity : 0, distance(t.WhenFalse));
                         distanceInfo = (trueDist1 <= falseDist1) ? (1 + trueDist1, t.WhenTrue) : (1 + falseDist1, t.WhenFalse);
                         break;
                     case BoundWhenDecisionDagNode w:
-                        var trueDist2 = Math.Max(reachabilityInfo?.Contains(new NullableWalker.DecisionDagReachabilityInfo(w, whenTrueBranch: true)) == false ? infinity : 0, distance(w.WhenTrue));
-                        var falseDist2 = Math.Max(reachabilityInfo?.Contains(new NullableWalker.DecisionDagReachabilityInfo(w, whenTrueBranch: false)) == false ? infinity : 0, distance(w.WhenFalse));
+                        var trueDist2 = Math.Max(reachabilityInfo?.Contains(new NullableWalker.DecisionDagReachabilityInfo(w, whenTrue: true)) == false ? infinity : 0, distance(w.WhenTrue));
+                        var falseDist2 = Math.Max(reachabilityInfo?.Contains(new NullableWalker.DecisionDagReachabilityInfo(w, whenTrue: false)) == false ? infinity : 0, distance(w.WhenFalse));
                         // add nodeCount to the distance if we need to flag that the path requires failure of a when clause
                         distanceInfo = (trueDist2 <= falseDist2) ? (1 + trueDist2, w.WhenTrue) : (1 + (falseDist2 < nodeCount ? nodeCount : 0) + falseDist2, w.WhenFalse);
                         break;

--- a/src/Compilers/CSharp/Portable/Binder/SwitchExpressionBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchExpressionBinder.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (n is BoundLeafDecisionDagNode leaf && leaf.Label == defaultLabel)
                 {
                     var samplePattern = PatternExplainer.SamplePatternForPathToDagNode(
-                        this, BoundDagTemp.ForOriginalInput(boundInputExpression), nodes, n, nullPaths: false, out bool requiresFalseWhenClause, out bool unnamedEnumValue);
+                        this, BoundDagTemp.ForOriginalInput(boundInputExpression), nodes, n, nullPaths: false, reachabilityInfo: null, out bool requiresFalseWhenClause, out bool unnamedEnumValue);
                     ErrorCode warningCode =
                         requiresFalseWhenClause ? ErrorCode.WRN_SwitchExpressionNotExhaustiveWithWhen :
                         unnamedEnumValue ? ErrorCode.WRN_SwitchExpressionNotExhaustiveWithUnnamedEnumValue :

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
@@ -299,7 +300,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Visit(node.Expression);
             var expressionState = ResultType;
 
-            var labelStateMap = LearnFromDecisionDag(node.Syntax, node.ReachabilityDecisionDag, node.Expression, expressionState, stateWhenNotNullOpt: null);
+            var labelStateMap = LearnFromDecisionDag(node.Syntax, node.ReachabilityDecisionDag, node.Expression, expressionState, stateWhenNotNullOpt: null, reachabilityInfo: null);
             foreach (var section in node.SwitchSections)
             {
                 foreach (var label in section.SwitchLabels)
@@ -378,7 +379,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundDecisionDag decisionDag,
             BoundExpression expression,
             TypeWithState expressionTypeWithState,
-            PossiblyConditionalState? stateWhenNotNullOpt)
+            PossiblyConditionalState? stateWhenNotNullOpt,
+            HashSet<DecisionDagReachabilityInfo> reachabilityInfo)
         {
             // We reuse the slot at the beginning of a switch (or is-pattern expression), pretending that we are
             // not copying the input to evaluate the patterns.  In this way we infer non-nullability of the original
@@ -531,7 +533,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 default:
                                     throw ExceptionUtilities.UnexpectedValue(p.Evaluation.Kind);
                             }
-                            gotoNodeWithCurrentState(p.Next, nodeBelievedReachable);
+                            gotoNodeWithCurrentState(p.Next, nodeBelievedReachable, from: p, whenTrueBranch: true);
                             break;
                         }
                     case BoundTestDecisionDagNode p:
@@ -549,8 +551,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     {
                                         learnFromNonNullTest(inputSlot, ref this.StateWhenTrue);
                                     }
-                                    gotoNode(p.WhenTrue, this.StateWhenTrue, nodeBelievedReachable);
-                                    gotoNode(p.WhenFalse, this.StateWhenFalse, nodeBelievedReachable);
+                                    gotoNode(p.WhenTrue, this.StateWhenTrue, nodeBelievedReachable, from: p, whenTrueBranch: true);
+                                    gotoNode(p.WhenFalse, this.StateWhenFalse, nodeBelievedReachable, from: p, whenTrueBranch: false);
                                     break;
                                 case BoundDagNonNullTest t:
                                     var inputMaybeNull = GetState(ref this.StateWhenTrue, inputSlot).MayBeNull();
@@ -564,8 +566,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                                         }
                                         learnFromNonNullTest(inputSlot, ref this.StateWhenTrue);
                                     }
-                                    gotoNode(p.WhenTrue, this.StateWhenTrue, nodeBelievedReachable);
-                                    gotoNode(p.WhenFalse, this.StateWhenFalse, nodeBelievedReachable & inputMaybeNull);
+                                    gotoNode(p.WhenTrue, this.StateWhenTrue, nodeBelievedReachable, from: p, whenTrueBranch: true);
+                                    gotoNode(p.WhenFalse, this.StateWhenFalse, nodeBelievedReachable & inputMaybeNull, from: p, whenTrueBranch: false);
                                     break;
                                 case BoundDagExplicitNullTest _:
                                     if (inputSlot > 0)
@@ -573,8 +575,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                                         LearnFromNullTest(inputSlot, inputType, ref this.StateWhenTrue, markDependentSlotsNotNull: true);
                                         learnFromNonNullTest(inputSlot, ref this.StateWhenFalse);
                                     }
-                                    gotoNode(p.WhenTrue, this.StateWhenTrue, nodeBelievedReachable);
-                                    gotoNode(p.WhenFalse, this.StateWhenFalse, nodeBelievedReachable);
+                                    gotoNode(p.WhenTrue, this.StateWhenTrue, nodeBelievedReachable, from: p, whenTrueBranch: true);
+                                    gotoNode(p.WhenFalse, this.StateWhenFalse, nodeBelievedReachable, from: p, whenTrueBranch: false);
                                     break;
                                 case BoundDagValueTest t:
                                     Debug.Assert(t.Value != ConstantValue.Null);
@@ -594,16 +596,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                                         learnFromNonNullTest(inputSlot, ref this.StateWhenTrue);
                                     }
                                     bool isFalseTest = t.Value == ConstantValue.False;
-                                    gotoNode(p.WhenTrue, isFalseTest ? this.StateWhenFalse : this.StateWhenTrue, nodeBelievedReachable);
-                                    gotoNode(p.WhenFalse, isFalseTest ? this.StateWhenTrue : this.StateWhenFalse, nodeBelievedReachable);
+                                    gotoNode(p.WhenTrue, isFalseTest ? this.StateWhenFalse : this.StateWhenTrue, nodeBelievedReachable, from: p, whenTrueBranch: true);
+                                    gotoNode(p.WhenFalse, isFalseTest ? this.StateWhenTrue : this.StateWhenFalse, nodeBelievedReachable, from: p, whenTrueBranch: false);
                                     break;
                                 case BoundDagRelationalTest _:
                                     if (inputSlot > 0)
                                     {
                                         learnFromNonNullTest(inputSlot, ref this.StateWhenTrue);
                                     }
-                                    gotoNode(p.WhenTrue, this.StateWhenTrue, nodeBelievedReachable);
-                                    gotoNode(p.WhenFalse, this.StateWhenFalse, nodeBelievedReachable);
+                                    gotoNode(p.WhenTrue, this.StateWhenTrue, nodeBelievedReachable, from: p, whenTrueBranch: true);
+                                    gotoNode(p.WhenFalse, this.StateWhenFalse, nodeBelievedReachable, from: p, whenTrueBranch: false);
                                     break;
                                 default:
                                     throw ExceptionUtilities.UnexpectedValue(test.Kind);
@@ -655,13 +657,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             VisitCondition(w.WhenExpression);
                             Debug.Assert(this.IsConditionalState);
-                            gotoNode(w.WhenTrue, this.StateWhenTrue, nodeBelievedReachable);
-                            gotoNode(w.WhenFalse, this.StateWhenFalse, nodeBelievedReachable);
+                            gotoNode(w.WhenTrue, this.StateWhenTrue, nodeBelievedReachable, from: w, whenTrueBranch: true);
+                            gotoNode(w.WhenFalse, this.StateWhenFalse, nodeBelievedReachable, from: w, whenTrueBranch: false);
                         }
                         else
                         {
                             Debug.Assert(w.WhenFalse is null);
-                            gotoNode(w.WhenTrue, this.State, nodeBelievedReachable);
+                            gotoNode(w.WhenTrue, this.State, nodeBelievedReachable, from: w, whenTrueBranch: true);
                         }
                         break;
                     default:
@@ -880,8 +882,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 };
             }
 
-            void gotoNodeWithCurrentState(BoundDecisionDagNode node, bool believedReachable)
+            void gotoNodeWithCurrentState(BoundDecisionDagNode node, bool believedReachable, BoundDecisionDagNode from, bool whenTrueBranch)
             {
+                if (believedReachable)
+                {
+                    reachabilityInfo?.Add(new DecisionDagReachabilityInfo(from, whenTrueBranch));
+                }
+
                 if (nodeStateMap.TryGetValue(node, out var stateAndReachable))
                 {
                     switch (IsConditionalState, stateAndReachable.state.IsConditionalState)
@@ -912,8 +919,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 nodeStateMap[node] = (PossiblyConditionalState.Create(this), believedReachable);
             }
 
-            void gotoNode(BoundDecisionDagNode node, LocalState state, bool believedReachable)
+            void gotoNode(BoundDecisionDagNode node, LocalState state, bool believedReachable, BoundDecisionDagNode from, bool whenTrueBranch)
             {
+                if (believedReachable)
+                {
+                    reachabilityInfo?.Add(new DecisionDagReachabilityInfo(from, whenTrueBranch));
+                }
+
                 PossiblyConditionalState result;
                 if (nodeStateMap.TryGetValue(node, out var stateAndReachable))
                 {
@@ -976,6 +988,27 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
+        internal struct DecisionDagReachabilityInfo(BoundDecisionDagNode source, bool whenTrue) : IEquatable<DecisionDagReachabilityInfo>
+        {
+            public readonly BoundDecisionDagNode Source = source;
+            public readonly bool WhenTrue = whenTrue;
+
+            public bool Equals(DecisionDagReachabilityInfo other)
+            {
+                return Source == (object)other.Source && WhenTrue == other.WhenTrue;
+            }
+
+            public override int GetHashCode()
+            {
+                return Hash.Combine(System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(Source), WhenTrue.GetHashCode());
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is DecisionDagReachabilityInfo && Equals((DecisionDagReachabilityInfo)obj);
+            }
+        }
+
         private void VisitSwitchExpressionCore(BoundSwitchExpression node, bool inferType)
         {
             // first, learn from any null tests in the patterns
@@ -991,7 +1024,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Visit(node.Expression);
             var expressionState = ResultType;
-            var labelStateMap = LearnFromDecisionDag(node.Syntax, node.ReachabilityDecisionDag, node.Expression, expressionState, stateWhenNotNullOpt: null);
+            var reachabilityInfo = PooledHashSet<DecisionDagReachabilityInfo>.GetInstance();
+            var labelStateMap = LearnFromDecisionDag(node.Syntax, node.ReachabilityDecisionDag, node.Expression, expressionState, stateWhenNotNullOpt: null, reachabilityInfo: reachabilityInfo);
             var endState = UnreachableState();
 
             if (!node.ReportedNotExhaustive && node.DefaultLabel != null &&
@@ -1002,13 +1036,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var nodes = node.ReachabilityDecisionDag.TopologicallySortedNodes;
                 var leaf = nodes.Where(n => n is BoundLeafDecisionDagNode leaf && leaf.Label == node.DefaultLabel).First();
                 var samplePattern = PatternExplainer.SamplePatternForPathToDagNode(
-                    _binder, BoundDagTemp.ForOriginalInput(node.Expression), nodes, leaf, nullPaths: true, out bool requiresFalseWhenClause, out _);
+                    _binder, BoundDagTemp.ForOriginalInput(node.Expression), nodes, leaf, nullPaths: true, reachabilityInfo, out bool requiresFalseWhenClause, out _);
                 ErrorCode warningCode = requiresFalseWhenClause ? ErrorCode.WRN_SwitchExpressionNotExhaustiveForNullWithWhen : ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull;
                 ReportDiagnostic(
                     warningCode,
                     ((SwitchExpressionSyntax)node.Syntax).SwitchKeyword.GetLocation(),
                     samplePattern);
             }
+
+            reachabilityInfo.Free();
 
             // collect expressions, conversions and result types
             int numSwitchArms = node.SwitchArms.Length;
@@ -1159,7 +1195,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             VisitForRewriting(node.Pattern);
             var hasStateWhenNotNull = VisitPossibleConditionalAccess(node.Expression, out var conditionalStateWhenNotNull);
             var expressionState = ResultType;
-            var labelStateMap = LearnFromDecisionDag(node.Syntax, node.ReachabilityDecisionDag, node.Expression, expressionState, hasStateWhenNotNull ? conditionalStateWhenNotNull : null);
+            var labelStateMap = LearnFromDecisionDag(node.Syntax, node.ReachabilityDecisionDag, node.Expression, expressionState, hasStateWhenNotNull ? conditionalStateWhenNotNull : null, reachabilityInfo: null);
             var trueState = labelStateMap.TryGetValue(node.IsNegated ? node.WhenFalseLabel : node.WhenTrueLabel, out var s1) ? s1.state : UnreachableState();
             var falseState = labelStateMap.TryGetValue(node.IsNegated ? node.WhenTrueLabel : node.WhenFalseLabel, out var s2) ? s2.state : UnreachableState();
             labelStateMap.Free();

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
@@ -988,7 +988,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        internal struct DecisionDagReachabilityInfo(BoundDecisionDagNode source, bool whenTrue) : IEquatable<DecisionDagReachabilityInfo>
+        internal readonly struct DecisionDagReachabilityInfo(BoundDecisionDagNode source, bool whenTrue) : IEquatable<DecisionDagReachabilityInfo>
         {
             public readonly BoundDecisionDagNode Source = source;
             public readonly bool WhenTrue = whenTrue;
@@ -1024,7 +1024,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Visit(node.Expression);
             var expressionState = ResultType;
-            var reachabilityInfo = PooledHashSet<DecisionDagReachabilityInfo>.GetInstance();
+            var reachabilityInfo = (!node.ReportedNotExhaustive && node.DefaultLabel != null) ? PooledHashSet<DecisionDagReachabilityInfo>.GetInstance() : null;
             var labelStateMap = LearnFromDecisionDag(node.Syntax, node.ReachabilityDecisionDag, node.Expression, expressionState, stateWhenNotNullOpt: null, reachabilityInfo: reachabilityInfo);
             var endState = UnreachableState();
 
@@ -1032,6 +1032,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 labelStateMap.TryGetValue(node.DefaultLabel, out var defaultLabelState) &&
                 defaultLabelState.believedReachable)
             {
+                Debug.Assert(reachabilityInfo is not null);
+
                 SetState(defaultLabelState.state);
                 var nodes = node.ReachabilityDecisionDag.TopologicallySortedNodes;
                 var leaf = nodes.Where(n => n is BoundLeafDecisionDagNode leaf && leaf.Label == node.DefaultLabel).First();
@@ -1044,7 +1046,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     samplePattern);
             }
 
-            reachabilityInfo.Free();
+            reachabilityInfo?.Free();
 
             // collect expressions, conversions and result types
             int numSwitchArms = node.SwitchArms.Length;

--- a/src/Compilers/CSharp/Test/CSharp15/UnionsTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/UnionsTests.cs
@@ -19059,15 +19059,15 @@ class Program
                 // (1000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
                 //             _ = s switch { { Value: {} } => 1 };
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(1000, 19),
-                // (2000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
+                // (2000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '{ Value: null }' is not covered.
                 //             _ = s switch { { Value: {} } => 1 };
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(2000, 19),
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("{ Value: null }").WithLocation(2000, 19),
                 // (3000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
                 //             _ = s switch { { Value: {} } => 1 };
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(3000, 19),
-                // (4000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
+                // (4000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '{ Value: null }' is not covered.
                 //             _ = s switch { { Value: {} } => 1 };
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(4000, 19)
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("{ Value: null }").WithLocation(4000, 19)
                 );
         }
 
@@ -19348,12 +19348,12 @@ class Program
             var comp2 = CreateCompilation(src2);
 
             comp2.VerifyDiagnostics(
-                // (1000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
+                // (1000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '{ Value: null }' is not covered.
                 //             _ = s switch { { Value: {} } => 1 };
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(1000, 19),
-                // (2000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("{ Value: null }").WithLocation(1000, 19),
+                // (2000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '{ Value: null }' is not covered.
                 //             _ = s switch { { Value: {} } => 1 };
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(2000, 19)
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("{ Value: null }").WithLocation(2000, 19)
                 );
         }
 
@@ -19569,12 +19569,12 @@ class Program
             var comp2 = CreateCompilation(src2);
 
             comp2.VerifyDiagnostics(
-                // (1000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
+                // (1000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '{ Value: null }' is not covered.
                 //             _ = s switch { { Value: {} } => 1 };
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(1000, 19),
-                // (2000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("{ Value: null }").WithLocation(1000, 19),
+                // (2000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '{ Value: null }' is not covered.
                 //             _ = s switch { { Value: {} } => 1 };
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(2000, 19)
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("{ Value: null }").WithLocation(2000, 19)
                 );
         }
 
@@ -22887,15 +22887,15 @@ class Program
                 // (1000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
                 //             _ = s switch { { Value: {} } => 1 };
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(1000, 19),
-                // (2000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
+                // (2000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '{ Value: null }' is not covered.
                 //             _ = s switch { { Value: {} } => 1 };
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(2000, 19),
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("{ Value: null }").WithLocation(2000, 19),
                 // (3000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
                 //             _ = s switch { { Value: {} } => 1 };
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(3000, 19),
-                // (4000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
+                // (4000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '{ Value: null }' is not covered.
                 //             _ = s switch { { Value: {} } => 1 };
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(4000, 19)
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("{ Value: null }").WithLocation(4000, 19)
                 );
         }
 
@@ -23225,12 +23225,12 @@ class Program
 
             // https://github.com/dotnet/roslyn/issues/83568
             comp2.VerifyDiagnostics(
-                // (1000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
+                // (1000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '{ Value: null }' is not covered.
                 //             _ = s switch { { Value: {} } => 1 };
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(1000, 19),
-                // (2000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("{ Value: null }").WithLocation(1000, 19),
+                // (2000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '{ Value: null }' is not covered.
                 //             _ = s switch { { Value: {} } => 1 };
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(2000, 19)
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("{ Value: null }").WithLocation(2000, 19)
                 );
         }
 
@@ -23483,12 +23483,12 @@ class Program
 
             // https://github.com/dotnet/roslyn/issues/83568
             comp2.VerifyDiagnostics(
-                // (1000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
+                // (1000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '{ Value: null }' is not covered.
                 //             _ = s switch { { Value: {} } => 1 };
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(1000, 19),
-                // (2000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("{ Value: null }").WithLocation(1000, 19),
+                // (2000,19): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '{ Value: null }' is not covered.
                 //             _ = s switch { { Value: {} } => 1 };
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(2000, 19)
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("{ Value: null }").WithLocation(2000, 19)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests5.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests5.cs
@@ -3077,12 +3077,12 @@ class N
             if (nullableEnable)
             {
                 comp.VerifyDiagnostics(
-                    // (12,21): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
+                    // (12,21): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '(Enum.One, Enum.One, null)' is not covered.
                     //         return this switch // 1
-                    Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(12, 21),
-                    // (27,21): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
+                    Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("(Enum.One, Enum.One, null)").WithLocation(12, 21),
+                    // (27,21): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '(Enum.One, Enum.One, null)' is not covered.
                     //         return this switch // 2
-                    Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(27, 21),
+                    Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("(Enum.One, Enum.One, null)").WithLocation(27, 21),
                     // (43,21): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '(Enum.One, Enum.One, null)' is not covered.
                     //         return this switch // 3
                     Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("(Enum.One, Enum.One, null)").WithLocation(43, 21),

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests_ListPatterns.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests_ListPatterns.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -6042,9 +6042,9 @@ class C
             // 0.cs(15,14): hidden CS9335: The pattern is redundant.
             //     { Count: 0 or > 1 } => 3, // 3
             Diagnostic(ErrorCode.HDN_RedundantPattern, "0 or > 1").WithLocation(15, 14),
-            // 0.cs(18,13): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
-            // _ = new C() switch // 4
-            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(18, 13),
+            // 0.cs(18,13): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '[null]' is not covered.
+            // _ = new C() switch // 6
+            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("[null]").WithLocation(18, 13),
             // 0.cs(27,6): hidden CS9335: The pattern is redundant.
             //     [null] => 2, // 5
             Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(27, 6),

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesVsPatterns.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesVsPatterns.cs
@@ -1398,9 +1398,9 @@ class Test
                 // (12,25): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '(null, _)' is not covered.
                 //         return (s1, s2) switch { // 1
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("(null, _)").WithLocation(12, 25),
-                // (18,25): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '(null, _)' is not covered.
+                // (18,25): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '(not null, null)' is not covered.
                 //         return (s1, s2) switch { // 2
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("(null, _)").WithLocation(18, 25),
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("(not null, null)").WithLocation(18, 25),
                 // (24,25): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '(null, _)' is not covered.
                 //         return (s1, s2) switch { // 3
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("(null, _)").WithLocation(24, 25),
@@ -3298,6 +3298,72 @@ class Container<T>
                 // (8,5): warning CS8602: Dereference of a possibly null reference.
                 //     z.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(8, 5)
+                );
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84100")]
+        public void TupleSwitchPreferNonNullCounterexample_Union()
+        {
+            var source = """
+                #nullable enable
+                public record A;
+                public record B;
+                public union U(A, B);
+
+                public static class Repro
+                {
+                    public static string Direct(U u) => u switch { A => "a", B => "b" };
+
+                    public static string Unconditional(U u, string? s) => (u, s) switch
+                    {
+                        (A, _) => "a",
+                        (B, _) => "b",
+                    };
+
+                #line 19
+                    public static string Conditional(U u, string? s) => (u, s) switch
+                    {
+                        (A, _) => "a",
+                        (B, { } t) => t,
+                    };
+                }
+                """;
+
+            var comp = CreateCompilation([source, UnionAttributeSource, IUnionSource], targetFramework: TargetFramework.Net100);
+            comp.VerifyDiagnostics(
+                // (19,64): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '(B, null)' is not covered.
+                //     public static string Conditional(U u, string? s) => (u, s) switch
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("(B, null)").WithLocation(19, 64)
+                );
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84100")]
+        public void TupleSwitchPreferNonNullCounterexample_BoolNullable()
+        {
+            var source = """
+                #nullable enable
+                public static class Repro
+                {
+                    public static string ConditionalBool(bool? u, string? s)
+                    {
+                        if (u is null) return "";
+
+                        u.Value.ToString();
+
+                        return (u, s) switch
+                        {
+                            (true, _) => "a",
+                            (false, { } t) => t,
+                        };
+                    }
+                }
+                """;
+
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (10,23): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '(false, null)' is not covered.
+                //         return (u, s) switch
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("(false, null)").WithLocation(10, 23)
                 );
         }
     }


### PR DESCRIPTION
Fixes #84100
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84207)