### PR TITLE
Fix crash in foreach deconstruction over null coalescing

### DIFF
--- a/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
@@ -626,6 +626,40 @@ public sealed partial class UseCollectionInitializerTests_CollectionExpression
             """);
 
     [Fact]
+    public Task TestInForEachDeconstructionOverNullCoalescing()
+        => TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    var dict = new Dictionary<string, List<int>>();
+                    foreach (var (x, y) in dict ?? [|new|] Dictionary<string, List<int>>())
+                    {
+                        //
+                    }
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    var dict = new Dictionary<string, List<int>>();
+                    foreach (var (x, y) in dict ?? [])
+                    {
+                        //
+                    }
+                }
+            }
+            """);
+
+    [Fact]
     public Task TestOnVariableDeclarator_If8()
         => TestInRegularAndScriptAsync(
             """
@@ -6819,4 +6853,3 @@ public sealed partial class UseCollectionInitializerTests_CollectionExpression
         }.RunAsync();
 #endif
 }
-

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -3296,9 +3296,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Given a foreach statement, get the symbol for the iteration variable
+        /// Given a foreach variable statement, get the symbol for the (first) iteration variable.
         /// </summary>
-        /// <param name="forEachVariableStatement"></param>
+        /// <param name="forEachVariableStatement">The foreach variable statement.</param>
         public ILocalSymbol GetDeclaredSymbol(ForEachVariableStatementSyntax forEachVariableStatement)
         {
             Binder enclosingBinder = this.GetEnclosingBinder(GetAdjustedNodePosition(forEachVariableStatement));
@@ -3310,7 +3310,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Binder foreachBinder = enclosingBinder.GetBinder(forEachVariableStatement);
 
-            // Binder.GetBinder can fail in presence of syntax errors. 
+            // Binder.GetBinder can fail in the presence of syntax errors.
             if (foreachBinder == null)
             {
                 return null;

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -3296,6 +3296,33 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
+        /// Given a foreach statement, get the symbol for the iteration variable
+        /// </summary>
+        /// <param name="forEachVariableStatement"></param>
+        public ILocalSymbol GetDeclaredSymbol(ForEachVariableStatementSyntax forEachVariableStatement)
+        {
+            Binder enclosingBinder = this.GetEnclosingBinder(GetAdjustedNodePosition(forEachVariableStatement));
+
+            if (enclosingBinder == null)
+            {
+                return null;
+            }
+
+            Binder foreachBinder = enclosingBinder.GetBinder(forEachVariableStatement);
+
+            // Binder.GetBinder can fail in presence of syntax errors. 
+            if (foreachBinder == null)
+            {
+                return null;
+            }
+
+            LocalSymbol local = foreachBinder.GetDeclaredLocalsForScope(forEachVariableStatement).FirstOrDefault();
+            return (local is SourceLocalSymbol { DeclarationKind: LocalDeclarationKind.ForEachIterationVariable } sourceLocal
+                ? GetAdjustedLocalSymbol(sourceLocal)
+                : local).GetPublicSymbol();
+        }
+
+        /// <summary>
         /// Given a local symbol, gets an updated version of that local symbol adjusted for nullability analysis
         /// if the analysis affects the local.
         /// </summary>
@@ -5191,6 +5218,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return this.GetDeclaredSymbol(usingDirective, cancellationToken);
                 case SyntaxKind.ForEachStatement:
                     return this.GetDeclaredSymbol((ForEachStatementSyntax)node);
+                case SyntaxKind.ForEachVariableStatement:
+                    return this.GetDeclaredSymbol((ForEachVariableStatementSyntax)node);
                 case SyntaxKind.CatchDeclaration:
                     return this.GetDeclaredSymbol((CatchDeclarationSyntax)node);
                 case SyntaxKind.JoinIntoClause:


### PR DESCRIPTION
The **UseCollectionInitializer** analyzer crashed when analyzing a foreach deconstruction statement (`foreach (var (x, y) in ...)`) whose collection was a null-coalescing expression over an object creation (`dict ?? new Dictionary<string, List<int>>()`).

Fixed by adding the missing case and adding related tests to avoid regression on this specific issue.

Found this issue when enabling analyzer on my code base and this prevented all analyzers from running until this pattern was removed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84417)