### PR TITLE
Dispose builders in declaration computer

### DIFF
--- a/src/Compilers/CSharp/CSharpAnalyzerDriver/CSharpDeclarationComputer.cs
+++ b/src/Compilers/CSharp/CSharpAnalyzerDriver/CSharpDeclarationComputer.cs
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.FieldDeclaration:
                     {
                         var t = (BaseFieldDeclarationSyntax)node;
-                        using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var attributes);
+                        using var _1 = ArrayBuilder<SyntaxNode>.GetInstance(out var attributes);
                         AddAttributes(t.AttributeLists, attributes);
                         foreach (var decl in t.Declaration.Variables)
                         {

--- a/src/Compilers/CSharp/CSharpAnalyzerDriver/CSharpDeclarationComputer.cs
+++ b/src/Compilers/CSharp/CSharpAnalyzerDriver/CSharpDeclarationComputer.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             var typeDeclaration = (TypeDeclarationSyntax)node;
                             Debug.Assert(ctor.MethodKind == MethodKind.Constructor && typeDeclaration.ParameterList is object);
 
-                            var codeBlocks = ArrayBuilder<SyntaxNode>.GetInstance();
+                            using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var codeBlocks);
                             AddParameterListInitializersAndAttributes(typeDeclaration.ParameterList, codeBlocks);
 
                             if (typeDeclaration.BaseList?.Types.FirstOrDefault() is PrimaryConstructorBaseTypeSyntax initializer)
@@ -114,7 +114,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
 
                             builder.Add(GetDeclarationInfo(node, associatedSymbol, codeBlocks));
-                            codeBlocks.Free();
                             return;
                         }
 
@@ -129,13 +128,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                             ComputeDeclarations(model, associatedSymbol: null, decl, shouldSkip, getSymbol, builder, newLevel, cancellationToken);
                         }
 
-                        var attributes = ArrayBuilder<SyntaxNode>.GetInstance();
+                        using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var attributes);
 
                         AddAttributes(t.AttributeLists, attributes);
                         AddTypeParameterListAttributes(t.TypeParameterList, attributes);
 
                         builder.Add(GetDeclarationInfo(model, node, getSymbol, attributes, cancellationToken));
-                        attributes.Free();
                         return;
                     }
 
@@ -147,23 +145,23 @@ namespace Microsoft.CodeAnalysis.CSharp
                             ComputeDeclarations(model, associatedSymbol: null, decl, shouldSkip, getSymbol, builder, newLevel, cancellationToken);
                         }
 
-                        var attributes = ArrayBuilder<SyntaxNode>.GetInstance();
+                        using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var attributes);
                         AddAttributes(t.AttributeLists, attributes);
 
                         builder.Add(GetDeclarationInfo(model, node, getSymbol, attributes, cancellationToken));
-                        attributes.Free();
+
                         return;
                     }
 
                 case SyntaxKind.EnumMemberDeclaration:
                     {
                         var t = (EnumMemberDeclarationSyntax)node;
-                        var codeBlocks = ArrayBuilder<SyntaxNode>.GetInstance();
+                        using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var codeBlocks);
                         codeBlocks.Add(t.EqualsValue);
                         AddAttributes(t.AttributeLists, codeBlocks);
 
                         builder.Add(GetDeclarationInfo(model, node, getSymbol, codeBlocks, cancellationToken));
-                        codeBlocks.Free();
+
                         return;
                     }
 
@@ -171,13 +169,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         var t = (DelegateDeclarationSyntax)node;
 
-                        var attributes = ArrayBuilder<SyntaxNode>.GetInstance();
+                        using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var attributes);
                         AddAttributes(t.AttributeLists, attributes);
                         AddParameterListInitializersAndAttributes(t.ParameterList, attributes);
                         AddTypeParameterListAttributes(t.TypeParameterList, attributes);
 
                         builder.Add(GetDeclarationInfo(model, node, getSymbol, attributes, cancellationToken));
-                        attributes.Free();
+
                         return;
                     }
 
@@ -191,11 +189,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 ComputeDeclarations(model, associatedSymbol: null, decl, shouldSkip, getSymbol, builder, newLevel, cancellationToken);
                             }
                         }
-                        var attributes = ArrayBuilder<SyntaxNode>.GetInstance();
+                        using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var attributes);
                         AddAttributes(t.AttributeLists, attributes);
                         builder.Add(GetDeclarationInfo(model, node, getSymbol, attributes, cancellationToken));
 
-                        attributes.Free();
                         return;
                     }
 
@@ -203,19 +200,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.FieldDeclaration:
                     {
                         var t = (BaseFieldDeclarationSyntax)node;
-                        var attributes = ArrayBuilder<SyntaxNode>.GetInstance();
+                        using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var attributes);
                         AddAttributes(t.AttributeLists, attributes);
                         foreach (var decl in t.Declaration.Variables)
                         {
-                            var codeBlocks = ArrayBuilder<SyntaxNode>.GetInstance();
+                            using var _2 = ArrayBuilder<SyntaxNode>.GetInstance(out var codeBlocks);
                             codeBlocks.Add(decl.Initializer);
                             codeBlocks.AddRange(attributes);
 
                             builder.Add(GetDeclarationInfo(model, decl, getSymbol, codeBlocks, cancellationToken));
-                            codeBlocks.Free();
                         }
 
-                        attributes.Free();
                         return;
                     }
 
@@ -246,12 +241,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                             ComputeDeclarations(model, associatedSymbol: null, t.ExpressionBody, shouldSkip, getSymbol, builder, levelsToCompute, cancellationToken);
                         }
 
-                        var codeBlocks = ArrayBuilder<SyntaxNode>.GetInstance();
+                        using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var codeBlocks);
                         codeBlocks.Add(t.Initializer);
                         AddAttributes(t.AttributeLists, codeBlocks);
                         builder.Add(GetDeclarationInfo(model, node, getSymbol, codeBlocks, cancellationToken));
 
-                        codeBlocks.Free();
                         return;
                     }
 
@@ -271,13 +265,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                             ComputeDeclarations(model, associatedSymbol: null, t.ExpressionBody, shouldSkip, getSymbol, builder, levelsToCompute, cancellationToken);
                         }
 
-                        var codeBlocks = ArrayBuilder<SyntaxNode>.GetInstance();
+                        using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var codeBlocks);
                         AddParameterListInitializersAndAttributes(t.ParameterList, codeBlocks);
                         AddAttributes(t.AttributeLists, codeBlocks);
 
                         builder.Add(GetDeclarationInfo(model, node, getSymbol, codeBlocks, cancellationToken));
 
-                        codeBlocks.Free();
                         return;
                     }
 
@@ -288,12 +281,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.InitAccessorDeclaration:
                     {
                         var t = (AccessorDeclarationSyntax)node;
-                        var blocks = ArrayBuilder<SyntaxNode>.GetInstance();
+                        using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var blocks);
                         blocks.AddIfNotNull(t.Body);
                         blocks.AddIfNotNull(t.ExpressionBody);
                         AddAttributes(t.AttributeLists, blocks);
                         builder.Add(GetDeclarationInfo(model, node, getSymbol, blocks, cancellationToken));
-                        blocks.Free();
 
                         return;
                     }
@@ -305,7 +297,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.OperatorDeclaration:
                     {
                         var t = (BaseMethodDeclarationSyntax)node;
-                        var codeBlocks = ArrayBuilder<SyntaxNode>.GetInstance();
+                        using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var codeBlocks);
                         AddParameterListInitializersAndAttributes(t.ParameterList, codeBlocks);
                         codeBlocks.Add(t.Body);
 
@@ -328,8 +320,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
 
                         builder.Add(GetDeclarationInfo(model, node, getSymbol, codeBlocks, cancellationToken));
-
-                        codeBlocks.Free();
                         return;
                     }
 
@@ -339,11 +329,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         if (associatedSymbol is IMethodSymbol)
                         {
-                            var codeBlocks = ArrayBuilder<SyntaxNode>.GetInstance();
+                            using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var codeBlocks);
                             codeBlocks.Add(t);
 
                             builder.Add(GetDeclarationInfo(model, node, getSymbol, codeBlocks, cancellationToken));
-                            codeBlocks.Free();
                         }
                         else
                         {
@@ -354,10 +343,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                             if (t.AttributeLists.Any())
                             {
-                                var attributes = ArrayBuilder<SyntaxNode>.GetInstance();
+                                using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var attributes);
                                 AddAttributes(t.AttributeLists, attributes);
                                 builder.Add(GetDeclarationInfo(model, node, getSymbol: false, attributes, cancellationToken));
-                                attributes.Free();
                             }
                         }
 

--- a/src/Compilers/CSharp/CSharpAnalyzerDriver/CSharpDeclarationComputer.cs
+++ b/src/Compilers/CSharp/CSharpAnalyzerDriver/CSharpDeclarationComputer.cs
@@ -202,13 +202,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var t = (BaseFieldDeclarationSyntax)node;
                         using var _1 = ArrayBuilder<SyntaxNode>.GetInstance(out var attributes);
                         AddAttributes(t.AttributeLists, attributes);
+                        using var _2 = ArrayBuilder<SyntaxNode>.GetInstance(out var codeBlocks);
                         foreach (var decl in t.Declaration.Variables)
                         {
-                            using var _2 = ArrayBuilder<SyntaxNode>.GetInstance(out var codeBlocks);
                             codeBlocks.Add(decl.Initializer);
                             codeBlocks.AddRange(attributes);
 
                             builder.Add(GetDeclarationInfo(model, decl, getSymbol, codeBlocks, cancellationToken));
+                            codeBlocks.Clear();
                         }
 
                         return;

--- a/src/Compilers/VisualBasic/BasicAnalyzerDriver/VisualBasicDeclarationComputer.vb
+++ b/src/Compilers/VisualBasic/BasicAnalyzerDriver/VisualBasicDeclarationComputer.vb
@@ -120,17 +120,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Dim attributes As ArrayBuilder(Of SyntaxNode) = Nothing
                     Using ArrayBuilder(Of SyntaxNode).GetInstance(attributes)
                         AddAttributes(t.AttributeLists, attributes)
-                        For Each decl In t.Declarators
-                            Dim initializer = GetInitializerNode(decl)
-                            Dim codeBlocks As ArrayBuilder(Of SyntaxNode) = Nothing
-                            Using ArrayBuilder(Of SyntaxNode).GetInstance(codeBlocks)
+                        Dim codeBlocks As ArrayBuilder(Of SyntaxNode) = Nothing
+                        Using ArrayBuilder(Of SyntaxNode).GetInstance(codeBlocks)
+                            For Each decl In t.Declarators
+                                Dim initializer = GetInitializerNode(decl)
                                 codeBlocks.Add(initializer)
                                 codeBlocks.AddRange(attributes)
                                 For Each identifier In decl.Names
                                     builder.Add(GetDeclarationInfo(model, identifier, getSymbol, codeBlocks, cancellationToken))
                                 Next
-                            End Using
-                        Next
+                                codeBlocks.Clear()
+                            Next
+                        End Using
                     End Using
 
                     Return

--- a/src/Compilers/VisualBasic/BasicAnalyzerDriver/VisualBasicDeclarationComputer.vb
+++ b/src/Compilers/VisualBasic/BasicAnalyzerDriver/VisualBasicDeclarationComputer.vb
@@ -77,68 +77,83 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     For Each decl In t.Members
                         ComputeDeclarationsCore(model, decl, shouldSkip, getSymbol, builder, newLevel, cancellationToken)
                     Next
-                    Dim attributes = ArrayBuilder(Of SyntaxNode).GetInstance()
-                    AddAttributes(t.EnumStatement.AttributeLists, attributes)
-                    builder.Add(GetDeclarationInfo(model, node, getSymbol, attributes, cancellationToken))
-                    attributes.Free()
+                    Dim attributes As ArrayBuilder(Of SyntaxNode) = Nothing
+                    Using ArrayBuilder(Of SyntaxNode).GetInstance(attributes)
+                        AddAttributes(t.EnumStatement.AttributeLists, attributes)
+                        builder.Add(GetDeclarationInfo(model, node, getSymbol, attributes, cancellationToken))
+                    End Using
+
                     Return
                 Case SyntaxKind.EnumStatement
                     Dim t = DirectCast(node, EnumStatementSyntax)
-                    Dim attributes = ArrayBuilder(Of SyntaxNode).GetInstance()
-                    AddAttributes(t.AttributeLists, attributes)
-                    builder.Add(GetDeclarationInfo(model, node, getSymbol, attributes, cancellationToken))
-                    attributes.Free()
+                    Dim attributes As ArrayBuilder(Of SyntaxNode) = Nothing
+                    Using ArrayBuilder(Of SyntaxNode).GetInstance(attributes)
+                        AddAttributes(t.AttributeLists, attributes)
+                        builder.Add(GetDeclarationInfo(model, node, getSymbol, attributes, cancellationToken))
+                    End Using
+
                     Return
                 Case SyntaxKind.EnumMemberDeclaration
                     Dim t = DirectCast(node, EnumMemberDeclarationSyntax)
-                    Dim codeBlocks = ArrayBuilder(Of SyntaxNode).GetInstance()
-                    codeBlocks.Add(t.Initializer)
-                    AddAttributes(t.AttributeLists, codeBlocks)
-                    builder.Add(GetDeclarationInfo(model, node, getSymbol, codeBlocks, cancellationToken))
-                    codeBlocks.Free()
+                    Dim codeBlocks As ArrayBuilder(Of SyntaxNode) = Nothing
+                    Using ArrayBuilder(Of SyntaxNode).GetInstance(codeBlocks)
+                        codeBlocks.Add(t.Initializer)
+                        AddAttributes(t.AttributeLists, codeBlocks)
+                        builder.Add(GetDeclarationInfo(model, node, getSymbol, codeBlocks, cancellationToken))
+                    End Using
+
                     Return
                 Case SyntaxKind.EventBlock
                     Dim t = DirectCast(node, EventBlockSyntax)
                     For Each decl In t.Accessors
                         ComputeDeclarationsCore(model, decl, shouldSkip, getSymbol, builder, newLevel, cancellationToken)
                     Next
-                    Dim codeBlocks = ArrayBuilder(Of SyntaxNode).GetInstance()
-                    AddMethodBaseCodeBlocks(t.EventStatement, codeBlocks)
-                    builder.Add(GetDeclarationInfo(model, node, getSymbol, codeBlocks, cancellationToken))
-                    codeBlocks.Free()
+                    Dim codeBlocks As ArrayBuilder(Of SyntaxNode) = Nothing
+                    Using ArrayBuilder(Of SyntaxNode).GetInstance(codeBlocks)
+                        AddMethodBaseCodeBlocks(t.EventStatement, codeBlocks)
+                        builder.Add(GetDeclarationInfo(model, node, getSymbol, codeBlocks, cancellationToken))
+                    End Using
+
                     Return
                 Case SyntaxKind.FieldDeclaration
                     Dim t = DirectCast(node, FieldDeclarationSyntax)
-                    Dim attributes = ArrayBuilder(Of SyntaxNode).GetInstance()
-                    AddAttributes(t.AttributeLists, attributes)
-                    For Each decl In t.Declarators
-                        Dim initializer = GetInitializerNode(decl)
-                        Dim codeBlocks = ArrayBuilder(Of SyntaxNode).GetInstance()
-                        codeBlocks.Add(initializer)
-                        codeBlocks.AddRange(attributes)
-                        For Each identifier In decl.Names
-                            builder.Add(GetDeclarationInfo(model, identifier, getSymbol, codeBlocks, cancellationToken))
+                    Dim attributes As ArrayBuilder(Of SyntaxNode) = Nothing
+                    Using ArrayBuilder(Of SyntaxNode).GetInstance(attributes)
+                        AddAttributes(t.AttributeLists, attributes)
+                        For Each decl In t.Declarators
+                            Dim initializer = GetInitializerNode(decl)
+                            Dim codeBlocks As ArrayBuilder(Of SyntaxNode) = Nothing
+                            Using ArrayBuilder(Of SyntaxNode).GetInstance(codeBlocks)
+                                codeBlocks.Add(initializer)
+                                codeBlocks.AddRange(attributes)
+                                For Each identifier In decl.Names
+                                    builder.Add(GetDeclarationInfo(model, identifier, getSymbol, codeBlocks, cancellationToken))
+                                Next
+                            End Using
                         Next
-                        codeBlocks.Free()
-                    Next
-                    attributes.Free()
+                    End Using
+
                     Return
                 Case SyntaxKind.PropertyBlock
                     Dim t = DirectCast(node, PropertyBlockSyntax)
                     For Each decl In t.Accessors
                         ComputeDeclarationsCore(model, decl, shouldSkip, getSymbol, builder, newLevel, cancellationToken)
                     Next
-                    Dim codeBlocks = ArrayBuilder(Of SyntaxNode).GetInstance()
-                    AddPropertyStatementCodeBlocks(t.PropertyStatement, codeBlocks)
-                    builder.Add(GetDeclarationInfo(model, node, getSymbol, codeBlocks, cancellationToken))
-                    codeBlocks.Free()
+                    Dim codeBlocks As ArrayBuilder(Of SyntaxNode) = Nothing
+                    Using ArrayBuilder(Of SyntaxNode).GetInstance(codeBlocks)
+                        AddPropertyStatementCodeBlocks(t.PropertyStatement, codeBlocks)
+                        builder.Add(GetDeclarationInfo(model, node, getSymbol, codeBlocks, cancellationToken))
+                    End Using
+
                     Return
                 Case SyntaxKind.PropertyStatement
                     Dim t = DirectCast(node, PropertyStatementSyntax)
-                    Dim codeBlocks = ArrayBuilder(Of SyntaxNode).GetInstance()
-                    AddPropertyStatementCodeBlocks(t, codeBlocks)
-                    builder.Add(GetDeclarationInfo(model, node, getSymbol, codeBlocks, cancellationToken))
-                    codeBlocks.Free()
+                    Dim codeBlocks As ArrayBuilder(Of SyntaxNode) = Nothing
+                    Using ArrayBuilder(Of SyntaxNode).GetInstance(codeBlocks)
+                        AddPropertyStatementCodeBlocks(t, codeBlocks)
+                        builder.Add(GetDeclarationInfo(model, node, getSymbol, codeBlocks, cancellationToken))
+                    End Using
+
                     Return
                 Case SyntaxKind.CompilationUnit
                     Dim t = DirectCast(node, CompilationUnitSyntax)
@@ -147,11 +162,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Next
 
                     If Not t.Attributes.IsEmpty Then
-                        Dim attributes = ArrayBuilder(Of SyntaxNode).GetInstance()
-                        AddAttributes(t.Attributes, attributes)
-                        builder.Add(GetDeclarationInfo(model, node, getSymbol, attributes, cancellationToken))
-                        attributes.Free()
+                        Dim attributes As ArrayBuilder(Of SyntaxNode) = Nothing
+                        Using ArrayBuilder(Of SyntaxNode).GetInstance(attributes)
+                            AddAttributes(t.Attributes, attributes)
+                            builder.Add(GetDeclarationInfo(model, node, getSymbol, attributes, cancellationToken))
+                        End Using
                     End If
+
                     Return
                 Case Else
                     Dim typeBlock = TryCast(node, TypeBlockSyntax)
@@ -159,38 +176,46 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         For Each decl In typeBlock.Members
                             ComputeDeclarationsCore(model, decl, shouldSkip, getSymbol, builder, newLevel, cancellationToken)
                         Next
-                        Dim attributes = ArrayBuilder(Of SyntaxNode).GetInstance()
-                        AddAttributes(typeBlock.BlockStatement.AttributeLists, attributes)
-                        builder.Add(GetDeclarationInfo(model, node, getSymbol, attributes, cancellationToken))
-                        attributes.Free()
+                        Dim attributes As ArrayBuilder(Of SyntaxNode) = Nothing
+                        Using ArrayBuilder(Of SyntaxNode).GetInstance(attributes)
+                            AddAttributes(typeBlock.BlockStatement.AttributeLists, attributes)
+                            builder.Add(GetDeclarationInfo(model, node, getSymbol, attributes, cancellationToken))
+                        End Using
+
                         Return
                     End If
 
                     Dim typeStatement = TryCast(node, TypeStatementSyntax)
                     If typeStatement IsNot Nothing Then
-                        Dim attributes = ArrayBuilder(Of SyntaxNode).GetInstance()
-                        AddAttributes(typeStatement.AttributeLists, attributes)
-                        builder.Add(GetDeclarationInfo(model, node, getSymbol, attributes, cancellationToken))
-                        attributes.Free()
+                        Dim attributes As ArrayBuilder(Of SyntaxNode) = Nothing
+                        Using ArrayBuilder(Of SyntaxNode).GetInstance(attributes)
+                            AddAttributes(typeStatement.AttributeLists, attributes)
+                            builder.Add(GetDeclarationInfo(model, node, getSymbol, attributes, cancellationToken))
+                        End Using
+
                         Return
                     End If
 
                     Dim methodBlock = TryCast(node, MethodBlockBaseSyntax)
                     If methodBlock IsNot Nothing Then
-                        Dim codeBlocks = ArrayBuilder(Of SyntaxNode).GetInstance()
-                        codeBlocks.Add(methodBlock)
-                        AddMethodBaseCodeBlocks(methodBlock.BlockStatement, codeBlocks)
-                        builder.Add(GetDeclarationInfo(model, node, getSymbol, codeBlocks, cancellationToken))
-                        codeBlocks.Free()
+                        Dim codeBlocks As ArrayBuilder(Of SyntaxNode) = Nothing
+                        Using ArrayBuilder(Of SyntaxNode).GetInstance(codeBlocks)
+                            codeBlocks.Add(methodBlock)
+                            AddMethodBaseCodeBlocks(methodBlock.BlockStatement, codeBlocks)
+                            builder.Add(GetDeclarationInfo(model, node, getSymbol, codeBlocks, cancellationToken))
+                        End Using
+
                         Return
                     End If
 
                     Dim methodStatement = TryCast(node, MethodBaseSyntax)
                     If methodStatement IsNot Nothing Then
-                        Dim codeBlocks = ArrayBuilder(Of SyntaxNode).GetInstance()
-                        AddMethodBaseCodeBlocks(methodStatement, codeBlocks)
-                        builder.Add(GetDeclarationInfo(model, node, getSymbol, codeBlocks, cancellationToken))
-                        codeBlocks.Free()
+                        Dim codeBlocks As ArrayBuilder(Of SyntaxNode) = Nothing
+                        Using ArrayBuilder(Of SyntaxNode).GetInstance(codeBlocks)
+                            AddMethodBaseCodeBlocks(methodStatement, codeBlocks)
+                            builder.Add(GetDeclarationInfo(model, node, getSymbol, codeBlocks, cancellationToken))
+                        End Using
+
                         Return
                     End If
 


### PR DESCRIPTION
Should fix a pooled object leak detected by https://github.com/dotnet/roslyn/issues/83972, for example in build https://dev.azure.com/dnceng-public/public/_build/results?buildId=1486724&view=logs&j=7ef38499-25b0-55d8-354c-2bfcf0659dd0&t=2227d71e-968d-58d1-9a20-5269a1f45134:

```
Microsoft.CodeAnalysis.CSharp.UnitTests.DiagnosticAnalyzerTests.TestCancellationDuringDiagnosticComputation(actionKind: Operation):

   Pool leak detected! The following pooled objects were not returned:
  Microsoft.CodeAnalysis.PooledObjects.ArrayBuilder`1[Microsoft.CodeAnalysis.SyntaxNode] (from ArrayBuilder.cs:508) (allocated at CSharpDeclarationComputer.cs:132): 1
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84339)