### PR TITLE
Use dedicated CS9395 message for uninitialized non-nullable events

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/Nullable/CSharpDeclareAsNullableCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/Nullable/CSharpDeclareAsNullableCodeFixProvider.cs
@@ -37,7 +37,8 @@ internal sealed class CSharpDeclareAsNullableCodeFixProvider() : SyntaxEditorBas
     // warning CS8600: Converting null literal or possible null value to non-nullable type.
     // warning CS8625: Cannot convert null literal to non-nullable reference type.
     // warning CS8618: Non-nullable property is uninitialized
-    public sealed override ImmutableArray<string> FixableDiagnosticIds => ["CS8603", "CS8600", "CS8625", "CS8618"];
+    // warning CS9395: Non-nullable event is uninitialized
+    public sealed override ImmutableArray<string> FixableDiagnosticIds => ["CS8603", "CS8600", "CS8625", "CS8618", "CS9395"];
 
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
@@ -246,7 +247,14 @@ internal sealed class CSharpDeclareAsNullableCodeFixProvider() : SyntaxEditorBas
 
         // string x;
         // Unassigned value that's not marked as null
-        if (node is VariableDeclaratorSyntax { Parent: VariableDeclarationSyntax { Parent: FieldDeclarationSyntax, Variables.Count: 1 } declarationSyntax })
+        if (node is VariableDeclaratorSyntax
+            {
+                Parent: VariableDeclarationSyntax
+                {
+                    Parent: FieldDeclarationSyntax or EventFieldDeclarationSyntax,
+                    Variables.Count: 1
+                } declarationSyntax
+            })
             return declarationSyntax.Type;
 
         // void M(string x = null) { }

--- a/src/Analyzers/CSharp/Tests/MakeMemberRequired/MakeMemberRequiredTests.cs
+++ b/src/Analyzers/CSharp/Tests/MakeMemberRequired/MakeMemberRequiredTests.cs
@@ -447,7 +447,7 @@ public sealed class MakeMemberRequiredTests
             
             class MyClass
             {
-                public event System.EventHandler {|CS8618:MyEvent|};
+                public event System.EventHandler {|CS9395:MyEvent|};
             }
             """,
             LanguageVersion = LanguageVersion.CSharp11,

--- a/src/Analyzers/CSharp/Tests/Nullable/CSharpDeclareAsNullableCodeFixTests.cs
+++ b/src/Analyzers/CSharp/Tests/Nullable/CSharpDeclareAsNullableCodeFixTests.cs
@@ -1108,6 +1108,27 @@ public sealed class CSharpDeclareAsNullableCodeFixTests(ITestOutputHelper logger
             """,
             parameters: s_nullableFeature);
 
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/81679")]
+    public Task FixEventDeclaration_Unassigned()
+        => TestInRegularAndScriptAsync(
+            """
+            #nullable enable
+
+            class C
+            {
+                private event System.Action [|OnEvent|];
+            }
+            """,
+            """
+            #nullable enable
+
+            class C
+            {
+                private event System.Action? OnEvent;
+            }
+            """,
+            parameters: s_nullableFeature);
+
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/44983")]
     public Task MultipleDeclarator_NoDiagnostic()
         => TestMissingInRegularAndScriptAsync(

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5656,6 +5656,12 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_UninitializedNonNullableField_Title" xml:space="preserve">
     <value>Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.</value>
   </data>
+  <data name="WRN_UninitializedNonNullableEvent" xml:space="preserve">
+    <value>Non-nullable event '{0}' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</value>
+  </data>
+  <data name="WRN_UninitializedNonNullableEvent_Title" xml:space="preserve">
+    <value>Non-nullable event must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</value>
+  </data>
   <data name="WRN_NullabilityMismatchInAssignment" xml:space="preserve">
     <value>Nullability of reference types in value of type '{0}' doesn't match target type '{1}'.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2505,6 +2505,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_NoBreakId = 9393,
         ERR_NoContinueId = 9394,
 
+        WRN_UninitializedNonNullableEvent = 9395,
+
         // Note: you will need to do the following after adding errors:
         //  1) Update ErrorFacts.IsBuildOnlyDiagnostic (src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs)
         //  2) Add message to CSharpResources.resx

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -30,6 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             nullableWarnings.Add(GetId(ErrorCode.WRN_NullReferenceReturn));
             nullableWarnings.Add(GetId(ErrorCode.WRN_NullReferenceArgument));
             nullableWarnings.Add(GetId(ErrorCode.WRN_UninitializedNonNullableField));
+            nullableWarnings.Add(GetId(ErrorCode.WRN_UninitializedNonNullableEvent));
             nullableWarnings.Add(GetId(ErrorCode.WRN_NullabilityMismatchInAssignment));
             nullableWarnings.Add(GetId(ErrorCode.WRN_NullabilityMismatchInArgument));
             nullableWarnings.Add(GetId(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput));
@@ -451,6 +452,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_NullabilityMismatchInReturnTypeOnExplicitImplementation:
                 case ErrorCode.WRN_NullabilityMismatchInParameterTypeOnExplicitImplementation:
                 case ErrorCode.WRN_UninitializedNonNullableField:
+                case ErrorCode.WRN_UninitializedNonNullableEvent:
                 case ErrorCode.WRN_NullabilityMismatchInAssignment:
                 case ErrorCode.WRN_NullabilityMismatchInArgument:
                 case ErrorCode.WRN_NullabilityMismatchInArgumentForOutput:
@@ -1965,6 +1967,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 or ErrorCode.WRN_NullabilityMismatchInReturnTypeOnExplicitImplementation
                 or ErrorCode.WRN_NullabilityMismatchInParameterTypeOnExplicitImplementation
                 or ErrorCode.WRN_UninitializedNonNullableField
+                or ErrorCode.WRN_UninitializedNonNullableEvent
                 or ErrorCode.WRN_NullabilityMismatchInAssignment
                 or ErrorCode.WRN_NullabilityMismatchInArgument
                 or ErrorCode.WRN_NullabilityMismatchInReturnTypeOfTargetDelegate
@@ -2603,6 +2606,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 or ErrorCode.ERR_ExplicitOrExtendedLayoutFieldRequiresUnsafeOrSafe
                 or ErrorCode.ERR_NoBreakId
                 or ErrorCode.ERR_NoContinueId
+                or ErrorCode.WRN_UninitializedNonNullableEvent
                     => false,
             };
 #pragma warning restore CS8524 // The switch expression does not handle some values of its input type (it is not exhaustive) involving an unnamed enum value.

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -841,8 +841,27 @@ namespace Microsoft.CodeAnalysis.CSharp
                     : NullableFlowState.MaybeNull;
                 if (memberState >= badState) // is 'memberState' as bad as or worse than 'badState'?
                 {
-                    var errorCode = usesFieldKeyword ? ErrorCode.WRN_UninitializedNonNullableBackingField : ErrorCode.WRN_UninitializedNonNullableField;
-                    var info = new CSDiagnosticInfo(errorCode, new object[] { symbol.Kind.Localize(), symbol.Name }, ImmutableArray<Symbol>.Empty, additionalLocations: symbol.Locations);
+                    CSDiagnosticInfo info;
+                    if (symbol.Kind == SymbolKind.Event)
+                    {
+                        info = new CSDiagnosticInfo(
+                            ErrorCode.WRN_UninitializedNonNullableEvent,
+                            new object[] { symbol.Name },
+                            ImmutableArray<Symbol>.Empty,
+                            additionalLocations: symbol.Locations);
+                    }
+                    else
+                    {
+                        var errorCode = usesFieldKeyword
+                            ? ErrorCode.WRN_UninitializedNonNullableBackingField
+                            : ErrorCode.WRN_UninitializedNonNullableField;
+                        info = new CSDiagnosticInfo(
+                            errorCode,
+                            new object[] { symbol.Kind.Localize(), symbol.Name },
+                            ImmutableArray<Symbol>.Empty,
+                            additionalLocations: symbol.Locations);
+                    }
+
                     Diagnostics.Add(info, exitLocation ?? symbol.GetFirstLocationOrNone());
                 }
             }

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -347,6 +347,7 @@
                 case ErrorCode.WRN_InterceptsLocationAttributeUnsupportedSignature:
                 case ErrorCode.WRN_RedundantPattern:
                 case ErrorCode.WRN_UnsafeMeaningless:
+                case ErrorCode.WRN_UninitializedNonNullableEvent:
                     return true;
                 default:
                     return false;

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -5995,6 +5995,16 @@
         <target state="translated">Při ukončovacím konstruktoru musí vlastnost, která nemůže mít hodnotu null, obsahovat hodnotu, která není null. Zvažte přidání modifikátoru required, deklarování vlastnosti jako vlastnosti s možnou hodnotou null nebo bezpečné ošetření případu, kdy má field v přístupovém objektu get hodnotu null.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UninitializedNonNullableEvent">
+        <source>Non-nullable event '{0}' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</source>
+        <target state="new">Non-nullable event '{0}' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UninitializedNonNullableEvent_Title">
+        <source>Non-nullable event must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</source>
+        <target state="new">Non-nullable event must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">
         <source>Non-nullable {0} '{1}' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the {0} as nullable.</source>
         <target state="translated">Proměnná {0} {1}, která nemůže být null, musí při ukončování konstruktoru obsahovat hodnotu, která není null. Zvažte přidání modifikátoru required nebo deklaraci {0} s možnou hodnotou null.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -5995,6 +5995,16 @@
         <target state="translated">Non-Nullable-Eigenschaft muss beim Beenden des Konstruktors einen Wert ungleich NULL enthalten. Fügen Sie den required-Modifizierer hinzu, deklarieren Sie die Eigenschaft als „nullable“ oder behandeln Sie sicher den Fall, dass „field“ im get-Accessor NULL ist.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UninitializedNonNullableEvent">
+        <source>Non-nullable event '{0}' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</source>
+        <target state="new">Non-nullable event '{0}' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UninitializedNonNullableEvent_Title">
+        <source>Non-nullable event must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</source>
+        <target state="new">Non-nullable event must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">
         <source>Non-nullable {0} '{1}' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the {0} as nullable.</source>
         <target state="translated">Non-Nullable-{0} „{1}“ muss beim Beenden des Konstruktors einen Wert ungleich NULL enthalten. Fügen Sie ggf. den „erforderlichen“ Modifizierer hinzu, oder deklarieren Sie den {0} als NULL-Werte zulassend.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -5995,6 +5995,16 @@
         <target state="translated">La propiedad que admite valores NULL debe contener un valor que no sea null al salir del constructor. Considere agregar el modificador “required”, declarar la propiedad como que no acepta valores null o manejar de forma segura el caso en que “field” sea null en el accesor “get”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UninitializedNonNullableEvent">
+        <source>Non-nullable event '{0}' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</source>
+        <target state="new">Non-nullable event '{0}' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UninitializedNonNullableEvent_Title">
+        <source>Non-nullable event must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</source>
+        <target state="new">Non-nullable event must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">
         <source>Non-nullable {0} '{1}' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the {0} as nullable.</source>
         <target state="translated">El elemento {0} "{1}" que no acepta valores NULL debe contener un valor distinto de NULL al salir del constructor. Considere la posibilidad de agregar el modificador "required'"o declarar el {0} como un valor que acepta valores NULL.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -5995,6 +5995,16 @@
         <target state="translated">Une propriété ne pouvant pas accepter la valeur Null doit contenir une valeur non nulle en sortant du constructeur. Envisagez d’ajouter le modificateur « required », de déclarer la propriété comme pouvant accepter la valeur Null, ou de gérer de manière sécurisée le cas où « field » est nul dans l’accesseur « get ».</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UninitializedNonNullableEvent">
+        <source>Non-nullable event '{0}' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</source>
+        <target state="new">Non-nullable event '{0}' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UninitializedNonNullableEvent_Title">
+        <source>Non-nullable event must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</source>
+        <target state="new">Non-nullable event must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">
         <source>Non-nullable {0} '{1}' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the {0} as nullable.</source>
         <target state="translated">Le {0} « {1} » non-nullable doit contenir une valeur autre que Null lors de la fermeture du constructeur. Envisagez d’ajouter le modificateur « required » ou de déclarer le {0} comme pouvant accepter la valeur Null.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -5995,6 +5995,16 @@ target:module               Compila un modulo che può essere aggiunto ad altro
         <target state="translated">La proprietà che non ammette i valori Null deve contenere un valore non Null all'uscita dal costruttore. Valutare l'opportunità di aggiungere il modificatore 'required', di dichiarare che la proprietà ammette valori Null o di gestire in sicurezza il caso in cui l'identificatore 'field' è Null nella funzione di accesso 'get'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UninitializedNonNullableEvent">
+        <source>Non-nullable event '{0}' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</source>
+        <target state="new">Non-nullable event '{0}' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UninitializedNonNullableEvent_Title">
+        <source>Non-nullable event must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</source>
+        <target state="new">Non-nullable event must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">
         <source>Non-nullable {0} '{1}' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the {0} as nullable.</source>
         <target state="translated">L'elemento {0} '{1}' non nullable deve contenere un valore non Null all'uscita dal costruttore. Prendere in considerazione l'aggiunta del modificatore 'required' o la dichiarazione di {0} come nullable.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -5995,6 +5995,16 @@
         <target state="translated">null 非許容プロパティには、コンストラクターの終了時に null 以外の値が入っていなければなりません。'required' 修飾子を追加するか、プロパティを null 許容として宣言するか、'get' アクセサーで 'field' が null である場合を安全に処理することを検討してください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UninitializedNonNullableEvent">
+        <source>Non-nullable event '{0}' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</source>
+        <target state="new">Non-nullable event '{0}' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UninitializedNonNullableEvent_Title">
+        <source>Non-nullable event must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</source>
+        <target state="new">Non-nullable event must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">
         <source>Non-nullable {0} '{1}' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the {0} as nullable.</source>
         <target state="translated">null 非許容の {0} '{1}' には、コンストラクターの終了時に null 以外の値が入っていなければなりません。'required' 修飾子を追加するか、{0} を Null 許容として宣言することを検討してください。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -5995,6 +5995,16 @@
         <target state="translated">null을 허용하지 않는 속성은 생성자를 종료할 때 null이 아닌 값을 포함해야 합니다. 'required' 한정자를 추가하거나, 속성을 nullable로 선언하거나, 'get' 접근자에서 'field'가 null인 경우를 안전하게 처리하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UninitializedNonNullableEvent">
+        <source>Non-nullable event '{0}' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</source>
+        <target state="new">Non-nullable event '{0}' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UninitializedNonNullableEvent_Title">
+        <source>Non-nullable event must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</source>
+        <target state="new">Non-nullable event must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">
         <source>Non-nullable {0} '{1}' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the {0} as nullable.</source>
         <target state="translated">null을 허용하지 않는 {0} '{1}'은(는) 생성자를 종료할 때 null이 아닌 값을 포함해야 합니다. 'required' 한정자를 추가하거나 {0}을(를) nullable로 선언하는 것이 좋습니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -5995,6 +5995,16 @@
         <target state="translated">Właściwość niedopuszczająca wartości null musi zawierać wartość inną niż null podczas zamykania konstruktora. Rozważ dodanie modyfikatora „required” lub zadeklarowanie właściwości jako dopuszczającej wartość null albo bezpieczne obsłużenie przypadku, gdy „field” jest wartością null w metodzie dostępu „get”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UninitializedNonNullableEvent">
+        <source>Non-nullable event '{0}' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</source>
+        <target state="new">Non-nullable event '{0}' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UninitializedNonNullableEvent_Title">
+        <source>Non-nullable event must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</source>
+        <target state="new">Non-nullable event must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">
         <source>Non-nullable {0} '{1}' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the {0} as nullable.</source>
         <target state="translated">Niedopuszczający wartości null element {0} „{1}” musi zawierać wartość inną niż null podczas kończenia działania konstruktora. Rozważ dodanie modyfikatora „required” lub zadeklarowanie {0} jako dopuszczającego wartość null.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -5995,6 +5995,16 @@
         <target state="translated">A propriedade não anulável deve conter um valor não nulo ao sair do construtor. Considere adicionar o modificador "obrigatório" ou declarar a propriedade como anulável ou tratar com segurança o caso em que "field" é nulo no acessador "get".</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UninitializedNonNullableEvent">
+        <source>Non-nullable event '{0}' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</source>
+        <target state="new">Non-nullable event '{0}' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UninitializedNonNullableEvent_Title">
+        <source>Non-nullable event must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</source>
+        <target state="new">Non-nullable event must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">
         <source>Non-nullable {0} '{1}' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the {0} as nullable.</source>
         <target state="translated">O {0} não anulável '{1}' precisa conter um valor não nulo ao sair do construtor. Considere adicionar o modificador "obrigatório" ou declarar o {0} como anulável.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -5995,6 +5995,16 @@
         <target state="translated">Свойство, не допускающее значения NULL, должно содержать значение, отличное от NULL, при выходе из конструктора. Попробуйте добавить модификатор "required", объявить свойство как допускающее значение NULL или безопасно обрабатывать случай, свойство "field" равно NULL в методе доступа "get".</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UninitializedNonNullableEvent">
+        <source>Non-nullable event '{0}' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</source>
+        <target state="new">Non-nullable event '{0}' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UninitializedNonNullableEvent_Title">
+        <source>Non-nullable event must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</source>
+        <target state="new">Non-nullable event must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">
         <source>Non-nullable {0} '{1}' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the {0} as nullable.</source>
         <target state="translated">{0} "{1}", не допускающий значения NULL, должен содержать значение, отличное от NULL, при выходе из конструктора. Рассмотрите возможность добавления модификатора "required" или объявления значения {0}, допускающего значение NULL.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -5995,6 +5995,16 @@
         <target state="translated">Null atanamaz özellik, yapıcıdan çıkarken null olmayan bir değer içermelidir. ‘required’ değiştiricisini eklemeyi, özelliği null atanabilir olarak tanımlamayı veya ‘get’ erişimcisinde ‘field’ null olduğunda durumu güvenli bir şekilde işlemeyi düşünün.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UninitializedNonNullableEvent">
+        <source>Non-nullable event '{0}' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</source>
+        <target state="new">Non-nullable event '{0}' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UninitializedNonNullableEvent_Title">
+        <source>Non-nullable event must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</source>
+        <target state="new">Non-nullable event must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">
         <source>Non-nullable {0} '{1}' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the {0} as nullable.</source>
         <target state="translated">Null atanamaz {0} '{1}', oluşturucudan çıkış yaparken null olmayan bir değer içermelidir. 'Gerekli' değiştiricisini ekleyin veya {0} değerini null atanabilir olarak bildirmeyi göz önünde bulundurun.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -5995,6 +5995,16 @@
         <target state="translated">退出构造函数时，不可为 null 的属性必须包含非 null 值。请考虑添加“required”修饰符，或将属性声明为可为 null，或安全地处理“get”访问器中“field”为 null 的情况。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UninitializedNonNullableEvent">
+        <source>Non-nullable event '{0}' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</source>
+        <target state="new">Non-nullable event '{0}' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UninitializedNonNullableEvent_Title">
+        <source>Non-nullable event must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</source>
+        <target state="new">Non-nullable event must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">
         <source>Non-nullable {0} '{1}' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the {0} as nullable.</source>
         <target state="translated">在退出构造函数时，不可为 null 的 {0} "{1}" 必须包含非 null 值。请考虑添加 "required" 修饰符或将该 {0} 声明为可为 null。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -5995,6 +5995,16 @@ strument:TestCoverage      產生檢測要收集
         <target state="translated">非可為 null 的屬性在建構函式結束時必須具有非 null 的值。請考慮加入 'required' 修飾元、將此屬性宣告為可為 null，或在 'get' 存取子中安全地處理 'field' 可能為 null 的情況。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UninitializedNonNullableEvent">
+        <source>Non-nullable event '{0}' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</source>
+        <target state="new">Non-nullable event '{0}' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UninitializedNonNullableEvent_Title">
+        <source>Non-nullable event must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</source>
+        <target state="new">Non-nullable event must contain a non-null value when exiting constructor. Consider declaring the event as nullable.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">
         <source>Non-nullable {0} '{1}' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the {0} as nullable.</source>
         <target state="translated">退出建構函式時，不可為 Null 的 {0} '{1}' 必須包含非 Null 值。請考慮新增 'required' 修飾元，或將 {0} 宣告為可以為 Null。</target>

--- a/src/Compilers/CSharp/Test/Emit3/Attributes/AttributeTests_Nullable.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Attributes/AttributeTests_Nullable.cs
@@ -3541,9 +3541,9 @@ internal class B : I<object>
                 // (10,30): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.NullableAttribute..ctor'
                 //     private event D<object?> E;
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "E").WithArguments("System.Runtime.CompilerServices.NullableAttribute", ".ctor").WithLocation(10, 30),
-                // (10,30): warning CS8618: Non-nullable event 'E' is uninitialized. Consider declaring the event as nullable.
+                // (10,30): warning CS9395: Non-nullable event 'E' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.
                 //     private event D<object?> E;
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "E").WithArguments("event", "E").WithLocation(10, 30),
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableEvent, "E").WithArguments("E").WithLocation(10, 30),
                 // (13,9): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.NullableAttribute..ctor'
                 //         object? f(object arg) => arg;
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "object?").WithArguments("System.Runtime.CompilerServices.NullableAttribute", ".ctor").WithLocation(13, 9),
@@ -3580,9 +3580,9 @@ internal class B : I<object>
                 // (23,29): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.NullableAttribute..ctor'
                 //     public event D<object?> E;
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "E").WithArguments("System.Runtime.CompilerServices.NullableAttribute", ".ctor").WithLocation(23, 29),
-                // (23,29): warning CS8618: Non-nullable event 'E' is uninitialized. Consider declaring the event as nullable.
+                // (23,29): warning CS9395: Non-nullable event 'E' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.
                 //     public event D<object?> E;
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "E").WithArguments("event", "E").WithLocation(23, 29),
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableEvent, "E").WithArguments("E").WithLocation(23, 29),
                 // (24,31): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.NullableAttribute..ctor'
                 //     private (object, object?) F;
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "F").WithArguments("System.Runtime.CompilerServices.NullableAttribute", ".ctor").WithLocation(24, 31));
@@ -3604,12 +3604,12 @@ internal class B : I<object>
                 // (10,30): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.NullableAttribute..ctor'
                 //     private event D<object?> E;
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "E").WithArguments("System.Runtime.CompilerServices.NullableAttribute", ".ctor").WithLocation(10, 30),
-                // (10,30): warning CS8618: Non-nullable event 'E' is uninitialized. Consider declaring the event as nullable.
+                // (10,30): warning CS9395: Non-nullable event 'E' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.
                 //     private event D<object?> E;
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "E").WithArguments("event", "E").WithLocation(10, 30),
-                // (23,29): warning CS8618: Non-nullable event 'E' is uninitialized. Consider declaring the event as nullable.
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableEvent, "E").WithArguments("E").WithLocation(10, 30),
+                // (23,29): warning CS9395: Non-nullable event 'E' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.
                 //     public event D<object?> E;
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "E").WithArguments("event", "E").WithLocation(23, 29)
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableEvent, "E").WithArguments("E").WithLocation(23, 29)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Emit3/FieldKeywordTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/FieldKeywordTests.cs
@@ -7279,9 +7279,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics(
-                // (5,39): warning CS8618: Non-nullable event 'E' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the event as nullable.
+                // (5,39): warning CS9395: Non-nullable event 'E' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.
                 //     public static event System.Action E; // 1
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "E").WithArguments("event", "E").WithLocation(5, 39),
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableEvent, "E").WithArguments("E").WithLocation(5, 39),
                 // (10,17): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //             E = null; // 2
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 17),

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableContextTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableContextTests.cs
@@ -1124,9 +1124,9 @@ class Program
     static event D E2;
 }";
             verify(source, expectedAnalyzedKeys: new[] { ".cctor" },
-                // (8,20): warning CS8618: Non-nullable event 'E2' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the event as nullable.
+                // (8,20): warning CS9395: Non-nullable event 'E2' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.
                 //     static event D E2;
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "E2").WithArguments("event", "E2").WithLocation(8, 20));
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableEvent, "E2").WithArguments("E2").WithLocation(8, 20));
 
             source =
 @"#pragma warning disable 67
@@ -1139,9 +1139,9 @@ class Program
     static event D E2;
 }";
             verify(source, expectedAnalyzedKeys: new[] { ".ctor" },
-                // (6,13): warning CS8618: Non-nullable event 'E1' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the event as nullable.
+                // (6,13): warning CS9395: Non-nullable event 'E1' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.
                 //     event D E1;
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "E1").WithArguments("event", "E1").WithLocation(6, 13));
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableEvent, "E1").WithArguments("E1").WithLocation(6, 13));
 
             static void verify(string source, string[] expectedAnalyzedKeys, params DiagnosticDescription[] expectedDiagnostics)
             {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UninitializedNonNullableFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UninitializedNonNullableFieldTests.cs
@@ -48,9 +48,9 @@ class C
 }";
             var comp = CreateCompilation(src, options: WithNullableEnable());
             comp.VerifyDiagnostics(
-                // (15,14): warning CS8618: Non-nullable event 'E1' is uninitialized. Consider declaring the event as nullable.
+                // (15,14): warning CS9395: Non-nullable event 'E1' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.
                 //     internal C()
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("event", "E1").WithLocation(15, 14));
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableEvent, "C").WithArguments("E1").WithLocation(15, 14));
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/81679")]
@@ -66,9 +66,9 @@ class C
                 """;
             var comp = CreateCompilation(source, options: WithNullableEnable());
             comp.VerifyDiagnostics(
-                // (5,25): warning CS8618: Non-nullable event 'OnEvent' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the event as nullable.
+                // (5,25): warning CS9395: Non-nullable event 'OnEvent' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.
                 //     public event Action OnEvent;
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "OnEvent").WithArguments("event", "OnEvent").WithLocation(5, 25),
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableEvent, "OnEvent").WithArguments("OnEvent").WithLocation(5, 25),
                 // (5,25): warning CS0067: The event 'C.OnEvent' is never used
                 //     public event Action OnEvent;
                 Diagnostic(ErrorCode.WRN_UnreferencedEvent, "OnEvent").WithArguments("C.OnEvent").WithLocation(5, 25));
@@ -457,9 +457,9 @@ class C
 }";
             var comp = CreateCompilation(source, options: WithNullableEnable());
             comp.VerifyDiagnostics(
-                // (5,28): warning CS8618: Non-nullable event 'E' is uninitialized. Consider declaring the event as nullable.
+                // (5,28): warning CS9395: Non-nullable event 'E' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.
                 //     private static event D E;
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "E").WithArguments("event", "E").WithLocation(5, 28));
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableEvent, "E").WithArguments("E").WithLocation(5, 28));
         }
 
         [Fact]
@@ -722,9 +722,9 @@ class C
 }";
             var comp = CreateCompilation(source, options: WithNullableEnable());
             comp.VerifyDiagnostics(
-                // (12,12): warning CS8618: Non-nullable event 'E4' is uninitialized. Consider declaring the event as nullable.
+                // (12,12): warning CS9395: Non-nullable event 'E4' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.
                 //     static C()
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("event", "E4").WithLocation(12, 12));
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableEvent, "C").WithArguments("E4").WithLocation(12, 12));
         }
 
         [Fact]
@@ -784,18 +784,18 @@ struct S
                 // (10,23): warning CS8618: Non-nullable property 'P1' is uninitialized. Consider declaring the property as nullable.
                 //         static object P1 { get; }
                 Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "P1").WithArguments("property", "P1").WithLocation(10, 23),
-                // (11,24): warning CS8618: Non-nullable event 'E1' is uninitialized. Consider declaring the event as nullable.
+                // (11,24): warning CS9395: Non-nullable event 'E1' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.
                 //         static event D E1;
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "E1").WithArguments("event", "E1").WithLocation(11, 24),
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableEvent, "E1").WithArguments("E1").WithLocation(11, 24),
                 // (12,16): warning CS8618: Non-nullable field 'F2' is uninitialized. Consider declaring the field as nullable.
                 //         object F2;
                 Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "F2").WithArguments("field", "F2").WithLocation(12, 16),
                 // (13,16): warning CS8618: Non-nullable property 'P2' is uninitialized. Consider declaring the property as nullable.
                 //         object P2 { get; }
                 Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "P2").WithArguments("property", "P2").WithLocation(13, 16),
-                // (14,17): warning CS8618: Non-nullable event 'E2' is uninitialized. Consider declaring the event as nullable.
+                // (14,17): warning CS9395: Non-nullable event 'E2' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.
                 //         event D E2;
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "E2").WithArguments("event", "E2").WithLocation(14, 17));
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableEvent, "E2").WithArguments("E2").WithLocation(14, 17));
         }
 
         // Each constructor is handled in isolation.
@@ -2011,9 +2011,9 @@ public interface I
                 // (6,26): warning CS8618: Non-nullable property 'F3' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
                 //     public static object F3 { get; set; } // 3
                 Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "F3").WithArguments("property", "F3").WithLocation(6, 26),
-                // (7,39): warning CS8618: Non-nullable event 'E1' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the event as nullable.
+                // (7,39): warning CS9395: Non-nullable event 'E1' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.
                 //     public static event System.Action E1; // 4, 5
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "E1").WithArguments("event", "E1").WithLocation(7, 39),
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableEvent, "E1").WithArguments("E1").WithLocation(7, 39),
                 // (7,39): warning CS0067: The event 'I.E1' is never used
                 //     public static event System.Action E1; // 4, 5
                 Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E1").WithArguments("I.E1").WithLocation(7, 39)
@@ -2054,9 +2054,9 @@ public interface I
                 // (16,12): warning CS8618: Non-nullable property 'F2' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
                 //     static I() // 2, 3, 4
                 Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "I").WithArguments("property", "F2").WithLocation(16, 12),
-                // (16,12): warning CS8618: Non-nullable event 'E1' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the event as nullable.
+                // (16,12): warning CS9395: Non-nullable event 'E1' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.
                 //     static I() // 2, 3, 4
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "I").WithArguments("event", "E1").WithLocation(16, 12),
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableEvent, "I").WithArguments("E1").WithLocation(16, 12),
                 // (16,12): warning CS8618: Non-nullable field 'F1' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable.
                 //     static I() // 2, 3, 4
                 Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "I").WithArguments("field", "F1").WithLocation(16, 12)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UninitializedNonNullableFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UninitializedNonNullableFieldTests.cs
@@ -53,6 +53,27 @@ class C
                 Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("event", "E1").WithLocation(15, 14));
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/81679")]
+        public void UninitializedNonNullableEvent_DoesNotSuggestRequired()
+        {
+            var source = """
+                using System;
+
+                public class C
+                {
+                    public event Action OnEvent;
+                }
+                """;
+            var comp = CreateCompilation(source, options: WithNullableEnable());
+            comp.VerifyDiagnostics(
+                // (5,25): warning CS8618: Non-nullable event 'OnEvent' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the event as nullable.
+                //     public event Action OnEvent;
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "OnEvent").WithArguments("event", "OnEvent").WithLocation(5, 25),
+                // (5,25): warning CS0067: The event 'C.OnEvent' is never used
+                //     public event Action OnEvent;
+                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "OnEvent").WithArguments("C.OnEvent").WithLocation(5, 25));
+        }
+
         [Fact]
         public void Event_InitialState()
         {

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
@@ -610,9 +610,9 @@ public class C
             VerifyAcrossCompilations(
                 source,
                 new[] { 
-                    // (8,20): warning CS8618: Non-nullable event 'D1' is uninitialized. Consider declaring the event as nullable.
+                    // (8,20): warning CS9395: Non-nullable event 'D1' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.
                     //     public event D D1;
-                    Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "D1").WithArguments("event", "D1").WithLocation(8, 20),
+                    Diagnostic(ErrorCode.WRN_UninitializedNonNullableEvent, "D1").WithArguments("D1").WithLocation(8, 20),
                     // (13,19): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
                     //     public event D? D4;
                     Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(13, 19)

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolEqualityTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolEqualityTests.cs
@@ -877,9 +877,9 @@ public class A<T>
 ";
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
-                // (6,41): warning CS8618: Non-nullable event 'MyEvent' is uninitialized. Consider declaring the event as nullable.
+                // (6,41): warning CS9395: Non-nullable event 'MyEvent' must contain a non-null value when exiting constructor. Consider declaring the event as nullable.
                 //     public event System.EventHandler<T> MyEvent;
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "MyEvent").WithArguments("event", "MyEvent").WithLocation(6, 41)
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableEvent, "MyEvent").WithArguments("MyEvent").WithLocation(6, 41)
                 );
 
             var syntaxTree = comp.SyntaxTrees[0];

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -348,6 +348,7 @@ class X
                         case ErrorCode.WRN_NullabilityMismatchInReturnTypeOnExplicitImplementation:
                         case ErrorCode.WRN_NullabilityMismatchInParameterTypeOnExplicitImplementation:
                         case ErrorCode.WRN_UninitializedNonNullableField:
+                        case ErrorCode.WRN_UninitializedNonNullableEvent:
                         case ErrorCode.WRN_NullabilityMismatchInAssignment:
                         case ErrorCode.WRN_NullabilityMismatchInArgument:
                         case ErrorCode.WRN_NullabilityMismatchInArgumentForOutput:


### PR DESCRIPTION
Fixes #81679

### Problem
An uninitialized non-nullable field-like event reported `CS8618` advising the `required` modifier, but `required` is invalid on events (applying it yields `CS0106`):

```csharp
public class C {
    public event Action OnEvent; // CS8618 ... Consider adding the 'required' modifier or declaring the event as nullable.
}
```

### Fix
Introduces a dedicated diagnostic for events, mirroring the earlier `WRN_UninitializedNonNullableBackingField` split (#75246), as suggested by @jjonescz:

- New `ErrorCode.WRN_UninitializedNonNullableEvent = 9395` (CS9395) with corrected wording: *"Non-nullable event '{0}' must contain a non-null value when exiting constructor. Consider declaring the event as nullable."* (no `required` advice).
- `NullableWalker` reports CS9395 when the member is an event; fields and properties keep `CS8618` unchanged.
- `ErrorFacts` (nullable warnings, warning level, non-build-only) + regenerated table; `CSharpResources.resx` message/title + 13 `.xlf` files.
- `CSharpDeclareAsNullableCodeFixProvider` now also fixes CS9395 and handles `EventFieldDeclarationSyntax`, so "declare the event as nullable" is actionable.

### Tests
- New repro `UninitializedNonNullableEvent_DoesNotSuggestRequired`.
- Updated static + instance event baselines across nullable suites.
- New `DeclareAsNullable` code-fix case for events; updated `MakeMemberRequiredTests.NotOnEventDeclaration` marker to CS9395.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84294)