### PR TITLE
Allow renaming symbol's file if all other symbol's locations are in source-generated documents

### DIFF
--- a/src/EditorFeatures/Core/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
+++ b/src/EditorFeatures/Core/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
@@ -154,15 +154,20 @@ internal abstract partial class AbstractEditorInlineRenameService
             if (RenameSymbol.Kind == SymbolKind.NamedType &&
                 this.Document.Project.Solution.CanApplyChange(ApplyChangesKind.ChangeDocumentInfo))
             {
-                if (RenameSymbol.Locations.Length > 1)
+                // Unlike RenameSymbol.Locations DefinitionLocations contains only
+                // non source-generated locations. Since we want the user to be able to rename a file
+                // if all other symbol's partial parts are in source-generated documents, we use this property
+                if (DefinitionLocations.Length > 1)
                 {
                     return InlineRenameFileRenameInfo.TypeWithMultipleLocations;
                 }
 
                 // Get the document that the symbol is defined in to compare
                 // the name with the symbol name. If they match allow
-                // rename file rename as part of the symbol rename
-                var symbolSourceDocument = this.Document.Project.Solution.GetDocument(RenameSymbol.Locations.Single().SourceTree);
+                // rename file rename as part of the symbol rename.
+                // Note: since source-generated partial parts are processed after the initial compilation
+                // the first location of RenameSymbol is always gonna be a non source-generated one
+                var symbolSourceDocument = this.Document.Project.Solution.GetDocument(RenameSymbol.Locations.First().SourceTree);
                 if (symbolSourceDocument != null && WorkspacePathUtilities.TypeNameMatchesDocumentName(symbolSourceDocument, RenameSymbol.Name))
                 {
                     return InlineRenameFileRenameInfo.Allowed;

--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -1724,6 +1724,38 @@ End Class
 
         <WpfTheory>
         <CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
+        <WorkItem("https://github.com/dotnet/roslyn/issues/84439")>
+        Public Sub VerifyFileRenameAllowedForPartialTypeWithAllButOneLocationInSourceGeneratedDocuments(host As RenameTestHost)
+            Using workspace = CreateWorkspaceWithWaiter(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document>
+                                partial class [|$$Test1|]
+                                {
+                                    void Blah()
+                                    {
+                                    }
+                                }
+                            </Document>
+                            <DocumentFromSourceGenerator>
+                                partial class Test1
+                                {
+                                    void BlahBlah()
+                                    {
+                                    }
+                                }
+                            </DocumentFromSourceGenerator>
+                        </Project>
+                    </Workspace>, host)
+
+                Dim session = StartSession(workspace)
+
+                Assert.Equal(InlineRenameFileRenameInfo.Allowed, session.FileRenameInfo)
+            End Using
+        End Sub
+
+        <WpfTheory>
+        <CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub VerifyFileRenameAllowedWithMultipleTypesOnMatchingName(host As RenameTestHost)
             Using workspace = CreateWorkspaceWithWaiter(
                     <Workspace>


### PR DESCRIPTION
Closes: https://github.com/dotnet/roslyn/issues/84439
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84479)