### PR TITLE
Enable import completion for types in cref doc comments

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/TypeImportCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/TypeImportCompletionProviderTests.cs
@@ -1458,7 +1458,57 @@ public sealed class TypeImportCompletionProviderTests : AbstractCSharpCompletion
     }
 
     [Fact]
-    public async Task ShouldNotTriggerInsideTrivia()
+    public async Task ShouldNotTriggerInsidePlainComment()
+    {
+        var file1 = $$"""
+            namespace Foo
+            {
+                public class Bar
+                {} 
+            }
+            """;
+
+        var file2 = """
+            namespace Baz
+            {
+                // B$$
+                class Bat
+                {
+                }
+            }
+            """;
+        var markup = CreateMarkupForSingleProject(file2, file1, LanguageNames.CSharp);
+        await VerifyTypeImportItemIsAbsentAsync(markup, "Bar", inlineDescription: "Foo");
+    }
+
+    [Fact]
+    public async Task ShouldNotTriggerInsideXmlDocText()
+    {
+        var file1 = $$"""
+            namespace Foo
+            {
+                public class Bar
+                {} 
+            }
+            """;
+
+        var file2 = """
+            namespace Baz
+            {
+                /// <summary>
+                /// B$$
+                /// </summary>
+                class Bat
+                {
+                }
+            }
+            """;
+        var markup = CreateMarkupForSingleProject(file2, file1, LanguageNames.CSharp);
+        await VerifyTypeImportItemIsAbsentAsync(markup, "Bar", inlineDescription: "Foo");
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/54742")]
+    public async Task TriggerInsideCref()
     {
         var file1 = $$"""
             namespace Foo
@@ -1480,7 +1530,97 @@ public sealed class TypeImportCompletionProviderTests : AbstractCSharpCompletion
             }
             """;
         var markup = CreateMarkupForSingleProject(file2, file1, LanguageNames.CSharp);
+        await VerifyTypeImportItemExistsAsync(markup, "Bar", glyph: (int)Glyph.ClassPublic, inlineDescription: "Foo");
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/54742")]
+    public async Task TriggerInsideCrefGenericType()
+    {
+        var file1 = $$"""
+            namespace Foo
+            {
+                public class Bar<T>
+                {} 
+            }
+            """;
+
+        var file2 = """
+            namespace Baz
+            {
+                /// <summary>
+                /// <see cref="B$$"/>
+                /// </summary>
+                class Bat
+                {
+                }
+            }
+            """;
+        var markup = CreateMarkupForSingleProject(file2, file1, LanguageNames.CSharp);
+        await VerifyTypeImportItemExistsAsync(markup, "Bar", displayTextSuffix: "<>", glyph: (int)Glyph.ClassPublic, inlineDescription: "Foo");
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/54742")]
+    public async Task ShouldNotTriggerInsideQualifiedCref()
+    {
+        var file1 = $$"""
+            namespace Foo
+            {
+                public class Bar
+                {} 
+            }
+            """;
+
+        var file2 = """
+            namespace Baz
+            {
+                /// <summary>
+                /// <see cref="Foo.B$$"/>
+                /// </summary>
+                class Bat
+                {
+                }
+            }
+            """;
+        var markup = CreateMarkupForSingleProject(file2, file1, LanguageNames.CSharp);
         await VerifyTypeImportItemIsAbsentAsync(markup, "Bar", inlineDescription: "Foo");
+    }
+
+    [WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/54742")]
+    public async Task Commit_InsideCref()
+    {
+        var file1 = $$"""
+            namespace Foo
+            {
+                public class Bar
+                {} 
+            }
+            """;
+
+        var file2 = """
+            namespace Baz
+            {
+                /// <summary>
+                /// <see cref="B$$"/>
+                /// </summary>
+                class Bat
+                {
+                }
+            }
+            """;
+        var markup = CreateMarkupForSingleProject(file2, file1, LanguageNames.CSharp);
+        await VerifyCustomCommitProviderAsync(markup, "Bar", """
+            using Foo;
+
+            namespace Baz
+            {
+                /// <summary>
+                /// <see cref="Bar"/>
+                /// </summary>
+                class Bat
+                {
+                }
+            }
+            """);
     }
     private static void AssertRelativeOrder(List<string> expectedTypesInRelativeOrder, ImmutableArray<CompletionItem> allCompletionItems)
     {

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/CrefCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/CrefCompletionProvider.cs
@@ -74,6 +74,11 @@ internal sealed class CrefCompletionProvider(
             Contract.ThrowIfNull(semanticModel);
 
             context.IsExclusive = true;
+
+            // We take over completion inside crefs, suppressing unrelated regular providers. However, unimported
+            // types are still valid in a cref, so allow the expand-item (import completion) providers to contribute
+            // their items alongside ours. See https://github.com/dotnet/roslyn/issues/54742.
+            context.AllowExpandedItemsWhileExclusive = true;
             context.AddItems(CreateCompletionItems(semanticModel, symbols, token, position));
 
             // Because we took over completion entirely as an exclusive provider, we have to ensure that appropriate

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/CrefCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/CrefCompletionProvider.cs
@@ -75,9 +75,7 @@ internal sealed class CrefCompletionProvider(
 
             context.IsExclusive = true;
 
-            // We take over completion inside crefs, suppressing unrelated regular providers. However, unimported
-            // types are still valid in a cref, so allow the expand-item (import completion) providers to contribute
-            // their items alongside ours. See https://github.com/dotnet/roslyn/issues/54742.
+            // Unimported types are valid in a cref, so let import completion still offer its items alongside ours.
             context.AllowExpandedItemsWhileExclusive = true;
             context.AddItems(CreateCompletionItems(semanticModel, symbols, token, position));
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/ImportCompletion/TypeImportCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/ImportCompletion/TypeImportCompletionProvider.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers;
@@ -34,6 +35,14 @@ internal sealed class TypeImportCompletionProvider : AbstractTypeImportCompletio
         => CompletionUtilities.IsTriggerCharacter(text, characterPosition, options);
 
     public override ImmutableHashSet<char> TriggerCharacters { get; } = CompletionUtilities.CommonTriggerCharacters;
+
+    protected override bool ShouldProvideCompletion(CompletionContext completionContext, SyntaxContext syntaxContext)
+    {
+        // In addition to the regular type contexts handled by the base provider, unimported types should be
+        // offered inside `cref` documentation comments.
+        return base.ShouldProvideCompletion(completionContext, syntaxContext)
+            || syntaxContext is CSharpSyntaxContext { IsCrefContext: true };
+    }
 
     protected override bool IsFinalSemicolonOfUsingOrExtern(SyntaxNode directive, SyntaxToken token)
     {

--- a/src/Features/Core/Portable/Completion/CompletionContext.cs
+++ b/src/Features/Core/Portable/Completion/CompletionContext.cs
@@ -99,11 +99,8 @@ public sealed class CompletionContext
     }
 
     /// <summary>
-    /// Set to true by an <see cref="IsExclusive"/> provider to indicate that, even though it takes over the
-    /// completion list, "expanded" items contributed by dedicated expand-item providers (e.g. unimported
-    /// type/import completion) should still be offered alongside its items. Has no effect unless the context is
-    /// also exclusive. This lets a provider such as the cref completion provider suppress unrelated regular
-    /// providers while still allowing unimported types to be suggested. See dotnet/roslyn#54742.
+    /// When <see cref="IsExclusive"/>, set this to still allow expand items (e.g. unimported types) to be shown
+    /// alongside this provider's items. Other regular providers remain suppressed. Has no effect unless exclusive.
     /// </summary>
     internal bool AllowExpandedItemsWhileExclusive { get; set; }
 

--- a/src/Features/Core/Portable/Completion/CompletionContext.cs
+++ b/src/Features/Core/Portable/Completion/CompletionContext.cs
@@ -99,6 +99,15 @@ public sealed class CompletionContext
     }
 
     /// <summary>
+    /// Set to true by an <see cref="IsExclusive"/> provider to indicate that, even though it takes over the
+    /// completion list, "expanded" items contributed by dedicated expand-item providers (e.g. unimported
+    /// type/import completion) should still be offered alongside its items. Has no effect unless the context is
+    /// also exclusive. This lets a provider such as the cref completion provider suppress unrelated regular
+    /// providers while still allowing unimported types to be suggested. See dotnet/roslyn#54742.
+    /// </summary>
+    internal bool AllowExpandedItemsWhileExclusive { get; set; }
+
+    /// <summary>
     /// The options that completion was started with.
     /// </summary>
     public OptionSet Options { get; }

--- a/src/Features/Core/Portable/Completion/CompletionService_GetCompletions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService_GetCompletions.cs
@@ -105,11 +105,8 @@ public abstract partial class CompletionService
         var exclusiveContexts = triggeredContexts.WhereAsArray(t => t.IsExclusive);
         if (!exclusiveContexts.IsEmpty)
         {
-            // Exclusive providers normally suppress every other item. However, an exclusive provider can opt
-            // into still allowing "expanded" items (e.g. unimported types) to be shown alongside its own items
-            // via CompletionContext.AllowExpandedItemsWhileExclusive (e.g. the cref completion provider). When
-            // every exclusive context opts in, also include the expand-item provider contexts and report the
-            // merged list as non-exclusive, so the editor's expanded-items pipeline isn't suppressed either.
+            // If every exclusive context opted into allowing expand items, include the expand-item contexts too
+            // and merge as non-exclusive so the editor still shows those items.
             if (exclusiveContexts.All(static t => t.AllowExpandedItemsWhileExclusive))
             {
                 var expandedContexts = triggeredContexts.WhereAsArray(static t => t.Provider.IsExpandItemProvider);

--- a/src/Features/Core/Portable/Completion/CompletionService_GetCompletions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService_GetCompletions.cs
@@ -104,7 +104,20 @@ public abstract partial class CompletionService
         // that's all we'll return.
         var exclusiveContexts = triggeredContexts.WhereAsArray(t => t.IsExclusive);
         if (!exclusiveContexts.IsEmpty)
+        {
+            // Exclusive providers normally suppress every other item. However, an exclusive provider can opt
+            // into still allowing "expanded" items (e.g. unimported types) to be shown alongside its own items
+            // via CompletionContext.AllowExpandedItemsWhileExclusive (e.g. the cref completion provider). When
+            // every exclusive context opts in, also include the expand-item provider contexts and report the
+            // merged list as non-exclusive, so the editor's expanded-items pipeline isn't suppressed either.
+            if (exclusiveContexts.All(static t => t.AllowExpandedItemsWhileExclusive))
+            {
+                var expandedContexts = triggeredContexts.WhereAsArray(static t => t.Provider.IsExpandItemProvider);
+                return MergeAndPruneCompletionLists(exclusiveContexts.AddRange(expandedContexts), options, isExclusive: false);
+            }
+
             return MergeAndPruneCompletionLists(exclusiveContexts, options, isExclusive: true);
+        }
 
         // Great!  We had some items.  Now we want to see if any of the other providers 
         // would like to augment the completion list.  For example, we might trigger


### PR DESCRIPTION
Fixes #54742.

Symbol import completion didn't work inside `<see cref="..."/>` doc comments, so typing an unimported type name offered no completion.
The `CrefCompletionProvider` marks its context exclusive, which normally suppresses expanded (unimported) items. This change lets an exclusive provider opt in to coexisting with expand items
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84440)