### PR TITLE
Fix #74474: rename usages of global using aliases

### DIFF
--- a/src/EditorFeatures/Test2/Rename/CSharp/AliasTests.vb
+++ b/src/EditorFeatures/Test2/Rename/CSharp/AliasTests.vb
@@ -188,6 +188,44 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.CSharp
             End Using
         End Sub
 
+        <Theory, WorkItem("https://github.com/dotnet/roslyn/issues/74474")>
+        <CombinatorialData>
+        Public Sub RenameGlobalUsingPrimitiveTypeAliasFromDeclaration(host As RenameTestHost)
+            Using result = RenameEngineResult.Create(_outputHelper,
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document>
+                            global using {|alias:$$MyInteger|} = int;
+                        </Document>
+                        <Document>
+                            public class C { public {|alias:MyInteger|} M() => 42; }
+                        </Document>
+                    </Project>
+                </Workspace>, host:=host, renameTo:="MyInt")
+
+                result.AssertLabeledSpansAre("alias", "MyInt", RelatedLocationType.NoConflict)
+            End Using
+        End Sub
+
+        <Theory, WorkItem("https://github.com/dotnet/roslyn/issues/74474")>
+        <CombinatorialData>
+        Public Sub RenameGlobalUsingPrimitiveTypeAliasFromUse(host As RenameTestHost)
+            Using result = RenameEngineResult.Create(_outputHelper,
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document>
+                            global using {|alias:MyInteger|} = int;
+                        </Document>
+                        <Document>
+                            public class C { public {|alias:$$MyInteger|} M() => 42; }
+                        </Document>
+                    </Project>
+                </Workspace>, host:=host, renameTo:="MyInt")
+
+                result.AssertLabeledSpansAre("alias", "MyInt", RelatedLocationType.NoConflict)
+            End Using
+        End Sub
+
         <Theory>
         <CombinatorialData>
         Public Sub RenameSimpleSpecialTypeAliasVariable(host As RenameTestHost)

--- a/src/EditorFeatures/Test2/Rename/CSharp/AliasTests.vb
+++ b/src/EditorFeatures/Test2/Rename/CSharp/AliasTests.vb
@@ -226,6 +226,50 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.CSharp
             End Using
         End Sub
 
+        <Theory, WorkItem("https://github.com/dotnet/roslyn/issues/74474")>
+        <CombinatorialData>
+        Public Sub RenameGlobalUsingNamedTypeAliasFromDeclaration(host As RenameTestHost)
+            Using result = RenameEngineResult.Create(_outputHelper,
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document>
+                            global using {|alias:$$MyHelper|} = N.Helper;
+                        </Document>
+                        <Document>
+                            namespace N { public class Helper { } }
+                        </Document>
+                        <Document>
+                            public class C { public {|alias:MyHelper|} M() => null; }
+                        </Document>
+                    </Project>
+                </Workspace>, host:=host, renameTo:="Renamed")
+
+                result.AssertLabeledSpansAre("alias", "Renamed", RelatedLocationType.NoConflict)
+            End Using
+        End Sub
+
+        <Theory, WorkItem("https://github.com/dotnet/roslyn/issues/74474")>
+        <CombinatorialData>
+        Public Sub RenameGlobalUsingNamedTypeAliasFromUse(host As RenameTestHost)
+            Using result = RenameEngineResult.Create(_outputHelper,
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document>
+                            global using {|alias:MyHelper|} = N.Helper;
+                        </Document>
+                        <Document>
+                            namespace N { public class Helper { } }
+                        </Document>
+                        <Document>
+                            public class C { public {|alias:$$MyHelper|} M() => null; }
+                        </Document>
+                    </Project>
+                </Workspace>, host:=host, renameTo:="Renamed")
+
+                result.AssertLabeledSpansAre("alias", "Renamed", RelatedLocationType.NoConflict)
+            End Using
+        End Sub
+
         <Theory>
         <CombinatorialData>
         Public Sub RenameSimpleSpecialTypeAliasVariable(host As RenameTestHost)

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferenceCache.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferenceCache.cs
@@ -94,7 +94,7 @@ internal sealed class FindReferenceCache
         => _symbolInfoCache.GetOrAdd(node, static (n, arg) => arg.SemanticModel.GetSymbolInfo(n, arg.cancellationToken), (SemanticModel, cancellationToken));
 
     public IAliasSymbol? GetAliasInfo(
-        ISemanticFactsService semanticFacts, SyntaxToken token, CancellationToken cancellationToken)
+        ISemanticFactsService semanticFacts, SyntaxToken token, HashSet<string> globalAliases, CancellationToken cancellationToken)
     {
         if (_aliasNameSet == null)
         {
@@ -102,7 +102,11 @@ internal sealed class FindReferenceCache
             Interlocked.CompareExchange(ref _aliasNameSet, set, null);
         }
 
-        if (_aliasNameSet.Contains(token.ValueText))
+        // The alias name set only contains aliases declared within this file's using directives.  A token may also
+        // bind through a global alias declared in another file (e.g. `global using MyInt = int;`), in which case the
+        // name will be present in the set of global aliases we're currently searching for.  Consider both so that
+        // references bound through a global alias get their `Alias` populated.
+        if (_aliasNameSet.Contains(token.ValueText) || globalAliases.Contains(token.ValueText))
             return SemanticModel.GetAliasInfo(token.GetRequiredParent(), cancellationToken);
 
         return null;

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
@@ -206,7 +206,7 @@ internal abstract partial class AbstractReferenceFinder : IReferenceFinder
     public static ReferenceLocation CreateReferenceLocation(FindReferencesDocumentState state, SyntaxToken token, CandidateReason reason, CancellationToken cancellationToken)
         => new(
             state.Document,
-            state.Cache.GetAliasInfo(state.SemanticFacts, token, cancellationToken),
+            state.Cache.GetAliasInfo(state.SemanticFacts, token, state.GlobalAliases, cancellationToken),
             token.GetLocation(),
             isImplicit: false,
             GetSymbolUsageInfo(token.GetRequiredParent(), state, cancellationToken),

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
@@ -355,6 +355,16 @@ internal sealed partial class SyntaxTreeIndex
             aliasInfo ??= [];
             aliasInfo.Add((alias.ValueText, name, arity, isGlobal: globalToken != default));
         }
+        else if (syntaxFacts.IsPredefinedType(usingTarget) &&
+                 syntaxFacts.TryGetPredefinedType(usingTarget.GetFirstToken(), out var predefinedType) &&
+                 predefinedType.GetMetadataName() is string predefinedName)
+        {
+            // For `using X = int` we want to index the alias as pointing at the metadata name (`Int32`) of the
+            // predefined type so that references searching for that type (which use its metadata name) can find the
+            // alias.  This mirrors the `using X = System.Int32` case handled above.
+            aliasInfo ??= [];
+            aliasInfo.Add((alias.ValueText, predefinedName, arity: 0, isGlobal: globalToken != default));
+        }
     }
 
     public static StringTable GetStringTable(ProjectState project)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Extensions/Symbols/PredefinedTypeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Extensions/Symbols/PredefinedTypeExtensions.cs
@@ -35,6 +35,36 @@ internal static class PredefinedTypeExtensions
             _ => SpecialType.None,
         };
 
+    /// <summary>
+    /// Gets the simple metadata name of the predefined type (e.g. <c>Int32</c> for <see cref="PredefinedType.Int32"/>),
+    /// matching the <see cref="ISymbol.Name"/> of the corresponding type symbol.  Returns <see langword="null"/> for
+    /// <see cref="PredefinedType.None"/>.
+    /// </summary>
+    public static string? GetMetadataName(this PredefinedType predefinedType)
+        => predefinedType switch
+        {
+            PredefinedType.Object => "Object",
+            PredefinedType.Void => "Void",
+            PredefinedType.Boolean => "Boolean",
+            PredefinedType.Char => "Char",
+            PredefinedType.SByte => "SByte",
+            PredefinedType.Byte => "Byte",
+            PredefinedType.Int16 => "Int16",
+            PredefinedType.UInt16 => "UInt16",
+            PredefinedType.Int32 => "Int32",
+            PredefinedType.UInt32 => "UInt32",
+            PredefinedType.Int64 => "Int64",
+            PredefinedType.UInt64 => "UInt64",
+            PredefinedType.Decimal => "Decimal",
+            PredefinedType.Single => "Single",
+            PredefinedType.Double => "Double",
+            PredefinedType.String => "String",
+            PredefinedType.DateTime => "DateTime",
+            PredefinedType.IntPtr => "IntPtr",
+            PredefinedType.UIntPtr => "UIntPtr",
+            _ => null,
+        };
+
     public static PredefinedType ToPredefinedType(this SpecialType specialType)
         => specialType switch
         {


### PR DESCRIPTION
Fixes #74474

## Problem
Renaming a `global using` alias only updated the alias **declaration**, not its usages in other files. This affected both primitive-type aliases (`global using MyInteger = int;`) and named-type aliases (`global using MyHelper = Some.Helper;`).

## Root cause
Two independent defects:

1. **Index gap (primitive-type aliases).** `SyntaxTreeIndex.TryAddAliasInfo` only recorded aliases whose RHS `IsSimpleName`. `int` is a `PredefinedTypeSyntax`, so `global using MyInteger = int;` was never indexed. `NamedTypeSymbolReferenceFinder.DetermineGlobalAliasesAsync` queries the index by the target's metadata name (`Int32`), found nothing, and never searched the file that uses `MyInteger`.

2. **Alias prefilter (all global aliases).** `FindReferenceCache.GetAliasInfo` gated `SemanticModel.GetAliasInfo` behind the *current file's* using directives (`GetAliasNameSet`). A global-alias usage in a file with no usings was filtered out, leaving `ReferenceLocation.Alias` null, so rename dropped the usage.

## Fix
- `PredefinedTypeExtensions.GetMetadataName` — maps a `PredefinedType` to its metadata name (e.g. `Int32`), matching the corresponding type symbol's `ISymbol.Name`.
- `SyntaxTreeIndex_Create.TryAddAliasInfo` — index predefined-type alias targets under their metadata name (mirrors the existing `using X = System.Int32` handling).
- `FindReferenceCache.GetAliasInfo` + `AbstractReferenceFinder.CreateReferenceLocation` — also consult `state.GlobalAliases` in the prefilter so global-alias usages resolve their `Alias` even in files with no usings.

Populating `ReferenceLocation.Alias` more often is safe for target-type rename: that path only includes an aliased location when `location.Alias.Name == referencedSymbol.Name` (e.g. renaming `Helper` still skips `MyHelper`).

## Tests
4 new `[Theory]`/`CombinatorialData` rename tests in `AliasTests.vb` (with `WorkItem`), covering primitive and named-type global aliases, renamed from both the declaration and a usage.

Validation: full Rename suite (2570) and FindReferences suite (3583) pass.

## Known limitation (follow-up)
Native-int aliases (`global using MyPtr = nint;`) are still not covered: C# parses `nint`/`nuint` as `IdentifierNameSyntax` (indexed as `nint`) while FindReferences searches by symbol name `IntPtr`. This is consistent with existing precedent (`CSharpDeclaredSymbolInfoFactoryService.GetSpecialTypeName` also omits native ints) and is left as a follow-up.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84317)