### PR TITLE
Restore F7 navigation to Razor files

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/ViewCodeCommandHandler.cs
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/ViewCodeCommandHandler.cs
@@ -107,7 +107,8 @@ internal sealed partial class ViewCodeCommandHandler(
 
     private bool TryGetRazorFilePath(string filePath, [NotNullWhen(true)] out string? razorFilePath)
     {
-        if (!filePath.EndsWith(RazorLSPConstants.CSharpFileExtension, StringComparison.OrdinalIgnoreCase))
+        if (!filePath.EndsWith(RazorLSPConstants.RazorFileExtension + RazorLSPConstants.CSharpFileExtension, StringComparison.OrdinalIgnoreCase) &&
+            !filePath.EndsWith(RazorLSPConstants.CSHTMLFileExtension + RazorLSPConstants.CSharpFileExtension, StringComparison.OrdinalIgnoreCase))
         {
             razorFilePath = null;
             return false;

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/ViewCodeCommandHandler.cs
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/ViewCodeCommandHandler.cs
@@ -45,12 +45,12 @@ internal sealed partial class ViewCodeCommandHandler(
 
     public CommandState GetCommandState(ViewCodeCommandArgs args)
     {
-        if (TryGetTargetFilePath(args.SubjectBuffer, out _, out var isVisible))
+        if (TryGetTargetFilePath(args.SubjectBuffer, out _, out var isRazorFile))
         {
-            return isVisible ? s_availableCommandState : s_hiddenAvailableCommandState;
+            return isRazorFile ? s_availableCommandState : s_hiddenAvailableCommandState;
         }
 
-        return CommandState.Unavailable;
+        return isRazorFile ? CommandState.Unavailable : CommandState.Unspecified;
     }
 
     public bool ExecuteCommand(ViewCodeCommandArgs args, CommandExecutionContext executionContext)
@@ -67,25 +67,26 @@ internal sealed partial class ViewCodeCommandHandler(
     private bool TryGetTargetFilePath(
         ITextBuffer buffer,
         [NotNullWhen(true)] out string? targetFilePath,
-        out bool isVisible)
+        out bool isRazorFile)
     {
         // Command state checks and execution should always happen on the main thread.
         // However, if that changes, we should assert because our FileExistsHelper will likely be corrupted.
         _joinableTaskContext.AssertUIThread();
 
+        isRazorFile = false;
         if (_textDocumentFactoryService.TryGetTextDocument(buffer, out var document) &&
             document?.FilePath is string filePath)
         {
-            if (TryGetCSharpFilePath(filePath, out targetFilePath) ||
-                TryGetRazorFilePath(filePath, out targetFilePath))
+            isRazorFile = FileUtilities.IsAnyRazorFilePath(filePath, StringComparison.OrdinalIgnoreCase);
+            if (isRazorFile
+                ? TryGetCSharpFilePath(filePath, out targetFilePath)
+                : TryGetRazorFilePath(filePath, out targetFilePath))
             {
-                isVisible = FileUtilities.IsAnyRazorFilePath(filePath, StringComparison.OrdinalIgnoreCase);
                 return true;
             }
         }
 
         targetFilePath = null;
-        isVisible = false;
         return false;
     }
 

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/ViewCodeCommandHandler.cs
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/ViewCodeCommandHandler.cs
@@ -21,6 +21,7 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient;
 [Name(nameof(ViewCodeCommandHandler))]
 [Export(typeof(ICommandHandler))]
 [ContentType(RazorConstants.RazorLSPContentTypeName)]
+[ContentType(RazorLSPConstants.CSharpContentTypeName)]
 [method: ImportingConstructor]
 internal sealed partial class ViewCodeCommandHandler(
     [Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider,
@@ -28,6 +29,11 @@ internal sealed partial class ViewCodeCommandHandler(
     JoinableTaskContext joinableTaskContext) : ICommandHandler<ViewCodeCommandArgs>
 {
     private static readonly CommandState s_availableCommandState = new(isAvailable: true, displayText: SR.View_Code);
+    private static readonly CommandState s_hiddenAvailableCommandState = new(
+        isAvailable: true,
+        isChecked: false,
+        isEnabled: true,
+        isVisible: false);
 
     private readonly IServiceProvider _serviceProvider = serviceProvider;
     private readonly ITextDocumentFactoryService _textDocumentFactoryService = textDocumentFactoryService;
@@ -39,9 +45,9 @@ internal sealed partial class ViewCodeCommandHandler(
 
     public CommandState GetCommandState(ViewCodeCommandArgs args)
     {
-        if (TryGetCSharpFilePath(args.SubjectBuffer, out _))
+        if (TryGetTargetFilePath(args.SubjectBuffer, out _, out var isVisible))
         {
-            return s_availableCommandState;
+            return isVisible ? s_availableCommandState : s_hiddenAvailableCommandState;
         }
 
         return CommandState.Unavailable;
@@ -49,25 +55,44 @@ internal sealed partial class ViewCodeCommandHandler(
 
     public bool ExecuteCommand(ViewCodeCommandArgs args, CommandExecutionContext executionContext)
     {
-        if (TryGetCSharpFilePath(args.SubjectBuffer, out var csharpFilePath))
+        if (TryGetTargetFilePath(args.SubjectBuffer, out var targetFilePath, out _))
         {
-            VsShellUtilities.OpenDocument(_serviceProvider, csharpFilePath);
+            VsShellUtilities.OpenDocument(_serviceProvider, targetFilePath);
             return true;
         }
 
         return false;
     }
 
-    private bool TryGetCSharpFilePath(ITextBuffer buffer, [NotNullWhen(true)] out string? codeFilePath)
+    private bool TryGetTargetFilePath(
+        ITextBuffer buffer,
+        [NotNullWhen(true)] out string? targetFilePath,
+        out bool isVisible)
     {
         // Command state checks and execution should always happen on the main thread.
         // However, if that changes, we should assert because our FileExistsHelper will likely be corrupted.
         _joinableTaskContext.AssertUIThread();
 
+        if (_textDocumentFactoryService.TryGetTextDocument(buffer, out var document) &&
+            document?.FilePath is string filePath)
+        {
+            if (TryGetCSharpFilePath(filePath, out targetFilePath) ||
+                TryGetRazorFilePath(filePath, out targetFilePath))
+            {
+                isVisible = FileUtilities.IsAnyRazorFilePath(filePath, StringComparison.OrdinalIgnoreCase);
+                return true;
+            }
+        }
+
+        targetFilePath = null;
+        isVisible = false;
+        return false;
+    }
+
+    private bool TryGetCSharpFilePath(string filePath, [NotNullWhen(true)] out string? codeFilePath)
+    {
         // Exclude imports files — they don't have nested code files.
-        if (_textDocumentFactoryService.TryGetTextDocument(buffer, out var document)
-            && document?.FilePath is string filePath
-            && FileUtilities.IsAnyRazorFilePath(filePath, StringComparison.OrdinalIgnoreCase)
+        if (FileUtilities.IsAnyRazorFilePath(filePath, StringComparison.OrdinalIgnoreCase)
             && Path.GetFileName(filePath) is string fileName
             && !string.Equals(fileName, ComponentHelpers.ImportsFileName, StringComparison.OrdinalIgnoreCase)
             && !string.Equals(fileName, MvcImportProjectFeature.ImportsFileName, StringComparison.OrdinalIgnoreCase))
@@ -77,6 +102,25 @@ internal sealed partial class ViewCodeCommandHandler(
         }
 
         codeFilePath = null;
+        return false;
+    }
+
+    private bool TryGetRazorFilePath(string filePath, [NotNullWhen(true)] out string? razorFilePath)
+    {
+        if (!filePath.EndsWith(RazorLSPConstants.CSharpFileExtension, StringComparison.OrdinalIgnoreCase))
+        {
+            razorFilePath = null;
+            return false;
+        }
+
+        razorFilePath = filePath[..^RazorLSPConstants.CSharpFileExtension.Length];
+        if (FileUtilities.IsAnyRazorFilePath(razorFilePath, StringComparison.OrdinalIgnoreCase) &&
+            _helper.FileExists(razorFilePath))
+        {
+            return true;
+        }
+
+        razorFilePath = null;
         return false;
     }
 }

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/LanguageClient/ViewCodeCommandHandlerTests.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/LanguageClient/ViewCodeCommandHandlerTests.cs
@@ -66,7 +66,7 @@ public class ViewCodeCommandHandlerTests(ITestOutputHelper testOutput) : Tooling
     }
 
     [UIFact]
-    public void NonRazorFile_NotAvailable()
+    public void NonRazorFile_Unspecified()
     {
         using var _ = CreateTestFiles("test.daveswebframework", out var razorFilePath);
 
@@ -74,7 +74,7 @@ public class ViewCodeCommandHandlerTests(ITestOutputHelper testOutput) : Tooling
 
         var result = handler.GetCommandState(args);
 
-        Assert.False(result.IsAvailable);
+        Assert.True(result.IsUnspecified);
     }
 
     [UIFact]
@@ -87,6 +87,7 @@ public class ViewCodeCommandHandlerTests(ITestOutputHelper testOutput) : Tooling
         var result = handler.GetCommandState(args);
 
         Assert.False(result.IsAvailable);
+        Assert.False(result.IsUnspecified);
     }
 
     [UIFact]
@@ -99,6 +100,7 @@ public class ViewCodeCommandHandlerTests(ITestOutputHelper testOutput) : Tooling
         var result = handler.GetCommandState(args);
 
         Assert.False(result.IsAvailable);
+        Assert.False(result.IsUnspecified);
     }
 
     [UIFact]
@@ -111,6 +113,7 @@ public class ViewCodeCommandHandlerTests(ITestOutputHelper testOutput) : Tooling
         var result = handler.GetCommandState(args);
 
         Assert.False(result.IsAvailable);
+        Assert.False(result.IsUnspecified);
     }
 
     [UIFact]
@@ -142,7 +145,7 @@ public class ViewCodeCommandHandlerTests(ITestOutputHelper testOutput) : Tooling
     }
 
     [UIFact]
-    public void RazorCodeBehindFile_NoRazorFile_NotAvailable()
+    public void RazorCodeBehindFile_NoRazorFile_Unspecified()
     {
         using var files = new TempFileCollection();
         var razorFilePath = Path.Combine(files.TempDir, "test.razor");
@@ -154,11 +157,11 @@ public class ViewCodeCommandHandlerTests(ITestOutputHelper testOutput) : Tooling
 
         var result = handler.GetCommandState(args);
 
-        Assert.False(result.IsAvailable);
+        Assert.True(result.IsUnspecified);
     }
 
     [UIFact]
-    public void CSharpFile_NotAvailable()
+    public void CSharpFile_Unspecified()
     {
         using var files = new TempFileCollection();
         var csharpFilePath = Path.Combine(files.TempDir, "test.cs");
@@ -169,7 +172,7 @@ public class ViewCodeCommandHandlerTests(ITestOutputHelper testOutput) : Tooling
 
         var result = handler.GetCommandState(args);
 
-        Assert.False(result.IsAvailable);
+        Assert.True(result.IsUnspecified);
     }
 
     private (ViewCodeCommandHandler, ViewCodeCommandArgs) CreateHandlerAndArgs(string filePath)

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/LanguageClient/ViewCodeCommandHandlerTests.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/LanguageClient/ViewCodeCommandHandlerTests.cs
@@ -25,6 +25,8 @@ public class ViewCodeCommandHandlerTests(ITestOutputHelper testOutput) : Tooling
         var result = handler.GetCommandState(args);
 
         Assert.True(result.IsAvailable);
+        Assert.True(result.IsEnabled);
+        Assert.True(result.IsVisible);
     }
 
     [UIFact]
@@ -37,6 +39,8 @@ public class ViewCodeCommandHandlerTests(ITestOutputHelper testOutput) : Tooling
         var result = handler.GetCommandState(args);
 
         Assert.True(result.IsAvailable);
+        Assert.True(result.IsEnabled);
+        Assert.True(result.IsVisible);
     }
 
     [UIFact]
@@ -49,6 +53,8 @@ public class ViewCodeCommandHandlerTests(ITestOutputHelper testOutput) : Tooling
         var result = handler.GetCommandState(args);
 
         Assert.True(result.IsAvailable);
+        Assert.True(result.IsEnabled);
+        Assert.True(result.IsVisible);
 
         files.Delete();
 
@@ -105,11 +111,70 @@ public class ViewCodeCommandHandlerTests(ITestOutputHelper testOutput) : Tooling
         Assert.False(result.IsAvailable);
     }
 
-    private (ViewCodeCommandHandler, ViewCodeCommandArgs) CreateHandlerAndArgs(string razorFilePath)
+    [UIFact]
+    public void RazorCodeBehindFile_Available()
+    {
+        using var _ = CreateTestFiles("test.razor", out var razorFilePath);
+
+        var (handler, args) = CreateHandlerAndArgs(razorFilePath + ".cs");
+
+        var result = handler.GetCommandState(args);
+
+        Assert.True(result.IsAvailable);
+        Assert.True(result.IsEnabled);
+        Assert.False(result.IsVisible);
+    }
+
+    [UIFact]
+    public void CsHtmlCodeBehindFile_Available()
+    {
+        using var _ = CreateTestFiles("test.cshtml", out var razorFilePath);
+
+        var (handler, args) = CreateHandlerAndArgs(razorFilePath + ".cs");
+
+        var result = handler.GetCommandState(args);
+
+        Assert.True(result.IsAvailable);
+        Assert.True(result.IsEnabled);
+        Assert.False(result.IsVisible);
+    }
+
+    [UIFact]
+    public void RazorCodeBehindFile_NoRazorFile_NotAvailable()
+    {
+        using var files = new TempFileCollection();
+        var razorFilePath = Path.Combine(files.TempDir, "test.razor");
+        var csharpFilePath = razorFilePath + ".cs";
+        File.WriteAllText(csharpFilePath, "");
+        files.AddFile(csharpFilePath, false);
+
+        var (handler, args) = CreateHandlerAndArgs(csharpFilePath);
+
+        var result = handler.GetCommandState(args);
+
+        Assert.False(result.IsAvailable);
+    }
+
+    [UIFact]
+    public void CSharpFile_NotAvailable()
+    {
+        using var files = new TempFileCollection();
+        var csharpFilePath = Path.Combine(files.TempDir, "test.cs");
+        File.WriteAllText(csharpFilePath, "");
+        files.AddFile(csharpFilePath, false);
+
+        var (handler, args) = CreateHandlerAndArgs(csharpFilePath);
+
+        var result = handler.GetCommandState(args);
+
+        Assert.False(result.IsAvailable);
+    }
+
+    private (ViewCodeCommandHandler, ViewCodeCommandArgs) CreateHandlerAndArgs(string filePath)
     {
         var textBuffer = StrictMock.Of<ITextBuffer>();
         var textDocument = StrictMock.Of<ITextDocument>(doc
-            => doc.FilePath == razorFilePath);
+            => doc.FilePath == filePath);
         var textDocumentFactory = StrictMock.Of<ITextDocumentFactoryService>(factory =>
             factory.TryGetTextDocument(textBuffer, out textDocument) == true);
 
@@ -129,10 +194,12 @@ public class ViewCodeCommandHandlerTests(ITestOutputHelper testOutput) : Tooling
         razorFilePath = Path.Combine(files.TempDir, razorFileName);
         var csharpFilePath = razorFilePath + ".cs";
 
-        // Create our temp file
+        // Create our temp files
+        File.WriteAllText(razorFilePath, "");
         File.WriteAllText(csharpFilePath, "");
 
-        // Add it to the list so it gets cleaned up
+        // Add them to the list so they get cleaned up
+        files.AddFile(razorFilePath, false);
         files.AddFile(csharpFilePath, false);
 
         return files;

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/LanguageClient/ViewCodeCommandHandlerTests.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/LanguageClient/ViewCodeCommandHandlerTests.cs
@@ -59,6 +59,8 @@ public class ViewCodeCommandHandlerTests(ITestOutputHelper testOutput) : Tooling
         files.Delete();
 
         // Even though the file doesn't exist now, we should still be available because the result is cached
+        result = handler.GetCommandState(args);
+
         Assert.True(result.IsAvailable);
         Assert.False(File.Exists(razorFilePath + ".cs"), "The premise of this test is bad and it should feel bad");
     }


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/3019050

## Summary
- export the Razor View Code command handler for C# code-behind buffers
- restore F7 navigation from `.razor.cs` and `.cshtml.cs` files to their existing Razor files
- keep reverse navigation available and enabled but hidden so the existing **View Page** context-menu item is not duplicated
- preserve visible Razor-to-code navigation and pass through unrelated C# files

## Test plan
- `dotnet build src\Razor\src\Razor\src\Microsoft.VisualStudio.LanguageServices.Razor\Microsoft.VisualStudio.LanguageServices.Razor.csproj --no-restore -v:q`
- `dotnet test src\Razor\src\Razor\test\Microsoft.VisualStudio.LanguageServices.Razor.UnitTests\Microsoft.VisualStudio.LanguageServices.Razor.UnitTests.csproj --filter "FullyQualifiedName~ViewCodeCommandHandlerTests" --no-restore -v:q`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84496)