### PR TITLE
Emit numeric prefix of SemVer2 versions in Win32 FIXEDFILEINFO

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/VersionHelperTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/VersionHelperTests.cs
@@ -166,8 +166,6 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParse(".1.2.", out version));
             Assert.Equal(expected, version);
-            Assert.False(VersionHelper.TryParse("1.234.56.7.8", out version));
-            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParse("*", out version));
             Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParse("-1.2.3.4", out version));
@@ -207,6 +205,16 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(new Version(1, 1, 31073, 23), version);
             Assert.False(VersionHelper.TryParse("65536.2.65536.1", out version));
             Assert.Equal(new Version(0, 2, 0, 1), version);
+            // More than four dot-separated components (e.g. SemVer2 informational versions).
+            // The leading numeric components are emitted rather than falling back to 0.0.0.0.
+            Assert.False(VersionHelper.TryParse("1.234.56.7.8", out version));
+            Assert.Equal(new Version(1, 234, 56, 7), version);
+            Assert.False(VersionHelper.TryParse("1.2.3-p.4.5+metadata", out version));
+            Assert.Equal(new Version(1, 2, 3, 0), version);
+            Assert.False(VersionHelper.TryParse("18.10.0-ci.26360.1+95817c0", out version));
+            Assert.Equal(new Version(18, 10, 0, 0), version);
+            Assert.False(VersionHelper.TryParse("1.2.3.4.5", out version));
+            Assert.Equal(new Version(1, 2, 3, 4), version);
         }
     }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/VersionHelperTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/VersionHelperTests.cs
@@ -142,6 +142,17 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.False(VersionHelper.TryParseAssemblyVersion("1.2. 3.4", allowWildcard: true, version: out version));
             Assert.Equal(expected, version);
 
+            // More than four dot-separated components (e.g. SemVer2 informational versions).
+            // Partial parsing is not allowed for assembly versions, so these fail to the null version.
+            Assert.False(VersionHelper.TryParseAssemblyVersion("1.2.3.4.5", allowWildcard: true, version: out version));
+            Assert.Equal(expected, version);
+            Assert.False(VersionHelper.TryParseAssemblyVersion("1.2.3.4.5", allowWildcard: false, version: out version));
+            Assert.Equal(expected, version);
+            Assert.False(VersionHelper.TryParseAssemblyVersion("1.2.3-p.4.5+metadata", allowWildcard: true, version: out version));
+            Assert.Equal(expected, version);
+            Assert.False(VersionHelper.TryParseAssemblyVersion("1.2.3.4.*", allowWildcard: true, version: out version));
+            Assert.Equal(expected, version);
+
             // U+FF11 FULLWIDTH DIGIT ONE 
             Assert.False(VersionHelper.TryParseAssemblyVersion("\uFF11.\uFF10.\uFF10.\uFF10", allowWildcard: true, version: out version));
             Assert.Equal(expected, version);

--- a/src/Compilers/Core/Portable/VersionHelper.cs
+++ b/src/Compilers/Core/Portable/VersionHelper.cs
@@ -66,15 +66,36 @@ namespace Microsoft.CodeAnalysis
             // the last must be a exactly single asterisk without whitespace.
             bool hasWildcard = allowWildcard && elements[elements.Length - 1] == "*";
 
-            if ((hasWildcard && elements.Length < 3) || elements.Length > 4)
+            if (hasWildcard && elements.Length < 3)
             {
                 version = AssemblyIdentity.NullVersion;
                 return false;
             }
 
+            // A Win32 FIXEDFILEINFO version has only four components. A string with more
+            // than four dot-separated components (e.g. a SemVer2 informational version such
+            // as "1.2.3-p.4.5+metadata", which splits into five elements) is not a well-formed
+            // n.n.n.n version. When partial parsing is not allowed (assembly versions) we reject
+            // it outright. Otherwise (file and product versions) we keep the first four elements
+            // and fall through to the partial parse below so the leading numeric components are
+            // still emitted rather than falling back to 0.0.0.0.
+            bool tooManyComponents = elements.Length > 4;
+            if (tooManyComponents)
+            {
+                if (!allowPartialParse)
+                {
+                    version = AssemblyIdentity.NullVersion;
+                    return false;
+                }
+
+                Array.Resize(ref elements, 4);
+            }
+
             ushort[] values = new ushort[4];
             int lastExplicitValue = hasWildcard ? elements.Length - 1 : elements.Length;
-            bool parseError = false;
+            // Dropping extra components means the input was not fully consumed, so the parse is
+            // never considered complete when there were too many components.
+            bool parseError = tooManyComponents;
             for (int i = 0; i < lastExplicitValue; i++)
             {
 

--- a/src/Compilers/Core/Portable/VersionHelper.cs
+++ b/src/Compilers/Core/Portable/VersionHelper.cs
@@ -79,22 +79,22 @@ namespace Microsoft.CodeAnalysis
             // it outright. Otherwise (file and product versions) we keep the first four elements
             // and fall through to the partial parse below so the leading numeric components are
             // still emitted rather than falling back to 0.0.0.0.
-int elementCount = elements.Length;
+            int elementCount = elements.Length;
 
-bool tooManyComponents = elementCount > 4;
-if (tooManyComponents)
-{
-    if (!allowPartialParse)
-    {
-        version = AssemblyIdentity.NullVersion;
-        return false;
-    }
+            bool tooManyComponents = elementCount > 4;
+            if (tooManyComponents)
+            {
+                if (!allowPartialParse)
+                {
+                    version = AssemblyIdentity.NullVersion;
+                    return false;
+                }
 
-    elementCount = 4;
-}
+                elementCount = 4;
+            }
 
-ushort[] values = new ushort[4];
-int lastExplicitValue = hasWildcard ? elementCount - 1 : elementCount;
+            ushort[] values = new ushort[4];
+            int lastExplicitValue = hasWildcard ? elementCount - 1 : elementCount;
             // Dropping extra components means the input was not fully consumed, so the parse is
             // never considered complete when there were too many components.
             bool parseError = tooManyComponents;

--- a/src/Compilers/Core/Portable/VersionHelper.cs
+++ b/src/Compilers/Core/Portable/VersionHelper.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             bool tooManyComponents = elements.Length > 4;
-            int elementCount = tooManyComponents ? 4 : elementCount;
+            int elementCount = tooManyComponents ? 4 : elements.Length;
 
             ushort[] values = new ushort[4];
             int lastExplicitValue = hasWildcard ? elementCount - 1 : elementCount;

--- a/src/Compilers/Core/Portable/VersionHelper.cs
+++ b/src/Compilers/Core/Portable/VersionHelper.cs
@@ -79,20 +79,22 @@ namespace Microsoft.CodeAnalysis
             // it outright. Otherwise (file and product versions) we keep the first four elements
             // and fall through to the partial parse below so the leading numeric components are
             // still emitted rather than falling back to 0.0.0.0.
-            bool tooManyComponents = elements.Length > 4;
-            if (tooManyComponents)
-            {
-                if (!allowPartialParse)
-                {
-                    version = AssemblyIdentity.NullVersion;
-                    return false;
-                }
+int elementCount = elements.Length;
 
-                Array.Resize(ref elements, 4);
-            }
+bool tooManyComponents = elementCount > 4;
+if (tooManyComponents)
+{
+    if (!allowPartialParse)
+    {
+        version = AssemblyIdentity.NullVersion;
+        return false;
+    }
 
-            ushort[] values = new ushort[4];
-            int lastExplicitValue = hasWildcard ? elements.Length - 1 : elements.Length;
+    elementCount = 4;
+}
+
+ushort[] values = new ushort[4];
+int lastExplicitValue = hasWildcard ? elementCount - 1 : elementCount;
             // Dropping extra components means the input was not fully consumed, so the parse is
             // never considered complete when there were too many components.
             bool parseError = tooManyComponents;

--- a/src/Compilers/Core/Portable/VersionHelper.cs
+++ b/src/Compilers/Core/Portable/VersionHelper.cs
@@ -66,12 +66,6 @@ namespace Microsoft.CodeAnalysis
             // the last must be a exactly single asterisk without whitespace.
             bool hasWildcard = allowWildcard && elements[elements.Length - 1] == "*";
 
-            if (hasWildcard && elements.Length < 3)
-            {
-                version = AssemblyIdentity.NullVersion;
-                return false;
-            }
-
             // A Win32 FIXEDFILEINFO version has only four components. A string with more
             // than four dot-separated components (e.g. a SemVer2 informational version such
             // as "1.2.3-p.4.5+metadata", which splits into five elements) is not a well-formed
@@ -79,19 +73,14 @@ namespace Microsoft.CodeAnalysis
             // it outright. Otherwise (file and product versions) we keep the first four elements
             // and fall through to the partial parse below so the leading numeric components are
             // still emitted rather than falling back to 0.0.0.0.
-            int elementCount = elements.Length;
-
-            bool tooManyComponents = elementCount > 4;
-            if (tooManyComponents)
+            if ((hasWildcard && elements.Length < 3) || (elements.Length > 4 && !allowPartialParse))
             {
-                if (!allowPartialParse)
-                {
-                    version = AssemblyIdentity.NullVersion;
-                    return false;
-                }
-
-                elementCount = 4;
+                version = AssemblyIdentity.NullVersion;
+                return false;
             }
+
+            bool tooManyComponents = elements.Length > 4;
+            int elementCount = tooManyComponents ? 4 : elementCount;
 
             ushort[] values = new ushort[4];
             int lastExplicitValue = hasWildcard ? elementCount - 1 : elementCount;


### PR DESCRIPTION
Fixes #35793

### Problem

VersionHelper.TryParse rejects any version string with **more than four** dot-separated components by returning `NullVersion` (`0.0.0.0`) up-front, before its partial-parse logic runs:

```csharp
if ((hasWildcard && elements.Length < 3) || elements.Length > 4)
{
    version = AssemblyIdentity.NullVersion;
    return false;
}
```

This method fills the Win32 `FIXEDFILEINFO` `dwProductVersion`/`dwFileVersion` (via `CvtRes.WriteVSFixedFileInfo`). A SemVer2 informational version with a **dotted** prerelease label splits into five or more elements and hits this early-out, so the binary `ProductVersionRaw` becomes `0.0.0.0` even though the string carries a valid numeric prefix:

| `AssemblyInformationalVersion` | dot-segments | `ProductVersionRaw` (before) |
| --- | --- | --- |
| `1.2.3-p-4.5+metadata` | 4 | `1.2.3.0` :white_check_mark: |
| `1.2.3-p.4.5+metadata` | 5 | `0.0.0.0` :x: |
| `18.10.0-ci.26360.1+abc` | 5 | `0.0.0.0` :x: |

Note the inconsistency: the same version merely rearranged (`-p-4.5` vs `-p.4.5`) parses fine because it stays at four components. Any assembly built with Arcade/SourceLink-style SemVer2 versions is affected, and `(Get-Command x.dll).Version` returns `0.0.0.0`.

### Fix

Only hard-fail on `> 4` components when partial parsing is disallowed (the assembly-version path via `TryParseAssemblyVersion`). For file and product versions (`allowPartialParse: true`), truncate to the first four components and fall through to the existing partial-parse loop, which already stops at the first non-numeric character. `parseError` is set so the parse is still reported as incomplete (`TryParse` returns `false`), preserving the "was the string fully consumed" contract.

Result: `1.2.3-p.4.5+metadata` now yields `1.2.3.0` instead of `0.0.0.0`. Assembly-version parsing behavior is unchanged.

### Testing

Updated `VersionHelperTests` — the `1.234.56.7.8` case moves from `ParseBad2` (was `0.0.0.0`) to `ParsePartial` (now `1.234.56.7`), and added SemVer2 coverage. All `VersionHelperTests` pass on `net10.0` and `net472`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84463)