### PR TITLE
Collect crash dumps on hang

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -315,6 +315,7 @@
       Infra
     -->
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageVersion Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.661903" />
     <PackageVersion Include="MSBuild.StructuredLogger" Version="2.3.113" />
     <PackageVersion Include="Mono.Options" Version="6.6.0.161" />
     <PackageVersion Include="Roslyn.Diagnostics.Analyzers" Version="$(RoslynDiagnosticsAnalyzersPackageVersion)" />

--- a/src/Tools/RunTests/DumpCollector.cs
+++ b/src/Tools/RunTests/DumpCollector.cs
@@ -1,0 +1,145 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.Diagnostics.NETCore.Client;
+
+namespace RunTests
+{
+    /// <summary>
+    /// Collects dump files from processes. Uses <see cref="DiagnosticsClient"/> for .NET Core
+    /// processes and MiniDumpWriteDump P/Invoke for .NET Framework processes.
+    /// </summary>
+    internal static class DumpCollector
+    {
+        /// <summary>
+        /// Attempts to collect a full memory dump from the specified process.
+        /// Returns true if the dump was successfully written.
+        /// </summary>
+        internal static bool TryDumpProcess(Process process, string dumpFilePath)
+        {
+            try
+            {
+                if (IsNetCoreProcess(process))
+                {
+                    return TryDumpNetCoreProcess(process, dumpFilePath);
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    return TryDumpWithMiniDumpWriteDump(process, dumpFilePath);
+                }
+                else
+                {
+                    Logger.Log($"Cannot dump non-.NET Core process {process.ProcessName} ({process.Id}) on non-Windows platform.");
+                    return false;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"Failed to dump process {process.ProcessName} ({process.Id}): {ex.Message}");
+                return false;
+            }
+        }
+
+        private static bool TryDumpNetCoreProcess(Process process, string dumpFilePath)
+        {
+            try
+            {
+                var client = new DiagnosticsClient(process.Id);
+                client.WriteDump(DumpType.Full, dumpFilePath, logDumpGeneration: false);
+                return File.Exists(dumpFilePath);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"DiagnosticsClient.WriteDump failed for process {process.Id}: {ex.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Determines if a process is a .NET Core process by checking if the diagnostics
+        /// IPC channel is available (the pipe/socket exists).
+        /// </summary>
+        private static bool IsNetCoreProcess(Process process)
+        {
+            try
+            {
+                // On Windows, .NET Core processes create a named pipe: dotnet-diagnostic-{pid}
+                // On Unix, they create a Unix domain socket in the temp directory.
+                // DiagnosticsClient.GetPublishedProcesses() returns all PIDs with active diagnostic ports.
+                var publishedProcesses = DiagnosticsClient.GetPublishedProcesses();
+                foreach (var pid in publishedProcesses)
+                {
+                    if (pid == process.Id)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+#pragma warning disable CA1416 // Validate platform compatibility
+        private static bool TryDumpWithMiniDumpWriteDump(Process process, string dumpFilePath)
+        {
+            try
+            {
+                using var fileStream = new FileStream(dumpFilePath, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+                // MiniDumpWithFullMemory = 0x00000002
+                var success = NativeMethods.MiniDumpWriteDump(
+                    process.Handle,
+                    (uint)process.Id,
+                    fileStream.SafeFileHandle.DangerousGetHandle(),
+                    NativeMethods.MINIDUMP_TYPE.MiniDumpWithFullMemory,
+                    IntPtr.Zero,
+                    IntPtr.Zero,
+                    IntPtr.Zero);
+
+                if (!success)
+                {
+                    var errorCode = Marshal.GetLastWin32Error();
+                    Logger.Log($"MiniDumpWriteDump failed for process {process.Id} with error code {errorCode}");
+                    // Clean up the empty/partial file
+                    try { fileStream.Close(); File.Delete(dumpFilePath); } catch { }
+                }
+
+                return success;
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"MiniDumpWriteDump failed for process {process.Id}: {ex.Message}");
+                return false;
+            }
+        }
+
+        private static class NativeMethods
+        {
+            [Flags]
+            internal enum MINIDUMP_TYPE : uint
+            {
+                MiniDumpWithFullMemory = 0x00000002,
+            }
+
+            [DllImport("dbghelp.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            internal static extern bool MiniDumpWriteDump(
+                IntPtr hProcess,
+                uint processId,
+                IntPtr hFile,
+                MINIDUMP_TYPE dumpType,
+                IntPtr exceptionParam,
+                IntPtr userStreamParam,
+                IntPtr callbackParam);
+        }
+#pragma warning restore CA1416 // Validate platform compatibility
+    }
+}

--- a/src/Tools/RunTests/ProcessTestExecutor.cs
+++ b/src/Tools/RunTests/ProcessTestExecutor.cs
@@ -36,14 +36,9 @@ namespace RunTests
                 fileContentsBuilder.AppendLine($@"/Logger:html;LogFileName={htmlResultsFilePath}");
             }
 
-            var blameOption = "CollectHangDump";
-            if (!options.CollectDumps)
-            {
-                // The 'CollectDumps' option uses operating system features to collect dumps when a process crashes. We
-                // only enable the test executor blame feature in remaining cases, as the latter relies on ProcDump and
-                // interferes with automatic crash dump collection on Windows.
-                blameOption = "CollectDump;CollectHangDump";
-            }
+            // Always use CollectDump and CollectHangDump to ensure we get actionable data on both
+            // crashes and hangs, matching the Helix configuration.
+            var blameOption = "CollectDump;CollectHangDump";
 
             // The 25 minute timeout in integration tests accounts for the fact that VSIX deployment and/or experimental hive reset and
             // configuration can take significant time (seems to vary from ~10 seconds to ~15 minutes), and the blame
@@ -231,61 +226,68 @@ namespace RunTests
         /// </summary>
         private static void CheckForCrashes(string? resultsFilePath, string displayName, string testResultsDirectory)
         {
-            var (dumpFiles, crashingTest, isHang) = detectDumpFiles();
+            var (dumpFiles, sequenceFiles, crashingTest, isHang) = detectDumpFiles();
             if (dumpFiles.Length == 0)
             {
                 return;
             }
 
             Logger.Log($"Detected dump files for {displayName}: {string.Join(", ", dumpFiles)}");
-            ConsoleUtil.WriteLine(ConsoleColor.Red, $"Test host crash/hang detected for {displayName}");
+
+            // Emit as AzDO timeline errors so they display prominently in the build results
+            var failureType = isHang ? "timeout" : "crash";
+            if (crashingTest is string test)
+            {
+                ConsoleUtil.Error($"Test host {failureType} detected for {displayName}. Test running at time of {failureType}: {test}");
+            }
+            else
+            {
+                ConsoleUtil.Error($"Test host {failureType} detected for {displayName}");
+            }
+
             foreach (var dump in dumpFiles)
             {
                 ConsoleUtil.WriteLine(ConsoleColor.Red, $"  Dump: {dump}");
             }
 
-            if (crashingTest is string test)
-            {
-                ConsoleUtil.WriteLine(ConsoleColor.Red, $"  Test running at time of crash: {test}");
-            }
+            // Copy sequence files to the test results directory so they are included in artifacts
+            copySequenceFilesToArtifacts(sequenceFiles, testResultsDirectory);
 
             if (resultsFilePath != null)
             {
                 writeSyntheticFailure(resultsFilePath, dumpFiles, crashingTest, isHang);
             }
 
-            (string[] DumpFiles, string? CrashingTest, bool IsHang) detectDumpFiles()
+            (string[] DumpFiles, string[] SequenceFiles, string? CrashingTest, bool IsHang) detectDumpFiles()
             {
                 if (!Directory.Exists(testResultsDirectory))
                 {
-                    return ([], null, false);
+                    return ([], [], null, false);
                 }
 
                 var dumpFiles = Directory.GetFiles(testResultsDirectory, "*.dmp", SearchOption.AllDirectories);
                 if (dumpFiles.Length == 0)
                 {
-                    return ([], null, false);
+                    return ([], [], null, false);
                 }
 
                 var isHang = dumpFiles.Any(f => Path.GetFileName(f).Contains("hangdump", StringComparison.OrdinalIgnoreCase));
                 string? crashingTest = null;
+                var allSequenceFiles = new List<string>();
 
                 var dumpDirectories = dumpFiles.Select(Path.GetDirectoryName).Distinct();
                 foreach (var dir in dumpDirectories)
                 {
                     if (dir == null) continue;
                     var sequenceFiles = Directory.GetFiles(dir, "Sequence_*.xml", SearchOption.TopDirectoryOnly);
-                    if (sequenceFiles.Length > 0)
+                    allSequenceFiles.AddRange(sequenceFiles);
+                    if (sequenceFiles.Length > 0 && crashingTest == null)
                     {
                         crashingTest = getLastTestFromSequenceFile(sequenceFiles[0]);
-                        if (crashingTest != null)
-                        {
-                            break;
-                        }
                     }
                 }
 
-                return (dumpFiles, crashingTest, isHang);
+                return (dumpFiles, allSequenceFiles.ToArray(), crashingTest, isHang);
             }
 
             static string? getLastTestFromSequenceFile(string sequenceFilePath)
@@ -301,6 +303,27 @@ namespace RunTests
                 catch
                 {
                     return null;
+                }
+            }
+
+            static void copySequenceFilesToArtifacts(string[] sequenceFiles, string testResultsDirectory)
+            {
+                foreach (var sequenceFile in sequenceFiles)
+                {
+                    try
+                    {
+                        var destPath = Path.Combine(testResultsDirectory, Path.GetFileName(sequenceFile));
+                        if (!string.Equals(Path.GetFullPath(sequenceFile), Path.GetFullPath(destPath), StringComparison.OrdinalIgnoreCase))
+                        {
+                            File.Copy(sequenceFile, destPath, overwrite: true);
+                        }
+
+                        Logger.Log($"Copied sequence file to artifacts: {destPath}");
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Log($"Warning: Failed to copy sequence file {sequenceFile}: {ex.Message}");
+                    }
                 }
             }
 

--- a/src/Tools/RunTests/ProcessUtil.cs
+++ b/src/Tools/RunTests/ProcessUtil.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Management;
 using System.Runtime.InteropServices;
 
@@ -12,19 +13,50 @@ namespace RunTests
 {
     internal static class ProcessUtil
     {
-        internal static int? TryGetParentProcessId(Process p)
+        /// <summary>
+        /// Get the command line of the provided <paramref name="process"/>, or <see langword="null"/>
+        /// if it can't be determined.
+        /// </summary>
+        /// <remarks>
+        /// This is a best effort API. The process may exit while the command line is being read, or the
+        /// current platform may not be supported.
+        /// </remarks>
+        internal static string? TryGetCommandLine(Process process)
         {
-            // System.Management is not supported outside of Windows.
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return TryGetCommandLineWindows(process);
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return TryGetCommandLineLinux(process);
+            }
+
+            return null;
+        }
+
+        private static string? TryGetCommandLineWindows(Process process)
+        {
+            try
+            {
+                using var mo = new ManagementObject("win32_process.handle='" + process.Id + "'");
+                mo.Get();
+                return mo["CommandLine"] as string;
+            }
+            catch
             {
                 return null;
             }
+        }
 
+        private static string? TryGetCommandLineLinux(Process process)
+        {
             try
             {
-                ManagementObject mo = new ManagementObject("win32_process.handle='" + p.Id + "'");
-                mo.Get();
-                return Convert.ToInt32(mo["ParentProcessId"]);
+                // /proc/<pid>/cmdline contains the arguments separated by null characters.
+                var raw = File.ReadAllText($"/proc/{process.Id}/cmdline");
+                return raw.Replace('\0', ' ').Trim();
             }
             catch
             {
@@ -33,22 +65,23 @@ namespace RunTests
         }
 
         /// <summary>
-        /// Return the list of processes which are direct children of the provided <paramref name="process"/> 
-        /// instance.
+        /// Return the set of <c>testhost</c> processes spawned by <c>dotnet test</c>. A process is
+        /// considered a test host when either:
+        /// <list type="number">
+        /// <item>its process name starts with <c>testhost</c>; or</item>
+        /// <item>its process name is <c>dotnet</c> and its command line references <c>testhost</c>.</item>
+        /// </list>
         /// </summary>
         /// <remarks>
         /// This is a best effort API.  It can be thwarted by process instances starting / stopping during
         /// the building of this list.
         /// </remarks>
-        internal static List<Process> GetProcessChildren(Process process) => GetProcessChildrenCore(process, Process.GetProcesses());
-
-        private static List<Process> GetProcessChildrenCore(Process parentProcess, IEnumerable<Process> processes)
+        internal static List<Process> GetTestHostProcesses()
         {
             var list = new List<Process>();
-            foreach (var process in processes)
+            foreach (var process in Process.GetProcesses())
             {
-                var parentId = TryGetParentProcessId(process);
-                if (parentId == parentProcess.Id)
+                if (IsTestHostProcess(process))
                 {
                     list.Add(process);
                 }
@@ -57,33 +90,42 @@ namespace RunTests
             return list;
         }
 
-        /// <summary>
-        /// Return the list of processes which are direct or indirect children of the provided <paramref name="process"/> 
-        /// instance.
-        /// </summary>
-        /// <remarks>
-        /// This is a best effort API.  It can be thwarted by process instances starting / stopping during
-        /// the building of this list.
-        /// </remarks>
-        internal static List<Process> GetProcessTree(Process process)
+        private static bool IsTestHostProcess(Process process)
         {
-            var processes = Process.GetProcesses();
-            var list = new List<Process>();
-            var toVisit = new Queue<Process>();
-            toVisit.Enqueue(process);
-
-            while (toVisit.Count > 0)
+            string name;
+            try
             {
-                var cur = toVisit.Dequeue();
-                var children = GetProcessChildrenCore(cur, processes);
-                foreach (var child in children)
+                name = process.ProcessName;
+            }
+            catch
+            {
+                // The process may have exited between enumeration and inspection.
+                return false;
+            }
+
+            // Process.ProcessName omits the file extension, but normalize defensively in case a future
+            // runtime change includes it.
+            if (name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+            {
+                name = name.Substring(0, name.Length - 4);
+            }
+
+            if (name.StartsWith("testhost", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (string.Equals(name, "dotnet", StringComparison.OrdinalIgnoreCase))
+            {
+                var commandLine = TryGetCommandLine(process);
+                if (commandLine is not null &&
+                    commandLine.IndexOf("testhost", StringComparison.OrdinalIgnoreCase) >= 0)
                 {
-                    toVisit.Enqueue(child);
-                    list.Add(child);
+                    return true;
                 }
             }
 
-            return list;
+            return false;
         }
     }
 }

--- a/src/Tools/RunTests/ProcessUtil.cs
+++ b/src/Tools/RunTests/ProcessUtil.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Management;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace RunTests
 {
@@ -36,6 +37,7 @@ namespace RunTests
             return null;
         }
 
+        [SupportedOSPlatform("windows")]
         private static string? TryGetCommandLineWindows(Process process)
         {
             try
@@ -44,12 +46,14 @@ namespace RunTests
                 mo.Get();
                 return mo["CommandLine"] as string;
             }
-            catch
+            catch (Exception ex)
             {
+                ConsoleUtil.Warning($"Failed to get command line for process {process.Id}: {ex.Message}");
                 return null;
             }
         }
 
+        [SupportedOSPlatform("linux")]
         private static string? TryGetCommandLineLinux(Process process)
         {
             try
@@ -58,8 +62,9 @@ namespace RunTests
                 var raw = File.ReadAllText($"/proc/{process.Id}/cmdline");
                 return raw.Replace('\0', ' ').Trim();
             }
-            catch
+            catch (Exception ex)
             {
+                ConsoleUtil.Warning($"Failed to get command line for process {process.Id}: {ex.Message}");
                 return null;
             }
         }
@@ -99,6 +104,7 @@ namespace RunTests
             }
             catch
             {
+                ConsoleUtil.Warning($"Failed to get process name for process {process.Id}");
                 // The process may have exited between enumeration and inspection.
                 return false;
             }

--- a/src/Tools/RunTests/Program.cs
+++ b/src/Tools/RunTests/Program.cs
@@ -224,30 +224,27 @@ namespace RunTests
             var dumpDir = options.LogFilesDirectory;
             Directory.CreateDirectory(dumpDir);
 
-            var counter = 0;
-            foreach (var proc in ProcessUtil.GetProcessTree(Process.GetCurrentProcess()).OrderBy(x => x.ProcessName))
+            if (options.CollectDumps)
             {
-                var name = proc.ProcessName;
-
-                // Skip processes that won't contribute to bug investigations.
-                if (name is "procdump" or "conhost")
+                var counter = 0;
+                foreach (var proc in ProcessUtil.GetTestHostProcesses().OrderBy(x => x.ProcessName))
                 {
-                    continue;
-                }
+                    var name = proc.ProcessName;
 
-                var dumpFilePath = Path.Combine(dumpDir, $"{name}-{counter}.dmp");
-                ConsoleUtil.Write($"Dumping {name} {proc.Id} to {dumpFilePath} ... ");
+                    var dumpFilePath = Path.Combine(dumpDir, $"{name}-{counter}.dmp");
+                    ConsoleUtil.Write($"Dumping {name} {proc.Id} to {dumpFilePath} ... ");
 
-                if (DumpCollector.TryDumpProcess(proc, dumpFilePath))
-                {
-                    ConsoleUtil.WriteLine($"succeeded ({new FileInfo(dumpFilePath).Length} bytes)");
-                }
-                else
-                {
-                    ConsoleUtil.WriteLine("FAILED");
-                }
+                    if (DumpCollector.TryDumpProcess(proc, dumpFilePath))
+                    {
+                        ConsoleUtil.WriteLine($"succeeded ({new FileInfo(dumpFilePath).Length} bytes)");
+                    }
+                    else
+                    {
+                        ConsoleUtil.WriteLine("FAILED");
+                    }
 
-                counter++;
+                    counter++;
+                }
             }
 
             WriteLogFile(options);

--- a/src/Tools/RunTests/Program.cs
+++ b/src/Tools/RunTests/Program.cs
@@ -210,45 +210,7 @@ namespace RunTests
         /// </summary>
         private static async Task HandleTimeout(Options options, CancellationToken cancellationToken)
         {
-            async Task DumpProcess(Process targetProcess, string procDumpExeFilePath, string dumpFilePath)
-            {
-                var name = targetProcess.ProcessName;
-
-                // Our space for saving dump files is limited. Skip dumping for processes that won't contribute
-                // to bug investigations.
-                if (name is "procdump" or "conhost")
-                {
-                    return;
-                }
-
-                ConsoleUtil.Write($"Dumping {name} {targetProcess.Id} to {dumpFilePath} ... ");
-                try
-                {
-                    var args = $"-accepteula -ma {targetProcess.Id} {dumpFilePath}";
-                    var processInfo = ProcessRunner.CreateProcess(procDumpExeFilePath, args, cancellationToken: cancellationToken);
-                    var processOutput = await processInfo.Result;
-
-                    // The exit code for procdump doesn't obey standard windows rules.  It will return non-zero
-                    // for successful cases (possibly returning the count of dumps that were written).  Best 
-                    // backup is to test for the dump file being present.
-                    if (File.Exists(dumpFilePath))
-                    {
-                        ConsoleUtil.WriteLine($"succeeded ({new FileInfo(dumpFilePath).Length} bytes)");
-                    }
-                    else
-                    {
-                        ConsoleUtil.WriteLine($"FAILED with {processOutput.ExitCode}");
-                        ConsoleUtil.WriteLine($"{procDumpExeFilePath} {args}");
-                        ConsoleUtil.WriteLine(string.Join(Environment.NewLine, processOutput.OutputLines));
-                    }
-                }
-                catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
-                {
-                    ConsoleUtil.WriteLine("FAILED");
-                    ConsoleUtil.WriteLine(ex.Message);
-                    Logger.Log("Failed to dump process", ex);
-                }
-            }
+            ConsoleUtil.Error("Test timeout exceeded, dumping remaining processes");
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -259,18 +221,33 @@ namespace RunTests
                 ConsoleUtil.WriteLine(string.Join(Environment.NewLine, output.ErrorLines));
             }
 
-            if (options.CollectDumps && !string.IsNullOrEmpty(options.ProcDumpFilePath))
-            {
-                ConsoleUtil.WriteLine("Roslyn Error: test timeout exceeded, dumping remaining processes");
+            var dumpDir = options.LogFilesDirectory;
+            Directory.CreateDirectory(dumpDir);
 
-                var counter = 0;
-                foreach (var proc in ProcessUtil.GetProcessTree(Process.GetCurrentProcess()).OrderBy(x => x.ProcessName))
+            var counter = 0;
+            foreach (var proc in ProcessUtil.GetProcessTree(Process.GetCurrentProcess()).OrderBy(x => x.ProcessName))
+            {
+                var name = proc.ProcessName;
+
+                // Skip processes that won't contribute to bug investigations.
+                if (name is "procdump" or "conhost")
                 {
-                    var dumpDir = options.LogFilesDirectory;
-                    var dumpFilePath = Path.Combine(dumpDir, $"{proc.ProcessName}-{counter}.dmp");
-                    await DumpProcess(proc, options.ProcDumpFilePath, dumpFilePath);
-                    counter++;
+                    continue;
                 }
+
+                var dumpFilePath = Path.Combine(dumpDir, $"{name}-{counter}.dmp");
+                ConsoleUtil.Write($"Dumping {name} {proc.Id} to {dumpFilePath} ... ");
+
+                if (DumpCollector.TryDumpProcess(proc, dumpFilePath))
+                {
+                    ConsoleUtil.WriteLine($"succeeded ({new FileInfo(dumpFilePath).Length} bytes)");
+                }
+                else
+                {
+                    ConsoleUtil.WriteLine("FAILED");
+                }
+
+                counter++;
             }
 
             WriteLogFile(options);

--- a/src/Tools/RunTests/RunTests.csproj
+++ b/src/Tools/RunTests/RunTests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Reflection.Metadata" />
     <PackageReference Include="System.Management" />
+    <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" />
     <PackageReference Include="Mono.Options" />
     <PackageReference Include="Newtonsoft.Json" />
     <ProjectReference Include="..\..\Compilers\Test\Core\Microsoft.CodeAnalysis.Test.Utilities.csproj" />


### PR DESCRIPTION
Our single machine jobs are failing with a hung test fairly often right now. This changes the process runner such that we actually get dumps when this happens. 