### PR TITLE
Fix extension member go-to-definition in metadata-as-source (#82258)

### DIFF
--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -10066,6 +10066,76 @@ AnonymousTypes(
             """,
             MainDescription($"Extensions.extension(System.String)"));
 
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/82258")]
+    public Task TestLegacyExtensionFromMetadataDocComment()
+        => VerifyWithReferenceWorkerAsync("""
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" LanguageVersion="Preview">
+                    <Document FilePath="SourceDocument"><![CDATA[
+            class C
+            {
+                void M(string s)
+                {
+                    s.$$Legacy();
+                }
+            }
+            ]]>
+                    </Document>
+                    <MetadataReferenceFromSource Language="C#" CommonReferences="true" IncludeXmlDocComments="true" LanguageVersion="Preview">
+                        <Document FilePath="ReferencedDocument"><![CDATA[
+            public static class Extensions
+            {
+                /// <summary>Legacy summary.</summary>
+                public static void Legacy(this string s) { }
+
+                extension(string s)
+                {
+                    /// <summary>Modern summary.</summary>
+                    public void Modern() { }
+                }
+            }
+            ]]>
+                        </Document>
+                    </MetadataReferenceFromSource>
+                </Project>
+            </Workspace>
+            """, MainDescription($"({CSharpFeaturesResources.extension}) void string.Legacy()"), Documentation("Legacy summary."));
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/82258")]
+    public Task TestModernExtensionFromMetadataDocComment()
+        => VerifyWithReferenceWorkerAsync("""
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" LanguageVersion="Preview">
+                    <Document FilePath="SourceDocument"><![CDATA[
+            class C
+            {
+                void M(string s)
+                {
+                    s.$$Modern();
+                }
+            }
+            ]]>
+                    </Document>
+                    <MetadataReferenceFromSource Language="C#" CommonReferences="true" IncludeXmlDocComments="true" LanguageVersion="Preview">
+                        <Document FilePath="ReferencedDocument"><![CDATA[
+            public static class Extensions
+            {
+                /// <summary>Legacy summary.</summary>
+                public static void Legacy(this string s) { }
+
+                extension(string s)
+                {
+                    /// <summary>Modern summary.</summary>
+                    public void Modern() { }
+                }
+            }
+            ]]>
+                        </Document>
+                    </MetadataReferenceFromSource>
+                </Project>
+            </Workspace>
+            """, MainDescription($"void Extensions.extension(string).Modern()"), Documentation("Modern summary."));
+
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72780")]
     public Task TestLocalVariableComment1()
         => TestAsync(

--- a/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
@@ -2856,6 +2856,55 @@ public sealed partial class MetadataAsSourceTests : AbstractMetadataAsSourceTest
             """);
     }
 
+    [WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/82258")]
+    public async Task TestNavigationViaNewExtensionMethodCS()
+    {
+        var metadata = """
+            public static class ObjectExtensions
+            {
+                extension(object o)
+                {
+                    public void M(int x) { }
+                }
+            }
+            """;
+        var sourceWithSymbolReference = """
+
+            class C
+            {
+                void M()
+                {
+                    new object().[|M|](5);
+                }
+            }
+            """;
+        using var context = TestContext.Create(
+            LanguageNames.CSharp,
+            [metadata],
+            includeXmlDocComments: false,
+            sourceWithSymbolReference: sourceWithSymbolReference,
+            languageVersion: "Preview",
+            metadataLanguageVersion: "Preview");
+        var navigationSymbol = await context.GetNavigationSymbolAsync();
+        var metadataAsSourceFile = await context.GenerateSourceAsync(navigationSymbol);
+        // BUG #82258: navigation should land on member M, but currently lands at the start of the file.
+        TestContext.VerifyResult(metadataAsSourceFile, $$"""
+            [||]#region {{FeaturesResources.Assembly}} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            // {{CodeAnalysisResources.InMemoryAssembly}}
+            #endregion
+
+            public static class ObjectExtensions
+            {
+                public static void M(this object o, int x);
+
+                public static class{{" "}}
+                {
+                    public void M(int x);
+                }
+            }
+            """);
+    }
+
     [WpfFact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/897006")]
     public async Task TestNavigationViaReducedExtensionMethodVB()
     {

--- a/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
@@ -2887,19 +2887,62 @@ public sealed partial class MetadataAsSourceTests : AbstractMetadataAsSourceTest
             metadataLanguageVersion: "Preview");
         var navigationSymbol = await context.GetNavigationSymbolAsync();
         var metadataAsSourceFile = await context.GenerateSourceAsync(navigationSymbol);
-        // BUG #82258: navigation should land on member M, but currently lands at the start of the file.
         TestContext.VerifyResult(metadataAsSourceFile, $$"""
-            [||]#region {{FeaturesResources.Assembly}} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            #region {{FeaturesResources.Assembly}} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
             // {{CodeAnalysisResources.InMemoryAssembly}}
             #endregion
 
             public static class ObjectExtensions
             {
-                public static void M(this object o, int x);
-
-                public static class{{" "}}
+                extension(object o)
                 {
-                    public void M(int x);
+                    public void [|M|](int x);
+                }
+            }
+            """);
+    }
+
+    [WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/82258")]
+    public async Task TestNavigationViaNewExtensionPropertyCS()
+    {
+        var metadata = """
+            public static class ObjectExtensions
+            {
+                extension(object o)
+                {
+                    public int P => 1;
+                }
+            }
+            """;
+        var sourceWithSymbolReference = """
+
+            class C
+            {
+                void M()
+                {
+                    _ = new object().[|P|];
+                }
+            }
+            """;
+        using var context = TestContext.Create(
+            LanguageNames.CSharp,
+            [metadata],
+            includeXmlDocComments: false,
+            sourceWithSymbolReference: sourceWithSymbolReference,
+            languageVersion: "Preview",
+            metadataLanguageVersion: "Preview");
+        var navigationSymbol = await context.GetNavigationSymbolAsync();
+        var metadataAsSourceFile = await context.GenerateSourceAsync(navigationSymbol);
+        TestContext.VerifyResult(metadataAsSourceFile, $$"""
+            #region {{FeaturesResources.Assembly}} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            // {{CodeAnalysisResources.InMemoryAssembly}}
+            #endregion
+
+            public static class ObjectExtensions
+            {
+                extension(object o)
+                {
+                    public int [|P|] { get; }
                 }
             }
             """);

--- a/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
@@ -2910,7 +2910,7 @@ public sealed partial class MetadataAsSourceTests : AbstractMetadataAsSourceTest
             {
                 extension(object o)
                 {
-                    public int P => 1;
+                    public int P { get => 1; set { } }
                 }
             }
             """;
@@ -2920,7 +2920,7 @@ public sealed partial class MetadataAsSourceTests : AbstractMetadataAsSourceTest
             {
                 void M()
                 {
-                    _ = new object().[|P|];
+                    new object().[|P|] = 1;
                 }
             }
             """;
@@ -2942,7 +2942,57 @@ public sealed partial class MetadataAsSourceTests : AbstractMetadataAsSourceTest
             {
                 extension(object o)
                 {
-                    public int [|P|] { get; }
+                    public int [|P|] { get; set; }
+                }
+            }
+            """);
+    }
+
+    [WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/82258")]
+    public async Task TestNavigationViaNewGenericExtensionMethodCS()
+    {
+        var metadata = """
+            #nullable enable
+
+            public static class ObjectExtensions
+            {
+                extension<T>(T t) where T : class?
+                {
+                    public void M() { }
+                }
+            }
+            """;
+        var sourceWithSymbolReference = """
+
+            class C
+            {
+                void M()
+                {
+                    new object().[|M|]();
+                }
+            }
+            """;
+        using var context = TestContext.Create(
+            LanguageNames.CSharp,
+            [metadata],
+            includeXmlDocComments: false,
+            sourceWithSymbolReference: sourceWithSymbolReference,
+            languageVersion: "Preview",
+            metadataLanguageVersion: "Preview");
+        var navigationSymbol = await context.GetNavigationSymbolAsync();
+        var metadataAsSourceFile = await context.GenerateSourceAsync(navigationSymbol);
+        TestContext.VerifyResult(metadataAsSourceFile, $$"""
+            #region {{FeaturesResources.Assembly}} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            // {{CodeAnalysisResources.InMemoryAssembly}}
+            #endregion
+
+            #nullable enable
+
+            public static class ObjectExtensions
+            {
+                extension<T>(T t) where T : class?
+                {
+                    public void [|M|]();
                 }
             }
             """);

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
@@ -26,7 +26,10 @@ internal abstract partial class AbstractMetadataAsSourceService
             _symbol = symbol;
 
             var allMembers = _symbol.GetMembers();
+            var extensionImplementationMembers = GetExtensionImplementationMembers(allMembers);
             var filteredMembers = from m in allMembers
+                                  where extensionImplementationMembers.Count == 0 ||
+                                        !extensionImplementationMembers.Contains(m.OriginalDefinition)
                                   where !m.HasUnsupportedMetadata
                                   where m.DeclaredAccessibility is Accessibility.Public or
                                         Accessibility.Protected or
@@ -39,6 +42,39 @@ internal abstract partial class AbstractMetadataAsSourceService
                                   select WrapMember(m, canImplementImplicitly, docCommentFormattingService);
 
             _members = [.. filteredMembers];
+        }
+
+        private static HashSet<ISymbol> GetExtensionImplementationMembers(ImmutableArray<ISymbol> allMembers)
+        {
+            var extensionImplementationMembers = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+
+            foreach (var member in allMembers)
+            {
+                if (member is INamedTypeSymbol { IsExtension: true } extensionType)
+                {
+                    foreach (var extensionMember in extensionType.GetMembers())
+                    {
+                        switch (extensionMember)
+                        {
+                            case IMethodSymbol method:
+                                AddExtensionImplementation(extensionImplementationMembers, method.AssociatedExtensionImplementation);
+                                break;
+                            case IPropertySymbol property:
+                                AddExtensionImplementation(extensionImplementationMembers, property.GetMethod?.AssociatedExtensionImplementation);
+                                AddExtensionImplementation(extensionImplementationMembers, property.SetMethod?.AssociatedExtensionImplementation);
+                                break;
+                        }
+                    }
+                }
+            }
+
+            return extensionImplementationMembers;
+        }
+
+        private static void AddExtensionImplementation(HashSet<ISymbol> extensionImplementationMembers, IMethodSymbol implementation)
+        {
+            if (implementation != null)
+                extensionImplementationMembers.Add(implementation.OriginalDefinition);
         }
 
         private static ISymbol WrapMember(ISymbol m, bool canImplementImplicitly, IDocumentationCommentFormattingService docCommentFormattingService)

--- a/src/Workspaces/CoreTest/UtilityTest/XmlDocumentationProviderTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/XmlDocumentationProviderTests.cs
@@ -3,9 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Xml.Linq;
+using Basic.Reference.Assemblies;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -43,5 +46,76 @@ public sealed class XmlDocumentationProviderTests
         var xmlDocument = XDocument.Parse(xml);
         Assert.Equal("member", xmlDocument.Root!.Name.LocalName);
         Assert.Equal("T:Microsoft.CodeAnalysis.AdditionalTextFile", xmlDocument.Root!.Attribute("name")!.Value);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/82258")]
+    public void XmlDocumentationProviderResolvesModernExtensionMemberFromEmittedXml()
+    {
+        var declaringSource = """
+public static class E
+{
+    /// <summary>Legacy summary.</summary>
+    public static void Legacy(this object o) { }
+
+    extension(object o)
+    {
+        /// <summary>Modern summary.</summary>
+        public void Modern() { }
+    }
+}
+""";
+        var parseOptions = new CSharpParseOptions(documentationMode: DocumentationMode.Diagnose, languageVersion: LanguageVersion.Preview);
+        var declaringComp = CSharpCompilation.Create(
+            "Lib",
+            [CSharpSyntaxTree.ParseText(declaringSource, parseOptions)],
+            NetCoreApp.References,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var peStream = new MemoryStream();
+        using var xmlStream = new MemoryStream();
+        var emitResult = declaringComp.Emit(peStream, xmlDocumentationStream: xmlStream);
+        Assert.True(emitResult.Success, string.Join("\r\n", emitResult.Diagnostics));
+
+        var xmlBytes = xmlStream.ToArray();
+        var emittedXml = Encoding.UTF8.GetString(xmlBytes);
+        var reference = AssemblyMetadata.CreateFromImage(peStream.ToArray()).GetReference(documentation: XmlDocumentationProvider.CreateFromBytes(xmlBytes));
+
+        var consumingSource = """
+class C
+{
+    void M()
+    {
+        new object().Legacy();
+        new object().Modern();
+    }
+}
+""";
+        var consumingTree = CSharpSyntaxTree.ParseText(consumingSource, parseOptions);
+        var consumingComp = CSharpCompilation.Create(
+            "Consumer",
+            [consumingTree],
+            NetCoreApp.References.Concat([reference]),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var diagnostics = consumingComp.GetDiagnostics();
+        Assert.True(diagnostics.All(diagnostic => diagnostic.Severity != DiagnosticSeverity.Error), string.Join("\r\n", diagnostics));
+
+        var model = consumingComp.GetSemanticModel(consumingTree);
+        var invocations = consumingTree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().ToArray();
+        var legacy = model.GetSymbolInfo(invocations.Single(invocation => invocation.ToString() == "new object().Legacy()")).Symbol!;
+        var modern = model.GetSymbolInfo(invocations.Single(invocation => invocation.ToString() == "new object().Modern()")).Symbol!;
+
+        // The compiler emits the modern extension member's summary under the (grouping-named) skeleton member
+        // and an <inheritdoc> entry for the synthesized implementation method.
+        Assert.Contains("""<summary>Legacy summary.</summary>""", emittedXml);
+        Assert.Contains("<inheritdoc cref=", emittedXml);
+        Assert.Contains("""<summary>Modern summary.</summary>""", emittedXml);
+
+        // Both the legacy and the modern extension member resolve their documentation across the metadata
+        // boundary from the real on-disk XML file (the NuGet package scenario from issue #82258).
+        Assert.Contains("""<summary>Legacy summary.</summary>""", legacy.GetDocumentationCommentXml());
+        Assert.Contains("""<summary>Modern summary.</summary>""", modern.GetDocumentationCommentXml());
+
+        Assert.True(modern.ContainingType.IsExtension);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/NamedTypeGenerator.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/NamedTypeGenerator.cs
@@ -173,7 +173,6 @@ internal static class NamedTypeGenerator
             case SyntaxKind.InterfaceDeclaration:
             case SyntaxKind.ClassDeclaration:
             case SyntaxKind.RecordDeclaration:
-            case SyntaxKind.ExtensionBlockDeclaration:
                 return ((TypeDeclarationSyntax)declaration).WithMembers(default);
 
             default:
@@ -198,7 +197,7 @@ internal static class NamedTypeGenerator
                 ExtensionKeyword,
                 GenerateTypeParameterList(namedType, info),
                 parameterList,
-                GenerateConstraintClauses(namedType),
+                GenerateExtensionConstraintClauses(namedType),
                 openBraceToken: default,
                 members: default,
                 closeBraceToken: default,
@@ -352,4 +351,38 @@ internal static class NamedTypeGenerator
 
     private static SyntaxList<TypeParameterConstraintClauseSyntax> GenerateConstraintClauses(INamedTypeSymbol namedType)
         => namedType.TypeParameters.GenerateConstraintClauses();
+
+    private static SyntaxList<TypeParameterConstraintClauseSyntax> GenerateExtensionConstraintClauses(INamedTypeSymbol namedType)
+    {
+        var constraintClauses = GenerateConstraintClauses(namedType);
+        if (constraintClauses.Count == 0)
+            return constraintClauses;
+
+        using var _ = ArrayBuilder<TypeParameterConstraintClauseSyntax>.GetInstance(out var updatedConstraintClauses);
+
+        foreach (var constraintClause in constraintClauses)
+        {
+            var updatedConstraintClause = constraintClause;
+            var typeParameter = namedType.TypeParameters.FirstOrDefault(
+                typeParameter => typeParameter.Name == constraintClause.Name.Identifier.ValueText);
+
+            if (typeParameter is { HasReferenceTypeConstraint: true, ReferenceTypeConstraintNullableAnnotation: NullableAnnotation.Annotated })
+            {
+                foreach (var constraint in constraintClause.Constraints)
+                {
+                    if (constraint is ClassOrStructConstraintSyntax classConstraint &&
+                        classConstraint.Kind() == SyntaxKind.ClassConstraint)
+                    {
+                        updatedConstraintClause = constraintClause.WithConstraints(
+                            constraintClause.Constraints.Replace(classConstraint, classConstraint.WithQuestionToken(QuestionToken)));
+                        break;
+                    }
+                }
+            }
+
+            updatedConstraintClauses.Add(updatedConstraintClause);
+        }
+
+        return [.. updatedConstraintClauses];
+    }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/NamedTypeGenerator.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/NamedTypeGenerator.cs
@@ -173,6 +173,7 @@ internal static class NamedTypeGenerator
             case SyntaxKind.InterfaceDeclaration:
             case SyntaxKind.ClassDeclaration:
             case SyntaxKind.RecordDeclaration:
+            case SyntaxKind.ExtensionBlockDeclaration:
                 return ((TypeDeclarationSyntax)declaration).WithMembers(default);
 
             default:

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/NamedTypeGenerator.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/NamedTypeGenerator.cs
@@ -173,6 +173,7 @@ internal static class NamedTypeGenerator
             case SyntaxKind.InterfaceDeclaration:
             case SyntaxKind.ClassDeclaration:
             case SyntaxKind.RecordDeclaration:
+            case SyntaxKind.ExtensionBlockDeclaration:
                 return ((TypeDeclarationSyntax)declaration).WithMembers(default);
 
             default:
@@ -185,6 +186,25 @@ internal static class NamedTypeGenerator
         CodeGenerationDestination destination,
         CSharpCodeGenerationContextInfo info)
     {
+        if (namedType.IsExtension)
+        {
+            var parameterList = namedType.ExtensionParameter is { } extensionParameter
+                ? ParameterGenerator.GenerateParameterList([extensionParameter], isExplicit: false, info)
+                : ParameterList();
+
+            return ExtensionBlockDeclaration(
+                GenerateAttributeDeclarations(namedType, info),
+                modifiers: default,
+                ExtensionKeyword,
+                GenerateTypeParameterList(namedType, info),
+                parameterList,
+                GenerateConstraintClauses(namedType),
+                openBraceToken: default,
+                members: default,
+                closeBraceToken: default,
+                semicolonToken: default);
+        }
+
         if (namedType.TypeKind == TypeKind.Enum)
         {
             return GenerateEnumDeclaration(namedType, destination, info);


### PR DESCRIPTION
Fixes #82258

## Problem

New-style C# extension members (declared in `extension(Receiver) { ... }` blocks) consumed from a **referenced assembly / NuGet package** had two reported IDE symptoms:

1. **Go to definition (F12)** landed at the top of the metadata-as-source file instead of on the extension member.
2. **Quick Info / XML docs** appeared not to show the member's documentation.

## Fix

### Navigation (the actual code fix)
Metadata-as-source had no concept of an extension block, so it emitted an empty-named class plus a duplicate synthesized implementation method. The `SymbolKey` lookup then failed and navigation fell back to `TextSpan(0, 0)` (top of file).

- `NamedTypeGenerator` now emits a real `ExtensionBlockDeclarationSyntax` when `namedType.IsExtension`, including a scoped constraint-clause helper that preserves nullable reference-type constraints (`where T : class?`), and handles the new declaration kind in `RemoveAllMembers`.
- `AbstractMetadataAsSourceService.WrappedNamedTypeSymbol` filters out the synthesized extension *implementation* methods so the generated source contains only the user-facing extension members.

### Docs / Quick Info
Verified at three layers (compiler symbol API, IDE Quick Info, and a faithful on-disk `XmlDocumentationProvider` / NuGet-package path) that extension-member XML docs already resolve correctly across the metadata boundary on current `main` — the compiler emits a skeleton `<member>` carrying the `<summary>` plus an `<inheritdoc>` entry for the implementation method, and the consuming symbol computes a matching documentation-comment id. No product change was required for the docs symptom; this PR adds **regression tests** locking in that behavior.

## Tests
- `MetadataAsSourceTests`: navigation to a new extension method, a settable extension property, and a generic extension method with a `class?` constraint.
- `SemanticQuickInfoSourceTests`: Quick Info shows docs for a modern extension member (and a legacy `this`-parameter control) consumed from metadata.
- `XmlDocumentationProviderTests`: end-to-end emit → on-disk XML → consume, asserting the modern extension member's summary resolves (the package scenario from the issue).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84313)