### PR TITLE
Offer fully-qualify code fix for unresolved types in cref attributes

### DIFF
--- a/src/Features/CSharp/Portable/FullyQualify/CSharpFullyQualifyCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/FullyQualify/CSharpFullyQualifyCodeFixProvider.cs
@@ -42,6 +42,11 @@ internal sealed class CSharpFullyQualifyCodeFixProvider() : AbstractFullyQualify
     /// </summary>
     private const string CS0308 = nameof(CS0308);
 
+    /// <summary>
+    /// XML comment has cref attribute that could not be resolved
+    /// </summary>
+    private const string CS1574 = nameof(CS1574);
+
     public override ImmutableArray<string> FixableDiagnosticIds { get; } =
-        [CS0103, CS0104, CS0246, CS0305, CS0308, IDEDiagnosticIds.UnboundIdentifierId];
+        [CS0103, CS0104, CS0246, CS0305, CS0308, CS1574, IDEDiagnosticIds.UnboundIdentifierId];
 }

--- a/src/Features/CSharpTest/FullyQualify/FullyQualifyTests.cs
+++ b/src/Features/CSharpTest/FullyQualify/FullyQualifyTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.CodeFixes.FullyQualify;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
@@ -1774,4 +1775,56 @@ class C
                 </Project>
             </Workspace>
             """, new TestParameters(testHost: testHost));
+
+    [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/84328")]
+    public Task TestInCref(TestHost testHost)
+        => TestInRegularAndScriptAsync(
+            """
+            /// <summary>
+            /// <see cref="[|INotifyPropertyChanged|]"/>
+            /// </summary>
+            class Class
+            {
+            }
+            """,
+            """
+            /// <summary>
+            /// <see cref="System.ComponentModel.INotifyPropertyChanged"/>
+            /// </summary>
+            class Class
+            {
+            }
+            """, new(testHost: testHost, parseOptions: new CSharpParseOptions(documentationMode: DocumentationMode.Diagnose)));
+
+    [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/84328")]
+    public Task TestInCref_Generic(TestHost testHost)
+        => TestInRegularAndScriptAsync(
+            """
+            /// <summary>
+            /// <see cref="[|IList{T}|]"/>
+            /// </summary>
+            class Class
+            {
+            }
+            """,
+            """
+            /// <summary>
+            /// <see cref="System.Collections.Generic.IList{T}"/>
+            /// </summary>
+            class Class
+            {
+            }
+            """, new(testHost: testHost, parseOptions: new CSharpParseOptions(documentationMode: DocumentationMode.Diagnose)));
+
+    [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/84328")]
+    public Task TestInCref_ExplicitTypePrefix(TestHost testHost)
+        => TestMissingInRegularAndScriptAsync(
+            """
+            /// <summary>
+            /// <see cref="T:[|INotifyPropertyChanged|]"/>
+            /// </summary>
+            class Class
+            {
+            }
+            """, new(testHost: testHost, parseOptions: new CSharpParseOptions(documentationMode: DocumentationMode.Diagnose)));
 }

--- a/src/Features/Core/Portable/FullyQualify/AbstractFullyQualifyService.cs
+++ b/src/Features/Core/Portable/FullyQualify/AbstractFullyQualifyService.cs
@@ -65,7 +65,7 @@ internal abstract partial class AbstractFullyQualifyService<TSimpleNameSyntax> :
         using (Logger.LogBlock(FunctionId.Refactoring_FullyQualify, cancellationToken))
         {
             var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var node = root.FindToken(span.Start).GetAncestors<SyntaxNode>().First(n => n.Span.Contains(span));
+            var node = root.FindToken(span.Start, findInsideTrivia: true).GetAncestors<SyntaxNode>().FirstOrDefault(n => n.Span.Contains(span));
 
             // Has to be a simple identifier or generic name.
             if (node == null || !CanFullyQualify(node, out var simpleName))


### PR DESCRIPTION
Fixes: #84328
Register CS1574 in the C# fully-qualify provider and search inside documentation-comment trivia so the fix is offered for unresolved type references in XML doc `<see cref="..."/>` attributes.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84346)