### PR TITLE
Respect inherited AttributeUsage in attribute completion filtering

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -436,6 +436,62 @@ public sealed partial class SymbolCompletionProviderTests : AbstractCSharpComple
             ItemExpectation.Absent("AttributeUsage"),
         ]);
 
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84394")]
+    public async Task AttributeTargetFiltering_InheritedAttributeUsage()
+    {
+        // AttributeUsage is inherited by derived attribute types. A method-only attribute and an attribute
+        // deriving from it (without its own AttributeUsage) should both be filtered out on a non-method target.
+        var code = """
+            [$$]
+            record struct TestRecordStruct
+            {
+            }
+
+            [System.AttributeUsage(System.AttributeTargets.Method)]
+            public class FactAttribute : System.Attribute
+            {
+            }
+
+            public class CulturedFactAttribute : FactAttribute
+            {
+            }
+            """;
+
+        await VerifyExpectedItemsAsync(code, [
+            ItemExpectation.Absent("Fact"),
+            ItemExpectation.Absent("CulturedFact")
+        ]);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84394")]
+    public async Task AttributeTargetFiltering_InheritedAttributeUsageOnValidTarget()
+    {
+        // On a valid (method) target both the method-only attribute and its derived attribute are offered.
+        var code = """
+            class TestClass
+            {
+                [$$]
+                public void M()
+                {
+                }
+            }
+
+            [System.AttributeUsage(System.AttributeTargets.Method)]
+            public class FactAttribute : System.Attribute
+            {
+            }
+
+            public class CulturedFactAttribute : FactAttribute
+            {
+            }
+            """;
+
+        await VerifyExpectedItemsAsync(code, [
+            ItemExpectation.Exists("Fact"),
+            ItemExpectation.Exists("CulturedFact")
+        ]);
+    }
+
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/7640")]
     public async Task AttributeTargetFiltering_AssemblyAttribute()
     {

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -915,6 +915,36 @@ $$
             End Using
         End Function
 
+        <WpfTheory, CombinatorialData>
+        <WorkItem("https://github.com/dotnet/roslyn/issues/84394")>
+        Public Async Function TestAttributeWithMethodTargetUsageFilteredWhenBoundToTypeTarget(showCompletionInArgumentLists As Boolean) As Task
+            ' When an attribute is being typed above a type declaration (no method target), attributes whose
+            ' AttributeUsage restricts them to methods should be filtered out. This must respect *inherited*
+            ' AttributeUsage: CulturedFactAttribute derives from a Method-only FactAttribute, so it too must be
+            ' filtered out. Otherwise typing "[Fact" would be completed to the still-visible "[CulturedFact".
+            Using state = TestStateFactory.CreateCSharpTestState(
+                              <Document><![CDATA[
+using System;
+
+[AttributeUsage(AttributeTargets.Method)]
+class FactAttribute : Attribute { }
+class CulturedFactAttribute : FactAttribute { }
+
+class C
+{
+    $$
+    internal partial record struct TypeWithStatefulConverter(int Value);
+}
+]]></Document>,
+                              showCompletionInArgumentLists:=showCompletionInArgumentLists)
+
+                state.SendTypeChars("[Fact")
+                Await state.WaitForAsynchronousOperationsAsync()
+                ' Neither Fact nor CulturedFact is a valid attribute on a type target, so neither should be offered.
+                Await state.AssertCompletionItemsDoNotContainAny("Fact", "CulturedFact")
+            End Using
+        End Function
+
         <WpfTheory(Skip:="https://github.com/dotnet/roslyn/issues/71851"), CombinatorialData>
         Public Async Function TestDeletingWholeWordResetCompletionToTheDefaultItem(showCompletionInArgumentLists As Boolean) As Task
             Using state = TestStateFactory.CreateCSharpTestState(

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Extensions/Symbols/ISymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Extensions/Symbols/ISymbolExtensions.cs
@@ -571,27 +571,28 @@ internal static partial class ISymbolExtensions
         // AttributeUsage is inherited: if the attribute type doesn't specify one directly, the effective
         // usage comes from the nearest base attribute type that does (matching the C# compiler's behavior).
         // Walk the base type chain to find it.
-        for (var currentType = attributeType; currentType is not null; currentType = currentType.BaseType)
+        var currentType = attributeType;
+        while (currentType is not null)
         {
             var attributeUsageAttribute = currentType.GetAttributes()
                 .FirstOrDefault(attr => attr.AttributeClass is { Name: "AttributeUsageAttribute", ContainingNamespace: { Name: "System", ContainingNamespace.IsGlobalNamespace: true } });
 
-            if (attributeUsageAttribute == null)
+            if (attributeUsageAttribute != null)
             {
-                // No AttributeUsage on this type; keep looking up the base chain.
-                continue;
+                // The first constructor argument is the AttributeTargets value
+                if (attributeUsageAttribute.ConstructorArguments is [{ Value: int targetsValue }, ..])
+                {
+                    var attributeTargets = (AttributeTargets)targetsValue;
+                    // Check if there's any overlap between the attribute's targets and the valid targets
+                    return (attributeTargets & validTargets) != 0;
+                }
+
+                // Found an AttributeUsage but couldn't determine the targets; default to allowing the attribute.
+                return true;
             }
 
-            // The first constructor argument is the AttributeTargets value
-            if (attributeUsageAttribute.ConstructorArguments is [{ Value: int targetsValue }, ..])
-            {
-                var attributeTargets = (AttributeTargets)targetsValue;
-                // Check if there's any overlap between the attribute's targets and the valid targets
-                return (attributeTargets & validTargets) != 0;
-            }
-
-            // Found an AttributeUsage but couldn't determine the targets; default to allowing the attribute.
-            return true;
+            // No AttributeUsage on this type; keep looking up the base chain.
+            currentType = currentType.BaseType;
         }
 
         // No AttributeUsage found anywhere in the inheritance chain; the default is AttributeTargets.All

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Extensions/Symbols/ISymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Extensions/Symbols/ISymbolExtensions.cs
@@ -567,25 +567,34 @@ internal static partial class ISymbolExtensions
 
     private static bool IsAttributeValidForTargets(INamedTypeSymbol attributeType, AttributeTargets validTargets)
     {
-        // Get the AttributeUsageAttribute applied to this attribute type
-        var attributeUsageAttribute = attributeType.GetAttributes()
-            .FirstOrDefault(attr => attr.AttributeClass is { Name: "AttributeUsageAttribute", ContainingNamespace: { Name: "System", ContainingNamespace.IsGlobalNamespace: true } });
-
-        if (attributeUsageAttribute == null)
+        // Get the AttributeUsageAttribute that determines the valid targets for this attribute type.
+        // AttributeUsage is inherited: if the attribute type doesn't specify one directly, the effective
+        // usage comes from the nearest base attribute type that does (matching the C# compiler's behavior).
+        // Walk the base type chain to find it.
+        for (var currentType = attributeType; currentType is not null; currentType = currentType.BaseType)
         {
-            // If no AttributeUsage is specified, the default is AttributeTargets.All
+            var attributeUsageAttribute = currentType.GetAttributes()
+                .FirstOrDefault(attr => attr.AttributeClass is { Name: "AttributeUsageAttribute", ContainingNamespace: { Name: "System", ContainingNamespace.IsGlobalNamespace: true } });
+
+            if (attributeUsageAttribute == null)
+            {
+                // No AttributeUsage on this type; keep looking up the base chain.
+                continue;
+            }
+
+            // The first constructor argument is the AttributeTargets value
+            if (attributeUsageAttribute.ConstructorArguments is [{ Value: int targetsValue }, ..])
+            {
+                var attributeTargets = (AttributeTargets)targetsValue;
+                // Check if there's any overlap between the attribute's targets and the valid targets
+                return (attributeTargets & validTargets) != 0;
+            }
+
+            // Found an AttributeUsage but couldn't determine the targets; default to allowing the attribute.
             return true;
         }
 
-        // The first constructor argument is the AttributeTargets value
-        if (attributeUsageAttribute.ConstructorArguments is [{ Value: int targetsValue }, ..])
-        {
-            var attributeTargets = (AttributeTargets)targetsValue;
-            // Check if there's any overlap between the attribute's targets and the valid targets
-            return (attributeTargets & validTargets) != 0;
-        }
-
-        // Default to allowing the attribute if we can't determine the targets
+        // No AttributeUsage found anywhere in the inheritance chain; the default is AttributeTargets.All
         return true;
     }
 


### PR DESCRIPTION
Fixes #84394
Typing `[Fact]` before a method existed would drop `Fact` from completion and complete to `[CulturedFact]` instead.

Attribute completion filters by `AttributeUsage` target, but `IsAttributeValidForTargets` only read the attribute type's *own* `AttributeUsage`. `FactAttribute` declares `[AttributeUsage(Method)]` and was correctly filtered out on a type target; `CulturedFactAttribute` only *inherits* that usage, so the check found nothing, defaulted to `AttributeTargets.All`, and left it as the only `…Fact` match.

To fix, we now walk the base type chain to resolve the effective `AttributeUsage`, matching the compiler's `GetAttributeUsageInfo`. Now both are filtered on a type target and both appear on a method target.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84426)