### PR TITLE
Refine WRN_ParamsArrayInLambdaOnly message

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -3066,7 +3066,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     if (lambdaParameter.IsParams && !delegateParameter.IsParams && p == lambdaSymbol.ParameterCount - 1)
                     {
-                        // Parameter {0} has params modifier in lambda but not in target delegate type.
+                        // Parameter number '{0}' has params modifier in lambda but not in target delegate type.
                         Error(diagnostics, ErrorCode.WRN_ParamsArrayInLambdaOnly, lambdaParameter.GetFirstLocation(), p + 1);
                     }
                 }

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7489,7 +7489,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>lambda params array</value>
   </data>
   <data name="WRN_ParamsArrayInLambdaOnly" xml:space="preserve">
-    <value>Parameter {0} has params modifier in lambda but not in target delegate type.</value>
+    <value>Parameter number '{0}' has params modifier in lambda but not in target delegate type.</value>
   </data>
   <data name="WRN_ParamsArrayInLambdaOnly_Title" xml:space="preserve">
     <value>Parameter has params modifier in lambda but not in target delegate type.</value>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -3783,8 +3783,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParamsArrayInLambdaOnly">
-        <source>Parameter {0} has params modifier in lambda but not in target delegate type.</source>
-        <target state="translated">Parametr {0} má modifikátor params ve výrazu lambda, ale ne v cílovém typu delegáta.</target>
+        <source>Parameter number '{0}' has params modifier in lambda but not in target delegate type.</source>
+        <target state="needs-review-translation">Parametr {0} má modifikátor params ve výrazu lambda, ale ne v cílovém typu delegáta.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -3783,8 +3783,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParamsArrayInLambdaOnly">
-        <source>Parameter {0} has params modifier in lambda but not in target delegate type.</source>
-        <target state="translated">Der Parameter {0} weist den Modifizierer „params“ in der Lambdafunktion auf, aber nicht im Delegattyp des Ziels.</target>
+        <source>Parameter number '{0}' has params modifier in lambda but not in target delegate type.</source>
+        <target state="needs-review-translation">Der Parameter {0} weist den Modifizierer „params“ in der Lambdafunktion auf, aber nicht im Delegattyp des Ziels.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -3783,8 +3783,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParamsArrayInLambdaOnly">
-        <source>Parameter {0} has params modifier in lambda but not in target delegate type.</source>
-        <target state="translated">El parámetro {0} tiene modificador de parámetros en lambda, pero no en el tipo delegado de destino.</target>
+        <source>Parameter number '{0}' has params modifier in lambda but not in target delegate type.</source>
+        <target state="needs-review-translation">El parámetro {0} tiene modificador de parámetros en lambda, pero no en el tipo delegado de destino.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -3783,8 +3783,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParamsArrayInLambdaOnly">
-        <source>Parameter {0} has params modifier in lambda but not in target delegate type.</source>
-        <target state="translated">Le paramètre {0} a un modificateur de paramètres dans l’expression lambda mais pas dans le type délégué cible.</target>
+        <source>Parameter number '{0}' has params modifier in lambda but not in target delegate type.</source>
+        <target state="needs-review-translation">Le paramètre {0} a un modificateur de paramètres dans l’expression lambda mais pas dans le type délégué cible.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -3783,8 +3783,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParamsArrayInLambdaOnly">
-        <source>Parameter {0} has params modifier in lambda but not in target delegate type.</source>
-        <target state="translated">Il parametro {0} contiene un modificatore di parametri in lambda ma non nel tipo delegato di destinazione.</target>
+        <source>Parameter number '{0}' has params modifier in lambda but not in target delegate type.</source>
+        <target state="needs-review-translation">Il parametro {0} contiene un modificatore di parametri in lambda ma non nel tipo delegato di destinazione.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -3783,8 +3783,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParamsArrayInLambdaOnly">
-        <source>Parameter {0} has params modifier in lambda but not in target delegate type.</source>
-        <target state="translated">パラメーター {0} にラムダの params 修飾子がありますが、ターゲット デリゲート型にはありません。</target>
+        <source>Parameter number '{0}' has params modifier in lambda but not in target delegate type.</source>
+        <target state="needs-review-translation">パラメーター {0} にラムダの params 修飾子がありますが、ターゲット デリゲート型にはありません。</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -3783,8 +3783,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParamsArrayInLambdaOnly">
-        <source>Parameter {0} has params modifier in lambda but not in target delegate type.</source>
-        <target state="translated">{0} 매개 변수에 람다의 매개 변수 한정자가 있지만 대상 대리자 형식에는 없습니다.</target>
+        <source>Parameter number '{0}' has params modifier in lambda but not in target delegate type.</source>
+        <target state="needs-review-translation">{0} 매개 변수에 람다의 매개 변수 한정자가 있지만 대상 대리자 형식에는 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -3783,8 +3783,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParamsArrayInLambdaOnly">
-        <source>Parameter {0} has params modifier in lambda but not in target delegate type.</source>
-        <target state="translated">Parametr {0} ma modyfikator params w wyrażeniu lambda, ale nie ma w docelowym typie delegata.</target>
+        <source>Parameter number '{0}' has params modifier in lambda but not in target delegate type.</source>
+        <target state="needs-review-translation">Parametr {0} ma modyfikator params w wyrażeniu lambda, ale nie ma w docelowym typie delegata.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -3783,8 +3783,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParamsArrayInLambdaOnly">
-        <source>Parameter {0} has params modifier in lambda but not in target delegate type.</source>
-        <target state="translated">O parâmetro {0} tem o modificador de parâmetros em lambda, mas não no tipo delegado de destino.</target>
+        <source>Parameter number '{0}' has params modifier in lambda but not in target delegate type.</source>
+        <target state="needs-review-translation">O parâmetro {0} tem o modificador de parâmetros em lambda, mas não no tipo delegado de destino.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -3783,8 +3783,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParamsArrayInLambdaOnly">
-        <source>Parameter {0} has params modifier in lambda but not in target delegate type.</source>
-        <target state="translated">У параметра {0} есть модификатор params в лямбде, но не в типе целевого делегата.</target>
+        <source>Parameter number '{0}' has params modifier in lambda but not in target delegate type.</source>
+        <target state="needs-review-translation">У параметра {0} есть модификатор params в лямбде, но не в типе целевого делегата.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -3783,8 +3783,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParamsArrayInLambdaOnly">
-        <source>Parameter {0} has params modifier in lambda but not in target delegate type.</source>
-        <target state="translated">{0} parametresi, lambda içinde parametre değiştiricisi içeriyor ancak hedef temsilci türünde içermiyor.</target>
+        <source>Parameter number '{0}' has params modifier in lambda but not in target delegate type.</source>
+        <target state="needs-review-translation">{0} parametresi, lambda içinde parametre değiştiricisi içeriyor ancak hedef temsilci türünde içermiyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -3783,8 +3783,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParamsArrayInLambdaOnly">
-        <source>Parameter {0} has params modifier in lambda but not in target delegate type.</source>
-        <target state="translated">参数 {0} 在 lambda 中具有参数修饰符，但在目标委托类型中没有参数修饰符。</target>
+        <source>Parameter number '{0}' has params modifier in lambda but not in target delegate type.</source>
+        <target state="needs-review-translation">参数 {0} 在 lambda 中具有参数修饰符，但在目标委托类型中没有参数修饰符。</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -3783,8 +3783,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParamsArrayInLambdaOnly">
-        <source>Parameter {0} has params modifier in lambda but not in target delegate type.</source>
-        <target state="translated">參數 {0} 在 Lambda 中具有參數修飾元，但不在目標委派類型中。</target>
+        <source>Parameter number '{0}' has params modifier in lambda but not in target delegate type.</source>
+        <target state="needs-review-translation">參數 {0} 在 Lambda 中具有參數修飾元，但不在目標委派類型中。</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ParamsCollectionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ParamsCollectionTests.cs
@@ -2710,7 +2710,7 @@ class Program
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/66389")]
-        public void ParamsArrayInLambdaOnly_MessageHasUnquotedArgument()
+        public void ParamsArrayInLambdaOnly_MessageHasQuotedArgument()
         {
             var source = """
 class C
@@ -2724,12 +2724,12 @@ class C
             var comp = CreateCompilation(source);
 
             comp.VerifyDiagnostics(
-                // (5,54): warning CS9100: Parameter 1 has params modifier in lambda but not in target delegate type.
+                // (5,54): warning CS9100: Parameter number '1' has params modifier in lambda but not in target delegate type.
                 //         System.Action<string[]> a = (params string[] s) => { };
                 Diagnostic(ErrorCode.WRN_ParamsArrayInLambdaOnly, "s").WithArguments("1").WithLocation(5, 54));
 
             var diagnostic = comp.GetDiagnostics().Single();
-            Assert.Equal("Parameter 1 has params modifier in lambda but not in target delegate type.",
+            Assert.Equal("Parameter number '1' has params modifier in lambda but not in target delegate type.",
                 diagnostic.GetMessage(System.Globalization.CultureInfo.InvariantCulture));
         }
 
@@ -2760,7 +2760,7 @@ class Program
                     AssertEx.Equal("void Program.<>c.<Main>b__0_0(params System.Collections.Generic.IEnumerable<System.Int64> x)", l1.ToTestDisplayString());
                     VerifyParamsAndAttribute(l1.Parameters.Last(), isParamCollection: true);
                 }).VerifyDiagnostics(
-                    // (7,72): warning CS9100: Parameter 1 has params modifier in lambda but not in target delegate type.
+                    // (7,72): warning CS9100: Parameter number '1' has params modifier in lambda but not in target delegate type.
                     //         System.Action<IEnumerable<long>> l = (params IEnumerable<long> x) => {};
                     Diagnostic(ErrorCode.WRN_ParamsArrayInLambdaOnly, "x").WithArguments("1").WithLocation(7, 72)
                     );
@@ -2792,7 +2792,7 @@ class Program
                 // (5,36): error CS0656: Missing compiler required member 'System.ParamArrayAttribute..ctor'
                 //         System.Action<long[]> l = (params long[] x) => {};
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "params").WithArguments("System.ParamArrayAttribute", ".ctor").WithLocation(5, 36),
-                // (5,50): warning CS9100: Parameter 1 has params modifier in lambda but not in target delegate type.
+                // (5,50): warning CS9100: Parameter number '1' has params modifier in lambda but not in target delegate type.
                 //         System.Action<long[]> l = (params long[] x) => {};
                 Diagnostic(ErrorCode.WRN_ParamsArrayInLambdaOnly, "x").WithArguments("1").WithLocation(5, 50)
                 );
@@ -2814,7 +2814,7 @@ class Program
                     AssertEx.Equal("void Program.<>c.<Main>b__0_0(params System.Int64[] x)", l1.ToTestDisplayString());
                     VerifyParamsAndAttribute(l1.Parameters.Last(), isParamArray: true);
                 }).VerifyDiagnostics(
-                    // (5,50): warning CS9100: Parameter 1 has params modifier in lambda but not in target delegate type.
+                    // (5,50): warning CS9100: Parameter number '1' has params modifier in lambda but not in target delegate type.
                     //         System.Action<long[]> l = (params long[] x) => {};
                     Diagnostic(ErrorCode.WRN_ParamsArrayInLambdaOnly, "x").WithArguments("1").WithLocation(5, 50)
                     );

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/ParamsCollectionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/ParamsCollectionTests.cs
@@ -2709,6 +2709,30 @@ class Program
                 );
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/66389")]
+        public void ParamsArrayInLambdaOnly_MessageHasUnquotedArgument()
+        {
+            var source = """
+class C
+{
+    static void M()
+    {
+        System.Action<string[]> a = (params string[] s) => { };
+    }
+}
+""";
+            var comp = CreateCompilation(source);
+
+            comp.VerifyDiagnostics(
+                // (5,54): warning CS9100: Parameter 1 has params modifier in lambda but not in target delegate type.
+                //         System.Action<string[]> a = (params string[] s) => { };
+                Diagnostic(ErrorCode.WRN_ParamsArrayInLambdaOnly, "s").WithArguments("1").WithLocation(5, 54));
+
+            var diagnostic = comp.GetDiagnostics().Single();
+            Assert.Equal("Parameter 1 has params modifier in lambda but not in target delegate type.",
+                diagnostic.GetMessage(System.Globalization.CultureInfo.InvariantCulture));
+        }
+
         [Fact]
         public void WRN_ParamsArrayInLambdaOnly_01()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
@@ -19240,7 +19240,7 @@ $@"{s_expressionOfTDelegate1ArgTypeName}[<>f__AnonymousDelegate0`2[System.Int32,
                 // (1,32): error CS0656: Missing compiler required member 'System.ParamArrayAttribute..ctor'
                 // System.Func<int[], int> lam = (params int[] xs) => xs.Length;
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "params").WithArguments("System.ParamArrayAttribute", ".ctor").WithLocation(1, 32),
-                // (1,45): warning CS9100: Parameter 1 has params modifier in lambda but not in target delegate type.
+                // (1,45): warning CS9100: Parameter number '1' has params modifier in lambda but not in target delegate type.
                 // System.Func<int[], int> lam = (params int[] xs) => xs.Length;
                 Diagnostic(ErrorCode.WRN_ParamsArrayInLambdaOnly, "xs").WithArguments("1").WithLocation(1, 45));
         }
@@ -19589,7 +19589,7 @@ $@"{s_expressionOfTDelegate1ArgTypeName}[<>f__AnonymousDelegate0`2[System.Int32,
                 withParams = (int[] xs) => xs.Length;
                 """;
             CreateCompilation(source).VerifyDiagnostics(
-                // (5,26): warning CS9100: Parameter 1 has params modifier in lambda but not in target delegate type.
+                // (5,26): warning CS9100: Parameter number '1' has params modifier in lambda but not in target delegate type.
                 // noParams = (params int[] xs) => xs.Length; // 1
                 Diagnostic(ErrorCode.WRN_ParamsArrayInLambdaOnly, "xs").WithArguments("1").WithLocation(5, 26));
         }
@@ -19630,7 +19630,7 @@ $@"{s_expressionOfTDelegate1ArgTypeName}[<>f__AnonymousDelegate0`2[System.Int32,
                 delegate int DelegateWithParams(params int[] xs);
                 """;
             CreateCompilation(source).VerifyDiagnostics(
-                // (5,27): warning CS9100: Parameter 1 has params modifier in lambda but not in target delegate type.
+                // (5,27): warning CS9100: Parameter number '1' has params modifier in lambda but not in target delegate type.
                 // dNoParams = (params int[] xs) => xs.Length; // 1
                 Diagnostic(ErrorCode.WRN_ParamsArrayInLambdaOnly, "xs").WithArguments("1").WithLocation(5, 27));
         }
@@ -19701,7 +19701,7 @@ $@"{s_expressionOfTDelegate1ArgTypeName}[<>f__AnonymousDelegate0`2[System.Int32,
                 // (8,31): warning CS9099: Parameter 1 has default value '2' in lambda but '1' in the target delegate type.
                 // DelegateWithDefault d6 = (int x = 2) => x; // 2
                 Diagnostic(ErrorCode.WRN_OptionalParamValueMismatch, "x").WithArguments("1", "2", "1").WithLocation(8, 31),
-                // (16,37): warning CS9100: Parameter 1 has params modifier in lambda but not in target delegate type.
+                // (16,37): warning CS9100: Parameter number '1' has params modifier in lambda but not in target delegate type.
                 // DelegateNoParams p3 = (params int[] xs) => xs.Length; // 3
                 Diagnostic(ErrorCode.WRN_ParamsArrayInLambdaOnly, "xs").WithArguments("1").WithLocation(16, 37));
         }
@@ -19742,7 +19742,7 @@ $@"{s_expressionOfTDelegate1ArgTypeName}[<>f__AnonymousDelegate0`2[System.Int32,
                 // (8,39): warning CS9099: Parameter 1 has default value '2' in lambda but '1' in the target delegate type.
                 // var d6 = new DelegateWithDefault((int x = 2) => x); // 2
                 Diagnostic(ErrorCode.WRN_OptionalParamValueMismatch, "x").WithArguments("1", "2", "1").WithLocation(8, 39),
-                // (16,45): warning CS9100: Parameter 1 has params modifier in lambda but not in target delegate type.
+                // (16,45): warning CS9100: Parameter number '1' has params modifier in lambda but not in target delegate type.
                 // var p3 = new DelegateNoParams((params int[] xs) => xs.Length); // 3
                 Diagnostic(ErrorCode.WRN_ParamsArrayInLambdaOnly, "xs").WithArguments("1").WithLocation(16, 45));
         }
@@ -19783,7 +19783,7 @@ $@"{s_expressionOfTDelegate1ArgTypeName}[<>f__AnonymousDelegate0`2[System.Int32,
                 // (8,37): warning CS9099: Parameter 1 has default value '2' in lambda but '1' in the target delegate type.
                 // var d6 = (DelegateWithDefault)((int x = 2) => x); // 2
                 Diagnostic(ErrorCode.WRN_OptionalParamValueMismatch, "x").WithArguments("1", "2", "1").WithLocation(8, 37),
-                // (16,43): warning CS9100: Parameter 1 has params modifier in lambda but not in target delegate type.
+                // (16,43): warning CS9100: Parameter number '1' has params modifier in lambda but not in target delegate type.
                 // var p3 = (DelegateNoParams)((params int[] xs) => xs.Length); // 3
                 Diagnostic(ErrorCode.WRN_ParamsArrayInLambdaOnly, "xs").WithArguments("1").WithLocation(16, 43));
         }
@@ -19820,7 +19820,7 @@ $@"{s_expressionOfTDelegate1ArgTypeName}[<>f__AnonymousDelegate0`2[System.Int32,
                 // (3,18): warning CS9099: Parameter 1 has default value '2' in lambda but '1' in the target delegate type.
                 // WithDefault((int x = 2) => x); // 2
                 Diagnostic(ErrorCode.WRN_OptionalParamValueMismatch, "x").WithArguments("1", "2", "1").WithLocation(3, 18),
-                // (7,24): warning CS9100: Parameter 1 has params modifier in lambda but not in target delegate type.
+                // (7,24): warning CS9100: Parameter number '1' has params modifier in lambda but not in target delegate type.
                 // NoParams((params int[] xs) => xs.Length); // 3
                 Diagnostic(ErrorCode.WRN_ParamsArrayInLambdaOnly, "xs").WithArguments("1").WithLocation(7, 24));
         }
@@ -19838,7 +19838,7 @@ $@"{s_expressionOfTDelegate1ArgTypeName}[<>f__AnonymousDelegate0`2[System.Int32,
                 // (1,20): warning CS9099: Parameter 2 has default value '2' in lambda but '<missing>' in the target delegate type.
                 // D d1 = (int a, int b = 2, params int[] c) => { }; // 1, 2
                 Diagnostic(ErrorCode.WRN_OptionalParamValueMismatch, "b").WithArguments("2", "2", "<missing>").WithLocation(1, 20),
-                // (1,40): warning CS9100: Parameter 3 has params modifier in lambda but not in target delegate type.
+                // (1,40): warning CS9100: Parameter number '3' has params modifier in lambda but not in target delegate type.
                 // D d1 = (int a, int b = 2, params int[] c) => { }; // 1, 2
                 Diagnostic(ErrorCode.WRN_ParamsArrayInLambdaOnly, "c").WithArguments("3").WithLocation(1, 40));
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -227,10 +227,10 @@ class C
                 // (66,39): error CS1670: params is not valid in this context
                 //         Action<int[]> q16 = delegate (params int[] p) { };
                 Diagnostic(ErrorCode.ERR_IllegalParams, "params").WithLocation(66, 39),
-                // (67,49): warning CS9100: Parameter 1 has params modifier in lambda but not in target delegate type.
+                // (67,49): warning CS9100: Parameter number '1' has params modifier in lambda but not in target delegate type.
                 //         Action<string[]> q17 = (params string[] s)=>{};
                 Diagnostic(ErrorCode.WRN_ParamsArrayInLambdaOnly, "s").WithArguments("1").WithLocation(67, 49),
-                // (68,61): warning CS9100: Parameter 2 has params modifier in lambda but not in target delegate type.
+                // (68,61): warning CS9100: Parameter number '2' has params modifier in lambda but not in target delegate type.
                 //         Action<int, double[]> q18 = (int x, params double[] s)=>{};
                 Diagnostic(ErrorCode.WRN_ParamsArrayInLambdaOnly, "s").WithArguments("2").WithLocation(68, 61),
                 // (70,41): error CS1593: Delegate 'Action' does not take 1 arguments
@@ -8973,7 +8973,7 @@ class Program
                 if (delegateModifier == "")
                 {
                     diagnostics.Add(
-                        // (7,24): warning CS9100: Parameter 1 has params modifier in lambda but not in target delegate type.
+                        // (7,24): warning CS9100: Parameter number '1' has params modifier in lambda but not in target delegate type.
                         //         D d = (params  a) => { };
                         Diagnostic(ErrorCode.WRN_ParamsArrayInLambdaOnly, "a").WithArguments("1"));
                 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SimpleLambdaParametersWithModifiersTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SimpleLambdaParametersWithModifiersTests.cs
@@ -920,7 +920,7 @@ public sealed class SimpleLambdaParametersWithModifiersTests : SemanticModelTest
                 // (7,16): error CS9272: Implicitly typed lambda parameter 'x' cannot have the 'params' modifier.
                 //         D d = (params x) =>
                 Diagnostic(ErrorCode.ERR_ImplicitlyTypedParamsParameter, "params").WithArguments("x").WithLocation(7, 16),
-                // (7,23): warning CS9100: Parameter 1 has params modifier in lambda but not in target delegate type.
+                // (7,23): warning CS9100: Parameter number '1' has params modifier in lambda but not in target delegate type.
                 //         D d = (params x) =>
                 Diagnostic(ErrorCode.WRN_ParamsArrayInLambdaOnly, "x").WithArguments("1").WithLocation(7, 23));
         }
@@ -1025,7 +1025,7 @@ public sealed class SimpleLambdaParametersWithModifiersTests : SemanticModelTest
                 // (7,23): error CS1611: The params parameter cannot be declared as ref
                 //         D d = (params ref x) => { };
                 Diagnostic(ErrorCode.ERR_ParamsCantBeWithModifier, "ref").WithArguments("ref").WithLocation(7, 23),
-                // (7,27): warning CS9100: Parameter 1 has params modifier in lambda but not in target delegate type.
+                // (7,27): warning CS9100: Parameter number '1' has params modifier in lambda but not in target delegate type.
                 //         D d = (params ref x) => { };
                 Diagnostic(ErrorCode.WRN_ParamsArrayInLambdaOnly, "x").WithArguments("1").WithLocation(7, 27));
 
@@ -1060,7 +1060,7 @@ public sealed class SimpleLambdaParametersWithModifiersTests : SemanticModelTest
                 // (7,20): error CS9272: Implicitly typed lambda parameter 'x' cannot have the 'params' modifier.
                 //         D d = (ref params x) => { };
                 Diagnostic(ErrorCode.ERR_ImplicitlyTypedParamsParameter, "params").WithArguments("x").WithLocation(7, 20),
-                // (7,27): warning CS9100: Parameter 1 has params modifier in lambda but not in target delegate type.
+                // (7,27): warning CS9100: Parameter number '1' has params modifier in lambda but not in target delegate type.
                 //         D d = (ref params x) => { };
                 Diagnostic(ErrorCode.WRN_ParamsArrayInLambdaOnly, "x").WithArguments("1").WithLocation(7, 27));
 


### PR DESCRIPTION
Fixes #66389

**Before:** `Parameter {0} has params modifier in lambda but not in target delegate type.`
**After:** `Parameter number '{0}' has params modifier in lambda but not in target delegate type.`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84291)