### PR TITLE
Guard Razor semantic token spans

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/SourceTextExtensions.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/SourceTextExtensions.cs
@@ -263,6 +263,32 @@ internal static class SourceTextExtensions
     public static TextSpan GetTextSpan(this SourceText text, LinePositionSpan span)
         => text.GetTextSpan(span.Start, span.End);
 
+    public static bool TryGetTextSpan(this SourceText text, LinePositionSpan span, out TextSpan textSpan)
+        => text.TryGetTextSpan(span.Start, span.End, out textSpan);
+
+    public static bool TryGetTextSpan(this SourceText text, LinePosition start, LinePosition end, out TextSpan textSpan)
+        => text.TryGetTextSpan(start.Line, start.Character, end.Line, end.Character, out textSpan);
+
+    public static bool TryGetTextSpan(this SourceText text, int startLine, int startCharacter, int endLine, int endCharacter, out TextSpan textSpan)
+    {
+        textSpan = default;
+
+        if (!text.TryGetAbsoluteIndex(startLine, startCharacter, out var start) ||
+            !text.TryGetAbsoluteIndex(endLine, endCharacter, out var end))
+        {
+            return false;
+        }
+
+        var length = end - start;
+        if (length < 0)
+        {
+            return false;
+        }
+
+        textSpan = new TextSpan(start, length);
+        return true;
+    }
+
     public static TextSpan GetTextSpan(this SourceText text, int startLine, int startCharacter, int endLine, int endCharacter)
     {
         var start = GetAbsoluteIndex(text, startLine, startCharacter, "Start");

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/RazorSemanticTokensInfoService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/RazorSemanticTokensInfoService.cs
@@ -77,7 +77,13 @@ internal sealed partial class RazorSemanticTokensInfoService(
 
         cancellationToken.ThrowIfCancellationRequested();
 
-        var textSpan = codeDocument.Source.Text.GetTextSpan(span);
+        var sourceText = codeDocument.Source.Text;
+        if (!sourceText.TryGetTextSpan(span, out var textSpan))
+        {
+            _logger.LogWarning($"Semantic tokens request span {span} was outside the bounds of {documentContext.Uri} with {sourceText.Lines.Count} lines. Returning null.");
+            return null;
+        }
+
         using var _ = s_pool.GetPooledObject(out var combinedSemanticRanges);
 
         SemanticTokensVisitor.AddSemanticRanges(combinedSemanticRanges, codeDocument, textSpan, _semanticTokensLegendService, colorBackground);
@@ -227,7 +233,12 @@ internal sealed partial class RazorSemanticTokensInfoService(
         using var _ = ArrayBuilderPool<LinePositionSpan>.GetPooledObject(out var csharpRanges);
         var csharpSourceText = codeDocument.GetCSharpSourceText();
         var sourceText = codeDocument.Source.Text;
-        var textSpan = sourceText.GetTextSpan(razorRange);
+        if (!sourceText.TryGetTextSpan(razorRange, out var textSpan))
+        {
+            ranges = [];
+            return false;
+        }
+
         var csharpDoc = codeDocument.GetRequiredCSharpDocument();
 
         // We want to find the min and max C# source mapping that corresponds with our Razor range.

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Extensions/SourceTextExtensionsTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Extensions/SourceTextExtensionsTest.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
@@ -38,5 +39,39 @@ public class SourceTextExtensionsTest
         var textSpan = sourceText.GetTextSpan(startLine: 0, startCharacter: 0, endLine: 0, endCharacter: int.MaxValue);
 
         Assert.Equal(new TextSpan(0, 5), textSpan);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/84104")]
+    public void TryGetTextSpan_ReturnsFalse_WhenEndLinePastEnd()
+    {
+        var sourceText = SourceText.From("hello\r\nworld");
+
+        var result = sourceText.TryGetTextSpan(
+            startLine: 0,
+            startCharacter: 0,
+            endLine: 28,
+            endCharacter: 0,
+            out var textSpan);
+
+        Assert.False(result);
+        Assert.Equal(default, textSpan);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/84104")]
+    public void TryGetTextSpan_ReturnsFalse_WhenEndBeforeStart()
+    {
+        var sourceText = SourceText.From("hello\r\nworld");
+
+        var result = sourceText.TryGetTextSpan(
+            startLine: 1,
+            startCharacter: 0,
+            endLine: 0,
+            endCharacter: 0,
+            out var textSpan);
+
+        Assert.False(result);
+        Assert.Equal(default, textSpan);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/84104 
Fixes https://github.com/dotnet/vscode-csharp/issues/9327

I've been trying to repro this for a while, running my local VS with extra logging etc. and haven't been able to hit it. I've decided therefore to give up, and just not bother the user if we get a bad request from the editor, and simply return no color info. Presumably the editor will follow up with another request, that is hopefully correct this time.

If semantic tokens is broken as a result, then I'm sure we'll find out about it, and will probably get more traction from the editor team with that sort of bug anyway.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84334)