### PR TITLE
Modernize "File-based apps VS Code support" doc

### DIFF
--- a/docs/features/file-based-programs-vscode.md
+++ b/docs/features/file-based-programs-vscode.md
@@ -206,7 +206,7 @@ For this reason, we intend to put `#!`-at-start as a standard for entry points o
 
 ## Future considerations
 
-This section is not intended to serve as permanent documentation but as more of a roadmap for a series of changes we may make in this area in the near future. It should not be necessary to read/understand this in order to evaluate a PR currently under review. i.e. anything that the current PR is actually implementing is covered in previous sections. Where individual tracking items exist, they are linked below.
+This section is not intended to serve as permanent documentation but as more of a roadmap for a series of changes we may make in this area in the near future. It should not be necessary to read/understand this in order to evaluate a PR currently under review. Anything that the current PR is actually implementing is covered in previous sections. Where individual tracking items exist, they are linked below.
 
 ### Treating files with no directives as file-based app entry points
 

--- a/docs/features/file-based-programs-vscode.md
+++ b/docs/features/file-based-programs-vscode.md
@@ -1,10 +1,18 @@
 # File-based programs VS Code support
 
-See also [dotnet-run-file.md](https://github.com/dotnet/sdk/blob/main/documentation/general/dotnet-run-file.md).
+See also:
+
+- [.NET SDK file-based apps](https://learn.microsoft.com/en-us/dotnet/core/sdk/file-based-apps)
+- [Microsoft Learn tutorial](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/tutorials/file-based-programs)
+- [General structure of a C# program](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/program-structure/)
+- [File-based app directives](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/program-structure/preprocessor-directives#file-based-app-directives)
+- [dotnet-run-file.md](https://github.com/dotnet/sdk/blob/main/documentation/general/dotnet-run-file.md)
 
 ## Feature overview
 
 A file-based program embeds a subset of MSBuild project capabilities into C# code, allowing single files to stand alone as ordinary projects.
+
+**File-based app** and **file-based program** are synonymous.
 
 The following is a file-based program:
 
@@ -16,7 +24,7 @@ So is the following:
 
 ```cs
 #!/usr/bin/env dotnet run
-#:sdk Microsoft.Net.Sdk
+#:sdk Microsoft.NET.Sdk
 #:package Newtonsoft.Json@13.0.3
 #:property LangVersion=preview
 
@@ -40,13 +48,13 @@ void Main()
 record Data(string field1, int field2);
 ```
 
-This basically works by having the `dotnet` command line interpret the `#:` directives in source files, produce a C# project XML document in memory, and pass it off to MSBuild. The in-memory project is sometimes called a "virtual project".
+The `dotnet` command line interprets the `#:` directives in source files, produces a C# project XML document in memory, and passes it off to MSBuild. The in-memory project is sometimes called a "virtual project".
 
 ## Rich miscellaneous files
 
-There is a long-standing backlog item to enhance the experience of working with miscellaneous files ("loose files" not associated with any project). We think that as part of the "file-based program" work, we can enable the following in such files without substantial issues:
+There is long-standing tracking to enhance the experience of working with miscellaneous files ("loose files" not associated with any project), including [issue 55287: MiscellaneousFilesWorkspace design debt](https://github.com/dotnet/roslyn/issues/55287), [issue 11599: lost IntelliSense when transferring a document to miscellaneous files](https://github.com/dotnet/roslyn/issues/11599), and [issue 80743: canonical miscellaneous files project for VS Code](https://github.com/dotnet/roslyn/issues/80743). As part of the file-based program work, we can enable the following in such files without substantial issues:
 - Syntax diagnostics.
-- Intellisense for the "default" set of references. e.g. those references which are included in the project created by `dotnet new console` with the current SDK.
+- IntelliSense for the "default" set of references, for example those references which are included in the project created by `dotnet new console` with the current SDK.
 - In certain cases, we can even enable semantic diagnostics, with reasonable confidence that the resulting errors are useful to the user.
 
 These changes to misc files behavior are called "rich miscellaneous files".
@@ -59,7 +67,7 @@ A C# file has multiple possible *classifications* in the editor:
 - **Project-Based App**. The file is part of an ordinary `.csproj` project.
 - **File-Based App**. The file is part of a "file-based app" project, i.e. it is either the entry point of a file-based app or it is `#:include`d by the entry point of the same.
 - **Miscellaneous File With Standard References and Semantic Errors**. The file is a valid entry point for either a file-based app, but lacks the `#:`/`#!` directives which give us high certainty that this is the user's intent.
-   - Tooling will light up accordingly, showing syntax errors, semantic errors, semantic info for the core library, etc. See *Rich miscellaneous files* section above.
+   - Tooling will light up accordingly, showing syntax errors, semantic errors, semantic info for the core library, etc. See [Rich miscellaneous files](#rich-miscellaneous-files).
    - These files will not be restored.
 - **Miscellaneous File With Standard References**. The file isn't part of any project, and heuristics indicate it's not intended to be a file-based app. The file uses the regular C# language (not the `.csx` scripting dialect).
    - Syntax errors and semantic info for the core library will appear in these files.
@@ -160,13 +168,13 @@ Manages projects for file-based programs and miscellaneous files.
 
 This project system effectively performs the classification process described in [File-based app detection](#file-based-app-detection) when a design-time build is performed for the project, and transitions the state of the project to match the latest classification.
 
-This uses the file-based program entry point file, translates it to a virtual msbuild project, then runs a design-time build on that project. If it detects missing assets, it may also restore the virtual project.
+This uses the file-based program entry point file, translates it to a virtual MSBuild project, then runs a design-time build on that project. If it detects missing assets, it may also restore the virtual project.
 
-It uses file watchers to watch the project globs and redo the design time build on relevant changes, such as changes to `#:` directives.
+It uses file watchers to watch the project globs and redo the design-time build on relevant changes, such as changes to `#:` directives.
 
 ## Automatic discovery
 
-The Roslyn LSP will automatically discover and load file-based apps in the opened workspace folders. The user can opt out of this discovery process by setting `"dotnet.fileBasedApps.enableAutomaticDiscovery": false`.
+The Roslyn LSP will automatically discover and load file-based apps in the opened workspace folders. The user can opt out of this discovery process by setting `"dotnet.fileBasedApps.enableAutomaticDiscovery": false`. This work was tracked by [PR 82863: file-based apps automatic discovery](https://github.com/dotnet/roslyn/pull/82863).
 For the first release of the feature in the VS Code C# extension, the setting will be disabled-by-default in the stable release channel and enabled-by-default in the prerelease channel.
 
 Certain subfolders in a workspace are excluded from this discovery process:
@@ -174,7 +182,7 @@ Certain subfolders in a workspace are excluded from this discovery process:
 - Any folders with names conventionally reserved for build artifacts, such as `artifacts`, `bin`, and `obj`.
 - Any folders marked "hidden" in the file system. `.git` and `.vs` typically fall into this.
 
-The first time discovery is performed in a workspace, the LSP will read all `.cs` files in the opened workspace folders which are not excluded by the above conditions. If the file content starts with `#!`, it is marked as a file-based app and loaded.
+The first time that discovery is performed in a workspace, the LSP will read all `.cs` files in the opened workspace folders which are not excluded by the above conditions. If the file content starts with `#!`, it is marked as a file-based app and loaded.
 
 A cache file is created after each discovery pass and stored in the user temp directory. This file holds:
 - The time that the previous discovery pass started.
@@ -190,28 +198,28 @@ The cache data allows the following optimizations in subsequent discovery passes
 This design requires files to start with `#!` in order to participate in discovery.
 Specifically, a discoverable file must start with either the byte sequence `0x23, 0x21` (ASCII/UTF-8 `#!`), or the byte sequence `0xEF, 0xBB, 0xBF, 0x23, 0x21` (UTF-8 BOM followed by `#!`).
 
-The reason for this is: we anticipate adding support for `#:` to non-entry-point files. This means that having `#:` is not going to be enough to identify a file as definitely the entry point.
+The reason for this is: we anticipate adding support for `#:` to non-entry-point files. This means that having `#:` is not going to be enough to identify a file as definitely the entry point. Related work is tracked by [issue 82292: `#:include` scenario](https://github.com/dotnet/roslyn/issues/82292), [PR 83185: transitive directive heuristic](https://github.com/dotnet/roslyn/pull/83185), and [PR 81284: included file-based app sources](https://github.com/dotnet/roslyn/pull/81284).
 
 Instead, it will be necessary to search for both `#:` and top-level statements at a minimum. This cost is acceptable for files that were explicitly opened in the editor, but is a bit steep for a broad discovery pass.
 
-For this reason, we intend to put `#!`-at-start as a standard for entry points of file-based apps. We plan on shipping an analyzer which reports a warning in files which contain both `#:include` and top-level statements, but do not have `#!` at the top.
+For this reason, we intend to put `#!`-at-start as a standard for entry points of file-based apps. Related live directive diagnostics work is tracked by [issue 80006: the live directive diagnostics issue](https://github.com/dotnet/roslyn/issues/80006) and [PR 80575: the live directive diagnostics PR](https://github.com/dotnet/roslyn/pull/80575).
 
 ## Future considerations
 
-This section is not intended to serve as permanent documentation but as more of a roadmap for a series of changes we may make in this area in the near future. It should not be necessary to read/understand this in order to evaluate a PR currently under review. i.e. anything that the current PR is actually implementing is covered in previous sections.
+This section is not intended to serve as permanent documentation but as more of a roadmap for a series of changes we may make in this area in the near future. It should not be necessary to read/understand this in order to evaluate a PR currently under review. i.e. anything that the current PR is actually implementing is covered in previous sections. Where individual tracking items exist, they are linked below.
 
 ### Treating files with no directives as file-based app entry points
 
-**Miscellaneous File With Standard References and Semantic Errors**, is a designation we essentially have in order to avoid restoring things we aren't 100% sure are file-based apps. This particularly includes files which have top-level statements, but no `#:`/`#!` directives.
+**Miscellaneous File With Standard References and Semantic Errors** is a designation we essentially have in order to avoid restoring things we aren't 100% sure are file-based apps. This particularly includes files which have top-level statements, but no `#:`/`#!` directives.
 
-We may want to make a change in the future, to stop using this designation for files which exist on disk, and instead classify files not part of an ordinary project, containing top-level statements, and with no csproj-in-cone, as being file-based apps. This would improve accuracy in the editor in certain cases, and make it easier to do things like avoid showing the *This is a miscellanous file, things may be broken* popup.
+We may want to stop using this designation for files which exist on disk. Instead, we may identify files that (1) contain top-level statements, (2) are not part of an ordinary project, and (3) have no `.csproj` in-cone. We'd classify these files as file-based apps. This would improve accuracy in the editor in certain cases and make it easier to do things like avoid showing the "This is a miscellaneous file, things may be broken" popup. Related tracking includes [issue 81252: Do not restore loose files which lack file-based app directives](https://github.com/dotnet/roslyn/issues/81252) and [PR 84385: Extract file-based app entry point heuristic](https://github.com/dotnet/roslyn/pull/84385).
 
 ### Allowing non-entry-point files to contain `#:` directives
 
-We are considering adding support for non-entry-point files to contain `#:` in the future. In this case, we would need an additional bit of information to distinguish entry points from non-entry-points.
+We are considering adding support for non-entry-point files to contain `#:` in the future. In this case, we would need an additional bit of information to distinguish entry points from non-entry-points. Related work is tracked by [the `#:include` scenario issue](https://github.com/dotnet/roslyn/issues/82292), [the transitive directive heuristic PR](https://github.com/dotnet/roslyn/pull/83185), and [included file-based app sources](https://github.com/dotnet/roslyn/pull/81284).
 For *multi-file file-based apps*, users should use a `#!` at the top of the entry point file to make it easy to identify.
 For *single-file file-based apps*, we think that just using `#:` and top-level statements together should be enough, to identify a file that was explicitly opened in the editor as an entry point.
 
 ### Checking top-level statements presence without doing a full parse
 
-Currently there are cases where we may end up needing to do an additional parse of a file just to check if it contains top-level statements. This is generally a situation we'd like to avoid, and, would prefer to either use a pattern where the file already exists in some project and has a syntax tree we can check incrementally, or, that we devise some other solution for performing our heuristics which doesn't require a full parse.
+Currently there are cases where we may end up needing to do an additional parse of a file just to check if it contains top-level statements. This is generally a situation we'd like to avoid, and, would prefer to either use a pattern where the file already exists in some project and has a syntax tree we can check incrementally, or, that we devise some other solution for performing our heuristics which doesn't require a full parse. This is tracked by [issue 78878: Determine if a source file contains top-level statements without doing a full additional parse](https://github.com/dotnet/roslyn/issues/78878).

--- a/docs/features/file-based-programs-vscode.md
+++ b/docs/features/file-based-programs-vscode.md
@@ -226,7 +226,11 @@ We may want to stop using this designation for files which exist on disk. Instea
 
 ### Allowing non-entry-point files to contain `#:` directives
 
-We are considering adding support for non-entry-point files to contain `#:` in the future. In this case, we would need an additional bit of information to distinguish entry points from non-entry-points. Related work is tracked by [the `#:include` scenario issue](https://github.com/dotnet/roslyn/issues/82292), [the transitive directive heuristic PR](https://github.com/dotnet/roslyn/pull/83185), and [included file-based app sources](https://github.com/dotnet/roslyn/pull/81284).
+We are considering adding support for non-entry-point files to contain `#:` in the future. In this case, we would need an additional bit of information to distinguish entry points from non-entry-points. Related work is tracked by:
+- [the `#:include` scenario issue](https://github.com/dotnet/roslyn/issues/82292)
+- [the transitive directive heuristic PR](https://github.com/dotnet/roslyn/pull/83185)
+- [included file-based app sources](https://github.com/dotnet/roslyn/pull/81284)
+
 For *multi-file file-based apps*, users should use a `#!` at the top of the entry point file to make it easy to identify.
 For *single-file file-based apps*, we think that just using `#:` and top-level statements together should be enough, to identify a file that was explicitly opened in the editor as an entry point.
 

--- a/docs/features/file-based-programs-vscode.md
+++ b/docs/features/file-based-programs-vscode.md
@@ -83,7 +83,8 @@ A C# file has multiple possible *classifications* in the editor:
    - Syntax errors, go-to-def on declarations in the same file, etc., may work.
    - When `enableFileBasedPrograms` is disabled, this classification is generally used instead of one of the *miscellaneous file with standard references* or *file-based app* classifications above.
 
-**NOTE:** This is intended to be a living document, and for the set of checks and classifications to possibly change over time depending on our needs.
+> [!NOTE]
+> This is intended to be a living document, and for the set of checks and classifications to possibly change over time depending on our needs.
 
 This is the decision tree for determining how to classify a C# file:
 

--- a/docs/features/file-based-programs-vscode.md
+++ b/docs/features/file-based-programs-vscode.md
@@ -227,9 +227,9 @@ We may want to stop using this designation for files which exist on disk. Instea
 ### Allowing non-entry-point files to contain `#:` directives
 
 We are considering adding support for non-entry-point files to contain `#:` in the future. In this case, we would need an additional bit of information to distinguish entry points from non-entry-points. Related work is tracked by:
+- [issue 81284: included file-based app sources](https://github.com/dotnet/roslyn/pull/81284)
 - [issue 82292: `#:include` scenario](https://github.com/dotnet/roslyn/issues/82292)
 - [PR 83185: transitive directive heuristic](https://github.com/dotnet/roslyn/pull/83185)
-- [issue 81284: included file-based app sources](https://github.com/dotnet/roslyn/pull/81284)
 
 For *multi-file file-based apps*, users should use a `#!` at the top of the entry point file to make it easy to identify.
 For *single-file file-based apps*, we think that just using `#:` and top-level statements together should be enough, to identify a file that was explicitly opened in the editor as an entry point.

--- a/docs/features/file-based-programs-vscode.md
+++ b/docs/features/file-based-programs-vscode.md
@@ -144,7 +144,7 @@ We also have a second, finer-grained opt-out flag `dotnet.projects.enableFileBas
 ## LSP handling of file-based apps
 
 When a C# file adds `#:` or `#!` directives, it becomes a file-based app.
-Conceptually, what happens is: the file becomes both a C# source file, and a project file, in one.
+Conceptually, the file becomes both a C# source file and a project file in one.
 
 Conversely, when all `#:`/`#!` directives are removed, it stops being a project file, and goes back to being a C# source file only. In this scheme, we think of a file which contains `#:` as being the "entry point file" of the file-based app.
 

--- a/docs/features/file-based-programs-vscode.md
+++ b/docs/features/file-based-programs-vscode.md
@@ -216,7 +216,7 @@ For this reason, we put `#!`-at-start as a standard for entry points of file-bas
 
 ## Future considerations
 
-This section is not intended to serve as permanent documentation but as more of a roadmap for a series of changes we may make in this area in the near future. It should not be necessary to read/understand this in order to evaluate a PR currently under review. Anything that the current PR is actually implementing is covered in previous sections. Where individual tracking items exist, they are linked below.
+This section is not intended to serve as permanent documentation but as more of a roadmap for a series of changes we may make in this area in the near future. It should not be necessary to read/understand this in order to evaluate a PR currently under review. Anything that the current PR is actually implementing is covered in previous sections.
 
 ### Treating files with no directives as file-based app entry points
 

--- a/docs/features/file-based-programs-vscode.md
+++ b/docs/features/file-based-programs-vscode.md
@@ -206,9 +206,9 @@ This design requires files to start with `#!` in order to participate in discove
 Specifically, a discoverable file must start with either the byte sequence `0x23, 0x21` (ASCII/UTF-8 `#!`), or the byte sequence `0xEF, 0xBB, 0xBF, 0x23, 0x21` (UTF-8 BOM followed by `#!`).
 
 The reason for this is: we anticipate adding support for `#:` to non-entry-point files. This means that having `#:` is not going to be enough to identify a file as definitely the entry point. Related work is tracked by:
+- [PR 81284: included file-based app sources](https://github.com/dotnet/roslyn/pull/81284)
 - [issue 82292: `#:include` scenario](https://github.com/dotnet/roslyn/issues/82292)
 - [PR 83185: transitive directive heuristic](https://github.com/dotnet/roslyn/pull/83185)
-- [PR 81284: included file-based app sources](https://github.com/dotnet/roslyn/pull/81284)
 
 Instead, it will be necessary to search for both `#:` and top-level statements at a minimum. This cost is acceptable for files that were explicitly opened in the editor, but is a bit steep for a broad discovery pass.
 

--- a/docs/features/file-based-programs-vscode.md
+++ b/docs/features/file-based-programs-vscode.md
@@ -227,7 +227,7 @@ We may want to stop using this designation for files which exist on disk. Instea
 ### Allowing non-entry-point files to contain `#:` directives
 
 We are considering adding support for non-entry-point files to contain `#:` in the future. In this case, we would need an additional bit of information to distinguish entry points from non-entry-points. Related work is tracked by:
-- [issue 81284: included file-based app sources](https://github.com/dotnet/roslyn/pull/81284)
+- [PR 81284: included file-based app sources](https://github.com/dotnet/roslyn/pull/81284)
 - [issue 82292: `#:include` scenario when entry point opened manually](https://github.com/dotnet/roslyn/issues/82292)
 - [PR 83185: Adjust heuristics to properly handle transitive directives](https://github.com/dotnet/roslyn/pull/83185)
 

--- a/docs/features/file-based-programs-vscode.md
+++ b/docs/features/file-based-programs-vscode.md
@@ -212,7 +212,7 @@ The reason for this is: we anticipate adding support for `#:` to non-entry-point
 
 Instead, it will be necessary to search for both `#:` and top-level statements at a minimum. This cost is acceptable for files that were explicitly opened in the editor, but is a bit steep for a broad discovery pass.
 
-For this reason, we intend to put `#!`-at-start as a standard for entry points of file-based apps. We plan to report a warning in files which contain both `#:include` and top-level statements, but do not have `#!` at the top. Related live directive diagnostics work is tracked by [issue 80006: live directive diagnostics](https://github.com/dotnet/roslyn/issues/80006) and [PR 80575: live directive diagnostics](https://github.com/dotnet/roslyn/pull/80575).
+For this reason, we put `#!`-at-start as a standard for entry points of file-based apps. We report a warning in files which contain both `#:include` and top-level statements, but do not have `#!` at the top. We did this in [PR 80575: File-based programs live directive diagnostics](https://github.com/dotnet/roslyn/pull/80575).
 
 ## Future considerations
 

--- a/docs/features/file-based-programs-vscode.md
+++ b/docs/features/file-based-programs-vscode.md
@@ -52,7 +52,13 @@ The `dotnet` command line interprets the `#:` directives in source files, produc
 
 ## Rich miscellaneous files
 
-There is long-standing tracking to enhance the experience of working with miscellaneous files ("loose files" not associated with any project), including [issue 55287: MiscellaneousFilesWorkspace design debt](https://github.com/dotnet/roslyn/issues/55287), [issue 11599: lost IntelliSense when transferring a document to miscellaneous files](https://github.com/dotnet/roslyn/issues/11599), and [issue 80743: canonical miscellaneous files project for VS Code](https://github.com/dotnet/roslyn/issues/80743). As part of the file-based app work, we can enable the following in such files without substantial issues:
+There is long-standing tracking to enhance the experience of working with miscellaneous files ("loose files" not associated with any project), including:
+
+- [issue 55287: MiscellaneousFilesWorkspace design debt](https://github.com/dotnet/roslyn/issues/55287)
+- [issue 11599: lost IntelliSense when transferring a document to miscellaneous files](https://github.com/dotnet/roslyn/issues/11599)
+- [issue 80743: canonical miscellaneous files project for VS Code](https://github.com/dotnet/roslyn/issues/80743).
+
+As part of the file-based app work, we can enable the following in such files without substantial issues:
 - Syntax diagnostics.
 - IntelliSense for the "default" set of references, for example those references which are included in the project created by `dotnet new console` with the current SDK.
 - In certain cases, we can even enable semantic diagnostics, with reasonable confidence that the resulting errors are useful to the user.

--- a/docs/features/file-based-programs-vscode.md
+++ b/docs/features/file-based-programs-vscode.md
@@ -227,9 +227,9 @@ We may want to stop using this designation for files which exist on disk. Instea
 ### Allowing non-entry-point files to contain `#:` directives
 
 We are considering adding support for non-entry-point files to contain `#:` in the future. In this case, we would need an additional bit of information to distinguish entry points from non-entry-points. Related work is tracked by:
-- [the `#:include` scenario issue](https://github.com/dotnet/roslyn/issues/82292)
-- [the transitive directive heuristic PR](https://github.com/dotnet/roslyn/pull/83185)
-- [included file-based app sources](https://github.com/dotnet/roslyn/pull/81284)
+- [issue 82292: `#:include` scenario](https://github.com/dotnet/roslyn/issues/82292)
+- [PR 83185: transitive directive heuristic](https://github.com/dotnet/roslyn/pull/83185)
+- [issue 81284: included file-based app sources](https://github.com/dotnet/roslyn/pull/81284)
 
 For *multi-file file-based apps*, users should use a `#!` at the top of the entry point file to make it easy to identify.
 For *single-file file-based apps*, we think that just using `#:` and top-level statements together should be enough, to identify a file that was explicitly opened in the editor as an entry point.

--- a/docs/features/file-based-programs-vscode.md
+++ b/docs/features/file-based-programs-vscode.md
@@ -72,7 +72,7 @@ The implementation strategy is: the editor creates a "canonical misc files proje
 A C# file has multiple possible *classifications* in the editor:
 - **Project-Based App**. The file is part of an ordinary `.csproj` project.
 - **File-Based App**. The file is part of a "file-based app" project, i.e. it is either the entry point of a file-based app or it is `#:include`d by the entry point of the same.
-- **Miscellaneous File With Standard References and Semantic Errors**. The file is a valid entry point for either a file-based app, but lacks the `#:`/`#!` directives which give us high certainty that this is the user's intent.
+- **Miscellaneous File With Standard References and Semantic Errors**. The file is a valid entry point for a file-based app, but lacks the `#:`/`#!` directives which give us high certainty that this is the user's intent.
    - Tooling will light up accordingly, showing syntax errors, semantic errors, semantic info for the core library, etc. See [Rich miscellaneous files](#rich-miscellaneous-files).
    - These files will not be restored.
 - **Miscellaneous File With Standard References**. The file isn't part of any project, and heuristics indicate it's not intended to be a file-based app. The file uses the regular C# language (not the `.csx` scripting dialect).

--- a/docs/features/file-based-programs-vscode.md
+++ b/docs/features/file-based-programs-vscode.md
@@ -228,8 +228,8 @@ We may want to stop using this designation for files which exist on disk. Instea
 
 We are considering adding support for non-entry-point files to contain `#:` in the future. In this case, we would need an additional bit of information to distinguish entry points from non-entry-points. Related work is tracked by:
 - [issue 81284: included file-based app sources](https://github.com/dotnet/roslyn/pull/81284)
-- [issue 82292: `#:include` scenario](https://github.com/dotnet/roslyn/issues/82292)
-- [PR 83185: transitive directive heuristic](https://github.com/dotnet/roslyn/pull/83185)
+- [issue 82292: `#:include` scenario when entry point opened manually](https://github.com/dotnet/roslyn/issues/82292)
+- [PR 83185: Adjust heuristics to properly handle transitive directives](https://github.com/dotnet/roslyn/pull/83185)
 
 For *multi-file file-based apps*, users should use a `#!` at the top of the entry point file to make it easy to identify.
 For *single-file file-based apps*, we think that just using `#:` and top-level statements together should be enough, to identify a file that was explicitly opened in the editor as an entry point.

--- a/docs/features/file-based-programs-vscode.md
+++ b/docs/features/file-based-programs-vscode.md
@@ -202,7 +202,7 @@ The reason for this is: we anticipate adding support for `#:` to non-entry-point
 
 Instead, it will be necessary to search for both `#:` and top-level statements at a minimum. This cost is acceptable for files that were explicitly opened in the editor, but is a bit steep for a broad discovery pass.
 
-For this reason, we intend to put `#!`-at-start as a standard for entry points of file-based apps. Related live directive diagnostics work is tracked by [issue 80006: the live directive diagnostics issue](https://github.com/dotnet/roslyn/issues/80006) and [PR 80575: the live directive diagnostics PR](https://github.com/dotnet/roslyn/pull/80575).
+For this reason, we intend to put `#!`-at-start as a standard for entry points of file-based apps. We plan to report a warning in files which contain both `#:include` and top-level statements, but do not have `#!` at the top. Related live directive diagnostics work is tracked by [issue 80006: live directive diagnostics](https://github.com/dotnet/roslyn/issues/80006) and [PR 80575: live directive diagnostics](https://github.com/dotnet/roslyn/pull/80575).
 
 ## Future considerations
 

--- a/docs/features/file-based-programs-vscode.md
+++ b/docs/features/file-based-programs-vscode.md
@@ -168,7 +168,7 @@ Manages projects for file-based apps and miscellaneous files.
 
 This project system effectively performs the classification process described in [File-based app detection](#file-based-app-detection) when a design-time build is performed for the project, and transitions the state of the project to match the latest classification.
 
-This uses the file-based app entry point file, translates it to a virtual MSBuild project, then runs a design-time build on that project. If it detects missing assets, it may also restore the virtual project.
+The project system uses the file-based app entry point file, translates it to a virtual MSBuild project, then runs a design-time build on that project. If it detects missing assets, it may also restore the virtual project.
 
 It uses file watchers to watch the project globs and redo the design-time build on relevant changes, such as changes to `#:` directives.
 

--- a/docs/features/file-based-programs-vscode.md
+++ b/docs/features/file-based-programs-vscode.md
@@ -54,8 +54,8 @@ The `dotnet` command line interprets the `#:` directives in source files, produc
 
 There is long-standing tracking to enhance the experience of working with miscellaneous files ("loose files" not associated with any project), including:
 
-- [issue 55287: MiscellaneousFilesWorkspace design debt](https://github.com/dotnet/roslyn/issues/55287)
 - [issue 11599: lost IntelliSense when transferring a document to miscellaneous files](https://github.com/dotnet/roslyn/issues/11599)
+- [issue 55287: MiscellaneousFilesWorkspace design debt](https://github.com/dotnet/roslyn/issues/55287)
 - [issue 80743: canonical miscellaneous files project for VS Code](https://github.com/dotnet/roslyn/issues/80743).
 
 As part of the file-based app work, we can enable the following in such files without substantial issues:

--- a/docs/features/file-based-programs-vscode.md
+++ b/docs/features/file-based-programs-vscode.md
@@ -205,7 +205,10 @@ The cache data allows the following optimizations in subsequent discovery passes
 This design requires files to start with `#!` in order to participate in discovery.
 Specifically, a discoverable file must start with either the byte sequence `0x23, 0x21` (ASCII/UTF-8 `#!`), or the byte sequence `0xEF, 0xBB, 0xBF, 0x23, 0x21` (UTF-8 BOM followed by `#!`).
 
-The reason for this is: we anticipate adding support for `#:` to non-entry-point files. This means that having `#:` is not going to be enough to identify a file as definitely the entry point. Related work is tracked by [issue 82292: `#:include` scenario](https://github.com/dotnet/roslyn/issues/82292), [PR 83185: transitive directive heuristic](https://github.com/dotnet/roslyn/pull/83185), and [PR 81284: included file-based app sources](https://github.com/dotnet/roslyn/pull/81284).
+The reason for this is: we anticipate adding support for `#:` to non-entry-point files. This means that having `#:` is not going to be enough to identify a file as definitely the entry point. Related work is tracked by:
+- [issue 82292: `#:include` scenario](https://github.com/dotnet/roslyn/issues/82292)
+- [PR 83185: transitive directive heuristic](https://github.com/dotnet/roslyn/pull/83185)
+- [PR 81284: included file-based app sources](https://github.com/dotnet/roslyn/pull/81284)
 
 Instead, it will be necessary to search for both `#:` and top-level statements at a minimum. This cost is acceptable for files that were explicitly opened in the editor, but is a bit steep for a broad discovery pass.
 

--- a/docs/features/file-based-programs-vscode.md
+++ b/docs/features/file-based-programs-vscode.md
@@ -156,7 +156,7 @@ One key assumption we are making is: it is not valid for a file-based app *entry
 
 An error is reported generally for presence of `#:`/`#!` directives in ordinary projects. Depending on the order that things load, such files may or may not also be detected as file-based app entry points.
 
-In this case we want the user to do one of 2 things to resolve the issue:
+In this case we want the user to do one of two things to resolve the issue:
 1. Delete the `#:`/`#!` directives. We will unload the file as file-based app in this case.
 2. Remove the file-based app entry point as a member of any ordinary project(s).
 

--- a/docs/features/file-based-programs-vscode.md
+++ b/docs/features/file-based-programs-vscode.md
@@ -1,5 +1,7 @@
 # File-based programs VS Code support
 
+**File-based app** and **file-based program** are synonymous.
+
 See also:
 
 - [.NET SDK file-based apps](https://learn.microsoft.com/en-us/dotnet/core/sdk/file-based-apps)
@@ -11,8 +13,6 @@ See also:
 ## Feature overview
 
 A file-based program embeds a subset of MSBuild project capabilities into C# code, allowing single files to stand alone as ordinary projects.
-
-**File-based app** and **file-based program** are synonymous.
 
 The following is a file-based program:
 

--- a/docs/features/file-based-programs-vscode.md
+++ b/docs/features/file-based-programs-vscode.md
@@ -1,4 +1,4 @@
-# File-based programs VS Code support
+# File-based apps VS Code support
 
 **File-based app** and **file-based program** are synonymous.
 
@@ -12,9 +12,9 @@ See also:
 
 ## Feature overview
 
-A file-based program embeds a subset of MSBuild project capabilities into C# code, allowing single files to stand alone as ordinary projects.
+A file-based app embeds a subset of MSBuild project capabilities into C# code, allowing single files to stand alone as ordinary projects.
 
-The following is a file-based program:
+The following is a file-based app:
 
 ```cs
 Console.WriteLine("Hello World!");
@@ -52,7 +52,7 @@ The `dotnet` command line interprets the `#:` directives in source files, produc
 
 ## Rich miscellaneous files
 
-There is long-standing tracking to enhance the experience of working with miscellaneous files ("loose files" not associated with any project), including [issue 55287: MiscellaneousFilesWorkspace design debt](https://github.com/dotnet/roslyn/issues/55287), [issue 11599: lost IntelliSense when transferring a document to miscellaneous files](https://github.com/dotnet/roslyn/issues/11599), and [issue 80743: canonical miscellaneous files project for VS Code](https://github.com/dotnet/roslyn/issues/80743). As part of the file-based program work, we can enable the following in such files without substantial issues:
+There is long-standing tracking to enhance the experience of working with miscellaneous files ("loose files" not associated with any project), including [issue 55287: MiscellaneousFilesWorkspace design debt](https://github.com/dotnet/roslyn/issues/55287), [issue 11599: lost IntelliSense when transferring a document to miscellaneous files](https://github.com/dotnet/roslyn/issues/11599), and [issue 80743: canonical miscellaneous files project for VS Code](https://github.com/dotnet/roslyn/issues/80743). As part of the file-based app work, we can enable the following in such files without substantial issues:
 - Syntax diagnostics.
 - IntelliSense for the "default" set of references, for example those references which are included in the project created by `dotnet new console` with the current SDK.
 - In certain cases, we can even enable semantic diagnostics, with reasonable confidence that the resulting errors are useful to the user.
@@ -127,12 +127,12 @@ This is the decision tree for determining how to classify a C# file:
 
 ### Opt-out
 
-We added an opt-out flag with option name `dotnet.projects.enableFileBasedPrograms`. If issues arise with the file-based program experience, then VS Code users should set the corresponding setting `"dotnet.projects.enableFileBasedPrograms": false` to revert back to the old miscellaneous files experience.
+We added an opt-out flag with option name `dotnet.projects.enableFileBasedPrograms`. If issues arise with the file-based app experience, then VS Code users should set the corresponding setting `"dotnet.projects.enableFileBasedPrograms": false` to revert back to the old miscellaneous files experience.
 
-We also have a second, finer-grained opt-out flag `dotnet.projects.enableFileBasedProgramsWhenAmbiguous`. This flag is conditional on the previous flag (i.e. it is ignored when `enableFileBasedPrograms` is `false`). This is used to allow opting out only in cases where it is unclear from the single file itself, whether it should be treated as a file-based program. Presence of `#:` or `#!` directives in a `.cs` file strongly indicates that the file is a file-based program, and editor functionality will continue to light up for such files, even when `enableFileBasedProgramsWhenAmbiguous` is `false`.
+We also have a second, finer-grained opt-out flag `dotnet.projects.enableFileBasedProgramsWhenAmbiguous`. This flag is conditional on the previous flag (i.e. it is ignored when `enableFileBasedPrograms` is `false`). This is used to allow opting out only in cases where it is unclear from the single file itself, whether it should be treated as a file-based app. Presence of `#:` or `#!` directives in a `.cs` file strongly indicates that the file is a file-based app, and editor functionality will continue to light up for such files, even when `enableFileBasedProgramsWhenAmbiguous` is `false`.
 
 > [!NOTE]
-> The second flag is being used on a short-term basis while we work out the set of heuristics and cross-component APIs needed to efficiently and satisfactorily resolve whether a file with top-level statements but no directives is a file-based program in the context of a complex workspace.
+> The second flag is being used on a short-term basis while we work out the set of heuristics and cross-component APIs needed to efficiently and satisfactorily resolve whether a file with top-level statements but no directives is a file-based app in the context of a complex workspace.
 
 ## LSP handling of file-based apps
 
@@ -164,11 +164,11 @@ We expect the appropriate project system(s) to be able to observe either of the 
 
 ### `FileBasedProgramsProjectSystem`
 
-Manages projects for file-based programs and miscellaneous files.
+Manages projects for file-based apps and miscellaneous files.
 
 This project system effectively performs the classification process described in [File-based app detection](#file-based-app-detection) when a design-time build is performed for the project, and transitions the state of the project to match the latest classification.
 
-This uses the file-based program entry point file, translates it to a virtual MSBuild project, then runs a design-time build on that project. If it detects missing assets, it may also restore the virtual project.
+This uses the file-based app entry point file, translates it to a virtual MSBuild project, then runs a design-time build on that project. If it detects missing assets, it may also restore the virtual project.
 
 It uses file watchers to watch the project globs and redo the design-time build on relevant changes, such as changes to `#:` directives.
 

--- a/docs/features/file-based-programs-vscode.md
+++ b/docs/features/file-based-programs-vscode.md
@@ -149,7 +149,7 @@ We are adding support for an `#:include` directive to file-based apps, which let
 
 Because all these projects are simply added as projects to the host workspace, it's expected that features like "active project context" and multi-targeting-aware Quick Info "just work" with all of them.
 
-One key assumption we are making is: it is not valid for a file-based app *entry point* to be a member of an ordinary project. e.g. you cannot have the following:
+One key assumption we are making is: it is not valid for a file-based app *entry point* to be a member of an ordinary project. For example, you cannot have the following:
 - `Util.cs` (an ordinary source file)
 - `App1.cs`, a file-based app entry point containing `#:include Util.cs`
 - `MyProject.csproj`, containing `<Compile Include="App1.cs" />` **<-- This part is considered malformed**

--- a/docs/features/file-based-programs-vscode.md
+++ b/docs/features/file-based-programs-vscode.md
@@ -94,7 +94,7 @@ This is the decision tree for determining how to classify a C# file:
    - **Yes** → Continue to next check
 
 4. **Does the file have an absolute path and exist on disk?** (i.e. it is not a "virtual document" created for a new, not-yet-saved file, or similar.)
-   - **No** → Classify as **Classify as Miscellaneous File With Standard References**
+   - **No** → Classify as **Miscellaneous File With Standard References**
    - **Yes** → Continue to next check
 
 5. **Does the file have `#!` directives?**


### PR DESCRIPTION
- Use "file-based app" instead of "file-based program", with top-of-file mention of synonymity
- Link related work items for each section
- Change "shebang at start" from future to past tense because the work has been done :)
- Notable updates on future considerations of "Treating files with no directives as file-based app entry points" based on discussion
- Misc changes to reduce verbosity, improve clarity, etc.