### PR TITLE
Instruct AI to wait for tests to complete

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@
 - Tests inherit from base classes: `CSharpTestBase`, `VisualBasicTestBase` (compiler), `AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest_NoEditor` (IDE analyzers)
 - Use `[UseExportProvider]` for MEF-dependent tests
 - Copilot coding agent setup preinstalls `roslyn-language-server` as a global tool and syncs the `dotnet/skills` catalog into `~/.copilot/skills`
-- Tests may take ~4 minutes to run, wait until tests complete unless the user asks otherwise.
+- Tests may take ~4 minutes to run, wait until tests complete.
 
 **Formatting**:
 - Whitespace formatting preferences are stored in the `.editorconfig` file

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@
 - Tests inherit from base classes: `CSharpTestBase`, `VisualBasicTestBase` (compiler), `AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest_NoEditor` (IDE analyzers)
 - Use `[UseExportProvider]` for MEF-dependent tests
 - Copilot coding agent setup preinstalls `roslyn-language-server` as a global tool and syncs the `dotnet/skills` catalog into `~/.copilot/skills`
+- Tests may take ~4 minutes to run, wait until tests complete unless the user asks otherwise.
 
 **Formatting**:
 - Whitespace formatting preferences are stored in the `.editorconfig` file

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@
 - Tests inherit from base classes: `CSharpTestBase`, `VisualBasicTestBase` (compiler), `AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest_NoEditor` (IDE analyzers)
 - Use `[UseExportProvider]` for MEF-dependent tests
 - Copilot coding agent setup preinstalls `roslyn-language-server` as a global tool and syncs the `dotnet/skills` catalog into `~/.copilot/skills`
-- Tests may take ~4 minutes to run, wait until tests complete.
+- Tests may take a while to build and run. Monitor output and wait until tests complete unless you're confident tests are hanging.
 
 **Formatting**:
 - Whitespace formatting preferences are stored in the `.editorconfig` file


### PR DESCRIPTION
Today in VS Code Chat, AI ran a `dotnet test ...` cmd only to cancel it after a couple minutes. The session could not be recovered and I instructed AI to re-run and wait, which it did.

Updating instructions so that waiting is the default behavior.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84234)