### PR TITLE
Respect object initializer severity for fade diagnostics

### DIFF
--- a/src/Analyzers/CSharp/Tests/UseObjectInitializer/UseObjectInitializerTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseObjectInitializer/UseObjectInitializerTests.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.UseObjectInitializer;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Testing;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -1041,8 +1042,8 @@ public sealed partial class UseObjectInitializerTests
             
                     void M()
                     {
-                        var c = [|new|] C();
-                        c.i = 1;
+                        var c = {|#0:new|} C();
+                        {|#1:c.|}i = 1;
                     }
                 }
                 """;
@@ -1105,6 +1106,21 @@ public sealed partial class UseObjectInitializerTests
             LanguageVersion = LanguageVersion.CSharp12,
         };
 
+        if (enabled)
+        {
+            test.TestState.ExpectedDiagnostics.AddRange(
+                [
+                    VerifyCS.Diagnostic("IDE0017")
+                        .WithSeverity(DiagnosticSeverity.Info)
+                        .WithLocation(0)
+                        .WithOptions(DiagnosticOptions.IgnoreAdditionalLocations),
+                    VerifyCS.Diagnostic("IDE0017")
+                        .WithSeverity(DiagnosticSeverity.Info)
+                        .WithLocation(1)
+                        .WithOptions(DiagnosticOptions.IgnoreAdditionalLocations),
+                ]);
+        }
+
         await test.RunAsync();
     }
 
@@ -1155,6 +1171,72 @@ public sealed partial class UseObjectInitializerTests
             dotnet_diagnostic.IDE0017.severity = warning
 
             build_property.EnableCodeStyleSeverity = {enabled}
+            """),
+                }
+            },
+            FixedState = { Sources = { fixedCode } },
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestCodeStyleOptionSeverityAppliesToFadeOutDiagnosticOverCategorySeverity()
+    {
+        var testCode =
+            """
+            class C
+            {
+                int i;
+
+                void M()
+                {
+                    var c = {|#0:new|} C();
+                    {|#1:c.|}i = 1;
+                }
+            }
+            """;
+
+        var fixedCode =
+            """
+            class C
+            {
+                int i;
+
+                void M()
+                {
+                    var c = new C
+                    {
+                        i = 1
+                    };
+                }
+            }
+            """;
+
+        await new VerifyCS.Test
+        {
+            TestState =
+            {
+                Sources = { testCode },
+                ExpectedDiagnostics =
+                {
+                    VerifyCS.Diagnostic("IDE0017")
+                        .WithSeverity(DiagnosticSeverity.Info)
+                        .WithLocation(0)
+                        .WithOptions(DiagnosticOptions.IgnoreAdditionalLocations),
+                    VerifyCS.Diagnostic("IDE0017")
+                        .WithSeverity(DiagnosticSeverity.Info)
+                        .WithLocation(1)
+                        .WithOptions(DiagnosticOptions.IgnoreAdditionalLocations),
+                },
+                AnalyzerConfigFiles =
+                {
+                    ("/.globalconfig", """
+            is_global = true
+
+            dotnet_style_object_initializer = true:suggestion
+            dotnet_analyzer_diagnostic.category-Style.severity = warning
+
+            build_property.EnableCodeStyleSeverity = true
             """),
                 }
             },

--- a/src/Analyzers/Core/Analyzers/UseObjectInitializer/AbstractUseObjectInitializerDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseObjectInitializer/AbstractUseObjectInitializerDiagnosticAnalyzer.cs
@@ -139,7 +139,7 @@ internal abstract partial class AbstractUseObjectInitializerDiagnosticAnalyzer<
             locations,
             properties: null));
 
-        FadeOutCode(context, matches, locations);
+        FadeOutCode(context, matches, locations, option.Notification);
 
         return;
     }
@@ -147,7 +147,8 @@ internal abstract partial class AbstractUseObjectInitializerDiagnosticAnalyzer<
     private void FadeOutCode(
         SyntaxNodeAnalysisContext context,
         ImmutableArray<Match<TExpressionSyntax, TStatementSyntax, TMemberAccessExpressionSyntax, TAssignmentStatementSyntax>> matches,
-        ImmutableArray<Location> locations)
+        ImmutableArray<Location> locations,
+        NotificationOption2 notification)
     {
         var syntaxTree = context.Node.SyntaxTree;
 
@@ -178,7 +179,7 @@ internal abstract partial class AbstractUseObjectInitializerDiagnosticAnalyzer<
             context.ReportDiagnostic(DiagnosticHelper.CreateWithLocationTags(
                 s_unnecessaryCodeDescriptor,
                 additionalUnnecessaryLocations[0],
-                NotificationOption2.ForSeverity(s_unnecessaryCodeDescriptor.DefaultSeverity),
+                notification,
                 context.Options,
                 additionalLocations: locations,
                 additionalUnnecessaryLocations: additionalUnnecessaryLocations.ToImmutableAndClear(),


### PR DESCRIPTION
## Summary

- Pass the configured `dotnet_style_object_initializer` notification severity to object-initializer fade diagnostics.
- Add a regression test where `dotnet_style_object_initializer = true:suggestion` coexists with `dotnet_analyzer_diagnostic.category-Style.severity = warning`, ensuring both IDE0017 diagnostics remain info/suggestion severity.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84324)