### PR TITLE
Migrate PR validation azure-public feed auth from PAT to WIF service connection

### DIFF
--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -213,9 +213,16 @@ extends:
             versionSpec: '4.9.2'
 
         # Authenticate with service connections to be able to publish packages to external nuget feeds.
+        # Authenticate to azure-public/vs-impl feed via WIF service connection
         - task: NuGetAuthenticate@1
           inputs:
-            nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk
+            azureDevOpsServiceConnection: dnceng-azure-public-vs-impl-push
+            feedUrl: https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json
+        # Authenticate to azure-public/vssdk feed via WIF service connection
+        - task: NuGetAuthenticate@1
+          inputs:
+            azureDevOpsServiceConnection: dnceng-azure-public-vs-impl-push
+            feedUrl: https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json
 
         # Needed because the build fails the NuGet Tools restore without it
         - task: UseDotNet@2


### PR DESCRIPTION
## Summary
Migrates the remaining PAT-backed NuGet auth in `azure-pipelines-pr-validation.yml` to the WIF-backed `dnceng-azure-public-vs-impl-push` service connection.

The official pipeline was already migrated in #84457, but the PR validation pipeline still used the legacy `nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk` form, which depends on the old PAT-backed service connections. This change switches it to per-feed `azureDevOpsServiceConnection` + `feedUrl`, matching official.

## Why
Part of the .NET Eng Services PAT-to-Entra migration (dnceng WI 10128 / 10129). This unblocks deletion of the old PAT-backed `azure-public/vssdk` and `azure-public/vs-impl` service connections.

The same service principal behind `dnceng-azure-public-vs-impl-push` has Contributor access to both the `vs-impl` and `vssdk` feeds, validated in [build 3018818](https://dev.azure.com/dnceng/internal/_build/results?buildId=3018818).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84501)