### PR TITLE
Encapsulate field: preserve field initializer

### DIFF
--- a/src/Features/CSharp/Portable/EncapsulateField/CSharpEncapsulateFieldService.cs
+++ b/src/Features/CSharp/Portable/EncapsulateField/CSharpEncapsulateFieldService.cs
@@ -92,7 +92,7 @@ internal sealed class CSharpEncapsulateFieldService() : AbstractEncapsulateField
 
             var field = semanticModel.GetDeclaredSymbol(declarator, cancellationToken) as IFieldSymbol;
 
-            var fieldToAdd = declarationAnnotation.AddAnnotationToSymbol(CodeGenerationSymbolFactory.CreateFieldSymbol(
+            var fieldToAdd = CodeGenerationSymbolFactory.CreateFieldSymbol(
                 field.GetAttributes(),
                 Accessibility.Private,
                 new DeclarationModifiers(isStatic: field.IsStatic, isReadOnly: field.IsReadOnly, isConst: field.IsConst),
@@ -100,7 +100,7 @@ internal sealed class CSharpEncapsulateFieldService() : AbstractEncapsulateField
                 field.Name,
                 field.HasConstantValue,
                 field.ConstantValue,
-                declarator.Initializer));
+                declarator.Initializer);
 
             var withField = await codeGenService.AddFieldAsync(
                 new CodeGenerationSolutionContext(
@@ -110,6 +110,10 @@ internal sealed class CSharpEncapsulateFieldService() : AbstractEncapsulateField
                 fieldToAdd,
                 cancellationToken).ConfigureAwait(false);
             root = await withField.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+            var newFieldDeclaration = root.GetAnnotatedNodes(CodeGenerator.Annotation).First() as FieldDeclarationSyntax;
+            var newFieldDeclarator = newFieldDeclaration.Declaration.Variables.First();
+            root = root.ReplaceNode(newFieldDeclarator, newFieldDeclarator.WithAdditionalAnnotations(declarationAnnotation));
 
             declarator = root.GetAnnotatedNodes<VariableDeclaratorSyntax>(tempAnnotation).First();
             declaration = declarator.Parent as VariableDeclarationSyntax;

--- a/src/Features/CSharp/Portable/EncapsulateField/CSharpEncapsulateFieldService.cs
+++ b/src/Features/CSharp/Portable/EncapsulateField/CSharpEncapsulateFieldService.cs
@@ -111,7 +111,7 @@ internal sealed class CSharpEncapsulateFieldService() : AbstractEncapsulateField
                 cancellationToken).ConfigureAwait(false);
             root = await withField.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
-            var newFieldDeclaration = root.GetAnnotatedNodes(CodeGenerator.Annotation).First() as FieldDeclarationSyntax;
+            var newFieldDeclaration = (FieldDeclarationSyntax)root.GetAnnotatedNodes(CodeGenerator.Annotation).First();
             var newFieldDeclarator = newFieldDeclaration.Declaration.Variables.First();
             root = root.ReplaceNode(newFieldDeclarator, newFieldDeclarator.WithAdditionalAnnotations(declarationAnnotation));
 

--- a/src/Features/CSharpTest/EncapsulateField/EncapsulateFieldTests.cs
+++ b/src/Features/CSharpTest/EncapsulateField/EncapsulateFieldTests.cs
@@ -482,6 +482,106 @@ public sealed class EncapsulateFieldTests : AbstractCSharpCodeActionTest_NoEdito
             }
             """, index: 0);
 
+    [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/82023")]
+    public Task EncapsulateSingleFieldWithInitializerInMultipleVariableDeclaration(TestHost host)
+        => TestAllOptionsOffAsync(host, """
+            class goo
+            {
+                public string [|a|] = 1.ToString(), b;
+            }
+            """, """
+            class goo
+            {
+                public string b;
+                private string a = 1.ToString();
+
+                public string A
+                {
+                    get
+                    {
+                        return a;
+                    }
+
+                    set
+                    {
+                        a = value;
+                    }
+                }
+            }
+            """, index: 0);
+
+    [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/82023")]
+    public Task EncapsulateMultipleFieldsWithInitializerInMultipleVariableDeclaration(TestHost host)
+        => TestAllOptionsOffAsync(host, """
+            class goo
+            {
+                public string [|a = 1.ToString(), b = 2.ToString()|];
+            }
+            """, """
+            class goo
+            {
+                private string b = 2.ToString();
+                private string a = 1.ToString();
+
+                public string A
+                {
+                    get
+                    {
+                        return a;
+                    }
+
+                    set
+                    {
+                        a = value;
+                    }
+                }
+
+                public string B
+                {
+                    get
+                    {
+                        return b;
+                    }
+
+                    set
+                    {
+                        b = value;
+                    }
+                }
+            }
+            """, index: 0);
+
+    [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/82023")]
+    public Task EncapsulateConstsWithInitializersInMultipleVariableDeclaration(TestHost host)
+        => TestAllOptionsOffAsync(host, """
+            class goo
+            {
+                public const string [|A = nameof(A), B = nameof(B)|];
+            }
+            """, """
+            class goo
+            {
+                private const string b = nameof(B);
+                private const string a = nameof(A);
+
+                public static string A
+                {
+                    get
+                    {
+                        return a;
+                    }
+                }
+
+                public static string B
+                {
+                    get
+                    {
+                        return b;
+                    }
+                }
+            }
+            """, index: 0);
+
     [Theory, CombinatorialData]
     public Task EncapsulateMultiplePrivateFields(TestHost host)
         => TestAllOptionsOffAsync(host, """

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/FieldGenerator.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/FieldGenerator.cs
@@ -92,9 +92,12 @@ internal static class FieldGenerator
             return reusableSyntax;
         }
 
-        var initializer = CodeGenerationFieldInfo.GetInitializer(field) is ExpressionSyntax initializerNode
-            ? EqualsValueClause(initializerNode)
-            : GenerateEqualsValue(field);
+        var initializer = CodeGenerationFieldInfo.GetInitializer(field) switch
+        {
+            EqualsValueClauseSyntax equalsValue => equalsValue,
+            ExpressionSyntax expr => EqualsValueClause(expr),
+            _ => GenerateEqualsValue(field)
+        };
 
         var fieldDeclaration = FieldDeclaration(
             AttributeGenerator.GenerateAttributeLists(field.GetAttributes(), info),


### PR DESCRIPTION
Fixes #82023.

The "Encapsulate field" action doesn't keep field's initializer because in [CSharpEncapsulateFieldService at line 95](https://github.com/dotnet/roslyn/blob/708c0a9669c6c996b7e13ea4b161d841bbfdf8b2/src/Features/CSharp/Portable/EncapsulateField/CSharpEncapsulateFieldService.cs#L95)
 1. it creates a new field symbol and attaches initializer to it in `CodeGenerationFieldInfo.Attach`
 2. then annotates it which creates a clone of the originally created symbol
 3. then passes that cloned symbol into [AddFieldAsync](https://github.com/dotnet/roslyn/blob/708c0a9669c6c996b7e13ea4b161d841bbfdf8b2/src/Features/CSharp/Portable/EncapsulateField/CSharpEncapsulateFieldService.cs#L110) which fails to get the initializer in `CodeGenerationFieldInfo.GetInfo` because `s_fieldToInfoMap` doesn't contain this cloned symbol as a key, it only holds the original one.

I fixed this by moving annotation of the new field declarator after it is created correctly with original initializer. I also needed to change `FieldGenerator.GenerateFieldDeclaration` because in this case initializer is already an `EqualsValueClauseSyntax`.

The issue happens only with multiple variable declarations, because otherwise the field node is just being updated.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84480)