### PR TITLE
Remove dead DotNet-VSTS-Infra-Access variable group reference

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -81,7 +81,6 @@ variables:
   # DevDiv drop access token is acquired via WIF service connection (dnceng-devdiv-drop-rw-code-rw-wif)
   # Get $AccessToken-dotnet-build-bot-public-repo from DotNet-Versions-Publish
   - group: DotNet-Versions-Publish
-  - group: DotNet-VSTS-Infra-Access
   - group: DotNet-DevDiv-Insertion-Workflow-Variables
   - group: AzureDevOps-Artifact-Feeds-Pats
   - name: _DevDivDropAccessToken


### PR DESCRIPTION
The \DotNet-VSTS-Infra-Access\ variable group (VG 4 in dnceng/internal) only contained the \dn-bot-devdiv-drop-r-code-r\ PAT which has been fully migrated to WIF:

- **WIF service connection**: \dnceng-devdiv-drop-rw-code-rw-wif\ (already in use by this pipeline)
- **PAT status**: Expired (May 31, 2026) and disabled in Key Vault
- **Secret manifest**: Removed from \.vault-config/product-builds-engkeyvault.yaml\ (arcade#16900)

The variable group is no longer needed and its only variable resolves to an empty/stale value. This is a no-op cleanup.

Related: https://dev.azure.com/dnceng/internal/_workitems/edit/10147
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84382)