### PR TITLE
Make Microsoft.Build.Tasks.CodeAnalysis AOT and single-file clean

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -219,6 +219,10 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                         commandLine.AppendSwitchIfNotNull("@", rspFile);
                     }
                 }
+#else
+                // IsSdkFrameworkToCoreBridgeTask is only ever true on .NET Framework, so the bridge-only
+                // response file handling above is never reached on .NET Core.
+                Debug.Assert(false, "The SDK framework-to-core bridge task only runs on .NET Framework MSBuild.");
 #endif
             }
 

--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -222,7 +222,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 #else
                 // IsSdkFrameworkToCoreBridgeTask is only ever true on .NET Framework, so the bridge-only
                 // response file handling above is never reached on .NET Core.
-                Debug.Assert(false, "The SDK framework-to-core bridge task only runs on .NET Framework MSBuild.");
+                Debug.Fail("The SDK framework-to-core bridge task only runs on .NET Framework MSBuild.");
 #endif
             }
 

--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -206,6 +206,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             {
                 commandLine.AppendSwitchIfNotNull("/sdkpath:", RuntimeEnvironment.GetRuntimeDirectory());
 
+#if NETFRAMEWORK
+                // This branch only runs in the .NET Framework to .NET Core bridge task, which always
+                // executes on .NET Framework MSBuild where this assembly is deployed as loose files on
+                // disk. Assembly.Location is therefore valid here and unreachable from any single-file or
+                // native AOT host, so it does not need to satisfy the IL3000 single-file analyzer.
                 if (!NoConfig)
                 {
                     var rspFile = Path.Combine(Path.GetDirectoryName(typeof(ManagedCompiler).Assembly.Location)!, "csc.rsp");
@@ -214,6 +219,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                         commandLine.AppendSwitchIfNotNull("@", rspFile);
                     }
                 }
+#endif
             }
 
             commandLine.AppendSwitchIfNotNull("/lib:", AdditionalLibPaths, ",");

--- a/src/Compilers/Core/MSBuildTask/MSBuild/Microsoft.Build.Tasks.CodeAnalysis.csproj
+++ b/src/Compilers/Core/MSBuildTask/MSBuild/Microsoft.Build.Tasks.CodeAnalysis.csproj
@@ -8,10 +8,10 @@
     <DefineConstants>$(DefineConstants);MICROSOFT_CODEANALYSIS_CONTRACTS_NO_VALUE_TASK</DefineConstants>
     <!--
       A .NET copy of this task assembly is included in the .NET SDK's Native AOT CLI, so it must be
-      clean for trimming, AOT, and single-file publishing. IsAotCompatible enables all three
-      analyzers (trim, AOT, and single-file).
+      clean for trimming, AOT, and single-file publishing. IsAotCompatible (enabled only for the .NET
+      build, not net472) turns on the trim, AOT, and single-file analyzers.
     -->
-    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
+    <IsAotCompatible Condition="'$(TargetFramework)' == '$(NetRoslynSourceBuild)'">true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Compilers/Core/MSBuildTask/MSBuild/Microsoft.Build.Tasks.CodeAnalysis.csproj
+++ b/src/Compilers/Core/MSBuildTask/MSBuild/Microsoft.Build.Tasks.CodeAnalysis.csproj
@@ -6,6 +6,12 @@
     <RootNamespace>Microsoft.CodeAnalysis.BuildTasks</RootNamespace>
     <TargetFrameworks>$(NetRoslynSourceBuild);net472</TargetFrameworks>
     <DefineConstants>$(DefineConstants);MICROSOFT_CODEANALYSIS_CONTRACTS_NO_VALUE_TASK</DefineConstants>
+    <!--
+      A .NET copy of this task assembly is included in the .NET SDK's Native AOT CLI, so it must be
+      clean for trimming, AOT, and single-file publishing. IsAotCompatible enables all three
+      analyzers (trim, AOT, and single-file).
+    -->
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
@@ -15,8 +15,24 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.BuildTasks
 {
+    /// <summary>
+    /// Base class for the MSBuild tasks that run the built-in managed compilers (<c>Csc</c>, <c>Vbc</c>,
+    /// <c>Csi</c>).
+    /// </summary>
     public abstract class ManagedToolTask : ToolTask
     {
+        // Task class hierarchy - ToolNameWithoutExtension is the only per-language input to the discovery
+        // machinery; every derived task reuses the same ManagedToolTask plumbing to turn <build task dir>
+        // into a concrete tool path:
+        //
+        // ToolTask                                   (MSBuild, Microsoft.Build.Utilities.Core)
+        //   └─ ManagedToolTask        (abstract)     defines GetBuildTaskDirectory / GetToolDirectory
+        //        ├─ ManagedCompiler   (abstract)     adds the VBCSCompiler build-server path
+        //        │    ├─ Csc                         ToolNameWithoutExtension = "csc"
+        //        │    └─ Vbc                         ToolNameWithoutExtension = "vbc"
+        //        └─ InteractiveCompiler (abstract)
+        //             └─ Csi                         ToolNameWithoutExtension = "csi"
+
         private bool? _useAppHost;
         internal readonly PropertyDictionary _store = new PropertyDictionary();
 
@@ -62,6 +78,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// </remarks>
         internal static bool IsBuiltinToolRunningOnCoreClr => RuntimeHostInfo.IsCoreClrRuntime || IsSdkFrameworkToCoreBridgeTask;
 
+        /// <summary>
+        /// The full path to the built-in compiler managed assembly (<c>csc.dll</c>) or, when an apphost is
+        /// present, the apphost executable (<c>csc.exe</c>) - the file named by <see cref="ToolName"/> inside
+        /// <see cref="GetToolDirectory"/>.
+        /// </summary>
         internal string PathToBuiltInTool => Path.Combine(GetToolDirectory(), ToolName);
 
         /// <summary>
@@ -89,11 +110,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         }
 
         /// <summary>
-        /// Generate the arguments to pass directly to the buitin tool. These do not include
+        /// Generate the arguments to pass directly to the built-in tool. These do not include
         /// arguments in the response file.
         /// </summary>
         /// <remarks>
-        /// This will be the same value whether the build occurs on .NET Core or .NET Framework. 
+        /// This will be the same value whether the build occurs on .NET Core or .NET Framework.
         /// </remarks>
         internal string GenerateToolArguments()
         {
@@ -128,7 +149,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         }
 
         /// <summary>
-        /// Generate the arguments to pass directly to the buitin tool. These do not include
+        /// Generate the arguments to pass directly to the built-in tool. These do not include
         /// arguments in the response file.
         /// </summary>
         /// <remarks>
@@ -224,6 +245,25 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             return items;
         }
 
+        // On-disk layout in the partially-AOT .NET SDK CLI: the runtime muxer (dotnet.exe) lives at the
+        // install root and loads <sdk_dir>\dotnet-aot.dll as a native library, so it is not a managed entry
+        // point running from the SDK directory - there AppContext.BaseDirectory is the install root, not the
+        // SDK directory (see GetBuildTaskDirectory for how the SDK directory is recovered):
+        //
+        // C:\Program Files\dotnet\                     <- install root; the muxer process runs from here
+        // ├─ dotnet.exe                                <- the muxer (the process / host)
+        // ├─ host\fxr\<ver>\hostfxr.dll
+        // └─ sdk\10.0.300\                             <- sdk_dir (passed to dotnet_execute)
+        //    ├─ dotnet.dll                             <- managed CLI fallback: Path.Join(sdk_dir, "dotnet.dll")
+        //    ├─ dotnet-aot.dll                         <- loaded by the muxer as a native lib; build tasks linked in
+        //    ├─ MSBuild.dll
+        //    └─ Roslyn\bincore\csc.dll                 <- the compiler the task launches (at <sdk_dir>\Roslyn\bincore)
+
+        /// <summary>
+        /// Returns the folder that holds the built-in compiler: on .NET Core the <c>bincore</c> subfolder of
+        /// the build task directory; on .NET Framework the build task directory itself, except the SDK
+        /// framework-to-core bridge task which reaches the sibling <c>..\bincore</c>.
+        /// </summary>
         internal static string GetToolDirectory()
         {
             var buildTaskDirectory = GetBuildTaskDirectory();
@@ -236,27 +276,52 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 #endif
         }
 
-        // Locating the sibling compiler under 'bincore' needs this assembly's on-disk directory via
-        // Assembly.Location, which is a loose-file-only operation - it returns an empty string in a
-        // single-file or native AOT host. This cannot be resolved with [RequiresAssemblyFiles] because the
-        // attribute would have to flow onto the sealed ToolTask overrides (GenerateFullPathToTool,
-        // GenerateCommandLineCommands, ToolName, ExecuteTool) whose base declarations are unannotated,
-        // which is itself an error (IL3003). The IL3000 is therefore suppressed.
+        /// <summary>
+        /// Answers a single question - "where, on disk, is this build task assembly?" - and is the anchor
+        /// from which <see cref="GetToolDirectory"/> locates the sibling compiler.
+        /// <para>
+        /// In the common loose-file MSBuild deployment this is the directory of
+        /// <see cref="System.Reflection.Assembly.Location"/>. In the partially-AOT .NET SDK CLI that path is
+        /// empty, so the versioned SDK directory the AOT host publishes as the <c>Microsoft.DotNet.Sdk.Root</c>
+        /// <see cref="AppContext"/> value is read first and this task's <c>Roslyn</c> subfolder is appended.
+        /// See <see href="https://github.com/dotnet/sdk/pull/55110"/>.
+        /// </para>
+        /// </summary>
 #if NET
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("SingleFile", "IL3000:Avoid accessing Assembly file path when publishing as a single file", Justification = "Assembly.Location is required to locate the sibling compiler when this task is deployed as loose files under MSBuild. [RequiresAssemblyFiles] cannot be used because it would flow onto the unannotated ToolTask overrides (IL3003).")]
+        // Assembly.Location is a loose-file-only API flagged by the single-file analyzer (IL3000): it
+        // returns an empty string under single-file / AOT. It cannot be annotated with
+        // [RequiresAssemblyFiles] because that attribute would have to flow onto the sealed ToolTask
+        // overrides (GenerateFullPathToTool, GenerateCommandLineCommands, ToolName, ExecuteTool), whose base
+        // declarations are not annotated - and that mismatch is itself an error (IL3003). Under single-file /
+        // AOT the Microsoft.DotNet.Sdk.Root AppContext value (checked first) supplies the directory, so the
+        // empty Assembly.Location is never used there and the IL3000 is suppressed.
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("SingleFile", "IL3000:Avoid accessing Assembly file path when publishing as a single file", Justification = "Assembly.Location is the loose-file path; single-file/AOT hosts have no on-disk location and instead read the Microsoft.DotNet.Sdk.Root AppContext value (checked first). [RequiresAssemblyFiles] cannot be used because it would flow onto the unannotated ToolTask overrides (IL3003).")]
 #endif
         internal static string GetBuildTaskDirectory()
         {
-            var buildTask = typeof(ManagedToolTask).Assembly;
-            var buildTaskDirectory = Path.GetDirectoryName(buildTask.Location);
-            if (buildTaskDirectory is null)
+#if NET
+            // Partially-AOT .NET SDK CLI host (the SDK's dotnet-aot.dll, loaded directly by the runtime
+            // muxer): Assembly.Location is empty and AppContext.BaseDirectory is the muxer's install root
+            // rather than the versioned SDK directory. The AOT bridge publishes the resolved SDK directory as
+            // the Microsoft.DotNet.Sdk.Root AppContext value for the assemblies compiled into it; out-of-repo
+            // code such as this build task reads it first. The build task ships in the "Roslyn" subfolder
+            // beneath the SDK directory. This name must match the constant published by the SDK's
+            // Microsoft.DotNet.Cli.Utils.SdkPaths.
+            if (AppContext.GetData("Microsoft.DotNet.Sdk.Root") is string { Length: > 0 } sdkDirectory)
             {
-                // This should not happen in supported product scenarios but could happen if a non-supported
-                // scenario tried to load our task (like AOT) and call through these members.
-                throw new InvalidOperationException("Unable to determine the location of the build task assembly.");
+                return Path.Combine(sdkDirectory, "Roslyn");
+            }
+#endif
+
+            // Loose-file MSBuild deployment (the common scenario on both .NET Framework and .NET Core, and
+            // the compiler toolset NuGet package): this assembly is on disk, so its own directory is the
+            // build task directory (for example <sdk>\Roslyn).
+            if (Path.GetDirectoryName(typeof(ManagedToolTask).Assembly.Location) is { Length: > 0 } buildTaskDirectory)
+            {
+                return buildTaskDirectory;
             }
 
-            return buildTaskDirectory;
+            throw new InvalidOperationException("Unable to determine the location of the build task assembly.");
         }
 
         protected override bool ValidateParameters()

--- a/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
@@ -21,18 +21,6 @@ namespace Microsoft.CodeAnalysis.BuildTasks
     /// </summary>
     public abstract class ManagedToolTask : ToolTask
     {
-        // Task class hierarchy - ToolNameWithoutExtension is the only per-language input to the discovery
-        // machinery; every derived task reuses the same ManagedToolTask plumbing to turn <build task dir>
-        // into a concrete tool path:
-        //
-        // ToolTask                                   (MSBuild, Microsoft.Build.Utilities.Core)
-        //   └─ ManagedToolTask        (abstract)     defines GetBuildTaskDirectory / GetToolDirectory
-        //        ├─ ManagedCompiler   (abstract)     adds the VBCSCompiler build-server path
-        //        │    ├─ Csc                         ToolNameWithoutExtension = "csc"
-        //        │    └─ Vbc                         ToolNameWithoutExtension = "vbc"
-        //        └─ InteractiveCompiler (abstract)
-        //             └─ Csi                         ToolNameWithoutExtension = "csi"
-
         private bool? _useAppHost;
         internal readonly PropertyDictionary _store = new PropertyDictionary();
 
@@ -185,6 +173,9 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             return Path.Combine(ToolPath ?? "", ToolExe);
         }
 
+        /// <summary>
+        /// Gets the base name used to derive the built-in tool's managed assembly and apphost names.
+        /// </summary>
         protected abstract string ToolNameWithoutExtension { get; }
 
         protected abstract void AddCommandLineCommands(CommandLineBuilderExtension commandLine);

--- a/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
@@ -236,15 +236,32 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 #endif
         }
 
+        // This task is an MSBuild ToolTask that shells out to the sibling compiler in the 'bincore'
+        // folder, so when it is deployed as loose files (the normal MSBuild scenario) it must discover
+        // the on-disk directory of this assembly. That is inherently a single-file-incompatible operation.
+        //
+        // The single-file / native AOT case is handled at run time: Assembly.Location returns an empty
+        // string and we fall back to AppContext.BaseDirectory below. In those hosts the real compiler
+        // location is supplied out-of-band anyway (e.g. via the CscToolPath/VbcToolPath MSBuild property),
+        // so the value computed here is not used to launch the compiler. The IL3000 warning is suppressed.
+#if NET
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("SingleFile", "IL3000:Avoid accessing Assembly file path when publishing as a single file", Justification = "Assembly.Location is required to locate the sibling compiler when deployed as loose files; single-file hosts fall back to AppContext.BaseDirectory and supply the compiler path out-of-band. [RequiresAssemblyFiles] cannot be used because it would conflict with the non-annotated ToolTask override it flows into (IL3003).")]
+#endif
         internal static string GetBuildTaskDirectory()
         {
-            var buildTask = typeof(ManagedToolTask).Assembly;
-            var buildTaskDirectory = Path.GetDirectoryName(buildTask.Location);
-            if (buildTaskDirectory is null)
+            var buildTaskDirectory = Path.GetDirectoryName(typeof(ManagedToolTask).Assembly.Location);
+            if (string.IsNullOrEmpty(buildTaskDirectory))
             {
-                // This should not happen in supported product scenarios but could happen if 
-                // a non-supported scenario tried to load our task (like AOT) and call
-                // through these members.
+                // Native AOT / single-file hosts report no on-disk assembly location. Fall back to the
+                // application base directory; the actual compiler location is supplied out-of-band in these
+                // scenarios (e.g. via the CscToolPath/VbcToolPath MSBuild property).
+                buildTaskDirectory = AppContext.BaseDirectory;
+            }
+
+            if (string.IsNullOrEmpty(buildTaskDirectory))
+            {
+                // This should not happen in supported product scenarios but could happen if a non-supported
+                // scenario tried to load our task and call through these members.
                 throw new InvalidOperationException("Unable to determine the location of the build task assembly.");
             }
 

--- a/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
@@ -247,7 +247,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         // On-disk layout in the partially-AOT .NET SDK CLI: the runtime muxer (dotnet.exe) lives at the
         // install root and loads <sdk_dir>\dotnet-aot.dll as a native library, so it is not a managed entry
-        // point running from the SDK directory - there AppContext.BaseDirectory is the install root, not the
+        // point running from the SDK directory - AppContext.BaseDirectory is the install root, not the
         // SDK directory (see GetBuildTaskDirectory for how the SDK directory is recovered):
         //
         // C:\Program Files\dotnet\                     <- install root; the muxer process runs from here

--- a/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
@@ -236,32 +236,23 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 #endif
         }
 
-        // This task is an MSBuild ToolTask that shells out to the sibling compiler in the 'bincore'
-        // folder, so when it is deployed as loose files (the normal MSBuild scenario) it must discover
-        // the on-disk directory of this assembly. That is inherently a single-file-incompatible operation.
-        //
-        // The single-file / native AOT case is handled at run time: Assembly.Location returns an empty
-        // string and we fall back to AppContext.BaseDirectory below. In those hosts the real compiler
-        // location is supplied out-of-band anyway (e.g. via the CscToolPath/VbcToolPath MSBuild property),
-        // so the value computed here is not used to launch the compiler. The IL3000 warning is suppressed.
+        // Locating the sibling compiler under 'bincore' needs this assembly's on-disk directory via
+        // Assembly.Location, which is a loose-file-only operation - it returns an empty string in a
+        // single-file or native AOT host. This cannot be resolved with [RequiresAssemblyFiles] because the
+        // attribute would have to flow onto the sealed ToolTask overrides (GenerateFullPathToTool,
+        // GenerateCommandLineCommands, ToolName, ExecuteTool) whose base declarations are unannotated,
+        // which is itself an error (IL3003). The IL3000 is therefore suppressed.
 #if NET
-        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("SingleFile", "IL3000:Avoid accessing Assembly file path when publishing as a single file", Justification = "Assembly.Location is required to locate the sibling compiler when deployed as loose files; single-file hosts fall back to AppContext.BaseDirectory and supply the compiler path out-of-band. [RequiresAssemblyFiles] cannot be used because it would conflict with the non-annotated ToolTask override it flows into (IL3003).")]
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("SingleFile", "IL3000:Avoid accessing Assembly file path when publishing as a single file", Justification = "Assembly.Location is required to locate the sibling compiler when this task is deployed as loose files under MSBuild. [RequiresAssemblyFiles] cannot be used because it would flow onto the unannotated ToolTask overrides (IL3003).")]
 #endif
         internal static string GetBuildTaskDirectory()
         {
-            var buildTaskDirectory = Path.GetDirectoryName(typeof(ManagedToolTask).Assembly.Location);
-            if (string.IsNullOrEmpty(buildTaskDirectory))
-            {
-                // Native AOT / single-file hosts report no on-disk assembly location. Fall back to the
-                // application base directory; the actual compiler location is supplied out-of-band in these
-                // scenarios (e.g. via the CscToolPath/VbcToolPath MSBuild property).
-                buildTaskDirectory = AppContext.BaseDirectory;
-            }
-
-            if (string.IsNullOrEmpty(buildTaskDirectory))
+            var buildTask = typeof(ManagedToolTask).Assembly;
+            var buildTaskDirectory = Path.GetDirectoryName(buildTask.Location);
+            if (buildTaskDirectory is null)
             {
                 // This should not happen in supported product scenarios but could happen if a non-supported
-                // scenario tried to load our task and call through these members.
+                // scenario tried to load our task (like AOT) and call through these members.
                 throw new InvalidOperationException("Unable to determine the location of the build task assembly.");
             }
 

--- a/src/Compilers/Core/MSBuildTask/Utilities.cs
+++ b/src/Compilers/Core/MSBuildTask/Utilities.cs
@@ -9,7 +9,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
-using System.Reflection;
 using System.Security;
 
 namespace Microsoft.CodeAnalysis.BuildTasks
@@ -161,26 +160,6 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                                                                 params object[] args)
         {
             return new ArgumentException(string.Format(CultureInfo.CurrentCulture, errorString, args));
-        }
-
-        internal static string? TryGetAssemblyPath(Assembly assembly)
-        {
-#if NETFRAMEWORK
-            if (assembly.GlobalAssemblyCache)
-            {
-                return null;
-            }
-
-            if (assembly.CodeBase is { } codebase)
-            {
-                var uri = new Uri(codebase);
-                return uri.IsFile ? uri.LocalPath : assembly.Location;
-            }
-
-            return null;
-#else
-            return assembly.Location;
-#endif
         }
     }
 }

--- a/src/Compilers/Core/MSBuildTask/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Vbc.cs
@@ -390,6 +390,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             {
                 commandLine.AppendSwitchIfNotNull("/sdkpath:", RuntimeEnvironment.GetRuntimeDirectory());
 
+#if NETFRAMEWORK
+                // This branch only runs in the .NET Framework to .NET Core bridge task, which always
+                // executes on .NET Framework MSBuild where this assembly is deployed as loose files on
+                // disk. Assembly.Location is therefore valid here and unreachable from any single-file or
+                // native AOT host, so it does not need to satisfy the IL3000 single-file analyzer.
                 if (!NoConfig)
                 {
                     var rspFile = Path.Combine(Path.GetDirectoryName(typeof(ManagedCompiler).Assembly.Location)!, "vbc.rsp");
@@ -398,6 +403,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                         commandLine.AppendSwitchIfNotNull("@", rspFile);
                     }
                 }
+#endif
             }
 
             commandLine.AppendSwitchIfNotNull("/baseaddress:", this.GetBaseAddressInHex());

--- a/src/Compilers/Core/MSBuildTask/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Vbc.cs
@@ -403,6 +403,10 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                         commandLine.AppendSwitchIfNotNull("@", rspFile);
                     }
                 }
+#else
+                // IsSdkFrameworkToCoreBridgeTask is only ever true on .NET Framework, so the bridge-only
+                // response file handling above is never reached on .NET Core.
+                Debug.Assert(false, "The SDK framework-to-core bridge task only runs on .NET Framework MSBuild.");
 #endif
             }
 

--- a/src/Compilers/Core/MSBuildTask/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Vbc.cs
@@ -406,7 +406,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 #else
                 // IsSdkFrameworkToCoreBridgeTask is only ever true on .NET Framework, so the bridge-only
                 // response file handling above is never reached on .NET Core.
-                Debug.Assert(false, "The SDK framework-to-core bridge task only runs on .NET Framework MSBuild.");
+                Debug.Fail("The SDK framework-to-core bridge task only runs on .NET Framework MSBuild.");
 #endif
             }
 

--- a/src/Compilers/Core/MSBuildTaskTests/MSBuildManagedToolTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/MSBuildManagedToolTests.cs
@@ -2,12 +2,25 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if NET
+using System;
+#endif
 using System.IO;
 using Roslyn.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests;
 
+// GetBuildTaskDirectory_UsesSdkRootAppContextData mutates the process-global "Microsoft.DotNet.Sdk.Root"
+// AppContext value, which GetBuildTaskDirectory (and therefore GetToolDirectory) reads. A non-parallel
+// collection gives this class exclusive execution so the mutation cannot leak into any other test.
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class ManagedToolTaskTestCollection
+{
+    public const string Name = nameof(ManagedToolTaskTestCollection);
+}
+
+[Collection(ManagedToolTaskTestCollection.Name)]
 public sealed class MSBuildManagedToolTests
 {
     [Fact]
@@ -32,4 +45,55 @@ public sealed class MSBuildManagedToolTests
     {
         Assert.Equal(RuntimeHostInfo.IsCoreClrRuntime, ManagedToolTask.IsBuiltinToolRunningOnCoreClr);
     }
+
+#if NET
+    [Fact]
+    public void GetBuildTaskDirectory_UsesSdkRootAppContextData()
+    {
+        // In the partially-AOT SDK CLI the host publishes the versioned SDK directory as this AppContext
+        // value; GetBuildTaskDirectory reads it and appends the "Roslyn" subfolder (this branch is .NET only).
+        // The value is not set in a normal test host - verify that first, then restore it in the finally.
+        const string sdkRootDataName = "Microsoft.DotNet.Sdk.Root";
+        Assert.Null(AppContext.GetData(sdkRootDataName));
+
+        var sdkDirectory = Path.Combine(Path.GetTempPath(), nameof(GetBuildTaskDirectory_UsesSdkRootAppContextData));
+        AppContext.SetData(sdkRootDataName, sdkDirectory);
+        try
+        {
+            var expectedBuildTaskDirectory = Path.Combine(sdkDirectory, "Roslyn");
+            var expectedToolDirectory = Path.Combine(expectedBuildTaskDirectory, "bincore");
+
+            // Derive a task so the resolved folders can be observed end to end.
+            var task = new TestManagedToolTask();
+
+            Assert.Equal(expectedBuildTaskDirectory, ManagedToolTask.GetBuildTaskDirectory());
+            Assert.Equal(expectedToolDirectory, ManagedToolTask.GetToolDirectory());
+            Assert.Equal(Path.Combine(expectedToolDirectory, "testtool.dll"), task.PathToBuiltInTool);
+        }
+        finally
+        {
+            AppContext.SetData(sdkRootDataName, null);
+        }
+
+        Assert.Null(AppContext.GetData(sdkRootDataName));
+    }
+
+    private sealed class TestManagedToolTask : ManagedToolTask
+    {
+        public TestManagedToolTask()
+            : base(ErrorString.ResourceManager)
+        {
+        }
+
+        protected override string ToolNameWithoutExtension => "testtool";
+
+        protected override void AddCommandLineCommands(CommandLineBuilderExtension commandLine)
+        {
+        }
+
+        protected override void AddResponseFileCommands(CommandLineBuilderExtension commandLine)
+        {
+        }
+    }
+#endif
 }

--- a/src/Compilers/Core/Portable/InternalUtilities/ReflectionUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ReflectionUtilities.cs
@@ -15,6 +15,9 @@ namespace Roslyn.Utilities
     {
         private static readonly Type Missing = typeof(void);
 
+#if NET
+        [RequiresUnreferencedCode("Type.GetType with a non-constant type name cannot be statically analyzed for trimming.")]
+#endif
         public static Type? TryGetType(string assemblyQualifiedName)
         {
             try
@@ -28,6 +31,9 @@ namespace Roslyn.Utilities
             }
         }
 
+#if NET
+        [RequiresUnreferencedCode("Resolves a type by its assembly-qualified name, which cannot be statically analyzed for trimming.")]
+#endif
         public static Type? TryGetType([NotNull] ref Type? lazyType, string assemblyQualifiedName)
         {
             if (lazyType == null)
@@ -42,6 +48,9 @@ namespace Roslyn.Utilities
         /// Find a <see cref="Type"/> instance by first probing the contract name and then the name as it
         /// would exist in mscorlib.  This helps satisfy both the CoreCLR and Desktop scenarios. 
         /// </summary>
+#if NET
+        [RequiresUnreferencedCode("Resolves a type by name, which cannot be statically analyzed for trimming.")]
+#endif
         public static Type? GetTypeFromEither(string contractName, string desktopName)
         {
             var type = TryGetType(contractName);
@@ -54,6 +63,9 @@ namespace Roslyn.Utilities
             return type;
         }
 
+#if NET
+        [RequiresUnreferencedCode("Resolves a type by name, which cannot be statically analyzed for trimming.")]
+#endif
         public static Type? GetTypeFromEither([NotNull] ref Type? lazyType, string contractName, string desktopName)
         {
             if (lazyType == null)
@@ -94,12 +106,20 @@ namespace Roslyn.Utilities
             return null;
         }
 
-        internal static MethodInfo? GetDeclaredMethod(this TypeInfo typeInfo, string name, params Type[] paramTypes)
+        internal static MethodInfo? GetDeclaredMethod(
+#if NET
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
+#endif
+            this TypeInfo typeInfo, string name, params Type[] paramTypes)
         {
             return FindItem(typeInfo.GetDeclaredMethods(name), paramTypes);
         }
 
-        internal static ConstructorInfo? GetDeclaredConstructor(this TypeInfo typeInfo, params Type[] paramTypes)
+        internal static ConstructorInfo? GetDeclaredConstructor(
+#if NET
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+#endif
+            this TypeInfo typeInfo, params Type[] paramTypes)
         {
             return FindItem(typeInfo.DeclaredConstructors, paramTypes);
         }

--- a/src/Dependencies/Contracts/ErrorReporting/FatalError.cs
+++ b/src/Dependencies/Contracts/ErrorReporting/FatalError.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         /// Copies the handler in this instance to the linked copy of this type in this other assembly.
         /// </summary>
         /// <remarks>
-        /// This file is in linked into multiple layers, but we want to ensure that all layers have the same copy.
+        /// This file is linked into multiple layers, but we want to ensure that all layers have the same copy.
         /// This lets us copy the handler in this instance into the same in another instance.
         /// </remarks>
 #if NET

--- a/src/Dependencies/Contracts/ErrorReporting/FatalError.cs
+++ b/src/Dependencies/Contracts/ErrorReporting/FatalError.cs
@@ -71,6 +71,9 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         /// This file is in linked into multiple layers, but we want to ensure that all layers have the same copy.
         /// This lets us copy the handler in this instance into the same in another instance.
         /// </remarks>
+#if NET
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Reflects over the FatalError type in the target assembly to copy error handlers, which cannot be statically analyzed for trimming.")]
+#endif
         public static void CopyHandlersTo(Assembly assembly)
         {
             copyHandlerTo(assembly, s_handler, nameof(s_handler));


### PR DESCRIPTION
A .NET copy of `Microsoft.Build.Tasks.CodeAnalysis` ships in the .NET SDK's Native AOT CLI, so the assembly must be clean for trimming, AOT, and single-file publishing.

This enables `IsAotCompatible` on the .NET build (which turns on the trim, AOT, and single-file analyzers) and resolves the resulting warnings. Most changes are annotations, dead-code guards, or a single scoped suppression; the one functional change is `GetBuildTaskDirectory` gaining an AOT-only resolution path (loose-file MSBuild behavior is unchanged).

### Changes

- **`Utilities.TryGetAssemblyPath`** - deleted. It was unused and relied on `Assembly.CodeBase`/`Location`.
- **`csc.rsp` / `vbc.rsp` lookups (`Csc.cs`, `Vbc.cs`)** - wrapped in `#if NETFRAMEWORK`. They only run inside `if (IsSdkFrameworkToCoreBridgeTask)`, which is compile-time `false` on .NET Core, so the `Assembly.Location` use there is dead code on the AOT target framework. Behavior is unchanged for the net472 bridge task.
- **`ManagedToolTask.GetBuildTaskDirectory`** - resolves the build task directory (the anchor for the sibling `bincore` compiler) and keeps one scoped `[UnconditionalSuppressMessage]` for the unavoidable `IL3000`. In the normal loose-file MSBuild scenario the directory is `Assembly.Location`. In the partially-AOT SDK CLI that is empty and `AppContext.BaseDirectory` is the runtime muxer's install root, so the method first reads the versioned SDK directory the AOT host publishes as the `Microsoft.DotNet.Sdk.Root` `AppContext` value (per [dotnet/sdk#55110](https://github.com/dotnet/sdk/pull/55110)) and appends the `Roslyn` subfolder. `[RequiresAssemblyFiles]` cannot be used because it would have to flow onto the sealed `ToolTask` overrides (`GenerateFullPathToTool`, `GenerateCommandLineCommands`, `ToolName`, `ExecuteTool`) whose base declarations are not annotated, which is itself an error (`IL3003`).
- **`ReflectionUtilities`** - added the trim annotations required to clear the `IL2057` / `IL2070` errors the Correctness legs hit. This shared Contracts file is linked into the task assembly via `Directory.Build.props`, so its reflection helpers must be annotated once the trim analyzer is enabled.
- **`FatalError.CopyHandlersTo`** - annotated `[RequiresUnreferencedCode]`. This shared Contracts file is globbed into the task assembly, and its reflection over the target type otherwise produces `IL2026` / `IL2075` once the trim analyzer is enabled.

### Validation

Built with `RunAnalyzers=true` and confirmed **0 IL warnings / 0 errors** on:

- `net10.0` (the AOT target)
- `net472`
- the net472 `Microsoft.Build.Tasks.CodeAnalysis.Sdk` bridge variant

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84335)