### PR TITLE
Revert "Remove unnecessary NuGetAuthenticate for public azure-public feeds"

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -288,6 +288,11 @@ extends:
           inputs:
             versionSpec: '4.9.2'
 
+        # Authenticate with service connections to be able to publish packages to external nuget feeds.
+        - task: NuGetAuthenticate@1
+          inputs:
+            nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk
+
         # Authenticate to DevDiv engineering feed via WIF service connection
         - task: NuGetAuthenticate@1
           inputs:

--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -212,6 +212,11 @@ extends:
           inputs:
             versionSpec: '4.9.2'
 
+        # Authenticate with service connections to be able to publish packages to external nuget feeds.
+        - task: NuGetAuthenticate@1
+          inputs:
+            nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk
+
         # Needed because the build fails the NuGet Tools restore without it
         - task: UseDotNet@2
           displayName: 'Use .NET Core sdk'


### PR DESCRIPTION
Reverts dotnet/roslyn#84427.

**Reason:** The removed NuGetAuthenticate step was required for **package publishing** (not just restore). The `eng/publish-assets.ps1` script uses `dotnet nuget push` to push packages to `azure-public/vside/_packaging/vssdk` and `azure-public/vside/_packaging/vs-impl`, and it relies on the NuGet credential provider set up by the NuGetAuthenticate task.

**Impact:** dotnet-roslyn-official builds on main are failing with 401 Unauthorized on the Publish Assets step since this PR merged (builds 3016874, 3016959, 3017687).

**Root cause of incorrect analysis:** The original PR code search looked for `publishFeedCredentials` in YAML but missed the PowerShell-based publish path (`eng/publish-assets.ps1` → `dotnet nuget push`).

cc @jaredpar
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84446)