### PR TITLE
Handle iterator safe contexts in ref safety analysis

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Flags.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Flags.cs
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // In C# 12 and below, we keep the (spec violating) behavior that iterator bodies inherit the safe/unsafe context
             // from their containing scope. Since there are errors for unsafe constructs directly in iterators,
             // this inherited unsafe context can be observed only in nested non-iterator local functions.
-            var withoutUnsafe = isIteratorBody && this.Compilation.IsFeatureEnabled(MessageID.IDS_FeatureRefUnsafeInIteratorAsync);
+            var withoutUnsafe = IsIteratorBodyWithSafeContext(this.Compilation, isIteratorBody);
 
             if (this.Flags.Includes(BinderFlags.UnsafeRegion))
             {
@@ -112,6 +112,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return !withoutUnsafe && modifiers.Any(SyntaxKind.UnsafeKeyword) && !this.Compilation.SourceModule.UseUpdatedMemorySafetyRules
                 ? new Binder(this, this.Flags | BinderFlags.UnsafeRegion)
                 : this;
+        }
+
+        internal static bool IsIteratorBodyWithSafeContext(CSharpCompilation compilation, bool isIteratorBody)
+        {
+            return isIteratorBody && compilation.IsFeatureEnabled(MessageID.IDS_FeatureRefUnsafeInIteratorAsync);
         }
 
         internal Binder WithCheckedOrUncheckedRegion(bool @checked)

--- a/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 compilation,
                 symbol,
                 node,
-                inUnsafeRegion: InUnsafeMethod(compilation, symbol),
+                inUnsafeRegion: InUnsafeContext(compilation, symbol),
                 useUpdatedEscapeRules: symbol.ContainingModule.UseUpdatedEscapeRules,
                 diagnostics);
             try
@@ -35,20 +35,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        /// <summary>
-        /// In C# 13 and above, iterator bodies define a safe context even when nested in an unsafe context
-        /// (matching <see cref="Binder.SetOrClearUnsafeRegionIfNecessary"/>). This ensures ref safety violations
-        /// inside such iterators remain errors instead of being downgraded to warnings.
-        /// </summary>
-        private static bool IsIteratorBodyWithSafeContext(CSharpCompilation compilation, Symbol symbol)
+        private static bool InUnsafeContext(CSharpCompilation compilation, Symbol symbol)
         {
-            return symbol is MethodSymbol { IsIterator: true }
-                && compilation.IsFeatureEnabled(MessageID.IDS_FeatureRefUnsafeInIteratorAsync);
-        }
-
-        private static bool InUnsafeMethod(CSharpCompilation compilation, Symbol symbol)
-        {
-            if (IsIteratorBodyWithSafeContext(compilation, symbol))
+            if (Binder.IsIteratorBodyWithSafeContext(compilation, isIteratorBody: symbol is MethodSymbol { IsIterator: true }))
             {
                 return false;
             }
@@ -385,7 +374,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitLocalFunctionStatement(BoundLocalFunctionStatement node)
         {
             var localFunction = (LocalFunctionSymbol)node.Symbol;
-            var inUnsafeRegion = !IsIteratorBodyWithSafeContext(_compilation, localFunction) && (_inUnsafeRegion || localFunction.IntroducesUnsafeContext);
+            var inUnsafeRegion = !Binder.IsIteratorBodyWithSafeContext(_compilation, isIteratorBody: localFunction.IsIterator) && (_inUnsafeRegion || localFunction.IntroducesUnsafeContext);
             var analysis = new RefSafetyAnalysis(_compilation, localFunction, node, inUnsafeRegion, _useUpdatedEscapeRules, _diagnostics);
             analysis.Visit(node.BlockBody);
             analysis.Visit(node.ExpressionBody);

--- a/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 compilation,
                 symbol,
                 node,
-                inUnsafeRegion: InUnsafeMethod(symbol),
+                inUnsafeRegion: InUnsafeMethod(compilation, symbol),
                 useUpdatedEscapeRules: symbol.ContainingModule.UseUpdatedEscapeRules,
                 diagnostics);
             try
@@ -35,8 +35,24 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private static bool InUnsafeMethod(Symbol symbol)
+        /// <summary>
+        /// In C# 13 and above, iterator bodies define a safe context even when nested in an unsafe context
+        /// (matching <see cref="Binder.SetOrClearUnsafeRegionIfNecessary"/>). This ensures ref safety violations
+        /// inside such iterators remain errors instead of being downgraded to warnings.
+        /// </summary>
+        private static bool IsIteratorBodyWithSafeContext(CSharpCompilation compilation, Symbol symbol)
         {
+            return symbol is MethodSymbol { IsIterator: true }
+                && compilation.IsFeatureEnabled(MessageID.IDS_FeatureRefUnsafeInIteratorAsync);
+        }
+
+        private static bool InUnsafeMethod(CSharpCompilation compilation, Symbol symbol)
+        {
+            if (IsIteratorBodyWithSafeContext(compilation, symbol))
+            {
+                return false;
+            }
+
             if (symbol is SourceMemberMethodSymbol { IntroducesUnsafeContext: true })
             {
                 return true;
@@ -369,7 +385,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitLocalFunctionStatement(BoundLocalFunctionStatement node)
         {
             var localFunction = (LocalFunctionSymbol)node.Symbol;
-            var inUnsafeRegion = _inUnsafeRegion || localFunction.IntroducesUnsafeContext;
+            var inUnsafeRegion = !IsIteratorBodyWithSafeContext(_compilation, localFunction) && (_inUnsafeRegion || localFunction.IntroducesUnsafeContext);
             var analysis = new RefSafetyAnalysis(_compilation, localFunction, node, inUnsafeRegion, _useUpdatedEscapeRules, _diagnostics);
             analysis.Visit(node.BlockBody);
             analysis.Visit(node.ExpressionBody);

--- a/src/Compilers/CSharp/Test/Emit3/RefUnsafeInIteratorAndAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/RefUnsafeInIteratorAndAsyncTests.cs
@@ -1366,6 +1366,113 @@ public class RefUnsafeInIteratorAndAsyncTests : CSharpTestBase
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/83564")]
+    public void RefAnalysis_Iterator_UnsafeBlock()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            class C
+            {
+                int field;
+
+                void M1()
+                {
+                    ref int outside = ref field;
+                    unsafe {
+                        int local = 1;
+                        outside = ref local; // 1
+                    }
+                }
+
+                IEnumerable<int> M2()
+                {
+                    ref int outside = ref field;
+                    unsafe {
+                        int local = 1;
+                        outside = ref local; // 2
+                    }
+                    yield return 1;
+                }
+            }
+            """;
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular12, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+            // (12,13): warning CS9085: This ref-assigns 'local' to 'outside' but 'local' has a narrower escape scope than 'outside'.
+            //             outside = ref local; // 1
+            Diagnostic(ErrorCode.WRN_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(12, 13),
+            // (18,17): error CS9202: Feature 'ref and unsafe in async and iterator methods' is not available in C# 12.0. Please use language version 13.0 or greater.
+            //         ref int outside = ref field;
+            Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion12, "outside").WithArguments("ref and unsafe in async and iterator methods", "13.0").WithLocation(18, 17),
+            // (19,9): error CS9202: Feature 'ref and unsafe in async and iterator methods' is not available in C# 12.0. Please use language version 13.0 or greater.
+            //         unsafe {
+            Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion12, "unsafe").WithArguments("ref and unsafe in async and iterator methods", "13.0").WithLocation(19, 9),
+            // (21,13): warning CS9085: This ref-assigns 'local' to 'outside' but 'local' has a narrower escape scope than 'outside'.
+            //             outside = ref local; // 2
+            Diagnostic(ErrorCode.WRN_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(21, 13));
+
+        var expectedDiagnostics = new[]
+        {
+            // (12,13): warning CS9085: This ref-assigns 'local' to 'outside' but 'local' has a narrower escape scope than 'outside'.
+            //             outside = ref local; // 1
+            Diagnostic(ErrorCode.WRN_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(12, 13),
+            // (21,13): warning CS9085: This ref-assigns 'local' to 'outside' but 'local' has a narrower escape scope than 'outside'.
+            //             outside = ref local; // 2
+            Diagnostic(ErrorCode.WRN_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(21, 13),
+        };
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/83564")]
+    public void RefAnalysis_Iterator_UnsafeBlockAndIterator()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            class C
+            {
+                int field;
+
+                IEnumerable<int> M()
+                {
+                    ref int outside = ref field;
+                    unsafe
+                    {
+                        int local = 1;
+                        outside = ref local;
+                        yield return 1;
+                    }
+                }
+            }
+            """;
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular12, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+            // (9,17): error CS9202: Feature 'ref and unsafe in async and iterator methods' is not available in C# 12.0. Please use language version 13.0 or greater.
+            //         ref int outside = ref field;
+            Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion12, "outside").WithArguments("ref and unsafe in async and iterator methods", "13.0").WithLocation(9, 17),
+            // (10,9): error CS9202: Feature 'ref and unsafe in async and iterator methods' is not available in C# 12.0. Please use language version 13.0 or greater.
+            //         unsafe
+            Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion12, "unsafe").WithArguments("ref and unsafe in async and iterator methods", "13.0").WithLocation(10, 9),
+            // (13,13): warning CS9085: This ref-assigns 'local' to 'outside' but 'local' has a narrower escape scope than 'outside'.
+            //             outside = ref local;
+            Diagnostic(ErrorCode.WRN_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(13, 13));
+
+        var expectedDiagnostics = new[]
+        {
+            // (13,13): warning CS9085: This ref-assigns 'local' to 'outside' but 'local' has a narrower escape scope than 'outside'.
+            //             outside = ref local;
+            Diagnostic(ErrorCode.WRN_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(13, 13),
+            // (14,13): error CS9238: Cannot use 'yield return' in an 'unsafe' block
+            //             yield return 1;
+            Diagnostic(ErrorCode.ERR_BadYieldInUnsafe, "yield").WithLocation(14, 13),
+        };
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/83564")]
     public void RefAnalysis_Iterator_LocalFunction()
     {
         var source = """
@@ -1469,6 +1576,71 @@ public class RefUnsafeInIteratorAndAsyncTests : CSharpTestBase
             // (51,17): error CS8374: Cannot ref-assign 'local' to 'outside' because 'local' has a narrower escape scope than 'outside'.
             //                 outside = ref local; // 4
             Diagnostic(ErrorCode.ERR_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(51, 17),
+        };
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/83564")]
+    public void RefAnalysis_Iterator_LocalFunction_UnsafeBlock()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            class C
+            {
+                int field;
+
+                void M1()
+                {
+                    unsafe
+                    {
+                        F1();
+                        F2();
+
+                        void F1()
+                        {
+                            ref int outside = ref field;
+                            {
+                                int local = 1;
+                                outside = ref local; // 1
+                            }
+                        }
+
+                        IEnumerable<int> F2()
+                        {
+                            ref int outside = ref field;
+                            {
+                                int local = 1;
+                                outside = ref local; // 2
+                            }
+                            yield return 1;
+                        }
+                    }
+                }
+            }
+            """;
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular12, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+            // (19,21): warning CS9085: This ref-assigns 'local' to 'outside' but 'local' has a narrower escape scope than 'outside'.
+            //                     outside = ref local; // 1
+            Diagnostic(ErrorCode.WRN_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(19, 21),
+            // (25,25): error CS9202: Feature 'ref and unsafe in async and iterator methods' is not available in C# 12.0. Please use language version 13.0 or greater.
+            //                 ref int outside = ref field;
+            Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion12, "outside").WithArguments("ref and unsafe in async and iterator methods", "13.0").WithLocation(25, 25),
+            // (28,21): warning CS9085: This ref-assigns 'local' to 'outside' but 'local' has a narrower escape scope than 'outside'.
+            //                     outside = ref local; // 2
+            Diagnostic(ErrorCode.WRN_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(28, 21));
+
+        var expectedDiagnostics = new[]
+        {
+            // (19,21): warning CS9085: This ref-assigns 'local' to 'outside' but 'local' has a narrower escape scope than 'outside'.
+            //                     outside = ref local; // 1
+            Diagnostic(ErrorCode.WRN_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(19, 21),
+            // (28,21): error CS8374: Cannot ref-assign 'local' to 'outside' because 'local' has a narrower escape scope than 'outside'.
+            //                     outside = ref local; // 2
+            Diagnostic(ErrorCode.ERR_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(28, 21),
         };
 
         CreateCompilation(source, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);

--- a/src/Compilers/CSharp/Test/Emit3/RefUnsafeInIteratorAndAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/RefUnsafeInIteratorAndAsyncTests.cs
@@ -1305,4 +1305,252 @@ public class RefUnsafeInIteratorAndAsyncTests : CSharpTestBase
         var comp = CreateCompilationWithTasksExtensions(source, options: TestOptions.ReleaseExe);
         CompileAndVerify(comp, expectedOutput: "123").VerifyDiagnostics();
     }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/83564")]
+    public void RefAnalysis_Iterator()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            class C
+            {
+                int field;
+
+                unsafe void M1()
+                {
+                    ref int outside = ref field;
+                    {
+                        int local = 1;
+                        outside = ref local; // 1
+                    }
+                }
+
+                unsafe IEnumerable<int> M2()
+                {
+                    ref int outside = ref field;
+                    {
+                        int local = 1;
+                        outside = ref local; // 2
+                    }
+                    yield return 1;
+                }
+            }
+            """;
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular12, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+            // (12,13): warning CS9085: This ref-assigns 'local' to 'outside' but 'local' has a narrower escape scope than 'outside'.
+            //             outside = ref local; // 1
+            Diagnostic(ErrorCode.WRN_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(12, 13),
+            // (16,29): error CS9202: Feature 'ref and unsafe in async and iterator methods' is not available in C# 12.0. Please use language version 13.0 or greater.
+            //     unsafe IEnumerable<int> M2()
+            Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion12, "M2").WithArguments("ref and unsafe in async and iterator methods", "13.0").WithLocation(16, 29),
+            // (18,17): error CS9202: Feature 'ref and unsafe in async and iterator methods' is not available in C# 12.0. Please use language version 13.0 or greater.
+            //         ref int outside = ref field;
+            Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion12, "outside").WithArguments("ref and unsafe in async and iterator methods", "13.0").WithLocation(18, 17),
+            // (21,13): warning CS9085: This ref-assigns 'local' to 'outside' but 'local' has a narrower escape scope than 'outside'.
+            //             outside = ref local; // 2
+            Diagnostic(ErrorCode.WRN_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(21, 13));
+
+        var expectedDiagnostics = new[]
+        {
+            // (12,13): warning CS9085: This ref-assigns 'local' to 'outside' but 'local' has a narrower escape scope than 'outside'.
+            //             outside = ref local; // 1
+            Diagnostic(ErrorCode.WRN_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(12, 13),
+            // (21,13): error CS8374: Cannot ref-assign 'local' to 'outside' because 'local' has a narrower escape scope than 'outside'.
+            //             outside = ref local; // 2
+            Diagnostic(ErrorCode.ERR_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(21, 13),
+        };
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/83564")]
+    public void RefAnalysis_Iterator_LocalFunction()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            class C
+            {
+                int field;
+
+                void M1()
+                {
+                    F1();
+                    F2();
+
+                    unsafe void F1()
+                    {
+                        ref int outside = ref field;
+                        {
+                            int local = 1;
+                            outside = ref local; // 1
+                        }
+                    }
+
+                    unsafe IEnumerable<int> F2()
+                    {
+                        ref int outside = ref field;
+                        {
+                            int local = 1;
+                            outside = ref local; // 2
+                        }
+                        yield return 1;
+                    }
+                }
+
+                IEnumerable<int> M2()
+                {
+                    F1();
+                    F2();
+
+                    unsafe void F1()
+                    {
+                        ref int outside = ref field;
+                        {
+                            int local = 1;
+                            outside = ref local; // 3
+                        }
+                    }
+
+                    unsafe IEnumerable<int> F2()
+                    {
+                        ref int outside = ref field;
+                        {
+                            int local = 1;
+                            outside = ref local; // 4
+                        }
+                        yield return 1;
+                    }
+
+                    yield return 1;
+                }
+            }
+            """;
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular12, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+            // (17,17): warning CS9085: This ref-assigns 'local' to 'outside' but 'local' has a narrower escape scope than 'outside'.
+            //                 outside = ref local; // 1
+            Diagnostic(ErrorCode.WRN_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(17, 17),
+            // (21,33): error CS9202: Feature 'ref and unsafe in async and iterator methods' is not available in C# 12.0. Please use language version 13.0 or greater.
+            //         unsafe IEnumerable<int> F2()
+            Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion12, "F2").WithArguments("ref and unsafe in async and iterator methods", "13.0").WithLocation(21, 33),
+            // (23,21): error CS9202: Feature 'ref and unsafe in async and iterator methods' is not available in C# 12.0. Please use language version 13.0 or greater.
+            //             ref int outside = ref field;
+            Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion12, "outside").WithArguments("ref and unsafe in async and iterator methods", "13.0").WithLocation(23, 21),
+            // (26,17): warning CS9085: This ref-assigns 'local' to 'outside' but 'local' has a narrower escape scope than 'outside'.
+            //                 outside = ref local; // 2
+            Diagnostic(ErrorCode.WRN_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(26, 17),
+            // (42,17): warning CS9085: This ref-assigns 'local' to 'outside' but 'local' has a narrower escape scope than 'outside'.
+            //                 outside = ref local; // 3
+            Diagnostic(ErrorCode.WRN_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(42, 17),
+            // (46,33): error CS9202: Feature 'ref and unsafe in async and iterator methods' is not available in C# 12.0. Please use language version 13.0 or greater.
+            //         unsafe IEnumerable<int> F2()
+            Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion12, "F2").WithArguments("ref and unsafe in async and iterator methods", "13.0").WithLocation(46, 33),
+            // (48,21): error CS9202: Feature 'ref and unsafe in async and iterator methods' is not available in C# 12.0. Please use language version 13.0 or greater.
+            //             ref int outside = ref field;
+            Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion12, "outside").WithArguments("ref and unsafe in async and iterator methods", "13.0").WithLocation(48, 21),
+            // (51,17): warning CS9085: This ref-assigns 'local' to 'outside' but 'local' has a narrower escape scope than 'outside'.
+            //                 outside = ref local; // 4
+            Diagnostic(ErrorCode.WRN_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(51, 17));
+
+        var expectedDiagnostics = new[]
+        {
+            // (17,17): warning CS9085: This ref-assigns 'local' to 'outside' but 'local' has a narrower escape scope than 'outside'.
+            //                 outside = ref local; // 1
+            Diagnostic(ErrorCode.WRN_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(17, 17),
+            // (26,17): error CS8374: Cannot ref-assign 'local' to 'outside' because 'local' has a narrower escape scope than 'outside'.
+            //                 outside = ref local; // 2
+            Diagnostic(ErrorCode.ERR_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(26, 17),
+            // (42,17): warning CS9085: This ref-assigns 'local' to 'outside' but 'local' has a narrower escape scope than 'outside'.
+            //                 outside = ref local; // 3
+            Diagnostic(ErrorCode.WRN_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(42, 17),
+            // (51,17): error CS8374: Cannot ref-assign 'local' to 'outside' because 'local' has a narrower escape scope than 'outside'.
+            //                 outside = ref local; // 4
+            Diagnostic(ErrorCode.ERR_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(51, 17),
+        };
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/83564")]
+    public void RefAnalysis_Iterator_LocalFunction_Nested()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            class C
+            {
+                int field;
+
+                void M1()
+                {
+                    F1();
+
+                    unsafe void F1()
+                    {
+                        ref int outside = ref field;
+                        {
+                            int local = 1;
+                            outside = ref local; // 1
+                        }
+
+                        F11();
+                        F12();
+
+                        void F11()
+                        {
+                            ref int outside = ref field;
+                            {
+                                int local = 1;
+                                outside = ref local; // 2
+                            }
+                        }
+
+                        IEnumerable<int> F12()
+                        {
+                            ref int outside = ref field;
+                            {
+                                int local = 1;
+                                outside = ref local; // 3
+                            }
+                            yield return 1;
+                        }
+                    }
+                }
+            }
+            """;
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular12, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+            // (16,17): warning CS9085: This ref-assigns 'local' to 'outside' but 'local' has a narrower escape scope than 'outside'.
+            //                 outside = ref local; // 1
+            Diagnostic(ErrorCode.WRN_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(16, 17),
+            // (27,21): warning CS9085: This ref-assigns 'local' to 'outside' but 'local' has a narrower escape scope than 'outside'.
+            //                     outside = ref local; // 2
+            Diagnostic(ErrorCode.WRN_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(27, 21),
+            // (33,25): error CS9202: Feature 'ref and unsafe in async and iterator methods' is not available in C# 12.0. Please use language version 13.0 or greater.
+            //                 ref int outside = ref field;
+            Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion12, "outside").WithArguments("ref and unsafe in async and iterator methods", "13.0").WithLocation(33, 25),
+            // (36,21): warning CS9085: This ref-assigns 'local' to 'outside' but 'local' has a narrower escape scope than 'outside'.
+            //                     outside = ref local; // 3
+            Diagnostic(ErrorCode.WRN_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(36, 21));
+
+        var expectedDiagnostics = new[]
+        {
+            // (16,17): warning CS9085: This ref-assigns 'local' to 'outside' but 'local' has a narrower escape scope than 'outside'.
+            //                 outside = ref local; // 1
+            Diagnostic(ErrorCode.WRN_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(16, 17),
+            // (27,21): warning CS9085: This ref-assigns 'local' to 'outside' but 'local' has a narrower escape scope than 'outside'.
+            //                     outside = ref local; // 2
+            Diagnostic(ErrorCode.WRN_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(27, 21),
+            // (36,21): error CS8374: Cannot ref-assign 'local' to 'outside' because 'local' has a narrower escape scope than 'outside'.
+            //                     outside = ref local; // 3
+            Diagnostic(ErrorCode.ERR_RefAssignNarrower, "outside = ref local").WithArguments("outside", "local").WithLocation(36, 21),
+        };
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular13, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/83564.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84254)