### PR TITLE
Enable Linux execution for issue #83159 Windows-only formatting tests

### DIFF
--- a/.github/memory/CONVENTIONS.md
+++ b/.github/memory/CONVENTIONS.md
@@ -41,6 +41,27 @@ var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
 var symbolInfo = semanticModel.GetSymbolInfo(expression, cancellationToken);
 ```
 
+### Elastic end-of-line trivia (IDE code fixes and refactorings)
+
+When inserting elastic newline trivia in **IDE code fixes/refactorings**, use `Environment.NewLine` to produce platform-appropriate line endings. Never use the hardcoded `SyntaxFactory.ElasticCarriageReturnLineFeed` (which is always `\r\n` CRLF) in IDE code:
+
+```csharp
+// ✅ Correct — respects platform line endings (LF on Linux, CRLF on Windows)
+using System;
+SyntaxFactory.ElasticEndOfLine(Environment.NewLine)
+
+// Via ISyntaxFacts (CSharpSyntaxFacts already fixed):
+syntaxFacts.ElasticCarriageReturnLineFeed  // OK — implementation uses Environment.NewLine
+
+// Via SyntaxGeneratorInternal (CSharpSyntaxGeneratorInternal already fixed):
+generator.ElasticCarriageReturnLineFeed    // OK — implementation uses Environment.NewLine
+
+// ❌ Avoid in IDE code — hardcoded CRLF breaks Linux tests
+SyntaxFactory.ElasticCarriageReturnLineFeed
+```
+
+Note: `SyntaxFactory.ElasticCarriageReturnLineFeed` is a valid compiler public API and must remain hardcoded CRLF — do NOT change it. The fix applies only to IDE/workspace layers that call it directly.
+
 ## Patterns Explicitly Avoided
 
 - **No `TODO` or `TODO2` comments** — CI correctness leg flags `TODO`. Track follow-up work as a GitHub issue and link it in code (e.g. `// https://github.com/dotnet/roslyn/issues/NNNN`). Existing `TODO2` markers are a frozen baseline from when enforcement started, not a pattern to follow.

--- a/.github/memory/CONVENTIONS.md
+++ b/.github/memory/CONVENTIONS.md
@@ -43,12 +43,13 @@ var symbolInfo = semanticModel.GetSymbolInfo(expression, cancellationToken);
 
 ### Elastic end-of-line trivia (IDE code fixes and refactorings)
 
-When inserting elastic newline trivia in **IDE code fixes/refactorings**, use `Environment.NewLine` to produce platform-appropriate line endings. Never use the hardcoded `SyntaxFactory.ElasticCarriageReturnLineFeed` (which is always `\r\n` CRLF) in IDE code:
+When inserting newline trivia in **IDE code fixes/refactorings**, use `Environment.NewLine` to produce platform-appropriate line endings. Never use hardcoded `CarriageReturnLineFeed`/`ElasticCarriageReturnLineFeed` trivia (always `\r\n` CRLF) in IDE code:
 
 ```csharp
 // ✅ Correct — respects platform line endings (LF on Linux, CRLF on Windows)
 using System;
 SyntaxFactory.ElasticEndOfLine(Environment.NewLine)
+SyntaxFactory.EndOfLine(Environment.NewLine)
 
 // Via ISyntaxFacts (CSharpSyntaxFacts already fixed):
 syntaxFacts.ElasticCarriageReturnLineFeed  // OK — implementation uses Environment.NewLine
@@ -58,9 +59,10 @@ generator.ElasticCarriageReturnLineFeed    // OK — implementation uses Environ
 
 // ❌ Avoid in IDE code — hardcoded CRLF breaks Linux tests
 SyntaxFactory.ElasticCarriageReturnLineFeed
+SyntaxFactory.CarriageReturnLineFeed
 ```
 
-Note: `SyntaxFactory.ElasticCarriageReturnLineFeed` is a valid compiler public API and must remain hardcoded CRLF — do NOT change it. The fix applies only to IDE/workspace layers that call it directly.
+Note: `SyntaxFactory.ElasticCarriageReturnLineFeed` and `SyntaxFactory.CarriageReturnLineFeed` are valid compiler APIs and remain hardcoded CRLF. IDE/workspace code should call `EndOfLine(Environment.NewLine)` / `ElasticEndOfLine(Environment.NewLine)` instead, and compiler fallback logic used by IDE features (for example `SyntaxNodeRemover`) should preserve discovered newline trivia or fall back to `Environment.NewLine`.
 
 ## Patterns Explicitly Avoided
 

--- a/.github/memory/known-issues/ide.md
+++ b/.github/memory/known-issues/ide.md
@@ -8,6 +8,15 @@ Layer-specific quirks for the IDE/Workspaces stack. Load when working under
 `src/{Analyzers,CodeStyle,Features,Workspaces,EditorFeatures,VisualStudio,LanguageServer}`.
 Cross-cutting issues live in `.github/memory/KNOWN_ISSUES.md`.
 
+## Remaining Windows-only tests (issue #83159)
+
+**Affected area:** `src/Features/CSharpTest/ConvertToRawString/` and `src/Analyzers/CSharp/Tests/MakeFieldReadonly/`
+**Description:** 11 tests remain `WindowsOnly` after the elastic-newline fix. They cannot be made cross-platform because their test data contains literal `\r\n` content:
+- 10 tests in `ConvertRegularStringToRawStringTests.cs` and `ConvertInterpolatedStringToRawStringTests.cs` — these convert string literals containing `\r\n` escape sequences to raw strings; the conversion preserves CRLF semantically, but the test's raw string expectations use the file's native LF on Linux, creating a mismatch.
+- 1 theory in `MakeFieldReadonlyTests.cs` — `MultipleFieldsAssignedInline_LeadingCommentAndWhitespace` uses `InlineData("\r\n")` and `InlineData("\r\n\r\n")` C# escape sequences; these are always CRLF regardless of file line endings, but the test compares against raw strings that have LF on Linux.
+
+**Workaround:** These tests are intentionally `[ConditionalFact/Theory(typeof(WindowsOnly), ...)]`.
+
 ## MEF composition failures surface as test failures
 
 **Affected area:** MEF-dependent IDE/Workspaces tests

--- a/src/Analyzers/CSharp/CodeFixes/ConvertToRecord/ConvertToRecordEngine.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ConvertToRecord/ConvertToRecordEngine.cs
@@ -660,7 +660,7 @@ internal static class ConvertToRecordEngine
                             .WithTrailingTrivia(exteriorTrivia)))
                         .Append(XmlText(XmlTextNewLine(lineFormattingOptions.NewLine, continueXmlDocumentationComment: false)))],
                         EndOfDocumentationCommentToken
-                            .WithTrailingTrivia(DocumentationCommentExterior("*/"), ElasticCarriageReturnLineFeed));
+                            .WithTrailingTrivia(DocumentationCommentExterior("*/"), ElasticEndOfLine(Environment.NewLine)));
             }
             else
             {
@@ -670,7 +670,7 @@ internal static class ConvertToRecordEngine
                     SyntaxKind.MultiLineDocumentationCommentTrivia,
                     [.. propertyParamComments.Skip(1)
                         .Prepend(XmlText(XmlTextLiteral(" ").WithLeadingTrivia(exteriorTrivia)))])
-                    .WithAppendedTrailingTrivia(ElasticCarriageReturnLineFeed);
+                    .WithAppendedTrailingTrivia(ElasticEndOfLine(Environment.NewLine));
             }
         }
 

--- a/src/Analyzers/CSharp/CodeFixes/MisplacedUsingDirectives/MisplacedUsingDirectivesCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/MisplacedUsingDirectives/MisplacedUsingDirectivesCodeFixProvider.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
@@ -376,7 +377,7 @@ internal sealed class MisplacedUsingDirectivesCodeFixProvider() : CodeFixProvide
         if (firstMemberTrivia is [(kind: SyntaxKind.EndOfLineTrivia), ..])
             return node;
 
-        var newFirstMember = firstMember.WithLeadingTrivia(firstMemberTrivia.Insert(0, SyntaxFactory.CarriageReturnLineFeed));
+        var newFirstMember = firstMember.WithLeadingTrivia(firstMemberTrivia.Insert(0, SyntaxFactory.EndOfLine(Environment.NewLine)));
         return node.ReplaceNode(firstMember, newFirstMember);
     }
 

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionInitializer/CSharpUseCollectionInitializerCodeFixProvider_CollectionInitializer.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionInitializer/CSharpUseCollectionInitializerCodeFixProvider_CollectionInitializer.cs
@@ -79,7 +79,7 @@ internal sealed partial class CSharpUseCollectionInitializerCodeFixProvider
                 var addLineBreak = item.IsToken || item == nodeOrTokenList.Last();
                 if (addLineBreak && item.GetTrailingTrivia() is not [.., (kind: SyntaxKind.EndOfLineTrivia)])
                 {
-                    nodesAndTokens.Add(item.WithAppendedTrailingTrivia(ElasticCarriageReturnLineFeed));
+                    nodesAndTokens.Add(item.WithAppendedTrailingTrivia(ElasticEndOfLine(Environment.NewLine)));
                 }
                 else
                 {

--- a/src/Analyzers/CSharp/CodeFixes/UseConditionalExpression/CSharpUseConditionalExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseConditionalExpression/CSharpUseConditionalExpressionHelpers.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -35,7 +36,7 @@ internal static class CSharpUseConditionalExpressionHelpers
 
         var finalConditional = conditional
             .WithColonToken(ColonToken.WithPrependedLeadingTrivia(ifStatement.Else.ElseKeyword.LeadingTrivia))
-            .WithWhenTrue(conditional.WhenTrue.WithAppendedTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed));
+            .WithWhenTrue(conditional.WhenTrue.WithAppendedTrailingTrivia(SyntaxFactory.ElasticEndOfLine(Environment.NewLine)));
         return (finalConditional, makeMultiLine: true);
     }
 }

--- a/src/Analyzers/CSharp/CodeFixes/UseExpressionBodyForLambda/UseExpressionBodyForLambdaCodeActionHelpers.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseExpressionBodyForLambda/UseExpressionBodyForLambdaCodeActionHelpers.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -71,7 +72,7 @@ internal static class UseExpressionBodyForLambdaCodeActionHelpers
         // statements to it.  So make a multi-line block so that things are formatted properly
         // for them to do so.
         return lambdaExpression.WithBody(Block(
-            OpenBraceToken.WithAppendedTrailingTrivia(ElasticCarriageReturnLineFeed),
+            OpenBraceToken.WithAppendedTrailingTrivia(ElasticEndOfLine(Environment.NewLine)),
             [statement],
             CloseBraceToken));
     }

--- a/src/Analyzers/CSharp/CodeFixes/UsePatternMatching/CSharpIsAndCastCheckCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UsePatternMatching/CSharpIsAndCastCheckCodeFixProvider.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
@@ -63,7 +64,7 @@ internal sealed partial class CSharpIsAndCastCheckCodeFixProvider() : SyntaxEdit
 
         var trivia = localDeclaration.GetLeadingTrivia().Concat(localDeclaration.GetTrailingTrivia())
                                      .Where(t => t.IsSingleOrMultiLineComment())
-                                     .SelectMany(t => ImmutableArray.Create(SyntaxFactory.Space, t, SyntaxFactory.ElasticCarriageReturnLineFeed))
+                                     .SelectMany(t => ImmutableArray.Create(SyntaxFactory.Space, t, SyntaxFactory.ElasticEndOfLine(Environment.NewLine)))
                                      .ToImmutableArray();
 
         editor.RemoveNode(localDeclaration);

--- a/src/Analyzers/CSharp/CodeFixes/UseSimpleUsingStatement/UseSimpleUsingStatementCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseSimpleUsingStatement/UseSimpleUsingStatementCodeFixProvider.cs
@@ -148,7 +148,7 @@ internal sealed class UseSimpleUsingStatementCodeFixProvider() : SyntaxEditorBas
                 if (!usingHasEndOfLineTrivia)
                 {
                     var newFirstStatement = statements.First()
-                        .WithPrependedLeadingTrivia(ElasticCarriageReturnLineFeed);
+                        .WithPrependedLeadingTrivia(ElasticEndOfLine(Environment.NewLine));
                     statements = statements.Replace(statements.First(), newFirstStatement);
                 }
 

--- a/src/Analyzers/CSharp/Tests/AddParameter/AddParameterTests.cs
+++ b/src/Analyzers/CSharp/Tests/AddParameter/AddParameterTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -241,7 +241,7 @@ public sealed class AddParameterTests(ITestOutputHelper logger)
             }
             """);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     [WorkItem("https://github.com/dotnet/roslyn/issues/20708")]
     public Task TestMultiLineParameters1()
         => TestInRegularAndScriptAsync(
@@ -312,7 +312,7 @@ public sealed class AddParameterTests(ITestOutputHelper logger)
             }
             """);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     [WorkItem("https://github.com/dotnet/roslyn/issues/20708")]
     public Task TestMultiLineParameters3()
         => TestInRegularAndScriptAsync(
@@ -348,7 +348,7 @@ public sealed class AddParameterTests(ITestOutputHelper logger)
             }
             """);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     [WorkItem("https://github.com/dotnet/roslyn/issues/20708")]
     public Task TestMultiLineParameters4()
         => TestInRegularAndScriptAsync(
@@ -423,7 +423,7 @@ public sealed class AddParameterTests(ITestOutputHelper logger)
             }
             """);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     [WorkItem("https://github.com/dotnet/roslyn/issues/20708")]
     public Task TestMultiLineParameters6()
         => TestInRegularAndScriptAsync(
@@ -1640,7 +1640,7 @@ public sealed class AddParameterTests(ITestOutputHelper logger)
             </Workspace>
             """);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     [WorkItem("https://github.com/dotnet/roslyn/issues/21446")]
     public async Task TestInvocation_Cascading_RootNotInSource()
     {

--- a/src/Analyzers/CSharp/Tests/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/Analyzers/CSharp/Tests/GenerateConstructor/GenerateConstructorTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -3753,7 +3753,7 @@ class C
             }
             """);
 
-    [ConditionalTheory(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Theory]
     [WorkItem("https://github.com/dotnet/roslyn/issues/22293")]
     [InlineData("void")]
     [InlineData("int")]
@@ -4650,7 +4650,7 @@ unsafe class C
             }
             """);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     [WorkItem("https://github.com/dotnet/roslyn/issues/50765")]
     public Task TestDelegateConstructorWithMissingType()
         => TestAsync("""

--- a/src/Analyzers/CSharp/Tests/GenerateMethod/GenerateMethodTests.cs
+++ b/src/Analyzers/CSharp/Tests/GenerateMethod/GenerateMethodTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -9504,7 +9504,7 @@ public sealed partial class GenerateMethodTests(ITestOutputHelper logger) : Abst
                             </Workspace>
             """);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task TestIfGeneratingInPartialClassWithFileFromSourceGenerator()
         => TestInRegularAndScriptAsync(
             """
@@ -10650,7 +10650,7 @@ public sealed partial class GenerateMethodTests(ITestOutputHelper logger) : Abst
             """);
     }
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public async Task GenerateInCollection3()
     {
         await TestInRegularAndScriptAsync(
@@ -10724,7 +10724,7 @@ public sealed partial class GenerateMethodTests(ITestOutputHelper logger) : Abst
             """);
     }
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public async Task GenerateInCollection5()
     {
         await TestInRegularAndScriptAsync(

--- a/src/Analyzers/CSharp/Tests/ImplementAbstractClass/ImplementAbstractClassTests.cs
+++ b/src/Analyzers/CSharp/Tests/ImplementAbstractClass/ImplementAbstractClassTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -2417,7 +2417,7 @@ public sealed partial class ImplementAbstractClassTests(ITestOutputHelper logger
             }
             """);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     [WorkItem("https://github.com/dotnet/roslyn/issues/75992")]
     public Task InsertMissingBraces()
         => TestAllOptionsOffAsync(

--- a/src/Analyzers/CSharp/Tests/ImplementInterface/ImplementInterfaceCodeFixTests.cs
+++ b/src/Analyzers/CSharp/Tests/ImplementInterface/ImplementInterfaceCodeFixTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -582,7 +582,7 @@ public sealed class ImplementInterfaceCodeFixTests
             }
             """);
 
-    [ConditionalTheory(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Theory]
     [CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/26323")]
     public Task TestMethodWhenClassBracesAreMissing2(
         [CombinatorialValues(0, 1)] int behavior)
@@ -3058,7 +3058,7 @@ public sealed class ImplementInterfaceCodeFixTests
             }
             """, index: 1);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task TestImplementEventThroughExplicitMember()
         => TestInRegularAndScriptAsync(
 @"interface IGoo { event System . EventHandler E ; } class CanGoo : IGoo { event System.EventHandler IGoo.E { add { } remove { } } } class HasCanGoo : {|CS0535:IGoo|} { CanGoo canGoo; }",
@@ -6071,7 +6071,7 @@ class B : IGoo
             }
             """, index: 3);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     [WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/941469")]
     public Task TestDoNotImplementDisposePatternForLocallyDefinedIDisposable()
         => TestWithAllCodeStyleOptionsOffAsync(

--- a/src/Analyzers/CSharp/Tests/MakeFieldReadonly/MakeFieldReadonlyTests.cs
+++ b/src/Analyzers/CSharp/Tests/MakeFieldReadonly/MakeFieldReadonlyTests.cs
@@ -214,6 +214,9 @@ public sealed class MakeFieldReadonlyTests(ITestOutputHelper logger)
             }
             """);
 
+    // WindowsOnly: InlineData values include literal \r\n strings which are tested against
+    // raw string literals. On Linux the raw strings use \n but the InlineData values are always
+    // \r\n C# escape sequences, creating a platform-specific mismatch in the parameterized cases.
     [ConditionalTheory(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
     [InlineData("")]
     [InlineData("\r\n")]

--- a/src/Analyzers/CSharp/Tests/MisplacedUsingDirectives/MisplacedUsingDirectivesTests.cs
+++ b/src/Analyzers/CSharp/Tests/MisplacedUsingDirectives/MisplacedUsingDirectivesTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -231,7 +231,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
     /// <summary>
     /// Verifies that using statements in a namespace produces the expected diagnostics.
     /// </summary>
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task WhenOutsidePreferred_UsingsInNamespace_UsingsMoved()
         => TestInRegularAndScriptAsync("""
             namespace TestNamespace
@@ -248,7 +248,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
             }
             """, OutsideNamespaceOption, placeSystemNamespaceFirst: true);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task WhenOutsidePreferred_UsingsInNamespace_UsingsMoved_FileScopedNamespace()
         => TestInRegularAndScriptAsync("""
             namespace TestNamespace;
@@ -266,7 +266,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
     /// <summary>
     /// Verifies that simplified using statements in a namespace are expanded during the code fix operation.
     /// </summary>
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task WhenOutsidePreferred_SimplifiedUsingInNamespace_UsingsMovedAndExpanded()
         => TestInRegularAndScriptAsync("""
             namespace System
@@ -309,7 +309,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
     /// <summary>
     /// Verifies that simplified using statements in a namespace are expanded during the code fix operation.
     /// </summary>
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task WhenOutsidePreferred_SimplifiedUsingAliasInNamespace_UsingsMovedAndExpanded()
         => TestInRegularAndScriptAsync("""
             namespace System.MyExtension
@@ -360,7 +360,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
     /// <summary>
     /// Verifies that the file header of a file is properly preserved when moving using statements out of a namespace.
     /// </summary>
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task WhenOutsidePreferred_UsingsInNamespaceAndCompilationUnitHasFileHeader_UsingsMovedAndHeaderPreserved()
         => TestInRegularAndScriptAsync("""
             // Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
@@ -381,7 +381,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
             }
             """, OutsideNamespaceOption, placeSystemNamespaceFirst: true);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task WhenOutsidePreferred_UsingsInNamespaceWithCommentsAndCompilationUnitHasFileHeader_UsingsMovedWithCommentsAndHeaderPreserved()
         => TestInRegularAndScriptAsync("""
             // Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
@@ -410,7 +410,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
             }
             """, OutsideNamespaceOption, placeSystemNamespaceFirst: true);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task WhenOutsidePreferred_UsingsInNamespace_UsingsMovedAndSystemPlacedFirstIgnored()
         => TestInRegularAndScriptAsync("""
             namespace Foo
@@ -450,7 +450,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
             }
             """, OutsideNamespaceOption, placeSystemNamespaceFirst: true);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task WhenOutsidePreferred_UsingsInNamespace_UsingsMovedAndAlphaSortIgnored()
         => TestInRegularAndScriptAsync("""
             namespace Foo
@@ -596,7 +596,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
             }
             """, OutsideNamespaceOption, placeSystemNamespaceFirst: true);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159"), WorkItem("https://github.com/dotnet/roslyn/issues/61773")]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/61773")]
     public Task WhenOutsidePreferred_MoveGlobalUsing1()
         => TestInRegularAndScriptAsync("""
             namespace N1
@@ -611,7 +611,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
             }
             """, OutsideNamespaceOption, placeSystemNamespaceFirst: true);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159"), WorkItem("https://github.com/dotnet/roslyn/issues/75961")]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75961")]
     public Task WhenOutsidePreferred_AliasToLocalType_FileScopedNamespace()
         => TestInRegularAndScriptAsync("""
             namespace Goo;
@@ -627,7 +627,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
             class C;
             """, OutsideNamespaceOption, placeSystemNamespaceFirst: true);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159"), WorkItem("https://github.com/dotnet/roslyn/issues/75961")]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75961")]
     public Task WhenOutsidePreferred_AliasToLocalType_BlockNamespace()
         => TestInRegularAndScriptAsync("""
             namespace Goo
@@ -649,7 +649,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
 
     #region OutsideNamespaceIgnoringAliases
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159"), WorkItem("https://github.com/dotnet/roslyn/issues/43271")]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/43271")]
     public Task WhenOutsideIgnoringAliasesPreferred_UsingsInNamespace_UsingsMoved()
         => TestInRegularAndScriptAsync("""
             namespace TestNamespace
@@ -668,7 +668,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
             }
             """, OutsideNamespaceIgnoringAliasesOption, placeSystemNamespaceFirst: true);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159"), WorkItem("https://github.com/dotnet/roslyn/issues/43271")]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/43271")]
     public Task WhenOutsideIgnoringAliasesPreferred_UsingsInNamespace_UsingsMoved_InnerType()
         => TestInRegularAndScriptAsync("""
             namespace TestNamespace
@@ -695,7 +695,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
             }
             """, OutsideNamespaceIgnoringAliasesOption, placeSystemNamespaceFirst: true);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159"), WorkItem("https://github.com/dotnet/roslyn/issues/43271")]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/43271")]
     public Task WhenOutsideIgnoringAliasesPreferred_UsingsInNamespace_UsingsMoved_AliasInMiddle()
         => TestInRegularAndScriptAsync("""
             namespace TestNamespace
@@ -785,7 +785,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
     /// <summary>
     /// Verifies that the code fix will move the using directives and not place System directives first.
     /// </summary>
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task WhenInsidePreferred_UsingsInCompilationUnit_UsingsMovedAndSystemPlacedFirstIgnored()
         => TestInRegularAndScriptAsync("""
             [|using Microsoft.CodeAnalysis;
@@ -828,7 +828,7 @@ public sealed class MisplacedUsingDirectivesTests(ITestOutputHelper logger)
     /// <summary>
     /// Verifies that the code fix will move the using directives and not sort them alphabetically.
     /// </summary>
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task WhenInsidePreferred_UsingsInCompilationUnit_UsingsAndWithAlphaSortIgnored()
         => TestInRegularAndScriptAsync("""
             [|using Microsoft.CodeAnalysis;

--- a/src/Analyzers/CSharp/Tests/UseAutoProperty/UseAutoPropertyTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseAutoProperty/UseAutoPropertyTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -2813,7 +2813,7 @@ public sealed partial class UseAutoPropertyTests(ITestOutputHelper logger)
             }
             """);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     [WorkItem("https://github.com/dotnet/roslyn/issues/25408")]
     public Task TestLinkedFile()
         => TestInRegularAndScriptAsync(

--- a/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1541,7 +1541,7 @@ public sealed partial class UseCollectionInitializerTests
             }
             """);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159"), WorkItem("https://github.com/dotnet/roslyn/issues/61066")]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/61066")]
     public Task TestInTopLevelStatements()
         => TestInRegularAndScriptAsync(
             """
@@ -1560,7 +1560,7 @@ public sealed partial class UseCollectionInitializerTests
 
             """, OutputKind.ConsoleApplication);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159"), WorkItem("https://github.com/dotnet/roslyn/issues/71245")]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/71245")]
     public Task TestCollectionExpressionArgument1()
         => TestInRegularAndScriptAsync(
             """

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeRemover.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeRemover.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             {
                 if (requiresNewLine)
                 {
-                    this.AddEndOfLine(GetEndOfLine(trivia) ?? SyntaxFactory.CarriageReturnLineFeed);
+                    this.AddEndOfLine(GetEndOfLine(trivia) ?? SyntaxFactory.EndOfLine(Environment.NewLine));
                 }
 
                 _residualTrivia.Add(trivia);

--- a/src/Features/CSharp/Portable/CodeFixes/Suppression/CSharpSuppressionCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/Suppression/CSharpSuppressionCodeFixProvider.cs
@@ -56,7 +56,7 @@ internal sealed class CSharpSuppressionCodeFixProvider : AbstractSuppressionCode
         var pragmaDirective = PragmaWarningDirectiveTrivia(disableOrRestoreKeyword, ids, true);
         pragmaDirective = (PragmaWarningDirectiveTriviaSyntax)formatNode(pragmaDirective, cancellationToken);
         var pragmaDirectiveTrivia = Trivia(pragmaDirective);
-        var endOfLineTrivia = CarriageReturnLineFeed;
+        var endOfLineTrivia = EndOfLine(Environment.NewLine);
         var triviaList = TriviaList(pragmaDirectiveTrivia);
 
         var title = includeTitle ? diagnostic.Descriptor.Title.ToString(CultureInfo.CurrentUICulture) : null;

--- a/src/Features/CSharp/Portable/ConvertAutoPropertyToFullProperty/CSharpConvertAutoPropertyToFullPropertyCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertAutoPropertyToFullProperty/CSharpConvertAutoPropertyToFullPropertyCodeRefactoringProvider.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System;
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -87,7 +88,7 @@ internal sealed class CSharpConvertAutoPropertyToFullPropertyCodeRefactoringProv
                 return ReplaceFieldExpression(accessor);
 
             var accessorDeclarationSyntax = accessor.WithBody(Block(
-                OpenBraceToken.WithLeadingTrivia(ElasticCarriageReturnLineFeed),
+                OpenBraceToken.WithLeadingTrivia(ElasticEndOfLine(Environment.NewLine)),
                 [statement],
                 CloseBraceToken.WithTrailingTrivia(accessor.SemicolonToken.TrailingTrivia)));
 

--- a/src/Features/CSharp/Portable/ConvertIfToSwitch/CSharpConvertIfToSwitchCodeRefactoringProvider.Rewriting.cs
+++ b/src/Features/CSharp/Portable/ConvertIfToSwitch/CSharpConvertIfToSwitchCodeRefactoringProvider.Rewriting.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -104,7 +105,7 @@ internal sealed partial class CSharpConvertIfToSwitchCodeRefactoringProvider
             CaseKeyword.WithTrailingTrivia(Space),
             AsPatternSyntax(label.Pattern, feature),
             AsWhenClause(label),
-            ColonToken.WithTrailingTrivia(ElasticCarriageReturnLineFeed));
+            ColonToken.WithTrailingTrivia(ElasticEndOfLine(Environment.NewLine)));
     }
 
     private static PatternSyntax AsPatternSyntax(AnalyzedPattern pattern, Feature feature)

--- a/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
@@ -338,7 +338,7 @@ internal sealed partial class ConvertPrimaryToRegularConstructorCodeRefactoringP
                     if (lastFieldOrProperty >= 0)
                     {
                         constructorDeclaration = constructorDeclaration
-                            .WithPrependedLeadingTrivia(ElasticCarriageReturnLineFeed);
+                            .WithPrependedLeadingTrivia(ElasticEndOfLine(Environment.NewLine));
 
                         return currentTypeDeclaration.WithMembers(
                             currentTypeDeclaration.Members.Insert(lastFieldOrProperty + 1, constructorDeclaration));

--- a/src/Features/CSharp/Portable/DocumentationComments/DocCommentConverter.cs
+++ b/src/Features/CSharp/Portable/DocumentationComments/DocCommentConverter.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -59,7 +60,7 @@ internal sealed class DocCommentConverter : CSharpSyntaxRewriter
                     if (commentLines.Count > 0)
                     {
                         newLeadingTrivia.Add(SyntaxFactory.Comment("//"));
-                        newLeadingTrivia.Add(SyntaxFactory.ElasticCarriageReturnLineFeed);
+                        newLeadingTrivia.Add(SyntaxFactory.ElasticEndOfLine(Environment.NewLine));
 
                         newLeadingTrivia.AddRange(commentLines);
                     }
@@ -95,7 +96,7 @@ internal sealed class DocCommentConverter : CSharpSyntaxRewriter
                 yield return SyntaxFactory.Comment("//");
             }
 
-            yield return SyntaxFactory.ElasticCarriageReturnLineFeed;
+            yield return SyntaxFactory.ElasticEndOfLine(Environment.NewLine);
         }
     }
 }

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
@@ -1033,14 +1033,14 @@ internal sealed partial class CSharpExtractMethodService
                     return method.ReplaceToken(
                             body.OpenBraceToken,
                             body.OpenBraceToken.WithAppendedTrailingTrivia(
-                                ElasticCarriageReturnLineFeed));
+                                ElasticEndOfLine(Environment.NewLine)));
                 }
                 else if (expressionBody != null)
                 {
                     return method.ReplaceToken(
                             expressionBody.ArrowToken,
                             expressionBody.ArrowToken.WithPrependedLeadingTrivia(
-                                ElasticCarriageReturnLineFeed));
+                                ElasticEndOfLine(Environment.NewLine)));
                 }
                 else
                 {

--- a/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService_IntroduceLocal.cs
+++ b/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService_IntroduceLocal.cs
@@ -127,7 +127,7 @@ internal sealed partial class CSharpIntroduceVariableService
 
         // Add an elastic newline so that the formatter will place this new lambda body across multiple lines.
         newBody = newBody
-            .WithOpenBraceToken(newBody.OpenBraceToken.WithAppendedTrailingTrivia(ElasticCarriageReturnLineFeed))
+            .WithOpenBraceToken(newBody.OpenBraceToken.WithAppendedTrailingTrivia(ElasticEndOfLine(Environment.NewLine)))
             .WithAdditionalAnnotations(Formatter.Annotation);
 
         return document.Document.WithSyntaxRoot(
@@ -255,7 +255,7 @@ internal sealed partial class CSharpIntroduceVariableService
 
         // Add an elastic newline so that the formatter will place this new block across multiple lines.
         newBody = newBody
-            .WithOpenBraceToken(newBody.OpenBraceToken.WithAppendedTrailingTrivia(ElasticCarriageReturnLineFeed))
+            .WithOpenBraceToken(newBody.OpenBraceToken.WithAppendedTrailingTrivia(ElasticEndOfLine(Environment.NewLine)))
             .WithAdditionalAnnotations(Formatter.Annotation);
 
         var newRoot = document.Root.ReplaceNode(oldParentingNode, WithBlockBody(oldParentingNode, newBody).WithTriviaFrom(oldParentingNode));
@@ -521,7 +521,7 @@ internal sealed partial class CSharpIntroduceVariableService
 
         // Attempt to use the same end of line as the next statement.  Fall back to an elastic newline if not present.
         newStatement = newStatement.WithTrailingTrivia(
-            nextStatement.GetTrailingTrivia() is [.., (kind: SyntaxKind.EndOfLineTrivia) endOfLine] ? endOfLine : ElasticCarriageReturnLineFeed);
+            nextStatement.GetTrailingTrivia() is [.., (kind: SyntaxKind.EndOfLineTrivia) endOfLine] ? endOfLine : ElasticEndOfLine(Environment.NewLine));
 
         return oldStatements.ReplaceRange(
             nextStatement, [newStatement, nextStatement]);

--- a/src/Features/CSharp/Portable/MetadataAsSource/CSharpMetadataAsSourceService.cs
+++ b/src/Features/CSharp/Portable/MetadataAsSource/CSharpMetadataAsSourceService.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -141,8 +142,8 @@ internal sealed partial class CSharpMetadataAsSourceService : AbstractMetadataAs
         return
         [
             Trivia(NullableDirectiveTrivia(Token(keyword), isActive: enable)),
-            ElasticCarriageReturnLineFeed,
-            ElasticCarriageReturnLineFeed,
+            ElasticEndOfLine(Environment.NewLine),
+            ElasticEndOfLine(Environment.NewLine),
         ];
     }
 

--- a/src/Features/CSharpTest/ConvertAutoPropertyToFullProperty/ConvertAutoPropertyToFullPropertyTests.cs
+++ b/src/Features/CSharpTest/ConvertAutoPropertyToFullProperty/ConvertAutoPropertyToFullPropertyTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1037,7 +1037,7 @@ public sealed partial class ConvertAutoPropertyToFullPropertyTests : AbstractCSh
             }
             """);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159"), WorkItem("https://github.com/dotnet/roslyn/issues/22146")]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/22146")]
     public async Task PartialClassInSeparateFiles1()
     {
         var file1 = """
@@ -1082,7 +1082,7 @@ public sealed partial class ConvertAutoPropertyToFullPropertyTests : AbstractCSh
             parameters: null);
     }
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159"), WorkItem("https://github.com/dotnet/roslyn/issues/22146")]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/22146")]
     public async Task PartialClassInSeparateFiles2()
     {
         var file1 = """

--- a/src/Features/CSharpTest/ConvertIfToSwitch/ConvertIfToSwitchTests.cs
+++ b/src/Features/CSharpTest/ConvertIfToSwitch/ConvertIfToSwitchTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -487,7 +487,7 @@ public sealed class ConvertIfToSwitchTests
         }.RunAsync();
     }
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task TestIsPatternExpression_01()
         => VerifyCS.VerifyRefactoringAsync(
             """
@@ -518,7 +518,7 @@ public sealed class ConvertIfToSwitchTests
             }
             """);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task TestIsPatternExpression_02_CSharp8()
         => new VerifyCS.Test
         {
@@ -552,7 +552,7 @@ public sealed class ConvertIfToSwitchTests
             LanguageVersion = LanguageVersion.CSharp8,
         }.RunAsync();
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task TestIsPatternExpression_02_CSharp9()
         => new VerifyCS.Test
         {
@@ -586,7 +586,7 @@ public sealed class ConvertIfToSwitchTests
             LanguageVersion = LanguageVersion.CSharp8,
         }.RunAsync();
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task TestIsPatternExpression_03()
         => VerifyCS.VerifyRefactoringAsync(
             """
@@ -617,7 +617,7 @@ public sealed class ConvertIfToSwitchTests
             }
             """);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task TestIsPatternExpression_04()
         => VerifyCS.VerifyRefactoringAsync(
             """
@@ -648,7 +648,7 @@ public sealed class ConvertIfToSwitchTests
             }
             """);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task TestComplexExpression_01()
         => VerifyCS.VerifyRefactoringAsync(
             """

--- a/src/Features/CSharpTest/ConvertToRawString/ConvertInterpolatedStringToRawStringTests.cs
+++ b/src/Features/CSharpTest/ConvertToRawString/ConvertInterpolatedStringToRawStringTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1295,6 +1295,9 @@ public sealed class ConvertInterpolatedStringToRawStringTests
             }
             """");
 
+    // WindowsOnly: These tests convert string literals containing literal \r\n escape sequences to raw strings.
+    // On Linux, the expected raw string output would need \n but the code correctly preserves \r\n from the original string,
+    // making the test platform-specific.
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
     public Task TestStringWithNewLine()
         => VerifyRefactoringAsync("""
@@ -1366,6 +1369,9 @@ public sealed class ConvertInterpolatedStringToRawStringTests
             }
             """");
 
+    // WindowsOnly: These tests convert string literals containing literal \r\n escape sequences to raw strings.
+    // On Linux, the expected raw string output would need \n but the code correctly preserves \r\n from the original string,
+    // making the test platform-specific.
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
     public Task TestStringWithNewLineAtStartAndEnd()
         => VerifyRefactoringAsync("""
@@ -1466,6 +1472,9 @@ public sealed class ConvertInterpolatedStringToRawStringTests
             }
             """", index: 1);
 
+    // WindowsOnly: These tests convert string literals containing literal \r\n escape sequences to raw strings.
+    // On Linux, the expected raw string output would need \n but the code correctly preserves \r\n from the original string,
+    // making the test platform-specific.
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
     public Task TestIndentedString()
         => VerifyRefactoringAsync("""
@@ -1516,6 +1525,9 @@ public sealed class ConvertInterpolatedStringToRawStringTests
             }
             """", index: 1);
 
+    // WindowsOnly: These tests convert string literals containing literal \r\n escape sequences to raw strings.
+    // On Linux, the expected raw string output would need \n but the code correctly preserves \r\n from the original string,
+    // making the test platform-specific.
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
     public Task TestIndentedStringTopLevel()
         => VerifyRefactoringAsync("""
@@ -1566,6 +1578,9 @@ public sealed class ConvertInterpolatedStringToRawStringTests
             }
             """");
 
+    // WindowsOnly: These tests convert string literals containing literal \r\n escape sequences to raw strings.
+    // On Linux, the expected raw string output would need \n but the code correctly preserves \r\n from the original string,
+    // making the test platform-specific.
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
     public Task TestIndentedStringOnOwnLine()
         => VerifyRefactoringAsync("""

--- a/src/Features/CSharpTest/ConvertToRawString/ConvertRegularStringToRawStringTests.cs
+++ b/src/Features/CSharpTest/ConvertToRawString/ConvertRegularStringToRawStringTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -336,6 +336,9 @@ public sealed class ConvertRegularStringToRawStringTests
             }
             """");
 
+    // WindowsOnly: These tests convert string literals containing literal \r\n escape sequences to raw strings.
+    // On Linux, the expected raw string output would need \n but the code correctly preserves \r\n from the original string,
+    // making the test platform-specific.
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
     public Task TestStringWithNewLine()
         => VerifyRefactoringAsync("""
@@ -383,6 +386,9 @@ public sealed class ConvertRegularStringToRawStringTests
             }
             """");
 
+    // WindowsOnly: These tests convert string literals containing literal \r\n escape sequences to raw strings.
+    // On Linux, the expected raw string output would need \n but the code correctly preserves \r\n from the original string,
+    // making the test platform-specific.
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
     public Task TestStringWithNewLineAtStartAndEnd()
         => VerifyRefactoringAsync("""
@@ -457,6 +463,9 @@ public sealed class ConvertRegularStringToRawStringTests
             }
             """", index: 1);
 
+    // WindowsOnly: These tests convert string literals containing literal \r\n escape sequences to raw strings.
+    // On Linux, the expected raw string output would need \n but the code correctly preserves \r\n from the original string,
+    // making the test platform-specific.
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
     public Task TestIndentedString()
         => VerifyRefactoringAsync("""
@@ -507,6 +516,9 @@ public sealed class ConvertRegularStringToRawStringTests
             }
             """", index: 1);
 
+    // WindowsOnly: These tests convert string literals containing literal \r\n escape sequences to raw strings.
+    // On Linux, the expected raw string output would need \n but the code correctly preserves \r\n from the original string,
+    // making the test platform-specific.
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
     public Task TestIndentedStringTopLevel()
         => VerifyRefactoringAsync("""
@@ -557,6 +569,9 @@ public sealed class ConvertRegularStringToRawStringTests
             }
             """");
 
+    // WindowsOnly: These tests convert string literals containing literal \r\n escape sequences to raw strings.
+    // On Linux, the expected raw string output would need \n but the code correctly preserves \r\n from the original string,
+    // making the test platform-specific.
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
     public Task TestIndentedStringOnOwnLine()
         => VerifyRefactoringAsync("""

--- a/src/Features/CSharpTest/ConvertToRecord/ConvertToRecordCodeRefactoringTests.cs
+++ b/src/Features/CSharpTest/ConvertToRecord/ConvertToRecordCodeRefactoringTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -3028,7 +3028,7 @@ public sealed class ConvertToRecordCodeRefactoringTests
             }
             """);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task TestMovePropertiesWithMultilineDocComments_NoClassSummary()
         => TestRefactoringAsync("""
             namespace N
@@ -3182,7 +3182,7 @@ public sealed class ConvertToRecordCodeRefactoringTests
             }
             """);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task TestMovePropertiesWithDocComments_NoClassSummary()
         => TestRefactoringAsync("""
             namespace N

--- a/src/Features/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
+++ b/src/Features/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1991,7 +1991,7 @@ public abstract partial class CSharpSuppressionTests : AbstractSuppressionDiagno
         """);
             }
 
-            [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+            [Fact]
             public Task TestSuppressionWithExistingGlobalSuppressionsDocument()
                 => TestAsync("""
                     <Workspace>
@@ -2062,7 +2062,7 @@ public abstract partial class CSharpSuppressionTests : AbstractSuppressionDiagno
 
                     """);
 
-            [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+            [Fact]
             public Task TestSuppressionWithExistingGlobalSuppressionsDocument3()
                 => TestAsync("""
                     <Workspace>
@@ -2106,7 +2106,7 @@ public abstract partial class CSharpSuppressionTests : AbstractSuppressionDiagno
 
                     """);
 
-            [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+            [Fact]
             public Task TestSuppressionWithUsingDirectiveInExistingGlobalSuppressionsDocument()
                 => TestAsync("""
                     <Workspace>
@@ -2136,7 +2136,7 @@ public abstract partial class CSharpSuppressionTests : AbstractSuppressionDiagno
 
                     """);
 
-            [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+            [Fact]
             public Task TestSuppressionWithoutUsingDirectiveInExistingGlobalSuppressionsDocument()
                 => TestAsync("""
                     <Workspace>

--- a/src/Features/CSharpTest/ExtractClass/ExtractClassTests.cs
+++ b/src/Features/CSharpTest/ExtractClass/ExtractClassTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1149,7 +1149,7 @@ public sealed class ExtractClassTests
         }.RunAsync();
     }
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     [WorkItem("https://github.com/dotnet/roslyn/issues/55746")]
     public async Task TestUsingsInsideNamespace()
     {

--- a/src/Features/CSharpTest/ExtractMethod/ExtractMethodCodeRefactoringTests.cs
+++ b/src/Features/CSharpTest/ExtractMethod/ExtractMethodCodeRefactoringTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1535,7 +1535,7 @@ public sealed class ExtractMethodCodeRefactoringTests : AbstractCSharpCodeAction
             }
             """ + TestResources.NetFX.ValueTuple.tuplelib_cs);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     [CompilerTrait(CompilerFeature.Tuples)]
     public Task TestDeconstruction2()
         => TestInRegularAndScriptAsync(
@@ -5790,7 +5790,7 @@ class Program
             ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
         }.RunAsync();
 
-    [ConditionalTheory(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Theory]
     [CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/67017")]
     public async Task TestPrimaryConstructorBaseList(bool withBody)
     {

--- a/src/Features/CSharpTest/GenerateFromMembers/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersTests.cs
+++ b/src/Features/CSharpTest/GenerateFromMembers/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -132,7 +132,7 @@ public sealed class AddConstructorParametersFromMembersTests
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(string.Format(FeaturesResources.Add_parameters_to_0, "Program(int i)"), codeAction.Title)
         }.RunAsync();
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     [WorkItem("https://github.com/dotnet/roslyn/issues/58040")]
     public Task TestProperlyWrapParameters2()
         => new VerifyCS.Test
@@ -180,7 +180,7 @@ public sealed class AddConstructorParametersFromMembersTests
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(string.Format(FeaturesResources.Add_parameters_to_0, "Program(int i, string s)"), codeAction.Title)
         }.RunAsync();
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     [WorkItem("https://github.com/dotnet/roslyn/issues/58040")]
     public Task TestProperlyWrapParameters3()
         => new VerifyCS.Test
@@ -226,7 +226,7 @@ public sealed class AddConstructorParametersFromMembersTests
             CodeActionVerifier = (codeAction, verifier) => verifier.Equal(string.Format(FeaturesResources.Add_parameters_to_0, "Program(int i, string s)"), codeAction.Title)
         }.RunAsync();
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     [WorkItem("https://github.com/dotnet/roslyn/issues/58040")]
     public Task TestProperlyWrapParameters4()
         => new VerifyCS.Test
@@ -2437,7 +2437,7 @@ public sealed class AddConstructorParametersFromMembersTests
             CodeActionIndex = 1
         }.RunAsync();
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     [WorkItem("https://github.com/dotnet/roslyn/issues/60816")]
     public Task TestAddMultipleParametersWithWrapping()
         => new VerifyCS.Test

--- a/src/Features/CSharpTest/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/Features/CSharpTest/IntroduceVariable/IntroduceVariableTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7749,7 +7749,7 @@ class C
             }
             """);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159"), WorkItem("https://github.com/dotnet/roslyn/issues/44291")]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/44291")]
     public Task TestIntroduceWithAmbiguousExtensionClass()
         => TestInRegularAndScriptAsync(
             """

--- a/src/Features/CSharpTest/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/Features/CSharpTest/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -2783,7 +2783,7 @@ index: 1);
             }
             """);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     [WorkItem("https://github.com/dotnet/roslyn/issues/72035")]
     public Task TestUpdateGetReferenceGeneratedPart()
         => TestInRegularAndScriptAsync(

--- a/src/Features/CSharpTest/SplitOrMergeIfStatements/SplitIntoConsecutiveIfStatementsTests.cs
+++ b/src/Features/CSharpTest/SplitOrMergeIfStatements/SplitIntoConsecutiveIfStatementsTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -927,7 +927,7 @@ public sealed class SplitIntoConsecutiveIfStatementsTests
             }
             """);
 
-    [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83159")]
+    [Fact]
     public Task SplitIntoSeparateStatementsIfControlFlowQuits4()
         => VerifyCS.VerifyRefactoringAsync("""
             class C

--- a/src/Workspaces/CSharpTest/CSharpSyntaxFactsServiceTests.cs
+++ b/src/Workspaces/CSharpTest/CSharpSyntaxFactsServiceTests.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System;
 using Microsoft.CodeAnalysis.CSharp.LanguageService;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -12,6 +13,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests;
 
 public sealed class CSharpSyntaxFactsServiceTests
 {
+    [Fact]
+    public void ElasticCarriageReturnLineFeed_UsesEnvironmentNewLine()
+    {
+        var service = CSharpSyntaxFacts.Instance;
+        var trivia = service.ElasticCarriageReturnLineFeed;
+
+        Assert.True(service.IsElastic(trivia));
+        Assert.Equal(Environment.NewLine, trivia.ToFullString());
+    }
+
     private static bool IsQueryKeyword(string markup)
     {
         MarkupTestFile.GetPosition(markup, out var code, out int position);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -39,7 +39,7 @@ internal class CSharpSyntaxFacts : AbstractSyntaxFacts, ISyntaxFacts
         => SyntaxFactory.ElasticMarker;
 
     public SyntaxTrivia ElasticCarriageReturnLineFeed
-        => SyntaxFactory.ElasticCarriageReturnLineFeed;
+        => SyntaxFactory.ElasticEndOfLine(Environment.NewLine);
 
     public ISyntaxKinds SyntaxKinds { get; } = CSharpSyntaxKinds.Instance;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/CSharpCodeGenerationHelpers.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/CSharpCodeGenerationHelpers.cs
@@ -186,7 +186,7 @@ internal static class CSharpCodeGenerationHelpers
 
         if (index != 0 && declarationList[index - 1].ContainsDiagnostics && AreBracesMissing(declarationList[index - 1]))
         {
-            return declarationList.Insert(index, declaration.WithLeadingTrivia(ElasticCarriageReturnLineFeed));
+            return declarationList.Insert(index, declaration.WithLeadingTrivia(ElasticEndOfLine(Environment.NewLine)));
         }
 
         return declarationList.Insert(index, declaration);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/TypeDeclarationSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/TypeDeclarationSyntaxExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -98,8 +99,8 @@ internal static class TypeDeclarationSyntaxExtensions
     {
         if (token.IsMissing || token.IsKind(SyntaxKind.None))
         {
-            var leadingTrivia = prependNewLineIfMissing ? token.LeadingTrivia.Insert(0, SyntaxFactory.ElasticCarriageReturnLineFeed) : token.LeadingTrivia;
-            var trailingTrivia = appendNewLineIfMissing ? token.TrailingTrivia.Insert(0, SyntaxFactory.ElasticCarriageReturnLineFeed) : token.TrailingTrivia;
+            var leadingTrivia = prependNewLineIfMissing ? token.LeadingTrivia.Insert(0, SyntaxFactory.ElasticEndOfLine(Environment.NewLine)) : token.LeadingTrivia;
+            var trailingTrivia = appendNewLineIfMissing ? token.TrailingTrivia.Insert(0, SyntaxFactory.ElasticEndOfLine(Environment.NewLine)) : token.TrailingTrivia;
             return SyntaxFactory.Token(leadingTrivia, kind, trailingTrivia).WithAdditionalAnnotations(Formatter.Annotation);
         }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSyntaxGeneratorInternal.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSyntaxGeneratorInternal.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
@@ -35,7 +36,7 @@ internal sealed class CSharpSyntaxGeneratorInternal() : SyntaxGeneratorInternal
         => SyntaxFactory.CarriageReturnLineFeed;
 
     public override SyntaxTrivia ElasticCarriageReturnLineFeed
-        => SyntaxFactory.ElasticCarriageReturnLineFeed;
+        => SyntaxFactory.ElasticEndOfLine(Environment.NewLine);
 
     public override bool SupportsThrowExpression()
         => true;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSyntaxGeneratorInternal.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSyntaxGeneratorInternal.cs
@@ -33,7 +33,7 @@ internal sealed class CSharpSyntaxGeneratorInternal() : SyntaxGeneratorInternal
         => CSharpSyntaxFacts.Instance;
 
     public override SyntaxTrivia CarriageReturnLineFeed
-        => SyntaxFactory.CarriageReturnLineFeed;
+        => SyntaxFactory.EndOfLine(Environment.NewLine);
 
     public override SyntaxTrivia ElasticCarriageReturnLineFeed
         => SyntaxFactory.ElasticEndOfLine(Environment.NewLine);


### PR DESCRIPTION
## Summary
- switch IDE elastic newline insertions from hardcoded CRLF to Environment.NewLine-backed trivia in code fixes/refactorings
- remove WindowsOnly attributes for issue #83159 tests that are now platform-agnostic
- keep only the truly CRLF-semantic tests Windows-only, with inline comments explaining why

## Validation
- dotnet build Ide.slnf
- dotnet build Compilers.slnf

## Remaining Windows-only tests
- ConvertToRawString tests that validate literal \r\n semantics
- one MakeFieldReadonly theory with InlineData("\r\n") / InlineData("\r\n\r\n")
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84415)