### PR TITLE
Create unique references per test to avoid stale caches

### DIFF
--- a/src/Razor/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Cohosting/CohostTestBase.cs
+++ b/src/Razor/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Cohosting/CohostTestBase.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Basic.Reference.Assemblies;
 using Microsoft.AspNetCore.Razor;
@@ -32,6 +34,10 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 
 public abstract class CohostTestBase(ITestOutputHelper testOutputHelper) : ToolingTestBase(testOutputHelper)
 {
+    private readonly Lazy<ImmutableArray<PortableExecutableReference>> _aspNet80References = new(
+        static () => CreateMetadataReferences(net461: false));
+    private readonly Lazy<ImmutableArray<PortableExecutableReference>> _net461References = new(
+        static () => CreateMetadataReferences(net461: true));
     private ExportProvider? _exportProvider;
     private TestIncompatibleProjectService _incompatibleProjectService = null!;
     private RemoteClientInitializationOptions _clientInitializationOptions;
@@ -198,12 +204,12 @@ public abstract class CohostTestBase(ITestOutputHelper testOutputHelper) : Tooli
         return CreateProjectAndRazorDocument(remoteWorkspace, projectId, miscellaneousFile, documentId, documentFilePath, contents, additionalFiles, inGlobalNamespace, addDefaultImports, projectConfigure);
     }
 
-    private protected static TextDocument CreateProjectAndRazorDocument(CodeAnalysis.Workspace workspace, ProjectId projectId, bool miscellaneousFile, DocumentId documentId, string documentFilePath, string contents, (string fileName, string contents)[]? additionalFiles, bool inGlobalNamespace, bool addDefaultImports, Action<RazorProjectBuilder>? projectConfigure)
+    private protected TextDocument CreateProjectAndRazorDocument(CodeAnalysis.Workspace workspace, ProjectId projectId, bool miscellaneousFile, DocumentId documentId, string documentFilePath, string contents, (string fileName, string contents)[]? additionalFiles, bool inGlobalNamespace, bool addDefaultImports, Action<RazorProjectBuilder>? projectConfigure)
     {
         return AddProjectAndRazorDocument(workspace.CurrentSolution, TestProjectData.SomeProject.FilePath, projectId, documentId, documentFilePath, contents, miscellaneousFile, additionalFiles, inGlobalNamespace, addDefaultImports, projectConfigure);
     }
 
-    private protected static TextDocument AddProjectAndRazorDocument(
+    private protected TextDocument AddProjectAndRazorDocument(
         Solution solution,
         [DisallowNull] string? projectFilePath,
         ProjectId projectId,
@@ -223,9 +229,8 @@ public abstract class CohostTestBase(ITestOutputHelper testOutputHelper) : Tooli
             projectConfigure(builder);
         }
 
-        builder.AddReferences(miscellaneousFile
-            ? Net461.ReferenceInfos.All.Select(r => r.Reference) // This isn't quite what Roslyn does, but its close enough for our tests
-            : AspNet80.ReferenceInfos.All.Select(r => r.Reference));
+        var references = miscellaneousFile ? _net461References : _aspNet80References;
+        builder.AddReferences(references.Value);
         builder.GenerateGlobalConfigFile = !miscellaneousFile;
         builder.RootNamespace = null;
 
@@ -282,4 +287,15 @@ public abstract class CohostTestBase(ITestOutputHelper testOutputHelper) : Tooli
 
     protected static string FilePath(string projectRelativeFileName)
         => Path.GetFullPath(Path.Combine(TestProjectData.SomeProjectPath, projectRelativeFileName));
+
+    private static ImmutableArray<PortableExecutableReference> CreateMetadataReferences(bool net461)
+    {
+        // Cohost workspaces and their MEF providers are disposed after each test. Roslyn's process-wide
+        // symbol-tree caches are keyed by both reference and metadata identity, so neither can cross that boundary.
+        return net461
+            ? Net461.ReferenceInfos.All.Select(static referenceInfo => MetadataReference.CreateFromImage(
+                ImmutableCollectionsMarshal.AsImmutableArray(referenceInfo.ImageBytes), referenceInfo.Reference.Properties, filePath: referenceInfo.FileName)).ToImmutableArray()
+            : AspNet80.ReferenceInfos.All.Select(static referenceInfo => MetadataReference.CreateFromImage(
+                ImmutableCollectionsMarshal.AsImmutableArray(referenceInfo.ImageBytes), referenceInfo.Reference.Properties, filePath: referenceInfo.FileName)).ToImmutableArray();
+    }
 }


### PR DESCRIPTION
Hopefully fixes https://github.com/dotnet/roslyn/issues/83775

The issue seems to be Roslyn caches things per-process, but we create MEF compositions per-test, and sometimes the two conflict and Roslyn ends up using a stale lazy value. This change should make sure Roslyn's cache keys are "more unique" (🙂) or at least match the way we do things.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84482)