### PR TITLE
Fix duplicate xUnit test case ID in TestBlockScopedNamespaces

### DIFF
--- a/src/EditorFeatures/CSharpTest/Formatting/CSharpNewDocumentFormattingServiceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CSharpNewDocumentFormattingServiceTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.AddImport;
 using Microsoft.CodeAnalysis.CodeStyle;
@@ -18,17 +17,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting;
 
 public sealed class CSharpNewDocumentFormattingServiceTests : AbstractNewDocumentFormattingServiceTests
 {
-    public static IEnumerable<object[]> EndOfDocumentSequences
-    {
-        get
-        {
-            yield return new object[] { "" };
-            yield return new object[] { """
-
-                """ };
-        }
-    }
-
     protected override string Language => LanguageNames.CSharp;
     protected override EditorTestWorkspace CreateTestWorkspace(string testCode, ParseOptions? parseOptions)
         => EditorTestWorkspace.CreateCSharp(testCode, parseOptions);
@@ -101,9 +89,17 @@ public sealed class CSharpNewDocumentFormattingServiceTests : AbstractNewDocumen
             parseOptions: new CSharpParseOptions(LanguageVersion.CSharp9));
     }
 
-    [Theory]
-    [MemberData(nameof(EndOfDocumentSequences))]
-    public Task TestBlockScopedNamespaces(string endOfDocumentSequence)
+    [Fact]
+    public Task TestBlockScopedNamespaces()
+        => TestBlockScopedNamespacesAsync(endOfDocumentSequence: "");
+
+    [Fact]
+    public Task TestBlockScopedNamespaces_WithTrailingNewline()
+        => TestBlockScopedNamespacesAsync(endOfDocumentSequence: """
+
+            """);
+
+    private Task TestBlockScopedNamespacesAsync(string endOfDocumentSequence)
         => TestAsync(testCode: $$"""
             namespace Goo;
 


### PR DESCRIPTION
xUnit was emitting a "Skipping test case with duplicate ID" warning for `TestBlockScopedNamespaces` because the `EndOfDocumentSequences` MemberData produced two test cases whose serialized display names were identical -- both rendered as `endOfDocumentSequence: ""` even though the actual values were `""` and `"\n"`. This caused one case to be silently skipped.

**Fix:** Replace the `[Theory]`/`MemberData` with two explicit `[Fact]` methods (`TestBlockScopedNamespaces` and `TestBlockScopedNamespaces_WithTrailingNewline`) that delegate to a shared `TestBlockScopedNamespacesAsync` helper. Each test now has a distinct name that xUnit can differentiate, while the core assertion logic remains in one place.

Before: 1 passed, 1 skipped (duplicate ID warning)
After: 2 passed, 0 skipped, no warning

Reproduce locally:

```
dotnet test src/EditorFeatures/CSharpTest/Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.csproj --filter "FullyQualifiedName~TestBlockScopedNamespaces"
```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84237)