### PR TITLE
Move require_api_files to global config to fix RS0016 on benchmark projects

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -144,9 +144,6 @@ dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 
 file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.\nSee the LICENSE file in the project root for more information.
 
-# RS0016: Only enable if API files are present
-dotnet_public_api_analyzer.require_api_files = true
-
 # IDE0055: Fix formatting
 # Workaround for https://github.com/dotnet/roslyn/issues/70570
 dotnet_diagnostic.IDE0055.severity = warning

--- a/eng/config/globalconfigs/Common.globalconfig
+++ b/eng/config/globalconfigs/Common.globalconfig
@@ -83,6 +83,12 @@ dotnet_diagnostic.RS0006.severity = error
 dotnet_diagnostic.RS0012.severity = warning
 dotnet_diagnostic.RS0014.severity = warning
 dotnet_diagnostic.RS0015.severity = warning
+# RS0016: Only enforce public API tracking when API files are present.
+# This must live in a global config (is_global = true) rather than .editorconfig because the
+# PublicApiAnalyzer reads this option from the first syntax tree of the compilation. For some
+# projects (e.g. IdeCoreBenchmarks) that first tree is a NuGet contentFiles '*.g.cs' file in the
+# global package cache outside the repo, where a path-scoped .editorconfig does not apply.
+dotnet_public_api_analyzer.require_api_files = true
 dotnet_diagnostic.RS0016.severity = error
 dotnet_diagnostic.RS0017.severity = error
 dotnet_diagnostic.RS0018.severity = warning

--- a/src/Razor/Shipping.globalconfig
+++ b/src/Razor/Shipping.globalconfig
@@ -2,6 +2,3 @@
 
 # CA2213: 'type' contains field 'field' that is of IDisposable type 'type', but it is never disposed
 dotnet_diagnostic.CA2213.severity = suggestion
-
-# RS0016: Add public types and members to the declared API
-dotnet_public_api_analyzer.require_api_files = true


### PR DESCRIPTION
The PublicApiAnalyzer reads dotnet_public_api_analyzer.require_api_files from the first syntax tree of the compilation. For projects like IdeCoreBenchmarks, that first tree is a NuGet contentFiles '*.g.cs' file restored into the global package cache outside the repo, where the root path-scoped .editorconfig does not apply. As a result the option was not seen, the analyzer bootstrapped with empty API data, and emitted RS0016 for every public symbol when building with analyzers (e.g. -p:RunAnalyzers=true / RoslynEnforceCodeStyle=true).

This was previously masked: CI restores packages into a repo-local .packages folder (-useGlobalNuGetCache:false), so the content file fell under the root .editorconfig and the option was honored. It only reproduced for developers using a global NuGet cache.

Move the setting into Common.globalconfig (is_global = true) so it applies to every compilation regardless of where the first source file lives, and remove the now-redundant path-scoped entry from .editorconfig.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84236)