### PR TITLE
Restore net8.0 asset for SemanticSearch.Extensions package

### DIFF
--- a/src/Tools/SemanticSearch/Extensions/Microsoft.CodeAnalysis.SemanticSearch.Extensions.csproj
+++ b/src/Tools/SemanticSearch/Extensions/Microsoft.CodeAnalysis.SemanticSearch.Extensions.csproj
@@ -4,6 +4,11 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>$(NetRoslynAll)</TargetFrameworks>
+    <!--
+      Must continue to ship a net8.0 asset even though NetRoslynAll no longer includes net8.0.
+      Source build only needs NetCurrent.
+    -->
+    <TargetFrameworks Condition="'$(DotNetBuildSourceOnly)' != 'true'">net8.0;$(TargetFrameworks)</TargetFrameworks>
 
     <!-- NuGet -->
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
The `Microsoft.CodeAnalysis.SemanticSearch.Extensions` package is consumed externally by a component that target net8.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84286)