### PR TITLE
doc(IncrementalGenerators): the square example is wrong, that's only a multiplication by a factor 2

### DIFF
--- a/docs/features/incremental-generators.md
+++ b/docs/features/incremental-generators.md
@@ -108,7 +108,7 @@ enumerable is actually iterated over:
 **IEnumerable**:
 
 ```csharp
-    var squares = Enumerable.Range(1, 10).Select(i => i * 2); 
+    var squares = Enumerable.Range(1, 10).Select(i => i * i); 
 
     // the code inside select is not executed until we iterate the collection
     foreach (var square in squares) { ... }


### PR DESCRIPTION
From the "IEnumerable" chapter : https://github.com/dotnet/roslyn/blob/main/docs/features/incremental-generators.md#pipeline-based-execution
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84340)