### PR TITLE
Fix #72884: don't report IDE0052 on written-through ref-returning properties

### DIFF
--- a/src/Analyzers/CSharp/Tests/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
@@ -1857,6 +1857,38 @@ public sealed class RemoveUnusedMembersTests
             }
             """, []);
 
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72884")]
+    public Task PropertyIsRefReturningAndIncremented()
+    {
+        // BUG #72884: false positive — A is read via A++ (ref return), IDE0052 should not fire here.
+        return VerifyCS.VerifyAnalyzerAsync("""
+            class C1
+            {
+                int a;
+                private ref int {|#0:A|} => ref a;
+                public void Increment() => A++;
+            }
+            """, new DiagnosticResult(
+            CSharpRemoveUnusedMembersDiagnosticAnalyzer.s_removeUnreadMembersRule)
+                .WithLocation(0)
+                .WithArguments("C1.A")
+                .WithOptions(DiagnosticOptions.IgnoreAdditionalLocations));
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72884")]
+    public Task PropertyIsRefReturningAndRead()
+    {
+        // Observed behavior: no IDE0052 diagnostic; plain read usage of the ref-returning property is handled correctly.
+        return VerifyCS.VerifyAnalyzerAsync("""
+            class C1
+            {
+                int a;
+                private ref int A => ref a;
+                public int Read() => A;
+            }
+            """, []);
+    }
+
     [Fact]
     public async Task IndexerIsIncrementedAndValueUsed()
     {

--- a/src/Analyzers/CSharp/Tests/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
@@ -1859,21 +1859,14 @@ public sealed class RemoveUnusedMembersTests
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72884")]
     public Task PropertyIsRefReturningAndIncremented()
-    {
-        // BUG #72884: false positive — A is read via A++ (ref return), IDE0052 should not fire here.
-        return VerifyCS.VerifyAnalyzerAsync("""
+        => VerifyCS.VerifyAnalyzerAsync("""
             class C1
             {
                 int a;
-                private ref int {|#0:A|} => ref a;
+                private ref int A => ref a;
                 public void Increment() => A++;
             }
-            """, new DiagnosticResult(
-            CSharpRemoveUnusedMembersDiagnosticAnalyzer.s_removeUnreadMembersRule)
-                .WithLocation(0)
-                .WithArguments("C1.A")
-                .WithOptions(DiagnosticOptions.IgnoreAdditionalLocations));
-    }
+            """, []);
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72884")]
     public Task PropertyIsRefReturningAndRead()
@@ -1888,6 +1881,39 @@ public sealed class RemoveUnusedMembersTests
             }
             """, []);
     }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72884")]
+    public Task PropertyIsRefReturningAndCompoundAssigned()
+        => VerifyCS.VerifyAnalyzerAsync("""
+            class C1
+            {
+                int a;
+                private ref int A => ref a;
+                public void M() => A += 5;
+            }
+            """, []);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72884")]
+    public Task PropertyIsRefReturningAndSimpleAssigned()
+        => VerifyCS.VerifyAnalyzerAsync("""
+            class C1
+            {
+                int a;
+                private ref int A => ref a;
+                public void M() => A = 5;
+            }
+            """, []);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72884")]
+    public Task RefReturningIndexerIsWrittenThrough()
+        => VerifyCS.VerifyAnalyzerAsync("""
+            class C1
+            {
+                int[] a = new int[1];
+                private ref int this[int i] => ref a[i];
+                public void M() => this[0]++;
+            }
+            """, []);
 
     [Fact]
     public async Task IndexerIsIncrementedAndValueUsed()

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
@@ -401,7 +401,15 @@ internal abstract class AbstractRemoveUnusedMembersDiagnosticAnalyzer<
                 // Get the value usage info.
                 var valueUsageInfo = memberReference.GetValueUsageInfo(operationContext.ContainingSymbol);
 
-                if (valueUsageInfo == ValueUsageInfo.ReadWrite)
+                if (memberSymbol is IPropertySymbol { RefKind: RefKind.Ref })
+                {
+                    // A writable ref-returning property/indexer always invokes its getter to obtain the
+                    // reference, even when the access is the target of a write (e.g. 'A = x', 'A++', 'A += y').
+                    // The reference is therefore always at least a read of the property and must not be
+                    // downgraded to write-only, which would cause a false IDE0052 'never read' report.
+                    valueUsageInfo |= ValueUsageInfo.Read;
+                }
+                else if (valueUsageInfo == ValueUsageInfo.ReadWrite)
                 {
                     Debug.Assert(memberReference.Parent is ICompoundAssignmentOperation compoundAssignment &&
                         compoundAssignment.Target == memberReference ||


### PR DESCRIPTION
Fixes #72884.

## Problem
IDE0052 (`Private member can be removed as the value assigned to it is never read`) was a false positive on a private **writable ref-returning** property that is written through:

```csharp
class C1
{
    int a;
    private ref int A => ref a;   // IDE0052 wrongly reported here
    public void Increment() => A++;
}
```

`A++` invokes the property **getter** to obtain the `ref int` and writes through the returned reference. There is no setter, so the property is genuinely read on every access and IDE0052 must not fire. `A = x` and `A += y` were affected the same way, as were ref-returning indexers.

## Fix
In `AbstractRemoveUnusedMembersDiagnosticAnalyzer.AnalyzeMemberReferenceOperation`, a writable ref-returning property/indexer reference always retains its Read bit (its getter is always invoked), so it is never downgraded to write-only:

```csharp
if (memberSymbol is IPropertySymbol { RefKind: RefKind.Ref })
{
    valueUsageInfo |= ValueUsageInfo.Read;
}
else if (valueUsageInfo == ValueUsageInfo.ReadWrite)
{
    // existing ReadWrite -> Write downgrade heuristic (unchanged)
}
```

`RefKind.RefReadOnly` is correctly excluded (it cannot be written through). Genuinely unreferenced ref properties still surface IDE0051 since they never reach this method.

## Tests
Added regression tests covering `A++`, `A += y`, `A = x`, and a ref-returning indexer (all expect no diagnostic), plus the existing read-only control. Verified ordinary write-only property increments still flag (no regression). Full `RemoveUnusedMembers` suite: 271 passed.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84316)