### PR TITLE
Restructure agent knowledge base for context-efficient loading

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,22 @@
 # More information: https://github.com/blog/2392-introducing-code-owners
 
 *.yml @dotnet/roslyn-infrastructure
+AGENTS.md @dotnet/roslyn-infrastructure
 .github/ @dotnet/roslyn-infrastructure
+.github/copilot-instructions.md @dotnet/roslyn-infrastructure
+.github/instructions/ @dotnet/roslyn-infrastructure
+.github/memory/ @dotnet/roslyn-infrastructure
+.github/skills/ @dotnet/roslyn-infrastructure
+
+.github/instructions/Compiler.instructions.md @dotnet/roslyn-compiler
+.github/instructions/IDE.instructions.md @dotnet/roslyn-ide
+.github/instructions/Razor.instructions.md @dotnet/razor-tooling
+.github/memory/known-issues/compiler.md @dotnet/roslyn-compiler
+.github/memory/known-issues/ide.md @dotnet/roslyn-ide
+.github/memory/known-issues/razor.md @dotnet/razor-tooling
+.github/memory/testing/compiler.md @dotnet/roslyn-compiler
+.github/memory/testing/ide.md @dotnet/roslyn-ide
+.github/memory/testing/razor.md @dotnet/razor-tooling
 
 docs/compilers @dotnet/roslyn-compiler
 docs/ide @dotnet/roslyn-ide

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,6 +36,7 @@ docs/             # Contributor & design docs
 ```bash
 dotnet build Compilers.slnf      # compilers only
 dotnet build Ide.slnf            # IDE only
+dotnet build Razor.slnf          # Razor compiler & tooling only
 dotnet build <path/to/Project.csproj>
 ```
 
@@ -72,7 +73,7 @@ Full conventions: `.github/memory/CONVENTIONS.md` and `.github/instructions/{Com
 When starting any task or answering any question about this repo:
 1. **Read `.github/memory/INDEX.md` first** — it's the loading map for the knowledge base. Use it to find authoritative answers before searching the file system.
 2. **For any non-trivial task, also read `.github/memory/ARCHITECTURE.md` and `.github/memory/CONVENTIONS.md`** as your baseline.
-3. **Read the path-scoped instruction file for the area you're editing** — `.github/instructions/Compiler.instructions.md`, `IDE.instructions.md`, or `Razor.instructions.md` (these auto-apply to `.cs`/`.vb` under their glob and carry the layer's directory detail, conventions, testing, and gotchas). Load other repo-wide memory files on demand per the INDEX.
+3. **Read the path-scoped instruction file for the area you're editing** — `.github/instructions/Compiler.instructions.md`, `IDE.instructions.md`, or `Razor.instructions.md` (these auto-apply to `.cs`/`.vb` under their glob and carry the layer's directory detail, conventions, and key files/APIs). For that layer's **known issues** and **test conventions**, load `.github/memory/known-issues/<area>.md` and `.github/memory/testing/<area>.md` on demand (see the INDEX loading map).
 4. After completing work, run the `update-docs` skill.
 
 ### Memory
@@ -88,8 +89,9 @@ When starting any task or answering any question about this repo:
 Every task that changes code must end with a doc pass:
 - Added or moved files? → Update `.github/memory/FILE_MAP.md` (top-level) and the matching `.github/instructions/<area>.instructions.md` (directory detail).
 - Changed a public interface, diagnostic ID, or API? → Update the relevant `.github/instructions/<area>.instructions.md` and `PublicAPI.Unshipped.txt`.
-- Hit something surprising or undocumented? → Repo-wide → `.github/memory/KNOWN_ISSUES.md`; layer-specific → the matching `.github/instructions/<area>.instructions.md`.
+- Hit something surprising or undocumented? → Repo-wide → `.github/memory/KNOWN_ISSUES.md`; layer-specific → `.github/memory/known-issues/<area>.md`.
 - Established a new pattern? → Repo-wide → `.github/memory/CONVENTIONS.md`; layer-specific → the matching `.github/instructions/<area>.instructions.md`.
+- Changed test base classes or conventions? → Repo-wide layout → `.github/memory/TESTING_STRATEGY.md`; layer-specific → `.github/memory/testing/<area>.md`.
 - Added/removed/renamed a memory file? → Update `.github/memory/INDEX.md`.
 
 ### Skills
@@ -101,7 +103,7 @@ Skills live in `.github/skills/<skill-name>/SKILL.md` and are auto-discovered by
 When making changes:
 1. **Read `.github/memory/INDEX.md` first.**
 2. For non-trivial tasks, read `ARCHITECTURE.md` and `CONVENTIONS.md`, and the `.github/instructions/<area>.instructions.md` for the area you're editing.
-3. **Build the specific project(s) modified** (`Compilers.slnf` / `Ide.slnf` / the project).
+3. **Build the specific project(s) modified** (`Compilers.slnf` / `Ide.slnf` / `Razor.slnf` / the project).
 4. **Run targeted tests** for affected test project(s).
 5. If you edited a `.resx`, run `/t:UpdateXlf`; if you edited Syntax/BoundNodes XML, regenerate code. Update `PublicAPI.Unshipped.txt` for public API changes.
 6. Follow existing patterns in similar files.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -74,7 +74,7 @@ When starting any task or answering any question about this repo:
 1. **Read `.github/memory/INDEX.md` first** — it's the loading map for the knowledge base. Use it to find authoritative answers before searching the file system.
 2. **For any non-trivial task, also read `.github/memory/ARCHITECTURE.md` and `.github/memory/CONVENTIONS.md`** as your baseline.
 3. **Read the path-scoped instruction file for the area you're editing** — `.github/instructions/Compiler.instructions.md`, `IDE.instructions.md`, or `Razor.instructions.md` (these auto-apply to `.cs`/`.vb` under their glob and carry the layer's directory detail, conventions, and key files/APIs). For that layer's **known issues** and **test conventions**, load `.github/memory/known-issues/<area>.md` and `.github/memory/testing/<area>.md` on demand (see the INDEX loading map).
-4. After completing work, run the `update-docs` skill.
+4. After completing work, run the `update-agent-docs` skill.
 
 ### Memory
 
@@ -96,7 +96,7 @@ Every task that changes code must end with a doc pass:
 
 ### Skills
 
-Skills live in `.github/skills/<skill-name>/SKILL.md` and are auto-discovered by their YAML `description`. Useful ones here include `code-review`, `ci-analysis`, `analyzer-codefix`, `merge-into-branch`, `snap`, and `update-docs`.
+Skills live in `.github/skills/<skill-name>/SKILL.md` and are auto-discovered by their YAML `description`. Useful ones here include `code-review`, `ci-analysis`, `analyzer-codefix`, `merge-into-branch`, `snap`, and `update-agent-docs`.
 
 ## Validation Checklist
 
@@ -107,4 +107,4 @@ When making changes:
 4. **Run targeted tests** for affected test project(s).
 5. If you edited a `.resx`, run `/t:UpdateXlf`; if you edited Syntax/BoundNodes XML, regenerate code. Update `PublicAPI.Unshipped.txt` for public API changes.
 6. Follow existing patterns in similar files.
-7. **Doc pass** (mandatory) — run the `update-docs` skill and apply the Doc Update Obligation above.
+7. **Doc pass** (mandatory) — run the `update-agent-docs` skill and apply the Doc Update Obligation above.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,108 @@
+# Roslyn (.NET Compiler Platform) — Copilot Instructions
+
+> This is the **canonical** repo-wide agent entry point. `AGENTS.md` at the repo root points here. Path-scoped rules in `.github/instructions/{Compiler,IDE,Razor}.instructions.md` apply automatically by area and supplement this file. This file establishes the memory-first orientation protocol and doc-maintenance obligation.
+
+## Project Overview
+
+Roslyn is the open-source C# and Visual Basic compilers plus the language services and IDE features built on their APIs. Built around **immutable** syntax trees, semantic models, symbols, and workspace snapshots. Major components:
+- **Compilers** (`src/Compilers/`) — C#/VB compilers (syntax, semantics, emit).
+- **Workspaces** (`src/Workspaces/`) — Solution/Project/Document model + MEF host.
+- **Features / EditorFeatures** (`src/Features/`, `src/EditorFeatures/`) — IDE features.
+- **Analyzers / CodeStyle** (`src/Analyzers/`, `src/CodeStyle/`) — IDE0xxx diagnostics & fixes.
+- **LanguageServer** (`src/LanguageServer/`) — LSP server.
+- **VisualStudio** (`src/VisualStudio/`) — VS integration.
+- **Razor** (`src/Razor/src/`) — Razor compiler & tooling (merged sub-tree).
+
+## Project Structure
+
+```
+src/
+  Compilers/      # C#/VB compilers (Core, CSharp, VisualBasic, Server)
+  Workspaces/     # Solution model, MSBuild loading, Remote (OOP)
+  Features/       # Language-agnostic IDE feature logic
+  EditorFeatures/ # Editor/text-buffer integration
+  Analyzers/      # IDE0xxx code-style analyzers & fixes
+  LanguageServer/ # LSP server
+  VisualStudio/   # VS language services & UI
+  Razor/src/      # Razor compiler + tooling (own layout)
+  ExpressionEvaluator/  Scripting/  Interactive/  RoslynAnalyzers/
+eng/              # Arcade build engineering (eng/common is DARC-synced)
+docs/             # Contributor & design docs
+```
+
+## Build & Test
+
+### Build specific projects during development (preferred)
+```bash
+dotnet build Compilers.slnf      # compilers only
+dotnet build Ide.slnf            # IDE only
+dotnet build <path/to/Project.csproj>
+```
+
+### Run tests for modified code
+```bash
+dotnet test <path/to/Specific.UnitTests.csproj>
+dotnet test <proj> --filter "FullyQualifiedName~MyTestClass"
+```
+
+Tests can take a while to build and run — monitor output and wait for completion unless you're confident a run is hung.
+
+### Full build/test (final validation only)
+```bash
+./build.sh   # Build.cmd on Windows
+./test.sh    # Test.cmd on Windows
+```
+
+Other entry points: `dotnet run --file eng/generate-compiler-code.cs` (regenerate Syntax/BoundNodes code), `dotnet msbuild <proj> /t:UpdateXlf` (refresh `.xlf` after `.resx` edits).
+
+## Code Style
+
+- 4-space indent for code; 2-space for project/XML/JSON. Never tabs. UTF-8-BOM, final newline for `*.cs`/`*.vb`.
+- **Blank lines must be completely empty** (no spaces/tabs); no trailing whitespace — both are hard lint failures.
+- Private fields `_camelCase`; namespaces `Microsoft.CodeAnalysis.[Language].[Area]`.
+- Always thread `CancellationToken` through async operations. (Null-checking style is layer-specific — see the area's instruction file: `Contract.ThrowIfNull` in IDE, `Debug.Assert` in the compiler.)
+- Language services are exported **per-language** (`[ExportLanguageService(..., LanguageNames.CSharp), Shared]`), never shared across C#/VB.
+- No `TODO`/`TODO2` comments — track follow-ups as linked GitHub issues in code; existing `TODO2`s are only a frozen enforcement baseline. No `PROTOTYPE` comments in PRs to `main`.
+- Update `PublicAPI.Unshipped.txt` for public API changes. Never hand-edit generated code or `eng/common`.
+
+Full conventions: `.github/memory/CONVENTIONS.md` and `.github/instructions/{Compiler,IDE,Razor}.instructions.md`.
+
+## Agent Orientation
+
+When starting any task or answering any question about this repo:
+1. **Read `.github/memory/INDEX.md` first** — it's the loading map for the knowledge base. Use it to find authoritative answers before searching the file system.
+2. **For any non-trivial task, also read `.github/memory/ARCHITECTURE.md` and `.github/memory/CONVENTIONS.md`** as your baseline.
+3. **Read the path-scoped instruction file for the area you're editing** — `.github/instructions/Compiler.instructions.md`, `IDE.instructions.md`, or `Razor.instructions.md` (these auto-apply to `.cs`/`.vb` under their glob and carry the layer's directory detail, conventions, testing, and gotchas). Load other repo-wide memory files on demand per the INDEX.
+4. After completing work, run the `update-docs` skill.
+
+### Memory
+
+`.github/memory/` is your persistent knowledge base. You may freely create new focused files, update existing ones when you find corrections, and reorganize when structure no longer fits. Use descriptive filenames.
+
+**Memory freshness is your responsibility.** Files can drift from the code:
+- **Always cross-check memory claims against actual code** before relying on them.
+- **If a memory file is stale, fix it immediately.** If you learn something worth keeping, write it to `.github/memory/` immediately.
+
+### Doc Update Obligation
+
+Every task that changes code must end with a doc pass:
+- Added or moved files? → Update `.github/memory/FILE_MAP.md` (top-level) and the matching `.github/instructions/<area>.instructions.md` (directory detail).
+- Changed a public interface, diagnostic ID, or API? → Update the relevant `.github/instructions/<area>.instructions.md` and `PublicAPI.Unshipped.txt`.
+- Hit something surprising or undocumented? → Repo-wide → `.github/memory/KNOWN_ISSUES.md`; layer-specific → the matching `.github/instructions/<area>.instructions.md`.
+- Established a new pattern? → Repo-wide → `.github/memory/CONVENTIONS.md`; layer-specific → the matching `.github/instructions/<area>.instructions.md`.
+- Added/removed/renamed a memory file? → Update `.github/memory/INDEX.md`.
+
+### Skills
+
+Skills live in `.github/skills/<skill-name>/SKILL.md` and are auto-discovered by their YAML `description`. Useful ones here include `code-review`, `ci-analysis`, `analyzer-codefix`, `merge-into-branch`, `snap`, and `update-docs`.
+
+## Validation Checklist
+
+When making changes:
+1. **Read `.github/memory/INDEX.md` first.**
+2. For non-trivial tasks, read `ARCHITECTURE.md` and `CONVENTIONS.md`, and the `.github/instructions/<area>.instructions.md` for the area you're editing.
+3. **Build the specific project(s) modified** (`Compilers.slnf` / `Ide.slnf` / the project).
+4. **Run targeted tests** for affected test project(s).
+5. If you edited a `.resx`, run `/t:UpdateXlf`; if you edited Syntax/BoundNodes XML, regenerate code. Update `PublicAPI.Unshipped.txt` for public API changes.
+6. Follow existing patterns in similar files.
+7. **Doc pass** (mandatory) — run the `update-docs` skill and apply the Doc Update Obligation above.

--- a/.github/instructions/Compiler.instructions.md
+++ b/.github/instructions/Compiler.instructions.md
@@ -15,9 +15,34 @@ Roslyn follows a **layered compiler architecture**:
 - `src/Compilers/Core/Portable/` - Language-agnostic compiler infrastructure
 - `src/Compilers/CSharp/Portable/` - C# compiler implementation  
 - `src/Compilers/VisualBasic/Portable/` - VB compiler implementation
+- `src/Compilers/Server/` - `VBCSCompiler` build server
 - `src/Dependencies/` - High-performance collections (`PooledObjects`, `Threading`)
 - `src/ExpressionEvaluator/` - Debugger expression evaluation (uses special `LexerMode.DebuggerSyntax`)
 - `src/Tools/` - Compiler tooling (BuildBoss, format tools, analyzers)
+
+### Essential Files for Context
+- `src/Compilers/CSharp/Portable/Errors/ErrorCode.cs` - All C# compiler error codes
+- `src/Compilers/CSharp/Portable/Errors/MessageID.cs` - Language feature version gating
+- `src/Compilers/CSharp/Portable/Syntax/Syntax.xml` - Syntax tree node definitions (generated code source)
+- `src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml` - Bound tree node definitions (generated code source)
+- `docs/wiki/Roslyn-Overview.md` - Architecture deep-dive
+
+## Code Generation
+
+Several core data structures are generated from XML definitions — **never edit the generated `.cs` or `.vb` files directly**:
+- **Syntax trees**: `src/Compilers/CSharp/Portable/Syntax/Syntax.xml`
+- **Bound trees**: `src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml`
+- After modifying these XML files, regenerate and build:
+  ```bash
+  dotnet run --file eng/generate-compiler-code.cs
+  dotnet build src/Compilers/{CSharp,VisualBasic}/Portable # choose the project matching the C# or VB syntax you changed
+  ```
+
+## Conventions
+
+- **MEF is not used in the compiler layer.** `ExportLanguageService` / `ImportingConstructor` and the IDE service model are IDE-layer concepts — ignore them here.
+- **Null checks**: validate internal-API preconditions with `Debug.Assert(...)` (a violated internal precondition may NRE in release); validate public APIs with explicit null checking when appropriate, throwing a dedicated exception with a localized string.
+- **Immutability** is via `Compilation` (`AddSyntaxTrees`/`RemoveSyntaxTrees`/`ReplaceSyntaxTree`), not the workspace `Document`/`Solution` model.
 
 ## Essential Patterns
 
@@ -63,6 +88,9 @@ dotnet run --file eng/generate-compiler-code.cs
 - **Cross-language patterns**: Many test patterns work for both C# and VB with minor syntax changes
 - **Verification baselines**: When helpers like `VerifyDiagnostics`, `VerifyEmitDiagnostics`, `VerifyIL`, and similar compiler test APIs fail with an `Actual:` block containing the expected test content, copy that block directly into the verification call.
 - **Keep tests focused**: Avoid unnecessary assertions. Tests should do the minimal work necessary to get to the core assertions that validate the issue being addressed. For example, use `Single()` instead of checking counts and then accessing the first element.
+- **Prefer raw string literals** (`"""..."""`) over verbatim strings (`@"..."`) for test source code.
+- **Use `comp.VerifyEmitDiagnostics()`** (rather than only `VerifyDiagnostics`) so reviewers can see whether the code under test is legal.
+- **Link work items**: For issue-driven changes, add a `WorkItem` alongside the test attribute, e.g. `[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/1234")]`.
 
 ## Debugger Integration
 

--- a/.github/instructions/Compiler.instructions.md
+++ b/.github/instructions/Compiler.instructions.md
@@ -68,13 +68,6 @@ dotnet build src/Compilers/CSharp/csc/AnyCpu/  # C# compiler
 dotnet run --file eng/generate-compiler-code.cs
 ```
 
-### Testing Strategy
-
-Compiler test base classes (`CSharpTestBase`/`VisualBasicTestBase`) and authoring
-conventions (`VerifyEmitDiagnostics`, baselines, `WorkItem`) live in
-`.github/memory/testing/compiler.md` — load it when writing or modifying tests.
-Known issues for this layer: `.github/memory/known-issues/compiler.md`.
-
 ## Debugger Integration
 
 **Expression Evaluator** uses special parsing modes:

--- a/.github/instructions/Compiler.instructions.md
+++ b/.github/instructions/Compiler.instructions.md
@@ -46,20 +46,6 @@ Several core data structures are generated from XML definitions — **never edit
 
 ## Essential Patterns
 
-### Test Structure Convention
-Inherit from language-specific base classes: `CSharpTestBase` for C#, `VisualBasicTestBase` for VB
-```cs
-public class MyTests : CSharpTestBase
-{
-    [Fact]
-    public void TestMethod()
-    {
-        var comp = CreateCompilation(sourceCode);
-        // Test compilation, symbols, diagnostics
-    }
-}
-```
-
 ### Memory Management
 - **Avoid LINQ in hot paths** - use manual enumeration or `struct` enumerators
 - **Avoid `foreach` over collections without struct enumerators** 
@@ -83,14 +69,11 @@ dotnet run --file eng/generate-compiler-code.cs
 ```
 
 ### Testing Strategy
-- **Unit tests**: Test individual compiler phases (lexing, parsing)
-- **Compilation tests**: Create `Compilation` objects and verify symbols/diagnostics
-- **Cross-language patterns**: Many test patterns work for both C# and VB with minor syntax changes
-- **Verification baselines**: When helpers like `VerifyDiagnostics`, `VerifyEmitDiagnostics`, `VerifyIL`, and similar compiler test APIs fail with an `Actual:` block containing the expected test content, copy that block directly into the verification call.
-- **Keep tests focused**: Avoid unnecessary assertions. Tests should do the minimal work necessary to get to the core assertions that validate the issue being addressed. For example, use `Single()` instead of checking counts and then accessing the first element.
-- **Prefer raw string literals** (`"""..."""`) over verbatim strings (`@"..."`) for test source code.
-- **Use `comp.VerifyEmitDiagnostics()`** (rather than only `VerifyDiagnostics`) so reviewers can see whether the code under test is legal.
-- **Link work items**: For issue-driven changes, add a `WorkItem` alongside the test attribute, e.g. `[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/1234")]`.
+
+Compiler test base classes (`CSharpTestBase`/`VisualBasicTestBase`) and authoring
+conventions (`VerifyEmitDiagnostics`, baselines, `WorkItem`) live in
+`.github/memory/testing/compiler.md` — load it when writing or modifying tests.
+Known issues for this layer: `.github/memory/known-issues/compiler.md`.
 
 ## Debugger Integration
 

--- a/.github/instructions/IDE.instructions.md
+++ b/.github/instructions/IDE.instructions.md
@@ -49,12 +49,6 @@ public MyService(IDependency dependency) { }
 - For localizable strings: `new LocalizableResourceString(nameof(FeaturesResources.Some_string), FeaturesResources.ResourceManager, typeof(FeaturesResources))`
 - After modifying `.resx` files, run `dotnet msbuild <path to csproj> /t:UpdateXlf` to update `.xlf` localization files
 
-## Testing Patterns
-
-IDE test infrastructure (`EditorTestWorkspace`, `[UseExportProvider]`, analyzer
-base classes, `TestInRegularAndScriptAsync`) and authoring conventions live in
-`.github/memory/testing/ide.md` — load it when writing or modifying tests.
-
 ## Analyzers & Code Fixes (IDE0xxx)
 
 - IDE code-style analyzers inherit from `AbstractBuiltInCodeStyleDiagnosticAnalyzer` — not raw `DiagnosticAnalyzer`
@@ -107,6 +101,3 @@ var methodDecl = generator.MethodDeclaration("MyMethod", ...);
 - **ImportingConstructor must be marked `[Obsolete]`** with `MefConstruction.ImportingConstructorMessage`
 - **Language services must be exported with a specific language name** — don't use generic exports for both C#/VB
 - **Workspace changes must use immutable updates** — `Workspace.SetCurrentSolution()`
-
-Layer-specific known issues and workarounds (spurious `RS0016`, MEF composition
-failures surfacing as test failures) live in `.github/memory/known-issues/ide.md`.

--- a/.github/instructions/IDE.instructions.md
+++ b/.github/instructions/IDE.instructions.md
@@ -51,27 +51,9 @@ public MyService(IDependency dependency) { }
 
 ## Testing Patterns
 
-### Test Workspace (MEF-dependent tests)
-```csharp
-[UseExportProvider]
-public class MyTests
-{
-    [Fact]
-    public async Task TestSomething()
-    {
-        var workspace = EditorTestWorkspace.CreateCSharp("class C { }");
-        var document = workspace.Documents.Single();
-    }
-}
-```
-
-### Test Conventions
-- Prefer raw string literals (`"""..."""`) over verbatim strings (`@"..."`) for test source code
-- Keep tests focused — avoid unnecessary intermediary assertions; use `.Single()` rather than asserting a count then indexing
-- Use `[UseExportProvider]` for any test that depends on MEF services
-- Analyzer tests inherit from `AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest_NoEditor` (and VB equivalents)
-- For analyzer/code-fix tests, use `TestInRegularAndScriptAsync` / `TestMissingInRegularAndScriptAsync`
-- Link work items: for issue-driven changes add a `WorkItem`, e.g. `[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/1234")]`
+IDE test infrastructure (`EditorTestWorkspace`, `[UseExportProvider]`, analyzer
+base classes, `TestInRegularAndScriptAsync`) and authoring conventions live in
+`.github/memory/testing/ide.md` — load it when writing or modifying tests.
 
 ## Analyzers & Code Fixes (IDE0xxx)
 
@@ -125,5 +107,6 @@ var methodDecl = generator.MethodDeclaration("MyMethod", ...);
 - **ImportingConstructor must be marked `[Obsolete]`** with `MefConstruction.ImportingConstructorMessage`
 - **Language services must be exported with a specific language name** — don't use generic exports for both C#/VB
 - **Workspace changes must use immutable updates** — `Workspace.SetCurrentSolution()`
-- **Test failures often indicate MEF composition issues** — check export attributes
-- **PublicApiAnalyzer false RS0016 with NuGet contentFiles**: the analyzer reads `dotnet_public_api_analyzer.require_api_files` from `compilation.SyntaxTrees.FirstOrDefault()`; if that first tree is a NuGet contentFiles `*.g.cs` outside the repo, the root `.editorconfig` option doesn't apply and `RS0016` fires spuriously
+
+Layer-specific known issues and workarounds (spurious `RS0016`, MEF composition
+failures surfacing as test failures) live in `.github/memory/known-issues/ide.md`.

--- a/.github/instructions/IDE.instructions.md
+++ b/.github/instructions/IDE.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "src/{Analyzers,CodeStyle,Features,Workspaces,EditorFeatures,VisualStudio}/**/*.{cs,vb}"
+applyTo: "src/{Analyzers,CodeStyle,Features,Workspaces,EditorFeatures,VisualStudio,LanguageServer}/**/*.{cs,vb}"
 ---
 
 # Roslyn IDE Development Guide

--- a/.github/instructions/IDE.instructions.md
+++ b/.github/instructions/IDE.instructions.md
@@ -11,7 +11,8 @@ Roslyn uses a **layered service architecture** built on MEF (Managed Extensibili
 - **Workspaces** (`src/Workspaces/`): Core abstractions — `Workspace`, `Solution`, `Project`, `Document`
 - **Features** (`src/Features/`): Language-agnostic IDE features (refactoring, navigation, completion)
 - **Analyzers** (`src/Analyzers/`): IDE diagnostic analyzers and code fixes (IDE0xxx diagnostics)
-- **LanguageServer** (`src/LanguageServer/`): Shared LSP protocol implementation and Roslyn LSP executable
+- **CodeStyle** (`src/CodeStyle/`): Code-style analyzer packaging shared with the command-line
+- **LanguageServer** (`src/LanguageServer/`): Shared LSP protocol implementation and Roslyn LSP executable (`roslyn-language-server`)
 - **EditorFeatures** (`src/EditorFeatures/`): VS Editor integration and text manipulation
 - **VisualStudio** (`src/VisualStudio/`): Visual Studio-specific implementations
 
@@ -66,8 +67,21 @@ public class MyTests
 
 ### Test Conventions
 - Prefer raw string literals (`"""..."""`) over verbatim strings (`@"..."`) for test source code
-- Keep tests focused — avoid unnecessary intermediary assertions
+- Keep tests focused — avoid unnecessary intermediary assertions; use `.Single()` rather than asserting a count then indexing
 - Use `[UseExportProvider]` for any test that depends on MEF services
+- Analyzer tests inherit from `AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest_NoEditor` (and VB equivalents)
+- For analyzer/code-fix tests, use `TestInRegularAndScriptAsync` / `TestMissingInRegularAndScriptAsync`
+- Link work items: for issue-driven changes add a `WorkItem`, e.g. `[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/1234")]`
+
+## Analyzers & Code Fixes (IDE0xxx)
+
+- IDE code-style analyzers inherit from `AbstractBuiltInCodeStyleDiagnosticAnalyzer` — not raw `DiagnosticAnalyzer`
+- Always provide a `FixAllProvider` for code fixes (typically `WellKnownFixAllProviders.BatchFixer`)
+- Diagnostic ID constants live in `src/Analyzers/Core/Analyzers/IDEDiagnosticIds.cs`
+
+## Out-of-Process (OOP) Services
+
+- ServiceHub components live under `src/Workspaces/Remote/` and have special deployment considerations for .NET Core vs .NET Framework — keep both targets in mind when changing remote services
 
 ## Key Development Patterns
 
@@ -112,3 +126,4 @@ var methodDecl = generator.MethodDeclaration("MyMethod", ...);
 - **Language services must be exported with a specific language name** — don't use generic exports for both C#/VB
 - **Workspace changes must use immutable updates** — `Workspace.SetCurrentSolution()`
 - **Test failures often indicate MEF composition issues** — check export attributes
+- **PublicApiAnalyzer false RS0016 with NuGet contentFiles**: the analyzer reads `dotnet_public_api_analyzer.require_api_files` from `compilation.SyntaxTrees.FirstOrDefault()`; if that first tree is a NuGet contentFiles `*.g.cs` outside the repo, the root `.editorconfig` option doesn't apply and `RS0016` fires spuriously

--- a/.github/instructions/Razor.instructions.md
+++ b/.github/instructions/Razor.instructions.md
@@ -4,10 +4,8 @@ applyTo: "src/Razor/**/*.{cs,vb}"
 
 # Razor Tooling and Compiler Instructions for AI Coding Agents
 
-These instructions complement the repository-wide guidance in
-`.github/copilot-instructions.md` and apply to
-all Razor sources under `src/Razor/`. Razor was merged into the Roslyn repo from
-`dotnet/razor`, and most files keep their original sub-tree layout
+Razor was merged into the Roslyn repo from `dotnet/razor`, and most files keep
+their original sub-tree layout
 (`src/Razor/src/Razor/...`, `src/Razor/src/Compiler/...`, `src/Razor/src/Shared/...`,
 `src/Razor/src/Analyzers/...`).
 
@@ -17,8 +15,6 @@ all Razor sources under `src/Razor/`. Razor was merged into the Roslyn repo from
   The bug is more likely in existing logic than a missing feature.
 - **Helpers**: Review existing helpers (`UsingDirectiveHelper`, `AddUsingsHelper`, etc.)
   before writing new utility methods. Don't duplicate.
-
-Build/packaging known issues and workarounds live in `.github/memory/known-issues/razor.md`.
 
 ## File Types
 
@@ -41,13 +37,6 @@ Build/packaging known issues and workarounds live in `.github/memory/known-issue
   `solution.GetDocumentIdsWithFilePath(filePath)` then `solution.GetAdditionalDocument(documentId)`.
 - **Remote services**: Place the public stub method (calling `RunServiceAsync`) directly
   above its private implementation method.
-
-## Testing
-
-Razor test conventions (`TestCode` span markers, Cohosting test locations,
-`UseTwoPhaseCompilation`) live in `.github/memory/testing/razor.md` — load it when
-writing or modifying tests. Known issues for this layer:
-`.github/memory/known-issues/razor.md`.
 
 ## Adding OOP Remote Services
 

--- a/.github/instructions/Razor.instructions.md
+++ b/.github/instructions/Razor.instructions.md
@@ -4,7 +4,8 @@ applyTo: "src/Razor/**/*.{cs,vb}"
 
 # Razor Tooling and Compiler Instructions for AI Coding Agents
 
-These instructions complement the repository-wide `AGENTS.md` and apply to
+These instructions complement the repository-wide guidance in
+`.github/copilot-instructions.md` and apply to
 all Razor sources under `src/Razor/`. Razor was merged into the Roslyn repo from
 `dotnet/razor`, and most files keep their original sub-tree layout
 (`src/Razor/src/Razor/...`, `src/Razor/src/Compiler/...`, `src/Razor/src/Shared/...`,
@@ -29,6 +30,10 @@ all Razor sources under `src/Razor/`. Razor was merged into the Roslyn repo from
   entry to `Microsoft.CodeAnalysis.Razor.CohostingShared.projitems` or
   `Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests.projitems`, or the file will not
   be built or tested by the importing projects.
+- **Duplicate global analyzer config keys**: Razor projects receive global configs from both
+  `eng/config/globalconfigs/*.globalconfig` and `src/Razor/*.globalconfig` overlays. The same key
+  in two global configs causes compiler error `MultipleGlobalAnalyzerKeys` (and the key is left
+  unset) — don't redefine a key already present in the base config.
 
 ## File Types
 

--- a/.github/instructions/Razor.instructions.md
+++ b/.github/instructions/Razor.instructions.md
@@ -13,27 +13,12 @@ all Razor sources under `src/Razor/`. Razor was merged into the Roslyn repo from
 
 ## Critical Rules
 
-- **Build wrappers**: Be careful passing `-projects` through `build.cmd` or PowerShell wrappers.
-  Do not pass a semicolon-delimited project list through a nested PowerShell command invocation,
-  because PowerShell can treat `;` as a statement separator and open `.csproj` files in
-  Visual Studio. Prefer a single project at a time, or invoke the underlying script in a way
-  that preserves the full `-projects` value as one argument.
 - **Bug fixes**: Look for existing code that already handles the scenario before adding new code.
   The bug is more likely in existing logic than a missing feature.
 - **Helpers**: Review existing helpers (`UsingDirectiveHelper`, `AddUsingsHelper`, etc.)
   before writing new utility methods. Don't duplicate.
-- **Shared projects need `.projitems` entries**: Files under
-  `src\Razor\src\Razor\src\Microsoft.CodeAnalysis.Razor.CohostingShared\` and
-  `src\Razor\src\Razor\test\Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests\`
-  are compiled through their `.projitems` files. Adding a new `.cs` file in either shared
-  tree is not enough by itself. You must also add a matching `<Compile Include="...">`
-  entry to `Microsoft.CodeAnalysis.Razor.CohostingShared.projitems` or
-  `Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests.projitems`, or the file will not
-  be built or tested by the importing projects.
-- **Duplicate global analyzer config keys**: Razor projects receive global configs from both
-  `eng/config/globalconfigs/*.globalconfig` and `src/Razor/*.globalconfig` overlays. The same key
-  in two global configs causes compiler error `MultipleGlobalAnalyzerKeys` (and the key is left
-  unset) — don't redefine a key already present in the base config.
+
+Build/packaging known issues and workarounds live in `.github/memory/known-issues/razor.md`.
 
 ## File Types
 
@@ -59,16 +44,10 @@ all Razor sources under `src/Razor/`. Razor was merged into the Roslyn repo from
 
 ## Testing
 
-- Use `TestCode` with `[|...|]` span markers for before/after test scenarios. Access
-  `input.Text` (cleaned) and `input.Span` (marked range).
-- Prefer raw string literals (`"""..."""`) over verbatim strings (`@"..."`).
-- Test end-user scenarios, not implementation details.
-- Verify/helper methods go at the bottom of test files. New test methods go above them.
-- New tooling tests go in
-  `src\Razor\src\Razor\test\Microsoft.VisualStudioCode.RazorExtension.UnitTests`
-  (Cohosting architecture).
-- Integration tests using `AdditionalSyntaxTrees` for tag helper discovery must set
-  `UseTwoPhaseCompilation => true` (see `ComponentDiscoveryIntegrationTest`).
+Razor test conventions (`TestCode` span markers, Cohosting test locations,
+`UseTwoPhaseCompilation`) live in `.github/memory/testing/razor.md` — load it when
+writing or modifying tests. Known issues for this layer:
+`.github/memory/known-issues/razor.md`.
 
 ## Adding OOP Remote Services
 

--- a/.github/memory/API_MAP.md
+++ b/.github/memory/API_MAP.md
@@ -15,6 +15,7 @@ Repo-wide entry points and the formal public-API tracking rules. Layer-specific 
 | `build.sh` / `Build.cmd` | Full solution build (Arcade). |
 | `dotnet build Compilers.slnf` | Compiler-only build. |
 | `dotnet build Ide.slnf` | IDE-only build. |
+| `dotnet build Razor.slnf` | Razor compiler & tooling-only build. |
 | `test.sh` / `Test.cmd` | Full test run. |
 | `dotnet test <test.csproj>` | Run a specific test project. |
 | `dotnet run --file eng/generate-compiler-code.cs` | Regenerate Syntax/BoundNodes code. |

--- a/.github/memory/API_MAP.md
+++ b/.github/memory/API_MAP.md
@@ -1,0 +1,33 @@
+---
+coverage: Repo-wide build/test entry points and PublicAPI tracking; layer-specific surfaces live in the instruction files
+---
+
+# API Map
+
+Repo-wide entry points and the formal public-API tracking rules. Layer-specific surfaces (compiler error codes, IDE diagnostic IDs, extensibility patterns) live in the path-scoped instruction files:
+- Compiler error codes, `MessageID`, Syntax/BoundNodes, codegen, `csc`/`vbc` → `.github/instructions/Compiler.instructions.md`
+- IDE diagnostic IDs, MEF service/analyzer/code-fix exports, LSP → `.github/instructions/IDE.instructions.md`
+
+## Build & Test Entry Points
+
+| Command | Purpose |
+|---------|---------|
+| `build.sh` / `Build.cmd` | Full solution build (Arcade). |
+| `dotnet build Compilers.slnf` | Compiler-only build. |
+| `dotnet build Ide.slnf` | IDE-only build. |
+| `test.sh` / `Test.cmd` | Full test run. |
+| `dotnet test <test.csproj>` | Run a specific test project. |
+| `dotnet run --file eng/generate-compiler-code.cs` | Regenerate Syntax/BoundNodes code. |
+| `dotnet msbuild <proj> /t:UpdateXlf` | Refresh `.xlf` after `.resx` changes. |
+
+Solution filters: `Roslyn.slnx` (full), `Compilers.slnf`, `Ide.slnf`, `Razor.slnf`.
+
+## Public API Tracking
+
+- Every public-API addition/change must update the owning project's `PublicAPI.Unshipped.txt`.
+- Enforced by the PublicApiAnalyzer (e.g., `RS0016` for undeclared public API). Promote entries to `PublicAPI.Shipped.txt` at release/snap time.
+
+## Resource Strings
+
+- Strings live in `.resx`, accessed via generated designer classes (`CSharpResources`, `FeaturesResources`, `AnalyzersResources`, …).
+- After editing a `.resx`, run `dotnet msbuild <project.csproj> /t:UpdateXlf` to refresh `.xlf` files.

--- a/.github/memory/ARCHITECTURE.md
+++ b/.github/memory/ARCHITECTURE.md
@@ -25,7 +25,7 @@ Layered bottom-up (lower layers must not depend on higher layers — see `docs/L
 | **Scripting / Interactive** | `src/Scripting/`, `src/Interactive/` | C#/VB scripting and REPL. |
 | **RoslynAnalyzers** | `src/RoslynAnalyzers/` | The `Microsoft.CodeAnalysis.*` analyzer packages (formerly dotnet/roslyn-analyzers). |
 
-For per-layer directory detail, key files, and testing, read the matching path-scoped instruction file instead of carrying all layers in context: `.github/instructions/Compiler.instructions.md`, `IDE.instructions.md`, `Razor.instructions.md`.
+For per-layer directory detail, key files, and coding conventions, read the matching path-scoped instruction file (`.github/instructions/{Compiler,IDE,Razor}.instructions.md`). That layer's known issues and test conventions live in `.github/memory/known-issues/<area>.md` and `.github/memory/testing/<area>.md` — load on demand (see `INDEX.md`).
 
 ## Key Abstractions
 

--- a/.github/memory/ARCHITECTURE.md
+++ b/.github/memory/ARCHITECTURE.md
@@ -1,0 +1,58 @@
+---
+coverage: System overview — components, layers, data flow
+---
+
+# Architecture
+
+Roslyn is the .NET Compiler Platform: the open-source C# and Visual Basic compilers plus the language services and IDE features built on their public APIs. Everything is built around **immutable** syntax trees, semantic models, symbols, and workspace/solution snapshots, exposed through rich analysis and code-generation APIs.
+
+## Components
+
+Layered bottom-up (lower layers must not depend on higher layers — see `docs/Layering.md`):
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| **Compilers** | `src/Compilers/` | C# and VB compilers: syntax trees, semantic models, symbols, emit. `Core` is shared; `CSharp` and `VisualBasic` are per-language. |
+| **Workspaces** | `src/Workspaces/` | Solution/Project/Document object model, host services, MEF composition. Language-agnostic core + per-language layers. |
+| **Features** | `src/Features/` | Language-agnostic IDE features: refactorings, completion, code fixes, navigation. |
+| **Analyzers** | `src/Analyzers/` | IDE code-style diagnostic analyzers and fixes (IDE0xxx). |
+| **CodeStyle** | `src/CodeStyle/` | Code-style analyzer packaging shared with the compiler/command-line. |
+| **EditorFeatures** | `src/EditorFeatures/` | Editor/text-buffer integration of Features. |
+| **LanguageServer** | `src/LanguageServer/` | LSP server consumed by the VS Code C# extension and `roslyn-language-server`. |
+| **VisualStudio** | `src/VisualStudio/` | VS-specific language services and UI integration. |
+| **Razor** | `src/Razor/src/` | Razor compiler + Razor IDE tooling (merged from `dotnet/razor`; keeps its own internal layout). |
+| **ExpressionEvaluator** | `src/ExpressionEvaluator/` | Debugger expression evaluator built on the compilers. |
+| **Scripting / Interactive** | `src/Scripting/`, `src/Interactive/` | C#/VB scripting and REPL. |
+| **RoslynAnalyzers** | `src/RoslynAnalyzers/` | The `Microsoft.CodeAnalysis.*` analyzer packages (formerly dotnet/roslyn-analyzers). |
+
+For per-layer directory detail, key files, and testing, read the matching path-scoped instruction file instead of carrying all layers in context: `.github/instructions/Compiler.instructions.md`, `IDE.instructions.md`, `Razor.instructions.md`.
+
+## Key Abstractions
+
+- **Immutability everywhere.** `SyntaxTree`, `Compilation`, `SemanticModel`, `Solution`, `Project`, `Document` are immutable. Mutations produce new instances via `With*`/`Add*` methods. The `Workspace` holds the current `Solution` snapshot.
+- **MEF composition.** Services are exported per-language with `[ExportLanguageService(typeof(IService), LanguageNames.CSharp), Shared]` and imported via `[ImportingConstructor]` (+ obsolete-guard). Tests that need MEF use `[UseExportProvider]`.
+- **Red/green syntax trees.** Public "red" syntax nodes wrap an internal immutable "green" node tree for cheap incremental reuse.
+- **Symbols & bound nodes.** Semantic analysis binds syntax to `ISymbol`/bound nodes; `SemanticModel` is the query entry point. Always thread `CancellationToken`.
+- **Code generation from XML.** Syntax (`Syntax.xml`) and bound (`BoundNodes.xml`) node classes are generated — never hand-edit the generated `.cs`.
+
+## Data Flow
+
+Primary compile path:
+1. Source text → lexer/parser → `SyntaxTree` (immutable).
+2. `Compilation` created from syntax trees + references; binders produce symbols and bound trees.
+3. `SemanticModel` answers semantic queries (`GetSymbolInfo`, `GetTypeInfo`, diagnostics).
+4. Emit phase lowers bound trees and writes IL/PE + PDB.
+
+Primary IDE path:
+1. `Workspace` exposes the current `Solution` snapshot.
+2. A feature gets a `Document`, asks for its `SyntaxTree`/`SemanticModel` (`await document.GetSemanticModelAsync(ct)`).
+3. The feature computes changes and returns a new `Document`/`Solution` (immutable update), which the host applies.
+
+## Active vs. Legacy
+
+| Area | Status | Notes |
+|------|--------|-------|
+| `src/Compilers`, `src/Workspaces`, `src/Features`, `src/LanguageServer` | Active | Primary development. |
+| `src/Razor` | Active | Merged sub-tree; follow `.github/instructions/Razor.instructions.md`. |
+| `eng/common`, `eng/config/globalconfigs` | Generated/Managed | Synced by DARC/Arcade — do not hand-edit `eng/common`. |
+| Generated `*.Generated.cs`, `Syntax.xml`-derived files | Generated | Regenerate via `dotnet run --file eng/generate-compiler-code.cs`. |

--- a/.github/memory/CONVENTIONS.md
+++ b/.github/memory/CONVENTIONS.md
@@ -1,0 +1,65 @@
+---
+coverage: Repo-wide code style, naming, immutability, resource & public-API rules (layer-specific conventions live in the instruction files)
+---
+
+# Conventions
+
+Authoritative formatting lives in `.editorconfig`; path-scoped rules live in `.github/instructions/{Compiler,IDE,Razor}.instructions.md` and apply automatically to files under their globs. This file holds only **repo-wide** conventions.
+
+**Layer-specific conventions live in the path-scoped instruction files — read the one for your area:**
+- MEF service/analyzer exports, per-language services, code-fix patterns → `.github/instructions/IDE.instructions.md` (these do **not** apply to the compiler).
+- Code generation, performance/pooling patterns → `.github/instructions/Compiler.instructions.md`.
+
+## Naming Conventions
+
+- **Namespaces:** `Microsoft.CodeAnalysis.[Language].[Area]` (e.g., `Microsoft.CodeAnalysis.CSharp.Formatting`).
+- **Private fields:** `_camelCase`.
+- **Types/methods/properties:** PascalCase. Interfaces prefixed `I`.
+
+## Code Style
+
+From `.editorconfig`:
+- Indentation: 4 spaces for `*.cs`/`*.vb`; 2 spaces for project/XML/JSON/PS1/SH files. Never tabs.
+- `*.cs`/`*.vb`: `insert_final_newline = true`, `charset = utf-8-bom`.
+- **Blank lines must contain no whitespace** (no spaces/tabs) — this is a hard lint failure.
+- **No trailing whitespace.**
+- File-scoped namespaces and `var`/expression-body preferences are enforced via editorconfig analyzers — follow the file you are editing.
+
+Running the formatter:
+- `dotnet format whitespace --folder . --include <path>` (the `--folder .`/`--include` form avoids a slow design-time build).
+
+## Patterns in Active Use
+
+### Immutability (all layers)
+```csharp
+// Use With*/Add*/Replace* to produce new instances — never mutate.
+// IDE/workspace: oldDocument.WithSyntaxRoot(newRoot)
+// Compiler:      compilation.ReplaceSyntaxTree(oldTree, newTree)
+
+// Always thread CancellationToken through async/semantic calls.
+var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
+var symbolInfo = semanticModel.GetSymbolInfo(expression, cancellationToken);
+```
+
+## Patterns Explicitly Avoided
+
+- **No `TODO` or `TODO2` comments** — CI correctness leg flags `TODO`. Track follow-up work as a GitHub issue and link it in code (e.g. `// https://github.com/dotnet/roslyn/issues/NNNN`). Existing `TODO2` markers are a frozen baseline from when enforcement started, not a pattern to follow.
+- **No `PROTOTYPE` comments in PRs targeting `main`** — CI enforces removal (they are allowed only on feature branches).
+- **Do not hand-edit generated code** (`Syntax.xml`/`BoundNodes.xml`-derived `.cs`, `eng/common`, `*.xlf` content beyond the regen tool).
+- **Do not break layering** — lower layers (Compilers) must not reference higher layers (Workspaces/Features/IDE). See `docs/Layering.md`.
+
+## Resources, Localization & Public API
+
+- Resource strings live in `.resx`, accessed via generated designer classes (`CSharpResources`, `FeaturesResources`, `AnalyzersResources`, …).
+- After editing a `.resx`, run `dotnet msbuild <project.csproj> /t:UpdateXlf` to refresh the `.xlf` translation files.
+- When adding/changing public APIs, update the project's `PublicAPI.Unshipped.txt` (the PublicApiAnalyzer / RS0016 enforces this).
+
+## Language / Framework Constraints
+
+- SDK pinned in `global.json` (currently .NET SDK `10.0.x`); VS toolset `17.14`.
+- Arcade-based build (`Microsoft.DotNet.Arcade.Sdk`); package versions centralized in `Directory.Packages.props`.
+
+## Documentation Files
+
+- New docs use **kebab-case** filenames (e.g., `roslyn-language-server-copilot-plugin.md`, not `Roslyn Language Server Copilot Plugin.md`).
+- Place docs in the appropriate `docs/` subdirectory (`docs/contributing/`, `docs/compilers/`, `docs/features/`, …); general docs that don't fit a subdirectory go directly in `docs/`.

--- a/.github/memory/FILE_MAP.md
+++ b/.github/memory/FILE_MAP.md
@@ -1,0 +1,38 @@
+---
+coverage: Top-level src/ overview; per-layer directory detail lives in the instruction files
+---
+
+# File Map
+
+Source lives under `src/`. Build orchestration is in `eng/` and root scripts; docs in `docs/`. A pervasive convention: a product project `X` has its tests in a sibling `XTest` / `*.UnitTests` project (e.g., `Workspaces/Core` ↔ `Workspaces/CoreTest`).
+
+This file is a **top-level map only**. For per-area directory detail, read the matching path-scoped instruction file:
+- Compiler areas → `.github/instructions/Compiler.instructions.md`
+- IDE areas → `.github/instructions/IDE.instructions.md`
+- Razor → `.github/instructions/Razor.instructions.md`
+
+## `src/` Areas
+
+| Area | Layer | Purpose |
+|------|-------|---------|
+| `Compilers/` | compiler | C#/VB compilers (`Core`, `CSharp`, `VisualBasic`, `Server`). |
+| `Dependencies/` | compiler | High-performance pooled collections & threading. |
+| `ExpressionEvaluator/` | compiler | Debugger expression evaluator. |
+| `Tools/` | compiler | Compiler tooling (BuildBoss, format tools). |
+| `Workspaces/` | ide | Solution/Project/Document model, MSBuild loading, Remote (OOP). |
+| `Features/`, `EditorFeatures/` | ide | IDE feature logic and editor integration. |
+| `Analyzers/`, `CodeStyle/` | ide | IDE0xxx code-style analyzers & fixes. |
+| `LanguageServer/` | ide | LSP server. |
+| `VisualStudio/` | ide | VS language services & UI. |
+| `Razor/src/` | razor | Razor compiler + tooling (own sub-tree layout). |
+| `Scripting/`, `Interactive/` | — | C#/VB scripting engine and REPL. |
+| `RoslynAnalyzers/` | — | Shipping `Microsoft.CodeAnalysis.*` analyzer packages. |
+| `Deployment/`, `NuGet/`, `Setup/`, `Test/` | — | Deployment/VSIX, packaging, shared test infrastructure. |
+
+## Non-source Roots
+
+| Path | Status | Purpose |
+|------|--------|---------|
+| `eng/` | Config / Generated | Arcade build engineering. `eng/common/` is DARC-synced — do not hand-edit. `eng/generate-compiler-code.cs` regenerates compiler code. |
+| `docs/` | Active | Contributor & design docs. New docs use kebab-case filenames in the right subdirectory. |
+| Root | Config | Entry points & solution filters: `build.sh`/`Build.cmd`, `test.sh`/`Test.cmd`, `Roslyn.slnx`, `Compilers.slnf`, `Ide.slnf`, `Razor.slnf`, `global.json`, `Directory.*.props/targets`, `Directory.Packages.props`. |

--- a/.github/memory/INDEX.md
+++ b/.github/memory/INDEX.md
@@ -18,17 +18,22 @@ This is the loading map for the agent knowledge base under `.github/memory/`. **
 | **`KNOWN_ISSUES.md`** | Repo-wide / cross-cutting quirks & workarounds | Always for code review; unfamiliar areas |
 | **`TESTING_STRATEGY.md`** | Test layout & how to run tests | When writing tests or debugging test failures |
 
-## Layer-specific knowledge (in the instruction files)
+## Layer-specific knowledge
 
-Per-layer directory detail, key files/APIs, testing, conventions, and known issues live in the path-scoped **instruction files**, which auto-apply when you edit `.cs`/`.vb` under their glob. Read the one for your area instead of carrying all layers in context:
+Per-layer directory detail, key files/APIs, and coding conventions live in the
+path-scoped **instruction files**, which auto-apply when you edit `.cs`/`.vb`
+under their glob. **Known issues** and **testing** are broken out into dedicated
+per-layer memory files so you load only what the task needs. Read the row for the
+area you're working in:
 
-| Instruction file | Layer (src areas) |
-|------------------|-------------------|
-| `.github/instructions/Compiler.instructions.md` | `Compilers`, `Dependencies`, `ExpressionEvaluator`, `Tools` |
-| `.github/instructions/IDE.instructions.md` | `Analyzers`, `CodeStyle`, `Features`, `Workspaces`, `EditorFeatures`, `VisualStudio`, `LanguageServer` |
-| `.github/instructions/Razor.instructions.md` | `Razor` |
+| Layer (src areas) | Instruction file (rules + dir detail) | Known issues | Testing |
+|-------------------|---------------------------------------|--------------|---------|
+| `Compilers`, `Dependencies`, `ExpressionEvaluator`, `Tools` | `.github/instructions/Compiler.instructions.md` | `known-issues/compiler.md` | `testing/compiler.md` |
+| `Analyzers`, `CodeStyle`, `Features`, `Workspaces`, `EditorFeatures`, `VisualStudio`, `LanguageServer` | `.github/instructions/IDE.instructions.md` | `known-issues/ide.md` | `testing/ide.md` |
+| `Razor` | `.github/instructions/Razor.instructions.md` | `known-issues/razor.md` | `testing/razor.md` |
 
-The repo-wide memory files above hold only cross-cutting content and point into these instruction files for layer specifics.
+The repo-wide memory files above hold only cross-cutting content and point into
+these layer files for specifics.
 
 <!-- Add rows here as new memory files are created -->
 
@@ -53,4 +58,4 @@ When you change the knowledge base, keep this index in sync:
 
 - **Added, removed, or renamed a memory file?** → Update this index.
 - **Significantly changed a file's purpose or scope?** → Update its row in the loading map.
-- **Added layer-specific knowledge?** → Put it in the matching `.github/instructions/<area>.instructions.md`, not in a repo-wide memory file.
+- **Added layer-specific knowledge?** → Known issues go in `known-issues/<area>.md`; test conventions go in `testing/<area>.md`; directory detail, key files/APIs, and coding conventions go in the matching `.github/instructions/<area>.instructions.md`. Keep it out of the repo-wide memory files.

--- a/.github/memory/INDEX.md
+++ b/.github/memory/INDEX.md
@@ -1,0 +1,56 @@
+---
+coverage: Index and loading map for all .github/memory/ knowledge-base files
+---
+
+# Memory Index
+
+This is the loading map for the agent knowledge base under `.github/memory/`. **Read this file first** when starting any task. Load other files **on demand** — and read only the path-scoped **instruction file** for the area you're working in (see below), not all of them. This keeps context small.
+
+## Repo-wide files (load as the task needs)
+
+| File | Purpose | When to load |
+|------|---------|--------------|
+| **`INDEX.md`** (this file) | Discovery map for the knowledge base | Always — read first |
+| **`ARCHITECTURE.md`** | Layered system overview & data flow (one row per layer) | Always for non-trivial tasks |
+| **`CONVENTIONS.md`** | Repo-wide code style, naming, immutability, resource & public-API rules | When writing or reviewing code |
+| **`FILE_MAP.md`** | Top-level `src/` map (one line per area) + layer pointers | When deciding which area/layer to work in |
+| **`API_MAP.md`** | Build/test entry points & PublicAPI tracking | When changing build, tests, or public APIs |
+| **`KNOWN_ISSUES.md`** | Repo-wide / cross-cutting quirks & workarounds | Always for code review; unfamiliar areas |
+| **`TESTING_STRATEGY.md`** | Test layout & how to run tests | When writing tests or debugging test failures |
+
+## Layer-specific knowledge (in the instruction files)
+
+Per-layer directory detail, key files/APIs, testing, conventions, and known issues live in the path-scoped **instruction files**, which auto-apply when you edit `.cs`/`.vb` under their glob. Read the one for your area instead of carrying all layers in context:
+
+| Instruction file | Layer (src areas) |
+|------------------|-------------------|
+| `.github/instructions/Compiler.instructions.md` | `Compilers`, `Dependencies`, `ExpressionEvaluator`, `Tools` |
+| `.github/instructions/IDE.instructions.md` | `Analyzers`, `CodeStyle`, `Features`, `Workspaces`, `EditorFeatures`, `VisualStudio`, `LanguageServer` |
+| `.github/instructions/Razor.instructions.md` | `Razor` |
+
+The repo-wide memory files above hold only cross-cutting content and point into these instruction files for layer specifics.
+
+<!-- Add rows here as new memory files are created -->
+
+## Related Existing Docs
+
+This repo predates this knowledge base and has authoritative docs the memory files cross-reference:
+
+- `AGENTS.md` — thin root pointer to `.github/copilot-instructions.md` (the canonical repo-wide guidance).
+- `.github/instructions/{Compiler,IDE,Razor}.instructions.md` — path-scoped layer rules **and** knowledge, applied automatically by area.
+- `.github/skills/*/SKILL.md` — task-specific skills (code-review, ci-analysis, snap, merge-into-branch, update-docs, etc.).
+- `docs/` — deep-dive docs (`docs/wiki/Roslyn-Overview.md`, `docs/Layering.md`, `docs/area-owners.md`).
+
+## Conventions
+
+- **Treat memory files as authoritative for repo conventions, but cross-check against actual code** — they can drift.
+- **Prefer small focused files over large monolithic ones.** Keep layer-specific detail in the matching `.github/instructions/<area>.instructions.md`, not in the repo-wide memory files.
+- **New files should have minimal frontmatter** with a `coverage:` field describing what the file covers.
+
+## Maintenance
+
+When you change the knowledge base, keep this index in sync:
+
+- **Added, removed, or renamed a memory file?** → Update this index.
+- **Significantly changed a file's purpose or scope?** → Update its row in the loading map.
+- **Added layer-specific knowledge?** → Put it in the matching `.github/instructions/<area>.instructions.md`, not in a repo-wide memory file.

--- a/.github/memory/INDEX.md
+++ b/.github/memory/INDEX.md
@@ -43,7 +43,7 @@ This repo predates this knowledge base and has authoritative docs the memory fil
 
 - `AGENTS.md` — thin root pointer to `.github/copilot-instructions.md` (the canonical repo-wide guidance).
 - `.github/instructions/{Compiler,IDE,Razor}.instructions.md` — path-scoped layer rules **and** knowledge, applied automatically by area.
-- `.github/skills/*/SKILL.md` — task-specific skills (code-review, ci-analysis, snap, merge-into-branch, update-docs, etc.).
+- `.github/skills/*/SKILL.md` — task-specific skills (code-review, ci-analysis, snap, merge-into-branch, update-agent-docs, etc.).
 - `docs/` — deep-dive docs (`docs/wiki/Roslyn-Overview.md`, `docs/Layering.md`, `docs/area-owners.md`).
 
 ## Conventions

--- a/.github/memory/INDEX.md
+++ b/.github/memory/INDEX.md
@@ -16,7 +16,7 @@ This is the loading map for the agent knowledge base under `.github/memory/`. **
 | **`FILE_MAP.md`** | Top-level `src/` map (one line per area) + layer pointers | When deciding which area/layer to work in |
 | **`API_MAP.md`** | Build/test entry points & PublicAPI tracking | When changing build, tests, or public APIs |
 | **`KNOWN_ISSUES.md`** | Repo-wide / cross-cutting quirks & workarounds | Always for code review; unfamiliar areas |
-| **`TESTING_STRATEGY.md`** | Test layout & how to run tests | When writing tests or debugging test failures |
+| **`TESTING_STRATEGY.md`** | Test layout, shared authoring conventions & how to run tests | When writing tests or debugging test failures |
 
 ## Layer-specific knowledge
 

--- a/.github/memory/KNOWN_ISSUES.md
+++ b/.github/memory/KNOWN_ISSUES.md
@@ -1,13 +1,14 @@
 ---
-coverage: Repo-wide / cross-cutting quirks and workarounds; layer-specific issues live in the instruction files
+coverage: Repo-wide / cross-cutting quirks and workarounds; layer-specific issues live in known-issues/{compiler,ide,razor}.md
 ---
 
 # Known Issues
 
-Repo-wide and cross-cutting issues only. Layer-specific gotchas live in the path-scoped instruction files:
-- Compiler → `.github/instructions/Compiler.instructions.md`
-- IDE (ServiceHub OOP, RS0016 contentFiles) → `.github/instructions/IDE.instructions.md`
-- Razor (duplicate globalconfig keys, `.projitems`) → `.github/instructions/Razor.instructions.md`
+Repo-wide and cross-cutting issues only. Layer-specific gotchas live in dedicated
+per-layer files (load only the one for your area):
+- Compiler → `.github/memory/known-issues/compiler.md`
+- IDE (spurious RS0016, MEF composition failures) → `.github/memory/known-issues/ide.md`
+- Razor (duplicate globalconfig keys, `.projitems`, build-wrapper `-projects`) → `.github/memory/known-issues/razor.md`
 
 ## Blank lines with whitespace fail linting
 

--- a/.github/memory/KNOWN_ISSUES.md
+++ b/.github/memory/KNOWN_ISSUES.md
@@ -7,8 +7,8 @@ coverage: Repo-wide / cross-cutting quirks and workarounds; layer-specific issue
 Repo-wide and cross-cutting issues only. Layer-specific gotchas live in dedicated
 per-layer files (load only the one for your area):
 - Compiler → `.github/memory/known-issues/compiler.md`
-- IDE (spurious RS0016, MEF composition failures) → `.github/memory/known-issues/ide.md`
-- Razor (duplicate globalconfig keys, `.projitems`, build-wrapper `-projects`) → `.github/memory/known-issues/razor.md`
+- IDE → `.github/memory/known-issues/ide.md`
+- Razor → `.github/memory/known-issues/razor.md`
 
 ## Blank lines with whitespace fail linting
 

--- a/.github/memory/KNOWN_ISSUES.md
+++ b/.github/memory/KNOWN_ISSUES.md
@@ -1,0 +1,36 @@
+---
+coverage: Repo-wide / cross-cutting quirks and workarounds; layer-specific issues live in the instruction files
+---
+
+# Known Issues
+
+Repo-wide and cross-cutting issues only. Layer-specific gotchas live in the path-scoped instruction files:
+- Compiler → `.github/instructions/Compiler.instructions.md`
+- IDE (ServiceHub OOP, RS0016 contentFiles) → `.github/instructions/IDE.instructions.md`
+- Razor (duplicate globalconfig keys, `.projitems`) → `.github/instructions/Razor.instructions.md`
+
+## Blank lines with whitespace fail linting
+
+**Affected area:** all `*.cs` / `*.vb`
+**Description:** Blank lines containing any space or tab fail lint/format; trailing whitespace also fails.
+**Workaround:** Keep blank lines completely empty; run `dotnet format whitespace --folder . --include <path>`.
+
+## Generated code must not be hand-edited
+
+**Affected area:** `Syntax.xml`/`BoundNodes.xml`-derived `.cs`, `eng/common`, `*.xlf`
+**Description:** These are produced by generators or external sync (DARC/Arcade); manual edits are overwritten or break builds.
+**Workaround:** Edit the source (XML/`.resx`), then regenerate (`dotnet run --file eng/generate-compiler-code.cs`, or `/t:UpdateXlf` for `.xlf`). Never edit `eng/common` by hand.
+
+## TODO / PROTOTYPE comments are CI-gated
+
+**Affected area:** whole repo, PRs targeting `main`
+**Description:** CI flags `TODO` comments; PROTOTYPE comments are disallowed in PRs to `main`.
+**Guidance:** Do **not** add new `TODO` or `TODO2` comments. Track follow-up work as a GitHub issue and link it in code (e.g. `// See https://github.com/dotnet/roslyn/issues/NNNN`). Existing `TODO2` markers are only a frozen baseline from when enforcement was introduced — they are not a pattern to copy. Remove all `PROTOTYPE` markers before merging to `main` (allowed only on feature branches).
+
+## Environmental test failures (not code bugs)
+
+**Affected area:** full `test.sh`/`Test.cmd` runs
+**Description:** A few tests fail for environment reasons unrelated to changes:
+- `RuntimeHostInfoTests.DotNetInPath_Symlinked` requires symlink-creation privilege (run elevated).
+- `Workspaces.MSBuild` `NewlyCreatedProjectsFromDotNetNew.Validate*TemplateProjects` fail without mobile (ios/tvos/macos/maccatalyst) dotnet workloads installed.
+**Workaround:** Prefer targeted test projects; treat these specific failures as environmental.

--- a/.github/memory/TESTING_STRATEGY.md
+++ b/.github/memory/TESTING_STRATEGY.md
@@ -1,13 +1,14 @@
 ---
-coverage: Repo-wide test layout & how to run tests; per-layer test base classes live in the instruction files
+coverage: Repo-wide test layout & how to run tests; per-layer test base classes live in testing/{compiler,ide,razor}.md
 ---
 
 # Testing Strategy
 
-Repo-wide test layout and run commands. **Per-layer test base classes and conventions** live in the path-scoped instruction files:
-- Compiler (`CSharpTestBase`, `VerifyEmitDiagnostics`) → `.github/instructions/Compiler.instructions.md`
-- IDE (`AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest_NoEditor`, `[UseExportProvider]`, `TestInRegularAndScriptAsync`) → `.github/instructions/IDE.instructions.md`
-- Razor (`TestCode` span markers) → `.github/instructions/Razor.instructions.md`
+Repo-wide test layout and run commands. **Per-layer test base classes and
+conventions** live in dedicated per-layer files (load only the one for your area):
+- Compiler (`CSharpTestBase`, `VerifyEmitDiagnostics`) → `.github/memory/testing/compiler.md`
+- IDE (`AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest_NoEditor`, `[UseExportProvider]`, `TestInRegularAndScriptAsync`) → `.github/memory/testing/ide.md`
+- Razor (`TestCode` span markers) → `.github/memory/testing/razor.md`
 
 ## Test Layout
 

--- a/.github/memory/TESTING_STRATEGY.md
+++ b/.github/memory/TESTING_STRATEGY.md
@@ -1,11 +1,12 @@
 ---
-coverage: Repo-wide test layout & how to run tests; per-layer test base classes live in testing/{compiler,ide,razor}.md
+coverage: Repo-wide test layout, run commands, and shared authoring conventions; per-layer test base classes live in testing/{compiler,ide,razor}.md
 ---
 
 # Testing Strategy
 
-Repo-wide test layout and run commands. **Per-layer test base classes and
-conventions** live in dedicated per-layer files (load only the one for your area):
+Repo-wide test layout, run commands, and shared authoring conventions. **Per-layer
+test base classes and conventions** live in dedicated per-layer files (load only
+the one for your area):
 - Compiler (`CSharpTestBase`, `VerifyEmitDiagnostics`) → `.github/memory/testing/compiler.md`
 - IDE (`AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest_NoEditor`, `[UseExportProvider]`, `TestInRegularAndScriptAsync`) → `.github/memory/testing/ide.md`
 - Razor (`TestCode` span markers) → `.github/memory/testing/razor.md`
@@ -25,7 +26,10 @@ Frameworks: xUnit with Roslyn test utilities.
 
 - Prefer raw string literals (`"""..."""`) over verbatim strings for test source code.
 - Keep tests focused: use `.Single()` rather than asserting a count then indexing.
-- For issue-linked changes add `[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/1234")]`.
+- For issue-linked changes, add a `WorkItem` attribute next to the test
+  attribute, e.g. `[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/1234")]`
+  or `[Theory, WorkItem("https://github.com/dotnet/roslyn/issues/1234")]`.
+  Use the originating GitHub issue/PR or Azure DevOps work item URL.
 
 ## Running Tests
 

--- a/.github/memory/TESTING_STRATEGY.md
+++ b/.github/memory/TESTING_STRATEGY.md
@@ -1,0 +1,49 @@
+---
+coverage: Repo-wide test layout & how to run tests; per-layer test base classes live in the instruction files
+---
+
+# Testing Strategy
+
+Repo-wide test layout and run commands. **Per-layer test base classes and conventions** live in the path-scoped instruction files:
+- Compiler (`CSharpTestBase`, `VerifyEmitDiagnostics`) → `.github/instructions/Compiler.instructions.md`
+- IDE (`AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest_NoEditor`, `[UseExportProvider]`, `TestInRegularAndScriptAsync`) → `.github/instructions/IDE.instructions.md`
+- Razor (`TestCode` span markers) → `.github/instructions/Razor.instructions.md`
+
+## Test Layout
+
+| Type | Location convention |
+|------|---------------------|
+| Unit tests | Sibling `*Test` / `*.UnitTests` project next to the product project (e.g., `Workspaces/Core` ↔ `Workspaces/CoreTest`). |
+| Compiler tests | `src/Compilers/*/Test/`. |
+| IDE/analyzer tests | `*Test` projects under `src/Features`, `src/Analyzers`, `src/EditorFeatures`. |
+| Integration tests | VS integration tests (`azure-pipelines-integration*.yml`); runnable locally on **Windows** hosts with a VS install, also run in CI. |
+
+Frameworks: xUnit with Roslyn test utilities.
+
+## Repo-wide Authoring Conventions
+
+- Prefer raw string literals (`"""..."""`) over verbatim strings for test source code.
+- Keep tests focused: use `.Single()` rather than asserting a count then indexing.
+- For issue-linked changes add `[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/1234")]`.
+
+## Running Tests
+
+### During development (preferred — targeted)
+```bash
+dotnet test <path/to/Specific.UnitTests.csproj>
+dotnet test <proj> --filter "FullyQualifiedName~MyTestClass"
+```
+Targeted runs are strongly preferred — the full suite is large and slow. Tests can take a while to build/run; wait for completion unless you're confident a run is hung.
+
+### Full suite (final validation only)
+```bash
+./test.sh        # or Test.cmd on Windows
+```
+
+### Test types to be aware of
+- VS integration tests (`azure-pipelines-integration*.yml`) require a VS install, so they run only on **Windows** hosts (not CI-only — they can be run locally on Windows). Prefer unit tests for the inner development loop; reach for integration tests when validating end-to-end VS behavior.
+- A handful of tests fail only for environmental reasons — see `KNOWN_ISSUES.md`.
+
+## CI
+
+PR validation runs via `azure-pipelines-pr-validation.yml` (Azure DevOps + Helix). For investigating failures, use the `ci-analysis`, `helix-investigation`, and `integration-test-analysis` skills.

--- a/.github/memory/TESTING_STRATEGY.md
+++ b/.github/memory/TESTING_STRATEGY.md
@@ -51,4 +51,4 @@ Targeted runs are strongly preferred — the full suite is large and slow. Tests
 
 ## CI
 
-PR validation runs via `azure-pipelines-pr-validation.yml` (Azure DevOps + Helix). For investigating failures, use the `ci-analysis`, `helix-investigation`, and `integration-test-analysis` skills.
+PR validation runs via `azure-pipelines-pr-validation.yml` (Azure DevOps + Helix). For investigating failures, use the `ci-analysis` and `integration-test-analysis` skills.

--- a/.github/memory/known-issues/compiler.md
+++ b/.github/memory/known-issues/compiler.md
@@ -1,0 +1,14 @@
+---
+coverage: Compiler-layer (src/{Compilers,Dependencies,ExpressionEvaluator,Tools}) known issues, quirks & workarounds
+---
+
+# Compiler — Known Issues
+
+Layer-specific quirks for the compiler. Load when working under
+`src/{Compilers,Dependencies,ExpressionEvaluator,Tools}`. Cross-cutting issues
+(generated code, CI marker gating, environmental test failures) live in
+`.github/memory/KNOWN_ISSUES.md`.
+
+_No compiler-specific known issues are currently documented. Add entries here as
+they are discovered, using the `Affected area` / `Description` / `Workaround`
+shape from the repo-wide `KNOWN_ISSUES.md`._

--- a/.github/memory/known-issues/ide.md
+++ b/.github/memory/known-issues/ide.md
@@ -1,0 +1,18 @@
+---
+coverage: IDE-layer (src/{Analyzers,CodeStyle,Features,Workspaces,EditorFeatures,VisualStudio,LanguageServer}) known issues, quirks & workarounds
+---
+
+# IDE — Known Issues
+
+Layer-specific quirks for the IDE/Workspaces stack. Load when working under
+`src/{Analyzers,CodeStyle,Features,Workspaces,EditorFeatures,VisualStudio,LanguageServer}`.
+Cross-cutting issues live in `.github/memory/KNOWN_ISSUES.md`.
+
+## MEF composition failures surface as test failures
+
+**Affected area:** MEF-dependent IDE/Workspaces tests
+**Description:** A missing/incorrect MEF export attribute often manifests as an
+unrelated-looking test failure rather than a clear composition error.
+**Workaround:** When IDE tests fail unexpectedly, check the export attributes
+first (`[ExportLanguageService]`/`[ExportWorkspaceService]`, `[Shared]`,
+`[ImportingConstructor]` + `[Obsolete(MefConstruction.ImportingConstructorMessage)]`).

--- a/.github/memory/known-issues/razor.md
+++ b/.github/memory/known-issues/razor.md
@@ -1,0 +1,39 @@
+---
+coverage: Razor-layer (src/Razor) known issues, quirks & workarounds
+---
+
+# Razor — Known Issues
+
+Layer-specific quirks for Razor tooling/compiler. Load when working under
+`src/Razor`. Cross-cutting issues live in `.github/memory/KNOWN_ISSUES.md`.
+
+## Build wrappers can mangle a semicolon-delimited `-projects` list
+
+**Affected area:** `build.cmd` / PowerShell build wrappers
+**Description:** Passing a semicolon-delimited project list through a nested
+PowerShell invocation can make PowerShell treat `;` as a statement separator and
+even open `.csproj` files in Visual Studio.
+**Workaround:** Build a single project at a time, or invoke the underlying script
+so the full `-projects` value is preserved as one argument.
+
+## Shared projects need `.projitems` entries
+
+**Affected area:** `Microsoft.CodeAnalysis.Razor.CohostingShared` (and its
+`.UnitTests`) shared projects
+**Description:** Files under
+`src\Razor\src\Razor\src\Microsoft.CodeAnalysis.Razor.CohostingShared\` and
+`src\Razor\src\Razor\test\Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests\`
+are compiled through their `.projitems` files. Adding a new `.cs` file to the
+shared tree is not enough on its own.
+**Workaround:** Also add a matching `<Compile Include="...">` entry to
+`Microsoft.CodeAnalysis.Razor.CohostingShared.projitems` or
+`Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests.projitems`, or the file
+won't be built/tested by the importing projects.
+
+## Duplicate global analyzer config keys (`MultipleGlobalAnalyzerKeys`)
+
+**Affected area:** Razor projects, which receive global configs from both
+`eng/config/globalconfigs/*.globalconfig` and `src/Razor/*.globalconfig` overlays
+**Description:** The same key in two global configs causes compiler error
+`MultipleGlobalAnalyzerKeys`, and the key is left unset.
+**Workaround:** Don't redefine a key already present in the base config.

--- a/.github/memory/testing/compiler.md
+++ b/.github/memory/testing/compiler.md
@@ -1,0 +1,45 @@
+---
+coverage: Compiler-layer (src/{Compilers,Dependencies,ExpressionEvaluator,Tools}) test base classes & authoring conventions
+---
+
+# Compiler — Testing
+
+Layer-specific test guidance for the compiler. Load when writing/modifying tests
+under `src/Compilers/*/Test/`. Repo-wide layout and run commands live in
+`.github/memory/TESTING_STRATEGY.md`.
+
+## Test structure
+
+Inherit from language-specific base classes: `CSharpTestBase` for C#,
+`VisualBasicTestBase` for VB.
+
+```cs
+public class MyTests : CSharpTestBase
+{
+    [Fact]
+    public void TestMethod()
+    {
+        var comp = CreateCompilation(sourceCode);
+        // Test compilation, symbols, diagnostics
+    }
+}
+```
+
+## Conventions
+
+- **Unit tests** target individual compiler phases (lexing, parsing); **compilation
+  tests** create `Compilation` objects and verify symbols/diagnostics.
+- **Cross-language patterns**: many test patterns work for both C# and VB with
+  minor syntax changes.
+- **Verification baselines**: when helpers like `VerifyDiagnostics`,
+  `VerifyEmitDiagnostics`, `VerifyIL`, and similar compiler test APIs fail with an
+  `Actual:` block containing the expected content, copy that block directly into
+  the verification call.
+- **Use `comp.VerifyEmitDiagnostics()`** (rather than only `VerifyDiagnostics`) so
+  reviewers can see whether the code under test is legal.
+- **Keep tests focused**: do the minimal work to reach the core assertions; use
+  `Single()` instead of checking counts then indexing.
+- **Prefer raw string literals** (`"""..."""`) over verbatim strings (`@"..."`)
+  for test source code.
+- **Link work items**: for issue-driven changes add a `WorkItem` alongside the
+  test attribute, e.g. `[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/1234")]`.

--- a/.github/memory/testing/compiler.md
+++ b/.github/memory/testing/compiler.md
@@ -4,9 +4,7 @@ coverage: Compiler-layer (src/{Compilers,Dependencies,ExpressionEvaluator,Tools}
 
 # Compiler — Testing
 
-Layer-specific test guidance for the compiler. Load when writing/modifying tests
-under `src/Compilers/*/Test/`. Repo-wide layout and run commands live in
-`.github/memory/TESTING_STRATEGY.md`.
+Layer-specific test guidance for compiler tests under `src/Compilers/*/Test/`.
 
 ## Test structure
 
@@ -41,5 +39,3 @@ public class MyTests : CSharpTestBase
   `Single()` instead of checking counts then indexing.
 - **Prefer raw string literals** (`"""..."""`) over verbatim strings (`@"..."`)
   for test source code.
-- **Link work items**: for issue-driven changes add a `WorkItem` alongside the
-  test attribute, e.g. `[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/1234")]`.

--- a/.github/memory/testing/ide.md
+++ b/.github/memory/testing/ide.md
@@ -4,9 +4,8 @@ coverage: IDE-layer (src/{Analyzers,CodeStyle,Features,Workspaces,EditorFeatures
 
 # IDE — Testing
 
-Layer-specific test guidance for the IDE/Workspaces stack. Load when
-writing/modifying tests under `src/{Features,Analyzers,EditorFeatures,...}`.
-Repo-wide layout and run commands live in `.github/memory/TESTING_STRATEGY.md`.
+Layer-specific test guidance for the IDE/Workspaces stack under
+`src/{Features,Analyzers,EditorFeatures,...}`.
 
 ## Test workspace (MEF-dependent tests)
 
@@ -36,5 +35,3 @@ public class MyTests
   test source code.
 - Keep tests focused — avoid unnecessary intermediary assertions; use `.Single()`
   rather than asserting a count then indexing.
-- Link work items: for issue-driven changes add a `WorkItem`, e.g.
-  `[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/1234")]`.

--- a/.github/memory/testing/ide.md
+++ b/.github/memory/testing/ide.md
@@ -1,0 +1,40 @@
+---
+coverage: IDE-layer (src/{Analyzers,CodeStyle,Features,Workspaces,EditorFeatures,VisualStudio,LanguageServer}) test base classes & authoring conventions
+---
+
+# IDE — Testing
+
+Layer-specific test guidance for the IDE/Workspaces stack. Load when
+writing/modifying tests under `src/{Features,Analyzers,EditorFeatures,...}`.
+Repo-wide layout and run commands live in `.github/memory/TESTING_STRATEGY.md`.
+
+## Test workspace (MEF-dependent tests)
+
+```csharp
+[UseExportProvider]
+public class MyTests
+{
+    [Fact]
+    public async Task TestSomething()
+    {
+        var workspace = EditorTestWorkspace.CreateCSharp("class C { }");
+        var document = workspace.Documents.Single();
+    }
+}
+```
+
+## Conventions
+
+- Use `[UseExportProvider]` for any test that depends on MEF services (a missing
+  attribute typically surfaces as an unrelated-looking failure).
+- Analyzer tests inherit from
+  `AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest_NoEditor` (and the VB
+  equivalents).
+- For analyzer/code-fix tests, use `TestInRegularAndScriptAsync` /
+  `TestMissingInRegularAndScriptAsync`.
+- Prefer raw string literals (`"""..."""`) over verbatim strings (`@"..."`) for
+  test source code.
+- Keep tests focused — avoid unnecessary intermediary assertions; use `.Single()`
+  rather than asserting a count then indexing.
+- Link work items: for issue-driven changes add a `WorkItem`, e.g.
+  `[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/1234")]`.

--- a/.github/memory/testing/razor.md
+++ b/.github/memory/testing/razor.md
@@ -1,0 +1,23 @@
+---
+coverage: Razor-layer (src/Razor) test base classes & authoring conventions
+---
+
+# Razor — Testing
+
+Layer-specific test guidance for Razor tooling/compiler. Load when
+writing/modifying tests under `src/Razor`. Repo-wide layout and run commands live
+in `.github/memory/TESTING_STRATEGY.md`.
+
+## Conventions
+
+- Use `TestCode` with `[|...|]` span markers for before/after scenarios. Access
+  `input.Text` (cleaned) and `input.Span` (the marked range).
+- Prefer raw string literals (`"""..."""`) over verbatim strings (`@"..."`).
+- Test end-user scenarios, not implementation details.
+- Verify/helper methods go at the bottom of test files; new test methods go above
+  them.
+- New tooling tests go in
+  `src\Razor\src\Razor\test\Microsoft.VisualStudioCode.RazorExtension.UnitTests`
+  (Cohosting architecture).
+- Integration tests using `AdditionalSyntaxTrees` for tag helper discovery must
+  set `UseTwoPhaseCompilation => true` (see `ComponentDiscoveryIntegrationTest`).

--- a/.github/memory/testing/razor.md
+++ b/.github/memory/testing/razor.md
@@ -4,9 +4,7 @@ coverage: Razor-layer (src/Razor) test base classes & authoring conventions
 
 # Razor — Testing
 
-Layer-specific test guidance for Razor tooling/compiler. Load when
-writing/modifying tests under `src/Razor`. Repo-wide layout and run commands live
-in `.github/memory/TESTING_STRATEGY.md`.
+Layer-specific test guidance for Razor tooling/compiler tests under `src/Razor`.
 
 ## Conventions
 

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -78,8 +78,9 @@ Code changes frequently outdate the agent knowledge base, but it's easy to miss 
 
 Launch a sub-agent (e.g., the `explore` or `task` agent) with the PR diff and list of changed files, and instruct it to verify whether the change should have updated — but didn't — any of the repo's living documentation:
 
-- **Knowledge base** (`.github/memory/`): `FILE_MAP.md` (files added/moved/renamed), `API_MAP.md`, `ARCHITECTURE.md`, `CONVENTIONS.md` (new patterns), `KNOWN_ISSUES.md` (surprising behavior/workarounds), `TESTING_STRATEGY.md`, and `INDEX.md` (if memory files were added/removed/renamed).
-- **Path-scoped instruction files** (`.github/instructions/{Compiler,IDE,Razor}.instructions.md`): layer-specific directory detail, key files/APIs, diagnostic IDs, conventions, testing, and gotchas for the area the change touches.
+- **Knowledge base** (`.github/memory/`): `FILE_MAP.md` (files added/moved/renamed), `API_MAP.md`, `ARCHITECTURE.md`, `CONVENTIONS.md` (new patterns), `KNOWN_ISSUES.md` (repo-wide surprising behavior/workarounds), `TESTING_STRATEGY.md` (repo-wide test layout), and `INDEX.md` (if memory files were added/removed/renamed).
+- **Per-layer memory files**: `.github/memory/known-issues/{compiler,ide,razor}.md` (layer-specific quirks/workarounds) and `.github/memory/testing/{compiler,ide,razor}.md` (layer-specific test base classes/conventions) for the area the change touches.
+- **Path-scoped instruction files** (`.github/instructions/{Compiler,IDE,Razor}.instructions.md`): layer-specific directory detail, key files/APIs, diagnostic IDs, and coding conventions for the area the change touches.
 - **Entry points**: `.github/copilot-instructions.md` and `AGENTS.md` when build/test/orientation guidance changes.
 
 The sub-agent should cross-check the diff against the `update-docs` skill checklist (`.github/skills/update-docs/SKILL.md`) and report, for each gap, **which doc file** is now stale or incomplete and **what specific update** is needed. Only flag genuine omissions — do not invent busywork. If the PR already updated the relevant docs, confirm that and move on.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -72,6 +72,20 @@ Now read the PR description, labels, linked issues (in full), author information
 9. **Ensure code suggestions are valid.** Any code you suggest must be syntactically correct and complete. Ensure any suggestion would result in working code.
 10. **Label in-scope vs. follow-up.** Distinguish between issues the PR should fix and out-of-scope improvements. Be explicit when a suggestion is a follow-up rather than a blocker.
 
+### Step 4: Documentation Freshness Check (sub-agent)
+
+Code changes frequently outdate the agent knowledge base, but it's easy to miss during a code-focused review. Delegate this to a dedicated sub-agent so it doesn't dilute the primary review's focus. If the environment cannot launch sub-agents, perform this check inline instead.
+
+Launch a sub-agent (e.g., the `explore` or `task` agent) with the PR diff and list of changed files, and instruct it to verify whether the change should have updated — but didn't — any of the repo's living documentation:
+
+- **Knowledge base** (`.github/memory/`): `FILE_MAP.md` (files added/moved/renamed), `API_MAP.md`, `ARCHITECTURE.md`, `CONVENTIONS.md` (new patterns), `KNOWN_ISSUES.md` (surprising behavior/workarounds), `TESTING_STRATEGY.md`, and `INDEX.md` (if memory files were added/removed/renamed).
+- **Path-scoped instruction files** (`.github/instructions/{Compiler,IDE,Razor}.instructions.md`): layer-specific directory detail, key files/APIs, diagnostic IDs, conventions, testing, and gotchas for the area the change touches.
+- **Entry points**: `.github/copilot-instructions.md` and `AGENTS.md` when build/test/orientation guidance changes.
+
+The sub-agent should cross-check the diff against the `update-docs` skill checklist (`.github/skills/update-docs/SKILL.md`) and report, for each gap, **which doc file** is now stale or incomplete and **what specific update** is needed. Only flag genuine omissions — do not invent busywork. If the PR already updated the relevant docs, confirm that and move on.
+
+Fold the sub-agent's findings into the review output as ⚠️ (or 💡 for minor) **Documentation** findings, and ask the author to make the updates. If a required doc update is missing for a behavior/API change, treat it as merge-blocking per the verdict rules.
+
 ## Multi-Model Review
 
 When the environment supports launching sub-agents with different models (e.g., the `task` tool with a `model` parameter), run the review in parallel across multiple model families to get diverse perspectives. Different models catch different classes of issues. If the environment does not support this, proceed with a single-model review.
@@ -125,6 +139,7 @@ When presenting the final review (whether as a PR comment or as output to the us
   - 💡 for minor suggestions or observations (nice-to-have)
 - **Cross-cutting analysis** should be included when relevant: check whether related code (sibling types, callers, VB compiler) is affected by the same issue or needs a similar fix.
 - **Test quality** should be assessed as its own finding when tests are part of the PR.
+- **Documentation freshness** (from Step 4) should be surfaced as its own finding when the change leaves any knowledge-base or instruction file stale.
 - Keep the review concise but thorough. Every claim should be backed by evidence from the code.
 
 ### Verdict Consistency Rules

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -83,7 +83,7 @@ Launch a sub-agent (e.g., the `explore` or `task` agent) with the PR diff and li
 - **Path-scoped instruction files** (`.github/instructions/{Compiler,IDE,Razor}.instructions.md`): layer-specific directory detail, key files/APIs, diagnostic IDs, and coding conventions for the area the change touches.
 - **Entry points**: `.github/copilot-instructions.md` and `AGENTS.md` when build/test/orientation guidance changes.
 
-The sub-agent should cross-check the diff against the `update-docs` skill checklist (`.github/skills/update-docs/SKILL.md`) and report, for each gap, **which doc file** is now stale or incomplete and **what specific update** is needed. Only flag genuine omissions — do not invent busywork. If the PR already updated the relevant docs, confirm that and move on.
+The sub-agent should cross-check the diff against the `update-agent-docs` skill checklist (`.github/skills/update-agent-docs/SKILL.md`) and report, for each gap, **which doc file** is now stale or incomplete and **what specific update** is needed. Only flag genuine omissions — do not invent busywork. If the PR already updated the relevant docs, confirm that and move on.
 
 Fold the sub-agent's findings into the review output as ⚠️ (or 💡 for minor) **Documentation** findings, and ask the author to make the updates. If a required doc update is missing for a behavior/API change, treat it as merge-blocking per the verdict rules.
 

--- a/.github/skills/update-agent-docs/SKILL.md
+++ b/.github/skills/update-agent-docs/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: update-docs
+name: update-agent-docs
 description: >
   Update the agent knowledge base after making code changes in the Roslyn repo. Run at the end of
   every task that modifies code, adds files, changes public APIs or diagnostics, or establishes new
   patterns. Keeps .github/memory/ fresh and reliable.
 ---
 
-# Update Docs
+# Update Agent Docs
 
 Run at the end of every task that changes code. This is not optional.
 

--- a/.github/skills/update-docs/SKILL.md
+++ b/.github/skills/update-docs/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: update-docs
+description: >
+  Update the agent knowledge base after making code changes in the Roslyn repo. Run at the end of
+  every task that modifies code, adds files, changes public APIs or diagnostics, or establishes new
+  patterns. Keeps .github/memory/ fresh and reliable.
+---
+
+# Update Docs
+
+Run at the end of every task that changes code. This is not optional.
+
+## Checklist
+
+**Files added or moved?** → Update `.github/memory/FILE_MAP.md` (top-level area) and the matching `.github/instructions/<area>.instructions.md` (directory detail).
+
+**Memory file added, removed, renamed, or had its purpose change?** → Update `.github/memory/INDEX.md` and any memory files that reference it.
+
+**Public API changed?** → Update the matching `.github/instructions/<area>.instructions.md` (Compiler/IDE) and the owning project's `PublicAPI.Unshipped.txt` (RS0016 enforces this). `API_MAP.md` covers only repo-wide entry points.
+
+**New compiler error code, IDE diagnostic ID, or resource string added?** → Reflect it in the matching `.github/instructions/<area>.instructions.md`; ensure `ErrorCode.cs` / `IDEDiagnosticIds.cs` / `.resx` (+ `/t:UpdateXlf`) are consistent.
+
+**New pattern established?** → If repo-wide, add to `.github/memory/CONVENTIONS.md`; if layer-specific, add to the matching `.github/instructions/<area>.instructions.md`.
+
+**Surprising or undocumented behavior found?** → Repo-wide → `.github/memory/KNOWN_ISSUES.md`; layer-specific → the matching `.github/instructions/<area>.instructions.md`.
+
+**Changed test base classes, locations, or how to run a suite?** → Repo-wide layout → `.github/memory/TESTING_STRATEGY.md`; layer-specific bases/conventions → the matching `.github/instructions/<area>.instructions.md`.
+
+**Any doc updated?** → No additional tracking needed. Git history tracks changes automatically.
+
+## Creating New Doc Files
+
+If knowledge doesn't fit existing files:
+- Create a new file in `.github/memory/` with a descriptive name (e.g., `incremental-generators.md`, not `misc.md`).
+- Add YAML frontmatter with a `coverage` field describing what it covers.
+- Add a row to `.github/memory/INDEX.md`.
+
+You do not need permission to create new files in `.github/memory/`. This space is yours to evolve.
+
+## Frontmatter Format
+
+New docs should have minimal frontmatter — only the `coverage` field:
+
+```yaml
+---
+coverage: Brief description of what this doc covers
+---
+```
+
+Do NOT add `last_updated`, `updated_by`, `confidence`, or date fields. Git history provides this without creating merge conflicts.

--- a/.github/skills/update-docs/SKILL.md
+++ b/.github/skills/update-docs/SKILL.md
@@ -22,9 +22,9 @@ Run at the end of every task that changes code. This is not optional.
 
 **New pattern established?** → If repo-wide, add to `.github/memory/CONVENTIONS.md`; if layer-specific, add to the matching `.github/instructions/<area>.instructions.md`.
 
-**Surprising or undocumented behavior found?** → Repo-wide → `.github/memory/KNOWN_ISSUES.md`; layer-specific → the matching `.github/instructions/<area>.instructions.md`.
+**Surprising or undocumented behavior found?** → Repo-wide → `.github/memory/KNOWN_ISSUES.md`; layer-specific → `.github/memory/known-issues/<area>.md`.
 
-**Changed test base classes, locations, or how to run a suite?** → Repo-wide layout → `.github/memory/TESTING_STRATEGY.md`; layer-specific bases/conventions → the matching `.github/instructions/<area>.instructions.md`.
+**Changed test base classes, locations, or how to run a suite?** → Repo-wide layout → `.github/memory/TESTING_STRATEGY.md`; layer-specific bases/conventions → `.github/memory/testing/<area>.md`.
 
 **Any doc updated?** → No additional tracking needed. Git history tracks changes automatically.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,116 +1,23 @@
-# Roslyn (.NET Compiler Platform) AI Coding Instructions
+# Roslyn (.NET Compiler Platform) — AI Agent Instructions
 
-## Architecture Overview
+This file is intentionally thin. The canonical, repo-wide agent guidance lives in
+**[`.github/copilot-instructions.md`](.github/copilot-instructions.md)** — read it first.
+It covers the project overview, build/test entry points, global code style, the
+memory-first orientation protocol, and the doc-update obligation.
 
-**Core Components** (layered from bottom-up):
-- **Compilers** (`src/Compilers/`): C# and VB.NET compilers — syntax trees, semantic models, symbols, and emit APIs
-- **Workspaces** (`src/Workspaces/`): Solution/project model, document management, and host services
-- **Features** (`src/Features/`): Language-agnostic IDE features (refactoring, completion, diagnostics)
-- **Analyzers** (`src/Analyzers/`): IDE diagnostic analyzers and code fixes (IDE0xxx)
-- **EditorFeatures** (`src/EditorFeatures/`): Editor-specific implementations and text buffer integration
-- **LanguageServer** (`src/LanguageServer/`): LSP implementation used by VS Code extension
-- **VisualStudio** (`src/VisualStudio/`): VS-specific language services and UI integration
-- **Razor** (`src/Razor/`): Razor compiler and Razor IDE tooling for `.razor`/`.cshtml` files (merged from `dotnet/razor`). The sub-tree kept its internal layout, so source actually lives under `src/Razor/src/Razor/`, `src/Razor/src/Compiler/`, `src/Razor/src/Shared/`, and `src/Razor/src/Analyzers/`. See `.github/instructions/Razor.instructions.md` for razor-specific guidance.
+## Where to find things
 
-## Development Workflow
+- **Repo-wide rules & orientation:** [`.github/copilot-instructions.md`](.github/copilot-instructions.md)
+- **Knowledge base (load on demand):** [`.github/memory/INDEX.md`](.github/memory/INDEX.md) — the loading map; start here for architecture, conventions, file map, APIs, known issues, and testing.
+- **Area-specific rules (auto-applied by path):** [`.github/instructions/`](.github/instructions/)
+  - [`Compiler.instructions.md`](.github/instructions/Compiler.instructions.md) — `src/{Compilers,Dependencies,ExpressionEvaluator,Tools}`
+  - [`IDE.instructions.md`](.github/instructions/IDE.instructions.md) — `src/{Analyzers,CodeStyle,Features,Workspaces,EditorFeatures,VisualStudio}`
+  - [`Razor.instructions.md`](.github/instructions/Razor.instructions.md) — `src/Razor`
+- **Task-specific skills:** [`.github/skills/`](.github/skills/) (auto-discovered; e.g. `code-review`, `ci-analysis`, `update-docs`).
 
-**Building**:
-- Windows: `build.cmd` / Unix: `build.sh` — Full solution build
-- `dotnet build Compilers.slnf` — Compiler-only build
-- `dotnet build Ide.slnf` — IDE-only build
-- Solution filters: `Roslyn.slnx` (full), `Compilers.slnf` (compilers), `Ide.slnf` (IDE)
+## Orientation protocol
 
-**Testing**:
-- Windows: `test.cmd` / Unix: `test.sh` — Run all tests
-- `dotnet test <path to test .csproj>` — Run specific test project
-- Tests inherit from base classes: `CSharpTestBase`, `VisualBasicTestBase` (compiler), `AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest_NoEditor` (IDE analyzers)
-- Use `[UseExportProvider]` for MEF-dependent tests
-- Copilot coding agent setup preinstalls `roslyn-language-server` as a global tool and syncs the `dotnet/skills` catalog into `~/.copilot/skills`
-- Tests may take a while to build and run. Monitor output and wait until tests complete unless you're confident tests are hanging.
-
-**Formatting**:
-- Whitespace formatting preferences are stored in the `.editorconfig` file
-- When running `dotnet format whitespace` use the `--folder .` option followed by `--include <path to file>` to avoid a design-time build
-- **Critical**: Blank lines must not contain any whitespace characters (spaces or tabs). This causes linting errors.
-
-**Localization**:
-- `dotnet msbuild <path to csproj> /t:UpdateXlf` — Update `.xlf` files after modifying `.resx` files
-- Resource strings accessed via generated designer classes (e.g., `CSharpResources.xxx`, `FeaturesResources.xxx`, `AnalyzersResources.xxx`)
-
-## Code Patterns
-
-**Service Architecture** (use MEF consistently):
-```csharp
-[ExportLanguageService(typeof(IMyService), LanguageNames.CSharp), Shared]
-[method: ImportingConstructor]
-[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class CSharpMyService : IMyService
-```
-
-**Roslyn API Usage**:
-```csharp
-// All syntax trees, documents, and solutions are immutable — use With* methods
-var newDocument = oldDocument.WithSyntaxTree(newTree);
-
-// Semantic analysis — always pass CancellationToken
-var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
-var symbolInfo = semanticModel.GetSymbolInfo(expression);
-```
-
-**Testing Conventions**:
-- If the change is related to a GitHub issue, add `WorkItem` alongside test attributes, for example `[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/1234")]`, replacing `1234` with the GitHub issue number
-- Prefer raw string literals (`"""..."""`) over verbatim strings (`@"..."`) when creating test source code
-- Keep tests focused — do minimal work to validate the core issue
-  - Use `.Single()` instead of asserting count and extracting elements
-  - For compiler tests, use `comp.VerifyEmitDiagnostics()` so reviewers can see if code is legal
-  - For IDE tests, use `TestInRegularAndScriptAsync` / `TestMissingInRegularAndScriptAsync`
-
-## Key Conventions
-
-- **Namespace Strategy**: `Microsoft.CodeAnalysis.[Language].[Area]` (e.g., `Microsoft.CodeAnalysis.CSharp.Formatting`)
-- **Immutability**: All syntax trees, documents, and solutions are immutable — create new instances for changes
-- **Cancellation**: Always thread `CancellationToken` through async operations
-- **MEF Lifecycle**: Use `[ImportingConstructor]` with `[Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]`
-- **Null checks**: Use `Contract.ThrowIfNull()` instead of manual null checks
-- **Private fields**: `_camelCase` naming
-- **PROTOTYPE Comments**: Used to track follow-up work in feature branches. Do not flag them in feature-branch PR reviews solely for their existence; they are disallowed in PRs targeting `main` (CI enforces removal).
-- **TODO Comments**: Do not add TODO comments. Use TODO2 comments instead if needed. The CI correctness leg monitors those.
-- **Code Formatting**: Avoid trailing spaces. Blank lines must be completely empty (no whitespace characters).
-- **Public API Tracking**: Update `PublicAPI.Unshipped.txt` when adding/changing public APIs
-
-## Code Generation
-
-Several core data structures are generated from XML definitions — never edit generated `.cs` files directly:
-- **Syntax trees**: `src/Compilers/CSharp/Portable/Syntax/Syntax.xml`
-- **Bound trees**: `src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml`
-- **After modifying XML files**, run: `dotnet run --file eng/generate-compiler-code.cs`
-
-## Common Gotchas
-
-- Follow existing conventions in the file you're editing
-- Language services must be exported per-language, not shared across C#/VB
-- Test failures often indicate MEF composition issues — check export attributes
-- ServiceHub components (`src/Workspaces/Remote/`) require special deployment considerations for .NET Core vs Framework
-- IDE analyzers should inherit from `AbstractBuiltInCodeStyleDiagnosticAnalyzer` for code style diagnostics, not raw `DiagnosticAnalyzer`
-- Always provide `FixAllProvider` (typically `WellKnownFixAllProviders.BatchFixer`) for code fixes
-- Do not manually modify files under `eng/common`; they are synchronized automatically by DARC and manual edits will be overwritten
-
-## Documentation
-
-**Creating new docs**:
-- Use **kebab-case** for file names (e.g., `roslyn-language-server-copilot-plugin.md`, not `Roslyn Language Server Copilot Plugin.md`)
-- Place docs in the appropriate subdirectory under `docs/` (e.g., `docs/contributing/`, `docs/compilers/`, `docs/features/`)
-- General docs that don't fit a subdirectory go directly in `docs/`
-
-## Essential Files for Context
-
-- `src/Compilers/CSharp/Portable/Errors/ErrorCode.cs` — All C# compiler error codes
-- `src/Compilers/CSharp/Portable/Errors/MessageID.cs` — Language feature version gating
-- `src/Analyzers/Core/Analyzers/IDEDiagnosticIds.cs` — All IDE diagnostic ID constants
-- `src/Compilers/CSharp/Portable/Syntax/Syntax.xml` — Syntax tree node definitions
-- `src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml` — Bound tree node definitions
-- `docs/wiki/Roslyn-Overview.md` — Architecture deep-dive
-
-## Code Review
-
-When performing a code review, follow the review process, priorities, conventions, and output format defined in the [code-review skill](/.github/skills/code-review/SKILL.md).
+1. Read [`.github/copilot-instructions.md`](.github/copilot-instructions.md).
+2. Read [`.github/memory/INDEX.md`](.github/memory/INDEX.md) and load only the memory files relevant to your task.
+3. The path-scoped instruction file for the area you're editing applies automatically — follow it.
+4. After changing code, run the `update-docs` skill to keep `.github/memory/` fresh.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,11 +13,11 @@ memory-first orientation protocol, and the doc-update obligation.
   - [`Compiler.instructions.md`](.github/instructions/Compiler.instructions.md) — `src/{Compilers,Dependencies,ExpressionEvaluator,Tools}`
   - [`IDE.instructions.md`](.github/instructions/IDE.instructions.md) — `src/{Analyzers,CodeStyle,Features,Workspaces,EditorFeatures,VisualStudio}`
   - [`Razor.instructions.md`](.github/instructions/Razor.instructions.md) — `src/Razor`
-- **Task-specific skills:** [`.github/skills/`](.github/skills/) (auto-discovered; e.g. `code-review`, `ci-analysis`, `update-docs`).
+- **Task-specific skills:** [`.github/skills/`](.github/skills/) (auto-discovered; e.g. `code-review`, `ci-analysis`, `update-agent-docs`).
 
 ## Orientation protocol
 
 1. Read [`.github/copilot-instructions.md`](.github/copilot-instructions.md).
 2. Read [`.github/memory/INDEX.md`](.github/memory/INDEX.md) and load only the memory files relevant to your task.
 3. The path-scoped instruction file for the area you're editing applies automatically — follow it.
-4. After changing code, run the `update-docs` skill to keep `.github/memory/` fresh.
+4. After changing code, run the `update-agent-docs` skill to keep `.github/memory/` fresh.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ memory-first orientation protocol, and the doc-update obligation.
 - **Knowledge base (load on demand):** [`.github/memory/INDEX.md`](.github/memory/INDEX.md) — the loading map; start here for architecture, conventions, file map, APIs, known issues, and testing.
 - **Area-specific rules (auto-applied by path):** [`.github/instructions/`](.github/instructions/)
   - [`Compiler.instructions.md`](.github/instructions/Compiler.instructions.md) — `src/{Compilers,Dependencies,ExpressionEvaluator,Tools}`
-  - [`IDE.instructions.md`](.github/instructions/IDE.instructions.md) — `src/{Analyzers,CodeStyle,Features,Workspaces,EditorFeatures,VisualStudio}`
+  - [`IDE.instructions.md`](.github/instructions/IDE.instructions.md) — `src/{Analyzers,CodeStyle,Features,Workspaces,EditorFeatures,VisualStudio,LanguageServer}`
   - [`Razor.instructions.md`](.github/instructions/Razor.instructions.md) — `src/Razor`
 - **Task-specific skills:** [`.github/skills/`](.github/skills/) (auto-discovered; e.g. `code-review`, `ci-analysis`, `update-agent-docs`).
 

--- a/eng/todo-check.ps1
+++ b/eng/todo-check.ps1
@@ -51,7 +51,10 @@ $prototypePathSpecs = @(
   ':!eng/todo-check.ps1',
   ':!AGENTS.md',
   ':!azure-pipelines.yml',
-  ':!docs/wiki/Compiler-release-process.md'
+  ':!docs/wiki/Compiler-release-process.md',
+  ':!.github/copilot-instructions.md',
+  ':!.github/memory/CONVENTIONS.md',
+  ':!.github/memory/KNOWN_ISSUES.md'
 )
 
 if ($env:SYSTEM_PULLREQUEST_TARGETBRANCH -eq "main") {
@@ -68,7 +71,10 @@ if ($env:SYSTEM_PULLREQUEST_TARGETBRANCH -eq "main") {
 $todo2PathSpecs = @(
   '.',
   ':!eng/todo-check.ps1',
-  ':!AGENTS.md'
+  ':!AGENTS.md',
+  ':!.github/copilot-instructions.md',
+  ':!.github/memory/CONVENTIONS.md',
+  ':!.github/memory/KNOWN_ISSUES.md'
 )
 
 $todo2s = Get-GitGrepMatches 'TODO2' $todo2PathSpecs


### PR DESCRIPTION
This PR explores moving our AI-agent documentation to the structure from https://github.com/abpiskunov/dev-skills, with the goal of improving context loading — agents read an `INDEX`-driven map and load only the memory/instruction files relevant to the area they're working in, rather than pulling one large monolithic instructions file into context.

We expect this documentation to change rapidly over time as we continue to work with Copilot in the product, so it should be treated as a living, evolving baseline rather than a finished spec.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84308)