### PR TITLE
Fix MessagePack vulnerability

### DIFF
--- a/eng/Directory.Packages.props
+++ b/eng/Directory.Packages.props
@@ -54,6 +54,7 @@
 
   <ItemGroup>
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.6.10" />
+    <PackageVersion Include="MessagePack" Version="2.5.302" />
 
     <!--
       Visual Studio


### PR DESCRIPTION
Updates the MessagePack dependency to 2.5.302.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84489)