### PR TITLE
Fix official build: Replace deleted 'DevDiv - VS package feed' SC with WIF equivalent

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -205,7 +205,7 @@ extends:
             packagesToPush: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\DevDivPackages\**\*.nupkg'
             allowPackageConflicts: true
             nuGetFeedType: external
-            publishFeedCredentials: 'DevDiv - VS package feed'
+            publishFeedCredentials: 'dnceng-devdiv-vs-feed-push'
 
           # Publish an artifact that the RoslynInsertionTool is able to find by its name.
           - output: pipelineArtifact


### PR DESCRIPTION
## Problem

The official Roslyn build has been failing since Jul 10 with:
> Job OfficialBuild: Step NuGetCommand input externalEndpoint references service connection **DevDiv - VS package feed** which could not be found.

The PAT-backed \DevDiv - VS package feed\ service connection no longer exists (deleted as part of PAT-to-Entra migrations).

## Fix

Replace with \dnceng-devdiv-vs-feed-push\ — the WIF-backed equivalent that:
- Targets the same VS feed (\devdiv.pkgs.visualstudio.com/_packaging/VS/nuget/v3/index.json\)
- Is already in production use by project-system for the same purpose
- Has been authorized for the roslyn-official pipeline (def 327)

## Impact

This is a one-line change to the \publishFeedCredentials\ in the CoreXT package publish step. No change to build logic.

cc @Youssef1313 @akoeplinger @akhera99
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84487)