### PR TITLE
Don't assume a Razor buffer is non-null, until we know it's ours

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorLSPTextViewConnectionListener.cs
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorLSPTextViewConnectionListener.cs
@@ -157,16 +157,16 @@ internal sealed partial class RazorLSPTextViewConnectionListener(
 
     public void SubjectBuffersDisconnected(ITextView textView, ConnectionReason reason, IReadOnlyCollection<ITextBuffer> subjectBuffers)
     {
+        if (!textView.TextBuffer.IsRazorLSPBuffer())
+        {
+            return;
+        }
+
         // When the TextView goes away so does the filter.  No need to do anything more.
         // However, we do need to detach from listening for option changes to avoid leaking.
         // We should switch to listening to a different TextView if the one we're listening
         // to is disconnected.
         Assumes.NotNull(_textBuffer);
-
-        if (!textView.TextBuffer.IsRazorLSPBuffer())
-        {
-            return;
-        }
 
         lock (_lock)
         {


### PR DESCRIPTION
Found in the logs of https://devdiv.visualstudio.com/DevDiv/_workitems/edit/3023073, we check the buffer type before assigning `_textBuffer`, but later assume it's not null _before_ that same check.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84337)