### PR TITLE
Allow try/catch/finally blocks to collapse independently

### DIFF
--- a/src/EditorFeatures/CSharpTest/Structure/BlockSyntaxStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/BlockSyntaxStructureTests.cs
@@ -26,12 +26,69 @@ public sealed class BlockSyntaxStructureTests : AbstractCSharpSyntaxNodeStructur
                     {
                         {|hint:try{|textspan:
                         {$$
-                        }
+                        }|}|}
                         catch 
                         {
                         }
                         finally
                         {
+                        }
+                    }
+                }
+                """,
+            Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
+
+    [Fact]
+    public Task TestCatchClause1()
+        => VerifyBlockSpansAsync("""
+                class C
+                {
+                    void M()
+                    {
+                        try
+                        {
+                        }
+                        {|hint:catch{|textspan:
+                        {$$
+                        }|}|}
+                        finally
+                        {
+                        }
+                    }
+                }
+                """,
+            Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
+
+    [Fact]
+    public Task TestCatchClause2()
+        => VerifyBlockSpansAsync("""
+                class C
+                {
+                    void M()
+                    {
+                        try
+                        {
+                        }
+                        {|hint:catch (System.Exception e){|textspan:
+                        {$$
+                        }|}|}
+                    }
+                }
+                """,
+            Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
+
+    [Fact]
+    public Task TestFinallyClause1()
+        => VerifyBlockSpansAsync("""
+                class C
+                {
+                    void M()
+                    {
+                        try
+                        {
+                        }
+                        {|hint:finally{|textspan:
+                        {$$
                         }|}|}
                     }
                 }

--- a/src/Features/CSharp/Portable/Structure/Providers/BlockSyntaxStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/BlockSyntaxStructureProvider.cs
@@ -88,7 +88,8 @@ internal sealed class BlockSyntaxStructureProvider : AbstractSyntaxNodeStructure
                 subHeadings.ToImmutableAndClear(),
                 autoCollapse: false));
         }
-        else if (parentKind == SyntaxKind.ElseClause || IsNonBlockStatement(parent))
+        else if (parentKind is SyntaxKind.ElseClause or SyntaxKind.CatchClause or SyntaxKind.FinallyClause ||
+                 IsNonBlockStatement(parent))
         {
             var autoCollapse = false;
 
@@ -177,12 +178,14 @@ internal sealed class BlockSyntaxStructureProvider : AbstractSyntaxNodeStructure
 
     private static int GetEnd(BlockSyntax node)
     {
-        if (node.Parent.IsKind(SyntaxKind.IfStatement))
+        if (node.Parent.IsKind(SyntaxKind.IfStatement) || node.Parent.IsKind(SyntaxKind.TryStatement))
         {
-            // For an if-statement, just collapse up to the end of the block.
-            // We don't want collapse the whole statement just for the 'true'
-            // portion.  Also, while outlining might be ok, the Indent-Guide
-            // would look very strange for nodes like:
+            // For an if-statement or try-statement, just collapse up to the end of the block.
+            // We don't want collapse the whole statement just for the 'true' portion (of an
+            // 'if'), or just the 'try' portion (of a 'try/catch/finally'). Each attached
+            // clause (else/catch/finally) gets its own collapsible region instead.
+            // Also, while outlining might be ok, the Indent-Guide would look very strange for nodes
+            // like:
             //
             //      if (goo)
             //      {

--- a/src/Features/CSharp/Portable/Structure/Providers/BlockSyntaxStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/BlockSyntaxStructureProvider.cs
@@ -181,7 +181,7 @@ internal sealed class BlockSyntaxStructureProvider : AbstractSyntaxNodeStructure
         if (node.Parent.IsKind(SyntaxKind.IfStatement) || node.Parent.IsKind(SyntaxKind.TryStatement))
         {
             // For an if-statement or try-statement, just collapse up to the end of the block.
-            // We don't want collapse the whole statement just for the 'true' portion (of an
+            // We don't want to collapse the whole statement just for the 'true' portion (of an
             // 'if'), or just the 'try' portion (of a 'try/catch/finally'). Each attached
             // clause (else/catch/finally) gets its own collapsible region instead.
             // Also, while outlining might be ok, the Indent-Guide would look very strange for nodes


### PR DESCRIPTION
Fixes #84451

In the C# editor, collapsing an `if`/`else if`/`else` chain lets you collapse each part independently. A `try`/`catch`/`finally` behaved differently: collapsing the `try` block collapsed the entire construct and the catch/finally blocks could not be collapsed on their own.

Fix:
`GetEnd` now returns the block's own end for `try` as well as `if`, so collapsing `try` covers only the try body. Added `CatchClause` and `FinallyClause` to the standalone-span branch, giving each `catch` and `finally` its own collapse region.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84507)