### PR TITLE
Set IsClosedTypeAttribute.DerivedTypes

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -8363,6 +8363,9 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_ClosedExplicitlyAbstract" xml:space="preserve">
     <value>'{0}': a closed type cannot be marked abstract because it is always implicitly abstract.</value>
   </data>
+  <data name="ERR_ClosedBadDerivedTypesProperty" xml:space="preserve">
+    <value>'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.</value>
+  </data>
   <data name="ERR_MissingUnionCaseTypes" xml:space="preserve">
     <value>A union type must have at least one union creation member.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2504,6 +2504,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         ERR_NoBreakId = 9393,
         ERR_NoContinueId = 9394,
+        ERR_ClosedBadDerivedTypesProperty = 9395,
 
         // Note: you will need to do the following after adding errors:
         //  1) Update ErrorFacts.IsBuildOnlyDiagnostic (src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs)

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -2603,6 +2603,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 or ErrorCode.ERR_ExplicitOrExtendedLayoutFieldRequiresUnsafeOrSafe
                 or ErrorCode.ERR_NoBreakId
                 or ErrorCode.ERR_NoContinueId
+                or ErrorCode.ERR_ClosedBadDerivedTypesProperty
                     => false,
             };
 #pragma warning restore CS8524 // The switch expression does not handle some values of its input type (it is not exhaustive) involving an unnamed enum value.

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1987,7 +1987,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (wellKnownDerivedTypesProperty is not null)
                 {
                     Binder.ReportUseSite(wellKnownDerivedTypesProperty, diagnostics, location);
-                    _ = Binder.GetWellKnownType(compilation, WellKnownType.System_Type, diagnostics, location);
+                    var systemType = Binder.GetWellKnownType(compilation, WellKnownType.System_Type, diagnostics, location);
 
                     var isValid = wellKnownDerivedTypesProperty is
                     {
@@ -1997,19 +1997,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         RefKind: RefKind.None,
                         ParameterCount: 0,
                         Type: ArrayTypeSymbol { ElementType: var elementType }
-                    } && elementType.Equals(compilation.GetWellKnownType(WellKnownType.System_Type), TypeCompareKind.AllIgnoreOptions);
+                    } && elementType.Equals(systemType, TypeCompareKind.AllIgnoreOptions);
+
                     if (!isValid)
                     {
                         diagnostics.Add(ErrorCode.ERR_ClosedBadDerivedTypesProperty, location);
                     }
                 }
 
-                var allDerivedTypesSymbols = isClosedTypeAttributeCtor.ContainingType.GetMembers("DerivedTypes");
-                foreach (var derivedTypesSymbol in allDerivedTypesSymbols)
+                if (isClosedTypeAttributeCtor is not null)
                 {
-                    if (!derivedTypesSymbol.Equals(wellKnownDerivedTypesProperty, TypeCompareKind.AllIgnoreOptions))
+                    var allDerivedTypesSymbols = isClosedTypeAttributeCtor.ContainingType.GetMembers("DerivedTypes");
+                    foreach (var derivedTypesSymbol in allDerivedTypesSymbols)
                     {
-                        diagnostics.Add(ErrorCode.ERR_ClosedBadDerivedTypesProperty, location);
+                        if (!derivedTypesSymbol.Equals(wellKnownDerivedTypesProperty, TypeCompareKind.AllIgnoreOptions))
+                        {
+                            diagnostics.Add(ErrorCode.ERR_ClosedBadDerivedTypesProperty, location);
+                        }
                     }
                 }
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1987,30 +1987,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (wellKnownDerivedTypesProperty is not null)
                 {
                     Binder.ReportUseSite(wellKnownDerivedTypesProperty, diagnostics, location);
-                    var systemType = Binder.GetWellKnownType(compilation, WellKnownType.System_Type, diagnostics, location);
 
-                    var isValid = wellKnownDerivedTypesProperty is
-                    {
-                        IsStatic: false,
-                        GetMethod.DeclaredAccessibility: Accessibility.Public,
-                        SetMethod.DeclaredAccessibility: Accessibility.Public,
-                        RefKind: RefKind.None,
-                        ParameterCount: 0,
-                        Type: ArrayTypeSymbol { ElementType: var elementType }
-                    } && elementType.Equals(systemType, TypeCompareKind.AllIgnoreOptions);
-
-                    if (!isValid)
+                    if (wellKnownDerivedTypesProperty is not
+                        {
+                            GetMethod.DeclaredAccessibility: Accessibility.Public,
+                            SetMethod.DeclaredAccessibility: Accessibility.Public
+                        })
                     {
                         diagnostics.Add(ErrorCode.ERR_ClosedBadDerivedTypesProperty, location);
                     }
                 }
-
-                if (isClosedTypeAttributeCtor is not null)
+                else if (isClosedTypeAttributeCtor is not null)
                 {
-                    var allDerivedTypesSymbols = isClosedTypeAttributeCtor.ContainingType.GetMembers("DerivedTypes");
-                    foreach (var derivedTypesSymbol in allDerivedTypesSymbols)
+                    foreach (var derivedTypesSymbol in isClosedTypeAttributeCtor.ContainingType.GetMembers("DerivedTypes"))
                     {
-                        if (!derivedTypesSymbol.Equals(wellKnownDerivedTypesProperty, TypeCompareKind.AllIgnoreOptions))
+                        if (derivedTypesSymbol.Kind == SymbolKind.Property)
                         {
                             diagnostics.Add(ErrorCode.ERR_ClosedBadDerivedTypesProperty, location);
                         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1979,8 +1979,39 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (this.IsClosed)
             {
                 // Ensure necessary attributes are present
-                _ = Binder.GetWellKnownTypeMember(DeclaringCompilation, WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__ctor, diagnostics, GetFirstLocation());
-                _ = Binder.GetWellKnownTypeMember(DeclaringCompilation, WellKnownMember.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute__ctor, diagnostics, GetFirstLocation());
+                var isClosedTypeAttributeCtor = Binder.GetWellKnownTypeMember(compilation, WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__ctor, diagnostics, location);
+                _ = Binder.GetWellKnownTypeMember(compilation, WellKnownMember.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute__ctor, diagnostics, location);
+
+                // DerivedTypes property is optional but must have expected shape if present
+                var wellKnownDerivedTypesProperty = (PropertySymbol?)compilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__DerivedTypes);
+                if (wellKnownDerivedTypesProperty is not null)
+                {
+                    Binder.ReportUseSite(wellKnownDerivedTypesProperty, diagnostics, location);
+                    _ = Binder.GetWellKnownType(compilation, WellKnownType.System_Type, diagnostics, location);
+
+                    var isValid = wellKnownDerivedTypesProperty is
+                    {
+                        IsStatic: false,
+                        GetMethod.DeclaredAccessibility: Accessibility.Public,
+                        SetMethod.DeclaredAccessibility: Accessibility.Public,
+                        RefKind: RefKind.None,
+                        ParameterCount: 0,
+                        Type: ArrayTypeSymbol { ElementType: var elementType }
+                    } && elementType.Equals(compilation.GetWellKnownType(WellKnownType.System_Type), TypeCompareKind.AllIgnoreOptions);
+                    if (!isValid)
+                    {
+                        diagnostics.Add(ErrorCode.ERR_ClosedBadDerivedTypesProperty, location);
+                    }
+                }
+
+                var allDerivedTypesSymbols = isClosedTypeAttributeCtor.ContainingType.GetMembers("DerivedTypes");
+                foreach (var derivedTypesSymbol in allDerivedTypesSymbols)
+                {
+                    if (!derivedTypesSymbol.Equals(wellKnownDerivedTypesProperty, TypeCompareKind.AllIgnoreOptions))
+                    {
+                        diagnostics.Add(ErrorCode.ERR_ClosedBadDerivedTypesProperty, location);
+                    }
+                }
             }
 
             var baseType = BaseTypeNoUseSiteDiagnostics;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -1805,14 +1805,14 @@ next:;
             if (IsClosed)
             {
                 ImmutableArray<KeyValuePair<WellKnownMember, TypedConstant>> namedArguments;
-                if (compilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__DerivedTypes) is not null)
+                var derivedTypesProperty = (PropertySymbol)compilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__DerivedTypes);
+                if (derivedTypesProperty is not null)
                 {
-                    var systemType = compilation.GetWellKnownType(WellKnownType.System_Type);
-                    var arrayOfSystemType = ArrayTypeSymbol.CreateSZArray(systemType.ContainingAssembly, TypeWithAnnotations.Create(systemType, NullableAnnotation.NotAnnotated));
+                    var propertyType = (ArrayTypeSymbol)derivedTypesProperty.Type;
                     var derivedTypesConstant = new TypedConstant(
-                        arrayOfSystemType,
+                        propertyType,
                         CandidateClosedSubtypeDefinitions.SelectAsArray(
-                            static (subtype, systemType) => new TypedConstant(systemType, TypedConstantKind.Type, subtype.GetUnboundGenericTypeOrSelf()), systemType));
+                            static (subtype, elementType) => new TypedConstant(elementType, TypedConstantKind.Type, subtype.GetUnboundGenericTypeOrSelf()), propertyType.ElementType));
 
                     namedArguments = [new KeyValuePair<WellKnownMember, TypedConstant>(
                         WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__DerivedTypes,

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -1809,7 +1809,7 @@ next:;
 
                 ImmutableArray<KeyValuePair<WellKnownMember, TypedConstant>> namedArguments;
                 // Note: some definitions of IsClosedTypeAttribute may be missing DerivedTypes property.
-                if (systemType is not null and not ErrorTypeSymbol && derivedTypesProperty != null)
+                if (systemType is not null and not ErrorTypeSymbol && derivedTypesProperty != null && !derivedTypesProperty.HasUseSiteError)
                 {
                     var arrayOfSystemType = ArrayTypeSymbol.CreateSZArray(systemType.ContainingAssembly, TypeWithAnnotations.Create(systemType, NullableAnnotation.NotAnnotated));
                     var derivedTypesConstant = new TypedConstant(
@@ -1826,11 +1826,12 @@ next:;
                     namedArguments = [];
                 }
 
-                AddSynthesizedAttribute(
-                    ref attributes,
-                    compilation.TrySynthesizeAttribute(
-                        WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__ctor,
-                        namedArguments: namedArguments));
+                var closedAttribute = compilation.TrySynthesizeAttribute(
+                    WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__ctor,
+                    namedArguments: namedArguments);
+                Debug.Assert(closedAttribute is not null);
+
+                AddSynthesizedAttribute(ref attributes, closedAttribute);
             }
 
             // Add MetadataUpdateOriginalTypeAttribute when a reloadable type is emitted to EnC delta

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -1804,12 +1804,10 @@ next:;
 
             if (IsClosed)
             {
-                var systemType = compilation.GetWellKnownType(WellKnownType.System_Type);
-                var derivedTypesProperty = compilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__DerivedTypes);
-
                 ImmutableArray<KeyValuePair<WellKnownMember, TypedConstant>> namedArguments;
-                if (derivedTypesProperty != null)
+                if (compilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__DerivedTypes) is { } derivedTypesProperty)
                 {
+                    var systemType = compilation.GetWellKnownType(WellKnownType.System_Type);
                     var arrayOfSystemType = ArrayTypeSymbol.CreateSZArray(systemType.ContainingAssembly, TypeWithAnnotations.Create(systemType, NullableAnnotation.NotAnnotated));
                     var derivedTypesConstant = new TypedConstant(
                         arrayOfSystemType,

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -1808,7 +1808,7 @@ next:;
                 var derivedTypesProperty = compilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__DerivedTypes);
 
                 ImmutableArray<KeyValuePair<WellKnownMember, TypedConstant>> namedArguments;
-                if (systemType is not null && derivedTypesProperty != null)
+                if (derivedTypesProperty != null)
                 {
                     var arrayOfSystemType = ArrayTypeSymbol.CreateSZArray(systemType.ContainingAssembly, TypeWithAnnotations.Create(systemType, NullableAnnotation.NotAnnotated));
                     var derivedTypesConstant = new TypedConstant(
@@ -1825,12 +1825,9 @@ next:;
                     namedArguments = default;
                 }
 
-                var closedAttribute = compilation.TrySynthesizeAttribute(
-                    WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__ctor,
-                    namedArguments: namedArguments);
-                Debug.Assert(closedAttribute is not null);
-
-                AddSynthesizedAttribute(ref attributes, closedAttribute);
+                AddSynthesizedAttribute(
+                    ref attributes,
+                    compilation.TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__ctor, namedArguments: namedArguments));
             }
 
             // Add MetadataUpdateOriginalTypeAttribute when a reloadable type is emitted to EnC delta

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -1808,14 +1808,13 @@ next:;
                 var derivedTypesProperty = compilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__DerivedTypes);
 
                 ImmutableArray<KeyValuePair<WellKnownMember, TypedConstant>> namedArguments;
-                // Note: some definitions of IsClosedTypeAttribute may be missing DerivedTypes property.
-                if (systemType is not null and not ErrorTypeSymbol && derivedTypesProperty != null && !derivedTypesProperty.HasUseSiteError)
+                if (systemType is not null && derivedTypesProperty != null)
                 {
                     var arrayOfSystemType = ArrayTypeSymbol.CreateSZArray(systemType.ContainingAssembly, TypeWithAnnotations.Create(systemType, NullableAnnotation.NotAnnotated));
                     var derivedTypesConstant = new TypedConstant(
                         arrayOfSystemType,
                         CandidateClosedSubtypeDefinitions.SelectAsArray(
-                            subtype => new TypedConstant(systemType, TypedConstantKind.Type, subtype.GetUnboundGenericTypeOrSelf())));
+                            static (subtype, systemType) => new TypedConstant(systemType, TypedConstantKind.Type, subtype.GetUnboundGenericTypeOrSelf()), systemType));
 
                     namedArguments = [new KeyValuePair<WellKnownMember, TypedConstant>(
                         WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__DerivedTypes,
@@ -1823,7 +1822,7 @@ next:;
                 }
                 else
                 {
-                    namedArguments = [];
+                    namedArguments = default;
                 }
 
                 var closedAttribute = compilation.TrySynthesizeAttribute(

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -1804,9 +1804,33 @@ next:;
 
             if (IsClosed)
             {
+                var systemType = compilation.GetWellKnownType(WellKnownType.System_Type);
+                var derivedTypesProperty = compilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__DerivedTypes);
+
+                ImmutableArray<KeyValuePair<WellKnownMember, TypedConstant>> namedArguments;
+                // Note: some definitions of IsClosedTypeAttribute may be missing DerivedTypes property.
+                if (systemType is not null and not ErrorTypeSymbol && derivedTypesProperty != null)
+                {
+                    var arrayOfSystemType = ArrayTypeSymbol.CreateSZArray(systemType.ContainingAssembly, TypeWithAnnotations.Create(systemType, NullableAnnotation.NotAnnotated));
+                    var derivedTypesConstant = new TypedConstant(
+                        arrayOfSystemType,
+                        CandidateClosedSubtypeDefinitions.SelectAsArray(
+                            subtype => new TypedConstant(systemType, TypedConstantKind.Type, subtype.GetUnboundGenericTypeOrSelf())));
+
+                    namedArguments = [new KeyValuePair<WellKnownMember, TypedConstant>(
+                        WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__DerivedTypes,
+                        derivedTypesConstant)];
+                }
+                else
+                {
+                    namedArguments = [];
+                }
+
                 AddSynthesizedAttribute(
                     ref attributes,
-                    compilation.TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__ctor));
+                    compilation.TrySynthesizeAttribute(
+                        WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__ctor,
+                        namedArguments: namedArguments));
             }
 
             // Add MetadataUpdateOriginalTypeAttribute when a reloadable type is emitted to EnC delta

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -1805,7 +1805,7 @@ next:;
             if (IsClosed)
             {
                 ImmutableArray<KeyValuePair<WellKnownMember, TypedConstant>> namedArguments;
-                if (compilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__DerivedTypes) is { } derivedTypesProperty)
+                if (compilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__DerivedTypes) is { })
                 {
                     var systemType = compilation.GetWellKnownType(WellKnownType.System_Type);
                     var arrayOfSystemType = ArrayTypeSymbol.CreateSZArray(systemType.ContainingAssembly, TypeWithAnnotations.Create(systemType, NullableAnnotation.NotAnnotated));

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -1805,7 +1805,7 @@ next:;
             if (IsClosed)
             {
                 ImmutableArray<KeyValuePair<WellKnownMember, TypedConstant>> namedArguments;
-                if (compilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__DerivedTypes) is { } derivedTypesProperty)
+                if (compilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__DerivedTypes) is not null)
                 {
                     var systemType = compilation.GetWellKnownType(WellKnownType.System_Type);
                     var arrayOfSystemType = ArrayTypeSymbol.CreateSZArray(systemType.ContainingAssembly, TypeWithAnnotations.Create(systemType, NullableAnnotation.NotAnnotated));

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -532,6 +532,11 @@
         <target state="translated">{0} neimplementuje člen rozhraní {1}. {2} nemůže implementovat {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ClosedBadDerivedTypesProperty">
+        <source>'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.</source>
+        <target state="new">'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ClosedBaseTypeBaseFromOtherAssembly">
         <source>'{0}': cannot use a closed type '{1}' from another assembly as a base type.</source>
         <target state="translated">{0}: Uzavřený typ {1} z jiného sestavení nelze použít jako základní typ.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -532,6 +532,11 @@
         <target state="translated">Der Schnittstellenmember "{1}" wird von "{0}" nicht implementiert. "{1}" kann von "{2}" nicht implementiert werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ClosedBadDerivedTypesProperty">
+        <source>'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.</source>
+        <target state="new">'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ClosedBaseTypeBaseFromOtherAssembly">
         <source>'{0}': cannot use a closed type '{1}' from another assembly as a base type.</source>
         <target state="translated">„{0}“: Ein geschlossener Typ „{1}“ aus einer anderen Assembly kann nicht als Basistyp verwendet werden.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -532,6 +532,11 @@
         <target state="translated">"{0}" no implementa el miembro de interfaz "{1}". "{2}" no puede implementar "{1}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ClosedBadDerivedTypesProperty">
+        <source>'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.</source>
+        <target state="new">'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ClosedBaseTypeBaseFromOtherAssembly">
         <source>'{0}': cannot use a closed type '{1}' from another assembly as a base type.</source>
         <target state="translated">"{0}": no se puede usar un tipo cerrado "{1}" de otro ensamblado como tipo base.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -532,6 +532,11 @@
         <target state="translated">'{0}' n'implémente pas le membre d'interface '{1}'. '{2}' ne peut pas implémenter '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ClosedBadDerivedTypesProperty">
+        <source>'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.</source>
+        <target state="new">'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ClosedBaseTypeBaseFromOtherAssembly">
         <source>'{0}': cannot use a closed type '{1}' from another assembly as a base type.</source>
         <target state="translated">« {0} » : nous ne pouvons pas utiliser un type fermé « {1} » provenant d’un autre assembly comme type de base.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -532,6 +532,11 @@
         <target state="translated">'{0}' non implementa il membro di interfaccia '{1}'. '{2}' non può implementare '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ClosedBadDerivedTypesProperty">
+        <source>'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.</source>
+        <target state="new">'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ClosedBaseTypeBaseFromOtherAssembly">
         <source>'{0}': cannot use a closed type '{1}' from another assembly as a base type.</source>
         <target state="translated">'{0}': non è possibile usare un tipo chiuso '{1}' di un altro assembly come tipo di base.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -532,6 +532,11 @@
         <target state="translated">'{0}' は、インターフェイス メンバー '{1}' を実装していません。'{2}' は '{1}' を実装できません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ClosedBadDerivedTypesProperty">
+        <source>'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.</source>
+        <target state="new">'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ClosedBaseTypeBaseFromOtherAssembly">
         <source>'{0}': cannot use a closed type '{1}' from another assembly as a base type.</source>
         <target state="translated">'{0}': 別のアセンブリの閉じた型 '{1}' を基本型として使用することはできません。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -532,6 +532,11 @@
         <target state="translated">'{0}'은(는) 인터페이스 멤버 '{1}'을(를) 구현하지 않습니다. '{2}'은(는) '{1}'을(를) 구현할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ClosedBadDerivedTypesProperty">
+        <source>'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.</source>
+        <target state="new">'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ClosedBaseTypeBaseFromOtherAssembly">
         <source>'{0}': cannot use a closed type '{1}' from another assembly as a base type.</source>
         <target state="translated">'{0}': 다른 어셈블리의 닫힌 형식 '{1}'을(를) 기본 형식으로 사용할 수 없습니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -532,6 +532,11 @@
         <target state="translated">Element „{0}” nie implementuje składowej interfejsu „{1}”. Element „{2}” nie może implementować elementu „{1}”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ClosedBadDerivedTypesProperty">
+        <source>'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.</source>
+        <target state="new">'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ClosedBaseTypeBaseFromOtherAssembly">
         <source>'{0}': cannot use a closed type '{1}' from another assembly as a base type.</source>
         <target state="translated">„{0}”: nie można użyć typu zamkniętego „{1}” z innego zestawu jako typu podstawowego.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -532,6 +532,11 @@
         <target state="translated">'{0}' não implementa o membro de interface '{1}'. '{2}' não pode implementar '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ClosedBadDerivedTypesProperty">
+        <source>'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.</source>
+        <target state="new">'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ClosedBaseTypeBaseFromOtherAssembly">
         <source>'{0}': cannot use a closed type '{1}' from another assembly as a base type.</source>
         <target state="translated">''{0}'': não é possível usar um tipo fechado ''{1}'' de outro assembly como um tipo base.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -532,6 +532,11 @@
         <target state="translated">"{0}" не реализует элемент интерфейса "{1}". "{2}" не может реализовывать "{1}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ClosedBadDerivedTypesProperty">
+        <source>'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.</source>
+        <target state="new">'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ClosedBaseTypeBaseFromOtherAssembly">
         <source>'{0}': cannot use a closed type '{1}' from another assembly as a base type.</source>
         <target state="translated">"{0}": невозможно использовать закрытый тип "{1}" из другой сборки в качестве базового типа.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -532,6 +532,11 @@
         <target state="translated">'{0}, '{1}' arabirim üyesini uygulamıyor. '{2}', '{1}' üyesini uygulayamaz.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ClosedBadDerivedTypesProperty">
+        <source>'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.</source>
+        <target state="new">'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ClosedBaseTypeBaseFromOtherAssembly">
         <source>'{0}': cannot use a closed type '{1}' from another assembly as a base type.</source>
         <target state="translated">'{0}': başka bir derlemedeki '{1}' kapalı türü temel tür olarak kullanılamaz.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -532,6 +532,11 @@
         <target state="translated">“{0}”不实现接口成员“{1}”。“{2}”无法实现“{1}”。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ClosedBadDerivedTypesProperty">
+        <source>'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.</source>
+        <target state="new">'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ClosedBaseTypeBaseFromOtherAssembly">
         <source>'{0}': cannot use a closed type '{1}' from another assembly as a base type.</source>
         <target state="translated">“{0}”: 无法使用其他程序集中的闭合类型”{1}”作为基类型。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -532,6 +532,11 @@
         <target state="translated">'{0}' 未實作介面成員 '{1}'。'{2}' 無法實作 '{1}'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ClosedBadDerivedTypesProperty">
+        <source>'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.</source>
+        <target state="new">'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ClosedBaseTypeBaseFromOtherAssembly">
         <source>'{0}': cannot use a closed type '{1}' from another assembly as a base type.</source>
         <target state="translated">'{0}': 無法使用來自另一個組件的封閉型別 '{1}' 作為基底型別。</target>

--- a/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
@@ -104,7 +104,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 extends [System.Runtime]System.Object
             {
                 .custom instance void System.Runtime.CompilerServices.IsClosedTypeAttribute::.ctor() = (
-                    01 00 00 00
+                    01 00 01 00 54 1d 50 0c 44 65 72 69 76 65 64 54
+                    79 70 65 73 00 00 00 00
                 )
                 // Methods
                 .method family hidebysig specialname rtspecialname 
@@ -157,7 +158,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 extends [System.Runtime]System.Object
             {
                 .custom instance void System.Runtime.CompilerServices.IsClosedTypeAttribute::.ctor() = (
-                    01 00 00 00
+                    01 00 01 00 54 1d 50 0c 44 65 72 69 76 65 64 54
+                    79 70 65 73 00 00 00 00
                 )
                 // Methods
                 .method public hidebysig specialname rtspecialname 
@@ -1042,7 +1044,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
             // Get attributes from metadata without doing any filtering
             AssertEx.SetEqual([
                     "System.Runtime.CompilerServices.RequiredMemberAttribute",
-                    "System.Runtime.CompilerServices.IsClosedTypeAttribute"
+                    "System.Runtime.CompilerServices.IsClosedTypeAttribute(DerivedTypes = {})"
                 ],
                 GetAttributeStrings(peModule.GetCustomAttributesForToken(classC.Handle)));
             AssertEx.SetEqual([
@@ -1116,7 +1118,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
             // Get attributes from metadata without doing any filtering
             AssertEx.SetEqual([
                     "System.Runtime.CompilerServices.RequiredMemberAttribute",
-                    "System.Runtime.CompilerServices.IsClosedTypeAttribute"
+                    "System.Runtime.CompilerServices.IsClosedTypeAttribute(DerivedTypes = {})"
                 ],
                 GetAttributeStrings(peModule.GetCustomAttributesForToken(classC.Handle)));
 

--- a/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
@@ -812,11 +812,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
             """;
 
         var comp = CreateCompilation([source, isClosedTypeAttribute], targetFramework: TargetFramework.Net100);
-        comp.VerifyDiagnostics(
-            // (1,14): error CS9395: 'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.
-            // closed class C;
-            Diagnostic(ErrorCode.ERR_ClosedBadDerivedTypesProperty, "C").WithLocation(1, 14)
-            );
+        comp.VerifyDiagnostics();
     }
 
     [Fact]
@@ -843,13 +839,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
             """;
 
         var comp = CreateCompilation([source, isClosedTypeAttribute], targetFramework: TargetFramework.Net100);
-        comp.VerifyDiagnostics(
-            // (1,14): error CS9395: 'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.
-            // closed class C;
-            Diagnostic(ErrorCode.ERR_ClosedBadDerivedTypesProperty, "C").WithLocation(1, 14),
-            // (1,14): error CS9395: 'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.
-            // closed class C;
-            Diagnostic(ErrorCode.ERR_ClosedBadDerivedTypesProperty, "C").WithLocation(1, 14));
+        comp.VerifyDiagnostics();
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
@@ -542,7 +542,6 @@ public sealed class ClosedClassesTests : CSharpTestBase
             """;
 
         var comp = CreateCompilation([source, isClosedTypeAttribute], targetFramework: TargetFramework.Net100);
-        comp.MakeTypeMissing(WellKnownType.System_Type);
 
         var verifier = CompileAndVerify(comp, symbolValidator: verifyMetadata, verify: Verification.Skipped);
         verifier.VerifyDiagnostics();
@@ -556,6 +555,143 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 ],
                 GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
         }
+    }
+
+    [Fact]
+    public void DerivedTypesMetadata_11()
+    {
+        // DerivedTypes from IL is missing a type
+        var ilSource = """
+      .class private auto ansi abstract beforefieldinit C
+          extends [mscorlib]System.Object
+      {
+          .custom instance void System.Runtime.CompilerServices.IsClosedTypeAttribute::.ctor() = (
+              01 00 01 00 54 1d 50 0c 44 65 72 69 76 65 64 54 // ...DerivedT
+              79 70 65 73 01 00 00 00 02 44 31                // ypes...D1
+          )
+          // Methods
+          .method family hidebysig specialname rtspecialname 
+              instance void .ctor () cil managed 
+          {
+              .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute::.ctor(string) = (
+                  01 00 0d 43 6c 6f 73 65 64 43 6c 61 73 73 65 73
+                  00 00
+              )
+              // Method begins at RVA 0x2050
+              // Code size 7 (0x7)
+              .maxstack 8
+              IL_0000: ldarg.0
+              IL_0001: call instance void [mscorlib]System.Object::.ctor()
+              IL_0006: ret
+          } // end of method C::.ctor
+      } // end of class C
+
+      .class private auto ansi beforefieldinit D1
+          extends C
+      {
+          // Methods
+          .method public hidebysig specialname rtspecialname 
+              instance void .ctor () cil managed 
+          {
+              // Method begins at RVA 0x2058
+              // Code size 7 (0x7)
+              .maxstack 8
+              IL_0000: ldarg.0
+              IL_0001: call instance void C::.ctor()
+              IL_0006: ret
+          } // end of method D1::.ctor
+      } // end of class D1
+
+      .class private auto ansi beforefieldinit D2
+          extends C
+      {
+          // Methods
+          .method public hidebysig specialname rtspecialname 
+              instance void .ctor () cil managed 
+          {
+              // Method begins at RVA 0x2058
+              // Code size 7 (0x7)
+              .maxstack 8
+              IL_0000: ldarg.0
+              IL_0001: call instance void C::.ctor()
+              IL_0006: ret
+          } // end of method D2::.ctor
+      } // end of class D2
+
+      .class public auto ansi sealed beforefieldinit System.Runtime.CompilerServices.IsClosedTypeAttribute
+          extends [mscorlib]System.Attribute
+      {
+          .custom instance void [mscorlib]System.AttributeUsageAttribute::.ctor(valuetype [mscorlib]System.AttributeTargets) = (
+              01 00 04 00 00 00 02 00 54 02 0d 41 6c 6c 6f 77
+              4d 75 6c 74 69 70 6c 65 00 54 02 09 49 6e 68 65
+              72 69 74 65 64 00
+          )
+          // Fields
+          .field private class [mscorlib]System.Type[] '<DerivedTypes>k__BackingField'
+          .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+              01 00 00 00
+          )
+          // Methods
+          .method public hidebysig specialname 
+              instance class [mscorlib]System.Type[] get_DerivedTypes () cil managed 
+          {
+              .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+                  01 00 00 00
+              )
+              // Method begins at RVA 0x2060
+              // Code size 7 (0x7)
+              .maxstack 8
+              IL_0000: ldarg.0
+              IL_0001: ldfld class [mscorlib]System.Type[] System.Runtime.CompilerServices.IsClosedTypeAttribute::'<DerivedTypes>k__BackingField'
+              IL_0006: ret
+          } // end of method IsClosedTypeAttribute::get_DerivedTypes
+          .method public hidebysig specialname 
+              instance void set_DerivedTypes (
+                  class [mscorlib]System.Type[] 'value'
+              ) cil managed 
+          {
+              .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+                  01 00 00 00
+              )
+              // Method begins at RVA 0x2068
+              // Code size 8 (0x8)
+              .maxstack 8
+              IL_0000: ldarg.0
+              IL_0001: ldarg.1
+              IL_0002: stfld class [mscorlib]System.Type[] System.Runtime.CompilerServices.IsClosedTypeAttribute::'<DerivedTypes>k__BackingField'
+              IL_0007: ret
+          } // end of method IsClosedTypeAttribute::set_DerivedTypes
+          .method public hidebysig specialname rtspecialname 
+              instance void .ctor () cil managed 
+          {
+              // Method begins at RVA 0x2071
+              // Code size 7 (0x7)
+              .maxstack 8
+              IL_0000: ldarg.0
+              IL_0001: call instance void [mscorlib]System.Attribute::.ctor()
+              IL_0006: ret
+          } // end of method IsClosedTypeAttribute::.ctor
+          // Properties
+          .property instance class [mscorlib]System.Type[] DerivedTypes()
+          {
+              .get instance class [mscorlib]System.Type[] System.Runtime.CompilerServices.IsClosedTypeAttribute::get_DerivedTypes()
+              .set instance void System.Runtime.CompilerServices.IsClosedTypeAttribute::set_DerivedTypes(class [mscorlib]System.Type[])
+          }
+      } // end of class System.Runtime.CompilerServices.IsClosedTypeAttribute
+      """;
+
+        var comp = CreateCompilationWithIL("", ilSource, TargetFramework.Net100);
+
+        var peType = (PENamedTypeSymbol)comp.GetMember("C");
+        var peModule = peType.ContainingPEModule;
+        AssertEx.SetEqual([
+                "System.Runtime.CompilerServices.IsClosedTypeAttribute(DerivedTypes = {typeof(D1)})"
+            ],
+            GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
+
+        AssertEx.SetEqual(["D1", "D2"], peType.CandidateClosedSubtypeDefinitions.ToTestDisplayStrings());
+        Assert.True(peType.TryGetClosedSubtypes(out var subtypes));
+        AssertEx.SetEqual(["D1", "D2"], subtypes.ToTestDisplayStrings());
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
@@ -238,7 +238,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
                     if (derivedType.IsConstructedGenericType)
                         throw new Exception(); // unexpected
 
-                    if (derivedType.GetGenericArguments() is [_, ..] args)
+                    if (derivedType.GetGenericArguments() is { Length: > 0 } args)
                     {
                         if (!derivedType.IsGenericTypeDefinition)
                             throw new Exception(); // unexpected
@@ -279,10 +279,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
             """;
 
         var verifier = CompileAndVerify(
-            [source, IsClosedTypeAttributeDefinition, s_reportHelper],
+            [source, IsClosedTypeAttributeDefinition, s_reportHelper, CompilerFeatureRequiredAttribute],
             symbolValidator: verifyMetadata,
-            targetFramework: TargetFramework.Net100,
-            verify: Verification.Skipped,
             expectedOutput: "2 D1 D2 <null>");
         verifier.VerifyDiagnostics();
 
@@ -327,10 +325,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
             """;
 
         var verifier = CompileAndVerify(
-            [source, IsClosedTypeAttributeDefinition, s_reportHelper],
+            [source, IsClosedTypeAttributeDefinition, s_reportHelper, CompilerFeatureRequiredAttribute],
             symbolValidator: verifyMetadata,
-            targetFramework: TargetFramework.Net100,
-            verify: Verification.Skipped,
             expectedOutput: "2 D1 D2 2 D3 D4 <null>");
         verifier.VerifyDiagnostics();
 
@@ -368,10 +364,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
             """;
 
         var verifier = CompileAndVerify(
-            [source, IsClosedTypeAttributeDefinition, s_reportHelper],
+            [source, IsClosedTypeAttributeDefinition, s_reportHelper, CompilerFeatureRequiredAttribute],
             symbolValidator: verifyMetadata,
-            targetFramework: TargetFramework.Net100,
-            verify: Verification.Skipped,
             expectedOutput: "5 D1 D2 D3`1[T] D4`1[T] D5`2[T,U]");
         verifier.VerifyDiagnostics();
 
@@ -404,10 +398,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
             """;
 
         var verifier = CompileAndVerify(
-            [source, IsClosedTypeAttributeDefinition, s_reportHelper],
+            [source, IsClosedTypeAttributeDefinition, s_reportHelper, CompilerFeatureRequiredAttribute],
             symbolValidator: verifyMetadata,
-            targetFramework: TargetFramework.Net100,
-            verify: Verification.Skipped,
             expectedOutput: "2 Container`1+D1`1[T,U] Container`1+D2[T] 2 Container`1+D1`1[T,U] Container`1+D2[T]");
         verifier.VerifyDiagnostics();
 
@@ -460,9 +452,9 @@ public sealed class ClosedClassesTests : CSharpTestBase
             }
             """;
 
-        var comp = CreateCompilation([source, isClosedTypeAttribute], targetFramework: TargetFramework.Net100);
+        var comp = CreateCompilation([source, isClosedTypeAttribute, CompilerFeatureRequiredAttribute]);
 
-        var verifier = CompileAndVerify(comp, symbolValidator: verifyMetadata, verify: Verification.Skipped);
+        var verifier = CompileAndVerify(comp, symbolValidator: verifyMetadata);
         verifier.VerifyDiagnostics();
 
         void verifyMetadata(ModuleSymbol module)

--- a/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
@@ -135,6 +135,16 @@ public sealed class ClosedClassesTests : CSharpTestBase
             var ctor = classC.Constructors.Single();
             // CompilerFeatureRequiredAttribute is filtered out
             Assert.Empty(ctor.GetAttributes());
+
+            if (module is PEModuleSymbol peModule)
+            {
+                var peType = (PENamedTypeSymbol)classC;
+                // Get attributes from metadata without doing any filtering
+                AssertEx.SetEqual([
+                        "System.Runtime.CompilerServices.IsClosedTypeAttribute(DerivedTypes = {})"
+                    ],
+                    GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
+            }
         }
     }
 
@@ -201,6 +211,350 @@ public sealed class ClosedClassesTests : CSharpTestBase
             Assert.True(classC.IsClosed);
             // attribute is filtered out of source and metadata symbols.
             Assert.Empty(classC.GetAttributes());
+        }
+    }
+
+    [Fact]
+    public void DerivedTypesMetadata_01()
+    {
+        // simple case
+        var source = """
+            closed class C;
+
+            class D1 : C;
+            class D2 : C;
+
+            class D3 : D1;
+            """;
+
+        var verifier = CompileAndVerify([source, IsClosedTypeAttributeDefinition], symbolValidator: verifyMetadata, targetFramework: TargetFramework.Net100, verify: Verification.Skipped);
+        verifier.VerifyDiagnostics();
+
+        void verifyMetadata(ModuleSymbol module)
+        {
+            var classC = module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
+            Assert.True(classC.IsClosed);
+            // attribute is filtered out of source and metadata symbols.
+            Assert.Empty(classC.GetAttributes());
+
+            var peModule = (PEModuleSymbol)module;
+            var peType = (PENamedTypeSymbol)classC;
+            // Get attributes from metadata without doing any filtering
+            AssertEx.SetEqual([
+                    "System.Runtime.CompilerServices.IsClosedTypeAttribute(DerivedTypes = {typeof(D1), typeof(D2)})"
+                ],
+                GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
+
+            peType = (PENamedTypeSymbol)module.GlobalNamespace.GetMember<NamedTypeSymbol>("D1");
+            AssertEx.Empty(GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
+        }
+    }
+
+    [Fact]
+    public void DerivedTypesMetadata_02()
+    {
+        // nested hierarchy
+        var source = """
+            closed class C;
+
+            closed class D1 : C;
+            class D2 : C;
+
+            class D3 : D1;
+            class D4 : D1;
+
+            class D5 : D4;
+            """;
+
+        var verifier = CompileAndVerify([source, IsClosedTypeAttributeDefinition], symbolValidator: verifyMetadata, targetFramework: TargetFramework.Net100, verify: Verification.Skipped);
+        verifier.VerifyDiagnostics();
+
+        void verifyMetadata(ModuleSymbol module)
+        {
+            var peModule = (PEModuleSymbol)module;
+            var peType = (PENamedTypeSymbol)module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
+            AssertEx.SetEqual([
+                    "System.Runtime.CompilerServices.IsClosedTypeAttribute(DerivedTypes = {typeof(D1), typeof(D2)})"
+                ],
+                GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
+
+            peType = (PENamedTypeSymbol)module.GlobalNamespace.GetMember<NamedTypeSymbol>("D1");
+            AssertEx.SetEqual([
+                    "System.Runtime.CompilerServices.IsClosedTypeAttribute(DerivedTypes = {typeof(D3), typeof(D4)})"
+                ],
+                GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
+        }
+    }
+
+    [Fact]
+    public void DerivedTypesMetadata_03()
+    {
+        // various generic subtypes
+        var source = """
+            closed class C<T>;
+
+            class D1 : C<string>;
+            class D2 : C<int>;
+            class D3<T> : C<T>;
+            class D4<T> : C<T*[]> where T : unmanaged;
+            class D5<T, U> : C<(T, U)>;
+            """;
+
+        var verifier = CompileAndVerify([source, IsClosedTypeAttributeDefinition], symbolValidator: verifyMetadata, targetFramework: TargetFramework.Net100, verify: Verification.Skipped);
+        verifier.VerifyDiagnostics();
+
+        void verifyMetadata(ModuleSymbol module)
+        {
+            var peModule = (PEModuleSymbol)module;
+            var peType = (PENamedTypeSymbol)module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
+            AssertEx.SetEqual([
+                    "System.Runtime.CompilerServices.IsClosedTypeAttribute(DerivedTypes = {typeof(D1), typeof(D2), typeof(D3<>), typeof(D4<>), typeof(D5<,>)})"
+                ],
+                GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
+        }
+    }
+
+    [Fact]
+    public void DerivedTypesMetadata_04()
+    {
+        // nested generic subtype
+        var source = """
+            closed class C<T, U>;
+
+            class Container<T>
+            {
+                internal class D1<U> : C<T, U>;
+                internal class D2 : C<T, string>;
+            }
+            """;
+
+        var verifier = CompileAndVerify([source, IsClosedTypeAttributeDefinition], symbolValidator: verifyMetadata, targetFramework: TargetFramework.Net100, verify: Verification.Skipped);
+        verifier.VerifyDiagnostics();
+
+        void verifyMetadata(ModuleSymbol module)
+        {
+            var peModule = (PEModuleSymbol)module;
+            var peType = (PENamedTypeSymbol)module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
+            AssertEx.SetEqual([
+                    "System.Runtime.CompilerServices.IsClosedTypeAttribute(DerivedTypes = {typeof(Container<>.D1<>), typeof(Container<>.D2)})"
+                ],
+                GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
+        }
+    }
+
+    [Fact]
+    public void DerivedTypesMetadata_05()
+    {
+        // System.Type is missing
+        var source = """
+            closed class C;
+
+            class D1 : C;
+            class D2 : C;
+            """;
+
+        var comp = CreateCompilation([source, IsClosedTypeAttributeDefinition], targetFramework: TargetFramework.Net100);
+        comp.MakeTypeMissing(WellKnownType.System_Type);
+
+        var verifier = CompileAndVerify(comp, symbolValidator: verifyMetadata, verify: Verification.Skipped);
+        verifier.VerifyDiagnostics();
+
+        void verifyMetadata(ModuleSymbol module)
+        {
+            var peModule = (PEModuleSymbol)module;
+            var peType = (PENamedTypeSymbol)module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
+            AssertEx.SetEqual([
+                    "System.Runtime.CompilerServices.IsClosedTypeAttribute"
+                ],
+                GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
+        }
+    }
+
+    [Fact]
+    public void DerivedTypesMetadata_06()
+    {
+        // DerivedTypes property is missing
+        var source = """
+            closed class C;
+
+            class D1 : C;
+            class D2 : C;
+            """;
+
+        var isClosedTypeAttribute = """
+            namespace System.Runtime.CompilerServices
+            {
+                [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+                public sealed class IsClosedTypeAttribute : Attribute;
+            }
+            """;
+
+        var comp = CreateCompilation([source, isClosedTypeAttribute], targetFramework: TargetFramework.Net100);
+
+        var verifier = CompileAndVerify(comp, symbolValidator: verifyMetadata, verify: Verification.Skipped);
+        verifier.VerifyDiagnostics();
+
+        void verifyMetadata(ModuleSymbol module)
+        {
+            var peModule = (PEModuleSymbol)module;
+            var peType = (PENamedTypeSymbol)module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
+            AssertEx.SetEqual([
+                    "System.Runtime.CompilerServices.IsClosedTypeAttribute"
+                ],
+                GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
+        }
+    }
+
+    [Fact]
+    public void DerivedTypesMetadata_07()
+    {
+        // DerivedTypes only has getter
+        var source = """
+            closed class C;
+
+            class D1 : C;
+            class D2 : C;
+            """;
+
+        var isClosedTypeAttribute = """
+            namespace System.Runtime.CompilerServices
+            {
+                [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+                public sealed class IsClosedTypeAttribute : Attribute
+                {
+                    public Type[] DerivedTypes { get; }
+                }
+            }
+            """;
+
+        var comp = CreateCompilation([source, isClosedTypeAttribute], targetFramework: TargetFramework.Net100);
+
+        var verifier = CompileAndVerify(comp, symbolValidator: verifyMetadata, verify: Verification.Skipped);
+        verifier.VerifyDiagnostics();
+
+        void verifyMetadata(ModuleSymbol module)
+        {
+            var peModule = (PEModuleSymbol)module;
+            var peType = (PENamedTypeSymbol)module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
+            AssertEx.SetEqual([
+                    "System.Runtime.CompilerServices.IsClosedTypeAttribute(DerivedTypes = {typeof(D1), typeof(D2)})"
+                ],
+                GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
+        }
+    }
+
+    [Fact]
+    public void DerivedTypesMetadata_08()
+    {
+        // DerivedTypes only has setter
+        var source = """
+            closed class C;
+
+            class D1 : C;
+            class D2 : C;
+            """;
+
+        var isClosedTypeAttribute = """
+            namespace System.Runtime.CompilerServices
+            {
+                [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+                public sealed class IsClosedTypeAttribute : Attribute
+                {
+                    public Type[] DerivedTypes { set { } }
+                }
+            }
+            """;
+
+        var comp = CreateCompilation([source, isClosedTypeAttribute], targetFramework: TargetFramework.Net100);
+
+        var verifier = CompileAndVerify(comp, symbolValidator: verifyMetadata, verify: Verification.Skipped);
+        verifier.VerifyDiagnostics();
+
+        void verifyMetadata(ModuleSymbol module)
+        {
+            var peModule = (PEModuleSymbol)module;
+            var peType = (PENamedTypeSymbol)module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
+            AssertEx.SetEqual([
+                    "System.Runtime.CompilerServices.IsClosedTypeAttribute(DerivedTypes = {typeof(D1), typeof(D2)})"
+                ],
+                GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
+        }
+    }
+
+    [Fact]
+    public void DerivedTypesMetadata_09()
+    {
+        // DerivedTypes inaccessible setter
+        var source = """
+            closed class C;
+
+            class D1 : C;
+            class D2 : C;
+            """;
+
+        var isClosedTypeAttribute = """
+            namespace System.Runtime.CompilerServices
+            {
+                [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+                public sealed class IsClosedTypeAttribute : Attribute
+                {
+                    public Type[] DerivedTypes { get; private set; }
+                }
+            }
+            """;
+
+        var comp = CreateCompilation([source, isClosedTypeAttribute], targetFramework: TargetFramework.Net100);
+
+        var verifier = CompileAndVerify(comp, symbolValidator: verifyMetadata, verify: Verification.Skipped);
+        verifier.VerifyDiagnostics();
+
+        void verifyMetadata(ModuleSymbol module)
+        {
+            var peModule = (PEModuleSymbol)module;
+            var peType = (PENamedTypeSymbol)module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
+            AssertEx.SetEqual([
+                    "System.Runtime.CompilerServices.IsClosedTypeAttribute(DerivedTypes = {typeof(D1), typeof(D2)})"
+                ],
+                GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
+        }
+    }
+
+    [Fact]
+    public void DerivedTypesMetadata_10()
+    {
+        // DerivedTypes wrong type
+        var source = """
+            closed class C;
+
+            class D1 : C;
+            class D2 : C;
+            """;
+
+        var isClosedTypeAttribute = """
+            namespace System.Runtime.CompilerServices
+            {
+                [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+                public sealed class IsClosedTypeAttribute : Attribute
+                {
+                    public int[] DerivedTypes { get; set; }
+                }
+            }
+            """;
+
+        var comp = CreateCompilation([source, isClosedTypeAttribute], targetFramework: TargetFramework.Net100);
+        comp.MakeTypeMissing(WellKnownType.System_Type);
+
+        var verifier = CompileAndVerify(comp, symbolValidator: verifyMetadata, verify: Verification.Skipped);
+        verifier.VerifyDiagnostics();
+
+        void verifyMetadata(ModuleSymbol module)
+        {
+            var peModule = (PEModuleSymbol)module;
+            var peType = (PENamedTypeSymbol)module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
+            AssertEx.SetEqual([
+                    "System.Runtime.CompilerServices.IsClosedTypeAttribute"
+                ],
+                GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
         }
     }
 
@@ -683,6 +1037,20 @@ public sealed class ClosedClassesTests : CSharpTestBase
 
         var classC = comp1.GetMember<NamedTypeSymbol>("C");
         Assert.False(classC.TryGetClosedSubtypes(out _));
+
+        CompileAndVerify(comp1, symbolValidator: verifyMetadata);
+        void verifyMetadata(ModuleSymbol module)
+        {
+            var peModule = (PEModuleSymbol)module;
+            {
+                var peType = (PENamedTypeSymbol)module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
+                // Get attributes from metadata without doing any filtering
+                AssertEx.SetEqual([
+                        "System.Runtime.CompilerServices.IsClosedTypeAttribute(DerivedTypes = {typeof(D1<>), typeof(D2<>), typeof(D3<>)})"
+                    ],
+                    GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
+            }
+        }
     }
 
     [Fact]
@@ -721,6 +1089,20 @@ public sealed class ClosedClassesTests : CSharpTestBase
         var classC = comp1.GetMember<NamedTypeSymbol>("C");
         Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
         Assert.Equal(["Outer<T>.D"], subtypes.ToTestDisplayStrings());
+
+        CompileAndVerify(comp1, symbolValidator: verifyMetadata);
+        void verifyMetadata(ModuleSymbol module)
+        {
+            var peModule = (PEModuleSymbol)module;
+            {
+                var peType = (PENamedTypeSymbol)module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
+                // Get attributes from metadata without doing any filtering
+                AssertEx.SetEqual([
+                        "System.Runtime.CompilerServices.IsClosedTypeAttribute(DerivedTypes = {typeof(Outer<>.D)})"
+                    ],
+                    GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
+            }
+        }
     }
 
     [Fact]
@@ -760,6 +1142,20 @@ public sealed class ClosedClassesTests : CSharpTestBase
         var classC = comp1.GetMember<NamedTypeSymbol>("C");
         Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
         Assert.Equal(["D"], subtypes.ToTestDisplayStrings());
+
+        CompileAndVerify(comp1, symbolValidator: verifyMetadata);
+        void verifyMetadata(ModuleSymbol module)
+        {
+            var peModule = (PEModuleSymbol)module;
+            {
+                var peType = (PENamedTypeSymbol)module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
+                // Get attributes from metadata without doing any filtering
+                AssertEx.SetEqual([
+                        "System.Runtime.CompilerServices.IsClosedTypeAttribute(DerivedTypes = {typeof(D)})"
+                    ],
+                    GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
+            }
+        }
     }
 
     [Fact]
@@ -1155,6 +1551,16 @@ public sealed class ClosedClassesTests : CSharpTestBase
             Assert.Equal("C", classC.ToTestDisplayString());
             Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
             Assert.Equal(["D1", "D2"], subtypes.ToTestDisplayStrings());
+
+            if (module is PEModuleSymbol peModule)
+            {
+                var peType = (PENamedTypeSymbol)classC;
+                // Get attributes from metadata without doing any filtering
+                AssertEx.SetEqual([
+                        "System.Runtime.CompilerServices.IsClosedTypeAttribute(DerivedTypes = {typeof(D1), typeof(D2)})"
+                    ],
+                    GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
+            }
         }
     }
 

--- a/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
@@ -909,6 +909,75 @@ public sealed class ClosedClassesTests : CSharpTestBase
     }
 
     [Fact]
+    public void DerivedTypesMetadata_18()
+    {
+        // DerivedTypes has a 'CompilerFeatureRequiredAttribute' for an unsupported feature, resulting in a use-site error.
+        var il = """
+            .assembly extern System.Runtime { .ver 10:0:0:0 .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A) }
+
+            .class public auto ansi sealed beforefieldinit System.Runtime.CompilerServices.IsClosedTypeAttribute
+                extends [System.Runtime]System.Attribute
+            {
+                .custom instance void [System.Runtime]System.AttributeUsageAttribute::.ctor(valuetype [System.Runtime]System.AttributeTargets) = (
+                    01 00 04 00 00 00 02 00 54 02 0d 41 6c 6c 6f 77
+                    4d 75 6c 74 69 70 6c 65 00 54 02 09 49 6e 68 65
+                    72 69 74 65 64 00
+                )
+                // Fields
+                .field private class [System.Runtime]System.Type[] '<DerivedTypes>k__BackingField'
+                // Methods
+                .method public hidebysig specialname 
+                    instance class [System.Runtime]System.Type[] get_DerivedTypes () cil managed 
+                {
+                    IL_0000: ldarg.0
+                    IL_0001: ldfld class [System.Runtime]System.Type[] System.Runtime.CompilerServices.IsClosedTypeAttribute::'<DerivedTypes>k__BackingField'
+                    IL_0006: ret
+                } // end of method IsClosedTypeAttribute::get_DerivedTypes
+                .method public hidebysig specialname 
+                    instance void set_DerivedTypes (
+                        class [System.Runtime]System.Type[] 'value'
+                    ) cil managed 
+                {
+                    IL_0000: ldarg.0
+                    IL_0001: ldarg.1
+                    IL_0002: stfld class [System.Runtime]System.Type[] System.Runtime.CompilerServices.IsClosedTypeAttribute::'<DerivedTypes>k__BackingField'
+                    IL_0007: ret
+                } // end of method IsClosedTypeAttribute::set_DerivedTypes
+                .method public hidebysig specialname rtspecialname 
+                    instance void .ctor () cil managed 
+                {
+                    IL_0000: ldarg.0
+                    IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+                    IL_0006: ret
+                } // end of method IsClosedTypeAttribute::.ctor
+                // Properties
+                .property instance class [System.Runtime]System.Type[] DerivedTypes()
+                {
+                    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute::.ctor(string) = (
+                        01 00 0b 4e 6f 6e 65 78 69 73 74 65 6e 74 00 00 // ...Nonexistent
+                    )
+                    .get instance class [System.Runtime]System.Type[] System.Runtime.CompilerServices.IsClosedTypeAttribute::get_DerivedTypes()
+                    .set instance void System.Runtime.CompilerServices.IsClosedTypeAttribute::set_DerivedTypes(class [System.Runtime]System.Type[])
+                }
+            } // end of class System.Runtime.CompilerServices.IsClosedTypeAttribute
+            """;
+
+        var ilComp = CompileIL(il);
+        var source = """
+            closed class C;
+
+            class D1 : C;
+            class D2 : C;
+            """;
+
+        var comp = CreateCompilation(source, references: [ilComp], targetFramework: TargetFramework.Net100);
+        comp.VerifyEmitDiagnostics(
+            // (1,14): error CS9041: 'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' requires compiler feature 'Nonexistent', which is not supported by this version of the C# compiler.
+            // closed class C;
+            Diagnostic(ErrorCode.ERR_UnsupportedCompilerFeature, "C").WithArguments("System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes", "Nonexistent").WithLocation(1, 14));
+    }
+
+    [Fact]
     public void PublicAPI_01()
     {
         var source = """

--- a/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
@@ -435,19 +435,10 @@ public sealed class ClosedClassesTests : CSharpTestBase
 
         var comp = CreateCompilation([source, IsClosedTypeAttributeDefinition], targetFramework: TargetFramework.Net100);
         comp.MakeTypeMissing(WellKnownType.System_Type);
-
-        var verifier = CompileAndVerify(comp, symbolValidator: verifyMetadata, verify: Verification.Skipped);
-        verifier.VerifyDiagnostics();
-
-        void verifyMetadata(ModuleSymbol module)
-        {
-            var peModule = (PEModuleSymbol)module;
-            var peType = (PENamedTypeSymbol)module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
-            AssertEx.SetEqual([
-                    "System.Runtime.CompilerServices.IsClosedTypeAttribute"
-                ],
-                GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
-        }
+        comp.VerifyDiagnostics(
+            // (1,14): error CS9395: 'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.
+            // closed class C;
+            Diagnostic(ErrorCode.ERR_ClosedBadDerivedTypesProperty, "C").WithLocation(1, 14));
     }
 
     [Fact]
@@ -508,19 +499,10 @@ public sealed class ClosedClassesTests : CSharpTestBase
             """;
 
         var comp = CreateCompilation([source, isClosedTypeAttribute], targetFramework: TargetFramework.Net100);
-
-        var verifier = CompileAndVerify(comp, symbolValidator: verifyMetadata, verify: Verification.Skipped);
-        verifier.VerifyDiagnostics();
-
-        void verifyMetadata(ModuleSymbol module)
-        {
-            var peModule = (PEModuleSymbol)module;
-            var peType = (PENamedTypeSymbol)module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
-            AssertEx.SetEqual([
-                    "System.Runtime.CompilerServices.IsClosedTypeAttribute(DerivedTypes = {typeof(D1), typeof(D2)})"
-                ],
-                GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
-        }
+        comp.VerifyDiagnostics(
+            // (1,14): error CS9395: The property 'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.
+            // closed class C;
+            Diagnostic(ErrorCode.ERR_ClosedBadDerivedTypesProperty, "C").WithLocation(1, 14));
     }
 
     [Fact]
@@ -546,23 +528,43 @@ public sealed class ClosedClassesTests : CSharpTestBase
             """;
 
         var comp = CreateCompilation([source, isClosedTypeAttribute], targetFramework: TargetFramework.Net100);
-
-        var verifier = CompileAndVerify(comp, symbolValidator: verifyMetadata, verify: Verification.Skipped);
-        verifier.VerifyDiagnostics();
-
-        void verifyMetadata(ModuleSymbol module)
-        {
-            var peModule = (PEModuleSymbol)module;
-            var peType = (PENamedTypeSymbol)module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
-            AssertEx.SetEqual([
-                    "System.Runtime.CompilerServices.IsClosedTypeAttribute(DerivedTypes = {typeof(D1), typeof(D2)})"
-                ],
-                GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
-        }
+        comp.VerifyDiagnostics(
+            // (1,14): error CS9395: The property 'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.
+            // closed class C;
+            Diagnostic(ErrorCode.ERR_ClosedBadDerivedTypesProperty, "C").WithLocation(1, 14));
     }
 
     [Fact]
     public void DerivedTypesMetadata_09()
+    {
+        // DerivedTypes getter is internal.
+        var source = """
+            closed class C;
+
+            class D1 : C;
+            class D2 : C;
+            """;
+
+        var isClosedTypeAttribute = """
+            namespace System.Runtime.CompilerServices
+            {
+                [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+                public sealed class IsClosedTypeAttribute : Attribute
+                {
+                    public Type[] DerivedTypes { internal get; set; }
+                }
+            }
+            """;
+
+        var comp = CreateCompilation([source, isClosedTypeAttribute], targetFramework: TargetFramework.Net100);
+        comp.VerifyEmitDiagnostics(
+            // (1,14): error CS9395: The property 'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.
+            // closed class C;
+            Diagnostic(ErrorCode.ERR_ClosedBadDerivedTypesProperty, "C").WithLocation(1, 14));
+    }
+
+    [Fact]
+    public void DerivedTypesMetadata_10()
     {
         // DerivedTypes inaccessible setter
         var source = """
@@ -584,23 +586,14 @@ public sealed class ClosedClassesTests : CSharpTestBase
             """;
 
         var comp = CreateCompilation([source, isClosedTypeAttribute], targetFramework: TargetFramework.Net100);
-
-        var verifier = CompileAndVerify(comp, symbolValidator: verifyMetadata, verify: Verification.Skipped);
-        verifier.VerifyDiagnostics();
-
-        void verifyMetadata(ModuleSymbol module)
-        {
-            var peModule = (PEModuleSymbol)module;
-            var peType = (PENamedTypeSymbol)module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
-            AssertEx.SetEqual([
-                    "System.Runtime.CompilerServices.IsClosedTypeAttribute(DerivedTypes = {typeof(D1), typeof(D2)})"
-                ],
-                GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
-        }
+        comp.VerifyDiagnostics(
+            // (1,14): error CS9395: The property 'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.
+            // closed class C;
+            Diagnostic(ErrorCode.ERR_ClosedBadDerivedTypesProperty, "C").WithLocation(1, 14));
     }
 
     [Fact]
-    public void DerivedTypesMetadata_10()
+    public void DerivedTypesMetadata_11()
     {
         // DerivedTypes wrong type
         var source = """
@@ -622,23 +615,53 @@ public sealed class ClosedClassesTests : CSharpTestBase
             """;
 
         var comp = CreateCompilation([source, isClosedTypeAttribute], targetFramework: TargetFramework.Net100);
-
-        var verifier = CompileAndVerify(comp, symbolValidator: verifyMetadata, verify: Verification.Skipped);
-        verifier.VerifyDiagnostics();
-
-        void verifyMetadata(ModuleSymbol module)
-        {
-            var peModule = (PEModuleSymbol)module;
-            var peType = (PENamedTypeSymbol)module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
-            AssertEx.SetEqual([
-                    "System.Runtime.CompilerServices.IsClosedTypeAttribute"
-                ],
-                GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
-        }
+        comp.VerifyDiagnostics(
+            // (1,14): error CS9395: 'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.
+            // closed class C;
+            Diagnostic(ErrorCode.ERR_ClosedBadDerivedTypesProperty, "C").WithLocation(1, 14)
+            );
     }
 
     [Fact]
-    public void DerivedTypesMetadata_11()
+    public void DerivedTypesMetadata_12()
+    {
+        // DerivedTypes property has parameters
+        var source1 = """
+            Namespace System.Runtime.CompilerServices
+                <System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple:=False, Inherited:=False)>
+                Public NotInheritable Class IsClosedTypeAttribute
+                    Inherits System.Attribute
+
+                    Private _derivedTypes As System.Type()
+
+                    Public Property DerivedTypes(Optional x As Integer = 0) As System.Type()
+                        Get
+                            Return _derivedTypes
+                        End Get
+                        Set(value As System.Type())
+                            _derivedTypes = value
+                        End Set
+                    End Property
+                End Class
+            End Namespace
+            """;
+
+        var source2 = """
+            closed class C;
+
+            class D1 : C;
+            class D2 : C;
+            """;
+
+        var comp = CreateCompilation([source2], references: [CreateVisualBasicCompilation(source1).EmitToImageReference()], targetFramework: TargetFramework.Net100);
+        comp.VerifyDiagnostics(
+            // (1,14): error CS9395: 'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.
+            // closed class C;
+            Diagnostic(ErrorCode.ERR_ClosedBadDerivedTypesProperty, "C").WithLocation(1, 14));
+    }
+
+    [Fact]
+    public void DerivedTypesMetadata_13()
     {
         // DerivedTypes from IL is missing a type
         var ilSource = """
@@ -772,6 +795,125 @@ public sealed class ClosedClassesTests : CSharpTestBase
         AssertEx.SetEqual(["D1", "D2"], peType.CandidateClosedSubtypeDefinitions.ToTestDisplayStrings());
         Assert.True(peType.TryGetClosedSubtypes(out var subtypes));
         AssertEx.SetEqual(["D1", "D2"], subtypes.ToTestDisplayStrings());
+    }
+
+    [Fact]
+    public void DerivedTypesMetadata_14()
+    {
+        // DerivedTypes is a field, not a property
+        var source = """
+            closed class C;
+
+            class D1 : C;
+            class D2 : C;
+            """;
+
+        var isClosedTypeAttribute = """
+            namespace System.Runtime.CompilerServices
+            {
+                [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+                public sealed class IsClosedTypeAttribute : Attribute
+                {
+                    public Type[] DerivedTypes;
+                }
+            }
+            """;
+
+        var comp = CreateCompilation([source, isClosedTypeAttribute], targetFramework: TargetFramework.Net100);
+        comp.VerifyDiagnostics(
+            // (1,14): error CS9395: 'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.
+            // closed class C;
+            Diagnostic(ErrorCode.ERR_ClosedBadDerivedTypesProperty, "C").WithLocation(1, 14)
+            );
+    }
+
+    [Fact]
+    public void DerivedTypesMetadata_15()
+    {
+        // DerivedTypes is a method, not a property
+        var source = """
+            closed class C;
+
+            class D1 : C;
+            class D2 : C;
+            """;
+
+        var isClosedTypeAttribute = """
+            namespace System.Runtime.CompilerServices
+            {
+                [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+                public sealed class IsClosedTypeAttribute : Attribute
+                {
+                    public Type[] DerivedTypes() => throw null;
+                }
+            }
+            """;
+
+        var comp = CreateCompilation([source, isClosedTypeAttribute], targetFramework: TargetFramework.Net100);
+        comp.VerifyDiagnostics(
+            // (1,14): error CS9395: 'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.
+            // closed class C;
+            Diagnostic(ErrorCode.ERR_ClosedBadDerivedTypesProperty, "C").WithLocation(1, 14));
+    }
+
+    [Fact]
+    public void DerivedTypesMetadata_16()
+    {
+        // DerivedTypes is static
+        var source = """
+            closed class C;
+
+            class D1 : C;
+            class D2 : C;
+            """;
+
+        var isClosedTypeAttribute = """
+            namespace System.Runtime.CompilerServices
+            {
+                [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+                public sealed class IsClosedTypeAttribute : Attribute
+                {
+                    public static Type[] DerivedTypes { get; set; }
+                }
+            }
+            """;
+
+        var comp = CreateCompilation([source, isClosedTypeAttribute], targetFramework: TargetFramework.Net100);
+        comp.VerifyDiagnostics(
+            // (1,14): error CS9395: 'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.
+            // closed class C;
+            Diagnostic(ErrorCode.ERR_ClosedBadDerivedTypesProperty, "C").WithLocation(1, 14)
+            );
+    }
+
+    [Fact]
+    public void DerivedTypesMetadata_17()
+    {
+        // DerivedTypes is ref-returning
+        var source = """
+            closed class C;
+
+            class D1 : C;
+            class D2 : C;
+            """;
+
+        var isClosedTypeAttribute = """
+            namespace System.Runtime.CompilerServices
+            {
+                [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+                public sealed class IsClosedTypeAttribute : Attribute
+                {
+                    private Type[] _derivedTypes = null;
+                    public ref Type[] DerivedTypes => ref _derivedTypes;
+                }
+            }
+            """;
+
+        var comp = CreateCompilation([source, isClosedTypeAttribute], targetFramework: TargetFramework.Net100);
+        comp.VerifyDiagnostics(
+            // (1,14): error CS9395: 'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.
+            // closed class C;
+            Diagnostic(ErrorCode.ERR_ClosedBadDerivedTypesProperty, "C").WithLocation(1, 14));
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
@@ -234,7 +234,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 Console.Write(" ");
                 foreach (var derivedType in attr.DerivedTypes)
                 {
-                    Console.Write(derivedType.FullName);                    
+                    Console.Write(derivedType.FullName);
                     if (derivedType.IsConstructedGenericType)
                         throw new Exception(); // unexpected
 

--- a/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
@@ -96,7 +96,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
             closed class C { }
             """;
 
-        var verifier = CompileAndVerify([source, IsClosedTypeAttributeDefinition], symbolValidator: verifySymbols, sourceSymbolValidator: verifySymbols, targetFramework: TargetFramework.Net100, verify: Verification.Skipped);
+        var verifier = CompileAndVerify([source, IsClosedTypeAttributeDefinition], symbolValidator: verifySymbols, sourceSymbolValidator: verifySymbols, targetFramework: TargetFramework.Net100, verify: Verification.FailsPEVerify);
         verifier.VerifyDiagnostics();
 
         verifier.VerifyTypeIL("C", """
@@ -160,7 +160,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
             }
             """;
 
-        var verifier = CompileAndVerify([source, IsClosedTypeAttributeDefinition], symbolValidator: verifySymbols, sourceSymbolValidator: verifySymbols, targetFramework: TargetFramework.Net100, verify: Verification.Skipped);
+        var verifier = CompileAndVerify([source, IsClosedTypeAttributeDefinition], symbolValidator: verifySymbols, sourceSymbolValidator: verifySymbols, targetFramework: TargetFramework.Net100, verify: Verification.FailsPEVerify);
         verifier.VerifyDiagnostics();
 
         verifier.VerifyTypeIL("C", """
@@ -1030,7 +1030,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
             class D2 : C;
             """;
 
-        var verifier = CompileAndVerify([source, IsClosedTypeAttributeDefinition], symbolValidator: verifySymbols, sourceSymbolValidator: verifySymbols, targetFramework: TargetFramework.Net100, verify: Verification.Skipped);
+        var verifier = CompileAndVerify([source, IsClosedTypeAttributeDefinition, CompilerFeatureRequiredAttribute], symbolValidator: verifySymbols, sourceSymbolValidator: verifySymbols);
         verifier.VerifyDiagnostics();
 
         void verifySymbols(ModuleSymbol module)
@@ -1878,7 +1878,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 public required string P { get; set; }
             }
             """;
-        var verifier = CompileAndVerify([source1, IsClosedTypeAttributeDefinition], targetFramework: TargetFramework.Net100, symbolValidator: verifyMetadataSymbols, verify: Verification.Skipped);
+        var verifier = CompileAndVerify([source1, IsClosedTypeAttributeDefinition], targetFramework: TargetFramework.Net100, symbolValidator: verifyMetadataSymbols, verify: Verification.FailsPEVerify);
         verifier.VerifyDiagnostics();
 
         verifyUse(verifier.Compilation.ToMetadataReference());
@@ -1956,7 +1956,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
             }
             """;
 
-        var verifier = CompileAndVerify([source1, IsClosedTypeAttributeDefinition], targetFramework: TargetFramework.Net100, symbolValidator: verifyMetadataSymbols, verify: Verification.Skipped);
+        var verifier = CompileAndVerify([source1, IsClosedTypeAttributeDefinition], targetFramework: TargetFramework.Net100, symbolValidator: verifyMetadataSymbols, verify: Verification.FailsPEVerify);
         verifier.VerifyDiagnostics();
 
         void verifyMetadataSymbols(ModuleSymbol module)
@@ -1995,7 +1995,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
             class D2 : C { }
             """;
 
-        var verifier = CompileAndVerify([source, IsClosedTypeAttributeDefinition], targetFramework: TargetFramework.Net100, sourceSymbolValidator: verify, symbolValidator: verify, verify: Verification.Skipped);
+        var verifier = CompileAndVerify([source, IsClosedTypeAttributeDefinition, CompilerFeatureRequiredAttribute], sourceSymbolValidator: verify, symbolValidator: verify);
         verifier.VerifyDiagnostics();
 
         static void verify(ModuleSymbol module)
@@ -3502,7 +3502,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
             class D2 : C { }
             """;
 
-        var comp = CreateCompilation([source, IsClosedTypeAttributeDefinition], targetFramework: TargetFramework.Net100);
+        var comp = CreateCompilation([source, IsClosedTypeAttributeDefinition, CompilerFeatureRequiredAttribute]);
         comp.VerifyDiagnostics();
 
         VerifyDecisionDagDump<SwitchExpressionSyntax>(comp, """
@@ -3515,7 +3515,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
             """,
             forLowering: true);
 
-        var verifier = CompileAndVerify(comp, verify: Verification.Skipped);
+        var verifier = CompileAndVerify(comp);
         verifier.VerifyIL("Program.M", """
             {
               // Code size       30 (0x1e)
@@ -3565,9 +3565,19 @@ public sealed class ClosedClassesTests : CSharpTestBase
 
             class D1 : C { }
             class D2 : C { }
+
+            namespace System.Runtime.CompilerServices
+            {
+                public class SwitchExpressionException : InvalidOperationException
+                {
+                    public SwitchExpressionException() {}
+                    public SwitchExpressionException(object unmatchedValue) => UnmatchedValue = unmatchedValue;
+                    public object UnmatchedValue { get; }
+                }
+            }
             """;
 
-        var comp = CreateCompilation([source, IsClosedTypeAttributeDefinition], targetFramework: TargetFramework.Net100);
+        var comp = CreateCompilation([source, IsClosedTypeAttributeDefinition, CompilerFeatureRequiredAttribute]);
         comp.VerifyDiagnostics();
 
         VerifyDecisionDagDump<SwitchExpressionSyntax>(comp, """
@@ -3587,7 +3597,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
             """,
             forLowering: true);
 
-        var verifier = CompileAndVerify(comp, verify: Verification.Skipped);
+        var verifier = CompileAndVerify(comp);
         verifier.VerifyIL("Program.M", """
             {
               // Code size       41 (0x29)

--- a/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
@@ -837,12 +837,16 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 public sealed class IsClosedTypeAttribute : Attribute
                 {
                     public Type[] DerivedTypes() => throw null;
+                    public Type[] DerivedTypes(bool ignored) => throw null;
                 }
             }
             """;
 
         var comp = CreateCompilation([source, isClosedTypeAttribute], targetFramework: TargetFramework.Net100);
         comp.VerifyDiagnostics(
+            // (1,14): error CS9395: 'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.
+            // closed class C;
+            Diagnostic(ErrorCode.ERR_ClosedBadDerivedTypesProperty, "C").WithLocation(1, 14),
             // (1,14): error CS9395: 'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.
             // closed class C;
             Diagnostic(ErrorCode.ERR_ClosedBadDerivedTypesProperty, "C").WithLocation(1, 14));
@@ -975,6 +979,35 @@ public sealed class ClosedClassesTests : CSharpTestBase
             // (1,14): error CS9041: 'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' requires compiler feature 'Nonexistent', which is not supported by this version of the C# compiler.
             // closed class C;
             Diagnostic(ErrorCode.ERR_UnsupportedCompilerFeature, "C").WithArguments("System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes", "Nonexistent").WithLocation(1, 14));
+    }
+
+    [Fact]
+    public void DerivedTypesMetadata_19()
+    {
+        // DerivedTypes property is internal.
+        var source = """
+            closed class C;
+
+            class D1 : C;
+            class D2 : C;
+            """;
+
+        var isClosedTypeAttribute = """
+            namespace System.Runtime.CompilerServices
+            {
+                [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+                public sealed class IsClosedTypeAttribute : Attribute
+                {
+                    internal Type[] DerivedTypes { get; set; }
+                }
+            }
+            """;
+
+        var comp = CreateCompilation([source, isClosedTypeAttribute], targetFramework: TargetFramework.Net100);
+        comp.VerifyEmitDiagnostics(
+            // (1,14): error CS9395: The property 'System.Runtime.CompilerServices.IsClosedTypeAttribute.DerivedTypes' must be an instance property with public get and set accessors, no parameters, and type 'System.Type[]'.
+            // closed class C;
+            Diagnostic(ErrorCode.ERR_ClosedBadDerivedTypesProperty, "C").WithLocation(1, 14));
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
@@ -655,7 +655,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
     [Fact]
     public void DerivedTypesMetadata_13()
     {
-        // DerivedTypes from IL is missing a type
+        // DerivedTypes argument from IL is missing a type
         var ilSource = """
       .class private auto ansi abstract beforefieldinit C
           extends [mscorlib]System.Object
@@ -811,8 +811,18 @@ public sealed class ClosedClassesTests : CSharpTestBase
             }
             """;
 
-        var comp = CreateCompilation([source, isClosedTypeAttribute], targetFramework: TargetFramework.Net100);
-        comp.VerifyDiagnostics();
+        var verifier = CompileAndVerify([source, isClosedTypeAttribute, CompilerFeatureRequiredAttribute], symbolValidator: verifyMetadata);
+        verifier.VerifyDiagnostics();
+
+        void verifyMetadata(ModuleSymbol module)
+        {
+            var peModule = (PEModuleSymbol)module;
+            var peType = (PENamedTypeSymbol)module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
+            AssertEx.SetEqual([
+                    "System.Runtime.CompilerServices.IsClosedTypeAttribute"
+                ],
+                GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
+        }
     }
 
     [Fact]
@@ -838,8 +848,18 @@ public sealed class ClosedClassesTests : CSharpTestBase
             }
             """;
 
-        var comp = CreateCompilation([source, isClosedTypeAttribute], targetFramework: TargetFramework.Net100);
-        comp.VerifyDiagnostics();
+        var verifier = CompileAndVerify([source, isClosedTypeAttribute, CompilerFeatureRequiredAttribute], symbolValidator: verifyMetadata);
+        verifier.VerifyDiagnostics();
+
+        void verifyMetadata(ModuleSymbol module)
+        {
+            var peModule = (PEModuleSymbol)module;
+            var peType = (PENamedTypeSymbol)module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
+            AssertEx.SetEqual([
+                    "System.Runtime.CompilerServices.IsClosedTypeAttribute"
+                ],
+                GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
+        }
     }
 
     [Fact]
@@ -1474,24 +1494,21 @@ public sealed class ClosedClassesTests : CSharpTestBase
             public class D2<T> : C<T[]> { }
             public unsafe class D3<T> : C<T*[]> where T : unmanaged { }
             """;
-        var comp1 = CreateCompilation([source1, IsClosedTypeAttributeDefinition], options: TestOptions.UnsafeDebugDll, targetFramework: TargetFramework.Net100);
-        comp1.VerifyEmitDiagnostics();
+        var comp1 = CreateCompilation([source1, IsClosedTypeAttributeDefinition, CompilerFeatureRequiredAttribute], options: TestOptions.UnsafeDebugDll);
 
         var classC = comp1.GetMember<NamedTypeSymbol>("C");
         Assert.False(classC.TryGetClosedSubtypes(out _));
 
-        CompileAndVerify(comp1, symbolValidator: verifyMetadata, verify: Verification.Skipped);
+        CompileAndVerify(comp1, symbolValidator: verifyMetadata).VerifyDiagnostics();
         void verifyMetadata(ModuleSymbol module)
         {
             var peModule = (PEModuleSymbol)module;
-            {
-                var peType = (PENamedTypeSymbol)module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
-                // Get attributes from metadata without doing any filtering
-                AssertEx.SetEqual([
-                        "System.Runtime.CompilerServices.IsClosedTypeAttribute(DerivedTypes = {typeof(D1<>), typeof(D2<>), typeof(D3<>)})"
-                    ],
-                    GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
-            }
+            var peType = (PENamedTypeSymbol)module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
+            // Get attributes from metadata without doing any filtering
+            AssertEx.SetEqual([
+                    "System.Runtime.CompilerServices.IsClosedTypeAttribute(DerivedTypes = {typeof(D1<>), typeof(D2<>), typeof(D3<>)})"
+                ],
+                GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
         }
     }
 
@@ -1525,25 +1542,22 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 public class D : C<U> { }
             }
             """;
-        var comp1 = CreateCompilation([source1, IsClosedTypeAttributeDefinition], targetFramework: TargetFramework.Net100);
-        comp1.VerifyEmitDiagnostics();
+        var comp1 = CreateCompilation([source1, IsClosedTypeAttributeDefinition, CompilerFeatureRequiredAttribute]);
 
         var classC = comp1.GetMember<NamedTypeSymbol>("C");
         Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
         Assert.Equal(["Outer<T>.D"], subtypes.ToTestDisplayStrings());
 
-        CompileAndVerify(comp1, symbolValidator: verifyMetadata, verify: Verification.Skipped);
+        CompileAndVerify(comp1, symbolValidator: verifyMetadata).VerifyDiagnostics();
         void verifyMetadata(ModuleSymbol module)
         {
             var peModule = (PEModuleSymbol)module;
-            {
-                var peType = (PENamedTypeSymbol)module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
-                // Get attributes from metadata without doing any filtering
-                AssertEx.SetEqual([
-                        "System.Runtime.CompilerServices.IsClosedTypeAttribute(DerivedTypes = {typeof(Outer<>.D)})"
-                    ],
-                    GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
-            }
+            var peType = (PENamedTypeSymbol)module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
+            // Get attributes from metadata without doing any filtering
+            AssertEx.SetEqual([
+                    "System.Runtime.CompilerServices.IsClosedTypeAttribute(DerivedTypes = {typeof(Outer<>.D)})"
+                ],
+                GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
         }
     }
 
@@ -1578,25 +1592,22 @@ public sealed class ClosedClassesTests : CSharpTestBase
             class D : C { }
             class E<T> : D { }
             """;
-        var comp1 = CreateCompilation([source1, IsClosedTypeAttributeDefinition], targetFramework: TargetFramework.Net100);
-        comp1.VerifyEmitDiagnostics();
+        var comp1 = CreateCompilation([source1, IsClosedTypeAttributeDefinition, CompilerFeatureRequiredAttribute]);
 
         var classC = comp1.GetMember<NamedTypeSymbol>("C");
         Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
         Assert.Equal(["D"], subtypes.ToTestDisplayStrings());
 
-        CompileAndVerify(comp1, symbolValidator: verifyMetadata, verify: Verification.Skipped);
+        CompileAndVerify(comp1, symbolValidator: verifyMetadata).VerifyDiagnostics();
         void verifyMetadata(ModuleSymbol module)
         {
             var peModule = (PEModuleSymbol)module;
-            {
-                var peType = (PENamedTypeSymbol)module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
-                // Get attributes from metadata without doing any filtering
-                AssertEx.SetEqual([
-                        "System.Runtime.CompilerServices.IsClosedTypeAttribute(DerivedTypes = {typeof(D)})"
-                    ],
-                    GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
-            }
+            var peType = (PENamedTypeSymbol)module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
+            // Get attributes from metadata without doing any filtering
+            AssertEx.SetEqual([
+                    "System.Runtime.CompilerServices.IsClosedTypeAttribute(DerivedTypes = {typeof(D)})"
+                ],
+                GetAttributeStrings(peModule.GetCustomAttributesForToken(peType.Handle)));
         }
     }
 

--- a/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
@@ -214,11 +214,62 @@ public sealed class ClosedClassesTests : CSharpTestBase
         }
     }
 
+    private static readonly string s_reportHelper = """
+        using System.Runtime.CompilerServices;
+        using System.Linq;
+        using System;
+
+        public partial class Program
+        {
+            public static void Report(Type type)
+            {
+                var attr = (IsClosedTypeAttribute)type.GetCustomAttributes(typeof(IsClosedTypeAttribute), inherit: false).FirstOrDefault();
+                if (attr is null)
+                {
+                    Console.Write("<null> ");
+                    return;
+                }
+
+                Console.Write(attr.DerivedTypes.Length);
+                Console.Write(" ");
+                foreach (var derivedType in attr.DerivedTypes)
+                {
+                    Console.Write(derivedType.FullName);                    
+                    if (derivedType.IsConstructedGenericType)
+                        throw new Exception(); // unexpected
+
+                    if (derivedType.GetGenericArguments() is [_, ..] args)
+                    {
+                        if (!derivedType.IsGenericTypeDefinition)
+                            throw new Exception(); // unexpected
+
+                        Console.Write("[");
+                        for (int i = 0; i < args.Length; i++)
+                        {
+                            if (i > 0)
+                            {
+                                Console.Write(",");
+                            }
+
+                            Console.Write(args[i].FullName ?? args[i].Name);
+                        }
+
+                        Console.Write("]");
+                    }
+                    Console.Write(" ");
+                }
+            }
+        }
+        """;
+
     [Fact]
     public void DerivedTypesMetadata_01()
     {
         // simple case
         var source = """
+            Report(typeof(C));
+            Report(typeof(D1));
+
             closed class C;
 
             class D1 : C;
@@ -227,7 +278,12 @@ public sealed class ClosedClassesTests : CSharpTestBase
             class D3 : D1;
             """;
 
-        var verifier = CompileAndVerify([source, IsClosedTypeAttributeDefinition], symbolValidator: verifyMetadata, targetFramework: TargetFramework.Net100, verify: Verification.Skipped);
+        var verifier = CompileAndVerify(
+            [source, IsClosedTypeAttributeDefinition, s_reportHelper],
+            symbolValidator: verifyMetadata,
+            targetFramework: TargetFramework.Net100,
+            verify: Verification.Skipped,
+            expectedOutput: "2 D1 D2 <null>");
         verifier.VerifyDiagnostics();
 
         void verifyMetadata(ModuleSymbol module)
@@ -255,6 +311,10 @@ public sealed class ClosedClassesTests : CSharpTestBase
     {
         // nested hierarchy
         var source = """
+            Report(typeof(C));
+            Report(typeof(D1));
+            Report(typeof(D5));
+
             closed class C;
 
             closed class D1 : C;
@@ -266,7 +326,12 @@ public sealed class ClosedClassesTests : CSharpTestBase
             class D5 : D4;
             """;
 
-        var verifier = CompileAndVerify([source, IsClosedTypeAttributeDefinition], symbolValidator: verifyMetadata, targetFramework: TargetFramework.Net100, verify: Verification.Skipped);
+        var verifier = CompileAndVerify(
+            [source, IsClosedTypeAttributeDefinition, s_reportHelper],
+            symbolValidator: verifyMetadata,
+            targetFramework: TargetFramework.Net100,
+            verify: Verification.Skipped,
+            expectedOutput: "2 D1 D2 2 D3 D4 <null>");
         verifier.VerifyDiagnostics();
 
         void verifyMetadata(ModuleSymbol module)
@@ -291,6 +356,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
     {
         // various generic subtypes
         var source = """
+            Report(typeof(C<>));
+
             closed class C<T>;
 
             class D1 : C<string>;
@@ -300,7 +367,12 @@ public sealed class ClosedClassesTests : CSharpTestBase
             class D5<T, U> : C<(T, U)>;
             """;
 
-        var verifier = CompileAndVerify([source, IsClosedTypeAttributeDefinition], symbolValidator: verifyMetadata, targetFramework: TargetFramework.Net100, verify: Verification.Skipped);
+        var verifier = CompileAndVerify(
+            [source, IsClosedTypeAttributeDefinition, s_reportHelper],
+            symbolValidator: verifyMetadata,
+            targetFramework: TargetFramework.Net100,
+            verify: Verification.Skipped,
+            expectedOutput: "5 D1 D2 D3`1[T] D4`1[T] D5`2[T,U]");
         verifier.VerifyDiagnostics();
 
         void verifyMetadata(ModuleSymbol module)
@@ -319,6 +391,9 @@ public sealed class ClosedClassesTests : CSharpTestBase
     {
         // nested generic subtype
         var source = """
+            Report(typeof(C<,>));
+            Report(typeof(C<int, string>));
+
             closed class C<T, U>;
 
             class Container<T>
@@ -328,7 +403,12 @@ public sealed class ClosedClassesTests : CSharpTestBase
             }
             """;
 
-        var verifier = CompileAndVerify([source, IsClosedTypeAttributeDefinition], symbolValidator: verifyMetadata, targetFramework: TargetFramework.Net100, verify: Verification.Skipped);
+        var verifier = CompileAndVerify(
+            [source, IsClosedTypeAttributeDefinition, s_reportHelper],
+            symbolValidator: verifyMetadata,
+            targetFramework: TargetFramework.Net100,
+            verify: Verification.Skipped,
+            expectedOutput: "2 Container`1+D1`1[T,U] Container`1+D2[T] 2 Container`1+D1`1[T,U] Container`1+D2[T]");
         verifier.VerifyDiagnostics();
 
         void verifyMetadata(ModuleSymbol module)
@@ -1174,7 +1254,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
         var classC = comp1.GetMember<NamedTypeSymbol>("C");
         Assert.False(classC.TryGetClosedSubtypes(out _));
 
-        CompileAndVerify(comp1, symbolValidator: verifyMetadata);
+        CompileAndVerify(comp1, symbolValidator: verifyMetadata, verify: Verification.Skipped);
         void verifyMetadata(ModuleSymbol module)
         {
             var peModule = (PEModuleSymbol)module;
@@ -1226,7 +1306,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
         Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
         Assert.Equal(["Outer<T>.D"], subtypes.ToTestDisplayStrings());
 
-        CompileAndVerify(comp1, symbolValidator: verifyMetadata);
+        CompileAndVerify(comp1, symbolValidator: verifyMetadata, verify: Verification.Skipped);
         void verifyMetadata(ModuleSymbol module)
         {
             var peModule = (PEModuleSymbol)module;
@@ -1279,7 +1359,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
         Assert.True(classC.TryGetClosedSubtypes(out var subtypes));
         Assert.Equal(["D"], subtypes.ToTestDisplayStrings());
 
-        CompileAndVerify(comp1, symbolValidator: verifyMetadata);
+        CompileAndVerify(comp1, symbolValidator: verifyMetadata, verify: Verification.Skipped);
         void verifyMetadata(ModuleSymbol module)
         {
             var peModule = (PEModuleSymbol)module;

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -1062,6 +1062,7 @@ namespace System
                     case WellKnownMember.System_ReadOnlyMemory_T__Slice_Int:
                     case WellKnownMember.System_ReadOnlyMemory_T__Slice_Int_Int:
                     case WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__ctor:
+                    case WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__DerivedTypes:
                         // Not yet in the platform.
                         continue;
                     case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile:

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -575,6 +575,7 @@ namespace Microsoft.CodeAnalysis
         System_Runtime_CompilerServices_MemorySafetyRulesAttribute__ctor,
         System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor,
         System_Runtime_CompilerServices_IsClosedTypeAttribute__ctor,
+        System_Runtime_CompilerServices_IsClosedTypeAttribute__DerivedTypes,
 
         System_MemoryExtensions__SequenceEqual_Span_T,
         System_MemoryExtensions__SequenceEqual_ReadOnlySpan_T,

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -3985,6 +3985,13 @@ namespace Microsoft.CodeAnalysis
                      0,                                                                                                                                     // Method Signature
                      (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
 
+                // System_Runtime_CompilerServices_IsClosedTypeAttribute__DerivedTypes
+                (byte)MemberFlags.Property,                                                                                 // Flags
+                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_CompilerServices_IsClosedTypeAttribute - WellKnownType.ExtSentinel),        // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    0,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.SZArray, (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Type, // Return Type
+
                 // System_MemoryExtensions__SequenceEqual_Span_T
                 (byte)(MemberFlags.Method | MemberFlags.Static),                                                               // Flags
                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_MemoryExtensions - WellKnownType.ExtSentinel),    // DeclaringTypeId
@@ -5804,6 +5811,7 @@ namespace Microsoft.CodeAnalysis
                 ".ctor",                                    // System_Runtime_CompilerServices_MemorySafetyRulesAttribute__ctor
                 ".ctor",                                    // System_Diagnostics_CodeAnalysis_RequiresUnsafeAttribute__ctor
                 ".ctor",                                    // System_Runtime_CompilerServices_IsClosedTypeAttribute__ctor
+                "DerivedTypes",                             // System_Runtime_CompilerServices_IsClosedTypeAttribute__DerivedTypes
                 "SequenceEqual",                            // System_MemoryExtensions__SequenceEqual_Span_T
                 "SequenceEqual",                            // System_MemoryExtensions__SequenceEqual_ReadOnlySpan_T
                 "AsSpan",                                   // System_MemoryExtensions__AsSpan_String

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -254,7 +254,10 @@ namespace System.Diagnostics.CodeAnalysis
             namespace System.Runtime.CompilerServices
             {
                 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
-                public sealed class IsClosedTypeAttribute : Attribute { }
+                public sealed class IsClosedTypeAttribute : Attribute
+                {
+                    public Type[] DerivedTypes { get; set; }
+                }
             }
             """;
 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -817,7 +817,8 @@ End Namespace
                          WellKnownMember.System_Runtime_CompilerServices_RequiresLocationAttribute__ctor,
                          WellKnownMember.System_Runtime_CompilerServices_ParamCollectionAttribute__ctor,
                          WellKnownMember.System_Runtime_CompilerServices_ExtensionMarkerAttribute__ctor,
-                         WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__ctor
+                         WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__ctor,
+                         WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__DerivedTypes
                         ' Not available yet, but will be in upcoming release.
                         Continue For
                     Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile,
@@ -1040,7 +1041,8 @@ End Namespace
                          WellKnownMember.System_Runtime_CompilerServices_RequiresLocationAttribute__ctor,
                          WellKnownMember.System_Runtime_CompilerServices_ParamCollectionAttribute__ctor,
                          WellKnownMember.System_Runtime_CompilerServices_ExtensionMarkerAttribute__ctor,
-                         WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__ctor
+                         WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__ctor,
+                         WellKnownMember.System_Runtime_CompilerServices_IsClosedTypeAttribute__DerivedTypes
                         ' Not available yet, but will be in upcoming release.
                         Continue For
                     Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile,


### PR DESCRIPTION
Implement metadata format change from https://github.com/dotnet/runtime/issues/129009

Notes:
- Compiler doesn't use DerivedTypes property as a source of information at all and (in this PR at least) doesn't verify correctness of the attribute when importing types from metadata.
- The DerivedTypes property does not need to exist, but, compiler will report an error if it doesn't have the expected shape. Perhaps we might eventually want to require the property to exist, but, for now we need to be compatible with frameworks where the property is missing.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84350)