### PR TITLE
Fix IDE0059 false positive for out arguments read in sibling arguments (#58564)

### DIFF
--- a/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
@@ -2023,6 +2023,145 @@ class C
             }
             """, optionName);
 
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/58564")]
+    [InlineData(nameof(PreferDiscard))]
+    [InlineData(nameof(PreferUnusedLocal))]
+    public Task NonRedundantAssignment_BeforeUseAsConstructorOutAndReadArgument(string optionName)
+        => TestMissingInRegularAndScriptAsync(
+            """
+            class C
+            {
+                C(out int x, int y) => x = y;
+
+                void M()
+                {
+                    int x;
+                    [|x|] = 1;
+                    _ = new C(out x, x);
+                }
+            }
+            """, optionName);
+
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/58564")]
+    [InlineData(nameof(PreferDiscard))]
+    [InlineData(nameof(PreferUnusedLocal))]
+    public Task NonRedundantAssignment_BeforeUseAsFunctionPointerOutAndReadArgument(string optionName)
+        => TestMissingInRegularAndScriptAsync(
+            """
+            class C
+            {
+                unsafe void M(delegate*<out int, int, void> f)
+                {
+                    int x;
+                    [|x|] = 1;
+                    f(out x, x);
+                }
+            }
+            """,
+            new TestParameters(
+                options: GetOptions(optionName),
+                compilationOptions: new CSharpCompilationOptions(outputKind: OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true)));
+
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/58564")]
+    [InlineData(nameof(PreferDiscard))]
+    [InlineData(nameof(PreferUnusedLocal))]
+    public async Task NonRedundantAssignments_BeforeUseAsOutAndReadArguments(string optionName)
+    {
+        await TestMissingInRegularAndScriptAsync(
+            """
+            class C
+            {
+                void M()
+                {
+                    int x;
+                    [|x|] = 1;
+                    int y;
+                    y = 2;
+                    M2(out x, x, out y, y);
+                }
+
+                void M2(out int x, int xValue, out int y, int yValue)
+                {
+                    x = xValue;
+                    y = yValue;
+                }
+            }
+            """, optionName);
+
+        await TestMissingInRegularAndScriptAsync(
+            """
+            class C
+            {
+                void M()
+                {
+                    int x;
+                    x = 1;
+                    int y;
+                    [|y|] = 2;
+                    M2(out x, x, out y, y);
+                }
+
+                void M2(out int x, int xValue, out int y, int yValue)
+                {
+                    x = xValue;
+                    y = yValue;
+                }
+            }
+            """, optionName);
+    }
+
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/58564")]
+    [InlineData(nameof(PreferDiscard))]
+    [InlineData(nameof(PreferUnusedLocal))]
+    public Task NonRedundantAssignment_BeforeReadAndUseAsOutArgument(string optionName)
+        => TestMissingInRegularAndScriptAsync(
+            """
+            class C
+            {
+                void M()
+                {
+                    int x;
+                    [|x|] = 1;
+                    M2(x, out x);
+                }
+
+                void M2(int y, out int x) => x = y;
+            }
+            """, optionName);
+
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/58564")]
+    [InlineData(nameof(PreferDiscard))]
+    [InlineData(nameof(PreferUnusedLocal))]
+    public Task Assignment_BeforeUseAsOutArgumentWithoutSiblingRead(string optionName)
+        => TestInRegularAndScriptAsync(
+            """
+            class C
+            {
+                int M()
+                {
+                    int x;
+                    [|x|] = 1;
+                    M2(out x);
+                    return x;
+                }
+
+                void M2(out int x) => x = 0;
+            }
+            """,
+            """
+            class C
+            {
+                int M()
+                {
+                    int x;
+                    M2(out x);
+                    return x;
+                }
+
+                void M2(out int x) => x = 0;
+            }
+            """, optionName);
+
     [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/40717")]
     [InlineData(nameof(PreferDiscard))]
     [InlineData(nameof(PreferUnusedLocal))]

--- a/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
@@ -2004,6 +2004,25 @@ class C
             }
             """, optionName);
 
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/58564")]
+    [InlineData(nameof(PreferDiscard))]
+    [InlineData(nameof(PreferUnusedLocal))]
+    public Task NonRedundantAssignment_BeforeUseAsOutAndReadArgument(string optionName)
+        => TestMissingInRegularAndScriptAsync(
+            """
+            class C
+            {
+                void M()
+                {
+                    int x;
+                    [|x|] = 1;
+                    M2(out x, x);
+                }
+
+                void M2(out int x, int y) => x = y;
+            }
+            """, optionName);
+
     [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/40717")]
     [InlineData(nameof(PreferDiscard))]
     [InlineData(nameof(PreferUnusedLocal))]

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.Walker.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.Walker.cs
@@ -26,7 +26,7 @@ internal static partial class SymbolUsageAnalysis
         private ISymbol _currentContainingSymbol;
         private IOperation _currentRootOperation;
         private CancellationToken _cancellationToken;
-        private PooledDictionary<IAssignmentOperation, PooledHashSet<(ISymbol, IOperation)>> _pendingWritesMap;
+        private PooledDictionary<IOperation, PooledHashSet<(ISymbol, IOperation)>> _pendingWritesMap;
 
         private static readonly ObjectPool<Walker> s_visitorPool = new(() => new Walker());
         private Walker() { }
@@ -55,7 +55,7 @@ internal static partial class SymbolUsageAnalysis
             Debug.Assert(_currentRootOperation == null);
             Debug.Assert(_pendingWritesMap == null);
 
-            _pendingWritesMap = PooledDictionary<IAssignmentOperation, PooledHashSet<(ISymbol, IOperation)>>.GetInstance();
+            _pendingWritesMap = PooledDictionary<IOperation, PooledHashSet<(ISymbol, IOperation)>>.GetInstance();
             try
             {
                 _currentContainingSymbol = containingSymbol;
@@ -179,6 +179,18 @@ internal static partial class SymbolUsageAnalysis
                 set.Add((symbolOpt, operation));
                 return true;
             }
+            else if (operation.Parent is IArgumentOperation { Parameter.RefKind: RefKind.Out } argument &&
+                argument.Parent is not null)
+            {
+                if (!_pendingWritesMap.TryGetValue(argument.Parent, out var set))
+                {
+                    set = PooledHashSet<(ISymbol, IOperation)>.GetInstance();
+                    _pendingWritesMap.Add(argument.Parent, set);
+                }
+
+                set.Add((symbolOpt, operation));
+                return true;
+            }
 
             return false;
         }
@@ -214,6 +226,22 @@ internal static partial class SymbolUsageAnalysis
                 }
 
                 _pendingWritesMap.Remove(operation);
+                pendingWrites.Free();
+            }
+        }
+
+        private void ProcessPendingWritesForArgumentContainer(IOperation operation)
+        {
+            if (_pendingWritesMap.TryGetValue(operation, out var pendingWrites))
+            {
+                foreach (var (symbolOpt, write) in pendingWrites)
+                {
+                    Debug.Assert(symbolOpt != null);
+                    OnWriteReferenceFound(symbolOpt, write, ValueUsageInfo.WritableReference);
+                }
+
+                _pendingWritesMap.Remove(operation);
+                pendingWrites.Free();
             }
         }
 
@@ -319,6 +347,7 @@ internal static partial class SymbolUsageAnalysis
         public override void VisitInvocation(IInvocationOperation operation)
         {
             base.VisitInvocation(operation);
+            ProcessPendingWritesForArgumentContainer(operation);
 
             switch (operation.TargetMethod.MethodKind)
             {
@@ -339,6 +368,31 @@ internal static partial class SymbolUsageAnalysis
                     AnalyzeLocalFunctionInvocation(operation.TargetMethod);
                     break;
             }
+        }
+
+        public override void VisitObjectCreation(IObjectCreationOperation operation)
+        {
+            foreach (var argument in operation.Arguments)
+            {
+                Visit(argument);
+            }
+
+            ProcessPendingWritesForArgumentContainer(operation);
+
+            Visit(operation.Initializer);
+        }
+
+        public override void VisitRaiseEvent(IRaiseEventOperation operation)
+        {
+            base.VisitRaiseEvent(operation);
+            // Defensive: VB RaiseEvent can contain an out-typed delegate argument that needs flushing.
+            ProcessPendingWritesForArgumentContainer(operation);
+        }
+
+        public override void VisitFunctionPointerInvocation(IFunctionPointerInvocationOperation operation)
+        {
+            base.VisitFunctionPointerInvocation(operation);
+            ProcessPendingWritesForArgumentContainer(operation);
         }
 
         private void AnalyzeLocalFunctionInvocation(IMethodSymbol localFunction)


### PR DESCRIPTION
Fixes #58564 (also resolves the closed duplicate #61347).

## Problem

IDE0059 ("Unnecessary assignment of a value") was a **false positive** when a local is initialized and then passed **both as an `out` argument and read in another argument of the same call**:

```cs
int a = 2;
bar(out a, a);   // IDE0059 wrongly flags `a = 2`; applying the suggested fix yields CS0165
```

The initial assignment is genuinely live — its value flows into the second argument before the `out` write takes effect — so removing it does not compile.

## Root cause

IDE0059 relies on the shared liveness pass in `SymbolUsageAnalysis.Walker`, used by both the operation-tree and control-flow-graph paths. The walker visits invocation arguments in evaluation order, so `out a` (arg 1) is visited before the sibling read `a` (arg 2). An `out` argument was recorded as a **definite write immediately**, which **cleared the prior reaching write** `a = 2`. The sibling read then "read" the just-recorded out-write instead of `a = 2`, leaving the real assignment unread → false IDE0059. (`ref` args were unaffected because they record a read first and use a maybe-written write that doesn't clear the prior write; `in` args are reads only.)

## Fix

Extend the walker's existing **pending-write deferral** mechanism — previously used only for assignment / deconstruction targets — to also cover `out` arguments. The `out` write is now recorded only **after all sibling arguments of the same call have been visited**, so sibling reads correctly see the prior value. The write keeps its original **definite-write** semantics, so a genuinely dead out-assignment (`x = 1; M2(out x);` with no sibling read) is still reported.

- `MakePendingWrite` defers writes whose parent is `IArgumentOperation { Parameter.RefKind: RefKind.Out }`, keyed on the containing call (map key widened from `IAssignmentOperation` to `IOperation`).
- New `ProcessPendingWritesForArgumentContainer` flushes those deferred writes and returns the pooled set to the pool.
- Flushed after `base.Visit…` in `VisitInvocation`, `VisitObjectCreation` (constructors: `new C(out x, x)`), `VisitRaiseEvent` (defensive for VB), and `VisitFunctionPointerInvocation` — the complete set of operations that own `IArgumentOperation`s, so no deferred write is ever lost. One change fixes both analysis paths.

## Tests

Added to `RemoveUnusedValueAssignmentTests`:

- `NonRedundantAssignment_BeforeUseAsOutAndReadArgument` — the repro, `M(out x, x)` reports nothing.
- `NonRedundantAssignment_BeforeUseAsConstructorOutAndReadArgument` — `new C(out x, x)` (object-creation path).
- `NonRedundantAssignments_BeforeUseAsOutAndReadArguments` — `M(out x, x, out y, y)`.
- `NonRedundantAssignment_BeforeReadAndUseAsOutArgument` — `M(x, out x)`.
- `NonRedundantAssignment_BeforeUseAsFunctionPointerOutAndReadArgument` — `delegate*<out int, int, void>` path.
- `Assignment_BeforeUseAsOutArgumentWithoutSiblingRead` — control: a dead out-assignment is **still** flagged.

Validation: `RemoveUnusedValueAssignmentTests` + `RemoveUnusedValueExpressionStatementTests` pass 617/617; broader remove-unused filter 749/749. No regressions.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84309)