### PR TITLE
Fix remaining duplicate test IDs in xUnit

### DIFF
--- a/src/Analyzers/CSharp/Tests/ConvertNamespace/ConvertToBlockScopedNamespaceAnalyzerTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertNamespace/ConvertToBlockScopedNamespaceAnalyzerTests.cs
@@ -111,9 +111,15 @@ public sealed class ConvertToBlockScopedNamespaceAnalyzerTests
             }
         }.RunAsync();
 
-    [Theory]
-    [MemberData(nameof(EndOfDocumentSequences))]
-    public Task TestConvertToBlockScopedInCSharp10WithDirectives1(string endOfDocumentSequence)
+    [Fact]
+    public Task TestConvertToBlockScopedInCSharp10WithDirectives1()
+        => TestConvertToBlockScopedInCSharp10WithDirectives1Async(endOfDocumentSequence: "");
+
+    [Fact]
+    public Task TestConvertToBlockScopedInCSharp10WithDirectives1_WithTrailingNewline()
+        => TestConvertToBlockScopedInCSharp10WithDirectives1Async(endOfDocumentSequence: Environment.NewLine);
+
+    private Task TestConvertToBlockScopedInCSharp10WithDirectives1Async(string endOfDocumentSequence)
         => new VerifyCS.Test
         {
             TestCode = $$"""

--- a/src/Analyzers/CSharp/Tests/ConvertNamespace/ConvertToBlockScopedNamespaceAnalyzerTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertNamespace/ConvertToBlockScopedNamespaceAnalyzerTests.cs
@@ -238,9 +238,15 @@ public sealed class ConvertToBlockScopedNamespaceAnalyzerTests
             }
         }.RunAsync();
 
-    [Theory]
-    [MemberData(nameof(EndOfDocumentSequences))]
-    public Task TestConvertToBlockWithNestedNamespaces2(string endOfDocumentSequence)
+    [Fact]
+    public Task TestConvertToBlockWithNestedNamespaces2()
+        => TestConvertToBlockWithNestedNamespaces2Async(endOfDocumentSequence: "");
+
+    [Fact]
+    public Task TestConvertToBlockWithNestedNamespaces2_WithTrailingNewline()
+        => TestConvertToBlockWithNestedNamespaces2Async(endOfDocumentSequence: Environment.NewLine);
+
+    private Task TestConvertToBlockWithNestedNamespaces2Async(string endOfDocumentSequence)
         => new VerifyCS.Test
         {
             TestCode = $$"""

--- a/src/Analyzers/CSharp/Tests/ConvertNamespace/ConvertToBlockScopedNamespaceAnalyzerTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertNamespace/ConvertToBlockScopedNamespaceAnalyzerTests.cs
@@ -173,9 +173,15 @@ public sealed class ConvertToBlockScopedNamespaceAnalyzerTests
             }
         }.RunAsync();
 
-    [Theory]
-    [MemberData(nameof(EndOfDocumentSequences))]
-    public Task TestConvertToBlockWithMultipleNamespaces(string endOfDocumentSequence)
+    [Fact]
+    public Task TestConvertToBlockWithMultipleNamespaces()
+        => TestConvertToBlockWithMultipleNamespacesAsync(endOfDocumentSequence: "");
+
+    [Fact]
+    public Task TestConvertToBlockWithMultipleNamespaces_WithTrailingNewline()
+        => TestConvertToBlockWithMultipleNamespacesAsync(endOfDocumentSequence: Environment.NewLine);
+
+    private Task TestConvertToBlockWithMultipleNamespacesAsync(string endOfDocumentSequence)
         => new VerifyCS.Test
         {
             TestCode = $$"""

--- a/src/Analyzers/CSharp/Tests/ConvertNamespace/ConvertToBlockScopedNamespaceAnalyzerTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertNamespace/ConvertToBlockScopedNamespaceAnalyzerTests.cs
@@ -302,9 +302,15 @@ public sealed class ConvertToBlockScopedNamespaceAnalyzerTests
             }
         }.RunAsync();
 
-    [Theory]
-    [MemberData(nameof(EndOfDocumentSequences))]
-    public Task TestConvertToBlockWithNestedNamespaces4(string endOfDocumentSequence)
+    [Fact]
+    public Task TestConvertToBlockWithNestedNamespaces4()
+        => TestConvertToBlockWithNestedNamespaces4Async(endOfDocumentSequence: "");
+
+    [Fact]
+    public Task TestConvertToBlockWithNestedNamespaces4_WithTrailingNewline()
+        => TestConvertToBlockWithNestedNamespaces4Async(endOfDocumentSequence: Environment.NewLine);
+
+    private Task TestConvertToBlockWithNestedNamespaces4Async(string endOfDocumentSequence)
         => new VerifyCS.Test
         {
             TestCode = $$"""

--- a/src/Analyzers/CSharp/Tests/ConvertNamespace/ConvertToBlockScopedNamespaceAnalyzerTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertNamespace/ConvertToBlockScopedNamespaceAnalyzerTests.cs
@@ -142,9 +142,15 @@ public sealed class ConvertToBlockScopedNamespaceAnalyzerTests
             }
         }.RunAsync();
 
-    [Theory]
-    [MemberData(nameof(EndOfDocumentSequences))]
-    public Task TestConvertToBlockScopedInCSharp10WithDirectives2(string endOfDocumentSequence)
+    [Fact]
+    public Task TestConvertToBlockScopedInCSharp10WithDirectives2()
+        => TestConvertToBlockScopedInCSharp10WithDirectives2Async(endOfDocumentSequence: "");
+
+    [Fact]
+    public Task TestConvertToBlockScopedInCSharp10WithDirectives2_WithTrailingNewline()
+        => TestConvertToBlockScopedInCSharp10WithDirectives2Async(endOfDocumentSequence: Environment.NewLine);
+
+    private Task TestConvertToBlockScopedInCSharp10WithDirectives2Async(string endOfDocumentSequence)
         => new VerifyCS.Test
         {
             TestCode = $$"""

--- a/src/Analyzers/CSharp/Tests/ConvertNamespace/ConvertToBlockScopedNamespaceAnalyzerTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertNamespace/ConvertToBlockScopedNamespaceAnalyzerTests.cs
@@ -270,9 +270,15 @@ public sealed class ConvertToBlockScopedNamespaceAnalyzerTests
             }
         }.RunAsync();
 
-    [Theory]
-    [MemberData(nameof(EndOfDocumentSequences))]
-    public Task TestConvertToBlockWithNestedNamespaces3(string endOfDocumentSequence)
+    [Fact]
+    public Task TestConvertToBlockWithNestedNamespaces3()
+        => TestConvertToBlockWithNestedNamespaces3Async(endOfDocumentSequence: "");
+
+    [Fact]
+    public Task TestConvertToBlockWithNestedNamespaces3_WithTrailingNewline()
+        => TestConvertToBlockWithNestedNamespaces3Async(endOfDocumentSequence: Environment.NewLine);
+
+    private Task TestConvertToBlockWithNestedNamespaces3Async(string endOfDocumentSequence)
         => new VerifyCS.Test
         {
             TestCode = $$"""

--- a/src/Analyzers/CSharp/Tests/ConvertNamespace/ConvertToBlockScopedNamespaceAnalyzerTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertNamespace/ConvertToBlockScopedNamespaceAnalyzerTests.cs
@@ -206,9 +206,15 @@ public sealed class ConvertToBlockScopedNamespaceAnalyzerTests
             }
         }.RunAsync();
 
-    [Theory]
-    [MemberData(nameof(EndOfDocumentSequences))]
-    public Task TestConvertToBlockWithNestedNamespaces1(string endOfDocumentSequence)
+    [Fact]
+    public Task TestConvertToBlockWithNestedNamespaces1()
+        => TestConvertToBlockWithNestedNamespaces1Async(endOfDocumentSequence: "");
+
+    [Fact]
+    public Task TestConvertToBlockWithNestedNamespaces1_WithTrailingNewline()
+        => TestConvertToBlockWithNestedNamespaces1Async(endOfDocumentSequence: Environment.NewLine);
+
+    private Task TestConvertToBlockWithNestedNamespaces1Async(string endOfDocumentSequence)
         => new VerifyCS.Test
         {
             TestCode = $$"""

--- a/src/Analyzers/CSharp/Tests/ConvertNamespace/ConvertToBlockScopedNamespaceAnalyzerTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertNamespace/ConvertToBlockScopedNamespaceAnalyzerTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeStyle;
@@ -22,15 +21,6 @@ using VerifyCS = CSharpCodeFixVerifier<ConvertToBlockScopedNamespaceDiagnosticAn
 
 public sealed class ConvertToBlockScopedNamespaceAnalyzerTests
 {
-    public static IEnumerable<object[]> EndOfDocumentSequences
-    {
-        get
-        {
-            yield return new object[] { "" };
-            yield return new object[] { Environment.NewLine };
-        }
-    }
-
     #region Convert To Block Scoped
 
     [Fact]
@@ -339,9 +329,15 @@ public sealed class ConvertToBlockScopedNamespaceAnalyzerTests
             }
         }.RunAsync();
 
-    [Theory]
-    [MemberData(nameof(EndOfDocumentSequences))]
-    public Task TestConvertToBlockWithNestedNamespaces5(string endOfDocumentSequence)
+    [Fact]
+    public Task TestConvertToBlockWithNestedNamespaces5()
+        => TestConvertToBlockWithNestedNamespaces5Async(endOfDocumentSequence: "");
+
+    [Fact]
+    public Task TestConvertToBlockWithNestedNamespaces5_WithTrailingNewline()
+        => TestConvertToBlockWithNestedNamespaces5Async(endOfDocumentSequence: Environment.NewLine);
+
+    private Task TestConvertToBlockWithNestedNamespaces5Async(string endOfDocumentSequence)
         => new VerifyCS.Test
         {
             TestCode = $$"""

--- a/src/Analyzers/CSharp/Tests/ConvertNamespace/ConvertToBlockScopedNamespaceAnalyzerTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertNamespace/ConvertToBlockScopedNamespaceAnalyzerTests.cs
@@ -85,9 +85,15 @@ public sealed class ConvertToBlockScopedNamespaceAnalyzerTests
             }
         }.RunAsync();
 
-    [Theory]
-    [MemberData(nameof(EndOfDocumentSequences))]
-    public Task TestConvertToBlockScopedInCSharp10WithFileScopedPreference(string endOfDocumentSequence)
+    [Fact]
+    public Task TestConvertToBlockScopedInCSharp10WithFileScopedPreference()
+        => TestConvertToBlockScopedInCSharp10WithFileScopedPreferenceAsync(endOfDocumentSequence: "");
+
+    [Fact]
+    public Task TestConvertToBlockScopedInCSharp10WithFileScopedPreference_WithTrailingNewline()
+        => TestConvertToBlockScopedInCSharp10WithFileScopedPreferenceAsync(endOfDocumentSequence: Environment.NewLine);
+
+    private Task TestConvertToBlockScopedInCSharp10WithFileScopedPreferenceAsync(string endOfDocumentSequence)
         => new VerifyCS.Test
         {
             TestCode = $$"""

--- a/src/EditorFeatures/CSharpTest/Formatting/CSharpNewDocumentFormattingServiceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CSharpNewDocumentFormattingServiceTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.AddImport;
 using Microsoft.CodeAnalysis.CodeStyle;
@@ -18,17 +17,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting;
 
 public sealed class CSharpNewDocumentFormattingServiceTests : AbstractNewDocumentFormattingServiceTests
 {
-    public static IEnumerable<object[]> EndOfDocumentSequences
-    {
-        get
-        {
-            yield return new object[] { "" };
-            yield return new object[] { """
-
-                """ };
-        }
-    }
-
     protected override string Language => LanguageNames.CSharp;
     protected override EditorTestWorkspace CreateTestWorkspace(string testCode, ParseOptions? parseOptions)
         => EditorTestWorkspace.CreateCSharp(testCode, parseOptions);
@@ -101,9 +89,17 @@ public sealed class CSharpNewDocumentFormattingServiceTests : AbstractNewDocumen
             parseOptions: new CSharpParseOptions(LanguageVersion.CSharp9));
     }
 
-    [Theory]
-    [MemberData(nameof(EndOfDocumentSequences))]
-    public Task TestBlockScopedNamespaces(string endOfDocumentSequence)
+    [Fact]
+    public Task TestBlockScopedNamespaces()
+        => TestBlockScopedNamespacesAsync(endOfDocumentSequence: "");
+
+    [Fact]
+    public Task TestBlockScopedNamespaces_WithTrailingNewline()
+        => TestBlockScopedNamespacesAsync(endOfDocumentSequence: """
+
+            """);
+
+    private Task TestBlockScopedNamespacesAsync(string endOfDocumentSequence)
         => TestAsync(testCode: $$"""
             namespace Goo;
 

--- a/src/Features/CSharpTest/ConvertNamespace/ConvertNamespaceRefactoringTests.cs
+++ b/src/Features/CSharpTest/ConvertNamespace/ConvertNamespaceRefactoringTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp;
@@ -22,8 +21,6 @@ using VerifyCS = CSharpCodeRefactoringVerifier<ConvertNamespaceCodeRefactoringPr
 [UseExportProvider]
 public sealed class ConvertNamespaceRefactoringTests
 {
-    public static IEnumerable<object[]> EndOfDocumentSequences => [[""], [Environment.NewLine]];
-
     #region Convert To File Scoped
 
     [Fact]
@@ -531,9 +528,15 @@ public sealed class ConvertNamespaceRefactoringTests
 
     #region Convert To Block Scoped
 
-    [Theory]
-    [MemberData(nameof(EndOfDocumentSequences))]
-    public Task TestConvertToBlockScopedInCSharp9(string endOfDocumentSequence)
+    [Fact]
+    public Task TestConvertToBlockScopedInCSharp9()
+        => TestConvertToBlockScopedInCSharp9Async(endOfDocumentSequence: "");
+
+    [Fact]
+    public Task TestConvertToBlockScopedInCSharp9_WithTrailingNewline()
+        => TestConvertToBlockScopedInCSharp9Async(endOfDocumentSequence: Environment.NewLine);
+
+    private Task TestConvertToBlockScopedInCSharp9Async(string endOfDocumentSequence)
         => new VerifyCS.Test
         {
             TestCode = $$"""

--- a/src/Features/CSharpTest/ConvertProgram/ConvertToTopLevelStatementsAnalyzerTests.cs
+++ b/src/Features/CSharpTest/ConvertProgram/ConvertToTopLevelStatementsAnalyzerTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp;
@@ -20,15 +19,6 @@ using VerifyCS = CSharpCodeFixVerifier<ConvertToTopLevelStatementsDiagnosticAnal
 
 public sealed class ConvertToTopLevelStatementsAnalyzerTests
 {
-    public static IEnumerable<object[]> EndOfDocumentSequences
-    {
-        get
-        {
-            yield return new object[] { "" };
-            yield return new object[] { Environment.NewLine };
-        }
-    }
-
     [Fact]
     public Task NotOfferedWhenUserPrefersProgramMain()
         => new VerifyCS.Test
@@ -1418,9 +1408,15 @@ public sealed class ConvertToTopLevelStatementsAnalyzerTests
             Options = { { CSharpCodeStyleOptions.PreferTopLevelStatements, true, NotificationOption2.Suggestion } },
         }.RunAsync();
 
-    [Theory]
-    [MemberData(nameof(EndOfDocumentSequences))]
-    public Task TestInTopLevelNamespaceWithOtherTypeThatIsReferenced(string endOfDocumentSequence)
+    [Fact]
+    public Task TestInTopLevelNamespaceWithOtherTypeThatIsReferenced()
+        => TestInTopLevelNamespaceWithOtherTypeThatIsReferencedAsync(endOfDocumentSequence: "");
+
+    [Fact]
+    public Task TestInTopLevelNamespaceWithOtherTypeThatIsReferenced_WithTrailingNewline()
+        => TestInTopLevelNamespaceWithOtherTypeThatIsReferencedAsync(endOfDocumentSequence: Environment.NewLine);
+
+    private Task TestInTopLevelNamespaceWithOtherTypeThatIsReferencedAsync(string endOfDocumentSequence)
         => new VerifyCS.Test
         {
             TestCode = $$"""

--- a/src/Features/CSharpTest/ConvertProgram/ConvertToTopLevelStatementsAnalyzerTests.cs
+++ b/src/Features/CSharpTest/ConvertProgram/ConvertToTopLevelStatementsAnalyzerTests.cs
@@ -1327,9 +1327,15 @@ public sealed class ConvertToTopLevelStatementsAnalyzerTests
             Options = { { CSharpCodeStyleOptions.PreferTopLevelStatements, true, NotificationOption2.Suggestion } },
         }.RunAsync();
 
-    [Theory]
-    [MemberData(nameof(EndOfDocumentSequences))]
-    public Task TestInTopLevelNamespaceWithOtherType(string endOfDocumentSequence)
+    [Fact]
+    public Task TestInTopLevelNamespaceWithOtherType()
+        => TestInTopLevelNamespaceWithOtherTypeAsync(endOfDocumentSequence: "");
+
+    [Fact]
+    public Task TestInTopLevelNamespaceWithOtherType_WithTrailingNewline()
+        => TestInTopLevelNamespaceWithOtherTypeAsync(endOfDocumentSequence: Environment.NewLine);
+
+    private Task TestInTopLevelNamespaceWithOtherTypeAsync(string endOfDocumentSequence)
         => new VerifyCS.Test
         {
             TestCode = $$"""


### PR DESCRIPTION
Builds on #84237 to fully mitigate skipped tests due to duplicate xUnit test IDs. A future PR (or modified version of this one, if requested), will ensure that duplicate IDs are an error that fails CI instead of the current state of non-blocking warnings.

Working to validate AI output before marking this as ready for review

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84246)