### PR TITLE
Migrate devdiv/dotnet-core-internal-tooling to WIF service connection

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -291,13 +291,19 @@ extends:
         # Authenticate with service connections to be able to publish packages to external nuget feeds.
         - task: NuGetAuthenticate@1
           inputs:
-            nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk, devdiv/dotnet-core-internal-tooling
+            nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk
 
         # Authenticate to DevDiv engineering feed via WIF service connection
         - task: NuGetAuthenticate@1
           inputs:
             azureDevOpsServiceConnection: devdiv-engineering-feed-r-wif
             feedUrl: https://devdiv.pkgs.visualstudio.com/_packaging/Engineering/nuget/v3/index.json
+
+        # Authenticate to DevDiv dotnet-core-internal-tooling feed via WIF service connection
+        - task: NuGetAuthenticate@1
+          inputs:
+            azureDevOpsServiceConnection: dnceng-devdiv-dotnet-core-internal-tooling-feed-rw-wif
+            feedUrl: https://pkgs.dev.azure.com/devdiv/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json
 
         # Needed for SBOM tool
         - task: UseDotNet@2


### PR DESCRIPTION
## Summary

Replace PAT-backed externalnugetfeed SC with WIF-based azureDevOpsServiceConnection for the devdiv/dotnet-core-internal-tooling NuGet feed.

## Motivation

Part of PAT disable policy migration ([dnceng WI 10124](https://dnceng.visualstudio.com/internal/_workitems/edit/10124)).

## Changes

- **Before:** nuGetServiceConnections: 'devdiv/dotnet-core-internal-tooling' (PAT-based ExternalNuGetFeed SC)
- **After:** azureDevOpsServiceConnection + feedUrl (WIF SC backed by Entra app)

## New Service Connection

- **Name:** dnceng-devdiv-dotnet-core-internal-tooling-feed-rw-wif
- **Type:** workloadidentityuser
- **Target:** https://pkgs.dev.azure.com/devdiv/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json

Same pattern as the devdiv/engineering feed migration (dotnet/roslyn#83918, dotnet/dotnet#6902).
