### PR TITLE
Skip internal API tracking when IVT only targets test/mock assemblies

### DIFF
--- a/src/RoslynAnalyzers/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
+++ b/src/RoslynAnalyzers/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
@@ -8,6 +8,9 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Text.RegularExpressions;
+using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
@@ -50,6 +53,20 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
         private const string BaseEditorConfigPath = "dotnet_public_api_analyzer";
         private const string BailOnMissingPublicApiFilesEditorConfigOptionName = $"{BaseEditorConfigPath}.require_api_files";
         private const string NamespaceToIgnoreInTrackingEditorConfigOptionName = $"{BaseEditorConfigPath}.skip_namespaces";
+
+        /// <summary>
+        /// Comma/semicolon-separated list of InternalsVisibleTo (IVT) target assembly names (supporting a trailing
+        /// <c>*</c> wildcard, e.g. <c>*.Tests</c>) that should be ignored when deciding whether internal API
+        /// tracking should run. See <see cref="ShouldTrackInternalApiBasedOnIvt"/>.
+        /// </summary>
+        private const string InternalApiSkipIvtEditorConfigOptionName = $"{BaseEditorConfigPath}.internal_api_skip_ivt";
+
+        /// <summary>
+        /// Well-known assembly name used by Castle DynamicProxy (which backs mocking frameworks such as Moq) for its
+        /// generated proxy assembly. IVT grants to this assembly never represent a real compatibility consumer, so it
+        /// is always ignored when deciding whether internal API tracking should run.
+        /// </summary>
+        private const string DynamicProxyGenAssemblyName = "DynamicProxyGenAssembly2";
 
         internal static readonly SymbolDisplayFormat ShortSymbolNameFormat =
             new(
@@ -111,6 +128,17 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
 
             void CheckAndRegisterImplementation(bool isPublic)
             {
+                // Internal API tracking (RS0051-RS0058) exists to catch binary-breaking changes across
+                // InternalsVisibleTo (IVT) boundaries. IVT grants to test projects and mocking frameworks
+                // (Moq/Castle proxies use the well-known assembly name 'DynamicProxyGenAssembly2') are not real
+                // compatibility consumers. When the only IVT grants target such assemblies, internal API tracking
+                // adds no value and only creates noise, so we skip registering the internal analyzer entirely.
+                // This only affects the internal analyzer instance; the public instance is never affected.
+                if (!isPublic && !ShouldTrackInternalApiBasedOnIvt(context.Compilation, context.Options))
+                {
+                    return;
+                }
+
                 var errors = new List<Diagnostic>();
                 // Switch to "RegisterAdditionalFileAction" available in Microsoft.CodeAnalysis "3.8.x" to report additional file diagnostics: https://github.com/dotnet/roslyn-analyzers/issues/3918
                 if (!TryGetAndValidateApiFiles(context, isPublic, errors, out var additionalFiles, out var shippedData, out var unshippedData))
@@ -324,6 +352,114 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
 
             skippedNamespaces = namespaceStrings.ToImmutableArray();
             return true;
+        }
+
+        /// <summary>
+        /// Determines whether internal API tracking should run for the given compilation, based on its
+        /// InternalsVisibleTo (IVT) grants. IVT is assembly-wide (not per-API), so the decision must be made at the
+        /// assembly level: we read the compilation assembly's IVT grants, drop the ones matching the ignore patterns
+        /// (always including the built-in <see cref="DynamicProxyGenAssemblyName"/> default plus anything configured
+        /// via <see cref="InternalApiSkipIvtEditorConfigOptionName"/>), and if no real (non-ignored) IVT target
+        /// remains we disable internal API tracking.
+        /// <para>
+        /// To stay conservative we only skip when there was at least one IVT grant and every grant is ignored. A
+        /// project with internal API files but zero IVT grants has still explicitly opted in (via the presence of the
+        /// InternalAPI.*.txt files), so we keep tracking in that case.
+        /// </para>
+        /// </summary>
+        private static bool ShouldTrackInternalApiBasedOnIvt(Compilation compilation, AnalyzerOptions analyzerOptions)
+        {
+            var internalsVisibleToAttribute = compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemRuntimeCompilerServicesInternalsVisibleToAttribute);
+            if (internalsVisibleToAttribute is null)
+            {
+                // Can't resolve the IVT attribute type; preserve existing behavior and keep tracking.
+                return true;
+            }
+
+            var ignorePatterns = GetInternalApiSkipIvtPatterns(analyzerOptions, compilation);
+
+            var sawAnyIvtGrant = false;
+            foreach (var attribute in compilation.Assembly.GetAttributes(internalsVisibleToAttribute))
+            {
+                if (attribute.ConstructorArguments.Length == 0 ||
+                    attribute.ConstructorArguments[0].Value is not string assemblyNameArgument ||
+                    string.IsNullOrWhiteSpace(assemblyNameArgument))
+                {
+                    continue;
+                }
+
+                sawAnyIvtGrant = true;
+
+                // The IVT argument has the form "AssemblyName, PublicKey=0024...". Strip everything from the first
+                // comma onward to obtain the simple assembly name before matching.
+                var simpleName = assemblyNameArgument;
+                var commaIndex = simpleName.IndexOf(',');
+                if (commaIndex >= 0)
+                {
+                    simpleName = simpleName[..commaIndex];
+                }
+
+                simpleName = simpleName.Trim();
+
+                if (!IsIgnoredIvtTarget(simpleName, ignorePatterns))
+                {
+                    // At least one real (non-ignored) IVT consumer exists; keep tracking.
+                    return true;
+                }
+            }
+
+            // Only skip when there was at least one IVT grant and all grants were ignored.
+            return !sawAnyIvtGrant;
+        }
+
+        private static ImmutableArray<string> GetInternalApiSkipIvtPatterns(AnalyzerOptions analyzerOptions, Compilation compilation)
+        {
+            var builder = ImmutableArray.CreateBuilder<string>();
+
+            // Always ignore the Castle DynamicProxy / Moq proxy assembly.
+            builder.Add(DynamicProxyGenAssemblyName);
+
+            // IVT is assembly-level, so read the (compilation-level) editorconfig option via the first syntax tree,
+            // mirroring TryGetEditorConfigOptionForMissingFiles.
+            if (compilation.SyntaxTrees.FirstOrDefault() is { } tree &&
+                TryGetEditorConfigOption(analyzerOptions, tree, InternalApiSkipIvtEditorConfigOptionName, out var patternsString) &&
+                !string.IsNullOrWhiteSpace(patternsString))
+            {
+                foreach (var pattern in patternsString.Split([',', ';'], StringSplitOptions.RemoveEmptyEntries))
+                {
+                    var trimmed = pattern.Trim();
+                    if (!string.IsNullOrEmpty(trimmed))
+                    {
+                        builder.Add(trimmed);
+                    }
+                }
+            }
+
+            return builder.ToImmutable();
+        }
+
+        private static bool IsIgnoredIvtTarget(string assemblySimpleName, ImmutableArray<string> ignorePatterns)
+        {
+            foreach (var pattern in ignorePatterns)
+            {
+                if (IsAssemblyNameWildcardMatch(assemblySimpleName, pattern))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsAssemblyNameWildcardMatch(string assemblySimpleName, string pattern)
+        {
+            if (!pattern.Contains('*'))
+            {
+                return string.Equals(assemblySimpleName, pattern, StringComparison.OrdinalIgnoreCase);
+            }
+
+            var regexPattern = "^" + Regex.Escape(pattern).Replace("\\*", ".*") + "$";
+            return Regex.IsMatch(assemblySimpleName, regexPattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
         }
 
         [SuppressMessage("MicrosoftCodeAnalysisPerformance", "RS1012:Start action has no registered actions", Justification = "This is not a start action")]

--- a/src/RoslynAnalyzers/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
+++ b/src/RoslynAnalyzers/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
@@ -55,9 +55,9 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
         private const string NamespaceToIgnoreInTrackingEditorConfigOptionName = $"{BaseEditorConfigPath}.skip_namespaces";
 
         /// <summary>
-        /// Comma/semicolon-separated list of InternalsVisibleTo (IVT) target assembly names (supporting a trailing
-        /// <c>*</c> wildcard, e.g. <c>*.Tests</c>) that should be ignored when deciding whether internal API
-        /// tracking should run. See <see cref="ShouldTrackInternalApiBasedOnIvt"/>.
+        /// Comma/semicolon-separated list of InternalsVisibleTo (IVT) target assembly names (supporting a
+        /// <c>*</c> wildcard anywhere in the pattern, e.g. <c>*.Tests</c>) that should be ignored when deciding
+        /// whether internal API tracking should run. See <see cref="ShouldTrackInternalApiBasedOnIvt"/>.
         /// </summary>
         private const string InternalApiSkipIvtEditorConfigOptionName = $"{BaseEditorConfigPath}.internal_api_skip_ivt";
 

--- a/src/RoslynAnalyzers/PublicApiAnalyzers/PublicApiAnalyzers.Help.md
+++ b/src/RoslynAnalyzers/PublicApiAnalyzers/PublicApiAnalyzers.Help.md
@@ -15,6 +15,21 @@ dotnet_public_api_analyzer.require_api_files = true
 
 See [Configuration options for code analysis](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-options) for more details on how to setup editorconfig based configuration.
 
+## Internal API tracking and InternalsVisibleTo
+
+The analyzer also supports tracking *internal* APIs (rules `RS0051`-`RS0058`) via `InternalAPI.Shipped.txt` / `InternalAPI.Unshipped.txt` files. Internal API tracking exists to catch binary-breaking changes across `InternalsVisibleTo` (IVT) boundaries.
+
+IVT grants to test projects and mocking frameworks are not real compatibility consumers, so they add no value to internal API tracking and only create noise. Because IVT is assembly-wide (not per-API), the analyzer makes this decision at the assembly level: it reads the compilation assembly's IVT grants, drops any that match the ignore patterns, and **if no real (non-ignored) IVT target remains, internal API tracking is disabled for that compilation**. To stay conservative, tracking is only disabled when there was at least one IVT grant and *every* grant is ignored; a project with internal API files but no IVT grants keeps tracking (the presence of the files is an explicit opt-in).
+
+The assembly name `DynamicProxyGenAssembly2` (used by Castle DynamicProxy, which backs mocking frameworks such as Moq) is **always** ignored by default. You can ignore additional IVT targets with the following .editorconfig option (a comma/semicolon-separated list; a trailing `*` wildcard and case-insensitive matching on the simple assembly name are supported):
+
+```ini
+[*.cs]
+dotnet_public_api_analyzer.internal_api_skip_ivt = *.Tests, *.UnitTests, MySpecificTestAssembly
+```
+
+This option only affects internal API tracking; public API tracking is never affected.
+
 ## Package version earlier than 3.3.x
 
 If you are using a `Microsoft.CodeAnalysis.PublicApiAnalyzers` package with version prior to 3.3.x, then you will need to manually create the following public API files in each project directory that needs to be analyzed. Additionally, you will need to mark the above files as analyzer additional files to enable analysis.

--- a/src/RoslynAnalyzers/PublicApiAnalyzers/PublicApiAnalyzers.Help.md
+++ b/src/RoslynAnalyzers/PublicApiAnalyzers/PublicApiAnalyzers.Help.md
@@ -21,7 +21,7 @@ The analyzer also supports tracking *internal* APIs (rules `RS0051`-`RS0058`) vi
 
 IVT grants to test projects and mocking frameworks are not real compatibility consumers, so they add no value to internal API tracking and only create noise. Because IVT is assembly-wide (not per-API), the analyzer makes this decision at the assembly level: it reads the compilation assembly's IVT grants, drops any that match the ignore patterns, and **if no real (non-ignored) IVT target remains, internal API tracking is disabled for that compilation**. To stay conservative, tracking is only disabled when there was at least one IVT grant and *every* grant is ignored; a project with internal API files but no IVT grants keeps tracking (the presence of the files is an explicit opt-in).
 
-The assembly name `DynamicProxyGenAssembly2` (used by Castle DynamicProxy, which backs mocking frameworks such as Moq) is **always** ignored by default. You can ignore additional IVT targets with the following .editorconfig option (a comma/semicolon-separated list; a trailing `*` wildcard and case-insensitive matching on the simple assembly name are supported):
+The assembly name `DynamicProxyGenAssembly2` (used by Castle DynamicProxy, which backs mocking frameworks such as Moq) is **always** ignored by default. You can ignore additional IVT targets with the following .editorconfig option (a comma/semicolon-separated list; a `*` wildcard anywhere in the pattern and case-insensitive matching on the simple assembly name are supported):
 
 ```ini
 [*.cs]

--- a/src/RoslynAnalyzers/PublicApiAnalyzers/UnitTests/DeclarePublicAPIAnalyzerTestsBase.cs
+++ b/src/RoslynAnalyzers/PublicApiAnalyzers/UnitTests/DeclarePublicAPIAnalyzerTestsBase.cs
@@ -3090,6 +3090,92 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests
             await test.RunAsync();
         }
 
+        [Fact]
+        public async Task InternalApi_IvtOnlyToDynamicProxyGenAssembly2_NotTracked()
+        {
+            // Internal-only behavior: when the only IVT grant targets the Moq/Castle proxy assembly,
+            // internal API tracking is disabled so no RS0051 fires.
+            if (!IsInternalTest)
+            {
+                return;
+            }
+
+            await VerifyCSharpAsync($$"""
+
+                using System.Runtime.CompilerServices;
+                [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+
+                {{EnabledModifierCSharp}} class C
+                {
+                    private C() { }
+                }
+                """, @"", @"");
+        }
+
+        [Fact]
+        public async Task InternalApi_IvtToRealAssembly_Tracked()
+        {
+            // A real (non-ignored) IVT consumer keeps internal API tracking enabled.
+            if (!IsInternalTest)
+            {
+                return;
+            }
+
+            await VerifyCSharpAsync($$"""
+
+                using System.Runtime.CompilerServices;
+                [assembly: InternalsVisibleTo("SomeRealConsumer")]
+
+                {{EnabledModifierCSharp}} class C
+                {
+                    private C() { }
+                }
+                """, @"", @"", GetCSharpResultAt(5, 8 + EnabledModifierCSharp.Length, DeclareNewApiRule, "C"));
+        }
+
+        [Fact]
+        public async Task InternalApi_IvtToTestAssemblyMatchedByEditorConfig_NotTracked()
+        {
+            // A user-configured ignore pattern (here '*.Tests') disables tracking when it matches the only IVT grant.
+            if (!IsInternalTest)
+            {
+                return;
+            }
+
+            await VerifyCSharpAsync($$"""
+
+                using System.Runtime.CompilerServices;
+                [assembly: InternalsVisibleTo("MyProject.Tests")]
+
+                {{EnabledModifierCSharp}} class C
+                {
+                    private C() { }
+                }
+                """, @"", @"", "[*]\r\ndotnet_public_api_analyzer.internal_api_skip_ivt = *.Tests");
+        }
+
+        [Fact]
+        public async Task InternalApi_MixedRealAndIgnoredIvt_Tracked()
+        {
+            // As long as one real IVT consumer remains, tracking stays enabled even when other grants are ignored.
+            if (!IsInternalTest)
+            {
+                return;
+            }
+
+            await VerifyCSharpAsync($$"""
+
+                using System.Runtime.CompilerServices;
+                [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+                [assembly: InternalsVisibleTo("SomeRealConsumer")]
+
+                {{EnabledModifierCSharp}} class C
+                {
+                    private C() { }
+                }
+                """, @"", @"", GetCSharpResultAt(6, 8 + EnabledModifierCSharp.Length, DeclareNewApiRule, "C"));
+        }
+
         #endregion
     }
 }

--- a/src/RoslynAnalyzers/PublicApiAnalyzers/UnitTests/DeclarePublicAPIAnalyzerTestsBase.cs
+++ b/src/RoslynAnalyzers/PublicApiAnalyzers/UnitTests/DeclarePublicAPIAnalyzerTestsBase.cs
@@ -3176,6 +3176,40 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests
                 """, @"", @"", GetCSharpResultAt(6, 8 + EnabledModifierCSharp.Length, DeclareNewApiRule, "C"));
         }
 
+        [Fact]
+        public async Task InternalApi_IvtWithPublicKeyAndDifferentCasing_TrimmedAndMatchedCaseInsensitively_NotTracked()
+        {
+            // Covers the strong-named IVT form "AssemblyName, PublicKey=...": the analyzer trims everything from the
+            // first comma onward to get the simple name, then matches case-insensitively. Here the grant differs in
+            // casing from both the built-in default and the configured pattern, and carries a PublicKey suffix.
+            if (!IsInternalTest)
+            {
+                return;
+            }
+
+            await VerifyCSharpAsync($$"""
+
+                using System.Runtime.CompilerServices;
+                [assembly: InternalsVisibleTo("dynamicproxygenassembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
+
+                {{EnabledModifierCSharp}} class C
+                {
+                    private C() { }
+                }
+                """, @"", @"");
+
+            await VerifyCSharpAsync($$"""
+
+                using System.Runtime.CompilerServices;
+                [assembly: InternalsVisibleTo("MyProject.TESTS, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
+
+                {{EnabledModifierCSharp}} class C
+                {
+                    private C() { }
+                }
+                """, @"", @"", "[*]\r\ndotnet_public_api_analyzer.internal_api_skip_ivt = *.Tests");
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
## Motivation

Internal API tracking (rules `RS0051`–`RS0058`, the `isPublic == false` analyzer instance) exists to catch binary-breaking changes across `InternalsVisibleTo` (IVT) boundaries. But IVT grants to **test projects** and **mocking frameworks** (Moq/Castle proxies use the well-known assembly name `DynamicProxyGenAssembly2`) are not real compatibility consumers. When the only IVT grants target such assemblies, internal API tracking adds no value and just creates noise.

This PR adds the ability to exclude known IVT targets so they don't drive internal API tracking.

## Design constraint: IVT is assembly-wide

IVT is assembly-wide, not per-API — you cannot tell which internal member a given IVT consumer uses. So the decision is made at the **assembly level**:

1. Read the compilation assembly's `InternalsVisibleTo` grants.
2. Drop the ones matching the ignore patterns.
3. If **no real (non-ignored) IVT target remains**, disable internal API tracking for that compilation (the internal `Impl` is never registered, so `RS0051`/`RS0058`/etc. don't fire).

This only affects the internal analyzer instance; the public analyzer is unaffected.

To stay conservative, tracking is only skipped when there was **at least one IVT grant and every grant is ignored**. A project with internal API files but zero IVT grants keeps tracking, since the presence of `InternalAPI.*.txt` files is an explicit opt-in that we must not silently override.

## New option + default

- `DynamicProxyGenAssembly2` is **always** ignored by default (built-in constant), since Moq/Castle proxies use it.
- New editorconfig option lets users add more patterns:

  ```ini
  [*.cs]
  dotnet_public_api_analyzer.internal_api_skip_ivt = *.Tests, *.UnitTests, MySpecificTestAssembly
  ```

  Comma/semicolon-separated list, trailing `*` wildcard supported, case-insensitive matching on the simple assembly name (the `AssemblyName, PublicKey=...` argument is trimmed to the simple name before matching). Read as a compilation-level option (via the first syntax tree), mirroring `require_api_files`.

## Tests

Added internal-only tests to `DeclarePublicAPIAnalyzerTestsBase` (guarded by `IsInternalTest`):

1. Internal type + IVT only to `DynamicProxyGenAssembly2` ⇒ no internal API diagnostics.
2. Internal type + IVT to a real assembly ⇒ still tracked (`RS0051` fires).
3. Internal type + IVT to a test assembly matched by the editorconfig option ⇒ not tracked.
4. Mixed real + ignored IVT ⇒ still tracked.

Full `DeclarePublicApiAnalyzerTests` suite is green (262/262).

## Docs

Added a section to `PublicApiAnalyzers.Help.md` documenting the new option and the built-in default.

## Related

Follow-up to #79658 and PR #84437 (which added exclusion of `[Embedded]` APIs).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84438)