### PR TITLE
Change dupe "Bat" to intended "Bar"

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExtensionMemberImportCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExtensionMemberImportCompletionProviderTests.cs
@@ -633,7 +633,7 @@ public sealed class ExtensionMemberImportCompletionProviderTests : AbstractCShar
             "IEnumerable<string>",
             "int",
             "Bat",
-            "Bat"
+            "Bar"
         }).Select(tuple => new List<object>() { tuple }));
 
     [Theory, MemberData(nameof(TypeParameterWithRefTypeData))]


### PR DESCRIPTION
This fixes another dupe test similar to #84237. The repro'ing command was:

```sh
dotnet test src/EditorFeatures/CSharpTest/Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.csproj --filter FullyQualifiedName~MatchingTypeParameter
```

which gave:

```
...
  Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests test net472 succeeded with 3 warning(s) (32.4s)
    C:\Program Files\dotnet\sdk\10.0.109\Microsoft.TestPlatform.targets(48,5): warning [xUnit.net 00:00:21.39] Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests: Skipping test case with duplicate ID '5ef35650688bc10f2bc081715d50318b00012a46' ('Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders.ExtensionMemberImportCompletionProviderTests.MatchingTypeParameter(type: "Bat", refType: None)' and 'Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders.ExtensionMemberImportCompletionProviderTests.MatchingTypeParameter(type: "Bat", refType: None)')
    C:\Program Files\dotnet\sdk\10.0.109\Microsoft.TestPlatform.targets(48,5): warning [xUnit.net 00:00:21.39] Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests: Skipping test case with duplicate ID 'ac704a7748f857c172004bde27c089b26ff22e0e' ('Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders.ExtensionMemberImportCompletionProviderTests.MatchingTypeParameter(type: "Bat", refType: Project)' and 'Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders.ExtensionMemberImportCompletionProviderTests.MatchingTypeParameter(type: "Bat", refType: Project)')
    C:\Program Files\dotnet\sdk\10.0.109\Microsoft.TestPlatform.targets(48,5): warning [xUnit.net 00:00:21.39] Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests: Skipping test case with duplicate ID '04b7616cd816557d5ddb4499b657a8ba32317379' ('Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders.ExtensionMemberImportCompletionProviderTests.MatchingTypeParameter(type: "Bat", refType: Metadata)' and 'Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders.ExtensionMemberImportCompletionProviderTests.MatchingTypeParameter(type: "Bat", refType: Metadata)')

Test summary: total: 9, failed: 0, succeeded: 9, skipped: 0, duration: 32.3s
Build succeeded with 3 warning(s) in 44.2s
```

A future PR will flag these duplicates as errors
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84289)