### PR TITLE
Exclude `[Embedded]` APIs from public/internal API tracking

### DIFF
--- a/src/RoslynAnalyzers/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+++ b/src/RoslynAnalyzers/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
@@ -913,8 +913,9 @@ start:
                     // Types marked with '[Microsoft.CodeAnalysis.Embedded]' (as well as their members) are an
                     // implementation detail that gets embedded into consuming assemblies. They should not be tracked
                     // as APIs. This also gives authors an opt-out for internal API tracking: applying the attribute to
-                    // an internal type excludes it (and its members) from tracking. The attribute only targets types,
-                    // so only check named types as we walk up the containing-type chain.
+                    // an internal type excludes it (and its members) from tracking. We intentionally only inspect named
+                    // types as we walk up the containing-type chain (for perf and because the compiler only emits this
+                    // attribute on types); this is a deliberate restriction, not a claim about the attribute's targets.
                     if (current is INamedTypeSymbol namedType && HasEmbeddedAttribute(namedType))
                     {
                         return false;

--- a/src/RoslynAnalyzers/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+++ b/src/RoslynAnalyzers/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
@@ -913,8 +913,9 @@ start:
                     // Types marked with '[Microsoft.CodeAnalysis.Embedded]' (as well as their members) are an
                     // implementation detail that gets embedded into consuming assemblies. They should not be tracked
                     // as APIs. This also gives authors an opt-out for internal API tracking: applying the attribute to
-                    // an internal type excludes it (and its members) from tracking.
-                    if (HasEmbeddedAttribute(current))
+                    // an internal type excludes it (and its members) from tracking. The attribute only targets types,
+                    // so only check named types as we walk up the containing-type chain.
+                    if (current is INamedTypeSymbol namedType && HasEmbeddedAttribute(namedType))
                     {
                         return false;
                     }
@@ -936,7 +937,7 @@ start:
                 return true;
             }
 
-            private static bool HasEmbeddedAttribute(ISymbol symbol)
+            private static bool HasEmbeddedAttribute(INamedTypeSymbol symbol)
             {
                 foreach (var attribute in symbol.GetAttributes())
                 {

--- a/src/RoslynAnalyzers/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+++ b/src/RoslynAnalyzers/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
@@ -910,6 +910,15 @@ start:
 
                 for (var current = symbol; current != null; current = current.ContainingType)
                 {
+                    // Types marked with '[Microsoft.CodeAnalysis.Embedded]' (as well as their members) are an
+                    // implementation detail that gets embedded into consuming assemblies. They should not be tracked
+                    // as APIs. This also gives authors an opt-out for internal API tracking: applying the attribute to
+                    // an internal type excludes it (and its members) from tracking.
+                    if (HasEmbeddedAttribute(current))
+                    {
+                        return false;
+                    }
+
                     switch (current.DeclaredAccessibility)
                     {
                         case Accessibility.Protected:
@@ -925,6 +934,34 @@ start:
                 }
 
                 return true;
+            }
+
+            private static bool HasEmbeddedAttribute(ISymbol symbol)
+            {
+                foreach (var attribute in symbol.GetAttributes())
+                {
+                    // Match 'Microsoft.CodeAnalysis.EmbeddedAttribute' by name rather than by symbol identity, since the
+                    // attribute is typically embedded (and hence duplicated) across assemblies, which makes a
+                    // well-known-type lookup ambiguous.
+                    if (attribute.AttributeClass is
+                        {
+                            Name: "EmbeddedAttribute",
+                            ContainingNamespace:
+                            {
+                                Name: "CodeAnalysis",
+                                ContainingNamespace:
+                                {
+                                    Name: "Microsoft",
+                                    ContainingNamespace.IsGlobalNamespace: true,
+                                },
+                            },
+                        })
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
             }
 
             private bool CanTypeBeExtended(ITypeSymbol type)

--- a/src/RoslynAnalyzers/PublicApiAnalyzers/UnitTests/DeclarePublicAPIAnalyzerTestsBase.cs
+++ b/src/RoslynAnalyzers/PublicApiAnalyzers/UnitTests/DeclarePublicAPIAnalyzerTestsBase.cs
@@ -338,6 +338,25 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests
                 }
                 """, @"", @"");
 
+        [Fact, WorkItem(79658, "https://github.com/dotnet/roslyn/issues/79658")]
+        public Task EmbeddedTypesAndMembersAreNotTrackedAsync()
+            => VerifyCSharpAsync($$"""
+
+                namespace Microsoft.CodeAnalysis
+                {
+                    [Embedded]
+                    internal sealed class EmbeddedAttribute : System.Attribute { }
+                }
+
+                [Microsoft.CodeAnalysis.Embedded]
+                internal class C
+                {
+                    internal int Field;
+                    internal int Property { get; set; }
+                    internal void Method() { }
+                }
+                """, @"", @"");
+
         [Fact]
         public Task SimpleMissingMember_CSharpAsync()
             => VerifyCSharpAsync($$"""

--- a/src/RoslynAnalyzers/PublicApiAnalyzers/UnitTests/DeclarePublicAPIAnalyzerTestsBase.cs
+++ b/src/RoslynAnalyzers/PublicApiAnalyzers/UnitTests/DeclarePublicAPIAnalyzerTestsBase.cs
@@ -354,6 +354,14 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests
                     internal int Field;
                     internal int Property { get; set; }
                     internal void Method() { }
+
+                    // Nested type is not itself annotated; it (and its members) must still be excluded
+                    // because an enclosing type is marked '[Embedded]'.
+                    internal class Nested
+                    {
+                        internal int NestedField;
+                        internal void NestedMethod() { }
+                    }
                 }
                 """, @"", @"");
 


### PR DESCRIPTION
Follow-up to dotnet/roslyn-analyzers#6160 (now living in `src/RoslynAnalyzers`), implementing the remaining piece of #79658: excluding APIs marked with `Microsoft.CodeAnalysis.EmbeddedAttribute` from API tracking.

### Motivation

#6160 added internal API tracking. The one thing it left out (per #79658) is embedded support. Types marked with `[Embedded]` are an implementation detail that the compiler embeds into consuming assemblies, so they shouldn't be tracked as APIs. This also provides the opt-out the issue asks for: an author can apply `[Embedded]` to an internal type to exclude it (and its members) from `InternalAPI.*.txt` tracking, forcing an explicit decision about what is part of the IVT-visible surface.

### Changes

- **`DeclarePublicApiAnalyzer.Impl.cs`**: `IsTrackedApiCore` now skips any symbol whose type — or any enclosing type — carries `Microsoft.CodeAnalysis.EmbeddedAttribute`. Added a `HasEmbeddedAttribute` helper that matches the attribute **by namespace + name** rather than by symbol identity, because the attribute is typically embedded (and hence duplicated) across assemblies, which makes a well-known-type lookup ambiguous.
- **`DeclarePublicAPIAnalyzerTestsBase.cs`**: added `EmbeddedTypesAndMembersAreNotTrackedAsync`, which runs under both the public and internal analyzer configurations and verifies that an `[Embedded]` type and its field/property/method produce no diagnostics.

This is effectively a no-op for public API tracking since embedded types are always internal.

### Validation

- Analyzer project builds clean (0 warnings / 0 errors).
- `DeclarePublicApiAnalyzerTests` suite: 256/256 passing, including the new test in both public and internal configurations.

Fixes #79658.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84437)