### PR TITLE
Migrate azure-public feed auth from PAT to WIF service connection

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -288,10 +288,17 @@ extends:
           inputs:
             versionSpec: '4.9.2'
 
-        # Authenticate with service connections to be able to publish packages to external nuget feeds.
+        # Authenticate to azure-public/vs-impl feed via WIF service connection
         - task: NuGetAuthenticate@1
           inputs:
-            nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk
+            azureDevOpsServiceConnection: dnceng-azure-public-vs-impl-push
+            feedUrl: https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json
+
+        # Authenticate to azure-public/vssdk feed via WIF service connection
+        - task: NuGetAuthenticate@1
+          inputs:
+            azureDevOpsServiceConnection: dnceng-azure-public-vs-impl-push
+            feedUrl: https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json
 
         # Authenticate to DevDiv engineering feed via WIF service connection
         - task: NuGetAuthenticate@1


### PR DESCRIPTION
Replace the PAT-backed `NuGetAuthenticate@1` (using `nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk`) with WIF-based authentication using the dedicated `dnceng-azure-public-vs-impl-push` service connection.

This follows the same pattern already proven in production for the devdiv/engineering and devdiv/dotnet-core-internal-tooling feeds in this same pipeline.

## What changed
- Replaced single `nuGetServiceConnections` call with two `azureDevOpsServiceConnection` + `feedUrl` calls (one per feed)
- Same SP has Contributor access on both feeds
- No change to build logic — `publish-assets.ps1` continues to use the ambient NuGet credential provider

## Service Connection
- **Name:** `dnceng-azure-public-vs-impl-push`
- **ID:** 41dcefaa-632f-4c08-b8e5-af399561020b
- **Type:** workloadidentityuser → azure-public org
- **App:** dnceng-azure-public-vs-impl-push (AppId: 3ff5217b-1740-4591-8d16-131dad1969db)

## Related
- AzDO WI 10128, 10129
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84457)