### PR TITLE
[LSP] Add progress when loading solution and progress

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.ProcessHost.UnitTests/Workspaces/AutoLoadProjectsTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.ProcessHost.UnitTests/Workspaces/AutoLoadProjectsTests.cs
@@ -100,17 +100,53 @@ public sealed class AutoLoadProjectsTests(ITestOutputHelper testOutputHelper) : 
         await AssertAutoLoadCompletedAsync(testLspServer, GetLoadingFileMessage(testLspServer, "Solutions/App.slnx"), GetLoadedFileMessage(testLspServer, "Solutions/App.slnx"));
     }
 
+    [Fact]
+    public async Task ReportsProgressForExplicitSolutionOpen()
+    {
+        var workspaceContent = LspWorkspaceContent.Empty
+            .WithFile("App.csproj", ProjectContent)
+            .WithFile("App.sln", CreateSolutionFile("App.csproj"))
+            .WithLoadPath("App.sln")
+            .WithRestore();
+
+        await using var testLspServer = await CreateLanguageServerAsync(
+            workspaceContent,
+            new LspServerLaunchOptions(),
+            CreateWorkDoneProgressClientCapabilities());
+
+        await AssertAutoLoadCompletedAsync(testLspServer, GetLoadingFileMessage(testLspServer, "App.sln"), GetLoadedFileMessage(testLspServer, "App.sln"));
+    }
+
+    [Fact]
+    public async Task ReportsProgressForExplicitProjectOpen()
+    {
+        var workspaceContent = LspWorkspaceContent.Empty
+            .WithFile("Project.csproj", ProjectContent)
+            .WithLoadPath("Project.csproj")
+            .WithRestore();
+
+        await using var testLspServer = await CreateLanguageServerAsync(
+            workspaceContent,
+            new LspServerLaunchOptions(),
+            CreateWorkDoneProgressClientCapabilities());
+
+        await AssertAutoLoadCompletedAsync(testLspServer, GetLoadingProjectsMessage(projectCount: 1), GetLoadedProjectsMessage(projectCount: 1));
+    }
+
     private Task<TestLspClient> CreateAutoLoadLanguageServerAsync(LspWorkspaceContent workspaceContent)
         => CreateLanguageServerAsync(
             workspaceContent,
             new LspServerLaunchOptions { AutoLoadProjects = true },
-            new VSInternalClientCapabilities
+            CreateWorkDoneProgressClientCapabilities());
+
+    private static VSInternalClientCapabilities CreateWorkDoneProgressClientCapabilities()
+        => new()
+        {
+            Window = new WindowClientCapabilities
             {
-                Window = new WindowClientCapabilities
-                {
-                    WorkDoneProgress = true,
-                }
-            });
+                WorkDoneProgress = true,
+            }
+        };
 
     private static LspWorkspaceContent CreateAutoLoadWorkspace()
         => LspWorkspaceContent.Empty.WithRestore();

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/OpenProjectsHandler.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/OpenProjectsHandler.cs
@@ -18,7 +18,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
 internal sealed class OpenProjectHandlerFactory() : ILspServiceFactory
 {
     public ILspService CreateILspService(LspServices lspServices, WellKnownLspServerKinds serverKind)
-        => new OpenProjectHandler(lspServices.GetRequiredService<LanguageServerProjectSystem>());
+        => new OpenProjectHandler(
+            lspServices.GetRequiredService<LanguageServerProjectSystem>(),
+            lspServices.GetRequiredService<WorkDoneProgressManager>());
 }
 
 [Method(OpenProjectName)]
@@ -27,18 +29,29 @@ internal sealed class OpenProjectHandler : ILspService, ILspServiceNotificationH
     internal const string OpenProjectName = "project/open";
 
     private readonly LanguageServerProjectSystem _projectSystem;
+    private readonly WorkDoneProgressManager _workDoneProgressManager;
 
-    public OpenProjectHandler(LanguageServerProjectSystem projectSystem)
+    public OpenProjectHandler(LanguageServerProjectSystem projectSystem, WorkDoneProgressManager workDoneProgressManager)
     {
         _projectSystem = projectSystem;
+        _workDoneProgressManager = workDoneProgressManager;
     }
 
     public bool MutatesSolutionState => false;
     public bool RequiresLSPSolution => false;
 
-    Task INotificationHandler<NotificationParams, RequestContext>.HandleNotificationAsync(NotificationParams request, RequestContext requestContext, CancellationToken cancellationToken)
+    async Task INotificationHandler<NotificationParams, RequestContext>.HandleNotificationAsync(NotificationParams request, RequestContext requestContext, CancellationToken cancellationToken)
     {
-        return _projectSystem.OpenProjectsAsync(request.Projects.SelectAsArray(p => p.GetDocumentFilePathFromUri()));
+        var projectPaths = request.Projects.SelectAsArray(p => p.GetDocumentFilePathFromUri());
+        await using var progressReporter = await _workDoneProgressManager.CreateWorkDoneProgressAsync(
+            reportProgressToClient: true,
+            title: string.Format(LanguageServerResources.Loading_0_projects, projectPaths.Length),
+            startMessage: string.Format(LanguageServerResources.Loading_0_projects, projectPaths.Length),
+            endMessage: string.Format(LanguageServerResources.Loaded_0_projects, projectPaths.Length),
+            clientCanCancel: false,
+            serverCancellationToken: cancellationToken);
+
+        await _projectSystem.OpenProjectsAsync(projectPaths, progressReporter);
     }
 
     internal sealed class NotificationParams

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/OpenProjectsHandler.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/OpenProjectsHandler.cs
@@ -42,15 +42,17 @@ internal sealed class OpenProjectHandler : ILspService, ILspServiceNotificationH
 
     async Task INotificationHandler<NotificationParams, RequestContext>.HandleNotificationAsync(NotificationParams request, RequestContext requestContext, CancellationToken cancellationToken)
     {
-        var projectPaths = request.Projects.SelectAsArray(p => p.GetDocumentFilePathFromUri());
+        var projectsLength = request.Projects.Length;
+        var loadingMessage = string.Format(LanguageServerResources.Loading_0_projects, projectsLength);
         await using var progressReporter = await _workDoneProgressManager.CreateWorkDoneProgressAsync(
             reportProgressToClient: true,
-            title: string.Format(LanguageServerResources.Loading_0_projects, projectPaths.Length),
-            startMessage: string.Format(LanguageServerResources.Loading_0_projects, projectPaths.Length),
-            endMessage: string.Format(LanguageServerResources.Loaded_0_projects, projectPaths.Length),
+            title: loadingMessage,
+            startMessage: loadingMessage,
+            endMessage: string.Format(LanguageServerResources.Loaded_0_projects, projectsLength),
             clientCanCancel: false,
             serverCancellationToken: cancellationToken);
 
+        var projectPaths = request.Projects.SelectAsArray(p => p.GetDocumentFilePathFromUri());
         await _projectSystem.OpenProjectsAsync(projectPaths, progressReporter);
     }
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/OpenSolutionHandler.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/OpenSolutionHandler.cs
@@ -42,10 +42,12 @@ internal sealed class OpenSolutionHandler : ILspService, ILspServiceNotification
     async Task INotificationHandler<NotificationParams, RequestContext>.HandleNotificationAsync(NotificationParams request, RequestContext requestContext, CancellationToken cancellationToken)
     {
         var solutionPath = request.Solution.GetDocumentFilePathFromUri();
+
+        var loadingMessage = string.Format(LanguageServerResources.Loading_0, solutionPath);
         await using var progressReporter = await _workDoneProgressManager.CreateWorkDoneProgressAsync(
             reportProgressToClient: true,
-            title: string.Format(LanguageServerResources.Loading_0, solutionPath),
-            startMessage: string.Format(LanguageServerResources.Loading_0, solutionPath),
+            title: loadingMessage,
+            startMessage: loadingMessage,
             endMessage: string.Format(LanguageServerResources.Loaded_0, solutionPath),
             clientCanCancel: false,
             serverCancellationToken: cancellationToken);

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/OpenSolutionHandler.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/OpenSolutionHandler.cs
@@ -17,7 +17,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
 internal sealed class OpenSolutionHandlerFactory() : ILspServiceFactory
 {
     public ILspService CreateILspService(LspServices lspServices, WellKnownLspServerKinds serverKind)
-        => new OpenSolutionHandler(lspServices.GetRequiredService<LanguageServerProjectSystem>());
+        => new OpenSolutionHandler(
+            lspServices.GetRequiredService<LanguageServerProjectSystem>(),
+            lspServices.GetRequiredService<WorkDoneProgressManager>());
 }
 
 [Method(OpenSolutionName)]
@@ -26,18 +28,29 @@ internal sealed class OpenSolutionHandler : ILspService, ILspServiceNotification
     internal const string OpenSolutionName = "solution/open";
 
     private readonly LanguageServerProjectSystem _projectSystem;
+    private readonly WorkDoneProgressManager _workDoneProgressManager;
 
-    public OpenSolutionHandler(LanguageServerProjectSystem projectSystem)
+    public OpenSolutionHandler(LanguageServerProjectSystem projectSystem, WorkDoneProgressManager workDoneProgressManager)
     {
         _projectSystem = projectSystem;
+        _workDoneProgressManager = workDoneProgressManager;
     }
 
     public bool MutatesSolutionState => false;
     public bool RequiresLSPSolution => false;
 
-    Task INotificationHandler<NotificationParams, RequestContext>.HandleNotificationAsync(NotificationParams request, RequestContext requestContext, CancellationToken cancellationToken)
+    async Task INotificationHandler<NotificationParams, RequestContext>.HandleNotificationAsync(NotificationParams request, RequestContext requestContext, CancellationToken cancellationToken)
     {
-        return _projectSystem.OpenSolutionAsync(request.Solution.GetDocumentFilePathFromUri());
+        var solutionPath = request.Solution.GetDocumentFilePathFromUri();
+        await using var progressReporter = await _workDoneProgressManager.CreateWorkDoneProgressAsync(
+            reportProgressToClient: true,
+            title: string.Format(LanguageServerResources.Loading_0, solutionPath),
+            startMessage: string.Format(LanguageServerResources.Loading_0, solutionPath),
+            endMessage: string.Format(LanguageServerResources.Loaded_0, solutionPath),
+            clientCanCancel: false,
+            serverCancellationToken: cancellationToken);
+
+        await _projectSystem.OpenSolutionAsync(solutionPath, progressReporter);
     }
 
     internal sealed class NotificationParams


### PR DESCRIPTION
## Problem
I am using the language server in neovim, and I am really missing any progress reporting on what is loading and how far along it is in the loading process.

## Solution
Notify progress to the client through the [progress support](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#progress) when loading solution and projects so the client can show this information
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84399)