### PR TITLE
Remove RemoteDocumentContext now that it's essentially useless

### DIFF
--- a/src/Razor/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Formatting/DocumentFormattingBenchmark.cs
+++ b/src/Razor/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Formatting/DocumentFormattingBenchmark.cs
@@ -14,7 +14,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.Razor.Formatting;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -27,7 +26,6 @@ using Microsoft.CodeAnalysis.Remote.Razor.Formatting;
 using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.NET.Sdk.Razor.SourceGenerators;
-using Roslyn.LanguageServer.Protocol;
 using AspNet80 = Basic.Reference.Assemblies.AspNet80;
 
 namespace Microsoft.AspNetCore.Razor.Microbenchmarks.Formatting;
@@ -44,7 +42,6 @@ public class DocumentFormattingBenchmark
     private const string DocumentRelativePath = "DocumentFormattingBenchmark.cshtml";
     private const string RootNamespace = "Benchmark";
 
-    private static readonly DocumentUri s_documentUri = ProtocolConversions.CreateAbsoluteDocumentUri(DocumentFilePath);
     private static readonly AnalyzerFileReference s_razorSourceGeneratorReference = new(
         typeof(RazorSourceGenerator).Assembly.Location,
         AnalyzerAssemblyLoader.Instance);
@@ -75,7 +72,7 @@ public class DocumentFormattingBenchmark
         var filePathService = new RemoteFilePathService();
         var snapshotManager = new RemoteSnapshotManager(filePathService, NoOpTelemetryReporter.Instance);
         var documentSnapshot = snapshotManager.GetSnapshot(document);
-        _documentContext = new RemoteDocumentContext(s_documentUri, documentSnapshot);
+        _documentContext = new RemoteDocumentContext(documentSnapshot);
 
         var hostServicesProvider = new RemoteHostServicesProvider();
         hostServicesProvider.SetWorkspaceProvider(new WorkspaceProvider(_workspace));

--- a/src/Razor/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Formatting/DocumentFormattingBenchmark.cs
+++ b/src/Razor/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Formatting/DocumentFormattingBenchmark.cs
@@ -47,7 +47,7 @@ public class DocumentFormattingBenchmark
         AnalyzerAssemblyLoader.Instance);
 
     private AdhocWorkspace? _workspace;
-    private RemoteDocumentContext? _documentContext;
+    private RemoteDocumentSnapshot? _documentSnapshot;
     private SourceText? _sourceText;
     private ImmutableArray<TextChange> _htmlChanges;
     private RazorFormattingService? _formattingService;
@@ -72,7 +72,7 @@ public class DocumentFormattingBenchmark
         var filePathService = new RemoteFilePathService();
         var snapshotManager = new RemoteSnapshotManager(filePathService, NoOpTelemetryReporter.Instance);
         var documentSnapshot = snapshotManager.GetSnapshot(document);
-        _documentContext = new RemoteDocumentContext(documentSnapshot);
+        _documentSnapshot = documentSnapshot;
 
         var hostServicesProvider = new RemoteHostServicesProvider();
         hostServicesProvider.SetWorkspaceProvider(new WorkspaceProvider(_workspace));
@@ -123,7 +123,7 @@ public class DocumentFormattingBenchmark
     private int FormatDocumentCore()
     {
         var changes = _formattingService.AssumeNotNull().GetDocumentFormattingChangesAsync(
-            _documentContext.AssumeNotNull(),
+            _documentSnapshot.AssumeNotNull(),
             _htmlChanges,
             range: null,
             _options,

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/AutoInsert/RemoteAutoInsertService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/AutoInsert/RemoteAutoInsertService.cs
@@ -76,7 +76,7 @@ internal sealed class RemoteAutoInsertService(in ServiceArgs args)
         RazorFormattingOptions options,
         CancellationToken cancellationToken)
     {
-        var sourceText = await remoteDocumentContext.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
+        var sourceText = await remoteDocumentContext.Snapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
         if (!sourceText.TryGetAbsoluteIndex(linePosition, out var index))
         {
             return Response.NoFurtherHandling;
@@ -205,7 +205,7 @@ internal sealed class RemoteAutoInsertService(in ServiceArgs args)
             return Response.NoFurtherHandling;
         }
 
-        var sourceText = await remoteDocumentContext.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
+        var sourceText = await remoteDocumentContext.Snapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
         return Response.Results(
             new RemoteAutoInsertTextEdit(
                 sourceText.GetLinePositionSpan(change.Span),

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/AutoInsert/RemoteAutoInsertService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/AutoInsert/RemoteAutoInsertService.cs
@@ -82,7 +82,7 @@ internal sealed class RemoteAutoInsertService(in ServiceArgs args)
             return Response.NoFurtherHandling;
         }
 
-        var codeDocument = await remoteDocumentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await remoteDocumentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         var clientSettings = _clientSettingsManager.GetClientSettings();
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/AutoInsert/RemoteAutoInsertService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/AutoInsert/RemoteAutoInsertService.cs
@@ -70,19 +70,19 @@ internal sealed class RemoteAutoInsertService(in ServiceArgs args)
             cancellationToken);
 
     private async ValueTask<Response> TryResolveInsertionAsync(
-        RemoteDocumentContext remoteDocumentContext,
+        RemoteDocumentSnapshot documentSnapshot,
         LinePosition linePosition,
         string character,
         RazorFormattingOptions options,
         CancellationToken cancellationToken)
     {
-        var sourceText = await remoteDocumentContext.Snapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        var sourceText = await documentSnapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
         if (!sourceText.TryGetAbsoluteIndex(linePosition, out var index))
         {
             return Response.NoFurtherHandling;
         }
 
-        var codeDocument = await remoteDocumentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         var clientSettings = _clientSettingsManager.GetClientSettings();
 
@@ -114,7 +114,7 @@ internal sealed class RemoteAutoInsertService(in ServiceArgs args)
             case RazorLanguageKind.CSharp:
                 var mappedPosition = positionInfo.Position.ToLinePosition();
                 return await TryResolveInsertionInCSharpAsync(
-                        remoteDocumentContext,
+                        documentSnapshot,
                         mappedPosition,
                         positionInfo.InDeclDocument,
                         character,
@@ -128,7 +128,7 @@ internal sealed class RemoteAutoInsertService(in ServiceArgs args)
     }
 
     private async ValueTask<Response> TryResolveInsertionInCSharpAsync(
-        RemoteDocumentContext remoteDocumentContext,
+        RemoteDocumentSnapshot documentSnapshot,
         LinePosition mappedPosition,
         bool inDeclDocument,
         string character,
@@ -156,7 +156,7 @@ internal sealed class RemoteAutoInsertService(in ServiceArgs args)
             return Response.NoFurtherHandling;
         }
 
-        var generatedDocument = await remoteDocumentContext.Snapshot
+        var generatedDocument = await documentSnapshot
             .GetGeneratedDocumentAsync(inDeclDocument, cancellationToken)
             .ConfigureAwait(false);
         var globalOptions = generatedDocument.Project.Solution.Services.ExportProvider.GetService<IGlobalOptionService>();
@@ -186,14 +186,14 @@ internal sealed class RemoteAutoInsertService(in ServiceArgs args)
         var csharpTextChange = new TextChange(csharpSourceText.GetTextSpan(autoInsertResponseItem.TextEdit.Range), autoInsertResponseItem.TextEdit.NewText);
         var mappedChange = autoInsertResponseItem.TextEditFormat == InsertTextFormat.Snippet
             ? await _razorFormattingService.TryGetCSharpSnippetFormattingEditAsync(
-                remoteDocumentContext,
+                documentSnapshot,
                 [csharpTextChange],
                 inDeclDocument,
                 options,
                 cancellationToken)
             .ConfigureAwait(false)
             : await _razorFormattingService.TryGetSingleCSharpEditAsync(
-                remoteDocumentContext,
+                documentSnapshot,
                 csharpTextChange,
                 inDeclDocument,
                 options,
@@ -205,7 +205,7 @@ internal sealed class RemoteAutoInsertService(in ServiceArgs args)
             return Response.NoFurtherHandling;
         }
 
-        var sourceText = await remoteDocumentContext.Snapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        var sourceText = await documentSnapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
         return Response.Results(
             new RemoteAutoInsertTextEdit(
                 sourceText.GetLinePositionSpan(change.Span),

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CallHierarchy/RemoteCallHierarchyService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CallHierarchy/RemoteCallHierarchyService.cs
@@ -37,15 +37,15 @@ internal sealed class RemoteCallHierarchyService(in ServiceArgs args) : RazorDoc
         => RunServiceAsync(
             solutionInfo,
             razorDocumentId,
-            context => PrepareCallHierarchyAsync(context, position, cancellationToken),
+            snapshot => PrepareCallHierarchyAsync(snapshot, position, cancellationToken),
             cancellationToken);
 
     private async ValueTask<RemoteResponse<CallHierarchyItem[]?>> PrepareCallHierarchyAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         Position position,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         if (!codeDocument.Source.Text.TryGetAbsoluteIndex(position, out var hostDocumentIndex))
         {
@@ -60,7 +60,7 @@ internal sealed class RemoteCallHierarchyService(in ServiceArgs args) : RazorDoc
             return RemoteResponse<CallHierarchyItem[]?>.NoFurtherHandling;
         }
 
-        var generatedDocument = await context.Snapshot
+        var generatedDocument = await snapshot
             .GetGeneratedDocumentAsync(positionInfo.InDeclDocument, cancellationToken)
             .ConfigureAwait(false);
 
@@ -73,7 +73,7 @@ internal sealed class RemoteCallHierarchyService(in ServiceArgs args) : RazorDoc
             // Razor implementation generated documents can contain call sites for members whose declarations live in the
             // paired declaration generated document. In that case Roslyn's prepare path can't create an item for the
             // implementation document, so retry while explicitly preferring the declaration document.
-            var declarationGeneratedDocument = await context.Snapshot.TryGetGeneratedDocumentAsync(declarationDocument: true, cancellationToken).ConfigureAwait(false);
+            var declarationGeneratedDocument = await snapshot.TryGetGeneratedDocumentAsync(declarationDocument: true, cancellationToken).ConfigureAwait(false);
             if (declarationGeneratedDocument is null)
             {
                 return RemoteResponse<CallHierarchyItem[]?>.NoFurtherHandling;
@@ -87,7 +87,7 @@ internal sealed class RemoteCallHierarchyService(in ServiceArgs args) : RazorDoc
             return RemoteResponse<CallHierarchyItem[]?>.NoFurtherHandling;
         }
 
-        var mappedItems = await MapItemsAsync(context, items, cancellationToken).ConfigureAwait(false);
+        var mappedItems = await MapItemsAsync(snapshot, items, cancellationToken).ConfigureAwait(false);
         return RemoteResponse<CallHierarchyItem[]?>.Results(mappedItems);
     }
 
@@ -99,15 +99,15 @@ internal sealed class RemoteCallHierarchyService(in ServiceArgs args) : RazorDoc
         => RunServiceAsync(
             solutionInfo,
             razorDocumentId,
-            context => GetIncomingCallsAsync(context, item, cancellationToken),
+            snapshot => GetIncomingCallsAsync(snapshot, item, cancellationToken),
             cancellationToken);
 
     private async ValueTask<RemoteResponse<CallHierarchyIncomingCall[]?>> GetIncomingCallsAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         CallHierarchyItem item,
         CancellationToken cancellationToken)
     {
-        var generatedDocument = await TryGetGeneratedDocumentForItemAsync(context, item, cancellationToken).ConfigureAwait(false);
+        var generatedDocument = await TryGetGeneratedDocumentForItemAsync(snapshot, item, cancellationToken).ConfigureAwait(false);
         if (generatedDocument is null)
         {
             return RemoteResponse<CallHierarchyIncomingCall[]?>.NoFurtherHandling;
@@ -125,13 +125,13 @@ internal sealed class RemoteCallHierarchyService(in ServiceArgs args) : RazorDoc
         foreach (var incomingCall in incomingCalls)
         {
             var originalFromUri = incomingCall.From.Uri.GetRequiredSystemUri();
-            var mappedFromItem = await MapItemAsync(context, incomingCall.From, cancellationToken).ConfigureAwait(false);
+            var mappedFromItem = await MapItemAsync(snapshot, incomingCall.From, cancellationToken).ConfigureAwait(false);
             if (mappedFromItem is null)
             {
                 continue;
             }
 
-            var mappedRanges = await MapRangesAsync(context, originalFromUri, incomingCall.FromRanges, cancellationToken).ConfigureAwait(false);
+            var mappedRanges = await MapRangesAsync(snapshot, originalFromUri, incomingCall.FromRanges, cancellationToken).ConfigureAwait(false);
             builder.Add(new CallHierarchyIncomingCall
             {
                 From = mappedFromItem,
@@ -150,15 +150,15 @@ internal sealed class RemoteCallHierarchyService(in ServiceArgs args) : RazorDoc
         => RunServiceAsync(
             solutionInfo,
             razorDocumentId,
-            context => GetOutgoingCallsAsync(context, item, cancellationToken),
+            snapshot => GetOutgoingCallsAsync(snapshot, item, cancellationToken),
             cancellationToken);
 
     private async ValueTask<RemoteResponse<CallHierarchyOutgoingCall[]?>> GetOutgoingCallsAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         CallHierarchyItem item,
         CancellationToken cancellationToken)
     {
-        var generatedDocument = await TryGetGeneratedDocumentForItemAsync(context, item, cancellationToken).ConfigureAwait(false);
+        var generatedDocument = await TryGetGeneratedDocumentForItemAsync(snapshot, item, cancellationToken).ConfigureAwait(false);
         if (generatedDocument is null)
         {
             return RemoteResponse<CallHierarchyOutgoingCall[]?>.NoFurtherHandling;
@@ -176,13 +176,13 @@ internal sealed class RemoteCallHierarchyService(in ServiceArgs args) : RazorDoc
         using var builder = new PooledArrayBuilder<CallHierarchyOutgoingCall>(outgoingCalls.Length);
         foreach (var outgoingCall in outgoingCalls)
         {
-            var mappedToItem = await MapItemAsync(context, outgoingCall.To, cancellationToken).ConfigureAwait(false);
+            var mappedToItem = await MapItemAsync(snapshot, outgoingCall.To, cancellationToken).ConfigureAwait(false);
             if (mappedToItem is null)
             {
                 continue;
             }
 
-            var mappedRanges = await MapRangesAsync(context, callerUri, outgoingCall.FromRanges, cancellationToken).ConfigureAwait(false);
+            var mappedRanges = await MapRangesAsync(snapshot, callerUri, outgoingCall.FromRanges, cancellationToken).ConfigureAwait(false);
             builder.Add(new CallHierarchyOutgoingCall
             {
                 To = mappedToItem,
@@ -194,21 +194,21 @@ internal sealed class RemoteCallHierarchyService(in ServiceArgs args) : RazorDoc
     }
 
     private static async ValueTask<SourceGeneratedDocument?> TryGetGeneratedDocumentForItemAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         CallHierarchyItem item,
         CancellationToken cancellationToken)
     {
         var resolveData = CallHierarchyHelpers.GetResolveData(item);
         var generatedDocumentUri = resolveData.TextDocument.DocumentUri.GetRequiredSystemUri();
-        return await context.Snapshot.TextDocument.Project.Solution.TryGetSourceGeneratedDocumentAsync(generatedDocumentUri, cancellationToken).ConfigureAwait(false);
+        return await snapshot.TextDocument.Project.Solution.TryGetSourceGeneratedDocumentAsync(generatedDocumentUri, cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task<CallHierarchyItem[]?> MapItemsAsync(RemoteDocumentContext context, CallHierarchyItem[] items, CancellationToken cancellationToken)
+    private async Task<CallHierarchyItem[]?> MapItemsAsync(RemoteDocumentSnapshot snapshot, CallHierarchyItem[] items, CancellationToken cancellationToken)
     {
         using var builder = new PooledArrayBuilder<CallHierarchyItem>(items.Length);
         foreach (var item in items)
         {
-            var mappedItem = await MapItemAsync(context, item, cancellationToken).ConfigureAwait(false);
+            var mappedItem = await MapItemAsync(snapshot, item, cancellationToken).ConfigureAwait(false);
             if (mappedItem is not null)
             {
                 builder.Add(mappedItem);
@@ -218,12 +218,12 @@ internal sealed class RemoteCallHierarchyService(in ServiceArgs args) : RazorDoc
         return builder.ToArray();
     }
 
-    private async Task<CallHierarchyItem?> MapItemAsync(RemoteDocumentContext context, CallHierarchyItem item, CancellationToken cancellationToken)
+    private async Task<CallHierarchyItem?> MapItemAsync(RemoteDocumentSnapshot snapshot, CallHierarchyItem item, CancellationToken cancellationToken)
     {
         var uri = item.Uri.GetRequiredSystemUri();
 
         var (mappedDocumentUri, mappedRange) = await DocumentMappingService
-            .MapToHostDocumentUriAndRangeAsync(context.Snapshot, uri, item.Range, cancellationToken)
+            .MapToHostDocumentUriAndRangeAsync(snapshot, uri, item.Range, cancellationToken)
             .ConfigureAwait(false);
 
         if (_filePathService.IsVirtualCSharpFile(mappedDocumentUri))
@@ -232,7 +232,7 @@ internal sealed class RemoteCallHierarchyService(in ServiceArgs args) : RazorDoc
         }
 
         var (mappedSelectionUri, mappedSelectionRange) = await DocumentMappingService
-            .MapToHostDocumentUriAndRangeAsync(context.Snapshot, uri, item.SelectionRange, cancellationToken)
+            .MapToHostDocumentUriAndRangeAsync(snapshot, uri, item.SelectionRange, cancellationToken)
             .ConfigureAwait(false);
 
         if (_filePathService.IsVirtualCSharpFile(mappedSelectionUri))
@@ -253,13 +253,13 @@ internal sealed class RemoteCallHierarchyService(in ServiceArgs args) : RazorDoc
         };
     }
 
-    private async Task<LspRange[]> MapRangesAsync(RemoteDocumentContext context, Uri documentUri, LspRange[] ranges, CancellationToken cancellationToken)
+    private async Task<LspRange[]> MapRangesAsync(RemoteDocumentSnapshot snapshot, Uri documentUri, LspRange[] ranges, CancellationToken cancellationToken)
     {
         using var builder = new PooledArrayBuilder<LspRange>(ranges.Length);
         foreach (var range in ranges)
         {
             var (mappedDocumentUri, mappedRange) = await DocumentMappingService
-                .MapToHostDocumentUriAndRangeAsync(context.Snapshot, documentUri, range, cancellationToken)
+                .MapToHostDocumentUriAndRangeAsync(snapshot, documentUri, range, cancellationToken)
                 .ConfigureAwait(false);
 
             if (_filePathService.IsVirtualCSharpFile(mappedDocumentUri))

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CallHierarchy/RemoteCallHierarchyService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CallHierarchy/RemoteCallHierarchyService.cs
@@ -45,7 +45,7 @@ internal sealed class RemoteCallHierarchyService(in ServiceArgs args) : RazorDoc
         Position position,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         if (!codeDocument.Source.Text.TryGetAbsoluteIndex(position, out var hostDocumentIndex))
         {

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/CSharp/CSharpCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/CSharp/CSharpCodeActionResolver.cs
@@ -36,7 +36,7 @@ internal sealed class CSharpCodeActionResolver(
     public string Action => LanguageServerConstants.CodeActions.Default;
 
     public async Task<CodeAction> ResolveAsync(
-        RemoteDocumentContext documentContext,
+        RemoteDocumentSnapshot snapshot,
         CodeAction codeAction,
         CancellationToken cancellationToken)
     {
@@ -46,7 +46,6 @@ internal sealed class CSharpCodeActionResolver(
             return codeAction;
         }
 
-        var snapshot = documentContext.Snapshot;
         var formattingOptions = _clientSettingsManager.GetClientSettings().ToRazorFormattingOptions();
 
         foreach (var textDocumentEdit in codeAction.Edit.EnumerateTextDocumentEdits())

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/CSharp/ICSharpCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/CSharp/ICSharpCodeActionResolver.cs
@@ -9,5 +9,5 @@ namespace Microsoft.CodeAnalysis.Razor.CodeActions;
 
 internal interface ICSharpCodeActionResolver : ICodeActionResolver
 {
-    Task<CodeAction> ResolveAsync(RemoteDocumentContext documentContext, CodeAction codeAction, CancellationToken cancellationToken);
+    Task<CodeAction> ResolveAsync(RemoteDocumentSnapshot documentSnapshot, CodeAction codeAction, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/CodeActionResolveService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/CodeActionResolveService.cs
@@ -36,7 +36,7 @@ internal sealed class CodeActionResolveService(
     private readonly IClientSettingsManager _clientSettingsManager = clientSettingsManager;
     private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<CodeActionResolveService>();
 
-    public async Task<CodeAction> ResolveCodeActionAsync(RemoteDocumentContext documentContext, CodeAction request, CodeAction? resolvedDelegatedCodeAction, CancellationToken cancellationToken)
+    public async Task<CodeAction> ResolveCodeActionAsync(RemoteDocumentSnapshot documentSnapshot, CodeAction request, CodeAction? resolvedDelegatedCodeAction, CancellationToken cancellationToken)
     {
         var resolutionParams = RazorCodeActionResolutionParams.Unwrap(request);
 
@@ -56,19 +56,19 @@ internal sealed class CodeActionResolveService(
         {
             case RazorLanguageKind.Razor:
                 return await ResolveRazorCodeActionAsync(
-                    documentContext,
+                    documentSnapshot,
                     request,
                     resolutionParams,
                     cancellationToken).ConfigureAwait(false);
             case RazorLanguageKind.CSharp:
                 return await ResolveCSharpCodeActionAsync(
-                    documentContext,
+                    documentSnapshot,
                     resolvedDelegatedCodeAction.AssumeNotNull(),
                     resolutionParams,
                     cancellationToken).ConfigureAwait(false);
             case RazorLanguageKind.Html:
                 return await ResolveHtmlCodeActionAsync(
-                    documentContext,
+                    documentSnapshot,
                     resolvedDelegatedCodeAction.AssumeNotNull(),
                     resolutionParams,
                     cancellationToken).ConfigureAwait(false);
@@ -79,7 +79,7 @@ internal sealed class CodeActionResolveService(
     }
 
     private async Task<CodeAction> ResolveRazorCodeActionAsync(
-        RemoteDocumentContext documentContext,
+        RemoteDocumentSnapshot documentSnapshot,
         CodeAction codeAction,
         RazorCodeActionResolutionParams resolutionParams,
         CancellationToken cancellationToken)
@@ -98,26 +98,26 @@ internal sealed class CodeActionResolveService(
         }
 
         var options = _clientSettingsManager.GetClientSettings().ToRazorFormattingOptions();
-        var edit = await resolver.ResolveAsync(documentContext, data, options, cancellationToken).ConfigureAwait(false);
+        var edit = await resolver.ResolveAsync(documentSnapshot, data, options, cancellationToken).ConfigureAwait(false);
         codeAction.Edit = edit;
         return codeAction;
     }
 
-    private async Task<CodeAction> ResolveCSharpCodeActionAsync(RemoteDocumentContext documentContext, CodeAction codeAction, RazorCodeActionResolutionParams resolutionParams, CancellationToken cancellationToken)
+    private async Task<CodeAction> ResolveCSharpCodeActionAsync(RemoteDocumentSnapshot documentSnapshot, CodeAction codeAction, RazorCodeActionResolutionParams resolutionParams, CancellationToken cancellationToken)
     {
         if (TryGetResolver(resolutionParams, _csharpCodeActionResolvers, out var resolver))
         {
-            return await resolver.ResolveAsync(documentContext, codeAction, cancellationToken).ConfigureAwait(false);
+            return await resolver.ResolveAsync(documentSnapshot, codeAction, cancellationToken).ConfigureAwait(false);
         }
 
         return codeAction;
     }
 
-    private async Task<CodeAction> ResolveHtmlCodeActionAsync(RemoteDocumentContext documentContext, CodeAction codeAction, RazorCodeActionResolutionParams resolutionParams, CancellationToken cancellationToken)
+    private async Task<CodeAction> ResolveHtmlCodeActionAsync(RemoteDocumentSnapshot documentSnapshot, CodeAction codeAction, RazorCodeActionResolutionParams resolutionParams, CancellationToken cancellationToken)
     {
         if (TryGetResolver(resolutionParams, _htmlCodeActionResolvers, out var resolver))
         {
-            return await resolver.ResolveAsync(documentContext, codeAction, cancellationToken).ConfigureAwait(false);
+            return await resolver.ResolveAsync(documentSnapshot, codeAction, cancellationToken).ConfigureAwait(false);
         }
 
         return codeAction;
@@ -162,13 +162,13 @@ internal sealed class CodeActionResolveService(
 
     internal readonly struct TestAccessor(CodeActionResolveService instance)
     {
-        public Task<CodeAction> ResolveRazorCodeActionAsync(RemoteDocumentContext documentContext, CodeAction codeAction, RazorCodeActionResolutionParams resolutionParams, CancellationToken cancellationToken)
-            => instance.ResolveRazorCodeActionAsync(documentContext, codeAction, resolutionParams, cancellationToken);
+        public Task<CodeAction> ResolveRazorCodeActionAsync(RemoteDocumentSnapshot documentSnapshot, CodeAction codeAction, RazorCodeActionResolutionParams resolutionParams, CancellationToken cancellationToken)
+            => instance.ResolveRazorCodeActionAsync(documentSnapshot, codeAction, resolutionParams, cancellationToken);
 
-        public Task<CodeAction> ResolveCSharpCodeActionAsync(RemoteDocumentContext documentContext, CodeAction codeAction, RazorCodeActionResolutionParams resolutionParams, CancellationToken cancellationToken)
-            => instance.ResolveCSharpCodeActionAsync(documentContext, codeAction, resolutionParams, cancellationToken);
+        public Task<CodeAction> ResolveCSharpCodeActionAsync(RemoteDocumentSnapshot documentSnapshot, CodeAction codeAction, RazorCodeActionResolutionParams resolutionParams, CancellationToken cancellationToken)
+            => instance.ResolveCSharpCodeActionAsync(documentSnapshot, codeAction, resolutionParams, cancellationToken);
 
-        public Task<CodeAction> ResolveHtmlCodeActionAsync(RemoteDocumentContext documentContext, CodeAction codeAction, RazorCodeActionResolutionParams resolutionParams, CancellationToken cancellationToken)
-            => instance.ResolveHtmlCodeActionAsync(documentContext, codeAction, resolutionParams, cancellationToken);
+        public Task<CodeAction> ResolveHtmlCodeActionAsync(RemoteDocumentSnapshot documentSnapshot, CodeAction codeAction, RazorCodeActionResolutionParams resolutionParams, CancellationToken cancellationToken)
+            => instance.ResolveHtmlCodeActionAsync(documentSnapshot, codeAction, resolutionParams, cancellationToken);
     }
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Html/HtmlCodeActionHelpers.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Html/HtmlCodeActionHelpers.cs
@@ -16,7 +16,7 @@ internal static class HtmlCodeActionHelpers
     {
         Assumes.NotNull(codeAction.Edit);
 
-        await razorEditService.MapWorkspaceEditAsync(documentSnapshot, codeAction.Edit, cancellationToken).ConfigureAwait(false);
+        await razorEditService.MapWorkspaceEditAsync(documentSnapshot.TextDocument.Project.Solution, codeAction.Edit, cancellationToken).ConfigureAwait(false);
 
         var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var htmlSourceText = codeDocument.GetHtmlSourceText(cancellationToken);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Html/HtmlCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Html/HtmlCodeActionResolver.cs
@@ -20,17 +20,17 @@ internal sealed class HtmlCodeActionResolver(IRazorEditService razorEditService)
     public string Action => LanguageServerConstants.CodeActions.Default;
 
     Task<CodeAction> IHtmlCodeActionResolver.ResolveAsync(
-        RemoteDocumentContext documentContext,
+        RemoteDocumentSnapshot documentSnapshot,
         CodeAction codeAction,
         CancellationToken cancellationToken)
-        => ResolveAsync(documentContext, codeAction, cancellationToken);
+        => ResolveAsync(documentSnapshot, codeAction, cancellationToken);
 
     public async Task<CodeAction> ResolveAsync(
-        RemoteDocumentContext documentContext,
+        RemoteDocumentSnapshot documentSnapshot,
         CodeAction codeAction,
         CancellationToken cancellationToken)
     {
-        await HtmlCodeActionHelpers.MapAndFixHtmlCodeActionEditAsync(_razorEditService, documentContext.Snapshot, codeAction, cancellationToken).ConfigureAwait(false);
+        await HtmlCodeActionHelpers.MapAndFixHtmlCodeActionEditAsync(_razorEditService, documentSnapshot, codeAction, cancellationToken).ConfigureAwait(false);
 
         return codeAction;
     }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Html/HtmlCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Html/HtmlCodeActionResolver.cs
@@ -19,12 +19,6 @@ internal sealed class HtmlCodeActionResolver(IRazorEditService razorEditService)
 
     public string Action => LanguageServerConstants.CodeActions.Default;
 
-    Task<CodeAction> IHtmlCodeActionResolver.ResolveAsync(
-        RemoteDocumentSnapshot documentSnapshot,
-        CodeAction codeAction,
-        CancellationToken cancellationToken)
-        => ResolveAsync(documentSnapshot, codeAction, cancellationToken);
-
     public async Task<CodeAction> ResolveAsync(
         RemoteDocumentSnapshot documentSnapshot,
         CodeAction codeAction,

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Html/IHtmlCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Html/IHtmlCodeActionResolver.cs
@@ -9,5 +9,5 @@ namespace Microsoft.CodeAnalysis.Razor.CodeActions;
 
 internal interface IHtmlCodeActionResolver : ICodeActionResolver
 {
-    Task<CodeAction> ResolveAsync(RemoteDocumentContext documentContext, CodeAction codeAction, CancellationToken cancellationToken);
+    Task<CodeAction> ResolveAsync(RemoteDocumentSnapshot documentSnapshot, CodeAction codeAction, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/ICodeActionResolveService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/ICodeActionResolveService.cs
@@ -9,5 +9,5 @@ namespace Microsoft.CodeAnalysis.Razor.CodeActions;
 
 internal interface ICodeActionResolveService
 {
-    Task<CodeAction> ResolveCodeActionAsync(RemoteDocumentContext documentContext, CodeAction request, CodeAction? resolvedDelegatedCodeAction, CancellationToken cancellationToken);
+    Task<CodeAction> ResolveCodeActionAsync(RemoteDocumentSnapshot documentSnapshot, CodeAction request, CodeAction? resolvedDelegatedCodeAction, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/AddUsingsCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/AddUsingsCodeActionResolver.cs
@@ -21,15 +21,13 @@ internal sealed class AddUsingsCodeActionResolver : IRazorCodeActionResolver
 {
     public string Action => LanguageServerConstants.CodeActions.AddUsing;
 
-    public async Task<WorkspaceEdit?> ResolveAsync(RemoteDocumentContext documentContext, JsonElement data, RazorFormattingOptions options, CancellationToken cancellationToken)
+    public async Task<WorkspaceEdit?> ResolveAsync(RemoteDocumentSnapshot documentSnapshot, JsonElement data, RazorFormattingOptions options, CancellationToken cancellationToken)
     {
         var actionParams = data.Deserialize<AddUsingsCodeActionParams>();
         if (actionParams is null)
         {
             return null;
         }
-
-        var documentSnapshot = documentContext.Snapshot;
 
         var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentSnapshot.Uri };

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/AddUsingsCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/AddUsingsCodeActionResolver.cs
@@ -32,7 +32,7 @@ internal sealed class AddUsingsCodeActionResolver : IRazorCodeActionResolver
         var documentSnapshot = documentContext.Snapshot;
 
         var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
-        var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentContext.Uri };
+        var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentSnapshot.Uri };
 
         using var documentChanges = new PooledArrayBuilder<TextDocumentEdit>();
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ComponentAccessibilityCodeActionProvider.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ComponentAccessibilityCodeActionProvider.cs
@@ -220,7 +220,7 @@ internal sealed class ComponentAccessibilityCodeActionProvider(IFileSystem fileS
         // Find all matching tag helpers
         using var _ = DictionaryPool<string, TagHelperPair>.GetPooledObject(out var matching);
 
-        var tagHelpers = await context.DocumentSnapshot.Project.GetTagHelpersAsync(cancellationToken).ConfigureAwait(false);
+        var tagHelpers = await context.DocumentSnapshot.ProjectSnapshot.GetTagHelpersAsync(cancellationToken).ConfigureAwait(false);
 
         foreach (var tagHelper in tagHelpers)
         {

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/CreateComponentCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/CreateComponentCodeActionResolver.cs
@@ -39,7 +39,7 @@ internal sealed class CreateComponentCodeActionResolver(LanguageServerFeatureOpt
             return null;
         }
 
-        var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var newComponentUri = LspFactory.CreateFilePathUri(actionParams.Path, _languageServerFeatureOptions);
 
         using var documentChanges = new PooledArrayBuilder<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>>();

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/CreateComponentCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/CreateComponentCodeActionResolver.cs
@@ -26,7 +26,7 @@ internal sealed class CreateComponentCodeActionResolver(LanguageServerFeatureOpt
 
     public string Action => LanguageServerConstants.CodeActions.CreateComponentFromTag;
 
-    public async Task<WorkspaceEdit?> ResolveAsync(RemoteDocumentContext documentContext, JsonElement data, RazorFormattingOptions options, CancellationToken cancellationToken)
+    public async Task<WorkspaceEdit?> ResolveAsync(RemoteDocumentSnapshot documentSnapshot, JsonElement data, RazorFormattingOptions options, CancellationToken cancellationToken)
     {
         var actionParams = data.Deserialize<CreateComponentCodeActionParams>();
         if (actionParams is null)
@@ -34,12 +34,12 @@ internal sealed class CreateComponentCodeActionResolver(LanguageServerFeatureOpt
             return null;
         }
 
-        if (!documentContext.Snapshot.FileKind.IsComponent())
+        if (!documentSnapshot.FileKind.IsComponent())
         {
             return null;
         }
 
-        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var newComponentUri = LspFactory.CreateFilePathUri(actionParams.Path, _languageServerFeatureOptions);
 
         using var documentChanges = new PooledArrayBuilder<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>>();

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
@@ -44,7 +44,7 @@ internal sealed class ExtractToCodeBehindCodeActionResolver(
 
         var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
 
-        var path = FilePathNormalizer.Normalize(documentContext.Uri.GetAbsoluteOrUNCPath());
+        var path = FilePathNormalizer.Normalize(documentContext.Snapshot.Uri.GetAbsoluteOrUNCPath());
         var codeBehindPath = FileUtilities.GenerateUniquePath(path, $"{Path.GetExtension(path)}.cs");
         var codeBehindUri = LspFactory.CreateFilePathUri(codeBehindPath, _languageServerFeatureOptions);
 
@@ -58,7 +58,7 @@ internal sealed class ExtractToCodeBehindCodeActionResolver(
 
         var removeRange = codeDocument.Source.Text.GetRange(actionParams.RemoveStart, actionParams.RemoveEnd);
 
-        var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier { DocumentUri = documentContext.Uri };
+        var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier { DocumentUri = documentContext.Snapshot.Uri };
         var codeBehindDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier { DocumentUri = codeBehindUri };
 
         var documentChanges = new SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>[]

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
@@ -48,7 +48,7 @@ internal sealed class ExtractToCodeBehindCodeActionResolver(
         var codeBehindPath = FileUtilities.GenerateUniquePath(path, $"{Path.GetExtension(path)}.cs");
         var codeBehindUri = LspFactory.CreateFilePathUri(codeBehindPath, _languageServerFeatureOptions);
 
-        var text = await documentContext.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
+        var text = codeDocument.Source.Text;
 
         var className = Path.GetFileNameWithoutExtension(path);
         var codeBlockContent = text.ToString(new TextSpan(actionParams.ExtractStart, actionParams.ExtractEnd - actionParams.ExtractStart)).Trim();

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
@@ -54,7 +54,7 @@ internal sealed class ExtractToCodeBehindCodeActionResolver(
         var codeBlockContent = text.ToString(new TextSpan(actionParams.ExtractStart, actionParams.ExtractEnd - actionParams.ExtractStart)).Trim();
         var codeBehindContent = GenerateCodeBehindClass(className, actionParams.Namespace, codeBlockContent, codeDocument);
 
-        codeBehindContent = await _roslynCodeActionHelpers.GetFormattedNewFileContentsAsync(documentSnapshot.Project, codeBehindUri.GetRequiredSystemUri(), codeBehindContent, cancellationToken).ConfigureAwait(false);
+        codeBehindContent = await _roslynCodeActionHelpers.GetFormattedNewFileContentsAsync(documentSnapshot.ProjectSnapshot, codeBehindUri.GetRequiredSystemUri(), codeBehindContent, cancellationToken).ConfigureAwait(false);
 
         var removeRange = codeDocument.Source.Text.GetRange(actionParams.RemoveStart, actionParams.RemoveEnd);
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
@@ -34,7 +34,7 @@ internal sealed class ExtractToCodeBehindCodeActionResolver(
 
     public string Action => LanguageServerConstants.CodeActions.ExtractToCodeBehind;
 
-    public async Task<WorkspaceEdit?> ResolveAsync(RemoteDocumentContext documentContext, JsonElement data, RazorFormattingOptions options, CancellationToken cancellationToken)
+    public async Task<WorkspaceEdit?> ResolveAsync(RemoteDocumentSnapshot documentSnapshot, JsonElement data, RazorFormattingOptions options, CancellationToken cancellationToken)
     {
         var actionParams = data.Deserialize<ExtractToCodeBehindCodeActionParams>();
         if (actionParams is null)
@@ -42,9 +42,9 @@ internal sealed class ExtractToCodeBehindCodeActionResolver(
             return null;
         }
 
-        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
-        var path = FilePathNormalizer.Normalize(documentContext.Snapshot.Uri.GetAbsoluteOrUNCPath());
+        var path = FilePathNormalizer.Normalize(documentSnapshot.Uri.GetAbsoluteOrUNCPath());
         var codeBehindPath = FileUtilities.GenerateUniquePath(path, $"{Path.GetExtension(path)}.cs");
         var codeBehindUri = LspFactory.CreateFilePathUri(codeBehindPath, _languageServerFeatureOptions);
 
@@ -54,11 +54,11 @@ internal sealed class ExtractToCodeBehindCodeActionResolver(
         var codeBlockContent = text.ToString(new TextSpan(actionParams.ExtractStart, actionParams.ExtractEnd - actionParams.ExtractStart)).Trim();
         var codeBehindContent = GenerateCodeBehindClass(className, actionParams.Namespace, codeBlockContent, codeDocument);
 
-        codeBehindContent = await _roslynCodeActionHelpers.GetFormattedNewFileContentsAsync(documentContext.Snapshot.Project, codeBehindUri.GetRequiredSystemUri(), codeBehindContent, cancellationToken).ConfigureAwait(false);
+        codeBehindContent = await _roslynCodeActionHelpers.GetFormattedNewFileContentsAsync(documentSnapshot.Project, codeBehindUri.GetRequiredSystemUri(), codeBehindContent, cancellationToken).ConfigureAwait(false);
 
         var removeRange = codeDocument.Source.Text.GetRange(actionParams.RemoveStart, actionParams.RemoveEnd);
 
-        var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier { DocumentUri = documentContext.Snapshot.Uri };
+        var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier { DocumentUri = documentSnapshot.Uri };
         var codeBehindDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier { DocumentUri = codeBehindUri };
 
         var documentChanges = new SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>[]

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
@@ -42,7 +42,7 @@ internal sealed class ExtractToCodeBehindCodeActionResolver(
             return null;
         }
 
-        var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         var path = FilePathNormalizer.Normalize(documentContext.Snapshot.Uri.GetAbsoluteOrUNCPath());
         var codeBehindPath = FileUtilities.GenerateUniquePath(path, $"{Path.GetExtension(path)}.cs");

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToComponentCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToComponentCodeActionResolver.cs
@@ -45,7 +45,7 @@ internal sealed class ExtractToComponentCodeActionResolver(
             return null;
         }
 
-        var componentDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var componentDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         var text = componentDocument.Source.Text;
         var path = FilePathNormalizer.Normalize(documentContext.Snapshot.Uri.GetAbsoluteOrUNCPath());

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToComponentCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToComponentCodeActionResolver.cs
@@ -32,7 +32,7 @@ internal sealed class ExtractToComponentCodeActionResolver(
 
     public string Action => LanguageServerConstants.CodeActions.ExtractToNewComponent;
 
-    public async Task<WorkspaceEdit?> ResolveAsync(RemoteDocumentContext documentContext, JsonElement data, RazorFormattingOptions options, CancellationToken cancellationToken)
+    public async Task<WorkspaceEdit?> ResolveAsync(RemoteDocumentSnapshot documentSnapshot, JsonElement data, RazorFormattingOptions options, CancellationToken cancellationToken)
     {
         if (data.ValueKind == JsonValueKind.Undefined)
         {
@@ -45,10 +45,10 @@ internal sealed class ExtractToComponentCodeActionResolver(
             return null;
         }
 
-        var componentDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var componentDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         var text = componentDocument.Source.Text;
-        var path = FilePathNormalizer.Normalize(documentContext.Snapshot.Uri.GetAbsoluteOrUNCPath());
+        var path = FilePathNormalizer.Normalize(documentSnapshot.Uri.GetAbsoluteOrUNCPath());
         var directoryName = Path.GetDirectoryName(path).AssumeNotNull();
         var templatePath = Path.Combine(directoryName, "Component.razor");
         var componentPath = FileUtilities.GenerateUniquePath(templatePath, ".razor");
@@ -89,7 +89,7 @@ internal sealed class ExtractToComponentCodeActionResolver(
             new CreateFile { DocumentUri = newComponentUri },
             new TextDocumentEdit
             {
-                TextDocument = new OptionalVersionedTextDocumentIdentifier { DocumentUri = documentContext.Snapshot.Uri },
+                TextDocument = new OptionalVersionedTextDocumentIdentifier { DocumentUri = documentSnapshot.Uri },
                 Edits =
                 [
                     new TextEdit

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToComponentCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToComponentCodeActionResolver.cs
@@ -48,7 +48,7 @@ internal sealed class ExtractToComponentCodeActionResolver(
         var componentDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
 
         var text = componentDocument.Source.Text;
-        var path = FilePathNormalizer.Normalize(documentContext.Uri.GetAbsoluteOrUNCPath());
+        var path = FilePathNormalizer.Normalize(documentContext.Snapshot.Uri.GetAbsoluteOrUNCPath());
         var directoryName = Path.GetDirectoryName(path).AssumeNotNull();
         var templatePath = Path.Combine(directoryName, "Component.razor");
         var componentPath = FileUtilities.GenerateUniquePath(templatePath, ".razor");
@@ -89,7 +89,7 @@ internal sealed class ExtractToComponentCodeActionResolver(
             new CreateFile { DocumentUri = newComponentUri },
             new TextDocumentEdit
             {
-                TextDocument = new OptionalVersionedTextDocumentIdentifier { DocumentUri = documentContext.Uri },
+                TextDocument = new OptionalVersionedTextDocumentIdentifier { DocumentUri = documentContext.Snapshot.Uri },
                 Edits =
                 [
                     new TextEdit

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToCssCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToCssCodeActionResolver.cs
@@ -45,7 +45,7 @@ internal sealed class ExtractToCssCodeActionResolver(
         var cssFilePath = $"{FilePathNormalizer.Normalize(documentContext.Snapshot.Uri.GetAbsoluteOrUNCPath())}.css";
         var cssFileUri = LspFactory.CreateFilePathUri(cssFilePath, _languageServerFeatureOptions);
 
-        var text = await documentContext.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
+        var text = codeDocument.Source.Text;
 
         var cssContent = text.ToString(new TextSpan(actionParams.ExtractStart, actionParams.ExtractEnd - actionParams.ExtractStart)).Trim();
         var removeRange = codeDocument.Source.Text.GetRange(actionParams.RemoveStart, actionParams.RemoveEnd);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToCssCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToCssCodeActionResolver.cs
@@ -32,7 +32,7 @@ internal sealed class ExtractToCssCodeActionResolver(
 
     public string Action => LanguageServerConstants.CodeActions.ExtractToCss;
 
-    public async Task<WorkspaceEdit?> ResolveAsync(RemoteDocumentContext documentContext, JsonElement data, RazorFormattingOptions options, CancellationToken cancellationToken)
+    public async Task<WorkspaceEdit?> ResolveAsync(RemoteDocumentSnapshot documentSnapshot, JsonElement data, RazorFormattingOptions options, CancellationToken cancellationToken)
     {
         var actionParams = data.Deserialize<ExtractToCssCodeActionParams>();
         if (actionParams is null)
@@ -40,9 +40,9 @@ internal sealed class ExtractToCssCodeActionResolver(
             return null;
         }
 
-        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
-        var cssFilePath = $"{FilePathNormalizer.Normalize(documentContext.Snapshot.Uri.GetAbsoluteOrUNCPath())}.css";
+        var cssFilePath = $"{FilePathNormalizer.Normalize(documentSnapshot.Uri.GetAbsoluteOrUNCPath())}.css";
         var cssFileUri = LspFactory.CreateFilePathUri(cssFilePath, _languageServerFeatureOptions);
 
         var text = codeDocument.Source.Text;
@@ -50,7 +50,7 @@ internal sealed class ExtractToCssCodeActionResolver(
         var cssContent = text.ToString(new TextSpan(actionParams.ExtractStart, actionParams.ExtractEnd - actionParams.ExtractStart)).Trim();
         var removeRange = codeDocument.Source.Text.GetRange(actionParams.RemoveStart, actionParams.RemoveEnd);
 
-        var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier { DocumentUri = documentContext.Snapshot.Uri };
+        var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier { DocumentUri = documentSnapshot.Uri };
         var cssDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier { DocumentUri = cssFileUri };
 
         using var changes = new PooledArrayBuilder<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>>(capacity: 3);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToCssCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToCssCodeActionResolver.cs
@@ -42,7 +42,7 @@ internal sealed class ExtractToCssCodeActionResolver(
 
         var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
 
-        var cssFilePath = $"{FilePathNormalizer.Normalize(documentContext.Uri.GetAbsoluteOrUNCPath())}.css";
+        var cssFilePath = $"{FilePathNormalizer.Normalize(documentContext.Snapshot.Uri.GetAbsoluteOrUNCPath())}.css";
         var cssFileUri = LspFactory.CreateFilePathUri(cssFilePath, _languageServerFeatureOptions);
 
         var text = await documentContext.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
@@ -50,7 +50,7 @@ internal sealed class ExtractToCssCodeActionResolver(
         var cssContent = text.ToString(new TextSpan(actionParams.ExtractStart, actionParams.ExtractEnd - actionParams.ExtractStart)).Trim();
         var removeRange = codeDocument.Source.Text.GetRange(actionParams.RemoveStart, actionParams.RemoveEnd);
 
-        var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier { DocumentUri = documentContext.Uri };
+        var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier { DocumentUri = documentContext.Snapshot.Uri };
         var cssDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier { DocumentUri = cssFileUri };
 
         using var changes = new PooledArrayBuilder<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>>(capacity: 3);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToCssCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/ExtractToCssCodeActionResolver.cs
@@ -40,7 +40,7 @@ internal sealed class ExtractToCssCodeActionResolver(
             return null;
         }
 
-        var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         var cssFilePath = $"{FilePathNormalizer.Normalize(documentContext.Snapshot.Uri.GetAbsoluteOrUNCPath())}.css";
         var cssFileUri = LspFactory.CreateFilePathUri(cssFilePath, _languageServerFeatureOptions);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/GenerateEventHandlerCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/GenerateEventHandlerCodeActionResolver.cs
@@ -47,7 +47,7 @@ internal sealed class GenerateEventHandlerCodeActionResolver(
         }
 
         var code = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
-        var razorFilePath = documentContext.Uri.GetDocumentFilePathFromUri();
+        var razorFilePath = documentContext.Snapshot.Uri.GetDocumentFilePathFromUri();
         var razorClassName = Path.GetFileNameWithoutExtension(razorFilePath);
         var codeBehindPath = $"{razorFilePath}.cs";
 
@@ -141,7 +141,7 @@ internal sealed class GenerateEventHandlerCodeActionResolver(
             DocumentChanges = new[] {
                 new TextDocumentEdit()
                 {
-                    TextDocument = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentContext.Uri },
+                    TextDocument = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentContext.Snapshot.Uri },
                     Edits = [code.Source.Text.GetTextEdit(razorChange)],
                 }
             }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/GenerateEventHandlerCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/GenerateEventHandlerCodeActionResolver.cs
@@ -46,7 +46,7 @@ internal sealed class GenerateEventHandlerCodeActionResolver(
             return null;
         }
 
-        var code = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var code = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var razorFilePath = documentContext.Snapshot.Uri.GetDocumentFilePathFromUri();
         var razorClassName = Path.GetFileNameWithoutExtension(razorFilePath);
         var codeBehindPath = $"{razorFilePath}.cs";

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/GenerateEventHandlerCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/GenerateEventHandlerCodeActionResolver.cs
@@ -175,7 +175,7 @@ internal sealed class GenerateEventHandlerCodeActionResolver(
 
     private async Task<SyntaxTree?> GetCodeBehindSyntaxTreeAsync(RemoteDocumentContext documentContext, string codeBehindPath, CancellationToken cancellationToken)
     {
-        var razorDocumentSnapshot = _snapshotManager.GetSnapshot(documentContext.TextDocument);
+        var razorDocumentSnapshot = _snapshotManager.GetSnapshot(documentContext.Snapshot.TextDocument);
         var solution = razorDocumentSnapshot.TextDocument.Project.Solution;
         var projectId = razorDocumentSnapshot.TextDocument.Project.Id;
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/GenerateEventHandlerCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/GenerateEventHandlerCodeActionResolver.cs
@@ -38,7 +38,7 @@ internal sealed class GenerateEventHandlerCodeActionResolver(
 
     public string Action => LanguageServerConstants.CodeActions.GenerateEventHandler;
 
-    public async Task<WorkspaceEdit?> ResolveAsync(RemoteDocumentContext documentContext, JsonElement data, RazorFormattingOptions options, CancellationToken cancellationToken)
+    public async Task<WorkspaceEdit?> ResolveAsync(RemoteDocumentSnapshot documentSnapshot, JsonElement data, RazorFormattingOptions options, CancellationToken cancellationToken)
     {
         var actionParams = data.Deserialize<GenerateEventHandlerCodeActionParams>();
         if (actionParams is null)
@@ -46,21 +46,21 @@ internal sealed class GenerateEventHandlerCodeActionResolver(
             return null;
         }
 
-        var code = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
-        var razorFilePath = documentContext.Snapshot.Uri.GetDocumentFilePathFromUri();
+        var code = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var razorFilePath = documentSnapshot.Uri.GetDocumentFilePathFromUri();
         var razorClassName = Path.GetFileNameWithoutExtension(razorFilePath);
         var codeBehindPath = $"{razorFilePath}.cs";
 
         // If we can't get the namespace, or the syntax tree (possibly because the file doesn't exist), or if the file does exist
         // but doesn't have the class declaration we'd expect, then we don't risk it and just generate a code block.
         if (!code.TryGetNamespace(fallbackToRootNamespace: true, out var razorNamespace) ||
-            await GetCodeBehindSyntaxTreeAsync(documentContext, codeBehindPath, cancellationToken).ConfigureAwait(false) is not { } syntaxTree ||
+            await GetCodeBehindSyntaxTreeAsync(documentSnapshot, codeBehindPath, cancellationToken).ConfigureAwait(false) is not { } syntaxTree ||
             GetCSharpClassDeclarationSyntax(syntaxTree, razorNamespace, razorClassName) is not { } classDecl)
         {
             return await GenerateEventHandlerInCodeBlockAsync(
                 code,
                 actionParams,
-                documentContext,
+                documentSnapshot,
                 options,
                 cancellationToken).ConfigureAwait(false);
         }
@@ -80,7 +80,7 @@ internal sealed class GenerateEventHandlerCodeActionResolver(
             character: 0,
             eventHandler);
 
-        var result = await _roslynCodeActionHelpers.GetSimplifiedTextEditsAsync(documentContext, codeBehindUri.GetRequiredSystemUri(), edit, cancellationToken).ConfigureAwait(false);
+        var result = await _roslynCodeActionHelpers.GetSimplifiedTextEditsAsync(documentSnapshot, codeBehindUri.GetRequiredSystemUri(), edit, cancellationToken).ConfigureAwait(false);
 
         var codeBehindTextDocEdit = new TextDocumentEdit()
         {
@@ -94,7 +94,7 @@ internal sealed class GenerateEventHandlerCodeActionResolver(
     private async Task<WorkspaceEdit?> GenerateEventHandlerInCodeBlockAsync(
         RazorCodeDocument code,
         GenerateEventHandlerCodeActionParams actionParams,
-        RemoteDocumentContext documentContext,
+        RemoteDocumentSnapshot documentSnapshot,
         RazorFormattingOptions options,
         CancellationToken cancellationToken)
     {
@@ -102,7 +102,7 @@ internal sealed class GenerateEventHandlerCodeActionResolver(
         // action. That's the magic that knows how to create a code block if one doesn't exist, or put the method in an existing one, and it will also ensure
         // the method gets properly formatted. That means it doesn't matter which C# document we use for the edit, so we'll just use the impl document since
         // it always exists.
-        var csharpSyntaxTree = await documentContext.Snapshot.GetCSharpSyntaxTreeAsync(declarationDocument: false, cancellationToken).ConfigureAwait(false);
+        var csharpSyntaxTree = await documentSnapshot.GetCSharpSyntaxTreeAsync(declarationDocument: false, cancellationToken).ConfigureAwait(false);
         var csharpSyntaxRoot = await csharpSyntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
         if (!csharpSyntaxRoot.TryGetClassDeclaration(out var classDecl))
         {
@@ -119,7 +119,7 @@ internal sealed class GenerateEventHandlerCodeActionResolver(
             eventHandler);
 
         // Call the simplifier to reduce things like `global::System.Threading.Task` down to just `Task`, if possible.
-        var result = await _roslynCodeActionHelpers.GetSimplifiedTextEditsAsync(documentContext, codeBehindUri: null, tempTextEdit, cancellationToken).ConfigureAwait(false);
+        var result = await _roslynCodeActionHelpers.GetSimplifiedTextEditsAsync(documentSnapshot, codeBehindUri: null, tempTextEdit, cancellationToken).ConfigureAwait(false);
         if (result is not { } edits)
         {
             return null;
@@ -128,7 +128,7 @@ internal sealed class GenerateEventHandlerCodeActionResolver(
         // Now we run the changes through the formatter, via the TryGetCSharpCodeActionEditAsync. This is the same as what the CSharpCodeActionResolver does.
         var csharpDocument = code.GetRequiredCSharpDocument(declarationDocument: false);
         var csharpTextChanges = edits.SelectAsArray(csharpDocument.Text.GetTextChange);
-        var formattedChange = await _razorFormattingService.TryGetCSharpCodeActionEditAsync(documentContext.Snapshot, csharpTextChanges,
+        var formattedChange = await _razorFormattingService.TryGetCSharpCodeActionEditAsync(documentSnapshot, csharpTextChanges,
             declarationDocument: false,
             options, cancellationToken).ConfigureAwait(false);
         if (formattedChange is not { } razorChange)
@@ -141,7 +141,7 @@ internal sealed class GenerateEventHandlerCodeActionResolver(
             DocumentChanges = new[] {
                 new TextDocumentEdit()
                 {
-                    TextDocument = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentContext.Snapshot.Uri },
+                    TextDocument = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentSnapshot.Uri },
                     Edits = [code.Source.Text.GetTextEdit(razorChange)],
                 }
             }
@@ -173,9 +173,9 @@ internal sealed class GenerateEventHandlerCodeActionResolver(
             """;
     }
 
-    private async Task<SyntaxTree?> GetCodeBehindSyntaxTreeAsync(RemoteDocumentContext documentContext, string codeBehindPath, CancellationToken cancellationToken)
+    private async Task<SyntaxTree?> GetCodeBehindSyntaxTreeAsync(RemoteDocumentSnapshot documentSnapshot, string codeBehindPath, CancellationToken cancellationToken)
     {
-        var razorDocumentSnapshot = _snapshotManager.GetSnapshot(documentContext.Snapshot.TextDocument);
+        var razorDocumentSnapshot = _snapshotManager.GetSnapshot(documentSnapshot.TextDocument);
         var solution = razorDocumentSnapshot.TextDocument.Project.Solution;
         var projectId = razorDocumentSnapshot.TextDocument.Project.Id;
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/IRazorCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/IRazorCodeActionResolver.cs
@@ -11,5 +11,5 @@ namespace Microsoft.CodeAnalysis.Razor.CodeActions;
 
 internal interface IRazorCodeActionResolver : ICodeActionResolver
 {
-    Task<WorkspaceEdit?> ResolveAsync(RemoteDocumentContext documentContext, JsonElement data, RazorFormattingOptions options, CancellationToken cancellationToken);
+    Task<WorkspaceEdit?> ResolveAsync(RemoteDocumentSnapshot documentSnapshot, JsonElement data, RazorFormattingOptions options, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/IRoslynCodeActionHelpers.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/IRoslynCodeActionHelpers.cs
@@ -15,9 +15,9 @@ internal interface IRoslynCodeActionHelpers
     /// <summary>
     /// Apply the edit to the specified document, get Roslyn to simplify it, and return the simplified edit
     /// </summary>
-    /// <param name="documentContext">The Razor document context for the edit</param>
+    /// <param name="documentSnapshot">The Razor document context for the edit</param>
     /// <param name="codeBehindUri">If present, the Roslyn document to apply the edit to. Otherwise the generated C# document will be used</param>
     /// <param name="edit">The edit to apply</param>
     /// <param name="cancellationToken">Cancellation token</param>
-    Task<TextEdit[]?> GetSimplifiedTextEditsAsync(RemoteDocumentContext documentContext, Uri? codeBehindUri, TextEdit edit, CancellationToken cancellationToken);
+    Task<TextEdit[]?> GetSimplifiedTextEditsAsync(RemoteDocumentSnapshot documentSnapshot, Uri? codeBehindUri, TextEdit edit, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/PromoteUsingCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/PromoteUsingCodeActionResolver.cs
@@ -41,7 +41,7 @@ internal sealed class PromoteUsingCodeActionResolver(IFileSystem fileSystem) : I
 
         var importsFileName = PromoteUsingCodeActionProvider.GetImportsFileName(documentContext.Snapshot.FileKind);
 
-        var file = FilePathNormalizer.Normalize(documentContext.Uri.GetAbsoluteOrUNCPath());
+        var file = FilePathNormalizer.Normalize(documentContext.Snapshot.Uri.GetAbsoluteOrUNCPath());
         var folder = Path.GetDirectoryName(file).AssumeNotNull();
         var importsFile = Path.GetFullPath(Path.Combine(folder, "..", importsFileName));
         var importFileUri = LspFactory.CreateFilePathUri(importsFile);
@@ -78,7 +78,7 @@ internal sealed class PromoteUsingCodeActionResolver(IFileSystem fileSystem) : I
 
         edits.Add(new TextDocumentEdit
         {
-            TextDocument = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentContext.Uri },
+            TextDocument = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentContext.Snapshot.Uri },
             Edits = [LspFactory.CreateTextEdit(removeRange, string.Empty)]
         });
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/PromoteUsingCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/PromoteUsingCodeActionResolver.cs
@@ -37,7 +37,7 @@ internal sealed class PromoteUsingCodeActionResolver(IFileSystem fileSystem) : I
             return null;
         }
 
-        var sourceText = await documentContext.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
+        var sourceText = await documentContext.Snapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
         var importsFileName = PromoteUsingCodeActionProvider.GetImportsFileName(documentContext.Snapshot.FileKind);
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/PromoteUsingCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/PromoteUsingCodeActionResolver.cs
@@ -29,7 +29,7 @@ internal sealed class PromoteUsingCodeActionResolver(IFileSystem fileSystem) : I
 
     public string Action => LanguageServerConstants.CodeActions.PromoteUsingDirective;
 
-    public async Task<WorkspaceEdit?> ResolveAsync(RemoteDocumentContext documentContext, JsonElement data, RazorFormattingOptions options, CancellationToken cancellationToken)
+    public async Task<WorkspaceEdit?> ResolveAsync(RemoteDocumentSnapshot documentSnapshot, JsonElement data, RazorFormattingOptions options, CancellationToken cancellationToken)
     {
         var actionParams = data.Deserialize<PromoteToUsingCodeActionParams>();
         if (actionParams is null)
@@ -37,11 +37,11 @@ internal sealed class PromoteUsingCodeActionResolver(IFileSystem fileSystem) : I
             return null;
         }
 
-        var sourceText = await documentContext.Snapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        var sourceText = await documentSnapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
-        var importsFileName = PromoteUsingCodeActionProvider.GetImportsFileName(documentContext.Snapshot.FileKind);
+        var importsFileName = PromoteUsingCodeActionProvider.GetImportsFileName(documentSnapshot.FileKind);
 
-        var file = FilePathNormalizer.Normalize(documentContext.Snapshot.Uri.GetAbsoluteOrUNCPath());
+        var file = FilePathNormalizer.Normalize(documentSnapshot.Uri.GetAbsoluteOrUNCPath());
         var folder = Path.GetDirectoryName(file).AssumeNotNull();
         var importsFile = Path.GetFullPath(Path.Combine(folder, "..", importsFileName));
         var importFileUri = LspFactory.CreateFilePathUri(importsFile);
@@ -78,7 +78,7 @@ internal sealed class PromoteUsingCodeActionResolver(IFileSystem fileSystem) : I
 
         edits.Add(new TextDocumentEdit
         {
-            TextDocument = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentContext.Snapshot.Uri },
+            TextDocument = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentSnapshot.Uri },
             Edits = [LspFactory.CreateTextEdit(removeRange, string.Empty)]
         });
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/RemoveUnnecessaryDirectivesCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/RemoveUnnecessaryDirectivesCodeActionResolver.cs
@@ -41,7 +41,7 @@ internal sealed class RemoveUnnecessaryDirectivesCodeActionResolver : IRazorCode
             {
                 new TextDocumentEdit
                 {
-                    TextDocument = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentContext.Uri },
+                    TextDocument = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentContext.Snapshot.Uri },
                     Edits = edits.ToArrayAndClear(),
                 }
             }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/RemoveUnnecessaryDirectivesCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/RemoveUnnecessaryDirectivesCodeActionResolver.cs
@@ -19,7 +19,7 @@ internal sealed class RemoveUnnecessaryDirectivesCodeActionResolver : IRazorCode
 {
     public string Action => LanguageServerConstants.CodeActions.RemoveUnnecessaryDirectives;
 
-    public async Task<WorkspaceEdit?> ResolveAsync(RemoteDocumentContext documentContext, JsonElement data, RazorFormattingOptions options, CancellationToken cancellationToken)
+    public async Task<WorkspaceEdit?> ResolveAsync(RemoteDocumentSnapshot documentSnapshot, JsonElement data, RazorFormattingOptions options, CancellationToken cancellationToken)
     {
         var actionParams = data.Deserialize<RemoveUnnecessaryDirectivesCodeActionParams>();
         if (actionParams is null)
@@ -27,7 +27,7 @@ internal sealed class RemoveUnnecessaryDirectivesCodeActionResolver : IRazorCode
             return null;
         }
 
-        var sourceText = await documentContext.Snapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        var sourceText = await documentSnapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
         using var edits = new PooledArrayBuilder<SumType<TextEdit, AnnotatedTextEdit>>();
         foreach (var directiveSpan in actionParams.UnusedDirectiveSpans)
@@ -41,7 +41,7 @@ internal sealed class RemoveUnnecessaryDirectivesCodeActionResolver : IRazorCode
             {
                 new TextDocumentEdit
                 {
-                    TextDocument = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentContext.Snapshot.Uri },
+                    TextDocument = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentSnapshot.Uri },
                     Edits = edits.ToArrayAndClear(),
                 }
             }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/RemoveUnnecessaryDirectivesCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/RemoveUnnecessaryDirectivesCodeActionResolver.cs
@@ -27,7 +27,7 @@ internal sealed class RemoveUnnecessaryDirectivesCodeActionResolver : IRazorCode
             return null;
         }
 
-        var sourceText = await documentContext.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
+        var sourceText = await documentContext.Snapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
         using var edits = new PooledArrayBuilder<SumType<TextEdit, AnnotatedTextEdit>>();
         foreach (var directiveSpan in actionParams.UnusedDirectiveSpans)

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/SimplifyFullyQualifiedComponentCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/SimplifyFullyQualifiedComponentCodeActionResolver.cs
@@ -36,7 +36,7 @@ internal sealed class SimplifyFullyQualifiedComponentCodeActionResolver : IRazor
         var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
         var text = codeDocument.Source.Text;
 
-        var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentContext.Uri };
+        var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentContext.Snapshot.Uri };
 
         // Check if we need to add a using directive.
         // We check the tag helpers available in the document to see if the simple component name

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/SimplifyFullyQualifiedComponentCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/SimplifyFullyQualifiedComponentCodeActionResolver.cs
@@ -33,7 +33,7 @@ internal sealed class SimplifyFullyQualifiedComponentCodeActionResolver : IRazor
             return null;
         }
 
-        var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var text = codeDocument.Source.Text;
 
         var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentContext.Snapshot.Uri };

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/SimplifyFullyQualifiedComponentCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/SimplifyFullyQualifiedComponentCodeActionResolver.cs
@@ -20,7 +20,7 @@ internal sealed class SimplifyFullyQualifiedComponentCodeActionResolver : IRazor
 {
     public string Action => LanguageServerConstants.CodeActions.SimplifyFullyQualifiedComponent;
 
-    public async Task<WorkspaceEdit?> ResolveAsync(RemoteDocumentContext documentContext, JsonElement data, RazorFormattingOptions options, CancellationToken cancellationToken)
+    public async Task<WorkspaceEdit?> ResolveAsync(RemoteDocumentSnapshot documentSnapshot, JsonElement data, RazorFormattingOptions options, CancellationToken cancellationToken)
     {
         if (data.ValueKind == JsonValueKind.Undefined)
         {
@@ -33,10 +33,10 @@ internal sealed class SimplifyFullyQualifiedComponentCodeActionResolver : IRazor
             return null;
         }
 
-        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var text = codeDocument.Source.Text;
 
-        var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentContext.Snapshot.Uri };
+        var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentSnapshot.Uri };
 
         // Check if we need to add a using directive.
         // We check the tag helpers available in the document to see if the simple component name

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/SimplifyTagToSelfClosingCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/SimplifyTagToSelfClosingCodeActionResolver.cs
@@ -18,7 +18,7 @@ internal sealed class SimplifyTagToSelfClosingCodeActionResolver : IRazorCodeAct
 {
     public string Action => LanguageServerConstants.CodeActions.SimplifyTagToSelfClosing;
 
-    public async Task<WorkspaceEdit?> ResolveAsync(RemoteDocumentContext documentContext, JsonElement data, RazorFormattingOptions options, CancellationToken cancellationToken)
+    public async Task<WorkspaceEdit?> ResolveAsync(RemoteDocumentSnapshot documentSnapshot, JsonElement data, RazorFormattingOptions options, CancellationToken cancellationToken)
     {
         if (data.ValueKind == JsonValueKind.Undefined)
         {
@@ -31,7 +31,7 @@ internal sealed class SimplifyTagToSelfClosingCodeActionResolver : IRazorCodeAct
             return null;
         }
 
-        var componentDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var componentDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         var text = componentDocument.Source.Text;
         var removeRange = text.GetRange(actionParams.StartTagCloseAngleIndex, actionParams.EndTagCloseAngleIndex);
@@ -40,7 +40,7 @@ internal sealed class SimplifyTagToSelfClosingCodeActionResolver : IRazorCodeAct
         {
             new TextDocumentEdit
             {
-                TextDocument = new OptionalVersionedTextDocumentIdentifier { DocumentUri= documentContext.Snapshot.Uri },
+                TextDocument = new OptionalVersionedTextDocumentIdentifier { DocumentUri= documentSnapshot.Uri },
                 Edits =
                 [
                     new TextEdit

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/SimplifyTagToSelfClosingCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/SimplifyTagToSelfClosingCodeActionResolver.cs
@@ -40,7 +40,7 @@ internal sealed class SimplifyTagToSelfClosingCodeActionResolver : IRazorCodeAct
         {
             new TextDocumentEdit
             {
-                TextDocument = new OptionalVersionedTextDocumentIdentifier { DocumentUri= documentContext.Uri },
+                TextDocument = new OptionalVersionedTextDocumentIdentifier { DocumentUri= documentContext.Snapshot.Uri },
                 Edits =
                 [
                     new TextEdit

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/SimplifyTagToSelfClosingCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/SimplifyTagToSelfClosingCodeActionResolver.cs
@@ -31,7 +31,7 @@ internal sealed class SimplifyTagToSelfClosingCodeActionResolver : IRazorCodeAct
             return null;
         }
 
-        var componentDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var componentDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         var text = componentDocument.Source.Text;
         var removeRange = text.GetRange(actionParams.StartTagCloseAngleIndex, actionParams.EndTagCloseAngleIndex);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/SortAndConsolidateUsingsCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/SortAndConsolidateUsingsCodeActionResolver.cs
@@ -17,9 +17,9 @@ internal sealed class SortAndConsolidateUsingsCodeActionResolver : IRazorCodeAct
 {
     public string Action => LanguageServerConstants.CodeActions.SortAndConsolidateUsings;
 
-    public async Task<WorkspaceEdit?> ResolveAsync(RemoteDocumentContext documentContext, JsonElement data, RazorFormattingOptions options, CancellationToken cancellationToken)
+    public async Task<WorkspaceEdit?> ResolveAsync(RemoteDocumentSnapshot documentSnapshot, JsonElement data, RazorFormattingOptions options, CancellationToken cancellationToken)
     {
-        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         if (!UsingDirectiveHelper.NeedsSortOrConsolidate(codeDocument))
         {
@@ -32,7 +32,7 @@ internal sealed class SortAndConsolidateUsingsCodeActionResolver : IRazorCodeAct
         {
             new TextDocumentEdit
             {
-                TextDocument = new OptionalVersionedTextDocumentIdentifier { DocumentUri = documentContext.Snapshot.Uri },
+                TextDocument = new OptionalVersionedTextDocumentIdentifier { DocumentUri = documentSnapshot.Uri },
                 Edits = [.. edits],
             }
         };

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/SortAndConsolidateUsingsCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/SortAndConsolidateUsingsCodeActionResolver.cs
@@ -32,7 +32,7 @@ internal sealed class SortAndConsolidateUsingsCodeActionResolver : IRazorCodeAct
         {
             new TextDocumentEdit
             {
-                TextDocument = new OptionalVersionedTextDocumentIdentifier { DocumentUri = documentContext.Uri },
+                TextDocument = new OptionalVersionedTextDocumentIdentifier { DocumentUri = documentContext.Snapshot.Uri },
                 Edits = [.. edits],
             }
         };

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/SortAndConsolidateUsingsCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/SortAndConsolidateUsingsCodeActionResolver.cs
@@ -19,7 +19,7 @@ internal sealed class SortAndConsolidateUsingsCodeActionResolver : IRazorCodeAct
 
     public async Task<WorkspaceEdit?> ResolveAsync(RemoteDocumentContext documentContext, JsonElement data, RazorFormattingOptions options, CancellationToken cancellationToken)
     {
-        var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         if (!UsingDirectiveHelper.NeedsSortOrConsolidate(codeDocument))
         {

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/WrapAttributesCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/WrapAttributesCodeActionResolver.cs
@@ -31,7 +31,7 @@ internal sealed class WrapAttributesCodeActionResolver : IRazorCodeActionResolve
         }
 
         var indentationString = FormattingUtilities.GetIndentationString(actionParams.IndentSize, options.InsertSpaces, options.TabSize);
-        var sourceText = await documentContext.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
+        var sourceText = await documentContext.Snapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
         using var edits = new PooledArrayBuilder<SumType<TextEdit, AnnotatedTextEdit>>();
 
         foreach (var position in actionParams.NewLinePositions)

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/WrapAttributesCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/WrapAttributesCodeActionResolver.cs
@@ -43,7 +43,7 @@ internal sealed class WrapAttributesCodeActionResolver : IRazorCodeActionResolve
 
         var tde = new TextDocumentEdit
         {
-            TextDocument = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentContext.Uri },
+            TextDocument = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentContext.Snapshot.Uri },
             Edits = edits.ToArray()
         };
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/WrapAttributesCodeActionResolver.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/Razor/WrapAttributesCodeActionResolver.cs
@@ -22,7 +22,7 @@ internal sealed class WrapAttributesCodeActionResolver : IRazorCodeActionResolve
 {
     public string Action => LanguageServerConstants.CodeActions.WrapAttributes;
 
-    public async Task<WorkspaceEdit?> ResolveAsync(RemoteDocumentContext documentContext, JsonElement data, RazorFormattingOptions options, CancellationToken cancellationToken)
+    public async Task<WorkspaceEdit?> ResolveAsync(RemoteDocumentSnapshot documentSnapshot, JsonElement data, RazorFormattingOptions options, CancellationToken cancellationToken)
     {
         var actionParams = data.Deserialize<WrapAttributesCodeActionParams>();
         if (actionParams is null)
@@ -31,7 +31,7 @@ internal sealed class WrapAttributesCodeActionResolver : IRazorCodeActionResolve
         }
 
         var indentationString = FormattingUtilities.GetIndentationString(actionParams.IndentSize, options.InsertSpaces, options.TabSize);
-        var sourceText = await documentContext.Snapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        var sourceText = await documentSnapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
         using var edits = new PooledArrayBuilder<SumType<TextEdit, AnnotatedTextEdit>>();
 
         foreach (var position in actionParams.NewLinePositions)
@@ -43,7 +43,7 @@ internal sealed class WrapAttributesCodeActionResolver : IRazorCodeActionResolve
 
         var tde = new TextDocumentEdit
         {
-            TextDocument = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentContext.Snapshot.Uri },
+            TextDocument = new OptionalVersionedTextDocumentIdentifier() { DocumentUri = documentSnapshot.Uri },
             Edits = edits.ToArray()
         };
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/RemoteCodeActionsService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/RemoteCodeActionsService.cs
@@ -29,12 +29,12 @@ internal sealed partial class RemoteCodeActionsService(in ServiceArgs args) : Ra
         => RunServiceAsync(
             solutionInfo,
             razorDocumentId,
-            context => GetCodeActionRequestInfoAsync(context, request, cancellationToken),
+            snapshot => GetCodeActionRequestInfoAsync(snapshot, request, cancellationToken),
             cancellationToken);
 
-    private async ValueTask<CodeActionRequestInfo> GetCodeActionRequestInfoAsync(RemoteDocumentContext context, VSCodeActionParams request, CancellationToken cancellationToken)
+    private async ValueTask<CodeActionRequestInfo> GetCodeActionRequestInfoAsync(RemoteDocumentSnapshot snapshot, VSCodeActionParams request, CancellationToken cancellationToken)
     {
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         var absoluteIndex = codeDocument.Source.Text.GetRequiredAbsoluteIndex(request.Range.Start);
         var positionInfo = GetPositionInfo(codeDocument, absoluteIndex);
@@ -59,7 +59,7 @@ internal sealed partial class RemoteCodeActionsService(in ServiceArgs args) : Ra
 
         async Task SetCSharpRequestAsync(bool inDeclDocument)
         {
-            var generatedRequest = await _codeActionsService.GetCSharpCodeActionsRequestAsync(context.Snapshot, request, inDeclDocument, cancellationToken).ConfigureAwait(false);
+            var generatedRequest = await _codeActionsService.GetCSharpCodeActionsRequestAsync(snapshot, request, inDeclDocument, cancellationToken).ConfigureAwait(false);
 
             if (generatedRequest is null)
             {
@@ -67,7 +67,7 @@ internal sealed partial class RemoteCodeActionsService(in ServiceArgs args) : Ra
             }
 
             // Since we're here, we may as well fill in the generated document Uri so the other caller won't have to calculate it
-            var generatedDocument = await context.Snapshot.GetGeneratedDocumentAsync(inDeclDocument, cancellationToken).ConfigureAwait(false);
+            var generatedDocument = await snapshot.GetGeneratedDocumentAsync(inDeclDocument, cancellationToken).ConfigureAwait(false);
             generatedRequest.TextDocument.DocumentUri = generatedDocument.GetURI();
 
             if (inDeclDocument)
@@ -85,24 +85,24 @@ internal sealed partial class RemoteCodeActionsService(in ServiceArgs args) : Ra
         => RunServiceAsync(
             solutionInfo,
             razorDocumentId,
-            context => GetCodeActionsAsync(context, request, htmlCodeActions, csharpCodeActions, csharpDeclCodeActions, cancellationToken),
+            snapshot => GetCodeActionsAsync(snapshot, request, htmlCodeActions, csharpCodeActions, csharpDeclCodeActions, cancellationToken),
             cancellationToken);
 
-    private async ValueTask<SumType<Command, CodeAction>[]?> GetCodeActionsAsync(RemoteDocumentContext context, VSCodeActionParams request, RazorVSInternalCodeAction[] htmlCodeActions, RazorVSInternalCodeAction[] csharpCodeActions, RazorVSInternalCodeAction[] csharpDeclCodeActions, CancellationToken cancellationToken)
+    private async ValueTask<SumType<Command, CodeAction>[]?> GetCodeActionsAsync(RemoteDocumentSnapshot snapshot, VSCodeActionParams request, RazorVSInternalCodeAction[] htmlCodeActions, RazorVSInternalCodeAction[] csharpCodeActions, RazorVSInternalCodeAction[] csharpDeclCodeActions, CancellationToken cancellationToken)
     {
         var supportsCodeActionResolve = _clientCapabilitiesService.ClientCapabilities.TextDocument?.CodeAction?.ResolveSupport is not null;
-        return await _codeActionsService.GetCodeActionsAsync(request, context.Snapshot, htmlCodeActions, csharpCodeActions, csharpDeclCodeActions, supportsCodeActionResolve, cancellationToken).ConfigureAwait(false);
+        return await _codeActionsService.GetCodeActionsAsync(request, snapshot, htmlCodeActions, csharpCodeActions, csharpDeclCodeActions, supportsCodeActionResolve, cancellationToken).ConfigureAwait(false);
     }
 
     public ValueTask<CodeAction> ResolveCodeActionAsync(JsonSerializableRazorSolutionWrapper solutionInfo, JsonSerializableDocumentId razorDocumentId, CodeAction request, CodeAction? delegatedCodeAction, CancellationToken cancellationToken)
         => RunServiceAsync(
             solutionInfo,
             razorDocumentId,
-            context => ResolveCodeActionAsync(context, request, delegatedCodeAction, cancellationToken),
+            snapshot => ResolveCodeActionAsync(snapshot, request, delegatedCodeAction, cancellationToken),
             cancellationToken);
 
-    private ValueTask<CodeAction> ResolveCodeActionAsync(RemoteDocumentContext context, CodeAction request, CodeAction? delegatedCodeAction, CancellationToken cancellationToken)
+    private ValueTask<CodeAction> ResolveCodeActionAsync(RemoteDocumentSnapshot snapshot, CodeAction request, CodeAction? delegatedCodeAction, CancellationToken cancellationToken)
     {
-        return new(_codeActionResolveService.ResolveCodeActionAsync(context, request, delegatedCodeAction, cancellationToken));
+        return new(_codeActionResolveService.ResolveCodeActionAsync(snapshot, request, delegatedCodeAction, cancellationToken));
     }
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/RemoteCodeActionsService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/RemoteCodeActionsService.cs
@@ -34,7 +34,7 @@ internal sealed partial class RemoteCodeActionsService(in ServiceArgs args) : Ra
 
     private async ValueTask<CodeActionRequestInfo> GetCodeActionRequestInfoAsync(RemoteDocumentContext context, VSCodeActionParams request, CancellationToken cancellationToken)
     {
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         var absoluteIndex = codeDocument.Source.Text.GetRequiredAbsoluteIndex(request.Range.Start);
         var positionInfo = GetPositionInfo(codeDocument, absoluteIndex);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/RoslynCodeActionHelpers.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/RoslynCodeActionHelpers.cs
@@ -49,14 +49,14 @@ internal sealed class RoslynCodeActionHelpers : IRoslynCodeActionHelpers
         else
         {
             // Edit is for inserting into a C# document
-            var solution = documentContext.TextDocument.Project.Solution;
+            var solution = documentContext.Snapshot.TextDocument.Project.Solution;
             var documentIds = solution.GetDocumentIdsWithUri(codeBehindUri);
             if (documentIds.Length == 0)
             {
                 return null;
             }
 
-            document = solution.GetRequiredDocument(documentIds.First(d => d.ProjectId == documentContext.TextDocument.Project.Id));
+            document = solution.GetRequiredDocument(documentIds.First(d => d.ProjectId == documentContext.Snapshot.TextDocument.Project.Id));
         }
 
         return await GetSimplifiedEditsAsync(document, edit, cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/RoslynCodeActionHelpers.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/RoslynCodeActionHelpers.cs
@@ -37,26 +37,26 @@ internal sealed class RoslynCodeActionHelpers : IRoslynCodeActionHelpers
         return GetFormattedNewFileContentAsync(document, cancellationToken);
     }
 
-    public async Task<TextEdit[]?> GetSimplifiedTextEditsAsync(RemoteDocumentContext documentContext, Uri? codeBehindUri, TextEdit edit, CancellationToken cancellationToken)
+    public async Task<TextEdit[]?> GetSimplifiedTextEditsAsync(RemoteDocumentSnapshot documentSnapshot, Uri? codeBehindUri, TextEdit edit, CancellationToken cancellationToken)
     {
         Document document;
         if (codeBehindUri is null)
         {
             // Edit is for inserting into the generated document. Since we're just getting the simplification edits, it doesn't matter
             // which C# document we use, so just use the impl document since it always exists.
-            document = await documentContext.Snapshot.GetGeneratedDocumentAsync(declarationDocument: false, cancellationToken).ConfigureAwait(false);
+            document = await documentSnapshot.GetGeneratedDocumentAsync(declarationDocument: false, cancellationToken).ConfigureAwait(false);
         }
         else
         {
             // Edit is for inserting into a C# document
-            var solution = documentContext.Snapshot.TextDocument.Project.Solution;
+            var solution = documentSnapshot.TextDocument.Project.Solution;
             var documentIds = solution.GetDocumentIdsWithUri(codeBehindUri);
             if (documentIds.Length == 0)
             {
                 return null;
             }
 
-            document = solution.GetRequiredDocument(documentIds.First(d => d.ProjectId == documentContext.Snapshot.TextDocument.Project.Id));
+            document = solution.GetRequiredDocument(documentIds.First(d => d.ProjectId == documentSnapshot.TextDocument.Project.Id));
         }
 
         return await GetSimplifiedEditsAsync(document, edit, cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeLens/RemoteCodeLensService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeLens/RemoteCodeLensService.cs
@@ -66,7 +66,7 @@ internal class RemoteCodeLensService(in ServiceArgs args) : RazorDocumentService
 
         static async ValueTask<RazorCSharpDocument> GetCSharpDocumentAsync(RemoteDocumentContext context, CancellationToken cancellationToken)
         {
-            var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+            var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
             // CodeLens items are only produced for the class members in a generated C# file, so they will always be in the
             // decl document if it exists.
             if (codeDocument.GetCSharpDocument(declarationDocument: true) is { } declCSharpDocument)

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeLens/RemoteCodeLensService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeLens/RemoteCodeLensService.cs
@@ -32,16 +32,15 @@ internal class RemoteCodeLensService(in ServiceArgs args) : RazorDocumentService
         => RunServiceAsync(
             solutionInfo,
             razorDocumentId,
-            context => GetCodeLensAsync(context, textDocumentIdentifier, cancellationToken),
+            snapshot => GetCodeLensAsync(snapshot, textDocumentIdentifier, cancellationToken),
             cancellationToken);
 
     private async ValueTask<LspCodeLens[]?> GetCodeLensAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         TextDocumentIdentifier textDocumentIdentifier,
         CancellationToken cancellationToken)
     {
-        var snapshot = context.Snapshot;
-        var csharpDocument = await GetCSharpDocumentAsync(context, cancellationToken).ConfigureAwait(false);
+        var csharpDocument = await GetCSharpDocumentAsync(snapshot, cancellationToken).ConfigureAwait(false);
         var generatedDocument = await snapshot.GetGeneratedDocumentAsync(csharpDocument.IsDeclarationDocument, cancellationToken).ConfigureAwait(false);
         var globalOptions = generatedDocument.Project.Solution.Services.ExportProvider.GetService<IGlobalOptionService>();
 
@@ -64,9 +63,9 @@ internal class RemoteCodeLensService(in ServiceArgs args) : RazorDocumentService
 
         return results.ToArrayAndClear();
 
-        static async ValueTask<RazorCSharpDocument> GetCSharpDocumentAsync(RemoteDocumentContext context, CancellationToken cancellationToken)
+        static async ValueTask<RazorCSharpDocument> GetCSharpDocumentAsync(RemoteDocumentSnapshot snapshot, CancellationToken cancellationToken)
         {
-            var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+            var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
             // CodeLens items are only produced for the class members in a generated C# file, so they will always be in the
             // decl document if it exists.
             if (codeDocument.GetCSharpDocument(declarationDocument: true) is { } declCSharpDocument)
@@ -86,12 +85,11 @@ internal class RemoteCodeLensService(in ServiceArgs args) : RazorDocumentService
         => RunServiceAsync(
             solutionInfo,
             razorDocumentId,
-            context => ResolveCodeLensAsync(context, codeLens, cancellationToken),
+            snapshot => ResolveCodeLensAsync(snapshot, codeLens, cancellationToken),
             cancellationToken);
 
-    private async ValueTask<LspCodeLens?> ResolveCodeLensAsync(RemoteDocumentContext context, LspCodeLens codeLens, CancellationToken cancellationToken)
+    private async ValueTask<LspCodeLens?> ResolveCodeLensAsync(RemoteDocumentSnapshot snapshot, LspCodeLens codeLens, CancellationToken cancellationToken)
     {
-        var snapshot = context.Snapshot;
         var razorData = RazorCodeLensResolveData.Unwrap(codeLens);
         if (razorData.OriginalData is { } originalData)
         {

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/CSharpCompletionItemFormatter.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/CSharpCompletionItemFormatter.cs
@@ -22,7 +22,7 @@ internal static class CSharpCompletionItemFormatter
 {
     public static async Task<VSInternalCompletionItem> FormatAsync(
         VSInternalCompletionItem resolvedCompletionItem,
-        RemoteDocumentContext documentContext,
+        RemoteDocumentSnapshot documentSnapshot,
         Solution solution,
         bool declarationDocument,
         RazorFormattingOptions options,
@@ -32,7 +32,7 @@ internal static class CSharpCompletionItemFormatter
         ILogger logger,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var csharpDocument = codeDocument.GetRequiredCSharpDocument(declarationDocument);
 
         // In VS Code, Roslyn does resolve via a custom command. Thats fine, but we have to modify the text edit sitting within it,
@@ -58,7 +58,7 @@ internal static class CSharpCompletionItemFormatter
                     return resolvedCompletionItem;
                 }
 
-                var formattedTextEdit = await FormatTextEditsAsync([complexEdit], documentContext, commandCSharpDocument, options, formattingService, cancellationToken).ConfigureAwait(false);
+                var formattedTextEdit = await FormatTextEditsAsync([complexEdit], documentSnapshot, commandCSharpDocument, options, formattingService, cancellationToken).ConfigureAwait(false);
                 if (formattedTextEdit is null)
                 {
                     resolvedCompletionItem.Command = null;
@@ -67,7 +67,7 @@ internal static class CSharpCompletionItemFormatter
                 {
                     args[0] = new TextDocumentIdentifier()
                     {
-                        DocumentUri = documentContext.Snapshot.Uri,
+                        DocumentUri = documentSnapshot.Uri,
                     };
                     args[1] = formattedTextEdit;
                     if (nextCursorPosition >= 0)
@@ -97,7 +97,7 @@ internal static class CSharpCompletionItemFormatter
         {
             if (resolvedCompletionItem.TextEdit.Value.TryGetFirst(out var textEdit))
             {
-                var formattedTextChange = await FormatTextEditsAsync([textEdit], documentContext, csharpDocument, options, formattingService, cancellationToken).ConfigureAwait(false);
+                var formattedTextChange = await FormatTextEditsAsync([textEdit], documentSnapshot, csharpDocument, options, formattingService, cancellationToken).ConfigureAwait(false);
                 if (formattedTextChange is not null)
                 {
                     resolvedCompletionItem.TextEdit = formattedTextChange;
@@ -113,7 +113,7 @@ internal static class CSharpCompletionItemFormatter
 
         if (resolvedCompletionItem.AdditionalTextEdits is not null)
         {
-            var formattedTextChange = await FormatTextEditsAsync(resolvedCompletionItem.AdditionalTextEdits, documentContext, csharpDocument, options, formattingService, cancellationToken).ConfigureAwait(false);
+            var formattedTextChange = await FormatTextEditsAsync(resolvedCompletionItem.AdditionalTextEdits, documentSnapshot, csharpDocument, options, formattingService, cancellationToken).ConfigureAwait(false);
             resolvedCompletionItem.AdditionalTextEdits = formattedTextChange is { } change ? [change] : null;
         }
 
@@ -130,13 +130,13 @@ internal static class CSharpCompletionItemFormatter
         return "null";
     }
 
-    private static async Task<TextEdit?> FormatTextEditsAsync(TextEdit[] textEdits, RemoteDocumentContext documentContext, RazorCSharpDocument csharpDocument, RazorFormattingOptions options, IRazorFormattingService formattingService, CancellationToken cancellationToken)
+    private static async Task<TextEdit?> FormatTextEditsAsync(TextEdit[] textEdits, RemoteDocumentSnapshot documentSnapshot, RazorCSharpDocument csharpDocument, RazorFormattingOptions options, IRazorFormattingService formattingService, CancellationToken cancellationToken)
     {
-        var sourceText = await documentContext.Snapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        var sourceText = await documentSnapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
         var changes = textEdits.SelectAsArray(csharpDocument.Text.GetTextChange);
         var formattedTextChange = await formattingService.TryGetCSharpSnippetFormattingEditAsync(
-            documentContext,
+            documentSnapshot,
             changes,
             csharpDocument.IsDeclarationDocument,
             options,

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/CSharpCompletionItemFormatter.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/CSharpCompletionItemFormatter.cs
@@ -67,7 +67,7 @@ internal static class CSharpCompletionItemFormatter
                 {
                     args[0] = new TextDocumentIdentifier()
                     {
-                        DocumentUri = documentContext.Uri,
+                        DocumentUri = documentContext.Snapshot.Uri,
                     };
                     args[1] = formattedTextEdit;
                     if (nextCursorPosition >= 0)

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/CSharpCompletionItemFormatter.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/CSharpCompletionItemFormatter.cs
@@ -32,7 +32,7 @@ internal static class CSharpCompletionItemFormatter
         ILogger logger,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var csharpDocument = codeDocument.GetRequiredCSharpDocument(declarationDocument);
 
         // In VS Code, Roslyn does resolve via a custom command. Thats fine, but we have to modify the text edit sitting within it,

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/CSharpCompletionItemFormatter.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/CSharpCompletionItemFormatter.cs
@@ -132,7 +132,7 @@ internal static class CSharpCompletionItemFormatter
 
     private static async Task<TextEdit?> FormatTextEditsAsync(TextEdit[] textEdits, RemoteDocumentContext documentContext, RazorCSharpDocument csharpDocument, RazorFormattingOptions options, IRazorFormattingService formattingService, CancellationToken cancellationToken)
     {
-        var sourceText = await documentContext.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
+        var sourceText = await documentContext.Snapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
         var changes = textEdits.SelectAsArray(csharpDocument.Text.GetTextChange);
         var formattedTextChange = await formattingService.TryGetCSharpSnippetFormattingEditAsync(

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
@@ -178,6 +178,7 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
         {
             return CompletionResults.CallHtml;
         }
+
         var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         GetRazorCompletionContextAndLocalHtmlCompletionList(

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
@@ -97,7 +97,7 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
         if (positionInfo.LanguageKind == RazorLanguageKind.Html
             && DelegatedCompletionHelper.ShouldIncludeSnippets(codeDocument, index, out isStartTagContext))
         {
-            // In start-tag snapshot, snippets are always available (triggered by typing '<').
+            // In start-tag context, snippets are always available (triggered by typing '<').
             // In text content, snippets are only available on explicit invocation (Ctrl+Space).
             shouldIncludeSnippets = isStartTagContext
                 || completionContext.InvokeKind == VSInternalCompletionInvokeKind.Explicit;
@@ -110,7 +110,7 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
     }
 
     /// <summary>
-    /// Determines whether completion should be suppressed for the current trigger snapshot.
+    /// Determines whether completion should be suppressed for the current trigger context.
     /// For example, '@' typed after '$' in Emmet numbering modifiers (e.g., ul>li.item$@-*5)
     /// should not trigger Razor completion.
     /// </summary>

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
@@ -70,7 +70,7 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
         Position position,
         CancellationToken cancellationToken)
     {
-        var sourceText = await remoteDocumentContext.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
+        var sourceText = await remoteDocumentContext.Snapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
         if (!sourceText.TryGetAbsoluteIndex(position, out var index))
         {
             return null;

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
@@ -61,16 +61,16 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
         => RunServiceAsync(
             solutionInfo,
             documentId,
-            context => GetPositionInfoAsync(context, completionContext, position, cancellationToken),
+            snapshot => GetPositionInfoAsync(snapshot, completionContext, position, cancellationToken),
             cancellationToken);
 
     private async ValueTask<CompletionPositionInfo?> GetPositionInfoAsync(
-        RemoteDocumentContext remoteDocumentContext,
+        RemoteDocumentSnapshot documentSnapshot,
         VSInternalCompletionContext completionContext,
         Position position,
         CancellationToken cancellationToken)
     {
-        var sourceText = await remoteDocumentContext.Snapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        var sourceText = await documentSnapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
         if (!sourceText.TryGetAbsoluteIndex(position, out var index))
         {
             return null;
@@ -81,7 +81,7 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
             return null;
         }
 
-        var codeDocument = await remoteDocumentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         var positionInfo = GetPositionInfo(codeDocument, index);
 
@@ -97,7 +97,7 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
         if (positionInfo.LanguageKind == RazorLanguageKind.Html
             && DelegatedCompletionHelper.ShouldIncludeSnippets(codeDocument, index, out isStartTagContext))
         {
-            // In start-tag context, snippets are always available (triggered by typing '<').
+            // In start-tag snapshot, snippets are always available (triggered by typing '<').
             // In text content, snippets are only available on explicit invocation (Ctrl+Space).
             shouldIncludeSnippets = isStartTagContext
                 || completionContext.InvokeKind == VSInternalCompletionInvokeKind.Explicit;
@@ -110,7 +110,7 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
     }
 
     /// <summary>
-    /// Determines whether completion should be suppressed for the current trigger context.
+    /// Determines whether completion should be suppressed for the current trigger snapshot.
     /// For example, '@' typed after '$' in Emmet numbering modifiers (e.g., ul>li.item$@-*5)
     /// should not trigger Razor completion.
     /// </summary>
@@ -146,8 +146,8 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
         => RunServiceAsync(
             solutionInfo,
             documentId,
-            context => GetCompletionAsync(
-                context,
+            snapshot => GetCompletionAsync(
+                snapshot,
                 positionInfo,
                 completionContext,
                 razorCompletionOptions,
@@ -156,7 +156,7 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
             cancellationToken);
 
     private async ValueTask<CompletionResponse> GetCompletionAsync(
-        RemoteDocumentContext remoteDocumentContext,
+        RemoteDocumentSnapshot documentSnapshot,
         CompletionPositionInfo positionInfo,
         VSInternalCompletionContext completionContext,
         RazorCompletionOptions razorCompletionOptions,
@@ -178,8 +178,6 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
         {
             return CompletionResults.CallHtml;
         }
-
-        var documentSnapshot = remoteDocumentContext.Snapshot;
         var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         GetRazorCompletionContextAndLocalHtmlCompletionList(
@@ -410,11 +408,11 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
         => RunServiceAsync(
             solutionInfo,
             documentId,
-            context => ResolveCompletionItemAsync(context, request, cancellationToken),
+            snapshot => ResolveCompletionItemAsync(snapshot, request, cancellationToken),
             cancellationToken);
 
     private ValueTask<VSInternalCompletionItem> ResolveCompletionItemAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         VSInternalCompletionItem request,
         CancellationToken cancellationToken)
     {
@@ -426,8 +424,8 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
 
         return originalRequestContext switch
         {
-            DelegatedCompletionResolutionContext resolutionContext => ResolveCSharpCompletionItemAsync(context, request, containingCompletionList, resolutionContext, cancellationToken),
-            RazorCompletionResolveContext razorResolutionContext => ResolveRazorCompletionItemAsync(context, request, razorResolutionContext, cancellationToken),
+            DelegatedCompletionResolutionContext resolutionContext => ResolveCSharpCompletionItemAsync(snapshot, request, containingCompletionList, resolutionContext, cancellationToken),
+            RazorCompletionResolveContext razorResolutionContext => ResolveRazorCompletionItemAsync(snapshot, request, razorResolutionContext, cancellationToken),
             LocalHtmlCompletionResolveContext localHtmlResolveContext => new(ResolveLocalHtmlCompletionItem(request, localHtmlResolveContext)),
             _ => LogAndReturnUnresolvedAsync(request),
         };
@@ -439,9 +437,9 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
         }
     }
 
-    private async ValueTask<VSInternalCompletionItem> ResolveRazorCompletionItemAsync(RemoteDocumentContext context, VSInternalCompletionItem request, RazorCompletionResolveContext razorResolutionContext, CancellationToken cancellationToken)
+    private async ValueTask<VSInternalCompletionItem> ResolveRazorCompletionItemAsync(RemoteDocumentSnapshot snapshot, VSInternalCompletionItem request, RazorCompletionResolveContext razorResolutionContext, CancellationToken cancellationToken)
     {
-        var componentAvailabilityService = new ComponentAvailabilityService(context.Snapshot.ProjectSnapshot.SolutionSnapshot);
+        var componentAvailabilityService = new ComponentAvailabilityService(snapshot.ProjectSnapshot.SolutionSnapshot);
 
         var result = await RazorCompletionItemResolver.ResolveAsync(
             request,
@@ -473,7 +471,7 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
         return request;
     }
 
-    private async ValueTask<VSInternalCompletionItem> ResolveCSharpCompletionItemAsync(RemoteDocumentContext context, VSInternalCompletionItem request, VSInternalCompletionList containingCompletionList, DelegatedCompletionResolutionContext resolutionContext, CancellationToken cancellationToken)
+    private async ValueTask<VSInternalCompletionItem> ResolveCSharpCompletionItemAsync(RemoteDocumentSnapshot documentSnapshot, VSInternalCompletionItem request, VSInternalCompletionList containingCompletionList, DelegatedCompletionResolutionContext resolutionContext, CancellationToken cancellationToken)
     {
         var oldData = request.Data;
         try
@@ -487,7 +485,6 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
                 request.Data = JsonSerializer.SerializeToElement(request.Data, JsonHelpers.JsonSerializerOptions);
             }
 
-            var documentSnapshot = context.Snapshot;
             var generatedDocument = await GetCSharpGeneratedDocumentAsync(documentSnapshot, resolutionContext.InDeclDocument, resolutionContext.ProvisionalTextEdit, cancellationToken).ConfigureAwait(false);
 
             var clientCapabilities = _clientCapabilitiesService.ClientCapabilities;
@@ -503,7 +500,7 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
 
             item = await CSharpCompletionItemFormatter.FormatAsync(
                 item,
-                context,
+                documentSnapshot,
                 generatedDocument.Project.Solution,
                 resolutionContext.InDeclDocument,
                 formattingOptions,

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
@@ -81,7 +81,7 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
             return null;
         }
 
-        var codeDocument = await remoteDocumentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await remoteDocumentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         var positionInfo = GetPositionInfo(codeDocument, index);
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Debugging/RemoteDataTipRangeService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Debugging/RemoteDataTipRangeService.cs
@@ -40,7 +40,7 @@ internal sealed class RemoteDataTipRangeService(in ServiceArgs args) : RazorDocu
         Position position,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var razorIndex = codeDocument.Source.Text.GetRequiredAbsoluteIndex(position);
 
         if (!_documentMappingService.TryMapToCSharpDocumentLinePosition(codeDocument, razorIndex, out var csharpPosition, out _, out var inDeclDocument))

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Debugging/RemoteDataTipRangeService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Debugging/RemoteDataTipRangeService.cs
@@ -31,16 +31,16 @@ internal sealed class RemoteDataTipRangeService(in ServiceArgs args) : RazorDocu
         return RunServiceAsync(
             solutionInfo,
             documentId,
-            context => GetDataTipRangeAsync(context, position, cancellationToken),
+            snapshot => GetDataTipRangeAsync(snapshot, position, cancellationToken),
             cancellationToken);
     }
 
     private async ValueTask<RemoteResponse<VSInternalDataTip?>> GetDataTipRangeAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         Position position,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var razorIndex = codeDocument.Source.Text.GetRequiredAbsoluteIndex(position);
 
         if (!_documentMappingService.TryMapToCSharpDocumentLinePosition(codeDocument, razorIndex, out var csharpPosition, out _, out var inDeclDocument))
@@ -49,7 +49,7 @@ internal sealed class RemoteDataTipRangeService(in ServiceArgs args) : RazorDocu
         }
 
         var csharpDocument = codeDocument.GetRequiredCSharpDocument(inDeclDocument);
-        var generatedDocument = await context.Snapshot.GetGeneratedDocumentAsync(inDeclDocument, cancellationToken).ConfigureAwait(false);
+        var generatedDocument = await snapshot.GetGeneratedDocumentAsync(inDeclDocument, cancellationToken).ConfigureAwait(false);
 
         var csharpResult = await DataTipRangeHandler.GetDataTipRangeAsync(generatedDocument, csharpPosition, cancellationToken).ConfigureAwait(false);
         if (csharpResult?.ExpressionRange is null)

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Debugging/RemoteDebugInfoService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Debugging/RemoteDebugInfoService.cs
@@ -37,7 +37,7 @@ internal sealed class RemoteDebugInfoService(in ServiceArgs args) : RazorDocumen
 
     public async ValueTask<LinePositionSpan?> ValidateBreakableRangeAsync(RemoteDocumentContext context, LinePositionSpan span, CancellationToken cancellationToken)
     {
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         if (!_documentMappingService.TryMapToCSharpDocumentLinePositionSpan(codeDocument, span, out var mappedSpan, out var inDeclDocument))
         {
@@ -66,7 +66,7 @@ internal sealed class RemoteDebugInfoService(in ServiceArgs args) : RazorDocumen
 
     private async ValueTask<LinePositionSpan?> ResolveBreakpointRangeAsync(RemoteDocumentContext context, LinePosition position, CancellationToken cancellationToken)
     {
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         if (!TryGetUsableProjectedIndex(codeDocument, position, out var projectedIndex, out var csharpDocument))
         {
             return null;
@@ -101,7 +101,7 @@ internal sealed class RemoteDebugInfoService(in ServiceArgs args) : RazorDocumen
 
     private async ValueTask<string[]?> ResolveProximityExpressionsAsync(RemoteDocumentContext context, LinePosition position, CancellationToken cancellationToken)
     {
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         if (!TryGetUsableProjectedIndex(codeDocument, position, out var projectedIndex, out var csharpDocument))
         {
             return null;

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Debugging/RemoteDebugInfoService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Debugging/RemoteDebugInfoService.cs
@@ -32,12 +32,12 @@ internal sealed class RemoteDebugInfoService(in ServiceArgs args) : RazorDocumen
         => RunServiceAsync(
             solutionInfo,
             documentId,
-            context => ValidateBreakableRangeAsync(context, span, cancellationToken),
+            snapshot => ValidateBreakableRangeAsync(snapshot, span, cancellationToken),
             cancellationToken);
 
-    public async ValueTask<LinePositionSpan?> ValidateBreakableRangeAsync(RemoteDocumentContext context, LinePositionSpan span, CancellationToken cancellationToken)
+    public async ValueTask<LinePositionSpan?> ValidateBreakableRangeAsync(RemoteDocumentSnapshot snapshot, LinePositionSpan span, CancellationToken cancellationToken)
     {
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         if (!_documentMappingService.TryMapToCSharpDocumentLinePositionSpan(codeDocument, span, out var mappedSpan, out var inDeclDocument))
         {
@@ -45,7 +45,7 @@ internal sealed class RemoteDebugInfoService(in ServiceArgs args) : RazorDocumen
         }
 
         var csharpDocument = codeDocument.GetRequiredCSharpDocument(inDeclDocument);
-        var generatedDocument = await context.Snapshot.GetGeneratedDocumentAsync(inDeclDocument, cancellationToken).ConfigureAwait(false);
+        var generatedDocument = await snapshot.GetGeneratedDocumentAsync(inDeclDocument, cancellationToken).ConfigureAwait(false);
 
         var result = await GetBreakableRangeAsync(generatedDocument, mappedSpan, cancellationToken).ConfigureAwait(false);
         if (result is { } csharpSpan &&
@@ -61,19 +61,19 @@ internal sealed class RemoteDebugInfoService(in ServiceArgs args) : RazorDocumen
         => RunServiceAsync(
             solutionInfo,
             documentId,
-            context => ResolveBreakpointRangeAsync(context, position, cancellationToken),
+            snapshot => ResolveBreakpointRangeAsync(snapshot, position, cancellationToken),
             cancellationToken);
 
-    private async ValueTask<LinePositionSpan?> ResolveBreakpointRangeAsync(RemoteDocumentContext context, LinePosition position, CancellationToken cancellationToken)
+    private async ValueTask<LinePositionSpan?> ResolveBreakpointRangeAsync(RemoteDocumentSnapshot snapshot, LinePosition position, CancellationToken cancellationToken)
     {
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         if (!TryGetUsableProjectedIndex(codeDocument, position, out var projectedIndex, out var csharpDocument))
         {
             return null;
         }
 
         // Now ask Roslyn to adjust the breakpoint to a valid location in the code
-        var syntaxTree = await context.Snapshot.GetCSharpSyntaxTreeAsync(csharpDocument.IsDeclarationDocument, cancellationToken).ConfigureAwait(false);
+        var syntaxTree = await snapshot.GetCSharpSyntaxTreeAsync(csharpDocument.IsDeclarationDocument, cancellationToken).ConfigureAwait(false);
         if (!BreakpointSpans.TryGetBreakpointSpan(syntaxTree, projectedIndex, cancellationToken, out var csharpBreakpointSpan))
         {
             return null;
@@ -96,19 +96,19 @@ internal sealed class RemoteDebugInfoService(in ServiceArgs args) : RazorDocumen
         => RunServiceAsync(
             solutionInfo,
             documentId,
-            context => ResolveProximityExpressionsAsync(context, position, cancellationToken),
+            snapshot => ResolveProximityExpressionsAsync(snapshot, position, cancellationToken),
             cancellationToken);
 
-    private async ValueTask<string[]?> ResolveProximityExpressionsAsync(RemoteDocumentContext context, LinePosition position, CancellationToken cancellationToken)
+    private async ValueTask<string[]?> ResolveProximityExpressionsAsync(RemoteDocumentSnapshot snapshot, LinePosition position, CancellationToken cancellationToken)
     {
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         if (!TryGetUsableProjectedIndex(codeDocument, position, out var projectedIndex, out var csharpDocument))
         {
             return null;
         }
 
         // Now ask Roslyn to adjust the breakpoint to a valid location in the code
-        var syntaxTree = await context.Snapshot.GetCSharpSyntaxTreeAsync(csharpDocument.IsDeclarationDocument, cancellationToken).ConfigureAwait(false);
+        var syntaxTree = await snapshot.GetCSharpSyntaxTreeAsync(csharpDocument.IsDeclarationDocument, cancellationToken).ConfigureAwait(false);
         var result = CSharpProximityExpressionsService.GetProximityExpressions(syntaxTree, projectedIndex, cancellationToken);
 
         return result?.ToArray();

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DevTools/RemoteDevToolsService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DevTools/RemoteDevToolsService.cs
@@ -36,9 +36,9 @@ internal sealed class RemoteDevToolsService(in ServiceArgs args) : RazorDocument
         => RunServiceAsync(
             solutionInfo,
             razorDocumentId,
-            async context =>
+            async snapshot =>
             {
-                var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+                var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
                 var csharpDocument = codeDocument.GetCSharpDocument(declarationDocument);
 
                 return csharpDocument?.Text.ToString();
@@ -52,9 +52,9 @@ internal sealed class RemoteDevToolsService(in ServiceArgs args) : RazorDocument
         => RunServiceAsync(
             solutionInfo,
             razorDocumentId,
-            async context =>
+            async snapshot =>
             {
-                var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+                var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
                 return codeDocument.GetHtmlSourceText(cancellationToken).ToString();
             },
             cancellationToken);
@@ -66,12 +66,12 @@ internal sealed class RemoteDevToolsService(in ServiceArgs args) : RazorDocument
         => RunServiceAsync(
             solutionInfo,
             razorDocumentId,
-            async context =>
+            async snapshot =>
             {
-                var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
-                var csharpSyntaxTree = await context.Snapshot.GetCSharpSyntaxTreeAsync(declarationDocument: false, cancellationToken).ConfigureAwait(false);
+                var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+                var csharpSyntaxTree = await snapshot.GetCSharpSyntaxTreeAsync(declarationDocument: false, cancellationToken).ConfigureAwait(false);
                 var declSyntaxTree = codeDocument.GetCSharpDocument(declarationDocument: true) is not null
-                    ? await context.Snapshot.GetCSharpSyntaxTreeAsync(declarationDocument: true, cancellationToken).ConfigureAwait(false)
+                    ? await snapshot.GetCSharpSyntaxTreeAsync(declarationDocument: true, cancellationToken).ConfigureAwait(false)
                     : null;
                 var csharpSyntaxRoot = await csharpSyntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
                 var declSyntaxRoot = declSyntaxTree is not null
@@ -94,9 +94,9 @@ internal sealed class RemoteDevToolsService(in ServiceArgs args) : RazorDocument
             context => GetTagHelpersJsonAsync(context, kind, cancellationToken),
             cancellationToken);
 
-    private static async ValueTask<string> GetTagHelpersJsonAsync(RemoteDocumentContext documentContext, TagHelpersKind kind, CancellationToken cancellationToken)
+    private static async ValueTask<string> GetTagHelpersJsonAsync(RemoteDocumentSnapshot documentSnapshot, TagHelpersKind kind, CancellationToken cancellationToken)
     {
-        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var tagHelpers = kind switch
         {
             TagHelpersKind.All => codeDocument.GetTagHelpers(),
@@ -182,9 +182,9 @@ internal sealed class RemoteDevToolsService(in ServiceArgs args) : RazorDocument
             context => GetRazorSyntaxTreeAsync(context, cancellationToken),
             cancellationToken);
 
-    private static async ValueTask<SyntaxVisualizerTree?> GetRazorSyntaxTreeAsync(RemoteDocumentContext documentContext, CancellationToken cancellationToken)
+    private static async ValueTask<SyntaxVisualizerTree?> GetRazorSyntaxTreeAsync(RemoteDocumentSnapshot documentSnapshot, CancellationToken cancellationToken)
     {
-        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var razorSyntaxTree = codeDocument.GetTagHelperRewrittenSyntaxTree();
 
         if (razorSyntaxTree?.Root == null)

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DevTools/RemoteDevToolsService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DevTools/RemoteDevToolsService.cs
@@ -38,7 +38,7 @@ internal sealed class RemoteDevToolsService(in ServiceArgs args) : RazorDocument
             razorDocumentId,
             async context =>
             {
-                var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+                var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
                 var csharpDocument = codeDocument.GetCSharpDocument(declarationDocument);
 
                 return csharpDocument?.Text.ToString();
@@ -54,7 +54,7 @@ internal sealed class RemoteDevToolsService(in ServiceArgs args) : RazorDocument
             razorDocumentId,
             async context =>
             {
-                var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+                var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
                 return codeDocument.GetHtmlSourceText(cancellationToken).ToString();
             },
             cancellationToken);
@@ -68,7 +68,7 @@ internal sealed class RemoteDevToolsService(in ServiceArgs args) : RazorDocument
             razorDocumentId,
             async context =>
             {
-                var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+                var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
                 var csharpSyntaxTree = await context.Snapshot.GetCSharpSyntaxTreeAsync(declarationDocument: false, cancellationToken).ConfigureAwait(false);
                 var declSyntaxTree = codeDocument.GetCSharpDocument(declarationDocument: true) is not null
                     ? await context.Snapshot.GetCSharpSyntaxTreeAsync(declarationDocument: true, cancellationToken).ConfigureAwait(false)
@@ -96,7 +96,7 @@ internal sealed class RemoteDevToolsService(in ServiceArgs args) : RazorDocument
 
     private static async ValueTask<string> GetTagHelpersJsonAsync(RemoteDocumentContext documentContext, TagHelpersKind kind, CancellationToken cancellationToken)
     {
-        var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var tagHelpers = kind switch
         {
             TagHelpersKind.All => codeDocument.GetTagHelpers(),
@@ -184,7 +184,7 @@ internal sealed class RemoteDevToolsService(in ServiceArgs args) : RazorDocument
 
     private static async ValueTask<SyntaxVisualizerTree?> GetRazorSyntaxTreeAsync(RemoteDocumentContext documentContext, CancellationToken cancellationToken)
     {
-        var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var razorSyntaxTree = codeDocument.GetTagHelperRewrittenSyntaxTree();
 
         if (razorSyntaxTree?.Root == null)

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Diagnostics/RazorDiagnosticHelper.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Diagnostics/RazorDiagnosticHelper.cs
@@ -23,8 +23,8 @@ internal static class RazorDiagnosticHelper
         return [new VSDiagnosticProjectInformation()
                 {
                     Context = null,
-                    ProjectIdentifier = documentSnapshot.Project.IntermediateOutputPath,
-                    ProjectName = documentSnapshot.Project.DisplayName
+                    ProjectIdentifier = documentSnapshot.ProjectSnapshot.IntermediateOutputPath,
+                    ProjectName = documentSnapshot.ProjectSnapshot.DisplayName
                 }];
     }
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Diagnostics/RemoteDiagnosticsService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Diagnostics/RemoteDiagnosticsService.cs
@@ -42,23 +42,23 @@ internal sealed class RemoteDiagnosticsService(in ServiceArgs args) : RazorDocum
         => RunServiceAsync(
             solutionInfo,
             documentId,
-            context => GetDiagnosticsAsync(context, csharpImplDiagnostics, csharpDeclDiagnostics, htmlDiagnostics, cancellationToken),
+            snapshot => GetDiagnosticsAsync(snapshot, csharpImplDiagnostics, csharpDeclDiagnostics, htmlDiagnostics, cancellationToken),
             cancellationToken);
 
     private async ValueTask<ImmutableArray<LspDiagnostic>> GetDiagnosticsAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         LspDiagnostic[] csharpImplDiagnostics,
         LspDiagnostic[] csharpDeclDiagnostics,
         LspDiagnostic[] htmlDiagnostics,
         CancellationToken cancellationToken)
     {
         // We've got C# and Html, lets get Razor diagnostics
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         ImmutableArray<LspDiagnostic> allDiagnostics = [
-            .. GetRazorDiagnostics(context, codeDocument),
-            .. await _translateDiagnosticsService.TranslateCSharpAsync(csharpImplDiagnostics, csharpDeclDiagnostics, context.Snapshot, cancellationToken).ConfigureAwait(false),
-            .. await _translateDiagnosticsService.TranslateHtmlAsync(htmlDiagnostics, context.Snapshot, cancellationToken).ConfigureAwait(false)
+            .. GetRazorDiagnostics(snapshot, codeDocument),
+            .. await _translateDiagnosticsService.TranslateCSharpAsync(csharpImplDiagnostics, csharpDeclDiagnostics, snapshot, cancellationToken).ConfigureAwait(false),
+            .. await _translateDiagnosticsService.TranslateHtmlAsync(htmlDiagnostics, snapshot, cancellationToken).ConfigureAwait(false)
         ];
 
         // Our final pass is to update all unused directive errors to ensure they display how we want in the IDE. Doing it here
@@ -106,7 +106,7 @@ internal sealed class RemoteDiagnosticsService(in ServiceArgs args) : RazorDocum
         return allDiagnostics;
     }
 
-    private static ImmutableArray<LspDiagnostic> GetRazorDiagnostics(RemoteDocumentContext context, RazorCodeDocument codeDocument)
+    private static ImmutableArray<LspDiagnostic> GetRazorDiagnostics(RemoteDocumentSnapshot snapshot, RazorCodeDocument codeDocument)
     {
         using var diagnostics = new PooledArrayBuilder<LspDiagnostic>();
 
@@ -114,7 +114,7 @@ internal sealed class RemoteDiagnosticsService(in ServiceArgs args) : RazorDocum
         // Right now Razor diagnostics are duplicated on both decl and impl documents, so it doesn't matter which
         // one we use.
         var razorDiagnostics = codeDocument.GetRequiredCSharpDocument(declarationDocument: false).Diagnostics;
-        var convertedDiagnostics = RazorDiagnosticHelper.Convert(razorDiagnostics, codeDocument.Source.Text, context.Snapshot);
+        var convertedDiagnostics = RazorDiagnosticHelper.Convert(razorDiagnostics, codeDocument.Source.Text, snapshot);
         diagnostics.AddRange(convertedDiagnostics);
 
         // For legacy files, that aren't imports, we also want to raise unused directive diagnostics. We only do this for
@@ -161,16 +161,16 @@ internal sealed class RemoteDiagnosticsService(in ServiceArgs args) : RazorDocum
         => RunServiceAsync(
             solutionInfo,
             documentId,
-            context => GetTaskListDiagnosticsAsync(context, csharpImplTaskItems, csharpDeclTaskItems, cancellationToken),
+            snapshot => GetTaskListDiagnosticsAsync(snapshot, csharpImplTaskItems, csharpDeclTaskItems, cancellationToken),
             cancellationToken);
 
     private async ValueTask<ImmutableArray<LspDiagnostic>> GetTaskListDiagnosticsAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         LspDiagnostic[] csharpImplTaskItems,
         LspDiagnostic[] csharpDeclTaskItems,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         using var diagnostics = new PooledArrayBuilder<LspDiagnostic>();
         diagnostics.AddRange(TaskListDiagnosticProvider.GetTaskListDiagnostics(codeDocument, _clientSettingsManager.GetClientSettings().AdvancedSettings.TaskListDescriptors));

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Diagnostics/RemoteDiagnosticsService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Diagnostics/RemoteDiagnosticsService.cs
@@ -53,7 +53,7 @@ internal sealed class RemoteDiagnosticsService(in ServiceArgs args) : RazorDocum
         CancellationToken cancellationToken)
     {
         // We've got C# and Html, lets get Razor diagnostics
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         ImmutableArray<LspDiagnostic> allDiagnostics = [
             .. GetRazorDiagnostics(context, codeDocument),
@@ -170,7 +170,7 @@ internal sealed class RemoteDiagnosticsService(in ServiceArgs args) : RazorDocum
         LspDiagnostic[] csharpDeclTaskItems,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         using var diagnostics = new PooledArrayBuilder<LspDiagnostic>();
         diagnostics.AddRange(TaskListDiagnosticProvider.GetTaskListDiagnostics(codeDocument, _clientSettingsManager.GetClientSettings().AdvancedSettings.TaskListDescriptors));

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentHighlight/RemoteDocumentHighlightService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentHighlight/RemoteDocumentHighlightService.cs
@@ -46,7 +46,7 @@ internal sealed partial class RemoteDocumentHighlightService(in ServiceArgs args
         LinePosition position,
         CancellationToken cancellationToken)
     {
-        var sourceText = await context.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
+        var sourceText = await context.Snapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
         if (!sourceText.TryGetAbsoluteIndex(position, out var index))
         {
             return Response.NoFurtherHandling;

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentHighlight/RemoteDocumentHighlightService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentHighlight/RemoteDocumentHighlightService.cs
@@ -38,21 +38,21 @@ internal sealed partial class RemoteDocumentHighlightService(in ServiceArgs args
         => RunServiceAsync(
             solutionInfo,
             razorDocumentId,
-            context => GetHighlightsAsync(context, position, cancellationToken),
+            snapshot => GetHighlightsAsync(snapshot, position, cancellationToken),
             cancellationToken);
 
     private async ValueTask<Response> GetHighlightsAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         LinePosition position,
         CancellationToken cancellationToken)
     {
-        var sourceText = await context.Snapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        var sourceText = await snapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
         if (!sourceText.TryGetAbsoluteIndex(position, out var index))
         {
             return Response.NoFurtherHandling;
         }
 
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         var languageKind = codeDocument.GetLanguageKind(index, rightAssociative: true);
         if (languageKind is RazorLanguageKind.Html)
@@ -73,7 +73,7 @@ internal sealed partial class RemoteDocumentHighlightService(in ServiceArgs args
         // document, because we would need to know a highlight location in the other document in order to know a position to ask for.
         // Fortunately none of the (at time of writing) keyword highlighters are for scenarios that would be valid across impl and decl
         // documents anyway.
-        var document = await context.Snapshot.GetGeneratedDocumentAsync(inDeclDocument, cancellationToken).ConfigureAwait(false);
+        var document = await snapshot.GetGeneratedDocumentAsync(inDeclDocument, cancellationToken).ConfigureAwait(false);
         var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
         var csharpDocument = codeDocument.GetRequiredCSharpDocument(inDeclDocument);
 
@@ -86,7 +86,7 @@ internal sealed partial class RemoteDocumentHighlightService(in ServiceArgs args
         // For reference highlights, we want to make sure to get references from both documents, as the user thinks they're just one, and
         // the results are much more useful. Fortunately Roslyn supports this, we just have to jump through a few little hoops when mapping
         // back to Razor positions.
-        var otherDocument = await context.Snapshot.TryGetGeneratedDocumentAsync(!inDeclDocument, cancellationToken).ConfigureAwait(false);
+        var otherDocument = await snapshot.TryGetGeneratedDocumentAsync(!inDeclDocument, cancellationToken).ConfigureAwait(false);
         var otherCSharpDocument = codeDocument.GetCSharpDocument(!inDeclDocument);
 
         var referenceHighlights = await GetReferenceHighlightsAsync(document, otherDocument, csharpDocument, otherCSharpDocument, csharpPosition, cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentHighlight/RemoteDocumentHighlightService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentHighlight/RemoteDocumentHighlightService.cs
@@ -52,7 +52,7 @@ internal sealed partial class RemoteDocumentHighlightService(in ServiceArgs args
             return Response.NoFurtherHandling;
         }
 
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         var languageKind = codeDocument.GetLanguageKind(index, rightAssociative: true);
         if (languageKind is RazorLanguageKind.Html)

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentMapping/IRazorEditService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentMapping/IRazorEditService.cs
@@ -36,5 +36,5 @@ internal interface IRazorEditService
     /// <summary>
     /// Maps C# changes in a workspace edit, to their equivalent Razor changes, modifying them in place
     /// </summary>
-    Task MapWorkspaceEditAsync(RemoteDocumentSnapshot contextDocumentSnapshot, WorkspaceEdit workspaceEdit, CancellationToken cancellationToken);
+    Task MapWorkspaceEditAsync(RemoteDocumentSnapshot documentSnapshot, WorkspaceEdit workspaceEdit, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentMapping/IRazorEditService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentMapping/IRazorEditService.cs
@@ -36,5 +36,5 @@ internal interface IRazorEditService
     /// <summary>
     /// Maps C# changes in a workspace edit, to their equivalent Razor changes, modifying them in place
     /// </summary>
-    Task MapWorkspaceEditAsync(RemoteDocumentSnapshot documentSnapshot, WorkspaceEdit workspaceEdit, CancellationToken cancellationToken);
+    Task MapWorkspaceEditAsync(Solution solution, WorkspaceEdit workspaceEdit, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentMapping/RazorEditService_WorkspaceEdit.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentMapping/RazorEditService_WorkspaceEdit.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Remote.Razor.DocumentMapping;
 
 internal partial class RazorEditService
 {
-    public async Task MapWorkspaceEditAsync(RemoteDocumentSnapshot documentSnapshot, WorkspaceEdit workspaceEdit, CancellationToken cancellationToken)
+    public async Task MapWorkspaceEditAsync(Solution solution, WorkspaceEdit workspaceEdit, CancellationToken cancellationToken)
     {
         // Collect both workspace edit shapes into TextDocumentEdits so URI coalescing and duplicate
         // edit handling run once across the whole edit.
@@ -28,7 +28,7 @@ internal partial class RazorEditService
             {
                 if (edit.TryGetFirst(out var textDocumentEdit))
                 {
-                    await MapTextDocumentEditAsync(documentSnapshot, textDocumentEdit, cancellationToken).ConfigureAwait(false);
+                    await MapTextDocumentEditAsync(solution, textDocumentEdit, cancellationToken).ConfigureAwait(false);
                 }
 
                 builder.Add(edit);
@@ -37,7 +37,7 @@ internal partial class RazorEditService
 
         if (workspaceEdit.Changes is { } changeMap)
         {
-            builder.AddRange(await MapDocumentEditsAsync(documentSnapshot, changeMap, cancellationToken).ConfigureAwait(false));
+            builder.AddRange(await MapDocumentEditsAsync(solution, changeMap, cancellationToken).ConfigureAwait(false));
         }
 
         var normalizedDocumentChanges = NormalizeDocumentChanges(builder.ToArrayAndClear());
@@ -97,7 +97,7 @@ internal partial class RazorEditService
         return normalizedDocumentChanges;
     }
 
-    private async Task MapTextDocumentEditAsync(RemoteDocumentSnapshot documentSnapshot, TextDocumentEdit entry, CancellationToken cancellationToken)
+    private async Task MapTextDocumentEditAsync(Solution solution, TextDocumentEdit entry, CancellationToken cancellationToken)
     {
         var generatedDocumentUri = entry.TextDocument.DocumentUri.GetRequiredSystemUri();
 
@@ -119,7 +119,6 @@ internal partial class RazorEditService
             return;
         }
 
-        var solution = documentSnapshot.TextDocument.Project.Solution;
         var razorDocument = await _snapshotManager.TryGetRazorDocumentAsync(solution, generatedDocumentUri, cancellationToken).ConfigureAwait(false);
         if (razorDocument is null)
         {
@@ -150,11 +149,10 @@ internal partial class RazorEditService
         entry.Edits = mappedEdits.SelectAsPlainArray(static e => new SumType<TextEdit, AnnotatedTextEdit>(e));
     }
 
-    private async Task<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>[]> MapDocumentEditsAsync(RemoteDocumentSnapshot documentSnapshot, Dictionary<string, TextEdit[]> changes, CancellationToken cancellationToken)
+    private async Task<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>[]> MapDocumentEditsAsync(Solution solution, Dictionary<string, TextEdit[]> changes, CancellationToken cancellationToken)
     {
         // Map legacy Changes into TextDocumentEdits so MapWorkspaceEditAsync can normalize both shapes together.
         using var builder = new PooledArrayBuilder<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>>(changes.Count);
-        var solution = documentSnapshot.TextDocument.Project.Solution;
 
         foreach (var (uriString, edits) in changes)
         {

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentMapping/RazorEditService_WorkspaceEdit.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentMapping/RazorEditService_WorkspaceEdit.cs
@@ -16,13 +16,8 @@ namespace Microsoft.CodeAnalysis.Remote.Razor.DocumentMapping;
 
 internal partial class RazorEditService
 {
-    public async Task MapWorkspaceEditAsync(RemoteDocumentSnapshot contextDocumentSnapshot, WorkspaceEdit workspaceEdit, CancellationToken cancellationToken)
+    public async Task MapWorkspaceEditAsync(RemoteDocumentSnapshot documentSnapshot, WorkspaceEdit workspaceEdit, CancellationToken cancellationToken)
     {
-        if (contextDocumentSnapshot is not RemoteDocumentSnapshot originSnapshot)
-        {
-            throw new InvalidOperationException("RemoteRazorEditService can only be used with RemoteDocumentSnapshot instances.");
-        }
-
         // Collect both workspace edit shapes into TextDocumentEdits so URI coalescing and duplicate
         // edit handling run once across the whole edit.
         using var builder = new PooledArrayBuilder<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>>();
@@ -33,7 +28,7 @@ internal partial class RazorEditService
             {
                 if (edit.TryGetFirst(out var textDocumentEdit))
                 {
-                    await MapTextDocumentEditAsync(originSnapshot, textDocumentEdit, cancellationToken).ConfigureAwait(false);
+                    await MapTextDocumentEditAsync(documentSnapshot, textDocumentEdit, cancellationToken).ConfigureAwait(false);
                 }
 
                 builder.Add(edit);
@@ -42,7 +37,7 @@ internal partial class RazorEditService
 
         if (workspaceEdit.Changes is { } changeMap)
         {
-            builder.AddRange(await MapDocumentEditsAsync(originSnapshot, changeMap, cancellationToken).ConfigureAwait(false));
+            builder.AddRange(await MapDocumentEditsAsync(documentSnapshot, changeMap, cancellationToken).ConfigureAwait(false));
         }
 
         var normalizedDocumentChanges = NormalizeDocumentChanges(builder.ToArrayAndClear());
@@ -102,7 +97,7 @@ internal partial class RazorEditService
         return normalizedDocumentChanges;
     }
 
-    private async Task MapTextDocumentEditAsync(RemoteDocumentSnapshot contextDocumentSnapshot, TextDocumentEdit entry, CancellationToken cancellationToken)
+    private async Task MapTextDocumentEditAsync(RemoteDocumentSnapshot documentSnapshot, TextDocumentEdit entry, CancellationToken cancellationToken)
     {
         var generatedDocumentUri = entry.TextDocument.DocumentUri.GetRequiredSystemUri();
 
@@ -124,7 +119,7 @@ internal partial class RazorEditService
             return;
         }
 
-        var solution = contextDocumentSnapshot.TextDocument.Project.Solution;
+        var solution = documentSnapshot.TextDocument.Project.Solution;
         var razorDocument = await _snapshotManager.TryGetRazorDocumentAsync(solution, generatedDocumentUri, cancellationToken).ConfigureAwait(false);
         if (razorDocument is null)
         {
@@ -155,11 +150,11 @@ internal partial class RazorEditService
         entry.Edits = mappedEdits.SelectAsPlainArray(static e => new SumType<TextEdit, AnnotatedTextEdit>(e));
     }
 
-    private async Task<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>[]> MapDocumentEditsAsync(RemoteDocumentSnapshot contextDocumentSnapshot, Dictionary<string, TextEdit[]> changes, CancellationToken cancellationToken)
+    private async Task<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>[]> MapDocumentEditsAsync(RemoteDocumentSnapshot documentSnapshot, Dictionary<string, TextEdit[]> changes, CancellationToken cancellationToken)
     {
         // Map legacy Changes into TextDocumentEdits so MapWorkspaceEditAsync can normalize both shapes together.
         using var builder = new PooledArrayBuilder<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>>(changes.Count);
-        var solution = contextDocumentSnapshot.TextDocument.Project.Solution;
+        var solution = documentSnapshot.TextDocument.Project.Solution;
 
         foreach (var (uriString, edits) in changes)
         {

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentSymbols/RemoteDocumentSymbolService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentSymbols/RemoteDocumentSymbolService.cs
@@ -62,7 +62,7 @@ internal sealed class RemoteDocumentSymbolService(in ServiceArgs args) : RazorDo
             csharpSymbols = ConvertDocumentSymbols(roslynDocumentSymbols);
         }
 
-        return _documentSymbolService.GetDocumentSymbols(context.Snapshot.FileKind, context.Uri, csharpDocument, csharpSymbols);
+        return _documentSymbolService.GetDocumentSymbols(context.Snapshot.FileKind, context.Snapshot.Uri, csharpDocument, csharpSymbols);
     }
 
     private static DocumentSymbol[] ConvertDocumentSymbols(DocumentSymbol[] roslynDocumentSymbols)

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentSymbols/RemoteDocumentSymbolService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentSymbols/RemoteDocumentSymbolService.cs
@@ -31,7 +31,7 @@ internal sealed class RemoteDocumentSymbolService(in ServiceArgs args) : RazorDo
 
     private async ValueTask<SumType<DocumentSymbol[], SymbolInformation[]>?> GetDocumentSymbolsAsync(RemoteDocumentContext context, bool useHierarchicalSymbols, CancellationToken cancellationToken)
     {
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         // We only care about fields, properties, methods etc. in document symbols, and for components those will exist in the declaration document.
         // For legacy documents, there is no declaration document, so we use the implementation document. An edge case is components that have no

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentSymbols/RemoteDocumentSymbolService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentSymbols/RemoteDocumentSymbolService.cs
@@ -26,12 +26,12 @@ internal sealed class RemoteDocumentSymbolService(in ServiceArgs args) : RazorDo
         => RunServiceAsync(
             solutionInfo,
             razorDocumentId,
-            context => GetDocumentSymbolsAsync(context, useHierarchicalSymbols, cancellationToken),
+            snapshot => GetDocumentSymbolsAsync(snapshot, useHierarchicalSymbols, cancellationToken),
             cancellationToken);
 
-    private async ValueTask<SumType<DocumentSymbol[], SymbolInformation[]>?> GetDocumentSymbolsAsync(RemoteDocumentContext context, bool useHierarchicalSymbols, CancellationToken cancellationToken)
+    private async ValueTask<SumType<DocumentSymbol[], SymbolInformation[]>?> GetDocumentSymbolsAsync(RemoteDocumentSnapshot snapshot, bool useHierarchicalSymbols, CancellationToken cancellationToken)
     {
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         // We only care about fields, properties, methods etc. in document symbols, and for components those will exist in the declaration document.
         // For legacy documents, there is no declaration document, so we use the implementation document. An edge case is components that have no
@@ -44,7 +44,7 @@ internal sealed class RemoteDocumentSymbolService(in ServiceArgs args) : RazorDo
             csharpDocument = codeDocument.GetRequiredCSharpDocument(declarationDocument: false);
         }
 
-        var generatedDocument = await context.Snapshot
+        var generatedDocument = await snapshot
             .GetGeneratedDocumentAsync(csharpDocument.IsDeclarationDocument, cancellationToken)
             .ConfigureAwait(false);
 
@@ -62,7 +62,7 @@ internal sealed class RemoteDocumentSymbolService(in ServiceArgs args) : RazorDo
             csharpSymbols = ConvertDocumentSymbols(roslynDocumentSymbols);
         }
 
-        return _documentSymbolService.GetDocumentSymbols(context.Snapshot.FileKind, context.Snapshot.Uri, csharpDocument, csharpSymbols);
+        return _documentSymbolService.GetDocumentSymbols(snapshot.FileKind, snapshot.Uri, csharpDocument, csharpSymbols);
     }
 
     private static DocumentSymbol[] ConvertDocumentSymbols(DocumentSymbol[] roslynDocumentSymbols)

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/FindAllReferences/RemoteFindAllReferencesService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/FindAllReferences/RemoteFindAllReferencesService.cs
@@ -54,7 +54,7 @@ internal sealed class RemoteFindAllReferencesService(in ServiceArgs args) : Razo
         Position position,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         if (!codeDocument.Source.Text.TryGetAbsoluteIndex(position, out var hostDocumentIndex))
         {

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/FindAllReferences/RemoteFindAllReferencesService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/FindAllReferences/RemoteFindAllReferencesService.cs
@@ -46,15 +46,15 @@ internal sealed class RemoteFindAllReferencesService(in ServiceArgs args) : Razo
         => RunServiceAsync(
             solutionInfo,
             documentId,
-            context => FindAllReferencesAsync(context, position, cancellationToken),
+            snapshot => FindAllReferencesAsync(snapshot, position, cancellationToken),
             cancellationToken);
 
     private async ValueTask<RemoteResponse<SumType<VSInternalReferenceItem, LspLocation>[]?>> FindAllReferencesAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         Position position,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         if (!codeDocument.Source.Text.TryGetAbsoluteIndex(position, out var hostDocumentIndex))
         {
@@ -72,7 +72,7 @@ internal sealed class RemoteFindAllReferencesService(in ServiceArgs args) : Razo
         }
 
         // Finally, call into C#.
-        var generatedDocument = await context.Snapshot
+        var generatedDocument = await snapshot
             .GetGeneratedDocumentAsync(positionInfo.InDeclDocument, cancellationToken)
             .ConfigureAwait(false);
         var globalOptions = generatedDocument.Project.Solution.Services.ExportProvider.GetService<IGlobalOptionService>();
@@ -116,7 +116,7 @@ internal sealed class RemoteFindAllReferencesService(in ServiceArgs args) : Razo
             var generatedDocumentUri = UriExtensions.GetRequiredSystemUri(location.DocumentUri);
             var (mappedUri, mappedRange) = await DocumentMappingService
                 .MapToHostDocumentUriAndRangeAsync(
-                    context.Snapshot,
+                    snapshot,
                     generatedDocumentUri,
                     location.Range.ToLinePositionSpan(),
                     cancellationToken)
@@ -140,7 +140,7 @@ internal sealed class RemoteFindAllReferencesService(in ServiceArgs args) : Razo
                     referenceItem.DocumentName = mappedUri.AbsolutePath;
 
                     var fixedResultText = await GetResultTextAsync(
-                        context,
+                        snapshot,
                         generatedDocumentUri,
                         mappedRange.Start.Line,
                         mappedUri.GetDocumentFilePathFromUri(),
@@ -160,7 +160,7 @@ internal sealed class RemoteFindAllReferencesService(in ServiceArgs args) : Razo
     }
 
     private async Task<string?> GetResultTextAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         Uri generatedDocumentUri,
         int lineNumber,
         string filePath,
@@ -186,12 +186,12 @@ internal sealed class RemoteFindAllReferencesService(in ServiceArgs args) : Razo
         // To identify which situation we're in, we try to map the start and the end of the line to C#, as an indicator. If
         // either start or end fail to map, it means the entire line is not C#
 
-        if (context.Snapshot.Project.SolutionSnapshot.GetProjectsContainingDocument(filePath).FirstOrDefault() is { } project &&
+        if (snapshot.Project.SolutionSnapshot.GetProjectsContainingDocument(filePath).FirstOrDefault() is { } project &&
             project.TryGetDocument(filePath, out var document))
         {
             var codeDoc = await document.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
             var line = codeDoc.Source.Text.Lines[lineNumber];
-            if (!context.Snapshot.TextDocument.Project.Solution.TryGetSourceGeneratedDocumentIdentity(generatedDocumentUri, out var identity))
+            if (!snapshot.TextDocument.Project.Solution.TryGetSourceGeneratedDocumentIdentity(generatedDocumentUri, out var identity))
             {
                 return null;
             }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/FindAllReferences/RemoteFindAllReferencesService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/FindAllReferences/RemoteFindAllReferencesService.cs
@@ -186,7 +186,7 @@ internal sealed class RemoteFindAllReferencesService(in ServiceArgs args) : Razo
         // To identify which situation we're in, we try to map the start and the end of the line to C#, as an indicator. If
         // either start or end fail to map, it means the entire line is not C#
 
-        if (snapshot.Project.SolutionSnapshot.GetProjectsContainingDocument(filePath).FirstOrDefault() is { } project &&
+        if (snapshot.ProjectSnapshot.SolutionSnapshot.GetProjectsContainingDocument(filePath).FirstOrDefault() is { } project &&
             project.TryGetDocument(filePath, out var document))
         {
             var codeDoc = await document.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/FindAllReferences/RemoteFindAllReferencesService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/FindAllReferences/RemoteFindAllReferencesService.cs
@@ -186,8 +186,7 @@ internal sealed class RemoteFindAllReferencesService(in ServiceArgs args) : Razo
         // To identify which situation we're in, we try to map the start and the end of the line to C#, as an indicator. If
         // either start or end fail to map, it means the entire line is not C#
 
-        // TODO: Note the call to RemoteSolutionSnapshot.GetProjectsContainingDocument(...) will be removed with the introduction of solution snapshots.
-        if (context.GetSolutionSnapshot().GetProjectsContainingDocument(filePath).FirstOrDefault() is { } project &&
+        if (context.Snapshot.Project.SolutionSnapshot.GetProjectsContainingDocument(filePath).FirstOrDefault() is { } project &&
             project.TryGetDocument(filePath, out var document))
         {
             var codeDoc = await document.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/FoldingRanges/RemoteFoldingRangeService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/FoldingRanges/RemoteFoldingRangeService.cs
@@ -33,29 +33,29 @@ internal sealed class RemoteFoldingRangeService(in ServiceArgs args) : RazorDocu
         => RunServiceAsync(
             solutionInfo,
             documentId,
-            context => GetFoldingRangesAsync(context, htmlRanges, cancellationToken),
+            snapshot => GetFoldingRangesAsync(snapshot, htmlRanges, cancellationToken),
             cancellationToken);
 
     private async ValueTask<ImmutableArray<RemoteFoldingRange>> GetFoldingRangesAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         ImmutableArray<RemoteFoldingRange> htmlRanges,
         CancellationToken cancellationToken)
     {
         var lineFoldingOnly = _clientCapabilitiesService.ClientCapabilities.TextDocument?.FoldingRange?.LineFoldingOnly ?? false;
-        var globalOptions = context.Snapshot.TextDocument.Project.Solution.Services.ExportProvider.GetService<IGlobalOptionService>();
+        var globalOptions = snapshot.TextDocument.Project.Solution.Services.ExportProvider.GetService<IGlobalOptionService>();
 
-        var generatedDocument = await context.Snapshot.GetGeneratedDocumentAsync(declarationDocument: false, cancellationToken).ConfigureAwait(false);
+        var generatedDocument = await snapshot.GetGeneratedDocumentAsync(declarationDocument: false, cancellationToken).ConfigureAwait(false);
         var csharpRanges = await FoldingRangesHandler.GetFoldingRangesAsync(globalOptions, generatedDocument, lineFoldingOnly, cancellationToken).ConfigureAwait(false);
 
         FoldingRange[]? declCSharpRanges = null;
-        if (await context.Snapshot.TryGetGeneratedDocumentAsync(declarationDocument: true, cancellationToken).ConfigureAwait(false) is SourceGeneratedDocument declGeneratedDocument)
+        if (await snapshot.TryGetGeneratedDocumentAsync(declarationDocument: true, cancellationToken).ConfigureAwait(false) is SourceGeneratedDocument declGeneratedDocument)
         {
             declCSharpRanges = await FoldingRangesHandler.GetFoldingRangesAsync(globalOptions, declGeneratedDocument, lineFoldingOnly, cancellationToken).ConfigureAwait(false);
         }
 
         var convertedHtml = htmlRanges.SelectAsArray(RemoteFoldingRange.ToLspFoldingRange);
 
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         return _foldingRangeService.GetFoldingRanges(codeDocument, csharpRanges, declCSharpRanges, convertedHtml, cancellationToken)
             .SelectAsArray(RemoteFoldingRange.FromLspFoldingRange);
     }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/FoldingRanges/RemoteFoldingRangeService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/FoldingRanges/RemoteFoldingRangeService.cs
@@ -42,7 +42,7 @@ internal sealed class RemoteFoldingRangeService(in ServiceArgs args) : RazorDocu
         CancellationToken cancellationToken)
     {
         var lineFoldingOnly = _clientCapabilitiesService.ClientCapabilities.TextDocument?.FoldingRange?.LineFoldingOnly ?? false;
-        var globalOptions = context.TextDocument.Project.Solution.Services.ExportProvider.GetService<IGlobalOptionService>();
+        var globalOptions = context.Snapshot.TextDocument.Project.Solution.Services.ExportProvider.GetService<IGlobalOptionService>();
 
         var generatedDocument = await context.Snapshot.GetGeneratedDocumentAsync(declarationDocument: false, cancellationToken).ConfigureAwait(false);
         var csharpRanges = await FoldingRangesHandler.GetFoldingRangesAsync(globalOptions, generatedDocument, lineFoldingOnly, cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/FoldingRanges/RemoteFoldingRangeService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/FoldingRanges/RemoteFoldingRangeService.cs
@@ -55,7 +55,7 @@ internal sealed class RemoteFoldingRangeService(in ServiceArgs args) : RazorDocu
 
         var convertedHtml = htmlRanges.SelectAsArray(RemoteFoldingRange.ToLspFoldingRange);
 
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         return _foldingRangeService.GetFoldingRanges(codeDocument, csharpRanges, declCSharpRanges, convertedHtml, cancellationToken)
             .SelectAsArray(RemoteFoldingRange.FromLspFoldingRange);
     }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Formatting/IRazorFormattingService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Formatting/IRazorFormattingService.cs
@@ -15,14 +15,14 @@ namespace Microsoft.CodeAnalysis.Remote.Razor.Formatting;
 internal interface IRazorFormattingService
 {
     Task<ImmutableArray<TextChange>> GetDocumentFormattingChangesAsync(
-       RemoteDocumentContext documentContext,
+       RemoteDocumentSnapshot documentSnapshot,
        ImmutableArray<TextChange> htmlEdits,
        LinePositionSpan? span,
        RazorFormattingOptions options,
        CancellationToken cancellationToken);
 
     Task<ImmutableArray<TextChange>> GetHtmlOnTypeFormattingChangesAsync(
-      RemoteDocumentContext documentContext,
+      RemoteDocumentSnapshot documentSnapshot,
       ImmutableArray<TextChange> htmlEdits,
       RazorFormattingOptions options,
       int hostDocumentIndex,
@@ -30,7 +30,7 @@ internal interface IRazorFormattingService
       CancellationToken cancellationToken);
 
     Task<ImmutableArray<TextChange>> GetCSharpOnTypeFormattingChangesAsync(
-      RemoteDocumentContext documentContext,
+      RemoteDocumentSnapshot documentSnapshot,
       RazorFormattingOptions options,
       int hostDocumentIndex,
       char triggerCharacter,
@@ -38,7 +38,7 @@ internal interface IRazorFormattingService
       CancellationToken cancellationToken);
 
     Task<TextChange?> TryGetSingleCSharpEditAsync(
-        RemoteDocumentContext documentContext,
+        RemoteDocumentSnapshot documentSnapshot,
         TextChange csharpEdit,
         bool declarationDocument,
         RazorFormattingOptions options,
@@ -52,7 +52,7 @@ internal interface IRazorFormattingService
        CancellationToken cancellationToken);
 
     Task<TextChange?> TryGetCSharpSnippetFormattingEditAsync(
-       RemoteDocumentContext documentContext,
+       RemoteDocumentSnapshot documentSnapshot,
        ImmutableArray<TextChange> csharpEdits,
        bool declarationDocument,
        RazorFormattingOptions options,

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Formatting/RazorFormattingService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Formatting/RazorFormattingService.cs
@@ -101,7 +101,7 @@ internal sealed class RazorFormattingService : IRazorFormattingService
         logger?.LogSourceText("InitialDocument", sourceText);
         LogSyntaxTree(logger, codeDocument);
 
-        var uri = documentContext.Uri;
+        var uri = documentContext.Snapshot.Uri;
         var documentSnapshot = documentContext.Snapshot;
         var context = FormattingContext.Create(
             documentSnapshot,

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Formatting/RazorFormattingService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Formatting/RazorFormattingService.cs
@@ -62,13 +62,13 @@ internal sealed class RazorFormattingService : IRazorFormattingService
     }
 
     public async Task<ImmutableArray<TextChange>> GetDocumentFormattingChangesAsync(
-        RemoteDocumentContext documentContext,
+        RemoteDocumentSnapshot documentSnapshot,
         ImmutableArray<TextChange> htmlChanges,
         LinePositionSpan? range,
         RazorFormattingOptions options,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         // Range formatting happens on every paste, and if there are Razor diagnostics in the file
         // that can make some very bad results. eg, given:
@@ -93,16 +93,15 @@ internal sealed class RazorFormattingService : IRazorFormattingService
             }
         }
 
-        var logger = _formattingLoggerFactory.CreateLogger(documentContext.Snapshot.FilePath, range is null ? "Full" : "Range");
-        logger?.LogObject("FileKind", documentContext.Snapshot.FileKind);
+        var logger = _formattingLoggerFactory.CreateLogger(documentSnapshot.FilePath, range is null ? "Full" : "Range");
+        logger?.LogObject("FileKind", documentSnapshot.FileKind);
         logger?.LogObject("Options", options);
         logger?.LogObject("HtmlChanges", htmlChanges.SelectAsArray(e => e.ToRazorTextChange()));
         logger?.LogObject("Range", range);
         logger?.LogSourceText("InitialDocument", sourceText);
         LogSyntaxTree(logger, codeDocument);
 
-        var uri = documentContext.Snapshot.Uri;
-        var documentSnapshot = documentContext.Snapshot;
+        var uri = documentSnapshot.Uri;
         var context = FormattingContext.Create(
             documentSnapshot,
             codeDocument,
@@ -135,11 +134,10 @@ internal sealed class RazorFormattingService : IRazorFormattingService
         return originalText.MinimizeTextChanges(normalizedChanges);
     }
 
-    public async Task<ImmutableArray<TextChange>> GetCSharpOnTypeFormattingChangesAsync(RemoteDocumentContext documentContext, RazorFormattingOptions options, int hostDocumentIndex, char triggerCharacter, bool declarationDocument, CancellationToken cancellationToken)
+    public async Task<ImmutableArray<TextChange>> GetCSharpOnTypeFormattingChangesAsync(RemoteDocumentSnapshot documentSnapshot, RazorFormattingOptions options, int hostDocumentIndex, char triggerCharacter, bool declarationDocument, CancellationToken cancellationToken)
     {
-        var documentSnapshot = documentContext.Snapshot;
 
-        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         return await ApplyFormattedChangesAsync(
                 documentSnapshot,
@@ -157,12 +155,11 @@ internal sealed class RazorFormattingService : IRazorFormattingService
                 cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<ImmutableArray<TextChange>> GetHtmlOnTypeFormattingChangesAsync(RemoteDocumentContext documentContext, ImmutableArray<TextChange> htmlChanges, RazorFormattingOptions options, int hostDocumentIndex, char triggerCharacter, CancellationToken cancellationToken)
+    public async Task<ImmutableArray<TextChange>> GetHtmlOnTypeFormattingChangesAsync(RemoteDocumentSnapshot documentSnapshot, ImmutableArray<TextChange> htmlChanges, RazorFormattingOptions options, int hostDocumentIndex, char triggerCharacter, CancellationToken cancellationToken)
     {
-        var documentSnapshot = documentContext.Snapshot;
 
         // Html formatting doesn't use the C# design time document
-        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         return await ApplyFormattedChangesAsync(
                 documentSnapshot,
@@ -180,11 +177,10 @@ internal sealed class RazorFormattingService : IRazorFormattingService
                 cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<TextChange?> TryGetSingleCSharpEditAsync(RemoteDocumentContext documentContext, TextChange csharpEdit, bool declarationDocument, RazorFormattingOptions options, CancellationToken cancellationToken)
+    public async Task<TextChange?> TryGetSingleCSharpEditAsync(RemoteDocumentSnapshot documentSnapshot, TextChange csharpEdit, bool declarationDocument, RazorFormattingOptions options, CancellationToken cancellationToken)
     {
-        var documentSnapshot = documentContext.Snapshot;
         // Since we've been provided with an edit from the C# generated doc, forcing design time would make things not line up
-        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         var razorChanges = await ApplyFormattedChangesAsync(
             documentSnapshot,
@@ -231,13 +227,11 @@ internal sealed class RazorFormattingService : IRazorFormattingService
             : null;
     }
 
-    public async Task<TextChange?> TryGetCSharpSnippetFormattingEditAsync(RemoteDocumentContext documentContext, ImmutableArray<TextChange> csharpChanges, bool declarationDocument, RazorFormattingOptions options, CancellationToken cancellationToken)
+    public async Task<TextChange?> TryGetCSharpSnippetFormattingEditAsync(RemoteDocumentSnapshot documentSnapshot, ImmutableArray<TextChange> csharpChanges, bool declarationDocument, RazorFormattingOptions options, CancellationToken cancellationToken)
     {
         csharpChanges = WrapCSharpSnippets(csharpChanges);
-
-        var documentSnapshot = documentContext.Snapshot;
         // Since we've been provided with edits from the C# generated doc, forcing design time would make things not line up
-        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         var razorChanges = await ApplyFormattedChangesAsync(
             documentSnapshot,

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Formatting/RemoteFormattingService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Formatting/RemoteFormattingService.cs
@@ -80,7 +80,7 @@ internal sealed class RemoteFormattingService(in ServiceArgs args) : RazorDocume
     private async ValueTask<ImmutableArray<TextChange>> GetOnTypeFormattingEditsAsync(RemoteDocumentContext context, ImmutableArray<TextChange> htmlChanges, LinePosition linePosition, string triggerCharacter, RazorFormattingOptions options, CancellationToken cancellationToken)
     {
         var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
-        var sourceText = await context.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
+        var sourceText = codeDocument.Source.Text;
         if (!sourceText.TryGetAbsoluteIndex(linePosition, out var hostDocumentIndex))
         {
             return [];

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Formatting/RemoteFormattingService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Formatting/RemoteFormattingService.cs
@@ -79,7 +79,7 @@ internal sealed class RemoteFormattingService(in ServiceArgs args) : RazorDocume
 
     private async ValueTask<ImmutableArray<TextChange>> GetOnTypeFormattingEditsAsync(RemoteDocumentContext context, ImmutableArray<TextChange> htmlChanges, LinePosition linePosition, string triggerCharacter, RazorFormattingOptions options, CancellationToken cancellationToken)
     {
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var sourceText = codeDocument.Source.Text;
         if (!sourceText.TryGetAbsoluteIndex(linePosition, out var hostDocumentIndex))
         {
@@ -119,7 +119,7 @@ internal sealed class RemoteFormattingService(in ServiceArgs args) : RazorDocume
 
     private async ValueTask<Response> GetOnTypeFormattingTriggerKindAsync(RemoteDocumentContext context, LinePosition linePosition, string triggerCharacter, CancellationToken cancellationToken)
     {
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var sourceText = codeDocument.Source.Text;
         if (!sourceText.TryGetAbsoluteIndex(linePosition, out var hostDocumentIndex))
         {

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Formatting/RemoteFormattingService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Formatting/RemoteFormattingService.cs
@@ -36,7 +36,7 @@ internal sealed class RemoteFormattingService(in ServiceArgs args) : RazorDocume
         => RunServiceAsync(
             solutionInfo,
             documentId,
-            context => new ValueTask<ImmutableArray<TextChange>>(_formattingService.GetDocumentFormattingChangesAsync(context, htmlChanges, span: null, options, cancellationToken)),
+            snapshot => new ValueTask<ImmutableArray<TextChange>>(_formattingService.GetDocumentFormattingChangesAsync(snapshot, htmlChanges, span: null, options, cancellationToken)),
             cancellationToken);
 
     public ValueTask<ImmutableArray<TextChange>> GetRangeFormattingEditsAsync(
@@ -49,11 +49,11 @@ internal sealed class RemoteFormattingService(in ServiceArgs args) : RazorDocume
         => RunServiceAsync(
             solutionInfo,
             documentId,
-            async context =>
+            async snapshot =>
             {
                 try
                 {
-                    return await _formattingService.GetDocumentFormattingChangesAsync(context, htmlChanges, linePositionSpan, options, cancellationToken).ConfigureAwait(false);
+                    return await _formattingService.GetDocumentFormattingChangesAsync(snapshot, htmlChanges, linePositionSpan, options, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception) when (options.FromPaste)
                 {
@@ -74,12 +74,12 @@ internal sealed class RemoteFormattingService(in ServiceArgs args) : RazorDocume
         => RunServiceAsync(
             solutionInfo,
             documentId,
-            context => GetOnTypeFormattingEditsAsync(context, htmlChanges, linePosition, character, options, cancellationToken),
+            snapshot => GetOnTypeFormattingEditsAsync(snapshot, htmlChanges, linePosition, character, options, cancellationToken),
             cancellationToken);
 
-    private async ValueTask<ImmutableArray<TextChange>> GetOnTypeFormattingEditsAsync(RemoteDocumentContext context, ImmutableArray<TextChange> htmlChanges, LinePosition linePosition, string triggerCharacter, RazorFormattingOptions options, CancellationToken cancellationToken)
+    private async ValueTask<ImmutableArray<TextChange>> GetOnTypeFormattingEditsAsync(RemoteDocumentSnapshot snapshot, ImmutableArray<TextChange> htmlChanges, LinePosition linePosition, string triggerCharacter, RazorFormattingOptions options, CancellationToken cancellationToken)
     {
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var sourceText = codeDocument.Source.Text;
         if (!sourceText.TryGetAbsoluteIndex(linePosition, out var hostDocumentIndex))
         {
@@ -93,7 +93,7 @@ internal sealed class RemoteFormattingService(in ServiceArgs args) : RazorDocume
 
         if (triggerCharacterKind is RazorLanguageKind.Html)
         {
-            return await _formattingService.GetHtmlOnTypeFormattingChangesAsync(context, htmlChanges, options, hostDocumentIndex, triggerCharacter[0], cancellationToken).ConfigureAwait(false);
+            return await _formattingService.GetHtmlOnTypeFormattingChangesAsync(snapshot, htmlChanges, options, hostDocumentIndex, triggerCharacter[0], cancellationToken).ConfigureAwait(false);
         }
 
         if (!DocumentMappingService.TryMapToCSharpDocumentLinePosition(codeDocument, hostDocumentIndex, out _, out _, out var inDeclDocument))
@@ -102,7 +102,7 @@ internal sealed class RemoteFormattingService(in ServiceArgs args) : RazorDocume
         }
 
         Debug.Assert(triggerCharacterKind is RazorLanguageKind.CSharp);
-        return await _formattingService.GetCSharpOnTypeFormattingChangesAsync(context, options, hostDocumentIndex, triggerCharacter[0], inDeclDocument, cancellationToken).ConfigureAwait(false);
+        return await _formattingService.GetCSharpOnTypeFormattingChangesAsync(snapshot, options, hostDocumentIndex, triggerCharacter[0], inDeclDocument, cancellationToken).ConfigureAwait(false);
     }
 
     public ValueTask<Response> GetOnTypeFormattingTriggerKindAsync(
@@ -114,12 +114,12 @@ internal sealed class RemoteFormattingService(in ServiceArgs args) : RazorDocume
         => RunServiceAsync(
             solutionInfo,
             documentId,
-            context => GetOnTypeFormattingTriggerKindAsync(context, linePosition, triggerCharacter, cancellationToken),
+            snapshot => GetOnTypeFormattingTriggerKindAsync(snapshot, linePosition, triggerCharacter, cancellationToken),
             cancellationToken);
 
-    private async ValueTask<Response> GetOnTypeFormattingTriggerKindAsync(RemoteDocumentContext context, LinePosition linePosition, string triggerCharacter, CancellationToken cancellationToken)
+    private async ValueTask<Response> GetOnTypeFormattingTriggerKindAsync(RemoteDocumentSnapshot snapshot, LinePosition linePosition, string triggerCharacter, CancellationToken cancellationToken)
     {
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var sourceText = codeDocument.Source.Text;
         if (!sourceText.TryGetAbsoluteIndex(linePosition, out var hostDocumentIndex))
         {

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/GoToDefinition/DefinitionService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/GoToDefinition/DefinitionService.cs
@@ -157,7 +157,7 @@ internal sealed class DefinitionService(
             return false;
         }
 
-        var project = documentSnapshot.Project;
+        var project = documentSnapshot.ProjectSnapshot;
 
         // Handle tilde paths (~/ or ~\) - these are relative to the project root
         if (filePath is ['~', '/' or '\\', ..])

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/GoToDefinition/RemoteGoToDefinitionService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/GoToDefinition/RemoteGoToDefinitionService.cs
@@ -85,7 +85,7 @@ internal sealed class RemoteGoToDefinitionService(in ServiceArgs args) : RazorDo
         var componentLocations = await _definitionService.GetDefinitionAsync(
             context.Snapshot,
             positionInfo,
-            context.GetSolutionSnapshot(),
+            context.Snapshot.Project.SolutionSnapshot,
             includeMvcTagHelpers: true,
             cancellationToken)
             .ConfigureAwait(false);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/GoToDefinition/RemoteGoToDefinitionService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/GoToDefinition/RemoteGoToDefinitionService.cs
@@ -85,7 +85,7 @@ internal sealed class RemoteGoToDefinitionService(in ServiceArgs args) : RazorDo
         var componentLocations = await _definitionService.GetDefinitionAsync(
             snapshot,
             positionInfo,
-            snapshot.Project.SolutionSnapshot,
+            snapshot.ProjectSnapshot.SolutionSnapshot,
             includeMvcTagHelpers: true,
             cancellationToken)
             .ConfigureAwait(false);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/GoToDefinition/RemoteGoToDefinitionService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/GoToDefinition/RemoteGoToDefinitionService.cs
@@ -61,15 +61,15 @@ internal sealed class RemoteGoToDefinitionService(in ServiceArgs args) : RazorDo
         => RunServiceAsync(
             solutionInfo,
             documentId,
-            context => GetDefinitionsAsync(context, position, cancellationToken),
+            snapshot => GetDefinitionsAsync(snapshot, position, cancellationToken),
             cancellationToken);
 
     private async ValueTask<RemoteResponse<LspLocation[]?>> GetDefinitionsAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         Position position,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         if (!codeDocument.Source.Text.TryGetAbsoluteIndex(position, out var hostDocumentIndex))
         {
@@ -83,9 +83,9 @@ internal sealed class RemoteGoToDefinitionService(in ServiceArgs args) : RazorDo
 
         // First, see if this is a tag helper. We ignore component attributes here, because they're better served by the C# handler.
         var componentLocations = await _definitionService.GetDefinitionAsync(
-            context.Snapshot,
+            snapshot,
             positionInfo,
-            context.Snapshot.Project.SolutionSnapshot,
+            snapshot.Project.SolutionSnapshot,
             includeMvcTagHelpers: true,
             cancellationToken)
             .ConfigureAwait(false);
@@ -99,7 +99,7 @@ internal sealed class RemoteGoToDefinitionService(in ServiceArgs args) : RazorDo
         if (positionInfo.LanguageKind is RazorLanguageKind.CSharp)
         {
             var stringLiteralLocations = await _definitionService.TryGetDefinitionFromStringLiteralAsync(
-                context.Snapshot,
+                snapshot,
                 positionInfo.Position,
                 positionInfo.InDeclDocument,
                 cancellationToken)
@@ -118,7 +118,7 @@ internal sealed class RemoteGoToDefinitionService(in ServiceArgs args) : RazorDo
         }
 
         // Finally, call into C#.
-        var generatedDocument = await context.Snapshot
+        var generatedDocument = await snapshot
             .GetGeneratedDocumentAsync(positionInfo.InDeclDocument, cancellationToken)
             .ConfigureAwait(false);
 
@@ -144,7 +144,7 @@ internal sealed class RemoteGoToDefinitionService(in ServiceArgs args) : RazorDo
             var (uri, range) = location;
 
             var (mappedDocumentUri, mappedRange) = await DocumentMappingService
-                .MapToHostDocumentUriAndRangeAsync(context.Snapshot, uri, range.ToLinePositionSpan(), cancellationToken)
+                .MapToHostDocumentUriAndRangeAsync(snapshot, uri, range.ToLinePositionSpan(), cancellationToken)
                 .ConfigureAwait(false);
 
             // Impl and decl generated documents can both contain a generated class declaration that maps to the same Razor location.

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/GoToDefinition/RemoteGoToDefinitionService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/GoToDefinition/RemoteGoToDefinitionService.cs
@@ -69,7 +69,7 @@ internal sealed class RemoteGoToDefinitionService(in ServiceArgs args) : RazorDo
         Position position,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         if (!codeDocument.Source.Text.TryGetAbsoluteIndex(position, out var hostDocumentIndex))
         {

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/GoToImplementation/RemoteGoToImplementationService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/GoToImplementation/RemoteGoToImplementationService.cs
@@ -47,7 +47,7 @@ internal sealed class RemoteGoToImplementationService(in ServiceArgs args) : Raz
         Position position,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         if (!codeDocument.Source.Text.TryGetAbsoluteIndex(position, out var hostDocumentIndex))
         {

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/GoToImplementation/RemoteGoToImplementationService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/GoToImplementation/RemoteGoToImplementationService.cs
@@ -39,15 +39,15 @@ internal sealed class RemoteGoToImplementationService(in ServiceArgs args) : Raz
         => RunServiceAsync(
             solutionInfo,
             documentId,
-            context => GetImplementationAsync(context, position, cancellationToken),
+            snapshot => GetImplementationAsync(snapshot, position, cancellationToken),
             cancellationToken);
 
     private async ValueTask<RemoteResponse<LspLocation[]?>> GetImplementationAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         Position position,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         if (!codeDocument.Source.Text.TryGetAbsoluteIndex(position, out var hostDocumentIndex))
         {
@@ -67,7 +67,7 @@ internal sealed class RemoteGoToImplementationService(in ServiceArgs args) : Raz
         }
 
         // Finally, call into C#.
-        var generatedDocument = await context.Snapshot
+        var generatedDocument = await snapshot
             .GetGeneratedDocumentAsync(positionInfo.InDeclDocument, cancellationToken)
             .ConfigureAwait(false);
 
@@ -96,7 +96,7 @@ internal sealed class RemoteGoToImplementationService(in ServiceArgs args) : Raz
             var (uri, range) = location;
 
             var (mappedDocumentUri, mappedRange) = await DocumentMappingService
-                .MapToHostDocumentUriAndRangeAsync(context.Snapshot, uri, range.ToLinePositionSpan(), cancellationToken)
+                .MapToHostDocumentUriAndRangeAsync(snapshot, uri, range.ToLinePositionSpan(), cancellationToken)
                 .ConfigureAwait(false);
 
             // Impl and decl generated documents can both contain a generated class declaration that maps to the same Razor location.

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Hover/RemoteHoverService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Hover/RemoteHoverService.cs
@@ -38,15 +38,15 @@ internal sealed class RemoteHoverService(in ServiceArgs args) : RazorDocumentSer
         => RunServiceAsync(
             solutionInfo,
             documentId,
-            context => GetHoverAsync(context, position, cancellationToken),
+            snapshot => GetHoverAsync(snapshot, position, cancellationToken),
             cancellationToken);
 
     private async ValueTask<RemoteResponse<LspHover?>> GetHoverAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         Position position,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         var sourceText = codeDocument.Source.Text;
         if (!sourceText.TryGetAbsoluteIndex(position, out var hostDocumentIndex))
@@ -64,7 +64,7 @@ internal sealed class RemoteHoverService(in ServiceArgs args) : RazorDocumentSer
 
         if (positionInfo.LanguageKind == RazorLanguageKind.CSharp)
         {
-            var generatedDocument = await context.Snapshot
+            var generatedDocument = await snapshot
                 .GetGeneratedDocumentAsync(positionInfo.InDeclDocument, cancellationToken)
                 .ConfigureAwait(false);
 
@@ -129,7 +129,7 @@ internal sealed class RemoteHoverService(in ServiceArgs args) : RazorDocumentSer
         // All of this will change when solution snapshots are available in the core Razor project model.
 
         // TODO: Remove this when solution snapshots are available in the core Razor project model.
-        var componentAvailabilityService = new ComponentAvailabilityService(context.Snapshot.ProjectSnapshot.SolutionSnapshot);
+        var componentAvailabilityService = new ComponentAvailabilityService(snapshot.ProjectSnapshot.SolutionSnapshot);
 
         var razorHover = await HoverFactory
             .GetHoverAsync(codeDocument, hostDocumentIndex, options, componentAvailabilityService, cancellationToken)

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Hover/RemoteHoverService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Hover/RemoteHoverService.cs
@@ -46,7 +46,7 @@ internal sealed class RemoteHoverService(in ServiceArgs args) : RazorDocumentSer
         Position position,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         var sourceText = codeDocument.Source.Text;
         if (!sourceText.TryGetAbsoluteIndex(position, out var hostDocumentIndex))

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/HtmlDocuments/RemoteHtmlDocumentService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/HtmlDocuments/RemoteHtmlDocumentService.cs
@@ -29,7 +29,7 @@ internal sealed class RemoteHtmlDocumentService(in ServiceArgs args) : RazorDocu
 
     private async ValueTask<string?> GetHtmlDocumentTextAsync(RemoteDocumentContext documentContext, CancellationToken cancellationToken)
     {
-        var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         return codeDocument.GetHtmlSourceText(cancellationToken).ToString();
     }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/HtmlDocuments/RemoteHtmlDocumentService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/HtmlDocuments/RemoteHtmlDocumentService.cs
@@ -27,9 +27,9 @@ internal sealed class RemoteHtmlDocumentService(in ServiceArgs args) : RazorDocu
             context => GetHtmlDocumentTextAsync(context, cancellationToken),
             cancellationToken);
 
-    private async ValueTask<string?> GetHtmlDocumentTextAsync(RemoteDocumentContext documentContext, CancellationToken cancellationToken)
+    private async ValueTask<string?> GetHtmlDocumentTextAsync(RemoteDocumentSnapshot documentSnapshot, CancellationToken cancellationToken)
     {
-        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         return codeDocument.GetHtmlSourceText(cancellationToken).ToString();
     }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/InlayHints/RemoteInlayHintService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/InlayHints/RemoteInlayHintService.cs
@@ -40,7 +40,7 @@ internal sealed class RemoteInlayHintService(in ServiceArgs args) : RazorDocumen
 
     private async ValueTask<InlayHint[]?> GetInlayHintsAsync(RemoteDocumentContext context, InlayHintParams inlayHintParams, bool displayAllOverride, CancellationToken cancellationToken)
     {
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         var span = inlayHintParams.Range.ToLinePositionSpan();
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/InlayHints/RemoteInlayHintService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/InlayHints/RemoteInlayHintService.cs
@@ -35,12 +35,12 @@ internal sealed class RemoteInlayHintService(in ServiceArgs args) : RazorDocumen
         => RunServiceAsync(
             solutionInfo,
             razorDocumentId,
-            context => GetInlayHintsAsync(context, inlayHintParams, displayAllOverride, cancellationToken),
+            snapshot => GetInlayHintsAsync(snapshot, inlayHintParams, displayAllOverride, cancellationToken),
             cancellationToken);
 
-    private async ValueTask<InlayHint[]?> GetInlayHintsAsync(RemoteDocumentContext context, InlayHintParams inlayHintParams, bool displayAllOverride, CancellationToken cancellationToken)
+    private async ValueTask<InlayHint[]?> GetInlayHintsAsync(RemoteDocumentSnapshot snapshot, InlayHintParams inlayHintParams, bool displayAllOverride, CancellationToken cancellationToken)
     {
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         var span = inlayHintParams.Range.ToLinePositionSpan();
 
@@ -74,7 +74,7 @@ internal sealed class RemoteInlayHintService(in ServiceArgs args) : RazorDocumen
             sawCSharpSpan = true;
 
             var inDeclDocument = csharpDocument.IsDeclarationDocument;
-            var generatedDocument = await context.Snapshot
+            var generatedDocument = await snapshot
                 .GetGeneratedDocumentAsync(inDeclDocument, cancellationToken)
                 .ConfigureAwait(false);
 
@@ -118,7 +118,7 @@ internal sealed class RemoteInlayHintService(in ServiceArgs args) : RazorDocumen
                         if (hint.TextEdits is not null)
                         {
                             var changes = hint.TextEdits.SelectAsArray(csharpSourceText.GetTextChange);
-                            var textChanges = await _razorEditService.MapCSharpEditsAsync(changes, inDeclDocument, context.Snapshot, cancellationToken).ConfigureAwait(false);
+                            var textChanges = await _razorEditService.MapCSharpEditsAsync(changes, inDeclDocument, snapshot, cancellationToken).ConfigureAwait(false);
 
                             var textEdits = textChanges.SelectAsArray(razorSourceText.GetTextEdit);
 
@@ -144,12 +144,12 @@ internal sealed class RemoteInlayHintService(in ServiceArgs args) : RazorDocumen
        => RunServiceAsync(
             solutionInfo,
             razorDocumentId,
-            context => ResolveInlayHintAsync(context, inlayHint, inDeclDocument, cancellationToken),
+            snapshot => ResolveInlayHintAsync(snapshot, inlayHint, inDeclDocument, cancellationToken),
             cancellationToken);
 
-    private async ValueTask<InlayHint> ResolveInlayHintAsync(RemoteDocumentContext context, InlayHint inlayHint, bool inDeclDocument, CancellationToken cancellationToken)
+    private async ValueTask<InlayHint> ResolveInlayHintAsync(RemoteDocumentSnapshot snapshot, InlayHint inlayHint, bool inDeclDocument, CancellationToken cancellationToken)
     {
-        var generatedDocument = await context.Snapshot
+        var generatedDocument = await snapshot
             .GetGeneratedDocumentAsync(inDeclDocument, cancellationToken)
             .ConfigureAwait(false);
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/InlineCompletion/RemoteInlineCompletionService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/InlineCompletion/RemoteInlineCompletionService.cs
@@ -32,7 +32,7 @@ internal sealed class RemoteInlineCompletionService(in ServiceArgs args) : Razor
 
     public async ValueTask<InlineCompletionRequestInfo?> GetInlineCompletionInfoAsync(RemoteDocumentContext context, LinePosition linePosition, CancellationToken cancellationToken)
     {
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         if (!codeDocument.Source.Text.TryGetAbsoluteIndex(linePosition, out var hostDocumentPosition))
         {
@@ -62,7 +62,7 @@ internal sealed class RemoteInlineCompletionService(in ServiceArgs args) : Razor
 
     private async ValueTask<FormattedInlineCompletionInfo?> FormatInlineCompletionAsync(RemoteDocumentContext context, bool inDeclDocument, RazorFormattingOptions options, LinePositionSpan span, string text, CancellationToken cancellationToken)
     {
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var csharpDocument = codeDocument.GetRequiredCSharpDocument(inDeclDocument);
 
         if (!_documentMappingService.TryMapToRazorDocumentRange(csharpDocument, span, out var razorRange))

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/InlineCompletion/RemoteInlineCompletionService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/InlineCompletion/RemoteInlineCompletionService.cs
@@ -27,12 +27,12 @@ internal sealed class RemoteInlineCompletionService(in ServiceArgs args) : Razor
         => RunServiceAsync(
             solutionInfo,
             documentId,
-            context => GetInlineCompletionInfoAsync(context, linePosition, cancellationToken),
+            snapshot => GetInlineCompletionInfoAsync(snapshot, linePosition, cancellationToken),
             cancellationToken);
 
-    public async ValueTask<InlineCompletionRequestInfo?> GetInlineCompletionInfoAsync(RemoteDocumentContext context, LinePosition linePosition, CancellationToken cancellationToken)
+    public async ValueTask<InlineCompletionRequestInfo?> GetInlineCompletionInfoAsync(RemoteDocumentSnapshot snapshot, LinePosition linePosition, CancellationToken cancellationToken)
     {
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         if (!codeDocument.Source.Text.TryGetAbsoluteIndex(linePosition, out var hostDocumentPosition))
         {
@@ -46,7 +46,7 @@ internal sealed class RemoteInlineCompletionService(in ServiceArgs args) : Razor
             return null;
         }
 
-        var generatedDocument = await context.Snapshot.GetGeneratedDocumentAsync(inDeclDocument, cancellationToken).ConfigureAwait(false);
+        var generatedDocument = await snapshot.GetGeneratedDocumentAsync(inDeclDocument, cancellationToken).ConfigureAwait(false);
         return new InlineCompletionRequestInfo(
             GeneratedDocumentUri: generatedDocument.CreateSystemUri(),
             Position: mappedPosition,
@@ -57,12 +57,12 @@ internal sealed class RemoteInlineCompletionService(in ServiceArgs args) : Razor
         => RunServiceAsync(
             solutionInfo,
             documentId,
-            context => FormatInlineCompletionAsync(context, inDeclDocument, options, span, text, cancellationToken),
+            snapshot => FormatInlineCompletionAsync(snapshot, inDeclDocument, options, span, text, cancellationToken),
             cancellationToken);
 
-    private async ValueTask<FormattedInlineCompletionInfo?> FormatInlineCompletionAsync(RemoteDocumentContext context, bool inDeclDocument, RazorFormattingOptions options, LinePositionSpan span, string text, CancellationToken cancellationToken)
+    private async ValueTask<FormattedInlineCompletionInfo?> FormatInlineCompletionAsync(RemoteDocumentSnapshot snapshot, bool inDeclDocument, RazorFormattingOptions options, LinePositionSpan span, string text, CancellationToken cancellationToken)
     {
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var csharpDocument = codeDocument.GetRequiredCSharpDocument(inDeclDocument);
 
         if (!_documentMappingService.TryMapToRazorDocumentRange(csharpDocument, span, out var razorRange))
@@ -72,7 +72,7 @@ internal sealed class RemoteInlineCompletionService(in ServiceArgs args) : Razor
 
         var hostDocumentIndex = codeDocument.Source.Text.GetRequiredAbsoluteIndex(razorRange.End);
 
-        var formattingContext = FormattingContext.Create(context.Snapshot, codeDocument, options, logger: null);
+        var formattingContext = FormattingContext.Create(snapshot, codeDocument, options, logger: null);
         if (!SnippetFormatter.TryGetSnippetWithAdjustedIndentation(formattingContext, text, hostDocumentIndex, out var newSnippetText))
         {
             return null;

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/LinkedEditingRange/RemoteLinkedEditingRangeService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/LinkedEditingRange/RemoteLinkedEditingRangeService.cs
@@ -43,7 +43,7 @@ internal sealed class RemoteLinkedEditingRangeService(in ServiceArgs args) : Raz
             return null;
         }
 
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         if (!codeDocument.Source.Text.TryGetSourceLocation(linePosition, out var validLocation))
         {
             return null;

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/LinkedEditingRange/RemoteLinkedEditingRangeService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/LinkedEditingRange/RemoteLinkedEditingRangeService.cs
@@ -30,11 +30,11 @@ internal sealed class RemoteLinkedEditingRangeService(in ServiceArgs args) : Raz
         => RunServiceAsync(
             solutionInfo,
             razorDocumentId,
-            context => GetRangesAsync(context, linePosition, cancellationToken),
+            snapshot => GetRangesAsync(snapshot, linePosition, cancellationToken),
             cancellationToken);
 
     public async ValueTask<LinePositionSpan[]?> GetRangesAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         LinePosition linePosition,
         CancellationToken cancellationToken)
     {
@@ -43,7 +43,7 @@ internal sealed class RemoteLinkedEditingRangeService(in ServiceArgs args) : Raz
             return null;
         }
 
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         if (!codeDocument.Source.Text.TryGetSourceLocation(linePosition, out var validLocation))
         {
             return null;

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/NestedFiles/RemoteAddNestedFileService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/NestedFiles/RemoteAddNestedFileService.cs
@@ -143,7 +143,7 @@ internal sealed class RemoteAddNestedFileService(in ServiceArgs args)
 
         // Format via Roslyn (handles file-scoped namespaces, indentation, etc.)
         content = await _roslynCodeActionHelpers.GetFormattedNewFileContentsAsync(
-            documentSnapshot.Project,
+            documentSnapshot.ProjectSnapshot,
             nestedFileUri.GetRequiredSystemUri(),
             content,
             cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/NestedFiles/RemoteAddNestedFileService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/NestedFiles/RemoteAddNestedFileService.cs
@@ -40,15 +40,15 @@ internal sealed class RemoteAddNestedFileService(in ServiceArgs args)
         => RunServiceAsync(
             solutionInfo,
             documentId,
-            context => GetNewNestedFileWorkspaceEditAsync(context, fileKind, cancellationToken),
+            snapshot => GetNewNestedFileWorkspaceEditAsync(snapshot, fileKind, cancellationToken),
             cancellationToken);
 
     private async ValueTask<WorkspaceEdit?> GetNewNestedFileWorkspaceEditAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         NestedFileKind fileKind,
         CancellationToken cancellationToken)
     {
-        var razorFilePath = context.Snapshot.FilePath;
+        var razorFilePath = snapshot.FilePath;
         if (GetNestedFilePath(razorFilePath, fileKind) is not string nestedFilePath)
         {
             return null;
@@ -57,7 +57,7 @@ internal sealed class RemoteAddNestedFileService(in ServiceArgs args)
         var nestedFileUri = LspFactory.CreateFilePathUri(nestedFilePath, _languageServerFeatureOptions);
 
         var content = await GenerateContentAsync(
-            fileKind, context, razorFilePath, nestedFileUri, cancellationToken).ConfigureAwait(false);
+            fileKind, snapshot, razorFilePath, nestedFileUri, cancellationToken).ConfigureAwait(false);
 
         var nestedFileDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier
         {
@@ -93,7 +93,7 @@ internal sealed class RemoteAddNestedFileService(in ServiceArgs args)
 
     private async Task<string> GenerateContentAsync(
         NestedFileKind fileKind,
-        RemoteDocumentContext documentContext,
+        RemoteDocumentSnapshot documentSnapshot,
         string razorFilePath,
         DocumentUri nestedFileUri,
         CancellationToken cancellationToken)
@@ -101,7 +101,7 @@ internal sealed class RemoteAddNestedFileService(in ServiceArgs args)
         return fileKind switch
         {
             NestedFileKind.CSharp => await GenerateCSharpContentAsync(
-                documentContext, razorFilePath, nestedFileUri, cancellationToken).ConfigureAwait(false),
+                documentSnapshot, razorFilePath, nestedFileUri, cancellationToken).ConfigureAwait(false),
             NestedFileKind.Css => GenerateCssContent(razorFilePath),
             NestedFileKind.JavaScript => GenerateJavaScriptContent(razorFilePath),
             _ => string.Empty
@@ -123,12 +123,12 @@ internal sealed class RemoteAddNestedFileService(in ServiceArgs args)
     }
 
     private async Task<string> GenerateCSharpContentAsync(
-        RemoteDocumentContext documentContext,
+        RemoteDocumentSnapshot documentSnapshot,
         string razorFilePath,
         DocumentUri nestedFileUri,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var className = Path.GetFileNameWithoutExtension(razorFilePath);
 
         // Use the Razor compiler's namespace resolution which handles @namespace directives,
@@ -143,7 +143,7 @@ internal sealed class RemoteAddNestedFileService(in ServiceArgs args)
 
         // Format via Roslyn (handles file-scoped namespaces, indentation, etc.)
         content = await _roslynCodeActionHelpers.GetFormattedNewFileContentsAsync(
-            documentContext.Snapshot.Project,
+            documentSnapshot.Project,
             nestedFileUri.GetRequiredSystemUri(),
             content,
             cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/NestedFiles/RemoteAddNestedFileService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/NestedFiles/RemoteAddNestedFileService.cs
@@ -128,7 +128,7 @@ internal sealed class RemoteAddNestedFileService(in ServiceArgs args)
         DocumentUri nestedFileUri,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var className = Path.GetFileNameWithoutExtension(razorFilePath);
 
         // Use the Razor compiler's namespace resolution which handles @namespace directives,

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentContext.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentContext.cs
@@ -17,9 +17,6 @@ internal sealed class RemoteDocumentContext(RemoteDocumentSnapshot snapshot)
 
     public TextDocument TextDocument => Snapshot.TextDocument;
 
-    public RemoteSolutionSnapshot GetSolutionSnapshot()
-        => Snapshot.ProjectSnapshot.SolutionSnapshot;
-
     private bool TryGetCodeDocument([NotNullWhen(true)] out RazorCodeDocument? codeDocument)
     {
         codeDocument = _codeDocument;

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentContext.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentContext.cs
@@ -6,14 +6,12 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
 
 internal sealed class RemoteDocumentContext(RemoteDocumentSnapshot snapshot)
 {
     private RazorCodeDocument? _codeDocument;
-    private SourceText? _sourceText;
 
     public RemoteDocumentSnapshot Snapshot { get; } = snapshot;
 
@@ -44,23 +42,6 @@ internal sealed class RemoteDocumentContext(RemoteDocumentSnapshot snapshot)
             // In race scenarios, when more than one RazorCodeDocument is produced, we want to
             // return whichever RazorCodeDocument is cached.
             return InterlockedOperations.Initialize(ref _codeDocument, codeDocument);
-        }
-    }
-
-    public ValueTask<SourceText> GetSourceTextAsync(CancellationToken cancellationToken)
-    {
-        return _sourceText is SourceText sourceText
-            ? new(sourceText)
-            : GetSourceTextCoreAsync(cancellationToken);
-
-        async ValueTask<SourceText> GetSourceTextCoreAsync(CancellationToken cancellationToken)
-        {
-            var sourceText = await Snapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
-
-            // Interlock to ensure that we only ever return one instance of RazorCodeDocument.
-            // In race scenarios, when more than one RazorCodeDocument is produced, we want to
-            // return whichever RazorCodeDocument is cached.
-            return InterlockedOperations.Initialize(ref _sourceText, sourceText);
         }
     }
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentContext.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentContext.cs
@@ -1,9 +1,0 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-namespace Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
-
-internal sealed class RemoteDocumentContext(RemoteDocumentSnapshot snapshot)
-{
-    public RemoteDocumentSnapshot Snapshot { get; } = snapshot;
-}

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentContext.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentContext.cs
@@ -6,6 +6,4 @@ namespace Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
 internal sealed class RemoteDocumentContext(RemoteDocumentSnapshot snapshot)
 {
     public RemoteDocumentSnapshot Snapshot { get; } = snapshot;
-
-    public TextDocument TextDocument => Snapshot.TextDocument;
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentContext.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentContext.cs
@@ -10,12 +10,11 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
 
-internal sealed class RemoteDocumentContext(DocumentUri uri, RemoteDocumentSnapshot snapshot)
+internal sealed class RemoteDocumentContext(RemoteDocumentSnapshot snapshot)
 {
     private RazorCodeDocument? _codeDocument;
     private SourceText? _sourceText;
 
-    public DocumentUri Uri { get; } = uri;
     public RemoteDocumentSnapshot Snapshot { get; } = snapshot;
 
     public TextDocument TextDocument => Snapshot.TextDocument;

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentContext.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentContext.cs
@@ -1,44 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor;
-using Microsoft.AspNetCore.Razor.Language;
-
 namespace Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
 
 internal sealed class RemoteDocumentContext(RemoteDocumentSnapshot snapshot)
 {
-    private RazorCodeDocument? _codeDocument;
-
     public RemoteDocumentSnapshot Snapshot { get; } = snapshot;
 
     public TextDocument TextDocument => Snapshot.TextDocument;
-
-    private bool TryGetCodeDocument([NotNullWhen(true)] out RazorCodeDocument? codeDocument)
-    {
-        codeDocument = _codeDocument;
-        return codeDocument is not null;
-    }
-
-    public ValueTask<RazorCodeDocument> GetCodeDocumentAsync(CancellationToken cancellationToken)
-    {
-        return TryGetCodeDocument(out var codeDocument)
-            ? new(codeDocument)
-            : GetCodeDocumentCoreAsync(cancellationToken);
-
-        async ValueTask<RazorCodeDocument> GetCodeDocumentCoreAsync(CancellationToken cancellationToken)
-        {
-            var codeDocument = await Snapshot
-                .GetGeneratedOutputAsync(cancellationToken)
-                .ConfigureAwait(false);
-
-            // Interlock to ensure that we only ever return one instance of RazorCodeDocument.
-            // In race scenarios, when more than one RazorCodeDocument is produced, we want to
-            // return whichever RazorCodeDocument is cached.
-            return InterlockedOperations.Initialize(ref _codeDocument, codeDocument);
-        }
-    }
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentContext.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentContext.cs
@@ -63,43 +63,4 @@ internal sealed class RemoteDocumentContext(RemoteDocumentSnapshot snapshot)
             return InterlockedOperations.Initialize(ref _sourceText, sourceText);
         }
     }
-
-    public ValueTask<RazorSyntaxTree> GetSyntaxTreeAsync(CancellationToken cancellationToken)
-    {
-        return TryGetCodeDocument(out var codeDocument)
-            ? new(GetSyntaxTreeCore(codeDocument))
-            : GetSyntaxTreeCoreAsync(cancellationToken);
-
-        static RazorSyntaxTree GetSyntaxTreeCore(RazorCodeDocument codeDocument)
-        {
-            return codeDocument.GetRequiredTagHelperRewrittenSyntaxTree();
-        }
-
-        async ValueTask<RazorSyntaxTree> GetSyntaxTreeCoreAsync(CancellationToken cancellationToken)
-        {
-            var codeDocument = await GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
-            return GetSyntaxTreeCore(codeDocument);
-        }
-    }
-
-#if SONICDEV
-    [System.Obsolete("PROTOTYPE(sonic): Call GetCodeDocument and get the right CSharpDocument from that, to prove that you thought about which document to get")]
-#endif
-    public ValueTask<SourceText> GetCSharpSourceTextAsync(CancellationToken cancellationToken)
-    {
-        return TryGetCodeDocument(out var codeDocument)
-            ? new(GetCSharpSourceTextCore(codeDocument))
-            : GetCSharpSourceTextCoreAsync(cancellationToken);
-
-        static SourceText GetCSharpSourceTextCore(RazorCodeDocument codeDocument)
-        {
-            return codeDocument.GetCSharpSourceText();
-        }
-
-        async ValueTask<SourceText> GetCSharpSourceTextCoreAsync(CancellationToken cancellationToken)
-        {
-            var codeDocument = await GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
-            return GetCSharpSourceTextCore(codeDocument);
-        }
-    }
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentSnapshot.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentSnapshot.cs
@@ -44,8 +44,6 @@ internal sealed class RemoteDocumentSnapshot
     public RazorFileKind FileKind => FileKinds.GetFileKindFromPath(FilePath);
     public string FilePath => TextDocument.FilePath.AssumeNotNull();
 
-    public RemoteProjectSnapshot Project => ProjectSnapshot;
-
     public ValueTask<SourceText> GetTextAsync(CancellationToken cancellationToken)
     {
         return TextDocument.TryGetText(out var result)

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentSnapshot.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentSnapshot.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor;
@@ -44,32 +43,15 @@ internal sealed class RemoteDocumentSnapshot
 
     public RazorFileKind FileKind => FileKinds.GetFileKindFromPath(FilePath);
     public string FilePath => TextDocument.FilePath.AssumeNotNull();
-    public string TargetPath => TextDocument.FilePath.AssumeNotNull();
 
     public RemoteProjectSnapshot Project => ProjectSnapshot;
 
     public ValueTask<SourceText> GetTextAsync(CancellationToken cancellationToken)
     {
-        return TryGetText(out var result)
+        return TextDocument.TryGetText(out var result)
             ? new(result)
             : new(TextDocument.GetTextAsync(cancellationToken));
     }
-
-    public ValueTask<VersionStamp> GetTextVersionAsync(CancellationToken cancellationToken)
-    {
-        return TryGetTextVersion(out var result)
-            ? new(result)
-            : new(TextDocument.GetTextVersionAsync(cancellationToken));
-    }
-
-    public bool TryGetText([NotNullWhen(true)] out SourceText? result)
-        => TextDocument.TryGetText(out result);
-
-    public bool TryGetTextVersion(out VersionStamp result)
-        => TextDocument.TryGetTextVersion(out result);
-
-    public bool TryGetGeneratedOutput([NotNullWhen(true)] out RazorCodeDocument? result)
-        => (result = _codeDocument) is not null;
 
     public async ValueTask<RazorCodeDocument> GetGeneratedOutputAsync(CancellationToken cancellationToken)
     {
@@ -108,14 +90,6 @@ internal sealed class RemoteDocumentSnapshot
             : await GetGeneratedDocumentInternalAsync(cancellationToken).ConfigureAwait(false);
     }
 
-#if SONICDEV
-    [System.Obsolete("PROTOTYPE(sonic): Call the overload that takes a bool to prove that you thought about which document to get")]
-#endif
-    public ValueTask<SourceGeneratedDocument> GetGeneratedDocumentAsync(CancellationToken cancellationToken)
-    {
-        return GetGeneratedDocumentInternalAsync(cancellationToken);
-    }
-
     private async ValueTask<SourceGeneratedDocument> GetGeneratedDocumentInternalAsync(CancellationToken cancellationToken)
     {
         if (_generatedDocument is not null)
@@ -125,18 +99,6 @@ internal sealed class RemoteDocumentSnapshot
 
         var generatedDocument = await ProjectSnapshot.GetRequiredGeneratedDocumentAsync(this, cancellationToken).ConfigureAwait(false);
         return InterlockedOperations.Initialize(ref _generatedDocument, generatedDocument);
-    }
-
-    /// <summary>
-    /// Returns the decl-half generated document for this Razor document, or <see langword="null"/> when the
-    /// source generator did not emit a decl-half for it. Caches the (possibly null) result.
-    /// </summary>
-#if SONICDEV
-    [System.Obsolete("PROTOTYPE(sonic): Call the overload that takes a bool to prove that you thought about which document to get")]
-#endif
-    public ValueTask<SourceGeneratedDocument?> TryGetDeclGeneratedDocumentAsync(CancellationToken cancellationToken)
-    {
-        return TryGetDeclGeneratedDocumentInternalAsync(cancellationToken);
     }
 
     private async ValueTask<SourceGeneratedDocument?> TryGetDeclGeneratedDocumentInternalAsync(CancellationToken cancellationToken)
@@ -151,14 +113,6 @@ internal sealed class RemoteDocumentSnapshot
         _declGeneratedDocument = declDocument;
         Volatile.Write(ref _declGeneratedDocumentInitialized, true);
         return declDocument;
-    }
-
-#if SONICDEV
-    [System.Obsolete("PROTOTYPE(sonic): Call the overload that takes a bool to prove that you thought about which document to get")]
-#endif
-    public ValueTask<SyntaxTree> GetCSharpSyntaxTreeAsync(CancellationToken cancellationToken)
-    {
-        return GetCSharpSyntaxTreeAsync(declarationDocument: false, cancellationToken);
     }
 
     public ValueTask<SyntaxTree> GetCSharpSyntaxTreeAsync(bool declarationDocument, CancellationToken cancellationToken)

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentSnapshot.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentSnapshot.cs
@@ -7,19 +7,29 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
 
 internal sealed class RemoteDocumentSnapshot
 {
-    public TextDocument TextDocument { get; }
-    public RemoteProjectSnapshot ProjectSnapshot { get; }
-
     private RazorCodeDocument? _codeDocument;
     private SourceGeneratedDocument? _generatedDocument;
     private SourceGeneratedDocument? _declGeneratedDocument;
     private bool _declGeneratedDocumentInitialized;
+
+    public TextDocument TextDocument { get; }
+    public RemoteProjectSnapshot ProjectSnapshot { get; }
+
+    public DocumentUri Uri
+    {
+        get
+        {
+            field ??= TextDocument.GetURI();
+            return field;
+        }
+    }
 
     public RemoteDocumentSnapshot(TextDocument textDocument, RemoteProjectSnapshot projectSnapshot)
     {

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentSnapshotExtensions.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentSnapshotExtensions.cs
@@ -28,7 +28,7 @@ internal static class RemoteDocumentSnapshotExtensions
             return null;
         }
 
-        var project = documentSnapshot.Project;
+        var project = documentSnapshot.ProjectSnapshot;
 
         // If we got this far, we can check for tag helpers
         var tagHelpers = await project.GetTagHelpersAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorDocumentServiceBase.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorDocumentServiceBase.cs
@@ -47,25 +47,25 @@ internal abstract class RazorDocumentServiceBase(in ServiceArgs args) : RazorBro
     protected ValueTask<T> RunServiceAsync<T>(
         RazorSolutionWrapper solutionInfo,
         DocumentId razorDocumentId,
-        Func<RemoteDocumentContext, ValueTask<T>> implementation,
+        Func<RemoteDocumentSnapshot, ValueTask<T>> implementation,
         CancellationToken cancellationToken)
     {
         return RunServiceAsync(
             solutionInfo,
             solution =>
             {
-                var documentContext = CreateRazorDocumentContext(solution, razorDocumentId);
-                if (documentContext is null)
+                var documentSnapshot = CreateRazorDocumentSnapshot(solution, razorDocumentId);
+                if (documentSnapshot is null)
                 {
                     return default;
                 }
 
-                return implementation(documentContext);
+                return implementation(documentSnapshot);
             },
             cancellationToken);
     }
 
-    protected RemoteDocumentContext? CreateRazorDocumentContext(Solution solution, DocumentId razorDocumentId)
+    protected RemoteDocumentSnapshot? CreateRazorDocumentSnapshot(Solution solution, DocumentId razorDocumentId)
     {
         var razorDocument = solution.GetAdditionalDocument(razorDocumentId);
         if (razorDocument is null)
@@ -75,6 +75,6 @@ internal abstract class RazorDocumentServiceBase(in ServiceArgs args) : RazorBro
 
         var documentSnapshot = SnapshotManager.GetSnapshot(razorDocument);
 
-        return new RemoteDocumentContext(documentSnapshot);
+        return documentSnapshot;
     }
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorDocumentServiceBase.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorDocumentServiceBase.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Remote;
@@ -76,6 +75,6 @@ internal abstract class RazorDocumentServiceBase(in ServiceArgs args) : RazorBro
 
         var documentSnapshot = SnapshotManager.GetSnapshot(razorDocument);
 
-        return new RemoteDocumentContext(razorDocument.GetURI(), documentSnapshot);
+        return new RemoteDocumentContext(documentSnapshot);
     }
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RemoveAndSortUsings/RemoteRemoveAndSortUsingsService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RemoveAndSortUsings/RemoteRemoveAndSortUsingsService.cs
@@ -38,7 +38,7 @@ internal sealed class RemoteRemoveAndSortUsingsService(in ServiceArgs args) : Ra
         RemoteDocumentContext context,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var sourceText = codeDocument.Source.Text;
         var syntaxTree = codeDocument.GetRequiredTagHelperRewrittenSyntaxTree();
         var allUsingDirectives = syntaxTree.GetUsingDirectives();
@@ -83,7 +83,7 @@ internal sealed class RemoteRemoveAndSortUsingsService(in ServiceArgs args) : Ra
         RemoteDocumentContext context,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         var textEdits = UsingDirectiveHelper.GetSortAndConsolidateEdits(codeDocument);
         return textEdits.SelectAsArray(codeDocument.Source.Text.GetTextChange);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RemoveAndSortUsings/RemoteRemoveAndSortUsingsService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RemoveAndSortUsings/RemoteRemoveAndSortUsingsService.cs
@@ -31,14 +31,14 @@ internal sealed class RemoteRemoveAndSortUsingsService(in ServiceArgs args) : Ra
         => RunServiceAsync(
             solutionInfo,
             documentId,
-            context => GetRemoveAndSortUsingsEditsAsync(context, cancellationToken),
+            snapshot => GetRemoveAndSortUsingsEditsAsync(snapshot, cancellationToken),
             cancellationToken);
 
     private static async ValueTask<ImmutableArray<TextChange>> GetRemoveAndSortUsingsEditsAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var sourceText = codeDocument.Source.Text;
         var syntaxTree = codeDocument.GetRequiredTagHelperRewrittenSyntaxTree();
         var allUsingDirectives = syntaxTree.GetUsingDirectives();
@@ -76,14 +76,14 @@ internal sealed class RemoteRemoveAndSortUsingsService(in ServiceArgs args) : Ra
         => RunServiceAsync(
             solutionInfo,
             documentId,
-            context => GetSortUsingsEditsAsync(context, cancellationToken),
+            snapshot => GetSortUsingsEditsAsync(snapshot, cancellationToken),
             cancellationToken);
 
     private static async ValueTask<ImmutableArray<TextChange>> GetSortUsingsEditsAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         var textEdits = UsingDirectiveHelper.GetSortAndConsolidateEdits(codeDocument);
         return textEdits.SelectAsArray(codeDocument.Source.Text.GetTextChange);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Rename/IRenameService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Rename/IRenameService.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Remote.Razor.Rename;
 internal interface IRenameService
 {
     Task<RenameResult> TryGetRazorRenameEditsAsync(
-        RemoteDocumentContext documentContext,
+        RemoteDocumentSnapshot documentSnapshot,
         DocumentPositionInfo positionInfo,
         string newName,
         RemoteSolutionSnapshot solutionSnapshot,
@@ -22,7 +22,7 @@ internal interface IRenameService
     /// Returns an edit that should occur after a .razor file has been renamed
     /// </summary>
     bool TryGetRazorFileRenameEdit(
-        RemoteDocumentContext documentContext,
+        RemoteDocumentSnapshot documentSnapshot,
         string newName,
         [NotNullWhen(true)] out WorkspaceEdit? workspaceEdit);
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Rename/RemoteRenameService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Rename/RemoteRenameService.cs
@@ -91,7 +91,7 @@ internal sealed class RemoteRenameService(in ServiceArgs args) : RazorDocumentSe
             return NoFurtherHandling;
         }
 
-        await _razorEditService.MapWorkspaceEditAsync(snapshot, csharpEdit, cancellationToken).ConfigureAwait(false);
+        await _razorEditService.MapWorkspaceEditAsync(snapshot.TextDocument.Project.Solution, csharpEdit, cancellationToken).ConfigureAwait(false);
 
         return Results(csharpEdit.Concat(razorEdit.Edit));
     }
@@ -256,7 +256,7 @@ internal sealed class RemoteRenameService(in ServiceArgs args) : RazorDocumentSe
             return null;
         }
 
-        await _razorEditService.MapWorkspaceEditAsync(snapshot, csharpEdit, cancellationToken).ConfigureAwait(false);
+        await _razorEditService.MapWorkspaceEditAsync(snapshot.TextDocument.Project.Solution, csharpEdit, cancellationToken).ConfigureAwait(false);
 
         _renameService.TryGetRazorFileRenameEdit(snapshot, newFileName, out var razorEdit);
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Rename/RemoteRenameService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Rename/RemoteRenameService.cs
@@ -70,7 +70,7 @@ internal sealed class RemoteRenameService(in ServiceArgs args) : RazorDocumentSe
             .ConfigureAwait(false);
 
         var razorEdit = await _renameService
-            .TryGetRazorRenameEditsAsync(snapshot, positionInfo, newName, snapshot.Project.SolutionSnapshot, cancellationToken)
+            .TryGetRazorRenameEditsAsync(snapshot, positionInfo, newName, snapshot.ProjectSnapshot.SolutionSnapshot, cancellationToken)
             .ConfigureAwait(false);
 
         if (razorEdit.Edit is null && positionInfo.LanguageKind != CodeAnalysis.Razor.Protocol.RazorLanguageKind.CSharp)

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Rename/RemoteRenameService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Rename/RemoteRenameService.cs
@@ -49,28 +49,28 @@ internal sealed class RemoteRenameService(in ServiceArgs args) : RazorDocumentSe
         => RunServiceAsync(
             solutionInfo,
             documentId,
-            context => GetRenameEditAsync(context, position, newName, cancellationToken),
+            snapshot => GetRenameEditAsync(snapshot, position, newName, cancellationToken),
             cancellationToken);
 
     private async ValueTask<RemoteResponse<WorkspaceEdit?>> GetRenameEditAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         Position position,
         string newName,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         var hostDocumentIndex = codeDocument.Source.Text.GetRequiredAbsoluteIndex(position);
         hostDocumentIndex = codeDocument.AdjustPositionForComponentEndTag(hostDocumentIndex);
 
         var positionInfo = GetPositionInfo(codeDocument, hostDocumentIndex, preferCSharpOverHtml: true);
 
-        var generatedDocument = await context.Snapshot
+        var generatedDocument = await snapshot
             .GetGeneratedDocumentAsync(positionInfo.InDeclDocument, cancellationToken)
             .ConfigureAwait(false);
 
         var razorEdit = await _renameService
-            .TryGetRazorRenameEditsAsync(context, positionInfo, newName, context.Snapshot.Project.SolutionSnapshot, cancellationToken)
+            .TryGetRazorRenameEditsAsync(snapshot, positionInfo, newName, snapshot.Project.SolutionSnapshot, cancellationToken)
             .ConfigureAwait(false);
 
         if (razorEdit.Edit is null && positionInfo.LanguageKind != CodeAnalysis.Razor.Protocol.RazorLanguageKind.CSharp)
@@ -91,7 +91,7 @@ internal sealed class RemoteRenameService(in ServiceArgs args) : RazorDocumentSe
             return NoFurtherHandling;
         }
 
-        await _razorEditService.MapWorkspaceEditAsync(context.Snapshot, csharpEdit, cancellationToken).ConfigureAwait(false);
+        await _razorEditService.MapWorkspaceEditAsync(snapshot, csharpEdit, cancellationToken).ConfigureAwait(false);
 
         return Results(csharpEdit.Concat(razorEdit.Edit));
     }
@@ -104,15 +104,15 @@ internal sealed class RemoteRenameService(in ServiceArgs args) : RazorDocumentSe
         => RunServiceAsync(
             solutionInfo,
             documentId,
-            context => GetPrepareRenameRangeAsync(context, position, cancellationToken),
+            snapshot => GetPrepareRenameRangeAsync(snapshot, position, cancellationToken),
             cancellationToken);
 
     private async ValueTask<RemoteResponse<LspRange?>> GetPrepareRenameRangeAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         Position position,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var sourceText = codeDocument.Source.Text;
 
         if (!sourceText.TryGetAbsoluteIndex(position, out var hostDocumentIndex))
@@ -134,7 +134,7 @@ internal sealed class RemoteRenameService(in ServiceArgs args) : RazorDocumentSe
             return RemoteResponse<LspRange?>.CallHtml;
         }
 
-        var generatedDocument = await context.Snapshot.GetGeneratedDocumentAsync(positionInfo.InDeclDocument, cancellationToken).ConfigureAwait(false);
+        var generatedDocument = await snapshot.GetGeneratedDocumentAsync(positionInfo.InDeclDocument, cancellationToken).ConfigureAwait(false);
 
         var csharpRange = await PrepareRenameHandler.GetRenameRangeAsync(generatedDocument, positionInfo.Position.ToLinePosition(), cancellationToken).ConfigureAwait(false);
 
@@ -169,7 +169,7 @@ internal sealed class RemoteRenameService(in ServiceArgs args) : RazorDocumentSe
         CancellationToken cancellationToken)
         => RunServiceAsync(
             solutionInfo,
-            context => GetFileRenameEditAsync(context, fileRenameRequest, cancellationToken),
+            snapshot => GetFileRenameEditAsync(snapshot, fileRenameRequest, cancellationToken),
             cancellationToken);
 
     private async ValueTask<WorkspaceEdit?> GetFileRenameEditAsync(Solution solution, RenameFilesParams fileRenameRequest, CancellationToken cancellationToken)
@@ -203,13 +203,13 @@ internal sealed class RemoteRenameService(in ServiceArgs args) : RazorDocumentSe
 
             Logger.LogDebug($"Rename for Razor document from {oldDoc.FilePath} to {newFileName}.");
 
-            var documentContext = CreateRazorDocumentContext(solution, oldDoc.Id);
-            if (documentContext is null)
+            var documentSnapshot = CreateRazorDocumentSnapshot(solution, oldDoc.Id);
+            if (documentSnapshot is null)
             {
                 continue;
             }
 
-            var documentEdit = await GetFileRenameEditAsync(documentContext, newFileName, cancellationToken).ConfigureAwait(false);
+            var documentEdit = await GetFileRenameEditAsync(documentSnapshot, newFileName, cancellationToken).ConfigureAwait(false);
             response = response.Concat(documentEdit);
         }
 
@@ -221,16 +221,16 @@ internal sealed class RemoteRenameService(in ServiceArgs args) : RazorDocumentSe
         return response;
     }
 
-    private async Task<WorkspaceEdit?> GetFileRenameEditAsync(RemoteDocumentContext context, string newFileName, CancellationToken cancellationToken)
+    private async Task<WorkspaceEdit?> GetFileRenameEditAsync(RemoteDocumentSnapshot snapshot, string newFileName, CancellationToken cancellationToken)
     {
-        if (!context.Snapshot.FileKind.IsComponent())
+        if (!snapshot.FileKind.IsComponent())
         {
             return null;
         }
 
         // We're renaming the class declaration of a generated C# class, which exists in both decl and impl documents, so we can just work from
         // the impl document since that will always exist. Decl may not.
-        var generatedDocument = await context.Snapshot.GetGeneratedDocumentAsync(declarationDocument: false, cancellationToken).ConfigureAwait(false);
+        var generatedDocument = await snapshot.GetGeneratedDocumentAsync(declarationDocument: false, cancellationToken).ConfigureAwait(false);
         var text = await generatedDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
         var tree = await generatedDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
         var declaration = tree.AssumeNotNull().DescendantNodes().OfType<ClassDeclarationSyntax>().FirstOrDefault();
@@ -256,9 +256,9 @@ internal sealed class RemoteRenameService(in ServiceArgs args) : RazorDocumentSe
             return null;
         }
 
-        await _razorEditService.MapWorkspaceEditAsync(context.Snapshot, csharpEdit, cancellationToken).ConfigureAwait(false);
+        await _razorEditService.MapWorkspaceEditAsync(snapshot, csharpEdit, cancellationToken).ConfigureAwait(false);
 
-        _renameService.TryGetRazorFileRenameEdit(context, newFileName, out var razorEdit);
+        _renameService.TryGetRazorFileRenameEdit(snapshot, newFileName, out var razorEdit);
 
         return csharpEdit.Concat(razorEdit);
     }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Rename/RemoteRenameService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Rename/RemoteRenameService.cs
@@ -58,7 +58,7 @@ internal sealed class RemoteRenameService(in ServiceArgs args) : RazorDocumentSe
         string newName,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         var hostDocumentIndex = codeDocument.Source.Text.GetRequiredAbsoluteIndex(position);
         hostDocumentIndex = codeDocument.AdjustPositionForComponentEndTag(hostDocumentIndex);
@@ -112,7 +112,7 @@ internal sealed class RemoteRenameService(in ServiceArgs args) : RazorDocumentSe
         Position position,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var sourceText = codeDocument.Source.Text;
 
         if (!sourceText.TryGetAbsoluteIndex(position, out var hostDocumentIndex))

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Rename/RemoteRenameService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Rename/RemoteRenameService.cs
@@ -70,7 +70,7 @@ internal sealed class RemoteRenameService(in ServiceArgs args) : RazorDocumentSe
             .ConfigureAwait(false);
 
         var razorEdit = await _renameService
-            .TryGetRazorRenameEditsAsync(context, positionInfo, newName, context.GetSolutionSnapshot(), cancellationToken)
+            .TryGetRazorRenameEditsAsync(context, positionInfo, newName, context.Snapshot.Project.SolutionSnapshot, cancellationToken)
             .ConfigureAwait(false);
 
         if (razorEdit.Edit is null && positionInfo.LanguageKind != CodeAnalysis.Razor.Protocol.RazorLanguageKind.CSharp)

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Rename/RenameService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Rename/RenameService.cs
@@ -45,7 +45,7 @@ internal sealed class RenameService(
             return new(Edit: null);
         }
 
-        var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         if (!TryGetOriginTagHelpers(codeDocument, positionInfo.HostDocumentIndex, out var originTagHelpers))
         {

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Rename/RenameService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Rename/RenameService.cs
@@ -33,19 +33,19 @@ internal sealed class RenameService(
     private readonly LanguageServerFeatureOptions _languageServerFeatureOptions = languageServerFeatureOptions;
 
     public async Task<RenameResult> TryGetRazorRenameEditsAsync(
-        RemoteDocumentContext documentContext,
+        RemoteDocumentSnapshot documentSnapshot,
         DocumentPositionInfo positionInfo,
         string newName,
         RemoteSolutionSnapshot solutionSnapshot,
         CancellationToken cancellationToken)
     {
         // We only support renaming of .razor components, not .cshtml tag helpers
-        if (!documentContext.Snapshot.FileKind.IsComponent())
+        if (!documentSnapshot.FileKind.IsComponent())
         {
             return new(Edit: null);
         }
 
-        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         if (!TryGetOriginTagHelpers(codeDocument, positionInfo.HostDocumentIndex, out var originTagHelpers))
         {
@@ -92,11 +92,11 @@ internal sealed class RenameService(
     }
 
     public bool TryGetRazorFileRenameEdit(
-        RemoteDocumentContext documentContext,
+        RemoteDocumentSnapshot documentSnapshot,
         string newName,
         [NotNullWhen(true)] out WorkspaceEdit? workspaceEdit)
     {
-        var oldPath = documentContext.Snapshot.FilePath;
+        var oldPath = documentSnapshot.FilePath;
         var newPath = MakeNewPath(oldPath, newName);
 
         using var documentChanges = new PooledArrayBuilder<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>>();

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SelectionRanges/RemoteSelectionRangeService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SelectionRanges/RemoteSelectionRangeService.cs
@@ -30,15 +30,15 @@ internal sealed class RemoteSelectionRangeService(in ServiceArgs args) : RazorDo
         => RunServiceAsync(
             solutionInfo,
             documentId,
-            context => GetSelectionRangesAsync(context, positions, cancellationToken),
+            snapshot => GetSelectionRangesAsync(snapshot, positions, cancellationToken),
             cancellationToken);
 
     private async ValueTask<SelectionRange[]?> GetSelectionRangesAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         Position[] positions,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         // Each position can map to either the implementation or declaration C# document. Keep the
         // position info in request order so we can query each generated document separately and still
@@ -95,7 +95,7 @@ internal sealed class RemoteSelectionRangeService(in ServiceArgs args) : RazorDo
                 return true;
             }
 
-            var generatedDocument = await context.Snapshot.GetGeneratedDocumentAsync(inDeclDocument, cancellationToken).ConfigureAwait(false);
+            var generatedDocument = await snapshot.GetGeneratedDocumentAsync(inDeclDocument, cancellationToken).ConfigureAwait(false);
 
             var csharpSelectionRanges = await SelectionRangeHandler.GetSelectionRangesAsync(generatedDocument, linePositions.ToImmutable(), cancellationToken).ConfigureAwait(false);
             if (csharpSelectionRanges is null)

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SelectionRanges/RemoteSelectionRangeService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SelectionRanges/RemoteSelectionRangeService.cs
@@ -38,7 +38,7 @@ internal sealed class RemoteSelectionRangeService(in ServiceArgs args) : RazorDo
         Position[] positions,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         // Each position can map to either the implementation or declaration C# document. Keep the
         // position info in request order so we can query each generated document separately and still

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/IRazorSemanticTokenInfoService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/IRazorSemanticTokenInfoService.cs
@@ -15,5 +15,5 @@ internal interface IRazorSemanticTokensInfoService
     /// Gets the int array representing the semantic tokens for the given range.
     /// </summary>
     /// <remarks>See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_semanticTokens for details about the int array</remarks>
-    Task<int[]?> GetSemanticTokensAsync(RemoteDocumentContext documentContext, LinePositionSpan range, bool colorBackground, Guid correlationId, CancellationToken cancellationToken);
+    Task<int[]?> GetSemanticTokensAsync(RemoteDocumentSnapshot documentSnapshot, LinePositionSpan range, bool colorBackground, Guid correlationId, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/RazorSemanticTokensInfoService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/RazorSemanticTokensInfoService.cs
@@ -79,7 +79,7 @@ internal sealed partial class RazorSemanticTokensInfoService(
         bool colorBackground,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/RazorSemanticTokensInfoService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/RazorSemanticTokensInfoService.cs
@@ -61,7 +61,7 @@ internal sealed partial class RazorSemanticTokensInfoService(
 
         var amount = semanticTokens is null ? "no" : (semanticTokens.Length / TokenSize).ToString(Thread.CurrentThread.CurrentCulture);
 
-        _logger.LogDebug($"Returned {amount} semantic tokens for span {span} in {documentContext.Uri}.");
+        _logger.LogDebug($"Returned {amount} semantic tokens for span {span} in {documentContext.Snapshot.Uri}.");
 
         if (semanticTokens is not null)
         {
@@ -108,7 +108,7 @@ internal sealed partial class RazorSemanticTokensInfoService(
         // We return null (which to the LSP is a no-op) to prevent flashing of CSharp elements.
         if (!successfullyRetrievedCSharpSemanticRanges)
         {
-            _logger.LogDebug($"Couldn't get C# tokens for {documentContext.Uri}. Returning null");
+            _logger.LogDebug($"Couldn't get C# tokens for {documentContext.Snapshot.Uri}. Returning null");
             return null;
         }
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/RazorSemanticTokensInfoService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/RazorSemanticTokensInfoService.cs
@@ -51,17 +51,17 @@ internal sealed partial class RazorSemanticTokensInfoService(
     private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<RazorSemanticTokensInfoService>();
 
     public async Task<int[]?> GetSemanticTokensAsync(
-        RemoteDocumentContext documentContext,
+        RemoteDocumentSnapshot documentSnapshot,
         LinePositionSpan span,
         bool colorBackground,
         Guid correlationId,
         CancellationToken cancellationToken)
     {
-        var semanticTokens = await GetSemanticTokensAsync(documentContext, span, correlationId, colorBackground, cancellationToken).ConfigureAwait(false);
+        var semanticTokens = await GetSemanticTokensAsync(documentSnapshot, span, correlationId, colorBackground, cancellationToken).ConfigureAwait(false);
 
         var amount = semanticTokens is null ? "no" : (semanticTokens.Length / TokenSize).ToString(Thread.CurrentThread.CurrentCulture);
 
-        _logger.LogDebug($"Returned {amount} semantic tokens for span {span} in {documentContext.Snapshot.Uri}.");
+        _logger.LogDebug($"Returned {amount} semantic tokens for span {span} in {documentSnapshot.Uri}.");
 
         if (semanticTokens is not null)
         {
@@ -73,13 +73,13 @@ internal sealed partial class RazorSemanticTokensInfoService(
     }
 
     private async Task<int[]?> GetSemanticTokensAsync(
-        RemoteDocumentContext documentContext,
+        RemoteDocumentSnapshot documentSnapshot,
         LinePositionSpan span,
         Guid correlationId,
         bool colorBackground,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -93,7 +93,7 @@ internal sealed partial class RazorSemanticTokensInfoService(
 
         try
         {
-            successfullyRetrievedCSharpSemanticRanges = await AddCSharpSemanticRangesAsync(combinedSemanticRanges, documentContext, codeDocument, span, colorBackground, correlationId, cancellationToken).ConfigureAwait(false);
+            successfullyRetrievedCSharpSemanticRanges = await AddCSharpSemanticRangesAsync(combinedSemanticRanges, documentSnapshot, codeDocument, span, colorBackground, correlationId, cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
@@ -108,7 +108,7 @@ internal sealed partial class RazorSemanticTokensInfoService(
         // We return null (which to the LSP is a no-op) to prevent flashing of CSharp elements.
         if (!successfullyRetrievedCSharpSemanticRanges)
         {
-            _logger.LogDebug($"Couldn't get C# tokens for {documentContext.Snapshot.Uri}. Returning null");
+            _logger.LogDebug($"Couldn't get C# tokens for {documentSnapshot.Uri}. Returning null");
             return null;
         }
 
@@ -123,7 +123,7 @@ internal sealed partial class RazorSemanticTokensInfoService(
 
     private async Task<bool> AddCSharpSemanticRangesAsync(
         List<SemanticRange> ranges,
-        RemoteDocumentContext documentContext,
+        RemoteDocumentSnapshot documentSnapshot,
         RazorCodeDocument codeDocument,
         LinePositionSpan razorSpan,
         bool colorBackground,
@@ -157,7 +157,7 @@ internal sealed partial class RazorSemanticTokensInfoService(
 
             _logger.LogDebug($"Requesting C# semantic tokens for correlation ID {correlationId}, decl half: {csharpDocument.IsDeclarationDocument}, and the server thinks there are {csharpDocument.Text.Lines.Count} lines of C#");
 
-            var csharpResponse = await GetCSharpSemanticTokensResponseAsync(documentContext.Snapshot, csharpDocument.IsDeclarationDocument, csharpRanges, correlationId, cancellationToken).ConfigureAwait(false);
+            var csharpResponse = await GetCSharpSemanticTokensResponseAsync(documentSnapshot, csharpDocument.IsDeclarationDocument, csharpRanges, correlationId, cancellationToken).ConfigureAwait(false);
 
             return ProcessCSharpResponse(ranges, codeDocument, csharpDocument, csharpResponse, razorSpan, colorBackground);
         }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/RemoteSemanticTokensService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/RemoteSemanticTokensService.cs
@@ -32,17 +32,17 @@ internal sealed partial class RemoteSemanticTokensService(in ServiceArgs args) :
         => RunServiceAsync(
             solutionInfo,
             razorDocumentId,
-            context => GetSemanticTokensDataAsync(context, span, correlationId, cancellationToken),
+            snapshot => GetSemanticTokensDataAsync(snapshot, span, correlationId, cancellationToken),
             cancellationToken);
 
     private async ValueTask<int[]?> GetSemanticTokensDataAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         LinePositionSpan span,
         Guid correlationId,
         CancellationToken cancellationToken)
     {
         return await _semanticTokensInfoService
-            .GetSemanticTokensAsync(context, span, _clientSettingsManager.GetClientSettings().AdvancedSettings.ColorBackground, correlationId, cancellationToken)
+            .GetSemanticTokensAsync(snapshot, span, _clientSettingsManager.GetClientSettings().AdvancedSettings.ColorBackground, correlationId, cancellationToken)
             .ConfigureAwait(false);
     }
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SignatureHelp/RemoteSignatureHelpService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SignatureHelp/RemoteSignatureHelpService.cs
@@ -27,18 +27,18 @@ internal sealed class RemoteSignatureHelpService(in ServiceArgs args) : RazorDoc
         => RunServiceAsync(
             solutionInfo,
             documentId,
-            context => GetSignatureHelpsAsync(context, position, cancellationToken),
+            snapshot => GetSignatureHelpsAsync(snapshot, position, cancellationToken),
             cancellationToken);
 
-    private async ValueTask<LspSignatureHelp?> GetSignatureHelpsAsync(RemoteDocumentContext context, Position position, CancellationToken cancellationToken)
+    private async ValueTask<LspSignatureHelp?> GetSignatureHelpsAsync(RemoteDocumentSnapshot snapshot, Position position, CancellationToken cancellationToken)
     {
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var linePosition = new LinePosition(position.Line, position.Character);
         var absoluteIndex = codeDocument.Source.Text.GetRequiredAbsoluteIndex(linePosition);
 
         if (DocumentMappingService.TryMapToCSharpDocumentLinePosition(codeDocument, absoluteIndex, out var mappedPosition, out _, out var inDeclDocument))
         {
-            var generatedDocument = await context.Snapshot.GetGeneratedDocumentAsync(inDeclDocument, cancellationToken).ConfigureAwait(false);
+            var generatedDocument = await snapshot.GetGeneratedDocumentAsync(inDeclDocument, cancellationToken).ConfigureAwait(false);
 
             var supportsVisualStudioExtensions = _clientCapabilitiesService.ClientCapabilities.SupportsVisualStudioExtensions;
             var signatureHelpService = generatedDocument.Project.Solution.Services.ExportProvider.GetService<SignatureHelpService>();

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SignatureHelp/RemoteSignatureHelpService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SignatureHelp/RemoteSignatureHelpService.cs
@@ -32,7 +32,7 @@ internal sealed class RemoteSignatureHelpService(in ServiceArgs args) : RazorDoc
 
     private async ValueTask<LspSignatureHelp?> GetSignatureHelpsAsync(RemoteDocumentContext context, Position position, CancellationToken cancellationToken)
     {
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var linePosition = new LinePosition(position.Line, position.Character);
         var absoluteIndex = codeDocument.Source.Text.GetRequiredAbsoluteIndex(linePosition);
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SpellCheck/CSharpSpellCheckRangeProvider.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SpellCheck/CSharpSpellCheckRangeProvider.cs
@@ -17,9 +17,8 @@ namespace Microsoft.CodeAnalysis.Remote.Razor.SpellCheck;
 [method: ImportingConstructor]
 internal sealed class CSharpSpellCheckRangeProvider() : ICSharpSpellCheckRangeProvider
 {
-    public async Task<ImmutableArray<SpellCheckRange>> GetCSharpSpellCheckRangesAsync(RemoteDocumentContext documentContext, CancellationToken cancellationToken)
+    public async Task<ImmutableArray<SpellCheckRange>> GetCSharpSpellCheckRangesAsync(RemoteDocumentSnapshot snapshot, CancellationToken cancellationToken)
     {
-        var snapshot = documentContext.Snapshot;
         using var ranges = new PooledArrayBuilder<SpellCheckRange>();
 
         // Spell-check spans can come from either generated C# document. Keep track of which document produced each range

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SpellCheck/ICSharpSpellCheckRangeProvider.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SpellCheck/ICSharpSpellCheckRangeProvider.cs
@@ -10,5 +10,5 @@ namespace Microsoft.CodeAnalysis.Remote.Razor.SpellCheck;
 
 internal interface ICSharpSpellCheckRangeProvider
 {
-    Task<ImmutableArray<SpellCheckRange>> GetCSharpSpellCheckRangesAsync(RemoteDocumentContext documentContext, CancellationToken cancellationToken);
+    Task<ImmutableArray<SpellCheckRange>> GetCSharpSpellCheckRangesAsync(RemoteDocumentSnapshot documentSnapshot, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SpellCheck/ISpellCheckService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SpellCheck/ISpellCheckService.cs
@@ -9,5 +9,5 @@ namespace Microsoft.CodeAnalysis.Remote.Razor.SpellCheck;
 
 internal interface ISpellCheckService
 {
-    Task<int[]> GetSpellCheckRangeTriplesAsync(RemoteDocumentContext documentContext, CancellationToken cancellationToken);
+    Task<int[]> GetSpellCheckRangeTriplesAsync(RemoteDocumentSnapshot documentSnapshot, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SpellCheck/RemoteSpellCheckService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SpellCheck/RemoteSpellCheckService.cs
@@ -23,11 +23,11 @@ internal sealed class RemoteSpellCheckService(in ServiceArgs args) : RazorDocume
         => RunServiceAsync(
             solutionInfo,
             razorDocumentId,
-            context => GetSpellCheckRangeTriplesAsync(context, cancellationToken),
+            snapshot => GetSpellCheckRangeTriplesAsync(snapshot, cancellationToken),
             cancellationToken);
 
-    private async ValueTask<int[]> GetSpellCheckRangeTriplesAsync(RemoteDocumentContext context, CancellationToken cancellationToken)
+    private async ValueTask<int[]> GetSpellCheckRangeTriplesAsync(RemoteDocumentSnapshot snapshot, CancellationToken cancellationToken)
     {
-        return await _spellCheckService.GetSpellCheckRangeTriplesAsync(context, cancellationToken).ConfigureAwait(false);
+        return await _spellCheckService.GetSpellCheckRangeTriplesAsync(snapshot, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SpellCheck/SpellCheckService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SpellCheck/SpellCheckService.cs
@@ -23,16 +23,16 @@ internal sealed class SpellCheckService(
     private readonly ICSharpSpellCheckRangeProvider _csharpSpellCheckService = csharpSpellCheckService;
     private readonly IDocumentMappingService _documentMappingService = documentMappingService;
 
-    public async Task<int[]> GetSpellCheckRangeTriplesAsync(RemoteDocumentContext documentContext, CancellationToken cancellationToken)
+    public async Task<int[]> GetSpellCheckRangeTriplesAsync(RemoteDocumentSnapshot documentSnapshot, CancellationToken cancellationToken)
     {
         using var builder = new PooledArrayBuilder<SpellCheckRange>();
 
-        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var syntaxTree = codeDocument.GetRequiredTagHelperRewrittenSyntaxTree();
 
         AddRazorSpellCheckRanges(ref builder.AsRef(), syntaxTree);
 
-        var csharpRanges = await _csharpSpellCheckService.GetCSharpSpellCheckRangesAsync(documentContext, cancellationToken).ConfigureAwait(false);
+        var csharpRanges = await _csharpSpellCheckService.GetCSharpSpellCheckRangesAsync(documentSnapshot, cancellationToken).ConfigureAwait(false);
         if (csharpRanges.Length > 0)
         {
             AddCSharpSpellCheckRanges(ref builder.AsRef(), csharpRanges, codeDocument);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SpellCheck/SpellCheckService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SpellCheck/SpellCheckService.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
@@ -27,15 +27,14 @@ internal sealed class SpellCheckService(
     {
         using var builder = new PooledArrayBuilder<SpellCheckRange>();
 
-        var syntaxTree = await documentContext.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var syntaxTree = codeDocument.GetRequiredTagHelperRewrittenSyntaxTree();
 
         AddRazorSpellCheckRanges(ref builder.AsRef(), syntaxTree);
 
         var csharpRanges = await _csharpSpellCheckService.GetCSharpSpellCheckRangesAsync(documentContext, cancellationToken).ConfigureAwait(false);
-
         if (csharpRanges.Length > 0)
         {
-            var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
             AddCSharpSpellCheckRanges(ref builder.AsRef(), csharpRanges, codeDocument);
         }
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/TypeHierarchy/RemoteTypeHierarchyService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/TypeHierarchy/RemoteTypeHierarchyService.cs
@@ -37,15 +37,15 @@ internal sealed class RemoteTypeHierarchyService(in ServiceArgs args) : RazorDoc
         => RunServiceAsync(
             solutionInfo,
             razorDocumentId,
-            context => PrepareTypeHierarchyAsync(context, position, cancellationToken),
+            snapshot => PrepareTypeHierarchyAsync(snapshot, position, cancellationToken),
             cancellationToken);
 
     private async ValueTask<RemoteResponse<TypeHierarchyItem[]?>> PrepareTypeHierarchyAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         Position position,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         if (!codeDocument.Source.Text.TryGetAbsoluteIndex(position, out var hostDocumentIndex))
         {
@@ -60,7 +60,7 @@ internal sealed class RemoteTypeHierarchyService(in ServiceArgs args) : RazorDoc
             return NoFurtherHandling;
         }
 
-        var generatedDocument = await context.Snapshot.GetGeneratedDocumentAsync(positionInfo.InDeclDocument, cancellationToken).ConfigureAwait(false);
+        var generatedDocument = await snapshot.GetGeneratedDocumentAsync(positionInfo.InDeclDocument, cancellationToken).ConfigureAwait(false);
         var items = await PrepareTypeHierarchyHandler.PrepareTypeHierarchyAsync(generatedDocument, positionInfo.Position.ToLinePosition(), cancellationToken)
             .ConfigureAwait(false);
 
@@ -69,7 +69,7 @@ internal sealed class RemoteTypeHierarchyService(in ServiceArgs args) : RazorDoc
             return NoFurtherHandling;
         }
 
-        var mappedItems = await MapItemsAsync(context, items, cancellationToken).ConfigureAwait(false);
+        var mappedItems = await MapItemsAsync(snapshot, items, cancellationToken).ConfigureAwait(false);
         return Results(mappedItems);
     }
 
@@ -81,15 +81,15 @@ internal sealed class RemoteTypeHierarchyService(in ServiceArgs args) : RazorDoc
         => RunServiceAsync(
             solutionInfo,
             razorDocumentId,
-            context => ResolveSupertypesAsync(context, item, cancellationToken),
+            snapshot => ResolveSupertypesAsync(snapshot, item, cancellationToken),
             cancellationToken);
 
     private async ValueTask<RemoteResponse<TypeHierarchyItem[]?>> ResolveSupertypesAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         TypeHierarchyItem item,
         CancellationToken cancellationToken)
     {
-        var generatedDocument = await TryGetGeneratedDocumentForItemAsync(context, item, cancellationToken).ConfigureAwait(false);
+        var generatedDocument = await TryGetGeneratedDocumentForItemAsync(snapshot, item, cancellationToken).ConfigureAwait(false);
         if (generatedDocument is null)
         {
             return NoFurtherHandling;
@@ -103,7 +103,7 @@ internal sealed class RemoteTypeHierarchyService(in ServiceArgs args) : RazorDoc
             return NoFurtherHandling;
         }
 
-        var mappedItems = await MapItemsAsync(context, items, cancellationToken).ConfigureAwait(false);
+        var mappedItems = await MapItemsAsync(snapshot, items, cancellationToken).ConfigureAwait(false);
         return Results(mappedItems);
     }
 
@@ -115,15 +115,15 @@ internal sealed class RemoteTypeHierarchyService(in ServiceArgs args) : RazorDoc
         => RunServiceAsync(
             solutionInfo,
             razorDocumentId,
-            context => ResolveSubtypesAsync(context, item, cancellationToken),
+            snapshot => ResolveSubtypesAsync(snapshot, item, cancellationToken),
             cancellationToken);
 
     private async ValueTask<RemoteResponse<TypeHierarchyItem[]?>> ResolveSubtypesAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         TypeHierarchyItem item,
         CancellationToken cancellationToken)
     {
-        var generatedDocument = await TryGetGeneratedDocumentForItemAsync(context, item, cancellationToken).ConfigureAwait(false);
+        var generatedDocument = await TryGetGeneratedDocumentForItemAsync(snapshot, item, cancellationToken).ConfigureAwait(false);
         if (generatedDocument is null)
         {
             return NoFurtherHandling;
@@ -137,37 +137,37 @@ internal sealed class RemoteTypeHierarchyService(in ServiceArgs args) : RazorDoc
             return NoFurtherHandling;
         }
 
-        var mappedItems = await MapItemsAsync(context, items, cancellationToken).ConfigureAwait(false);
+        var mappedItems = await MapItemsAsync(snapshot, items, cancellationToken).ConfigureAwait(false);
         return Results(mappedItems);
     }
 
     private static async ValueTask<SourceGeneratedDocument?> TryGetGeneratedDocumentForItemAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         TypeHierarchyItem item,
         CancellationToken cancellationToken)
     {
         var resolveData = TypeHierarchyHelpers.GetResolveData(item);
         var generatedDocumentUri = resolveData.TextDocument.DocumentUri.GetRequiredSystemUri();
-        if (!context.Snapshot.TextDocument.Project.Solution.TryGetSourceGeneratedDocumentIdentity(generatedDocumentUri, out var identity))
+        if (!snapshot.TextDocument.Project.Solution.TryGetSourceGeneratedDocumentIdentity(generatedDocumentUri, out var identity))
         {
             return null;
         }
 
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var csharpDocument = codeDocument.GetCSharpDocumentForHintName(identity.HintName);
 
-        return await context.Snapshot.GetGeneratedDocumentAsync(csharpDocument.IsDeclarationDocument, cancellationToken).ConfigureAwait(false);
+        return await snapshot.GetGeneratedDocumentAsync(csharpDocument.IsDeclarationDocument, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<TypeHierarchyItem[]?> MapItemsAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         TypeHierarchyItem[] items,
         CancellationToken cancellationToken)
     {
         using var mappedItems = new PooledArrayBuilder<TypeHierarchyItem>(items.Length);
         foreach (var item in items)
         {
-            var mappedItem = await MapItemAsync(context, item, cancellationToken).ConfigureAwait(false);
+            var mappedItem = await MapItemAsync(snapshot, item, cancellationToken).ConfigureAwait(false);
             if (mappedItem is not null)
             {
                 mappedItems.Add(mappedItem);
@@ -178,14 +178,14 @@ internal sealed class RemoteTypeHierarchyService(in ServiceArgs args) : RazorDoc
     }
 
     private async Task<TypeHierarchyItem?> MapItemAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         TypeHierarchyItem item,
         CancellationToken cancellationToken)
     {
         var uri = item.Uri.GetRequiredSystemUri();
 
         var (mappedDocumentUri, mappedRange) = await DocumentMappingService
-            .MapToHostDocumentUriAndRangeAsync(context.Snapshot, uri, item.Range, cancellationToken)
+            .MapToHostDocumentUriAndRangeAsync(snapshot, uri, item.Range, cancellationToken)
             .ConfigureAwait(false);
         if (_filePathService.IsVirtualCSharpFile(mappedDocumentUri))
         {
@@ -193,7 +193,7 @@ internal sealed class RemoteTypeHierarchyService(in ServiceArgs args) : RazorDoc
         }
 
         var (mappedSelectionUri, mappedSelectionRange) = await DocumentMappingService
-            .MapToHostDocumentUriAndRangeAsync(context.Snapshot, uri, item.SelectionRange, cancellationToken)
+            .MapToHostDocumentUriAndRangeAsync(snapshot, uri, item.SelectionRange, cancellationToken)
             .ConfigureAwait(false);
         if (_filePathService.IsVirtualCSharpFile(mappedSelectionUri))
         {

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/TypeHierarchy/RemoteTypeHierarchyService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/TypeHierarchy/RemoteTypeHierarchyService.cs
@@ -45,7 +45,7 @@ internal sealed class RemoteTypeHierarchyService(in ServiceArgs args) : RazorDoc
         Position position,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         if (!codeDocument.Source.Text.TryGetAbsoluteIndex(position, out var hostDocumentIndex))
         {
@@ -153,7 +153,7 @@ internal sealed class RemoteTypeHierarchyService(in ServiceArgs args) : RazorDoc
             return null;
         }
 
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var csharpDocument = codeDocument.GetCSharpDocumentForHintName(identity.HintName);
 
         return await context.Snapshot.GetGeneratedDocumentAsync(csharpDocument.IsDeclarationDocument, cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/UriPresentation/RemoteUriPresentationService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/UriPresentation/RemoteUriPresentationService.cs
@@ -48,7 +48,7 @@ internal sealed partial class RemoteUriPresentationService(in ServiceArgs args) 
             return Response.NoFurtherHandling;
         }
 
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         var languageKind = codeDocument.GetLanguageKind(index, rightAssociative: true);
         if (languageKind is not RazorLanguageKind.Html)

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/UriPresentation/RemoteUriPresentationService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/UriPresentation/RemoteUriPresentationService.cs
@@ -66,7 +66,7 @@ internal sealed partial class RemoteUriPresentationService(in ServiceArgs args) 
             return Response.CallHtml;
         }
 
-        var solution = context.TextDocument.Project.Solution;
+        var solution = context.Snapshot.TextDocument.Project.Solution;
         if (!solution.TryGetRazorDocument(razorFileUri, out var otherDocument))
         {
             return Response.CallHtml;

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/UriPresentation/RemoteUriPresentationService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/UriPresentation/RemoteUriPresentationService.cs
@@ -32,23 +32,23 @@ internal sealed partial class RemoteUriPresentationService(in ServiceArgs args) 
         => RunServiceAsync(
             solutionInfo,
             razorDocumentId,
-            context => GetPresentationAsync(context, span, uris, cancellationToken),
+            snapshot => GetPresentationAsync(snapshot, span, uris, cancellationToken),
             cancellationToken);
 
     private async ValueTask<Response> GetPresentationAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         LinePositionSpan span,
         Uri[]? uris,
         CancellationToken cancellationToken)
     {
-        var sourceText = await context.Snapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        var sourceText = await snapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
         if (!sourceText.TryGetAbsoluteIndex(span.Start, out var index))
         {
             // If the position is invalid then we shouldn't expect to be able to handle a Html response
             return Response.NoFurtherHandling;
         }
 
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         var languageKind = codeDocument.GetLanguageKind(index, rightAssociative: true);
         if (languageKind is not RazorLanguageKind.Html)
@@ -66,7 +66,7 @@ internal sealed partial class RemoteUriPresentationService(in ServiceArgs args) 
             return Response.CallHtml;
         }
 
-        var solution = context.Snapshot.TextDocument.Project.Solution;
+        var solution = snapshot.TextDocument.Project.Solution;
         if (!solution.TryGetRazorDocument(razorFileUri, out var otherDocument))
         {
             return Response.CallHtml;

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/UriPresentation/RemoteUriPresentationService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/UriPresentation/RemoteUriPresentationService.cs
@@ -41,7 +41,7 @@ internal sealed partial class RemoteUriPresentationService(in ServiceArgs args) 
         Uri[]? uris,
         CancellationToken cancellationToken)
     {
-        var sourceText = await context.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
+        var sourceText = await context.Snapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
         if (!sourceText.TryGetAbsoluteIndex(span.Start, out var index))
         {
             // If the position is invalid then we shouldn't expect to be able to handle a Html response

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/WrapWithTag/RemoteWrapWithTagService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/WrapWithTag/RemoteWrapWithTagService.cs
@@ -35,7 +35,7 @@ internal sealed partial class RemoteWrapWithTagService(in ServiceArgs args) : Ra
         LinePositionSpan range,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         if (WrapWithTagHelper.TryGetValidWrappingRange(codeDocument, range, out var adjustedRange))
         {
             return Response.Results(adjustedRange);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/WrapWithTag/RemoteWrapWithTagService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/WrapWithTag/RemoteWrapWithTagService.cs
@@ -27,15 +27,15 @@ internal sealed partial class RemoteWrapWithTagService(in ServiceArgs args) : Ra
         => RunServiceAsync(
             solutionInfo,
             razorDocumentId,
-            context => GetValidWrappingRangeAsync(context, range, cancellationToken),
+            snapshot => GetValidWrappingRangeAsync(snapshot, range, cancellationToken),
             cancellationToken);
 
     private static async ValueTask<Response> GetValidWrappingRangeAsync(
-        RemoteDocumentContext context,
+        RemoteDocumentSnapshot snapshot,
         LinePositionSpan range,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await context.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         if (WrapWithTagHelper.TryGetValidWrappingRange(codeDocument, range, out var adjustedRange))
         {
             return Response.Results(adjustedRange);

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.UnitTests/CodeActions/HtmlCodeActionProviderTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.UnitTests/CodeActions/HtmlCodeActionProviderTest.cs
@@ -82,10 +82,9 @@ public class HtmlCodeActionProviderTest
 
         var razorEditServiceMock = new StrictMock<IRazorEditService>();
         razorEditServiceMock
-            .Setup(x => x.MapWorkspaceEditAsync(It.IsAny<RemoteDocumentSnapshot>(), It.IsAny<WorkspaceEdit>(), It.IsAny<CancellationToken>()))
-            .Callback<RemoteDocumentSnapshot, WorkspaceEdit, CancellationToken>((snapshot, edit, _) =>
+            .Setup(x => x.MapWorkspaceEditAsync(It.IsAny<Solution>(), It.IsAny<WorkspaceEdit>(), It.IsAny<CancellationToken>()))
+            .Callback<Solution, WorkspaceEdit, CancellationToken>((_, edit, _) =>
             {
-                Assert.IsType<RemoteDocumentSnapshot>(snapshot);
                 var textDocumentEdit = edit.EnumerateTextDocumentEdits().First();
                 textDocumentEdit.TextDocument.DocumentUri = ProtocolConversions.CreateAbsoluteDocumentUri(documentPath);
                 textDocumentEdit.Edits = [LspFactory.CreateTextEdit(context.SourceText.GetRange(span), "Goo /*~~~~~~~~~~~*/ Bar")];

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.UnitTests/CodeActions/HtmlCodeActionResolverTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.UnitTests/CodeActions/HtmlCodeActionResolverTest.cs
@@ -37,10 +37,9 @@ public class HtmlCodeActionResolverTest
 
         var razorEditServiceMock = new StrictMock<IRazorEditService>();
         razorEditServiceMock
-            .Setup(x => x.MapWorkspaceEditAsync(It.IsAny<RemoteDocumentSnapshot>(), It.IsAny<WorkspaceEdit>(), It.IsAny<CancellationToken>()))
-            .Callback<RemoteDocumentSnapshot, WorkspaceEdit, CancellationToken>((snapshot, edit, _) =>
+            .Setup(x => x.MapWorkspaceEditAsync(It.IsAny<Solution>(), It.IsAny<WorkspaceEdit>(), It.IsAny<CancellationToken>()))
+            .Callback<Solution, WorkspaceEdit, CancellationToken>((_, edit, _) =>
             {
-                Assert.IsType<RemoteDocumentSnapshot>(snapshot);
                 var textDocumentEdit = edit.EnumerateTextDocumentEdits().First();
                 textDocumentEdit.TextDocument.DocumentUri = new(documentPath);
                 textDocumentEdit.Edits = [LspFactory.CreateTextEdit(sourceText.GetRange(span), "Goo /*~~~~~~~~~~~*/ Bar")];

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.UnitTests/CodeActions/HtmlCodeActionResolverTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.UnitTests/CodeActions/HtmlCodeActionResolverTest.cs
@@ -32,7 +32,7 @@ public class HtmlCodeActionResolverTest
 
         var documentPath = TestProjectData.SomeProjectComponentFile1.FilePath;
         var documentUri = ProtocolConversions.CreateAbsoluteDocumentUri(documentPath);
-        var (context, sourceText, workspace) = CreateDocumentContext(documentUri, documentPath, contents);
+        var (context, sourceText, workspace) = CreateDocumentContext(documentPath, contents);
         using var workspaceLifetime = workspace;
 
         var razorEditServiceMock = new StrictMock<IRazorEditService>();
@@ -82,7 +82,7 @@ public class HtmlCodeActionResolverTest
         Assert.Equal("Goo @(DateTime.Now) Bar", changed.ToString());
     }
 
-    private static (RemoteDocumentContext Context, SourceText SourceText, AdhocWorkspace Workspace) CreateDocumentContext(DocumentUri documentUri, string filePath, string text)
+    private static (RemoteDocumentContext Context, SourceText SourceText, AdhocWorkspace Workspace) CreateDocumentContext(string filePath, string text)
     {
         var sourceText = SourceText.From(text);
 
@@ -100,6 +100,6 @@ public class HtmlCodeActionResolverTest
         var snapshotManager = new RemoteSnapshotManager(new RemoteFilePathService(), NoOpTelemetryReporter.Instance);
         var snapshot = snapshotManager.GetSnapshot(document);
 
-        return (new RemoteDocumentContext(documentUri, snapshot), sourceText, workspace);
+        return (new RemoteDocumentContext(snapshot), sourceText, workspace);
     }
 }

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.UnitTests/CodeActions/HtmlCodeActionResolverTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.UnitTests/CodeActions/HtmlCodeActionResolverTest.cs
@@ -32,7 +32,7 @@ public class HtmlCodeActionResolverTest
 
         var documentPath = TestProjectData.SomeProjectComponentFile1.FilePath;
         var documentUri = ProtocolConversions.CreateAbsoluteDocumentUri(documentPath);
-        var (context, sourceText, workspace) = CreateDocumentContext(documentPath, contents);
+        var (snapshot, sourceText, workspace) = CreateDocumentSnapshot(documentPath, contents);
         using var workspaceLifetime = workspace;
 
         var razorEditServiceMock = new StrictMock<IRazorEditService>();
@@ -69,7 +69,7 @@ public class HtmlCodeActionResolverTest
         };
 
         // Act
-        var action = await resolver.ResolveAsync(context, codeAction, CancellationToken.None);
+        var action = await resolver.ResolveAsync(snapshot, codeAction, CancellationToken.None);
 
         // Assert
         Assert.NotNull(action.Edit);
@@ -82,7 +82,7 @@ public class HtmlCodeActionResolverTest
         Assert.Equal("Goo @(DateTime.Now) Bar", changed.ToString());
     }
 
-    private static (RemoteDocumentContext Context, SourceText SourceText, AdhocWorkspace Workspace) CreateDocumentContext(string filePath, string text)
+    private static (RemoteDocumentSnapshot Snapshot, SourceText SourceText, AdhocWorkspace Workspace) CreateDocumentSnapshot(string filePath, string text)
     {
         var sourceText = SourceText.From(text);
 
@@ -100,6 +100,6 @@ public class HtmlCodeActionResolverTest
         var snapshotManager = new RemoteSnapshotManager(new RemoteFilePathService(), NoOpTelemetryReporter.Instance);
         var snapshot = snapshotManager.GetSnapshot(document);
 
-        return (new RemoteDocumentContext(snapshot), sourceText, workspace);
+        return (snapshot, sourceText, workspace);
     }
 }


### PR DESCRIPTION
Follow up to the previous document cleanup PR, `RemoteDocumentContext` is just a `DocumentUri` and a `RemoteDocumentSnapshot`, and a bunch of methods that call through to `RemoteDocumentSnapshot` and cache results (which `RemoteDocumentSnapshot` also does), but with different names.

This PR moves the Uri property over to `RemoteDocumentSnapshot`, moves all calls to anything in `RemoteDocumentContext` onto the `Snapshot` property, and then finally removes `RemoteDocumentContext` entirely.

This was all just abstractions to enable the old language server and cohosting to exist at the same time, and have code spread across layers, so its all pretty mechanical cleanup. Commit-at-a-time review will tell the story in pieces, but not sure it's strictly necessary. Only a couple of manual commits at the end to do some obvious cleanup.

As before, if the feature branch merges before this, this can just be retargeted at main, it's not strictly "sonic".