### PR TITLE
Fix typo in resource string for stale project message

### DIFF
--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -2698,7 +2698,7 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
     <value>One or more changes result in a new type being created by the compiler, which requires restarting the application because it is not supported by the runtime</value>
   </data>
   <data name="Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2" xml:space="preserve">
-    <value>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuit; {2}</value>
+    <value>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuilt; {2}</value>
   </data>
   <data name="Changing_source_file_0_in_a_project_1_that_does_not_support_hot_reload_requires_restarting_the_application_2" xml:space="preserve">
     <value>Changing source file '{0}' in a project '{1}' that does not support Hot Reload requires restarting the application; {2}</value>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -471,8 +471,8 @@ Ujistěte se, že specifikátor tt použijete pro jazyky, pro které je nezbytn�
         <note />
       </trans-unit>
       <trans-unit id="Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2">
-        <source>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuit; {2}</source>
-        <target state="translated">Změna zdrojového souboru {0} v zastaralém projektu {1} nemá žádný vliv, dokud projekt nebude znovu sestaven; {2}</target>
+        <source>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuilt; {2}</source>
+        <target state="needs-review-translation">Změna zdrojového souboru {0} v zastaralém projektu {1} nemá žádný vliv, dokud projekt nebude znovu sestaven; {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_the_application">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -471,8 +471,8 @@ Stellen Sie sicher, dass Sie den Bezeichner "tt" für Sprachen verwenden, für d
         <note />
       </trans-unit>
       <trans-unit id="Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2">
-        <source>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuit; {2}</source>
-        <target state="translated">Das Ändern der Quelldatei „{0}“ in einem veralteten Projekt „{1}“ hat keine Wirkung, bis das Projekt neu erstellt wird; {2}</target>
+        <source>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuilt; {2}</source>
+        <target state="needs-review-translation">Das Ändern der Quelldatei „{0}“ in einem veralteten Projekt „{1}“ hat keine Wirkung, bis das Projekt neu erstellt wird; {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_the_application">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -471,8 +471,8 @@ Asegúrese de usar el especificador "tt" para los idiomas para los que es necesa
         <note />
       </trans-unit>
       <trans-unit id="Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2">
-        <source>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuit; {2}</source>
-        <target state="translated">Cambiar el archivo de origen “{0}” en un proyecto obsoleto {1} no tiene efecto hasta que se reconstruya el proyecto; {2}</target>
+        <source>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuilt; {2}</source>
+        <target state="needs-review-translation">Cambiar el archivo de origen “{0}” en un proyecto obsoleto {1} no tiene efecto hasta que se reconstruya el proyecto; {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_the_application">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -471,8 +471,8 @@ Veillez à utiliser le spécificateur "tt" pour les langues où il est nécessai
         <note />
       </trans-unit>
       <trans-unit id="Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2">
-        <source>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuit; {2}</source>
-        <target state="translated">La modification du fichier source « {0} » dans un projet obsolète « {1} » n’a aucun effet tant que le projet n’est pas reconstruit, {2}</target>
+        <source>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuilt; {2}</source>
+        <target state="needs-review-translation">La modification du fichier source « {0} » dans un projet obsolète « {1} » n’a aucun effet tant que le projet n’est pas reconstruit, {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_the_application">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -471,8 +471,8 @@ Assicurarsi di usare l'identificatore "tt" per le lingue per le quali è necessa
         <note />
       </trans-unit>
       <trans-unit id="Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2">
-        <source>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuit; {2}</source>
-        <target state="translated">La modifica del file di origine '{0}' in un progetto non aggiornato '{1}' non ha alcun effetto finché il progetto non viene ricompilato; {2}</target>
+        <source>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuilt; {2}</source>
+        <target state="needs-review-translation">La modifica del file di origine '{0}' in un progetto non aggiornato '{1}' non ha alcun effetto finché il progetto non viene ricompilato; {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_the_application">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -471,8 +471,8 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <note />
       </trans-unit>
       <trans-unit id="Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2">
-        <source>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuit; {2}</source>
-        <target state="translated">古いプロジェクト '{1}' でソース ファイル '{0}' を変更しても、プロジェクトが再構築されるまで影響がありません。{2}</target>
+        <source>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuilt; {2}</source>
+        <target state="needs-review-translation">古いプロジェクト '{1}' でソース ファイル '{0}' を変更しても、プロジェクトが再構築されるまで影響がありません。{2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_the_application">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -471,8 +471,8 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <note />
       </trans-unit>
       <trans-unit id="Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2">
-        <source>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuit; {2}</source>
-        <target state="translated">오래된 프로젝트 '{1}'에서 소스 파일 '{0}'을(를) 변경해도 프로젝트를 다시 빌드하기 전까지는 적용되지 않습니다. {2}</target>
+        <source>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuilt; {2}</source>
+        <target state="needs-review-translation">오래된 프로젝트 '{1}'에서 소스 파일 '{0}'을(를) 변경해도 프로젝트를 다시 빌드하기 전까지는 적용되지 않습니다. {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_the_application">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -471,8 +471,8 @@ Pamiętaj, aby nie używać specyfikatora „tt” dla wszystkich języków, w k
         <note />
       </trans-unit>
       <trans-unit id="Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2">
-        <source>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuit; {2}</source>
-        <target state="translated">Zmiana pliku źródłowego „{0}” w nieaktualnym projekcie „{1}” nie ma żadnego efektu, dopóki projekt nie zostanie przebudowany; {2}</target>
+        <source>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuilt; {2}</source>
+        <target state="needs-review-translation">Zmiana pliku źródłowego „{0}” w nieaktualnym projekcie „{1}” nie ma żadnego efektu, dopóki projekt nie zostanie przebudowany; {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_the_application">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -471,8 +471,8 @@ Verifique se o especificador "tt" foi usado para idiomas para os quais é necess
         <note />
       </trans-unit>
       <trans-unit id="Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2">
-        <source>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuit; {2}</source>
-        <target state="translated">Alterar o arquivo de origem '{0}' em um projeto obsoleto '{1}' não tem efeito até que o projeto seja reconstruído; {2}</target>
+        <source>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuilt; {2}</source>
+        <target state="needs-review-translation">Alterar o arquivo de origem '{0}' em um projeto obsoleto '{1}' não tem efeito até que o projeto seja reconstruído; {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_the_application">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -471,8 +471,8 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <note />
       </trans-unit>
       <trans-unit id="Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2">
-        <source>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuit; {2}</source>
-        <target state="translated">Изменение исходного файла "{0}" в устаревшем проекте "{1}" вступит в силу только после повторной сборки проекта. {2}</target>
+        <source>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuilt; {2}</source>
+        <target state="needs-review-translation">Изменение исходного файла "{0}" в устаревшем проекте "{1}" вступит в силу только после повторной сборки проекта. {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_the_application">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -471,8 +471,8 @@ AM ve PM arasındaki farkın korunmasının gerekli olduğu diller için "tt" be
         <note />
       </trans-unit>
       <trans-unit id="Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2">
-        <source>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuit; {2}</source>
-        <target state="translated">Eski bir projedeki ('{1}') kaynak dosyayı ,('{0}') değiştirmenin, proje yeniden derlenene kadar hiçbir etkisi olmaz; {2}</target>
+        <source>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuilt; {2}</source>
+        <target state="needs-review-translation">Eski bir projedeki ('{1}') kaynak dosyayı ,('{0}') değiştirmenin, proje yeniden derlenene kadar hiçbir etkisi olmaz; {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_the_application">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -471,8 +471,8 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <note />
       </trans-unit>
       <trans-unit id="Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2">
-        <source>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuit; {2}</source>
-        <target state="translated">在重新生成项目之前，更改过时项目 "{1}" 中的源文件 "{0}" 将不起作用；{2}</target>
+        <source>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuilt; {2}</source>
+        <target state="needs-review-translation">在重新生成项目之前，更改过时项目 "{1}" 中的源文件 "{0}" 将不起作用；{2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_the_application">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -471,8 +471,8 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <note />
       </trans-unit>
       <trans-unit id="Changing_source_file_0_in_a_stale_project_1_has_no_effect_until_the_project_is_rebuilt_2">
-        <source>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuit; {2}</source>
-        <target state="translated">在專案重新建置之前，於過時的專案 '{1}' 中變更來源檔案 '{0}' 不會產生效果; {2}</target>
+        <source>Changing source file '{0}' in a stale project '{1}' has no effect until the project is rebuilt; {2}</source>
+        <target state="needs-review-translation">在專案重新建置之前，於過時的專案 '{1}' 中變更來源檔案 '{0}' 不會產生效果; {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_the_containing_namespace_of_0_from_1_to_2_requires_restarting_the_application">


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/84469
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84471)