### PR TITLE
Unsafe evolution: report error for `unsafe` with no effect

### DIFF
--- a/docs/compilers/CSharp/Warnversion Warning Waves.md
+++ b/docs/compilers/CSharp/Warnversion Warning Waves.md
@@ -13,14 +13,6 @@ In a typical project, this setting is controlled by the `AnalysisLevel` property
 which determines the `WarningLevel` property (passed to the `Csc` task).
 For more information on `AnalysisLevel`, see https://devblogs.microsoft.com/dotnet/automatically-find-latent-bugs-in-your-code-with-net-5/
 
-## Warning level 11
-
-The compiler shipped with .NET 11 (the C# 15 compiler) contains the following warnings which are reported only under `/warn:11` or higher.
-
-| Warning ID | Description |
-|------------|-------------|
-| CS9377 | [The 'unsafe' modifier does not have any effect here under the current rules](https://github.com/dotnet/csharplang/issues/9704) |
-
 ## Warning level 10
 
 The compiler shipped with .NET 10 (the C# 14 compiler) contains the following warnings which are reported only under `/warn:10` or higher.

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -8306,11 +8306,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>An unsafe context is required for constructor '{0}' marked as 'unsafe' to satisfy the 'new()' constraint of type parameter '{1}' in '{2}'</value>
     <comment>'unsafe' and 'new()' should not be localized. {2} is the generic method or type.</comment>
   </data>
-  <data name="WRN_UnsafeMeaningless" xml:space="preserve">
-    <value>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</value>
-    <comment>'unsafe' is a keyword, should not be localized.</comment>
-  </data>
-  <data name="WRN_UnsafeMeaningless_Title" xml:space="preserve">
+  <data name="ERR_UnsafeMeaningless" xml:space="preserve">
     <value>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</value>
     <comment>'unsafe' is a keyword, should not be localized.</comment>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2480,7 +2480,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_UnionConstructorCallsDefaultConstructor = 9375,
 
         ERR_UnsafeConstructorConstraint = 9376,
-        WRN_UnsafeMeaningless = 9377,
+        ERR_UnsafeMeaningless = 9377,
 
         ERR_PPShebangNotOnFirstLine = 9378,
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -210,10 +210,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             // docs/compilers/CSharp/Warnversion Warning Waves.md
             switch (code)
             {
-                case ErrorCode.WRN_UnsafeMeaningless:
-                    // Warning level 11 is exclusively for warnings introduced in the compiler
-                    // shipped with dotnet 11 (C# 15) and that can be reported for pre-existing code.
-                    return 11;
                 case ErrorCode.WRN_UnassignedInternalRefField:
                     // Warning level 10 is exclusively for warnings introduced in the compiler
                     // shipped with dotnet 10 (C# 14) and that can be reported for pre-existing code.
@@ -2587,7 +2583,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 or ErrorCode.ERR_InstanceCtorWithOneParameterInUnion
                 or ErrorCode.ERR_UnionConstructorCallsDefaultConstructor
                 or ErrorCode.ERR_UnsafeConstructorConstraint
-                or ErrorCode.WRN_UnsafeMeaningless
+                or ErrorCode.ERR_UnsafeMeaningless
                 or ErrorCode.ERR_RequiresUnsafeAttributeInSource
                 or ErrorCode.ERR_ClosedTypeNameDisallowed
                 or ErrorCode.ERR_ClosedSealedStatic

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -346,7 +346,6 @@
                 case ErrorCode.WRN_UnscopedRefAttributeOldRules:
                 case ErrorCode.WRN_InterceptsLocationAttributeUnsupportedSignature:
                 case ErrorCode.WRN_RedundantPattern:
-                case ErrorCode.WRN_UnsafeMeaningless:
                     return true;
                 default:
                     return false;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
@@ -183,8 +183,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                                                                 location, diagnostics);
                 }
 
-                if (!modifierErrors &&
-                    (mods & DeclarationModifiers.Unsafe) == DeclarationModifiers.Unsafe &&
+                if ((mods & DeclarationModifiers.Unsafe) == DeclarationModifiers.Unsafe &&
                     containingType.ContainingModule.UseUpdatedMemorySafetyRules)
                 {
                     diagnostics.Add(ErrorCode.ERR_UnsafeMeaningless,

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
@@ -182,6 +182,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                                                                 DeclarationModifiers.Extern,
                                                                                 location, diagnostics);
                 }
+
+                if (!modifierErrors &&
+                    (mods & DeclarationModifiers.Unsafe) == DeclarationModifiers.Unsafe &&
+                    containingType.ContainingModule.UseUpdatedMemorySafetyRules)
+                {
+                    diagnostics.Add(ErrorCode.ERR_UnsafeMeaningless,
+                        syntax.Modifiers.GetModifierLocation(SyntaxKind.UnsafeKeyword, location));
+                }
             }
 
             return mods;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDestructorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDestructorSymbol.cs
@@ -141,6 +141,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             mods = (mods & ~DeclarationModifiers.AccessibilityMask) | DeclarationModifiers.Protected; // we mark destructors protected in the symbol table
 
+            if (!modifierErrors &&
+                (mods & DeclarationModifiers.Unsafe) == DeclarationModifiers.Unsafe &&
+                containingType.ContainingModule.UseUpdatedMemorySafetyRules)
+            {
+                diagnostics.Add(ErrorCode.ERR_UnsafeMeaningless,
+                    modifiers.GetModifierLocation(SyntaxKind.UnsafeKeyword, location));
+            }
+
             return mods;
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDestructorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDestructorSymbol.cs
@@ -141,8 +141,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             mods = (mods & ~DeclarationModifiers.AccessibilityMask) | DeclarationModifiers.Protected; // we mark destructors protected in the symbol table
 
-            if (!modifierErrors &&
-                (mods & DeclarationModifiers.Unsafe) == DeclarationModifiers.Unsafe &&
+            if ((mods & DeclarationModifiers.Unsafe) == DeclarationModifiers.Unsafe &&
                 containingType.ContainingModule.UseUpdatedMemorySafetyRules)
             {
                 diagnostics.Add(ErrorCode.ERR_UnsafeMeaningless,

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -387,8 +387,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics.Add(ErrorCode.ERR_SealedStaticClass, GetFirstLocation(), this);
             }
 
-            if (!modifierErrors &&
-                (mods & DeclarationModifiers.Unsafe) == DeclarationModifiers.Unsafe &&
+            if ((mods & DeclarationModifiers.Unsafe) == DeclarationModifiers.Unsafe &&
                 this.ContainingModule.UseUpdatedMemorySafetyRules)
             {
                 diagnostics.Add(ErrorCode.ERR_UnsafeMeaningless, GetFirstLocation());

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -391,7 +391,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 (mods & DeclarationModifiers.Unsafe) == DeclarationModifiers.Unsafe &&
                 this.ContainingModule.UseUpdatedMemorySafetyRules)
             {
-                diagnostics.Add(ErrorCode.WRN_UnsafeMeaningless, GetFirstLocation());
+                diagnostics.Add(ErrorCode.ERR_UnsafeMeaningless, GetFirstLocation());
             }
 
             switch (typeKind)

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -2812,6 +2812,11 @@
         <target state="translated">Nezabezpečený kontext je vyžadován pro konstruktor {0} označený jako unsafe, aby se vyhovělo omezení new() parametru typu {1} v {2}</target>
         <note>'unsafe' and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
+      <trans-unit id="ERR_UnsafeMeaningless">
+        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
+        <target state="new">The 'unsafe' modifier does not have any effect here under the current memory safety rules.</target>
+        <note>'unsafe' is a keyword, should not be localized.</note>
+      </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
         <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe'</source>
         <target state="translated">{0} se musí použít v nebezpečném kontextu, protože má označení unsafe</target>
@@ -6024,16 +6029,6 @@
         <source>Parameter is unread. Did you forget to use it to initialize the property with that name?</source>
         <target state="translated">Parametr se nepřečetl. Nezapomněli jste ho použít k inicializaci vlastnosti s daným názvem?</target>
         <note />
-      </trans-unit>
-      <trans-unit id="WRN_UnsafeMeaningless">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="translated">Modifikátor „unsafe“ nemá v rámci aktuálních pravidel zabezpečení paměti žádný vliv.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="WRN_UnsafeMeaningless_Title">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="translated">Modifikátor „unsafe“ nemá v rámci aktuálních pravidel zabezpečení paměti žádný vliv.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
       </trans-unit>
       <trans-unit id="WRN_UnscopedRefAttributeOldRules">
         <source>UnscopedRefAttribute is only valid in C# 11 or later or when targeting net7.0 or later.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -2812,11 +2812,6 @@
         <target state="translated">Nezabezpečený kontext je vyžadován pro konstruktor {0} označený jako unsafe, aby se vyhovělo omezení new() parametru typu {1} v {2}</target>
         <note>'unsafe' and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
-      <trans-unit id="ERR_UnsafeMeaningless">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="new">The 'unsafe' modifier does not have any effect here under the current memory safety rules.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
-      </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
         <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe'</source>
         <target state="translated">{0} se musí použít v nebezpečném kontextu, protože má označení unsafe</target>
@@ -6029,6 +6024,11 @@
         <source>Parameter is unread. Did you forget to use it to initialize the property with that name?</source>
         <target state="translated">Parametr se nepřečetl. Nezapomněli jste ho použít k inicializaci vlastnosti s daným názvem?</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnsafeMeaningless">
+        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
+        <target state="translated">Modifikátor „unsafe“ nemá v rámci aktuálních pravidel zabezpečení paměti žádný vliv.</target>
+        <note>'unsafe' is a keyword, should not be localized.</note>
       </trans-unit>
       <trans-unit id="WRN_UnscopedRefAttributeOldRules">
         <source>UnscopedRefAttribute is only valid in C# 11 or later or when targeting net7.0 or later.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -2812,11 +2812,6 @@
         <target state="translated">Für den als „unsafe“ markierten Konstruktor „{0}“ ist ein unsicherer Kontext erforderlich, um die „new()“-Einschränkung des Typparameters „{1}“ in „{2}“ zu erfüllen</target>
         <note>'unsafe' and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
-      <trans-unit id="ERR_UnsafeMeaningless">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="new">The 'unsafe' modifier does not have any effect here under the current memory safety rules.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
-      </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
         <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe'</source>
         <target state="translated">„{0}“ muss in einem unsicheren Kontext verwendet werden, da er als „unsicher“ gekennzeichnet ist</target>
@@ -6029,6 +6024,11 @@
         <source>Parameter is unread. Did you forget to use it to initialize the property with that name?</source>
         <target state="translated">Der Parameter wird nicht gelesen. Möglicherweise haben Sie ihn nicht zum Initialisieren der gleichnamigen Eigenschaft verwendet?</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnsafeMeaningless">
+        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
+        <target state="translated">Der „unsafe“-Modifizierer hat hier unter den aktuellen Speichersicherheitsregeln keine Auswirkungen.</target>
+        <note>'unsafe' is a keyword, should not be localized.</note>
       </trans-unit>
       <trans-unit id="WRN_UnscopedRefAttributeOldRules">
         <source>UnscopedRefAttribute is only valid in C# 11 or later or when targeting net7.0 or later.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -2812,6 +2812,11 @@
         <target state="translated">Für den als „unsafe“ markierten Konstruktor „{0}“ ist ein unsicherer Kontext erforderlich, um die „new()“-Einschränkung des Typparameters „{1}“ in „{2}“ zu erfüllen</target>
         <note>'unsafe' and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
+      <trans-unit id="ERR_UnsafeMeaningless">
+        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
+        <target state="new">The 'unsafe' modifier does not have any effect here under the current memory safety rules.</target>
+        <note>'unsafe' is a keyword, should not be localized.</note>
+      </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
         <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe'</source>
         <target state="translated">„{0}“ muss in einem unsicheren Kontext verwendet werden, da er als „unsicher“ gekennzeichnet ist</target>
@@ -6024,16 +6029,6 @@
         <source>Parameter is unread. Did you forget to use it to initialize the property with that name?</source>
         <target state="translated">Der Parameter wird nicht gelesen. Möglicherweise haben Sie ihn nicht zum Initialisieren der gleichnamigen Eigenschaft verwendet?</target>
         <note />
-      </trans-unit>
-      <trans-unit id="WRN_UnsafeMeaningless">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="translated">Der „unsafe“-Modifizierer hat hier unter den aktuellen Speichersicherheitsregeln keine Auswirkungen.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="WRN_UnsafeMeaningless_Title">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="translated">Der „unsafe“-Modifizierer hat hier unter den aktuellen Speichersicherheitsregeln keine Auswirkungen.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
       </trans-unit>
       <trans-unit id="WRN_UnscopedRefAttributeOldRules">
         <source>UnscopedRefAttribute is only valid in C# 11 or later or when targeting net7.0 or later.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -2812,6 +2812,11 @@
         <target state="translated">Se requiere un contexto no seguro para que el constructor "{0}" marcado como "unsafe" cumpla la restricción "new()" del parámetro de tipo "{1}" en "{2}"</target>
         <note>'unsafe' and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
+      <trans-unit id="ERR_UnsafeMeaningless">
+        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
+        <target state="new">The 'unsafe' modifier does not have any effect here under the current memory safety rules.</target>
+        <note>'unsafe' is a keyword, should not be localized.</note>
+      </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
         <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe'</source>
         <target state="translated">"{0}" debe usarse en un contexto no seguro porque está marcado como "unsafe"</target>
@@ -6024,16 +6029,6 @@
         <source>Parameter is unread. Did you forget to use it to initialize the property with that name?</source>
         <target state="translated">El parámetro no se ha leído ¿Olvidó usarlo para inicializar la propiedad con ese nombre?</target>
         <note />
-      </trans-unit>
-      <trans-unit id="WRN_UnsafeMeaningless">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="translated">El modificador "unsafe" no tiene ningún efecto aquí en las reglas de seguridad de memoria actuales.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="WRN_UnsafeMeaningless_Title">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="translated">El modificador "unsafe" no tiene ningún efecto aquí en las reglas de seguridad de memoria actuales.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
       </trans-unit>
       <trans-unit id="WRN_UnscopedRefAttributeOldRules">
         <source>UnscopedRefAttribute is only valid in C# 11 or later or when targeting net7.0 or later.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -2812,11 +2812,6 @@
         <target state="translated">Se requiere un contexto no seguro para que el constructor "{0}" marcado como "unsafe" cumpla la restricción "new()" del parámetro de tipo "{1}" en "{2}"</target>
         <note>'unsafe' and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
-      <trans-unit id="ERR_UnsafeMeaningless">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="new">The 'unsafe' modifier does not have any effect here under the current memory safety rules.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
-      </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
         <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe'</source>
         <target state="translated">"{0}" debe usarse en un contexto no seguro porque está marcado como "unsafe"</target>
@@ -6029,6 +6024,11 @@
         <source>Parameter is unread. Did you forget to use it to initialize the property with that name?</source>
         <target state="translated">El parámetro no se ha leído ¿Olvidó usarlo para inicializar la propiedad con ese nombre?</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnsafeMeaningless">
+        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
+        <target state="translated">El modificador "unsafe" no tiene ningún efecto aquí en las reglas de seguridad de memoria actuales.</target>
+        <note>'unsafe' is a keyword, should not be localized.</note>
       </trans-unit>
       <trans-unit id="WRN_UnscopedRefAttributeOldRules">
         <source>UnscopedRefAttribute is only valid in C# 11 or later or when targeting net7.0 or later.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -2812,6 +2812,11 @@
         <target state="translated">Un contexte non sécurisé est requis pour le constructeur « {0} » marqué comme « unsafe » afin de satisfaire la contrainte « new() » du paramètre de type « {1} » dans « {2} »</target>
         <note>'unsafe' and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
+      <trans-unit id="ERR_UnsafeMeaningless">
+        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
+        <target state="new">The 'unsafe' modifier does not have any effect here under the current memory safety rules.</target>
+        <note>'unsafe' is a keyword, should not be localized.</note>
+      </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
         <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe'</source>
         <target state="translated">« {0} » doit être utilisé dans un contexte non sécurisé, car il est marqué comme « unsafe »</target>
@@ -6024,16 +6029,6 @@
         <source>Parameter is unread. Did you forget to use it to initialize the property with that name?</source>
         <target state="translated">Le paramètre est non lu. Avez-vous oublié de l'utiliser pour initialiser la propriété portant ce nom ?</target>
         <note />
-      </trans-unit>
-      <trans-unit id="WRN_UnsafeMeaningless">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="translated">Le modificateur « unsafe » n’a aucun effet ici selon les règles actuelles de sécurité de la mémoire.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="WRN_UnsafeMeaningless_Title">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="translated">Le modificateur « unsafe » n’a aucun effet ici selon les règles actuelles de sécurité de la mémoire.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
       </trans-unit>
       <trans-unit id="WRN_UnscopedRefAttributeOldRules">
         <source>UnscopedRefAttribute is only valid in C# 11 or later or when targeting net7.0 or later.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -2812,11 +2812,6 @@
         <target state="translated">Un contexte non sécurisé est requis pour le constructeur « {0} » marqué comme « unsafe » afin de satisfaire la contrainte « new() » du paramètre de type « {1} » dans « {2} »</target>
         <note>'unsafe' and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
-      <trans-unit id="ERR_UnsafeMeaningless">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="new">The 'unsafe' modifier does not have any effect here under the current memory safety rules.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
-      </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
         <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe'</source>
         <target state="translated">« {0} » doit être utilisé dans un contexte non sécurisé, car il est marqué comme « unsafe »</target>
@@ -6029,6 +6024,11 @@
         <source>Parameter is unread. Did you forget to use it to initialize the property with that name?</source>
         <target state="translated">Le paramètre est non lu. Avez-vous oublié de l'utiliser pour initialiser la propriété portant ce nom ?</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnsafeMeaningless">
+        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
+        <target state="translated">Le modificateur « unsafe » n’a aucun effet ici selon les règles actuelles de sécurité de la mémoire.</target>
+        <note>'unsafe' is a keyword, should not be localized.</note>
       </trans-unit>
       <trans-unit id="WRN_UnscopedRefAttributeOldRules">
         <source>UnscopedRefAttribute is only valid in C# 11 or later or when targeting net7.0 or later.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -2812,11 +2812,6 @@
         <target state="translated">Per il costruttore "{0}" contrassegnato come "unsafe" o è necessario un contesto unsafe per soddisfare il vincolo "new()" del parametro di tipo "{1}" in "{2}"</target>
         <note>'unsafe' and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
-      <trans-unit id="ERR_UnsafeMeaningless">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="new">The 'unsafe' modifier does not have any effect here under the current memory safety rules.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
-      </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
         <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe'</source>
         <target state="translated">"{0}" deve essere usato in un contesto unsafe perché è contrassegnato come "unsafe"</target>
@@ -6029,6 +6024,11 @@ target:module               Compila un modulo che può essere aggiunto ad altro
         <source>Parameter is unread. Did you forget to use it to initialize the property with that name?</source>
         <target state="translated">Il parametro non è stato letto. Si è dimenticato di usarlo per inizializzare la proprietà con tale nome?</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnsafeMeaningless">
+        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
+        <target state="translated">Il modificatore "unsafe" non ha alcun effetto qui secondo le regole correnti di sicurezza della memoria.</target>
+        <note>'unsafe' is a keyword, should not be localized.</note>
       </trans-unit>
       <trans-unit id="WRN_UnscopedRefAttributeOldRules">
         <source>UnscopedRefAttribute is only valid in C# 11 or later or when targeting net7.0 or later.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -2812,6 +2812,11 @@
         <target state="translated">Per il costruttore "{0}" contrassegnato come "unsafe" o è necessario un contesto unsafe per soddisfare il vincolo "new()" del parametro di tipo "{1}" in "{2}"</target>
         <note>'unsafe' and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
+      <trans-unit id="ERR_UnsafeMeaningless">
+        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
+        <target state="new">The 'unsafe' modifier does not have any effect here under the current memory safety rules.</target>
+        <note>'unsafe' is a keyword, should not be localized.</note>
+      </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
         <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe'</source>
         <target state="translated">"{0}" deve essere usato in un contesto unsafe perché è contrassegnato come "unsafe"</target>
@@ -6024,16 +6029,6 @@ target:module               Compila un modulo che può essere aggiunto ad altro
         <source>Parameter is unread. Did you forget to use it to initialize the property with that name?</source>
         <target state="translated">Il parametro non è stato letto. Si è dimenticato di usarlo per inizializzare la proprietà con tale nome?</target>
         <note />
-      </trans-unit>
-      <trans-unit id="WRN_UnsafeMeaningless">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="translated">Il modificatore "unsafe" non ha alcun effetto qui secondo le regole correnti di sicurezza della memoria.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="WRN_UnsafeMeaningless_Title">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="translated">Il modificatore "unsafe" non ha alcun effetto qui secondo le regole correnti di sicurezza della memoria.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
       </trans-unit>
       <trans-unit id="WRN_UnscopedRefAttributeOldRules">
         <source>UnscopedRefAttribute is only valid in C# 11 or later or when targeting net7.0 or later.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -2812,11 +2812,6 @@
         <target state="translated">'{2}' の型パラメーター '{1}' の 'new()' 制約を満たすには、'unsafe' としてマークされたコンストラクター '{0}' に安全ではないコンテキストが必要です</target>
         <note>'unsafe' and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
-      <trans-unit id="ERR_UnsafeMeaningless">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="new">The 'unsafe' modifier does not have any effect here under the current memory safety rules.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
-      </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
         <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe'</source>
         <target state="translated">'{0}' は 'unsafe' としてマークされているため、安全でないコンテキストで使用する必要があります</target>
@@ -6029,6 +6024,11 @@
         <source>Parameter is unread. Did you forget to use it to initialize the property with that name?</source>
         <target state="translated">パラメーターが未読のため、この名前のプロパティを初期化するために使用していることを確認する必要がある</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnsafeMeaningless">
+        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
+        <target state="translated">現在のメモリ安全性規則においては、'unsafe' 修飾子による影響はありません。</target>
+        <note>'unsafe' is a keyword, should not be localized.</note>
       </trans-unit>
       <trans-unit id="WRN_UnscopedRefAttributeOldRules">
         <source>UnscopedRefAttribute is only valid in C# 11 or later or when targeting net7.0 or later.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -2812,6 +2812,11 @@
         <target state="translated">'{2}' の型パラメーター '{1}' の 'new()' 制約を満たすには、'unsafe' としてマークされたコンストラクター '{0}' に安全ではないコンテキストが必要です</target>
         <note>'unsafe' and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
+      <trans-unit id="ERR_UnsafeMeaningless">
+        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
+        <target state="new">The 'unsafe' modifier does not have any effect here under the current memory safety rules.</target>
+        <note>'unsafe' is a keyword, should not be localized.</note>
+      </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
         <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe'</source>
         <target state="translated">'{0}' は 'unsafe' としてマークされているため、安全でないコンテキストで使用する必要があります</target>
@@ -6024,16 +6029,6 @@
         <source>Parameter is unread. Did you forget to use it to initialize the property with that name?</source>
         <target state="translated">パラメーターが未読のため、この名前のプロパティを初期化するために使用していることを確認する必要がある</target>
         <note />
-      </trans-unit>
-      <trans-unit id="WRN_UnsafeMeaningless">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="translated">現在のメモリ安全性規則においては、'unsafe' 修飾子による影響はありません。</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="WRN_UnsafeMeaningless_Title">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="translated">現在のメモリ安全性規則においては、'unsafe' 修飾子による影響はありません。</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
       </trans-unit>
       <trans-unit id="WRN_UnscopedRefAttributeOldRules">
         <source>UnscopedRefAttribute is only valid in C# 11 or later or when targeting net7.0 or later.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -2812,11 +2812,6 @@
         <target state="translated">'{2}'에서 '{1}' 형식 매개 변수의 'new()' 제약 조건을 충족하려면 'unsafe'로 표시된 '{0}' 생성자에 안전하지 않은 컨텍스트가 필요합니다.</target>
         <note>'unsafe' and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
-      <trans-unit id="ERR_UnsafeMeaningless">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="new">The 'unsafe' modifier does not have any effect here under the current memory safety rules.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
-      </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
         <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe'</source>
         <target state="translated">'{0}'은(는) 'unsafe'로 표시되어 있으므로 안전하지 않은 컨텍스트에서 사용해야 합니다.</target>
@@ -6029,6 +6024,11 @@
         <source>Parameter is unread. Did you forget to use it to initialize the property with that name?</source>
         <target state="translated">매개 변수를 읽을 수 없습니다. 이 매개 변수를 사용하여 해당 이름으로 속성을 초기화했는지 확인하세요.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnsafeMeaningless">
+        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
+        <target state="translated">'안전하지 않은' 한정자는 현재 메모리 안전 규칙에서 아무런 영향을 주지 않습니다.</target>
+        <note>'unsafe' is a keyword, should not be localized.</note>
       </trans-unit>
       <trans-unit id="WRN_UnscopedRefAttributeOldRules">
         <source>UnscopedRefAttribute is only valid in C# 11 or later or when targeting net7.0 or later.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -2812,6 +2812,11 @@
         <target state="translated">'{2}'에서 '{1}' 형식 매개 변수의 'new()' 제약 조건을 충족하려면 'unsafe'로 표시된 '{0}' 생성자에 안전하지 않은 컨텍스트가 필요합니다.</target>
         <note>'unsafe' and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
+      <trans-unit id="ERR_UnsafeMeaningless">
+        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
+        <target state="new">The 'unsafe' modifier does not have any effect here under the current memory safety rules.</target>
+        <note>'unsafe' is a keyword, should not be localized.</note>
+      </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
         <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe'</source>
         <target state="translated">'{0}'은(는) 'unsafe'로 표시되어 있으므로 안전하지 않은 컨텍스트에서 사용해야 합니다.</target>
@@ -6024,16 +6029,6 @@
         <source>Parameter is unread. Did you forget to use it to initialize the property with that name?</source>
         <target state="translated">매개 변수를 읽을 수 없습니다. 이 매개 변수를 사용하여 해당 이름으로 속성을 초기화했는지 확인하세요.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="WRN_UnsafeMeaningless">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="translated">'안전하지 않은' 한정자는 현재 메모리 안전 규칙에서 아무런 영향을 주지 않습니다.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="WRN_UnsafeMeaningless_Title">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="translated">'안전하지 않은' 한정자는 현재 메모리 안전 규칙에서 아무런 영향을 주지 않습니다.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
       </trans-unit>
       <trans-unit id="WRN_UnscopedRefAttributeOldRules">
         <source>UnscopedRefAttribute is only valid in C# 11 or later or when targeting net7.0 or later.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -2812,6 +2812,11 @@
         <target state="translated">Niebezpieczny kontekst jest wymagany dla konstruktora „{0}” oznaczonego jako „unsafe”, aby spełniać ograniczenie „new()” parametru typu „{1}” w „{2}”</target>
         <note>'unsafe' and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
+      <trans-unit id="ERR_UnsafeMeaningless">
+        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
+        <target state="new">The 'unsafe' modifier does not have any effect here under the current memory safety rules.</target>
+        <note>'unsafe' is a keyword, should not be localized.</note>
+      </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
         <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe'</source>
         <target state="translated">Atrybut „{0}” musi być używany w niebezpiecznym kontekście, ponieważ jest oznaczony jako „unsafe”</target>
@@ -6024,16 +6029,6 @@
         <source>Parameter is unread. Did you forget to use it to initialize the property with that name?</source>
         <target state="translated">Parametr nie został odczytany. Czy zapomniano użyć go do zainicjowania właściwości o tej nazwie?</target>
         <note />
-      </trans-unit>
-      <trans-unit id="WRN_UnsafeMeaningless">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="translated">Modyfikator „unsafe” nie ma tutaj żadnego wpływu w bieżących regułach zabezpieczeń pamięci.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="WRN_UnsafeMeaningless_Title">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="translated">Modyfikator „unsafe” nie ma tutaj żadnego wpływu w bieżących regułach zabezpieczeń pamięci.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
       </trans-unit>
       <trans-unit id="WRN_UnscopedRefAttributeOldRules">
         <source>UnscopedRefAttribute is only valid in C# 11 or later or when targeting net7.0 or later.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -2812,11 +2812,6 @@
         <target state="translated">Niebezpieczny kontekst jest wymagany dla konstruktora „{0}” oznaczonego jako „unsafe”, aby spełniać ograniczenie „new()” parametru typu „{1}” w „{2}”</target>
         <note>'unsafe' and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
-      <trans-unit id="ERR_UnsafeMeaningless">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="new">The 'unsafe' modifier does not have any effect here under the current memory safety rules.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
-      </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
         <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe'</source>
         <target state="translated">Atrybut „{0}” musi być używany w niebezpiecznym kontekście, ponieważ jest oznaczony jako „unsafe”</target>
@@ -6029,6 +6024,11 @@
         <source>Parameter is unread. Did you forget to use it to initialize the property with that name?</source>
         <target state="translated">Parametr nie został odczytany. Czy zapomniano użyć go do zainicjowania właściwości o tej nazwie?</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnsafeMeaningless">
+        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
+        <target state="translated">Modyfikator „unsafe” nie ma tutaj żadnego wpływu w bieżących regułach zabezpieczeń pamięci.</target>
+        <note>'unsafe' is a keyword, should not be localized.</note>
       </trans-unit>
       <trans-unit id="WRN_UnscopedRefAttributeOldRules">
         <source>UnscopedRefAttribute is only valid in C# 11 or later or when targeting net7.0 or later.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -2812,6 +2812,11 @@
         <target state="translated">Um contexto não seguro é necessário para o construtor ''{0}'' marcado como ''unsafe'' para satisfazer a restrição ''new()'' do parâmetro de tipo ''{1}'' em ''{2}''</target>
         <note>'unsafe' and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
+      <trans-unit id="ERR_UnsafeMeaningless">
+        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
+        <target state="new">The 'unsafe' modifier does not have any effect here under the current memory safety rules.</target>
+        <note>'unsafe' is a keyword, should not be localized.</note>
+      </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
         <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe'</source>
         <target state="translated">"{0}" deve ser usado em um contexto não seguro porque está marcado como "unsafe"</target>
@@ -6024,16 +6029,6 @@
         <source>Parameter is unread. Did you forget to use it to initialize the property with that name?</source>
         <target state="translated">O parâmetro não foi lido. Você esqueceu de usá-lo para inicializar a propriedade com esse nome?</target>
         <note />
-      </trans-unit>
-      <trans-unit id="WRN_UnsafeMeaningless">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="translated">O modificador 'unsafe' não tem efeito aqui, segundo as regras de segurança de memória atuais.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="WRN_UnsafeMeaningless_Title">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="translated">O modificador 'unsafe' não tem efeito aqui, segundo as regras de segurança de memória atuais.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
       </trans-unit>
       <trans-unit id="WRN_UnscopedRefAttributeOldRules">
         <source>UnscopedRefAttribute is only valid in C# 11 or later or when targeting net7.0 or later.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -2812,11 +2812,6 @@
         <target state="translated">Um contexto não seguro é necessário para o construtor ''{0}'' marcado como ''unsafe'' para satisfazer a restrição ''new()'' do parâmetro de tipo ''{1}'' em ''{2}''</target>
         <note>'unsafe' and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
-      <trans-unit id="ERR_UnsafeMeaningless">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="new">The 'unsafe' modifier does not have any effect here under the current memory safety rules.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
-      </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
         <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe'</source>
         <target state="translated">"{0}" deve ser usado em um contexto não seguro porque está marcado como "unsafe"</target>
@@ -6029,6 +6024,11 @@
         <source>Parameter is unread. Did you forget to use it to initialize the property with that name?</source>
         <target state="translated">O parâmetro não foi lido. Você esqueceu de usá-lo para inicializar a propriedade com esse nome?</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnsafeMeaningless">
+        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
+        <target state="translated">O modificador 'unsafe' não tem efeito aqui, segundo as regras de segurança de memória atuais.</target>
+        <note>'unsafe' is a keyword, should not be localized.</note>
       </trans-unit>
       <trans-unit id="WRN_UnscopedRefAttributeOldRules">
         <source>UnscopedRefAttribute is only valid in C# 11 or later or when targeting net7.0 or later.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -2812,6 +2812,11 @@
         <target state="translated">Для конструктора "{0}", помеченного как "unsafe", требуется небезопасный контекст, чтобы удовлетворить ограничение "new()" параметра типа "{1}" в "{2}"</target>
         <note>'unsafe' and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
+      <trans-unit id="ERR_UnsafeMeaningless">
+        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
+        <target state="new">The 'unsafe' modifier does not have any effect here under the current memory safety rules.</target>
+        <note>'unsafe' is a keyword, should not be localized.</note>
+      </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
         <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe'</source>
         <target state="translated">"{0}" должен использоваться в небезопасном контексте, так как он помечен как "unsafe"</target>
@@ -6024,16 +6029,6 @@
         <source>Parameter is unread. Did you forget to use it to initialize the property with that name?</source>
         <target state="translated">Параметр не читается. Возможно, вы забыли использовать его для инициализации свойства с таким же именем?</target>
         <note />
-      </trans-unit>
-      <trans-unit id="WRN_UnsafeMeaningless">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="translated">Модификатор "unsafe" в данном случае не оказывает влияния в соответствии с действующими правилами безопасности памяти.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="WRN_UnsafeMeaningless_Title">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="translated">Модификатор "unsafe" в данном случае не оказывает влияния в соответствии с действующими правилами безопасности памяти.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
       </trans-unit>
       <trans-unit id="WRN_UnscopedRefAttributeOldRules">
         <source>UnscopedRefAttribute is only valid in C# 11 or later or when targeting net7.0 or later.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -2812,11 +2812,6 @@
         <target state="translated">Для конструктора "{0}", помеченного как "unsafe", требуется небезопасный контекст, чтобы удовлетворить ограничение "new()" параметра типа "{1}" в "{2}"</target>
         <note>'unsafe' and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
-      <trans-unit id="ERR_UnsafeMeaningless">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="new">The 'unsafe' modifier does not have any effect here under the current memory safety rules.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
-      </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
         <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe'</source>
         <target state="translated">"{0}" должен использоваться в небезопасном контексте, так как он помечен как "unsafe"</target>
@@ -6029,6 +6024,11 @@
         <source>Parameter is unread. Did you forget to use it to initialize the property with that name?</source>
         <target state="translated">Параметр не читается. Возможно, вы забыли использовать его для инициализации свойства с таким же именем?</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnsafeMeaningless">
+        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
+        <target state="translated">Модификатор "unsafe" в данном случае не оказывает влияния в соответствии с действующими правилами безопасности памяти.</target>
+        <note>'unsafe' is a keyword, should not be localized.</note>
       </trans-unit>
       <trans-unit id="WRN_UnscopedRefAttributeOldRules">
         <source>UnscopedRefAttribute is only valid in C# 11 or later or when targeting net7.0 or later.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -2812,6 +2812,11 @@
         <target state="translated">'unsafe' olarak işaretlenen '{0}' oluşturucusu için, '{1}' içindeki '{2}' tür parametresinin 'new()' kısıtlamasını karşılamak üzere güvenli olmayan bir bağlam gereklidir</target>
         <note>'unsafe' and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
+      <trans-unit id="ERR_UnsafeMeaningless">
+        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
+        <target state="new">The 'unsafe' modifier does not have any effect here under the current memory safety rules.</target>
+        <note>'unsafe' is a keyword, should not be localized.</note>
+      </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
         <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe'</source>
         <target state="translated">'{0}' 'unsafe' olarak işaretlendiği için güvenli olmayan bir bağlamda kullanılmalıdır</target>
@@ -6024,16 +6029,6 @@
         <source>Parameter is unread. Did you forget to use it to initialize the property with that name?</source>
         <target state="translated">Parametre okunmadı. Bu ada sahip özelliği başlatmak için bu parametreyi kullanmayı unutmuş olabilirsiniz.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="WRN_UnsafeMeaningless">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="translated">'unsafe' değiştiricisi, mevcut bellek güvenliği kuralları altında burada herhangi bir etkiye sahip değildir.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="WRN_UnsafeMeaningless_Title">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="translated">'unsafe' değiştiricisi, mevcut bellek güvenliği kuralları altında burada herhangi bir etkiye sahip değildir.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
       </trans-unit>
       <trans-unit id="WRN_UnscopedRefAttributeOldRules">
         <source>UnscopedRefAttribute is only valid in C# 11 or later or when targeting net7.0 or later.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -2812,11 +2812,6 @@
         <target state="translated">'unsafe' olarak işaretlenen '{0}' oluşturucusu için, '{1}' içindeki '{2}' tür parametresinin 'new()' kısıtlamasını karşılamak üzere güvenli olmayan bir bağlam gereklidir</target>
         <note>'unsafe' and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
-      <trans-unit id="ERR_UnsafeMeaningless">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="new">The 'unsafe' modifier does not have any effect here under the current memory safety rules.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
-      </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
         <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe'</source>
         <target state="translated">'{0}' 'unsafe' olarak işaretlendiği için güvenli olmayan bir bağlamda kullanılmalıdır</target>
@@ -6029,6 +6024,11 @@
         <source>Parameter is unread. Did you forget to use it to initialize the property with that name?</source>
         <target state="translated">Parametre okunmadı. Bu ada sahip özelliği başlatmak için bu parametreyi kullanmayı unutmuş olabilirsiniz.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnsafeMeaningless">
+        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
+        <target state="translated">'unsafe' değiştiricisi, mevcut bellek güvenliği kuralları altında burada herhangi bir etkiye sahip değildir.</target>
+        <note>'unsafe' is a keyword, should not be localized.</note>
       </trans-unit>
       <trans-unit id="WRN_UnscopedRefAttributeOldRules">
         <source>UnscopedRefAttribute is only valid in C# 11 or later or when targeting net7.0 or later.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -2812,11 +2812,6 @@
         <target state="translated">标记为 'unsafe' 的构造函数“{0}”需要不安全上下文，以满足“{2}”中类型参数“{1}”的 'new()' 约束</target>
         <note>'unsafe' and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
-      <trans-unit id="ERR_UnsafeMeaningless">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="new">The 'unsafe' modifier does not have any effect here under the current memory safety rules.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
-      </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
         <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe'</source>
         <target state="translated">必须在不安全的上下文中使用“{0}”，因为它被标记为 'unsafe'</target>
@@ -6029,6 +6024,11 @@
         <source>Parameter is unread. Did you forget to use it to initialize the property with that name?</source>
         <target state="translated">参数未读。是否忘记通过它来使用该名称初始化属性?</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnsafeMeaningless">
+        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
+        <target state="translated">根据当前内存安全规则，"unsafe" 修饰符在此处没有任何效果。</target>
+        <note>'unsafe' is a keyword, should not be localized.</note>
       </trans-unit>
       <trans-unit id="WRN_UnscopedRefAttributeOldRules">
         <source>UnscopedRefAttribute is only valid in C# 11 or later or when targeting net7.0 or later.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -2812,6 +2812,11 @@
         <target state="translated">标记为 'unsafe' 的构造函数“{0}”需要不安全上下文，以满足“{2}”中类型参数“{1}”的 'new()' 约束</target>
         <note>'unsafe' and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
+      <trans-unit id="ERR_UnsafeMeaningless">
+        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
+        <target state="new">The 'unsafe' modifier does not have any effect here under the current memory safety rules.</target>
+        <note>'unsafe' is a keyword, should not be localized.</note>
+      </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
         <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe'</source>
         <target state="translated">必须在不安全的上下文中使用“{0}”，因为它被标记为 'unsafe'</target>
@@ -6024,16 +6029,6 @@
         <source>Parameter is unread. Did you forget to use it to initialize the property with that name?</source>
         <target state="translated">参数未读。是否忘记通过它来使用该名称初始化属性?</target>
         <note />
-      </trans-unit>
-      <trans-unit id="WRN_UnsafeMeaningless">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="translated">根据当前内存安全规则，"unsafe" 修饰符在此处没有任何效果。</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="WRN_UnsafeMeaningless_Title">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="translated">根据当前内存安全规则，"unsafe" 修饰符在此处没有任何效果。</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
       </trans-unit>
       <trans-unit id="WRN_UnscopedRefAttributeOldRules">
         <source>UnscopedRefAttribute is only valid in C# 11 or later or when targeting net7.0 or later.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -2812,6 +2812,11 @@
         <target state="translated">標示為 'unsafe' 的建構函式 '{0}' 需要不安全的內容，才能符合 '{2}' 中類型參數 '{1}' 的 'new()' 限制</target>
         <note>'unsafe' and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
+      <trans-unit id="ERR_UnsafeMeaningless">
+        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
+        <target state="new">The 'unsafe' modifier does not have any effect here under the current memory safety rules.</target>
+        <note>'unsafe' is a keyword, should not be localized.</note>
+      </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
         <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe'</source>
         <target state="translated">'{0}' 必須在不安全的內容中使用，因為它被標示為 'unsafe'</target>
@@ -6024,16 +6029,6 @@ strument:TestCoverage      產生檢測要收集
         <source>Parameter is unread. Did you forget to use it to initialize the property with that name?</source>
         <target state="translated">參數未讀取。是否忘記使用該參數來初始化該名稱的屬性?</target>
         <note />
-      </trans-unit>
-      <trans-unit id="WRN_UnsafeMeaningless">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="translated">根據目前的記憶體安全規則，'unsafe' 修飾元在此不會產生任何效果。</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="WRN_UnsafeMeaningless_Title">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="translated">根據目前的記憶體安全規則，'unsafe' 修飾元在此不會產生任何效果。</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
       </trans-unit>
       <trans-unit id="WRN_UnscopedRefAttributeOldRules">
         <source>UnscopedRefAttribute is only valid in C# 11 or later or when targeting net7.0 or later.</source>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -2812,11 +2812,6 @@
         <target state="translated">標示為 'unsafe' 的建構函式 '{0}' 需要不安全的內容，才能符合 '{2}' 中類型參數 '{1}' 的 'new()' 限制</target>
         <note>'unsafe' and 'new()' should not be localized. {2} is the generic method or type.</note>
       </trans-unit>
-      <trans-unit id="ERR_UnsafeMeaningless">
-        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
-        <target state="new">The 'unsafe' modifier does not have any effect here under the current memory safety rules.</target>
-        <note>'unsafe' is a keyword, should not be localized.</note>
-      </trans-unit>
       <trans-unit id="ERR_UnsafeMemberOperation">
         <source>'{0}' must be used in an unsafe context because it is marked as 'unsafe'</source>
         <target state="translated">'{0}' 必須在不安全的內容中使用，因為它被標示為 'unsafe'</target>
@@ -6029,6 +6024,11 @@ strument:TestCoverage      產生檢測要收集
         <source>Parameter is unread. Did you forget to use it to initialize the property with that name?</source>
         <target state="translated">參數未讀取。是否忘記使用該參數來初始化該名稱的屬性?</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnsafeMeaningless">
+        <source>The 'unsafe' modifier does not have any effect here under the current memory safety rules.</source>
+        <target state="translated">根據目前的記憶體安全規則，'unsafe' 修飾元在此不會產生任何效果。</target>
+        <note>'unsafe' is a keyword, should not be localized.</note>
       </trans-unit>
       <trans-unit id="WRN_UnscopedRefAttributeOldRules">
         <source>UnscopedRefAttribute is only valid in C# 11 or later or when targeting net7.0 or later.</source>

--- a/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests.cs
@@ -5814,6 +5814,21 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
     }
 
     [Fact]
+    public void UnsafeClass_OtherModifierErrors()
+    {
+        var source = """
+            unsafe virtual class C;
+            """;
+        CreateCompilation(source, options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules()).VerifyDiagnostics(
+            // (1,22): error CS0106: The modifier 'virtual' is not valid for this item
+            // unsafe virtual class C;
+            Diagnostic(ErrorCode.ERR_BadMemberFlag, "C").WithArguments("virtual").WithLocation(1, 22),
+            // (1,22): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            // unsafe virtual class C;
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "C").WithLocation(1, 22));
+    }
+
+    [Fact]
     public void Member_Method_ConvertToFunctionPointer()
     {
         CompileAndVerifyUnsafe(
@@ -9349,6 +9364,24 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
     }
 
     [Fact]
+    public void Member_Constructor_Static_OtherModifierErrors()
+    {
+        var source = """
+            class C
+            {
+                unsafe virtual static C() { }
+            }
+            """;
+        CreateCompilation(source, options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules()).VerifyDiagnostics(
+            // (3,5): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            //     unsafe virtual static C() { }
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "unsafe").WithLocation(3, 5),
+            // (3,27): error CS0106: The modifier 'virtual' is not valid for this item
+            //     unsafe virtual static C() { }
+            Diagnostic(ErrorCode.ERR_BadMemberFlag, "C").WithArguments("virtual").WithLocation(3, 27));
+    }
+
+    [Fact]
     public void Member_Constructor_Attribute()
     {
         CompileAndVerifyUnsafe(
@@ -9782,6 +9815,24 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             expectedUnsafeSymbols: [],
             expectedSafeSymbols: ["C.Finalize"],
             expectedDefinition: AttributeDefinition.None);
+    }
+
+    [Fact]
+    public void Member_Destructor_OtherModifierErrors()
+    {
+        var source = """
+            class C
+            {
+                unsafe virtual ~C() { }
+            }
+            """;
+        CreateCompilation(source, options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules()).VerifyDiagnostics(
+            // (3,5): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            //     unsafe virtual ~C() { }
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "unsafe").WithLocation(3, 5),
+            // (3,21): error CS0106: The modifier 'virtual' is not valid for this item
+            //     unsafe virtual ~C() { }
+            Diagnostic(ErrorCode.ERR_BadMemberFlag, "C").WithArguments("virtual").WithLocation(3, 21));
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests.cs
@@ -79,15 +79,30 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 .VerifyDiagnostics(expectedDiagnosticsWithOldLangVersion);
         }
 
-        var libUpdated = CompileAndVerify([lib, .. additionalSources],
-            targetFramework: targetFramework,
-            parseOptions: parseOptions,
-            options: optionsDll.WithUpdatedMemorySafetyRules(),
-            verify: verify,
-            symbolValidator: symbolValidator)
-            .VerifyDiagnostics(expectedLibDiagnostics ?? []);
+        var libUpdatedHasErrors = expectedLibDiagnostics?.Any(d => !ErrorFacts.IsWarning((ErrorCode)d.Code)) == true;
 
-        var libUpdatedRefs = new MetadataReference[] { libUpdated.GetImageReference(), libUpdated.Compilation.ToMetadataReference() };
+        MetadataReference[] libUpdatedRefs;
+
+        if (libUpdatedHasErrors)
+        {
+            var libUpdated = CreateCompilation([lib, .. additionalSources],
+                targetFramework: targetFramework,
+                parseOptions: parseOptions,
+                options: optionsDll.WithUpdatedMemorySafetyRules())
+                .VerifyDiagnostics(expectedLibDiagnostics ?? []);
+            libUpdatedRefs = [libUpdated.ToMetadataReference()];
+        }
+        else
+        {
+            var libUpdated = CompileAndVerify([lib, .. additionalSources],
+                targetFramework: targetFramework,
+                parseOptions: parseOptions,
+                options: optionsDll.WithUpdatedMemorySafetyRules(),
+                verify: verify,
+                symbolValidator: symbolValidator)
+                .VerifyDiagnostics(expectedLibDiagnostics ?? []);
+            libUpdatedRefs = [libUpdated.GetImageReference(), libUpdated.Compilation.ToMetadataReference()];
+        }
 
         foreach (var libUpdatedRef in libUpdatedRefs)
         {
@@ -4639,8 +4654,10 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             unsafe enum E { A }
             unsafe record R;
             unsafe delegate void D();
+            unsafe union N(int);
             class X
             {
+                unsafe static X() { }
                 unsafe X() { }
                 unsafe ~X() { }
                 unsafe int f;
@@ -4649,7 +4666,13 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 unsafe event System.Action E { add { } remove { } }
                 public static unsafe implicit operator int(X x) => 0;
             }
+            unsafe partial class P1;
+            partial class P1;
+            partial class P2;
+            unsafe partial class P2;
             """;
+
+        CSharpTestSource sources = [source, IsExternalInitTypeDefinition, IUnionSource, UnionAttributeSource];
 
         var expectedDiagnostics = new[]
         {
@@ -4658,63 +4681,98 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             Diagnostic(ErrorCode.ERR_BadMemberFlag, "E").WithArguments("unsafe").WithLocation(10, 13),
         };
 
-        CreateCompilation([source, IsExternalInitTypeDefinition], options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
-
-        CreateCompilation([source, IsExternalInitTypeDefinition], options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules().WithWarningLevel(10)).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(sources, options: TestOptions.UnsafeReleaseExe).VerifyDiagnostics(expectedDiagnostics);
 
         expectedDiagnostics =
         [
-            // (7,14): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            // (7,14): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
             // unsafe class C;
-            Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "C").WithLocation(7, 14),
-            // (8,15): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "C").WithLocation(7, 14),
+            // (8,15): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
             // unsafe struct S;
-            Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "S").WithLocation(8, 15),
-            // (9,18): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "S").WithLocation(8, 15),
+            // (9,18): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
             // unsafe interface I;
-            Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "I").WithLocation(9, 18),
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "I").WithLocation(9, 18),
             // (10,13): error CS0106: The modifier 'unsafe' is not valid for this item
             // unsafe enum E { A }
             Diagnostic(ErrorCode.ERR_BadMemberFlag, "E").WithArguments("unsafe").WithLocation(10, 13),
-            // (11,15): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            // (11,15): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
             // unsafe record R;
-            Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "R").WithLocation(11, 15),
-            // (12,22): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "R").WithLocation(11, 15),
+            // (12,22): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
             // unsafe delegate void D();
-            Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "D").WithLocation(12, 22),
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "D").WithLocation(12, 22),
+            // (13,14): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            // unsafe union N(int);
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "N").WithLocation(13, 14),
+            // (16,5): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            //     unsafe static X() { }
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "unsafe").WithLocation(16, 5),
+            // (18,5): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            //     unsafe ~X() { }
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "unsafe").WithLocation(18, 5),
+            // (25,22): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            // unsafe partial class P1;
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "P1").WithLocation(25, 22),
+            // (27,15): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            // partial class P2;
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "P2").WithLocation(27, 15),
         ];
 
-        CreateCompilation([source, IsExternalInitTypeDefinition], options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules()).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(sources, options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules()).VerifyDiagnostics(expectedDiagnostics);
 
-        CreateCompilation([source, IsExternalInitTypeDefinition], options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules().WithWarningLevel(11)).VerifyDiagnostics(expectedDiagnostics);
-
-        CreateCompilation([source, IsExternalInitTypeDefinition],
+        CreateCompilation(sources,
             parseOptions: TestOptions.RegularNext,
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules()).VerifyDiagnostics(expectedDiagnostics);
 
-        CreateCompilation([source, IsExternalInitTypeDefinition],
+        CreateCompilation(sources,
             parseOptions: TestOptions.Regular14,
             options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules()).VerifyDiagnostics(
             // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
             Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
-            // (7,14): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            // (7,14): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
             // unsafe class C;
-            Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "C").WithLocation(7, 14),
-            // (8,15): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "C").WithLocation(7, 14),
+            // (8,15): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
             // unsafe struct S;
-            Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "S").WithLocation(8, 15),
-            // (9,18): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "S").WithLocation(8, 15),
+            // (9,18): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
             // unsafe interface I;
-            Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "I").WithLocation(9, 18),
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "I").WithLocation(9, 18),
             // (10,13): error CS0106: The modifier 'unsafe' is not valid for this item
             // unsafe enum E { A }
             Diagnostic(ErrorCode.ERR_BadMemberFlag, "E").WithArguments("unsafe").WithLocation(10, 13),
-            // (11,15): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            // (11,15): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
             // unsafe record R;
-            Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "R").WithLocation(11, 15),
-            // (12,22): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "R").WithLocation(11, 15),
+            // (12,22): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
             // unsafe delegate void D();
-            Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "D").WithLocation(12, 22));
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "D").WithLocation(12, 22),
+            // (13,1): error CS8803: Top-level statements must precede namespace and type declarations.
+            // unsafe union N(int);
+            Diagnostic(ErrorCode.ERR_TopLevelStatementAfterNamespaceOrType, "unsafe union N(int);").WithLocation(13, 1),
+            // (13,8): error CS0246: The type or namespace name 'union' could not be found (are you missing a using directive or an assembly reference?)
+            // unsafe union N(int);
+            Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "union").WithArguments("union").WithLocation(13, 8),
+            // (13,14): error CS8112: Local function 'N(int)' must declare a body because it is not marked 'static extern'.
+            // unsafe union N(int);
+            Diagnostic(ErrorCode.ERR_LocalFunctionMissingBody, "N").WithArguments("N(int)").WithLocation(13, 14),
+            // (13,19): error CS1001: Identifier expected
+            // unsafe union N(int);
+            Diagnostic(ErrorCode.ERR_IdentifierExpected, ")").WithLocation(13, 19),
+            // (16,5): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            //     unsafe static X() { }
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "unsafe").WithLocation(16, 5),
+            // (18,5): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            //     unsafe ~X() { }
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "unsafe").WithLocation(18, 5),
+            // (25,22): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            // unsafe partial class P1;
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "P1").WithLocation(25, 22),
+            // (27,15): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            // partial class P2;
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "P2").WithLocation(27, 15));
     }
 
     [Fact]
@@ -4766,21 +4824,21 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CreateCompilation(source, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeReleaseExe).VerifyEmitDiagnostics();
         CreateCompilation(source, options: TestOptions.UnsafeReleaseExe).VerifyEmitDiagnostics();
         CreateCompilation(source, options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules()).VerifyEmitDiagnostics(
-            // (19,14): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            // (19,14): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
             // unsafe class C;
-            Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "C").WithLocation(19, 14),
-            // (20,15): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "C").WithLocation(19, 14),
+            // (20,15): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
             // unsafe struct S;
-            Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "S").WithLocation(20, 15),
-            // (21,18): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "S").WithLocation(20, 15),
+            // (21,18): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
             // unsafe interface I;
-            Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "I").WithLocation(21, 18),
-            // (22,15): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "I").WithLocation(21, 18),
+            // (22,15): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
             // unsafe record R;
-            Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "R").WithLocation(22, 15),
-            // (23,22): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "R").WithLocation(22, 15),
+            // (23,22): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
             // unsafe delegate void D();
-            Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "D").WithLocation(23, 22));
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "D").WithLocation(23, 22));
     }
 
     [Fact]
@@ -4811,9 +4869,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         CreateCompilation(source, parseOptions: TestOptions.RegularNext, options: TestOptions.UnsafeReleaseExe).VerifyEmitDiagnostics();
         CreateCompilation(source, options: TestOptions.UnsafeReleaseExe).VerifyEmitDiagnostics();
         CreateCompilation(source, options: TestOptions.UnsafeReleaseExe.WithUpdatedMemorySafetyRules()).VerifyEmitDiagnostics(
-            // (11,22): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            // (11,22): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
             // unsafe delegate int* D();
-            Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "D").WithLocation(11, 22));
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "D").WithLocation(11, 22));
     }
 
     [Fact]
@@ -4958,9 +5016,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             // (6,20): error CS9360: This operation may only be used in an unsafe context
             //     unsafe int f = *(default(int*));
             Diagnostic(ErrorCode.ERR_UnsafeOperation, "*").WithLocation(6, 20),
-            // (8,14): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            // (8,14): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
             // unsafe class D
-            Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "D").WithLocation(8, 14),
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "D").WithLocation(8, 14),
             // (10,28): error CS9360: This operation may only be used in an unsafe context
             //     int M(int* p) { return *p; }
             Diagnostic(ErrorCode.ERR_UnsafeOperation, "*").WithLocation(10, 28),
@@ -5173,9 +5231,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             // (19,6): error CS9362: 'A.A()' must be used in an unsafe context because it is marked as 'unsafe'
             //     [A] unsafe void M2() { }
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "A").WithArguments("A.A()").WithLocation(19, 6),
-            // (22,14): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            // (22,14): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
             // unsafe class UnsafeTest
-            Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "UnsafeTest").WithLocation(22, 14),
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "UnsafeTest").WithLocation(22, 14),
             // (26,6): error CS9362: 'A.A()' must be used in an unsafe context because it is marked as 'unsafe'
             //     [A] void M2() { }
             Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "A").WithArguments("A.A()").WithLocation(26, 6));
@@ -5227,9 +5285,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             // (4,21): error CS9360: This operation may only be used in an unsafe context
             //     void M2(int x = *(default(int*))) { }
             Diagnostic(ErrorCode.ERR_UnsafeOperation, "*").WithLocation(4, 21),
-            // (7,14): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            // (7,14): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
             // unsafe class D
-            Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "D").WithLocation(7, 14),
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "D").WithLocation(7, 14),
             // (9,20): error CS9360: This operation may only be used in an unsafe context
             //     void M(int x = *(default(int*))) { }
             Diagnostic(ErrorCode.ERR_UnsafeOperation, "*").WithLocation(9, 20),
@@ -5377,22 +5435,15 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             #pragma warning disable CS0169 // unused field
                 unsafe int F;
             }
-            unsafe class U;
-            unsafe delegate void D();
             """;
         CSharpTestSource source =
         [
             declarationsSource,
             CompilerFeatureRequiredAttribute,
-            """
-            namespace System.Diagnostics.CodeAnalysis
-            {
-                public sealed class RequiresUnsafeAttribute : Attribute;
-            }
-            """,
+            RequiresUnsafeAttributeDefinition,
         ];
 
-        string[] safeSymbols = ["C", "U", "D"];
+        string[] safeSymbols = ["C"];
         string[] unsafeSymbols =
         [
             "C.<M0>g__F|0_0",
@@ -5437,13 +5488,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                         expectedSafeSymbols: [.. safeSymbols],
                         expectedDefinition: AttributeDefinition.FromSource);
                 })
-                .VerifyDiagnostics(
-                // (16,14): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
-                // unsafe class U;
-                Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "U").WithLocation(16, 14),
-                // (17,22): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
-                // unsafe delegate void D();
-                Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "D").WithLocation(17, 22));
+                .VerifyDiagnostics();
         }
 
         CreateCompilation(source,
@@ -5451,13 +5496,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
             // error CS8630: Invalid 'MemorySafetyRules' value: '2' for C# 14.0. Please use language version 'preview' or greater.
-            Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1),
-            // (16,14): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
-            // unsafe class U;
-            Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "U").WithLocation(16, 14),
-            // (17,22): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
-            // unsafe delegate void D();
-            Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "D").WithLocation(17, 22));
+            Diagnostic(ErrorCode.ERR_CompilationOptionNotAvailable).WithArguments("MemorySafetyRules", "2", "14.0", "preview").WithLocation(1, 1));
 
         source =
         [
@@ -5513,13 +5552,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "unsafe").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute").WithLocation(12, 5),
             // (14,5): error CS0518: Predefined type 'System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute' is not defined or imported
             //     unsafe int F;
-            Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "unsafe").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute").WithLocation(14, 5),
-            // (16,14): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
-            // unsafe class U;
-            Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "U").WithLocation(16, 14),
-            // (17,22): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
-            // unsafe delegate void D();
-            Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "D").WithLocation(17, 22));
+            Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "unsafe").WithArguments("System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute").WithLocation(14, 5));
     }
 
     [Theory, CombinatorialData]
@@ -5774,9 +5807,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             ],
             expectedLibDiagnostics:
             [
-                // (2,21): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+                // (2,21): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
                 // public unsafe class C
-                Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "C").WithLocation(2, 21),
+                Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "C").WithLocation(2, 21),
             ]);
     }
 
@@ -5839,15 +5872,15 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 // (2,8): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'unsafe'
                 // D2 b = C.M;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "C.M").WithArguments("C.M()").WithLocation(2, 8),
-                // (7,22): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+                // (7,22): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
                 // unsafe delegate void D2();
-                Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "D2").WithLocation(7, 22),
+                Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "D2").WithLocation(7, 22),
             ],
             expectedDiagnosticsWhenReferencingLegacyLib:
             [
-                // (7,22): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+                // (7,22): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
                 // unsafe delegate void D2();
-                Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "D2").WithLocation(7, 22),
+                Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "D2").WithLocation(7, 22),
             ]);
     }
 
@@ -8196,12 +8229,12 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 // (3,36): error CS9362: 'A.F' must be used in an unsafe context because it is marked as 'unsafe'
                 // [A(P1 = 0, P2 = 0, P3 = 0, P4 = 0, F = 0, G = 0)] unsafe class C2;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "F = 0").WithArguments("A.F").WithLocation(3, 36),
-                // (3,64): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+                // (3,64): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
                 // [A(P1 = 0, P2 = 0, P3 = 0, P4 = 0, F = 0, G = 0)] unsafe class C2;
-                Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "C2").WithLocation(3, 64),
-                // (4,15): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+                Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "C2").WithLocation(3, 64),
+                // (4,15): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
                 // partial class C3
-                Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "C3").WithLocation(4, 15),
+                Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "C3").WithLocation(4, 15),
                 // (6,16): error CS9362: 'A.P2.set' must be used in an unsafe context because it is marked as 'unsafe'
                 //     [A(P1 = 0, P2 = 0, P3 = 0, P4 = 0, F = 0, G = 0)] void M1() { }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "P2 = 0").WithArguments("A.P2.set").WithLocation(6, 16),
@@ -8223,12 +8256,12 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             ],
             expectedDiagnosticsWhenReferencingLegacyLib:
             [
-                // (3,64): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+                // (3,64): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
                 // [A(P1 = 0, P2 = 0, P3 = 0, P4 = 0, F = 0, G = 0)] unsafe class C2;
-                Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "C2").WithLocation(3, 64),
-                // (4,15): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+                Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "C2").WithLocation(3, 64),
+                // (4,15): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
                 // partial class C3
-                Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "C3").WithLocation(4, 15),
+                Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "C3").WithLocation(4, 15),
             ]);
     }
 
@@ -9043,9 +9076,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 // (17,44): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'unsafe'
                 //     unsafe public event System.Action U2 = C.M();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "C.M()").WithArguments("C.M()").WithLocation(17, 44),
-                // (19,14): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+                // (19,14): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
                 // unsafe class U
-                Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "U").WithLocation(19, 14),
+                Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "U").WithLocation(19, 14),
                 // (21,37): error CS9360: This operation may only be used in an unsafe context
                 //     public event System.Action E1 = default(delegate*<System.Action>)();
                 Diagnostic(ErrorCode.ERR_UnsafeOperation, "default(delegate*<System.Action>)()").WithLocation(21, 37),
@@ -9085,9 +9118,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 // (16,44): error CS9360: This operation may only be used in an unsafe context
                 //     unsafe public event System.Action U1 = default(delegate*<System.Action>)();
                 Diagnostic(ErrorCode.ERR_UnsafeOperation, "default(delegate*<System.Action>)()").WithLocation(16, 44),
-                // (19,14): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+                // (19,14): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
                 // unsafe class U
-                Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "U").WithLocation(19, 14),
+                Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "U").WithLocation(19, 14),
                 // (21,37): error CS9360: This operation may only be used in an unsafe context
                 //     public event System.Action E1 = default(delegate*<System.Action>)();
                 Diagnostic(ErrorCode.ERR_UnsafeOperation, "default(delegate*<System.Action>)()").WithLocation(21, 37),
@@ -9131,9 +9164,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             ],
             expectedLibDiagnostics:
             [
-                // (6,21): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+                // (6,21): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
                 // public unsafe class C2(int x)
-                Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "C2").WithLocation(6, 21),
+                Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "C2").WithLocation(6, 21),
             ]);
     }
 
@@ -9201,21 +9234,21 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 // (18,1): error CS9362: 'B.B()' must be used in an unsafe context because it is marked as 'unsafe'
                 // unsafe class C3 : B;
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "unsafe class C3 : B;").WithArguments("B.B()").WithLocation(18, 1),
-                // (18,14): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+                // (18,14): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
                 // unsafe class C3 : B;
-                Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "C3").WithLocation(18, 14),
-                // (19,14): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+                Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "C3").WithLocation(18, 14),
+                // (19,14): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
                 // unsafe class C4 : B
-                Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "C4").WithLocation(19, 14),
+                Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "C4").WithLocation(19, 14),
                 // (21,5): error CS9362: 'B.B()' must be used in an unsafe context because it is marked as 'unsafe'
                 //     public C4() { }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "public C4() { }").WithArguments("B.B()").WithLocation(21, 5),
                 // (22,22): error CS9362: 'B.B()' must be used in an unsafe context because it is marked as 'unsafe'
                 //     public C4(int x) : base() { }
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, ": base()").WithArguments("B.B()").WithLocation(22, 22),
-                // (24,14): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+                // (24,14): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
                 // unsafe class D2() : B();
-                Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "D2").WithLocation(24, 14),
+                Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "D2").WithLocation(24, 14),
                 // (24,21): error CS9362: 'B.B()' must be used in an unsafe context because it is marked as 'unsafe'
                 // unsafe class D2() : B();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "B()").WithArguments("B.B()").WithLocation(24, 21),
@@ -9225,15 +9258,15 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 // (5,5): error CS9362: 'C5.C5()' must be used in an unsafe context because it is marked as 'unsafe'
                 // _ = new C5();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "new C5()").WithArguments("C5.C5()").WithLocation(5, 5),
-                // (18,14): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+                // (18,14): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
                 // unsafe class C3 : B;
-                Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "C3").WithLocation(18, 14),
-                // (19,14): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+                Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "C3").WithLocation(18, 14),
+                // (19,14): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
                 // unsafe class C4 : B
-                Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "C4").WithLocation(19, 14),
-                // (24,14): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+                Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "C4").WithLocation(19, 14),
+                // (24,14): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
                 // unsafe class D2() : B();
-                Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "D2").WithLocation(24, 14),
+                Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "D2").WithLocation(24, 14),
             ]);
     }
 
@@ -9306,7 +9339,13 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             optionsDll: TestOptions.UnsafeReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All),
             expectedUnsafeSymbols: [],
             expectedSafeSymbols: ["C", "C..cctor"],
-            expectedDiagnostics: []);
+            expectedDiagnostics: [],
+            expectedLibDiagnostics:
+            [
+                // (4,5): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+                //     unsafe static C() { }
+                Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "unsafe").WithLocation(4, 5),
+            ]);
     }
 
     [Fact]
@@ -9731,6 +9770,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             ],
             options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules())
             .VerifyDiagnostics(
+            // (3,5): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+            //     unsafe ~C() { }
+            Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "unsafe").WithLocation(3, 5),
             // (4,16): error CS0245: Destructors and object.Finalize cannot be called directly. Consider calling IDisposable.Dispose if available.
             //     void M() { Finalize(); }
             Diagnostic(ErrorCode.ERR_CallingFinalizeDeprecated, "Finalize()").WithLocation(4, 16));
@@ -10613,9 +10655,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 // (8,21): error CS9362: 'C.M()' must be used in an unsafe context because it is marked as 'unsafe'
                 //     unsafe int U2 = C.M();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "C.M()").WithArguments("C.M()").WithLocation(8, 21),
-                // (10,14): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+                // (10,14): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
                 // unsafe class U
-                Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "U").WithLocation(10, 14),
+                Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "U").WithLocation(10, 14),
                 // (12,14): error CS9360: This operation may only be used in an unsafe context
                 //     int F1 = *default(int*);
                 Diagnostic(ErrorCode.ERR_UnsafeOperation, "*").WithLocation(12, 14),
@@ -10646,9 +10688,9 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 // (7,21): error CS9360: This operation may only be used in an unsafe context
                 //     unsafe int U1 = *default(int*);
                 Diagnostic(ErrorCode.ERR_UnsafeOperation, "*").WithLocation(7, 21),
-                // (10,14): warning CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+                // (10,14): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
                 // unsafe class U
-                Diagnostic(ErrorCode.WRN_UnsafeMeaningless, "U").WithLocation(10, 14),
+                Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "U").WithLocation(10, 14),
                 // (12,14): error CS9360: This operation may only be used in an unsafe context
                 //     int F1 = *default(int*);
                 Diagnostic(ErrorCode.ERR_UnsafeOperation, "*").WithLocation(12, 14),
@@ -14116,8 +14158,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             Diagnostic(ErrorCode.ERR_ExternMemberRequiresUnsafeOrSafe, "extern").WithLocation(25, 16));
     }
 
-    [Theory, CombinatorialData]
-    public void SafeModifier_Extern_SafeUnsafe(bool updatedRules)
+    [Fact]
+    public void SafeModifier_Extern_SafeUnsafe()
     {
         var source = """
             #pragma warning disable CS0067, CS0626, CS0824, CS8321 // unused event, extern without attributes, extern constructor, unused local function
@@ -14136,7 +14178,8 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             }
             """;
 
-        CreateCompilation(source, options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules(updatedRules)).VerifyDiagnostics(
+        var expectedDiagnostics = new[]
+        {
             // (4,5): error CS9388: The 'safe' modifier may only be used on members that are not marked 'unsafe' and are either 'extern', or field-like in types with explicit or extended layout.
             //     safe unsafe public extern void M1();
             Diagnostic(ErrorCode.ERR_SafeModifierUnsupportedTarget, "safe").WithLocation(4, 5),
@@ -14157,7 +14200,18 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             Diagnostic(ErrorCode.ERR_SafeModifierUnsupportedTarget, "safe").WithLocation(9, 5),
             // (12,9): error CS9388: The 'safe' modifier may only be used on members that are not marked 'unsafe' and are either 'extern', or field-like in types with explicit or extended layout.
             //         safe unsafe static extern void Local1();
-            Diagnostic(ErrorCode.ERR_SafeModifierUnsupportedTarget, "safe").WithLocation(12, 9));
+            Diagnostic(ErrorCode.ERR_SafeModifierUnsupportedTarget, "safe").WithLocation(12, 9),
+        };
+
+        CreateCompilation(source, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(expectedDiagnostics);
+
+        CreateCompilation(source, options: TestOptions.UnsafeReleaseDll.WithUpdatedMemorySafetyRules()).VerifyDiagnostics(
+            [
+                .. expectedDiagnostics,
+                // (9,10): error CS9377: The 'unsafe' modifier does not have any effect here under the current memory safety rules.
+                //     safe unsafe extern ~C();
+                Diagnostic(ErrorCode.ERR_UnsafeMeaningless, "unsafe").WithLocation(9, 10),
+            ]);
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -481,10 +481,6 @@ class X
                             // These are the warnings introduced with the warning "wave" shipped with dotnet 10 and C# 14.
                             Assert.Equal(10, ErrorFacts.GetWarningLevel(errorCode));
                             break;
-                        case ErrorCode.WRN_UnsafeMeaningless:
-                            // These are the warnings introduced with the warning "wave" shipped with dotnet 11 and C# 15.
-                            Assert.Equal(11, ErrorFacts.GetWarningLevel(errorCode));
-                            break;
                         default:
                             // If a new warning is added, this test will fail
                             // and whoever is adding the new warning will have to update it with the expected error level.


### PR DESCRIPTION
Test plan: https://github.com/dotnet/roslyn/issues/81207

Implements this part of the speclet https://github.com/dotnet/csharplang/blob/b7b9a110c2e1a1b9dbdf3068bd742154e472c782/proposals/unsafe-evolution.md#unsafe-modifiers-and-contexts:

> `unsafe` on the following declarations produces an error because it does not have a meaning anymore:
>
> -   `delegate`,
> -   static constructor,
> -   destructor,
> -   type declaration (`class`, `struct`, etc.).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84378)