### PR TITLE
Tolerate missing session in EnC Hot Reload lifecycle callbacks

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTrackingServiceTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTrackingServiceTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Contracts.EditAndContinue;
 using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.EditAndContinue.UnitTests;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
@@ -122,5 +123,20 @@ public sealed class ActiveStatementTrackingServiceTests
             $"V0 →←@[11..16): NonLeafFrame",
             $"V0 →←@[21..26): LeafFrame"
         ], spans6.Select(s => $"{s.Span}: {s.Flags}"));
+    }
+
+    [Fact]
+    public void EndTracking_WithoutStartTracking_IsNoOp()
+    {
+        // Regression test: an unbalanced EndTracking -- for example when the debugger delivers an
+        // exit-break-state transition without a matching enter-break-state, or after a debugging session
+        // failed to start -- must be a benign no-op. Previously it threw, which was reported as a
+        // non-fatal Watson and disabled the Hot Reload session for the remainder of the debug session.
+        using var workspace = new EditorTestWorkspace();
+        var service = workspace.Services.GetRequiredService<IActiveStatementTrackingService>();
+
+        // No StartTracking has been called: EndTracking must not throw, and must be idempotent.
+        service.EndTracking();
+        service.EndTracking();
     }
 }

--- a/src/EditorFeatures/Core/EditAndContinue/ActiveStatementTrackingService.cs
+++ b/src/EditorFeatures/Core/EditAndContinue/ActiveStatementTrackingService.cs
@@ -83,8 +83,14 @@ internal sealed class ActiveStatementTrackingService(Workspace workspace, IAsync
 
     public void EndTracking()
     {
-        var session = Interlocked.Exchange(ref _session, null);
-        Contract.ThrowIfNull(session, "Active statement tracking not started.");
+        // Tolerate EndTracking being called without a matching StartTracking (e.g. when the debugger
+        // delivers an unbalanced break-state transition). This is a benign no-op rather than an error:
+        // throwing here would be reported as a non-fatal Watson and would disable the Hot Reload session.
+        if (Interlocked.Exchange(ref _session, null) is not { } session)
+        {
+            return;
+        }
+
         session.EndTracking();
 
         TrackingChanged?.Invoke();
@@ -178,6 +184,11 @@ internal sealed class ActiveStatementTrackingService(Workspace workspace, IAsync
             {
                 // nop
             }
+            catch (ObjectDisposedException)
+            {
+                // The tracking session was torn down (its CancellationTokenSource disposed by EndTracking)
+                // concurrently with this best-effort span update. This is a benign teardown race, not an error.
+            }
             catch (Exception e) when (FatalError.ReportAndCatch(e))
             {
                 // nop
@@ -244,6 +255,11 @@ internal sealed class ActiveStatementTrackingService(Workspace workspace, IAsync
             catch (OperationCanceledException)
             {
                 // nop
+            }
+            catch (ObjectDisposedException)
+            {
+                // The tracking session was torn down (its CancellationTokenSource disposed by EndTracking)
+                // concurrently with this best-effort span update. This is a benign teardown race, not an error.
             }
             catch (Exception e) when (FatalError.ReportAndCatch(e))
             {

--- a/src/EditorFeatures/Core/EditAndContinue/ManagedHotReloadLanguageServiceImpl.cs
+++ b/src/EditorFeatures/Core/EditAndContinue/ManagedHotReloadLanguageServiceImpl.cs
@@ -31,16 +31,6 @@ internal sealed class ManagedHotReloadLanguageServiceImpl(
     IEditAndContinueLogReporter logReporter,
     IDiagnosticsRefresher diagnosticRefresher) : IManagedHotReloadLanguageService3, IEditAndContinueSolutionProvider
 {
-    private sealed class NoSessionException : InvalidOperationException
-    {
-        public NoSessionException()
-            : base("Internal error: no session.")
-        {
-            // unique enough HResult to distinguish from other exceptions
-            HResult = unchecked((int)0x801315087);
-        }
-    }
-
     private bool _disabled;
     private DebuggingSessionProxy? _debuggingSession;
 
@@ -49,8 +39,17 @@ internal sealed class ManagedHotReloadLanguageServiceImpl(
 
     public event Action<Solution>? SolutionCommitted;
 
-    private DebuggingSessionProxy GetDebuggingSession()
-        => _debuggingSession ?? throw new NoSessionException();
+    /// <summary>
+    /// Returns the active debugging session to operate on, or <see langword="null"/> if there is none and
+    /// the operation should be a no-op. The session is absent when Hot Reload has been disabled for the
+    /// current debug session, or when no session is active because it failed to start, has already ended,
+    /// or a debugger callback raced with session start/teardown. The debugger drives these lifecycle
+    /// callbacks across process boundaries and may deliver them in these states (for example after the
+    /// session has been torn down), so treating the absence of a session as a benign no-op avoids throwing
+    /// and reporting a non-fatal Watson for an expected condition.
+    /// </summary>
+    private DebuggingSessionProxy? TryGetActiveSession()
+        => _disabled ? null : _debuggingSession;
 
     internal void Disable(Exception e)
     {
@@ -115,14 +114,13 @@ internal sealed class ManagedHotReloadLanguageServiceImpl(
 
     private async ValueTask BreakStateOrCapabilitiesChangedAsync(bool? inBreakState, CancellationToken cancellationToken)
     {
-        if (_disabled)
+        if (TryGetActiveSession() is not { } session)
         {
             return;
         }
 
         try
         {
-            var session = GetDebuggingSession();
             var solution = (inBreakState == true) ? await solutionSnapshotProvider.GetCurrentSolutionAsync(cancellationToken).ConfigureAwait(false) : null;
 
             await session.BreakStateOrCapabilitiesChangedAsync(inBreakState, cancellationToken).ConfigureAwait(false);
@@ -154,7 +152,7 @@ internal sealed class ManagedHotReloadLanguageServiceImpl(
 
     public async ValueTask CommitUpdatesAsync(CancellationToken cancellationToken)
     {
-        if (_disabled)
+        if (TryGetActiveSession() is not { } session)
         {
             return;
         }
@@ -174,7 +172,7 @@ internal sealed class ManagedHotReloadLanguageServiceImpl(
 
         try
         {
-            await GetDebuggingSession().CommitSolutionUpdateAsync(cancellationToken).ConfigureAwait(false);
+            await session.CommitSolutionUpdateAsync(cancellationToken).ConfigureAwait(false);
         }
         catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))
         {
@@ -185,7 +183,7 @@ internal sealed class ManagedHotReloadLanguageServiceImpl(
 
     public async ValueTask DiscardUpdatesAsync(CancellationToken cancellationToken)
     {
-        if (_disabled)
+        if (TryGetActiveSession() is not { } session)
         {
             return;
         }
@@ -194,7 +192,7 @@ internal sealed class ManagedHotReloadLanguageServiceImpl(
 
         try
         {
-            await GetDebuggingSession().DiscardSolutionUpdateAsync(cancellationToken).ConfigureAwait(false);
+            await session.DiscardSolutionUpdateAsync(cancellationToken).ConfigureAwait(false);
         }
         catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))
         {
@@ -209,11 +207,11 @@ internal sealed class ManagedHotReloadLanguageServiceImpl(
     {
         sessionState.IsSessionActive = false;
 
-        if (!_disabled)
+        if (TryGetActiveSession() is { } session)
         {
             try
             {
-                await GetDebuggingSession().EndDebuggingSessionAsync(cancellationToken).ConfigureAwait(false);
+                await session.EndDebuggingSessionAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))
             {
@@ -283,7 +281,7 @@ internal sealed class ManagedHotReloadLanguageServiceImpl(
 
     public async ValueTask<ManagedHotReloadUpdates> GetUpdatesAsync(ImmutableArray<RunningProjectInfo> runningProjects, CancellationToken cancellationToken)
     {
-        if (_disabled)
+        if (TryGetActiveSession() is not { } session)
         {
             return new ManagedHotReloadUpdates([], [], [], []);
         }
@@ -292,7 +290,7 @@ internal sealed class ManagedHotReloadLanguageServiceImpl(
         var activeStatementSpanProvider = activeStatementTrackingController.GetSpanProvider(solution);
         var runningProjectOptions = runningProjects.ToRunningProjectOptions(solution, static info => (info.ProjectInstanceId.ProjectFilePath, info.ProjectInstanceId.TargetFramework, info.RestartAutomatically));
 
-        var result = await GetDebuggingSession().EmitSolutionUpdateAsync(solution, runningProjectOptions, activeStatementSpanProvider, cancellationToken).ConfigureAwait(false);
+        var result = await session.EmitSolutionUpdateAsync(solution, runningProjectOptions, activeStatementSpanProvider, cancellationToken).ConfigureAwait(false);
 
         switch (result.ModuleUpdates.Status)
         {

--- a/src/EditorFeatures/Test/EditAndContinue/EditorManagedHotReloadLanguageServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditorManagedHotReloadLanguageServiceTests.cs
@@ -474,4 +474,90 @@ public sealed class EditorManagedHotReloadLanguageServiceTests : EditAndContinue
 
         await languageService.EndSessionAsync(CancellationToken.None);
     }
+
+    [Fact]
+    public async Task LifecycleCallbacksWithoutActiveSession_AreNoOps()
+    {
+        // Regression test for a non-fatal Watson reported as vs/ide/vbcs/nonfatalwatson
+        // (ManagedHotReloadLanguageServiceImpl -> NoSessionException). The debugger drives Hot Reload
+        // lifecycle callbacks across process boundaries and may deliver a stray break-state /
+        // capabilities-changed / commit / discard / get-updates callback when no debugging session is
+        // active -- before a session has started, or after one has been torn down by EndSessionAsync.
+        // These must be benign no-ops. Before the fix they threw NoSessionException (GetUpdates) or a
+        // Contract violation (Commit/Discard) out of the callback, or reported a non-fatal Watson and
+        // disabled Hot Reload (break-state / capabilities changed).
+
+        var localComposition = EditorTestCompositions.LanguageServerProtocolEditorFeatures
+            .AddExcludedPartTypes(
+                typeof(EditAndContinueService.WorkspaceServiceFactory))
+            .AddParts(
+                typeof(NoCompilationLanguageService),
+                typeof(MockHostWorkspaceProvider),
+                typeof(MockServiceBrokerProvider),
+                typeof(MockEditAndContinueServiceFactory),
+                typeof(MockManagedHotReloadService));
+
+        using var localWorkspace = new TestWorkspace(composition: localComposition);
+        ((MockHostWorkspaceProvider)localWorkspace.GetService<IHostWorkspaceProvider>()).Workspace = localWorkspace;
+
+        ((MockServiceBroker)localWorkspace.Services.GetRequiredService<IServiceBrokerProvider>().ServiceBroker).CreateService = t => t switch
+        {
+            _ when t == typeof(DebuggerContracts.IHotReloadLogger) => new MockHotReloadLogger(),
+            _ => throw ExceptionUtilities.UnexpectedValue(t)
+        };
+
+        var mockEncService = (MockEditAndContinueService)localWorkspace.Services.GetRequiredService<IEditAndContinueWorkspaceService>().Service;
+        mockEncService.StartDebuggingSessionImpl = (_, _, _, _) => new DebuggingSessionId(1);
+
+        var localFactory = localWorkspace.GetService<ManagedHotReloadLanguageServiceFactory>();
+        var localBroker = localWorkspace.Services.GetRequiredService<IServiceBrokerProvider>().ServiceBroker;
+        var localSnapshotProvider = localWorkspace.GetService<ISolutionSnapshotProvider>();
+        using var pdbMatchingSourceTextProvider = new PdbMatchingSourceTextProvider(localWorkspace);
+        var localService = localFactory.Create(localBroker, localSnapshotProvider, localWorkspace.GetService<IHostWorkspaceProvider>(), pdbMatchingSourceTextProvider);
+
+        var sessionState = localWorkspace.GetService<IEditAndContinueSessionTracker>();
+
+        // Brings the service into the "no active session" state with the disabled flag cleared --
+        // the same state in which a stray callback previously threw or reported a fault.
+        async Task EndActiveSessionAsync()
+        {
+            await localService.StartSessionAsync(CancellationToken.None);
+            Assert.True(sessionState.IsSessionActive);
+
+            await localService.EndSessionAsync(CancellationToken.None);
+            Assert.False(sessionState.IsSessionActive);
+        }
+
+        // No session has ever been started.
+        var updatesBeforeStart = await localService.GetUpdatesAsync(ImmutableArray<DebuggerContracts.RunningProjectInfo>.Empty, CancellationToken.None);
+        Assert.Empty(updatesBeforeStart.Updates);
+        Assert.Empty(updatesBeforeStart.Diagnostics);
+
+        // Session started then torn down: each stray callback must be a benign no-op. The service is
+        // returned to the post-teardown state before each callback so the callbacks are exercised
+        // independently (the first callback no longer masks the rest by disabling Hot Reload).
+        await EndActiveSessionAsync();
+        var updatesAfterEnd = await localService.GetUpdatesAsync(ImmutableArray<DebuggerContracts.RunningProjectInfo>.Empty, CancellationToken.None);
+        Assert.Empty(updatesAfterEnd.Updates);
+        Assert.Empty(updatesAfterEnd.Diagnostics);
+
+        await EndActiveSessionAsync();
+        await localService.CommitUpdatesAsync(CancellationToken.None);
+
+        await EndActiveSessionAsync();
+        await localService.DiscardUpdatesAsync(CancellationToken.None);
+
+        await EndActiveSessionAsync();
+        await localService.EnterBreakStateAsync(CancellationToken.None);
+
+        await EndActiveSessionAsync();
+        await localService.ExitBreakStateAsync(CancellationToken.None);
+
+        await EndActiveSessionAsync();
+        await localService.OnCapabilitiesChangedAsync(CancellationToken.None);
+
+        // A second EndSession without an active session is also a no-op.
+        await localService.EndSessionAsync(CancellationToken.None);
+        Assert.False(sessionState.IsSessionActive);
+    }
 }


### PR DESCRIPTION
The debugger drives the Hot Reload lifecycle callbacks (enter/exit break state, capabilities changed, commit/discard updates, get updates, end session) across process boundaries, and can deliver a stray callback when no debugging session is active: before a session starts, after `EndSessionAsync` tears one down, or when a session failed to start.

Today those callbacks route through `GetDebuggingSession()`, which throws `NoSessionException` (reported as a `vs/ide/vbcs/nonfatalwatson` non-fatal Watson), or hit a `Contract.ThrowIfNull` on the pending solution. `ActiveStatementTrackingService.EndTracking` also throws on an unbalanced call, and `TrackActiveSpansAsync` can observe an `ObjectDisposedException` when its `CancellationTokenSource` is disposed during teardown. These are all expected, benign races rather than product errors, and each currently produces a non-fatal Watson.

This change:
- Replaces `GetDebuggingSession()`/`NoSessionException` with a nullable `TryGetActiveSession()` helper, so break-state, capabilities-changed, commit, discard, get-updates, and end-session no-op when there is no active session (mirroring the existing `HasChangesAsync` null guard).
- Makes `ActiveStatementTrackingService.EndTracking` idempotent.
- Treats the tracking-session teardown `ObjectDisposedException` as benign in both `TrackActiveSpansAsync` overloads.

The `NoSessionException` path is self-suppressing only until the first occurrence, because the catch in `StartSessionAsync` used to latch `_disabled` for the life of the process. #83747 now resets `_disabled` on every `StartSessionAsync` (so Hot Reload can recover across debug sessions), which means these benign races report on every session that hits them rather than once per process. This is straightforward hardening to stop emitting the faults.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84273)