### PR TITLE
Filter false CSS024 diagnostics from Html

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Diagnostics/RazorTranslateDiagnosticsService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Diagnostics/RazorTranslateDiagnosticsService.cs
@@ -249,9 +249,10 @@ internal sealed class RazorTranslateDiagnosticsService(IDocumentMappingService d
             CSSErrorCodes.MissingOpeningBrace or
             CSSErrorCodes.MissingClassNameAfterDot or
             CSSErrorCodes.MissingSelectorAfterCombinator or
-            CSSErrorCodes.MissingPropertyName or
-            CSSErrorCodes.MissingPropertyValue or
             CSSErrorCodes.MissingSelectorBeforeCombinatorCode => IsAtCSharpTransitionInStyleBlock(diagnostic, sourceText, syntaxTree),
+            CSSErrorCodes.MissingPropertyValue or
+            CSSErrorCodes.MissingPropertyName => IsAtCSharpTransitionInStyleBlock(diagnostic, sourceText, syntaxTree) ||
+                IsOutsideAttribute(diagnostic, sourceText, syntaxTree),
             HtmlErrorCodes.UnexpectedEndTagErrorCode => IsHtmlWithBangAndMatchingTags(diagnostic, sourceText, syntaxTree),
             HtmlErrorCodes.InvalidNestingErrorCode => IsAnyFilteredInvalidNestingError(diagnostic, sourceText, syntaxTree),
             HtmlErrorCodes.MissingEndTagErrorCode => syntaxTree.Options.FileKind.IsComponent(), // Redundant with RZ9980 in Components
@@ -313,6 +314,18 @@ internal sealed class RazorTranslateDiagnosticsService(IDocumentMappingService d
             }
 
             return owner.FirstAncestorOrSelf<BaseMarkupElementSyntax>(static n => n.StartTag?.Name.Content == "style") is not null;
+        }
+
+        static bool IsOutsideAttribute(LspDiagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree)
+        {
+            if (!sourceText.TryGetAbsoluteIndex(diagnostic.Range.Start, out var absoluteIndex))
+            {
+                return false;
+            }
+
+            var owner = syntaxTree.Root.FindInnermostNode(absoluteIndex);
+            return owner is not null &&
+                owner.FirstAncestorOrSelf<SyntaxNode>(static n => n.IsAnyAttributeSyntax()) is null;
         }
 
         // Ideally this would be solved instead by not emitting the "!" at the HTML backing file,
@@ -475,20 +488,20 @@ internal sealed class RazorTranslateDiagnosticsService(IDocumentMappingService d
         }
 
         return false;
+    }
 
-        static bool CheckIfAttributeContainsNonMarkupNodes(RazorSyntaxNode attributeNode)
-        {
-            return attributeNode.DescendantNodes().Any(IsNotMarkupOrCommentNode);
-        }
+    private static bool CheckIfAttributeContainsNonMarkupNodes(RazorSyntaxNode attributeNode)
+    {
+        return attributeNode.DescendantNodes().Any(IsNotMarkupOrCommentNode);
+    }
 
-        static bool IsNotMarkupOrCommentNode(SyntaxNode node)
-        {
-            return !(node is
-                MarkupBlockSyntax or
-                MarkupSyntaxNode or
-                GenericBlockSyntax or
-                RazorCommentBlockSyntax);
-        }
+    private static bool IsNotMarkupOrCommentNode(SyntaxNode node)
+    {
+        return !(node is
+            MarkupBlockSyntax or
+            MarkupSyntaxNode or
+            GenericBlockSyntax or
+            RazorCommentBlockSyntax);
     }
 
     private LspDiagnostic[] FilterCSharpDiagnostics(LspDiagnostic[] diagnostics, RazorCodeDocument codeDocument)

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Diagnostics/RazorTranslateDiagnosticsService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Diagnostics/RazorTranslateDiagnosticsService.cs
@@ -249,10 +249,10 @@ internal sealed class RazorTranslateDiagnosticsService(IDocumentMappingService d
             CSSErrorCodes.MissingOpeningBrace or
             CSSErrorCodes.MissingClassNameAfterDot or
             CSSErrorCodes.MissingSelectorAfterCombinator or
-            CSSErrorCodes.MissingSelectorBeforeCombinatorCode => IsAtCSharpTransitionInStyleBlock(diagnostic, sourceText, syntaxTree),
             CSSErrorCodes.MissingPropertyValue or
+            CSSErrorCodes.MissingSelectorBeforeCombinatorCode => IsAtCSharpTransitionInStyleBlock(diagnostic, sourceText, syntaxTree),
             CSSErrorCodes.MissingPropertyName => IsAtCSharpTransitionInStyleBlock(diagnostic, sourceText, syntaxTree) ||
-                IsOutsideAttribute(diagnostic, sourceText, syntaxTree),
+                IsOutsideAttributeAndStyleBlock(diagnostic, sourceText, syntaxTree),
             HtmlErrorCodes.UnexpectedEndTagErrorCode => IsHtmlWithBangAndMatchingTags(diagnostic, sourceText, syntaxTree),
             HtmlErrorCodes.InvalidNestingErrorCode => IsAnyFilteredInvalidNestingError(diagnostic, sourceText, syntaxTree),
             HtmlErrorCodes.MissingEndTagErrorCode => syntaxTree.Options.FileKind.IsComponent(), // Redundant with RZ9980 in Components
@@ -316,7 +316,7 @@ internal sealed class RazorTranslateDiagnosticsService(IDocumentMappingService d
             return owner.FirstAncestorOrSelf<BaseMarkupElementSyntax>(static n => n.StartTag?.Name.Content == "style") is not null;
         }
 
-        static bool IsOutsideAttribute(LspDiagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree)
+        static bool IsOutsideAttributeAndStyleBlock(LspDiagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree)
         {
             if (!sourceText.TryGetAbsoluteIndex(diagnostic.Range.Start, out var absoluteIndex))
             {
@@ -325,7 +325,9 @@ internal sealed class RazorTranslateDiagnosticsService(IDocumentMappingService d
 
             var owner = syntaxTree.Root.FindInnermostNode(absoluteIndex);
             return owner is not null &&
-                owner.FirstAncestorOrSelf<SyntaxNode>(static n => n.IsAnyAttributeSyntax()) is null;
+                owner.FirstAncestorOrSelf<SyntaxNode>(static n =>
+                    n.IsAnyAttributeSyntax() ||
+                    n is BaseMarkupElementSyntax { StartTag.Name.Content: "style" }) is null;
         }
 
         // Ideally this would be solved instead by not emitting the "!" at the HTML backing file,

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Diagnostics/RazorTranslateDiagnosticsService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Diagnostics/RazorTranslateDiagnosticsService.cs
@@ -488,20 +488,20 @@ internal sealed class RazorTranslateDiagnosticsService(IDocumentMappingService d
         }
 
         return false;
-    }
 
-    private static bool CheckIfAttributeContainsNonMarkupNodes(RazorSyntaxNode attributeNode)
-    {
-        return attributeNode.DescendantNodes().Any(IsNotMarkupOrCommentNode);
-    }
+        static bool CheckIfAttributeContainsNonMarkupNodes(RazorSyntaxNode attributeNode)
+        {
+            return attributeNode.DescendantNodes().Any(IsNotMarkupOrCommentNode);
+        }
 
-    private static bool IsNotMarkupOrCommentNode(SyntaxNode node)
-    {
-        return !(node is
-            MarkupBlockSyntax or
-            MarkupSyntaxNode or
-            GenericBlockSyntax or
-            RazorCommentBlockSyntax);
+        static bool IsNotMarkupOrCommentNode(SyntaxNode node)
+        {
+            return !(node is
+                MarkupBlockSyntax or
+                MarkupSyntaxNode or
+                GenericBlockSyntax or
+                RazorCommentBlockSyntax);
+        }
     }
 
     private LspDiagnostic[] FilterCSharpDiagnostics(LspDiagnostic[] diagnostics, RazorCodeDocument codeDocument)

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostDocumentPullDiagnosticsTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostDocumentPullDiagnosticsTest.cs
@@ -462,6 +462,31 @@ public partial class CohostDocumentPullDiagnosticsTest
     }
 
     [Fact]
+    public Task DontFilterPropertyNameInStyleBlock()
+    {
+        TestCode input = """
+            <style>
+                .foo {
+                    {|CSS024:/****/|}
+                }
+            </style>
+            """;
+
+        return VerifyDiagnosticsAsync(input,
+            htmlResponse: [new VSInternalDiagnosticReport
+            {
+                Diagnostics =
+                [
+                    new LspDiagnostic
+                    {
+                        Code = CSSErrorCodes.MissingPropertyName,
+                        Range = SourceText.From(input.Text).GetRange(new TextSpan(input.Text.IndexOf("/"), "/****/".Length))
+                    },
+                ]
+            }]);
+    }
+
+    [Fact]
     [WorkItem("https://github.com/dotnet/razor/issues/13191")]
     public Task FilterPropertyNameOutsideAttribute()
     {

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostDocumentPullDiagnosticsTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostDocumentPullDiagnosticsTest.cs
@@ -17,6 +17,7 @@ using Microsoft.CodeAnalysis.Remote.Razor.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
+using WorkItemAttribute = Roslyn.Test.Utilities.WorkItemAttribute;
 
 namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 
@@ -458,6 +459,82 @@ public partial class CohostDocumentPullDiagnosticsTest
                     },
                 ]
             }]);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13191")]
+    public Task FilterPropertyNameOutsideAttribute()
+    {
+        TestCode input = """
+            @if (true)
+            {
+                <MudCard Outlined="true" Class="mud-width-full" Elevation="3"
+                         HeaderClass="@((SelectedFileId == DefaultMessageId) ? "selected" : "unselected")">
+                    <div class="d-flex flex-column align-center justify-center pa-3" style="height: 120px;">
+                        <span style="width: 179px; height: 100%; background-color: black;"></span>
+                    </div>
+
+                    <div class="d-flex card-actions-cursor" style="padding-bottom: 10px; padding-top: 10px; border-top: 1px solid var(--mud-palette-lines-default);">
+                        <span>Default message</span>
+                    </div>
+                </MudCard>
+            }
+
+            <div style="{|CSS024:/****/|}"></div>
+
+            @code
+            {
+                private string SelectedFileId { get; set; } = "";
+                private string DefaultMessageId { get; } = "Default";
+            }
+            """;
+
+        var sourceText = SourceText.From(input.Text);
+
+        // Sometimes the Html server will report the diagnostic range as the whole component, or even multiple.
+        var diagnosticStart = input.Text.IndexOf("    <MudCard");
+        var diagnosticEnd = input.Text.IndexOf("        <div class=\"d-flex card-actions-cursor\"");
+
+        return VerifyDiagnosticsAsync(
+            input,
+            htmlResponse: [new VSInternalDiagnosticReport
+            {
+                Diagnostics =
+                [
+                    new LspDiagnostic
+                    {
+                        Code = CSSErrorCodes.MissingPropertyName,
+                        Range = sourceText.GetRange(TextSpan.FromBounds(diagnosticStart, diagnosticEnd))
+                    },
+                    new LspDiagnostic
+                    {
+                        Code = CSSErrorCodes.MissingPropertyName,
+                        Range = sourceText.GetRange(new TextSpan(input.Text.IndexOf("/****/"), "/****/".Length))
+                    },
+                ]
+            }],
+            additionalFiles:
+            [
+                (FilePath("MudCard.razor"), """
+                    @code
+                    {
+                        [Parameter]
+                        public bool Outlined { get; set; }
+
+                        [Parameter]
+                        public string Class { get; set; }
+
+                        [Parameter]
+                        public int Elevation { get; set; }
+
+                        [Parameter]
+                        public string HeaderClass { get; set; }
+
+                        [Parameter]
+                        public RenderFragment ChildContent { get; set; }
+                    }
+                    """)
+            ]);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/13191

Sometimes it seems the Html server gets a bit weird and reports huge ranges for CSS diagnostics. Easy enough to filter them out though, since we know they're reported on attributes, so we can tell if the server is confused.

Just to show you how wrong the data reported is:
<img width="753" height="240" alt="image" src="https://github.com/user-attachments/assets/ef2564f6-bde8-4819-9f87-6f8d69dcdb3b" />

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84320)