### PR TITLE
Use platform newline for C# elastic syntax facts

### DIFF
--- a/src/Workspaces/CSharpTest/CSharpSyntaxFactsServiceTests.cs
+++ b/src/Workspaces/CSharpTest/CSharpSyntaxFactsServiceTests.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System;
 using Microsoft.CodeAnalysis.CSharp.LanguageService;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -12,6 +13,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests;
 
 public sealed class CSharpSyntaxFactsServiceTests
 {
+    [Fact]
+    public void ElasticCarriageReturnLineFeed_UsesEnvironmentNewLine()
+    {
+        var service = CSharpSyntaxFacts.Instance;
+        var trivia = service.ElasticCarriageReturnLineFeed;
+
+        Assert.True(service.IsElastic(trivia));
+        Assert.Equal(Environment.NewLine, trivia.ToFullString());
+    }
+
     private static bool IsQueryKeyword(string markup)
     {
         MarkupTestFile.GetPosition(markup, out var code, out int position);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -39,7 +39,7 @@ internal class CSharpSyntaxFacts : AbstractSyntaxFacts, ISyntaxFacts
         => SyntaxFactory.ElasticMarker;
 
     public SyntaxTrivia ElasticCarriageReturnLineFeed
-        => SyntaxFactory.ElasticCarriageReturnLineFeed;
+        => SyntaxFactory.ElasticEndOfLine(Environment.NewLine);
 
     public ISyntaxKinds SyntaxKinds { get; } = CSharpSyntaxKinds.Instance;
 


### PR DESCRIPTION
Extracted from #84347 as a small, reviewable slice.\n\nThis updates the C# syntax facts service so its default elastic end-of-line trivia uses the current platform newline instead of hard-coded CRLF. This is one of the lower-level pieces needed before broader code-action/refactoring line-ending preservation work.\n\nValidation:\n- dotnet test src\\Workspaces\\CSharpTest\\Microsoft.CodeAnalysis.CSharp.Workspaces.UnitTests.csproj --filter FullyQualifiedName~CSharpSyntaxFactsServiceTests
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84407)