### PR TITLE
Remove unnecessary NuGetAuthenticate for public azure-public feeds

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -288,11 +288,6 @@ extends:
           inputs:
             versionSpec: '4.9.2'
 
-        # Authenticate with service connections to be able to publish packages to external nuget feeds.
-        - task: NuGetAuthenticate@1
-          inputs:
-            nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk
-
         # Authenticate to DevDiv engineering feed via WIF service connection
         - task: NuGetAuthenticate@1
           inputs:

--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -212,11 +212,6 @@ extends:
           inputs:
             versionSpec: '4.9.2'
 
-        # Authenticate with service connections to be able to publish packages to external nuget feeds.
-        - task: NuGetAuthenticate@1
-          inputs:
-            nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk
-
         # Needed because the build fails the NuGet Tools restore without it
         - task: UseDotNet@2
           displayName: 'Use .NET Core sdk'


### PR DESCRIPTION
## Summary

Removes the \NuGetAuthenticate@1\ steps that authenticate to \zure-public/vs-impl\ and \zure-public/vssdk\ service connections. These feeds are **publicly readable** and do not require authentication for NuGet restore operations.

## Verification

Both feeds respond with 200 (service index) without any auth headers:
- \https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json\
- \https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json\

No push/publish operations target these feeds from this repo (confirmed via org-wide code search).

## Context

Part of the dnceng PAT-to-Entra migration effort:
- [WI 10128](https://dnceng.visualstudio.com/internal/_workitems/edit/10128) — azure-public/vssdk
- [WI 10129](https://dnceng.visualstudio.com/internal/_workitems/edit/10129) — azure-public/vs-impl

The DevDiv feed authentication steps (already WIF-migrated) are retained.

## Files Changed
- \zure-pipelines-official.yml\ — removed NuGetAuthenticate step for azure-public feeds
- \zure-pipelines-pr-validation.yml\ — removed NuGetAuthenticate step for azure-public feeds
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84427)