### PR TITLE
Change the default for test.includeSourceGeneratedFilesInRealTimeDiscovery

### DIFF
--- a/src/VisualStudio/Core/Def/PackageRegistration.pkgdef
+++ b/src/VisualStudio/Core/Def/PackageRegistration.pkgdef
@@ -74,4 +74,4 @@
 [$RootKey$\SettingsManifests\{6cf2e545-6109-4730-8883-cf43d7aec3e1}]
 @="Microsoft.VisualStudio.LanguageServices.Setup.RoslynPackage"
 "ManifestPath"="$PackageFolder$\UnifiedSettings\roslynSettings.registration.json"
-"CacheTag"=qword:ABE9BBF01CC8B289
+"CacheTag"=qword:FD69333BD2711FE5

--- a/src/VisualStudio/Core/Def/UnifiedSettings/roslynSettings.registration.json
+++ b/src/VisualStudio/Core/Def/UnifiedSettings/roslynSettings.registration.json
@@ -7,12 +7,8 @@
     "test.includeSourceGeneratedFilesInRealTimeDiscovery": {
       "title": "@Include_Roslyn_source_generated_files;..\\Microsoft.VisualStudio.LanguageServices.dll",
       "type": "boolean",
-      "default": true,
-      "enableWhen": "${config:test.realTimeDiscovery} == 'true'",
-      "alternateDefault": {
-        "flagName": "UnitTesting.DisableRoslynSourceGeneratedFiles",
-        "default": false
-      }
+      "default": false,
+      "enableWhen": "${config:test.realTimeDiscovery} == 'true'"
     }
   }
 }


### PR DESCRIPTION
We've rolled out the A/B experiment to 100% without any complaints, so counting this as the official new default seems reasonable. We're going to leave the option in for awhile longer so we still have an escape hatch if the impacted users weren't covered by the rollout or the failure is more obscure.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84452)