### PR TITLE
Reuse our fault reporting code from Visual Studio

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/TelemetryReporterTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/TelemetryReporterTests.cs
@@ -44,14 +44,6 @@ public sealed class TelemetryReporterTests(ITestOutputHelper testOutputHelper) :
     }
 
     [Fact]
-    public async Task TestFault()
-    {
-        await using var testServer = await CreateLanguageServerAsync();
-        var service = await CreateReporterAsync(testServer);
-        service.ReportFault(GetEventName(nameof(TestFault)), "test description", logLevel: 2, forceDump: false, processId: 0, new Exception());
-    }
-
-    [Fact]
     public async Task TestBlockLogging()
     {
         await using var testServer = await CreateLanguageServerAsync();

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Contracts/ITelemetryReporter.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Contracts/ITelemetryReporter.cs
@@ -10,5 +10,4 @@ internal interface ITelemetryReporter : IDisposable
     void Log(string name, List<KeyValuePair<string, object?>> properties);
     void LogBlockStart(string eventName, int kind, int blockId);
     void LogBlockEnd(int blockId, List<KeyValuePair<string, object?>> properties, CancellationToken cancellationToken);
-    void ReportFault(string eventName, string description, int logLevel, bool forceDump, int processId, Exception exception);
 }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Logging/RoslynLogger.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Logging/RoslynLogger.cs
@@ -31,10 +31,6 @@ internal sealed class RoslynLogger : ILogger
     {
         Contract.ThrowIfTrue(_instance is not null);
 
-        FatalError.ErrorReporterHandler handler = ReportFault;
-        FatalError.SetHandlers(handler, nonFatalHandler: handler);
-        FatalError.CopyHandlersTo(typeof(Compilation).Assembly);
-
         if (reporter is not null && telemetryLevel is not null)
         {
             reporter.InitializeSession(telemetryLevel, sessionId, isDefaultSession: true);
@@ -51,45 +47,6 @@ internal sealed class RoslynLogger : ILogger
         else
         {
             Logger.SetLogger(AggregateLogger.Create(currentLogger, _instance));
-        }
-    }
-
-    private static void ReportFault(Exception exception, ErrorSeverity severity, bool forceDump)
-    {
-        try
-        {
-            if (exception is OperationCanceledException { InnerException: { } oceInnerException })
-            {
-                ReportFault(oceInnerException, severity, forceDump);
-                return;
-            }
-
-            if (exception is AggregateException aggregateException)
-            {
-                // We (potentially) have multiple exceptions; let's just report each of them
-                foreach (var innerException in aggregateException.Flatten().InnerExceptions)
-                    ReportFault(innerException, severity, forceDump);
-
-                return;
-            }
-
-            // Copy locally, as otherwise if we report a fault during shutdown we might also null reference (and then fatally crash the process)
-            var telemetryReporter = _telemetryReporter;
-            if (telemetryReporter is not null)
-            {
-                var eventName = GetEventName(FunctionId.NonFatalWatson);
-                var description = GetDescription(exception);
-                var currentProcess = Process.GetCurrentProcess();
-                telemetryReporter.ReportFault(eventName, description, (int)severity, forceDump, currentProcess.Id, exception);
-            }
-        }
-        catch (OutOfMemoryException)
-        {
-            FailFast.OnFatalException(exception);
-        }
-        catch (Exception e)
-        {
-            FailFast.OnFatalException(e);
         }
     }
 
@@ -175,47 +132,6 @@ internal sealed class RoslynLogger : ILogger
     private static bool IgnoreReporting(LogMessage logMessage)
         => _telemetryReporter is null ||
            logMessage.LogLevel < LogLevel.Information;
-
-    private static string GetDescription(Exception exception)
-    {
-        const string CodeAnalysisNamespace = nameof(Microsoft) + "." + nameof(CodeAnalysis);
-
-        // Be resilient to failing here.  If we can't get a suitable name, just fall back to the standard name we
-        // used to report.
-        try
-        {
-            // walk up the stack looking for the first call from a type that isn't in the ErrorReporting namespace.
-            var frames = new StackTrace(exception).GetFrames();
-
-            // On the .NET Framework, GetFrames() can return null even though it's not documented as such.
-            // At least one case here is if the exception's stack trace itself is null.
-            if (frames != null)
-            {
-                foreach (var frame in frames)
-                {
-                    var method = frame?.GetMethod();
-                    var methodName = method?.Name;
-                    if (methodName == null)
-                        continue;
-
-                    var declaringTypeName = method?.DeclaringType?.FullName;
-                    if (declaringTypeName == null)
-                        continue;
-
-                    if (!declaringTypeName.StartsWith(CodeAnalysisNamespace))
-                        continue;
-
-                    return declaringTypeName + "." + methodName;
-                }
-            }
-        }
-        catch
-        {
-        }
-
-        // If we couldn't get a stack, do this
-        return exception.Message;
-    }
 
     private const string EventPrefix = "vs/ide/vbcs/";
     private const string PropertyPrefix = "vs.ide.vbcs.";

--- a/src/VisualStudio/Core/Def/Watson/FaultReporter.cs
+++ b/src/VisualStudio/Core/Def/Watson/FaultReporter.cs
@@ -38,6 +38,8 @@ internal static class FaultReporter
         FatalError.CopyHandlersTo(typeof(Compilation).Assembly);
     }
 
+    public static bool IncludeServiceHubLogFiles = true;
+
     private static FaultSeverity ConvertSeverity(ErrorSeverity severity)
     {
         return severity switch
@@ -166,15 +168,17 @@ internal static class FaultReporter
 
                     if (faultUtility is FaultEvent { IsIncludedInWatsonSample: true })
                     {
-                        // add ServiceHub log files:
-                        foreach (var path in CollectServiceHubLogFilePaths())
+                        if (IncludeServiceHubLogFiles)
                         {
-                            faultUtility.AddFile(path);
-                        }
+                            foreach (var path in CollectServiceHubLogFilePaths())
+                            {
+                                faultUtility.AddFile(path);
+                            }
 
-                        foreach (var loghubPath in CollectLogHubFilePaths())
-                        {
-                            faultUtility.AddFile(loghubPath);
+                            foreach (var loghubPath in CollectLogHubFilePaths())
+                            {
+                                faultUtility.AddFile(loghubPath);
+                            }
                         }
                     }
 

--- a/src/VisualStudio/DevKit/Impl/Logging/VSCodeTelemetryLogger.cs
+++ b/src/VisualStudio/DevKit/Impl/Logging/VSCodeTelemetryLogger.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.Text;
 using System.Threading;
 using Microsoft.CodeAnalysis.Contracts.Telemetry;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Telemetry;
 using Microsoft.Extensions.Logging;
@@ -23,7 +24,6 @@ internal sealed class VSCodeTelemetryLogger : ITelemetryReporter
     private TelemetrySession? _telemetrySession;
 
     private const string CollectorApiKey = "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255";
-    private static int _dumpsSubmitted = 0;
 
     private readonly ILogger _logger;
 
@@ -56,6 +56,10 @@ internal sealed class VSCodeTelemetryLogger : ITelemetryReporter
         _telemetrySession = session;
 
         TelemetryLogger.Create(_telemetrySession, logDelta: false);
+
+        FaultReporter.InitializeFatalErrorHandlers();
+        FaultReporter.IncludeServiceHubLogFiles = false;
+        FaultReporter.RegisterTelemetrySesssion(_telemetrySession);
     }
 
     public void Log(string name, List<KeyValuePair<string, object?>> properties)
@@ -103,42 +107,6 @@ internal sealed class VSCodeTelemetryLogger : ITelemetryReporter
             userTask.End(result);
         else
             throw new InvalidCastException($"Unexpected value for scope: {scope}");
-    }
-
-    public void ReportFault(string eventName, string description, int logLevel, bool forceDump, int processId, Exception exception)
-    {
-        if (_telemetrySession is null)
-        {
-            return;
-        }
-
-        var faultEvent = new FaultEvent(
-            eventName: eventName,
-            description: description,
-            (FaultSeverity)logLevel,
-            exceptionObject: exception,
-            gatherEventDetails: faultUtility =>
-            {
-                if (forceDump)
-                {
-                    // Let's just send a maximum of three; number chosen arbitrarily
-                    if (Interlocked.Increment(ref _dumpsSubmitted) <= 3)
-                        faultUtility.AddProcessDump(processId);
-                }
-
-                if (faultUtility is FaultEvent { IsIncludedInWatsonSample: true })
-                {
-                    // if needed, add any extra logs here
-                }
-
-                // Returning "0" signals that, if sampled, we should send data to Watson. 
-                // Any other value will cancel the Watson report. We never want to trigger a process dump manually, 
-                // we'll let TargetedNotifications determine if a dump should be collected.
-                // See https://aka.ms/roslynnfwdocs for more details
-                return 0;
-            });
-
-        _telemetrySession.PostEvent(faultEvent);
     }
 
     public void Dispose()

--- a/src/VisualStudio/DevKit/Impl/Microsoft.VisualStudio.LanguageServices.DevKit.csproj
+++ b/src/VisualStudio/DevKit/Impl/Microsoft.VisualStudio.LanguageServices.DevKit.csproj
@@ -24,6 +24,7 @@
     <Compile Include="..\..\..\Workspaces\Remote\ServiceHub\Services\EditAndContinue\HotReloadLoggerProxy.cs" Link="EditAndContinue\HotReloadLoggerProxy.cs" />
     <Compile Include="..\..\..\VisualStudio\Core\Def\Telemetry\Shared\*.cs" LinkBase="Logging" />
     <Compile Include="..\..\..\VisualStudio\Core\Def\PdbSourceDocument\AbstractSourceLinkService.cs" />
+    <Compile Include="..\..\Core\Def\Watson\FaultReporter.cs" Link="Logging\FaultReporter.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We copied/pasted the code into DevKit for reporting faults, but we then went and improved the Visual Studio version to better immunize frames, and that enhancement never made it to the DevKit side. This deletes the DevKit code and unifies it.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84509)