### PR TITLE
Fix official build: Use NuGetAuthenticate for CoreXT package push to VS feed

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -197,16 +197,6 @@ extends:
             accessToken: $(_DevDivDropAccessToken)
             dropRetentionDays: 90
 
-          # Publish insertion packages to CoreXT store.
-          - output: nuget
-            displayName: 'Publish CoreXT Packages'
-            condition: succeeded()
-            packageParentPath: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\DevDivPackages'
-            packagesToPush: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\DevDivPackages\**\*.nupkg'
-            allowPackageConflicts: true
-            nuGetFeedType: external
-            publishFeedCredentials: 'dnceng-devdiv-vs-feed-push'
-
           # Publish an artifact that the RoslynInsertionTool is able to find by its name.
           - output: pipelineArtifact
             displayName: 'Publish Artifact VSSetup'
@@ -312,6 +302,12 @@ extends:
             azureDevOpsServiceConnection: dnceng-devdiv-dotnet-core-internal-tooling-feed-rw-wif
             feedUrl: https://pkgs.dev.azure.com/devdiv/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json
 
+        # Authenticate to DevDiv VS (CoreXT) feed via WIF service connection
+        - task: NuGetAuthenticate@1
+          inputs:
+            azureDevOpsServiceConnection: dnceng-devdiv-vs-feed-push
+            feedUrl: https://pkgs.dev.azure.com/devdiv/_packaging/VS/nuget/v3/index.json
+
         # Needed for SBOM tool
         - task: UseDotNet@2
           displayName: 'Use .NET Core 3.1 runtime'
@@ -378,6 +374,27 @@ extends:
             filePath: 'eng\publish-assets.ps1'
             arguments: '-configuration $(BuildConfiguration)'
           condition: succeeded()
+
+        # Publish insertion packages to CoreXT store (DevDiv/VS feed)
+        # Uses ambient credentials from NuGetAuthenticate@1 above
+        - task: PowerShell@2
+          displayName: 'Publish CoreXT Packages'
+          condition: succeeded()
+          inputs:
+            targetType: inline
+            script: |
+              $feedUrl = "https://pkgs.dev.azure.com/devdiv/_packaging/VS/nuget/v3/index.json"
+              $packages = Get-ChildItem -Path "$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\DevDivPackages" -Recurse -Filter "*.nupkg"
+              Write-Host "Found $($packages.Count) packages to push"
+              foreach ($pkg in $packages) {
+                Write-Host "Pushing $($pkg.Name)..."
+                & dotnet nuget push $pkg.FullName --source $feedUrl --api-key AzureDevOps --skip-duplicate
+                if ($LASTEXITCODE -ne 0) {
+                  Write-Error "Failed to push $($pkg.Name)"
+                  exit 1
+                }
+              }
+              Write-Host "Successfully pushed $($packages.Count) packages"
 
         # Publish OptProf configuration files to the artifact service
         # ArtifactServices.Drop.PAT is set via WIF service connection for cross account access (dnceng -> devdiv)


### PR DESCRIPTION
## Problem

Build [3021319](https://dev.azure.com/dnceng/internal/_build/results?buildId=3021319) (dotnet-roslyn-official) fails immediately with:

> The pipeline is not valid. Job OfficialBuild: Step NuGetCommand input externalEndpoint expects a service connection of type ExternalNuGetFeed but the provided service connection dnceng-devdiv-vs-feed-push is of type workloadidentityuser.

The previous fix (#84487) replaced the deleted \DevDiv - VS package feed\ SC (type \ExternalNuGetFeed\) with \dnceng-devdiv-vs-feed-push\ (type \workloadidentityuser\/WIF). However, the 1ES template \output: nuget\ step with \
uGetFeedType: external\ requires an \ExternalNuGetFeed\ type SC — WIF service connections are incompatible with that input.

## Fix

Replace the \output: nuget\ approach with the same pattern already used in this pipeline for \s-impl\ and \ssdk\ feeds:

1. **Add \NuGetAuthenticate@1\** for the DevDiv/VS feed using the WIF service connection — this sets up the NuGet credential provider for the feed URL
2. **Add a PowerShell push step** that calls \dotnet nuget push\ — the credential provider handles auth automatically
3. **Remove the \output: nuget\ block** that required the incompatible SC type

The \--skip-duplicate\ flag is equivalent to the previous \llowPackageConflicts: true\ setting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84490)