### PR TITLE
[labeled break/continue] Add labeled break/continue to the Compiler Test Plan

### DIFF
--- a/docs/contributing/Compiler Test Plan.md
+++ b/docs/contributing/Compiler Test Plan.md
@@ -222,8 +222,10 @@ lock(…) … // including variant on an instance of the `System.Threading.Lock`
 using (…) … // including `await` variant
 yield return …;
 yield break;
-break; // including labeled variant `break label;`
-continue; // including labeled variant `continue label;`
+break;
+continue;
+break label;
+continue label;
 ```
 
 ## Expression classifications

--- a/docs/contributing/Compiler Test Plan.md
+++ b/docs/contributing/Compiler Test Plan.md
@@ -222,8 +222,8 @@ lock(…) … // including variant on an instance of the `System.Threading.Lock`
 using (…) … // including `await` variant
 yield return …;
 yield break;
-break;
-continue;
+break; // including labeled variant `break label;`
+continue; // including labeled variant `continue label;`
 ```
 
 ## Expression classifications


### PR DESCRIPTION
Adds the labeled `break label;` / `continue label;` variants to the `Statements` list in the [Compiler Test Plan](https://github.com/dotnet/roslyn/blob/main/docs/contributing/Compiler%20Test%20Plan.md), so future feature test plans consider exercising them (matching the doc's existing "including ... variant" annotations).

Relates to test plan #83209
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84233)