### PR TITLE
Use the shared KnownMonikers.Sparkle for the On-The-Fly Docs Copilot icon

### DIFF
--- a/src/EditorFeatures/Core/Copilot/CopilotConstants.cs
+++ b/src/EditorFeatures/Core/Copilot/CopilotConstants.cs
@@ -9,10 +9,6 @@ namespace Microsoft.CodeAnalysis.Editor.Copilot;
 
 internal static class CopilotConstants
 {
-    public const int CopilotIconLogoId = 1;
-    public const int CopilotIconSparkleId = 2;
-    public const int CopilotIconSparkleBlueId = 3;
-
     /// <summary>
     /// This flag is used to indicate that a thinking state tip should be shown.
     /// This will eventually be defined in Microsoft.VisualStudio.Language.Suggestions.TipStyle once the behavior is finalized.
@@ -20,6 +16,5 @@ internal static class CopilotConstants
     // Copied from https://devdiv.visualstudio.com/DevDiv/_git/IntelliCode-VS?path=%2Fsrc%2FVSIX%2FIntelliCode.VSIX%2FSuggestionService%2FImplementation%2FSuggestionSession.cs&amp
     public const TipStyle ShowThinkingStateTipStyle = (TipStyle)0x20;
 
-    public static readonly Guid CopilotIconMonikerGuid = new("{4515B9BD-70A1-45FA-9545-D4536417C596}");
     public static readonly Guid CopilotQuotaExceededGuid = new("39B0DEDE-D931-4A92-9AA2-3447BC4998DC");
 }

--- a/src/EditorFeatures/Core/QuickInfo/OnTheFlyDocsView.xaml.cs
+++ b/src/EditorFeatures/Core/QuickInfo/OnTheFlyDocsView.xaml.cs
@@ -22,6 +22,7 @@ using Microsoft.CodeAnalysis.QuickInfo;
 using Microsoft.CodeAnalysis.QuickInfo.Presentation;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Shell;
@@ -88,7 +89,7 @@ internal sealed partial class OnTheFlyDocsView : UserControl, INotifyPropertyCha
         _document = onTheFlyDocsElement.Document;
         _serviceProvider = serviceProvider;
 
-        var sparkle = new ImageElement(new VisualStudio.Core.Imaging.ImageId(CopilotConstants.CopilotIconMonikerGuid, CopilotConstants.CopilotIconSparkleId));
+        var sparkle = new ImageElement(new VisualStudio.Core.Imaging.ImageId(KnownMonikers.Sparkle.Guid, KnownMonikers.Sparkle.Id));
         object onDemandLinkText = _onTheFlyDocsInfo.IsContentExcluded
             ? ToUIElement(new ContainerElement(ContainerElementStyle.Wrapped, new ClassifiedTextElement([new ClassifiedTextRun(ClassificationTypeNames.Text, EditorFeaturesResources.Describe_is_unavailable_since_the_referenced_document_is_excluded_by_your_organization)])))
             : ClassifiedTextElement.CreateHyperlink(EditorFeaturesResources.Describe, EditorFeaturesResources.Generate_summary_with_Copilot, () => RequestResults());


### PR DESCRIPTION
The On-The-Fly Docs quick-info view rendered its Copilot sparkle icon by constructing an `ImageId` from a hard-coded copy of a private image-manifest GUID (`CopilotConstants.CopilotIconMonikerGuid` + `CopilotIconSparkleId`).

That GUID belongs to a private Copilot image manifest shipped inside Visual Studio, which is being removed. This change repoints the icon to `KnownMonikers.Sparkle` from the shared VS Image Catalog — already referenced in `EditorFeatures/Core` (e.g. Inline Diagnostics and Inline Rename use `KnownMonikers.StatusError`/`StatusWarning`) — and deletes the now-unused private icon ids and moniker GUID from `CopilotConstants`.

No behavioral change: `KnownMonikers.Sparkle` is the same sparkle artwork the private moniker resolved to.

*Cowritten with Copilot*
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84401)