### PR TITLE
Don't let a disconnected RPC client crash the BuildHost process

### DIFF
--- a/src/Workspaces/MSBuild/BuildHost/NetFrameworkBuildHost.cs
+++ b/src/Workspaces/MSBuild/BuildHost/NetFrameworkBuildHost.cs
@@ -27,7 +27,7 @@ internal sealed class NetFrameworkBuildHost : AbstractBuildHost
         if (instance is null)
         {
             logger.LogCritical("No compatible MSBuild instance could be found.");
-            var server = new RpcServer(pipeStream);
+            var server = new RpcServer(pipeStream, logger);
             return (new NoNetFrameworkFoundBuildHost(logger, server), server);
         }
 
@@ -58,7 +58,7 @@ internal sealed class NetFrameworkBuildHost : AbstractBuildHost
             culture: null,
             activationAttributes: null);
 
-        var rpcServer = new RpcServer(pipeStream, factory.CreateMethodInvoker());
+        var rpcServer = new RpcServer(pipeStream, factory.CreateMethodInvoker(), logger);
         return (factory.CreateBuildHost(logger, rpcServer), rpcServer);
     }
 

--- a/src/Workspaces/MSBuild/BuildHost/Program.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Program.cs
@@ -47,7 +47,7 @@ internal static class Program
 
         if (PlatformInformation.IsRunningOnMono)
         {
-            server = new RpcServer(pipeServer);
+            server = new RpcServer(pipeServer, logger);
             buildHost = new MonoBuildHost(logger, server);
         }
         else

--- a/src/Workspaces/MSBuild/BuildHost/Program.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Program.cs
@@ -55,7 +55,7 @@ internal static class Program
             (buildHost, server) = NetFrameworkBuildHost.Create(logger, pipeServer);
         }
 #else
-        server = new RpcServer(pipeServer);
+        server = new RpcServer(pipeServer, logger);
         buildHost = new NetCoreBuildHost(logger, server);
 #endif
 

--- a/src/Workspaces/MSBuild/BuildHost/Rpc/RpcServer.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Rpc/RpcServer.cs
@@ -178,6 +178,7 @@ internal sealed class RpcServer
             {
                 // The client may have already disconnected (e.g. gave up waiting for this response); don't let that crash the host.
                 _logger?.LogWarning($"Failed to write RPC response: {e.GetType().Name} (0x{e.HResult:x8}): {e.Message}");
+            }
         }
     }
 

--- a/src/Workspaces/MSBuild/BuildHost/Rpc/RpcServer.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Rpc/RpcServer.cs
@@ -177,8 +177,7 @@ internal sealed class RpcServer
             catch (IOException e)
             {
                 // The client may have already disconnected (e.g. gave up waiting for this response); don't let that crash the host.
-                _logger?.LogWarning($"Failed to write RPC response: {e}");
-            }
+                _logger?.LogWarning($"Failed to write RPC response: {e.GetType().Name} (0x{e.HResult:x8}): {e.Message}");
         }
     }
 

--- a/src/Workspaces/MSBuild/BuildHost/Rpc/RpcServer.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Rpc/RpcServer.cs
@@ -32,21 +32,23 @@ internal sealed class RpcServer
     private readonly SemaphoreSlim _sendingStreamSemaphore = new(initialCount: 1);
     private readonly TextReader _streamReader;
     private readonly RpcMethodInvoker _rpcMethodInvoker;
+    private readonly BuildHostLogger? _logger;
 
     private readonly ConcurrentDictionary<int, object> _rpcTargets = [];
     private volatile int _nextRpcTargetIndex = -1; // We'll start at -1 so the first value becomes zero
 
     private readonly CancellationTokenSource _shutdownTokenSource = new();
 
-    public RpcServer(PipeStream stream) : this(stream, new RpcMethodInvoker())
+    public RpcServer(PipeStream stream, BuildHostLogger? logger = null) : this(stream, new RpcMethodInvoker(), logger)
     {
     }
 
-    public RpcServer(PipeStream stream, RpcMethodInvoker methodInvoker)
+    public RpcServer(PipeStream stream, RpcMethodInvoker methodInvoker, BuildHostLogger? logger = null)
     {
         _streamWriter = new StreamWriter(stream, JsonSettings.StreamEncoding);
         _streamReader = new StreamReader(stream, JsonSettings.StreamEncoding);
         _rpcMethodInvoker = methodInvoker;
+        _logger = logger;
     }
 
     public int AddTarget(object rpcTarget)
@@ -167,8 +169,16 @@ internal sealed class RpcServer
 #endif
         using (await _sendingStreamSemaphore.DisposableWaitAsync().ConfigureAwait(false))
         {
-            await _streamWriter.WriteLineAsync(responseJson).ConfigureAwait(false);
-            await _streamWriter.FlushAsync().ConfigureAwait(false);
+            try
+            {
+                await _streamWriter.WriteLineAsync(responseJson).ConfigureAwait(false);
+                await _streamWriter.FlushAsync().ConfigureAwait(false);
+            }
+            catch (IOException e)
+            {
+                // The client may have already disconnected (e.g. gave up waiting for this response); don't let that crash the host.
+                _logger?.LogWarning($"Failed to write RPC response: {e}");
+            }
         }
     }
 

--- a/src/Workspaces/MSBuild/Test/Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests.csproj
+++ b/src/Workspaces/MSBuild/Test/Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <Compile Include="..\BuildHost\Rpc\RpcMethodInvoker.cs" Link="Rpc\RpcMethodInvoker.cs"/>
     <Compile Include="..\BuildHost\Rpc\RpcServer.cs" Link="Rpc\RpcServer.cs"/>
+    <Compile Include="..\BuildHost\BuildHostLogger.cs" Link="BuildHostLogger.cs"/>
     <Compile Remove="Resources\**\*.*" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Workspaces/MSBuild/Test/RpcTests.cs
+++ b/src/Workspaces/MSBuild/Test/RpcTests.cs
@@ -254,13 +254,15 @@ public sealed class RpcTests
 
         try
         {
-            // Don't call client.Start(): we're simulating the client having already given up and disconnected
-            // before the server gets a chance to respond.
-            _ = client.InvokeAsync(targetObject: 0, nameof(ObjectWithRealAsyncMethod.WaitAsync), [], CancellationToken.None);
+            client.Start();
+            var invokeTask = client.InvokeAsync(targetObject: 0, nameof(ObjectWithRealAsyncMethod.WaitAsync), [], CancellationToken.None);
 
             rpcTarget.WaitUntilRequest(index: 0);
             pipeClient.Dispose();
             rpcTarget.Complete(index: 0);
+
+            // The client's read loop notices the disconnect and faults the outstanding request.
+            await Assert.ThrowsAnyAsync<Exception>(() => invokeTask);
 
             // Before the fix, the write failure here would crash RunAsync via Task.WhenAll.
             await serverRunTask;

--- a/src/Workspaces/MSBuild/Test/RpcTests.cs
+++ b/src/Workspaces/MSBuild/Test/RpcTests.cs
@@ -231,7 +231,7 @@ public sealed class RpcTests
         await rpcPair.Client.InvokeAsync(targetObject: 0, nameof(ObjectWithMethodThatShutsDownServer.Shutdown), [], CancellationToken.None);
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84411")]
     public async Task ResponseWriteAfterClientDisconnectDoesNotCrashServer()
     {
         // Unlike RequestThatClosesServerDoesNotThrow, this forces the client-already-disconnected ordering

--- a/src/Workspaces/MSBuild/Test/RpcTests.cs
+++ b/src/Workspaces/MSBuild/Test/RpcTests.cs
@@ -231,6 +231,46 @@ public sealed class RpcTests
         await rpcPair.Client.InvokeAsync(targetObject: 0, nameof(ObjectWithMethodThatShutsDownServer.Shutdown), [], CancellationToken.None);
     }
 
+    [Fact]
+    public async Task ResponseWriteAfterClientDisconnectDoesNotCrashServer()
+    {
+        // Unlike RequestThatClosesServerDoesNotThrow, this forces the client-already-disconnected ordering
+        // deterministically instead of relying on a race.
+        var pipeName = Guid.NewGuid().ToString();
+        var pipeServer = NamedPipeUtil.CreateServer(pipeName, PipeDirection.InOut);
+        var pipeServerConnectionTask = pipeServer.WaitForConnectionAsync();
+        var pipeClient = NamedPipeUtil.CreateClient(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+
+        pipeClient.Connect();
+        await pipeServerConnectionTask;
+
+        var server = new RpcServer(pipeServer);
+        var serverRunTask = server.RunAsync();
+
+        var rpcTarget = new ObjectWithRealAsyncMethod();
+        server.AddTarget(rpcTarget);
+
+        var client = new RpcClient(pipeClient);
+
+        try
+        {
+            // Don't call client.Start(): we're simulating the client having already given up and disconnected
+            // before the server gets a chance to respond.
+            _ = client.InvokeAsync(targetObject: 0, nameof(ObjectWithRealAsyncMethod.WaitAsync), [], CancellationToken.None);
+
+            rpcTarget.WaitUntilRequest(index: 0);
+            pipeClient.Dispose();
+            rpcTarget.Complete(index: 0);
+
+            // Before the fix, the write failure here would crash RunAsync via Task.WhenAll.
+            await serverRunTask;
+        }
+        finally
+        {
+            pipeServer.Dispose();
+        }
+    }
+
 #pragma warning disable CA1822 // Mark members as static
 
     private sealed class ObjectWithHelloMethod { public string Hello(string name) { return "Hello " + name; } }

--- a/src/Workspaces/MSBuild/Test/RpcTests.cs
+++ b/src/Workspaces/MSBuild/Test/RpcTests.cs
@@ -267,6 +267,7 @@ public sealed class RpcTests
         }
         finally
         {
+            pipeClient.Dispose();
             pipeServer.Dispose();
         }
     }

--- a/src/Workspaces/MSBuild/Test/RpcTests.cs
+++ b/src/Workspaces/MSBuild/Test/RpcTests.cs
@@ -6,6 +6,7 @@ extern alias MSBuildWorkspaces;
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.IO.Pipes;
 using System.Threading;
 using System.Threading.Tasks;
@@ -244,7 +245,8 @@ public sealed class RpcTests
         pipeClient.Connect();
         await pipeServerConnectionTask;
 
-        var server = new RpcServer(pipeServer);
+        var loggerOutput = new StringWriter();
+        var server = new RpcServer(pipeServer, new BuildHostLogger(loggerOutput));
         var serverRunTask = server.RunAsync();
 
         var rpcTarget = new ObjectWithRealAsyncMethod();
@@ -266,6 +268,9 @@ public sealed class RpcTests
 
             // Before the fix, the write failure here would crash RunAsync via Task.WhenAll.
             await serverRunTask;
+
+            // Confirm we actually hit the expected catch block, not some other path that happens not to crash.
+            Assert.Contains("Failed to write RPC response", loggerOutput.ToString());
         }
         finally
         {


### PR DESCRIPTION
## Summary

Fixes #84411.

`RpcServer.ProcessRequestAsync` in `src/Workspaces/MSBuild/BuildHost/Rpc/RpcServer.cs` had no exception handling around its response-write block. If the RPC caller had already disconnected its end of the pipe by the time `BuildHost.exe` tried to write a response, the resulting `IOException` was unhandled and propagated out of a fire-and-forget task in `RunAsync()`'s `Task.WhenAll`, crashing the entire `BuildHost.exe` process.

This PR wraps that write in a try/catch that logs (via a newly threaded-through, optional `BuildHostLogger?`) and swallows `IOException`, matching the existing broad-catch-and-log convention already used for this class of "other side of the pipe is gone" scenario elsewhere in the codebase (`BuildHostProcessManager.DisposeAsync()`, `BuildServerConnection.cs`), rather than introducing a new, narrower pattern based on specific HResults.

## Changes

- `src/Workspaces/MSBuild/BuildHost/Rpc/RpcServer.cs`: added an optional `BuildHostLogger? _logger` field, threaded through both constructors; wrapped the response `WriteLineAsync`/`FlushAsync` calls in `try { ... } catch (IOException e) { _logger?.LogWarning(...); }`.
- `src/Workspaces/MSBuild/BuildHost/Program.cs`: pass the existing in-scope `logger` to both `new RpcServer(...)` call sites.
- `src/Workspaces/MSBuild/BuildHost/NetFrameworkBuildHost.cs`: same, for both call sites (the no-MSBuild-found path and the normal `Factory`-based path).
- `src/Workspaces/MSBuild/Test/RpcTests.cs`: added `ResponseWriteAfterClientDisconnectDoesNotCrashServer`, which deterministically forces the client-already-disconnected ordering (rather than relying on the timing-dependent race in `RequestThatClosesServerDoesNotThrow`) and asserts `RunAsync()` completes normally instead of throwing.
- `src/Workspaces/MSBuild/Test/Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests.csproj`: linked `BuildHost/BuildHostLogger.cs` into the test project, since `RpcServer.cs` (already linked in) now references it.

## Testing

- New test `ResponseWriteAfterClientDisconnectDoesNotCrashServer` passes against the fix, and was verified to fail (reproducing the original unhandled-crash behavior) against the pre-fix code by temporarily reverting the change locally.
- Full `src/Workspaces/MSBuild/Test` (`Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests`) suite passes locally with no regressions introduced by this change.
- Root cause and fix were validated against a real-world crash (Windows Error Reporting dump showing `System.IO.IOException: Pipe is broken`, `HResult=0x800700E8`/`ERROR_NO_DATA`, no `InnerException`) captured while driving `roslyn-language-server` under sustained load from a third-party client; see the linked issue for the full investigation ruling out other causes (client architecture, Windows Defender, environment-specific artifacts) before concluding this is a genuine Roslyn-side bug.

## Note for reviewers

- `RpcServer`'s constructors gain a new optional `BuildHostLogger? logger = null` parameter (default `null`) so no other call site needed to change beyond passing through the logger that was already in scope at each of the three existing construction sites.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84412)