### PR TITLE
Add project and state unloading to the BuildHost 

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
@@ -119,7 +119,7 @@ internal sealed class LanguageServerProjectSystem : LanguageServerProjectLoader,
         var preferredBuildHostKind = BuildHostProcessManager.GetKindForProject(projectPath);
         var (buildHost, actualBuildHostKind) = await buildHostProcessManager.GetBuildHostWithFallbackAsync(preferredBuildHostKind, projectPath, cancellationToken);
 
-        var loadedFile = await buildHost.LoadProjectFileAsync(projectPath, languageName, cancellationToken);
+        await using var loadedFile = await buildHost.LoadProjectFileAsync(projectPath, languageName, cancellationToken);
         return new RemoteProjectLoadResult
         {
             ProjectFileInfos = await loadedFile.GetProjectFileInfosAsync(cancellationToken),

--- a/src/Workspaces/MSBuild/BuildHost/AbstractBuildHost.cs
+++ b/src/Workspaces/MSBuild/BuildHost/AbstractBuildHost.cs
@@ -188,7 +188,7 @@ internal abstract class AbstractBuildHost :
     private int AddProjectFileTarget(Build.Evaluation.Project? project, string languageName, DiagnosticLog log)
     {
         Contract.ThrowIfNull(_buildManager);
-        return _server.AddTarget(new ProjectFile(languageName, project, _buildManager, log));
+        return _server.AddTarget(new ProjectFile(languageName, project, _buildManager, _server, log));
     }
 
     public Task<string?> TryGetProjectOutputPathAsync(string projectFilePath, CancellationToken cancellationToken)

--- a/src/Workspaces/MSBuild/BuildHost/Build/ProjectBuildManager.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Build/ProjectBuildManager.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
+using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Roslyn.Utilities;
 using MSB = Microsoft.Build;
@@ -59,10 +60,22 @@ internal sealed class ProjectBuildManager : IDisposable
     public string[] KnownCommandLineParserLanguages { get; }
 
     private readonly MSB.Evaluation.ProjectCollection _projectCollection;
-    private readonly MSBuildDiagnosticLogger _buildLogger = new()
-    {
-        Verbosity = MSB.Framework.LoggerVerbosity.Normal
-    };
+    private readonly MSBuildDiagnosticLogger _buildLogger = new() { Verbosity = MSB.Framework.LoggerVerbosity.Normal };
+    private readonly MSB.Execution.BuildParameters _buildParameters;
+
+    /// <summary>
+    /// An object used as a monitor to guard <see cref="_activeBuilds"/> and <see cref="_unloadedProjectsSinceLastCacheReset"/>.
+    /// For us to call <see cref="MSB.Execution.BuildManager.ResetCaches"/>; we need to end builds, call ResetCaches, and then begin build again.
+    /// This lets us easily count how many active builds there are, wait until that hits zero, and then block new builds from starting until
+    /// we're done with the reset.
+    ///
+    /// It's unclear if we could do a simpler approach taking advantage of the fact that EndBuild() will block on running builds, but it appears
+    /// submissions that aren't actually started will not get blocked for, which we need.
+    /// </summary>
+    private readonly object _activeBuildsLock = new object();
+    private int _activeBuilds;
+    private int _unloadedProjectsSinceLastCacheReset;
+
     private bool _disposed;
 
     public ProjectBuildManager(string[] knownCommandLineParserLanguages, Dictionary<string, string> globalProperties, ILogger? msbuildLogger = null, int? maxNodeCount = null)
@@ -84,7 +97,7 @@ internal sealed class ProjectBuildManager : IDisposable
         // Pass empty loggers array to workaround LoggerException when passing binary logger to both evaluation and build. See https://github.com/dotnet/msbuild/issues/11867
         _projectCollection = new MSB.Evaluation.ProjectCollection(allProperties, loggers: [], MSB.Evaluation.ToolsetDefinitionLocations.Default);
 
-        var buildParameters = new MSB.Execution.BuildParameters(_projectCollection)
+        _buildParameters = new MSB.Execution.BuildParameters(_projectCollection)
         {
             // The loggers are not inherited from the project collection, so specify both the
             // binlog logger and the _buildLogger for the build steps.
@@ -99,9 +112,9 @@ internal sealed class ProjectBuildManager : IDisposable
         };
 
         if (maxNodeCount is int nodeCount)
-            buildParameters.MaxNodeCount = nodeCount;
+            _buildParameters.MaxNodeCount = nodeCount;
 
-        MSB.Execution.BuildManager.DefaultBuildManager.BeginBuild(buildParameters);
+        MSB.Execution.BuildManager.DefaultBuildManager.BeginBuild(_buildParameters);
     }
 
     public async Task<(MSB.Evaluation.Project? project, DiagnosticLog log)> LoadProjectAsync(
@@ -319,10 +332,18 @@ internal sealed class ProjectBuildManager : IDisposable
         // the RPC layer we use to call into the BuildHost doesn't support cancellation anyways so there's no reason to have lots of extra code.
         cancellationToken.ThrowIfCancellationRequested();
 
-        var submission = MSB.Execution.BuildManager.DefaultBuildManager.PendBuildRequest(requestData);
+        // Before we start a build, record that one is running; this will block if we're currently clearing caches.
+        lock (_activeBuildsLock)
+        {
+            _activeBuilds++;
+        }
+
+        BuildSubmission? submission = null;
 
         try
         {
+            submission = MSB.Execution.BuildManager.DefaultBuildManager.PendBuildRequest(requestData);
+
             // The SubmissionId is assigned by PendBuildRequest and is the same SubmissionId that appears on the
             // BuildEventContext of every event raised while this submission builds.
             _buildLogger.RegisterLog(submission.SubmissionId, log);
@@ -348,13 +369,41 @@ internal sealed class ProjectBuildManager : IDisposable
         }
         finally
         {
+            lock (_activeBuildsLock)
+            {
+                _activeBuilds--;
+
+                if (_activeBuilds == 0)
+                    Monitor.PulseAll(_activeBuildsLock);
+            }
+
             // Ensure the log is cleaned up if it's still there no matter if we take an exceptional path or not
-            _buildLogger.TryUnregisterLog(submission.SubmissionId);
+            if (submission is not null)
+                _buildLogger.TryUnregisterLog(submission.SubmissionId);
         }
     }
 
     public void UnloadProject(MSB.Evaluation.Project project)
     {
         _projectCollection.UnloadProject(project);
+
+        lock (_activeBuildsLock)
+        {
+            // If we've unloaded a lot of projects since our last reset, let's just reset it. 500 is chosen with no evidence
+            // whatsoever.
+            if (++_unloadedProjectsSinceLastCacheReset >= 500)
+            {
+                _unloadedProjectsSinceLastCacheReset = 0;
+
+                // We need to wait until there are no active builds before we reset caches
+                while (_activeBuilds > 0)
+                    Monitor.Wait(_activeBuildsLock);
+
+                // No active builds, so clear caches
+                MSB.Execution.BuildManager.DefaultBuildManager.EndBuild();
+                MSB.Execution.BuildManager.DefaultBuildManager.ResetCaches();
+                MSB.Execution.BuildManager.DefaultBuildManager.BeginBuild(_buildParameters);
+            }
+        }
     }
 }

--- a/src/Workspaces/MSBuild/BuildHost/Build/ProjectBuildManager.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Build/ProjectBuildManager.cs
@@ -352,4 +352,9 @@ internal sealed class ProjectBuildManager : IDisposable
             _buildLogger.TryUnregisterLog(submission.SubmissionId);
         }
     }
+
+    public void UnloadProject(MSB.Evaluation.Project project)
+    {
+        _projectCollection.UnloadProject(project);
+    }
 }

--- a/src/Workspaces/MSBuild/BuildHost/MSBuild/ProjectFile/ProjectFile.cs
+++ b/src/Workspaces/MSBuild/BuildHost/MSBuild/ProjectFile/ProjectFile.cs
@@ -17,6 +17,7 @@ internal sealed class ProjectFile(
     string language,
     MSB.Evaluation.Project? project,
     ProjectBuildManager buildManager,
+    RpcServer server,
     DiagnosticLog log) :
 #if NETFRAMEWORK
     MarshalByRefObject, // We need this object to pass across the AppDomain boundary when on .NET Framework
@@ -258,5 +259,13 @@ internal sealed class ProjectFile(
         }
 
         project.Save();
+    }
+
+    public void Dispose()
+    {
+        server.RemoveTarget(this);
+
+        if (project is not null)
+            buildManager.UnloadProject(project);
     }
 }

--- a/src/Workspaces/MSBuild/BuildHost/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj
+++ b/src/Workspaces/MSBuild/BuildHost/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj
@@ -69,6 +69,7 @@
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\NoMessagePumpSyncContext.cs" Link="Utilities\NoMessagePumpSyncContext.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\SpecializedSyncContext.cs" Link="Utilities\SpecializedSyncContext.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\SemaphoreSlimExtensions.cs" Link="Utilities\SemaphoreSlimExtensions.cs" />
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\ReaderWriterLockSlimExtensions.cs" Link="Utilities\ReaderWriterLockSlimExtensions.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\Symbols\LanguageNames.cs" Link="Compiler\LanguageNames.cs" />
     <Compile Include="..\..\..\Compilers\Shared\NamedPipeUtil.cs" Link="Utilities\NamedPipeUtil.cs" />
 

--- a/src/Workspaces/MSBuild/BuildHost/Rpc/RpcServer.cs
+++ b/src/Workspaces/MSBuild/BuildHost/Rpc/RpcServer.cs
@@ -33,8 +33,13 @@ internal sealed class RpcServer
     private readonly TextReader _streamReader;
     private readonly RpcMethodInvoker _rpcMethodInvoker;
 
-    private readonly ConcurrentDictionary<int, object> _rpcTargets = [];
-    private volatile int _nextRpcTargetIndex = -1; // We'll start at -1 so the first value becomes zero
+    /// <summary>
+    /// A lock to guard <see cref="_rpcTargets"/>, <see cref="_rpcTargetToIndex"/> and <see cref="_nextRpcTargetIndex"/>.
+    /// </summary>
+    private readonly ReaderWriterLockSlim _rpcTargetsLock = new();
+    private readonly Dictionary<int, object> _rpcTargets = [];
+    private readonly Dictionary<object, int> _rpcTargetToIndex = [];
+    private int _nextRpcTargetIndex = 0;
 
     private readonly CancellationTokenSource _shutdownTokenSource = new();
 
@@ -53,11 +58,28 @@ internal sealed class RpcServer
     {
         // Loop until we successfully have a new index for this; practically we don't expect this to ever collide, since that'd mean we'd have
         // billions of long lived projects, but...
-        while (true)
+        using (_rpcTargetsLock.DisposableWrite())
         {
-            var nextIndex = Interlocked.Increment(ref _nextRpcTargetIndex);
-            if (_rpcTargets.TryAdd(nextIndex, rpcTarget))
-                return nextIndex;
+            while (true)
+            {
+                var nextIndex = _nextRpcTargetIndex++;
+                if (!_rpcTargets.ContainsKey(nextIndex))
+                {
+                    _rpcTargets.Add(nextIndex, rpcTarget);
+                    _rpcTargetToIndex.Add(rpcTarget, nextIndex);
+                    return nextIndex;
+                }
+            }
+        }
+    }
+
+    public void RemoveTarget(object rpcTarget)
+    {
+        using (_rpcTargetsLock.DisposableWrite())
+        {
+            Contract.ThrowIfFalse(_rpcTargetToIndex.TryGetValue(rpcTarget, out var targetIndex));
+            _rpcTargetToIndex.Remove(rpcTarget);
+            _rpcTargets.Remove(targetIndex);
         }
     }
 
@@ -115,9 +137,14 @@ internal sealed class RpcServer
 
         try
         {
-            Contract.ThrowIfFalse(
-                _rpcTargets.TryGetValue(request.TargetObject, out var rpcTarget),
-                $"Received a request for target object {request.TargetObject} but we don't have a registered object for that.");
+            object rpcTarget;
+
+            using (_rpcTargetsLock.DisposableRead())
+            {
+                Contract.ThrowIfFalse(
+                    _rpcTargets.TryGetValue(request.TargetObject, out rpcTarget!),
+                    $"Received a request for target object {request.TargetObject} but we don't have a registered object for that.");
+            }
 
             var method = rpcTarget.GetType().GetMethod(request.Method, BindingFlags.Public | BindingFlags.Instance);
 

--- a/src/Workspaces/MSBuild/Contracts/IProjectFile.cs
+++ b/src/Workspaces/MSBuild/Contracts/IProjectFile.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,7 +11,7 @@ namespace Microsoft.CodeAnalysis.MSBuild;
 /// <summary>
 /// RPC methods.
 /// </summary>
-internal interface IProjectFile
+internal interface IProjectFile : IDisposable
 {
     DiagnosticLogItem[] GetDiagnosticLogItems();
     Task<ProjectFileInfo[]> GetProjectFileInfosAsync(CancellationToken cancellationToken);

--- a/src/Workspaces/MSBuild/Core/MSBuild/BuildHostProjectFileInfoProvider.cs
+++ b/src/Workspaces/MSBuild/Core/MSBuild/BuildHostProjectFileInfoProvider.cs
@@ -31,6 +31,7 @@ internal sealed class BuildHostProjectFileInfoProvider(
             targetFramework: null,
             () => buildHost.LoadProjectFileAsync(projectPath, languageName, cancellationToken)
         ).ConfigureAwait(false);
+        await using var _ = projectFile.ConfigureAwait(false);
 
         // If there were any failures during load, we won't be able to build the project. So, bail early with an empty project.
         var diagnosticItems = await projectFile.GetDiagnosticLogItemsAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/MSBuild/Core/MSBuild/MSBuildWorkspace.cs
+++ b/src/Workspaces/MSBuild/Core/MSBuild/MSBuildWorkspace.cs
@@ -387,6 +387,16 @@ public sealed class MSBuildWorkspace : Workspace
         }
         finally
         {
+            // Ensure that even if we have an issue with disposal that we still null out the field.
+            try
+            {
+                _applyChangesProjectFile?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
+            catch (Exception exception)
+            {
+                Reporter.Report(new ProjectDiagnostic(WorkspaceDiagnosticKind.Failure, exception.Message, projectChanges.ProjectId));
+            }
+
             _applyChangesProjectFile = null;
         }
     }

--- a/src/Workspaces/MSBuild/Core/Rpc/RemoteProjectFile.cs
+++ b/src/Workspaces/MSBuild/Core/Rpc/RemoteProjectFile.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -9,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.CodeAnalysis.MSBuild;
 
-internal sealed class RemoteProjectFile
+internal sealed class RemoteProjectFile : IAsyncDisposable
 {
     private readonly RpcClient _client;
     private readonly int _remoteProjectFileTargetObject;
@@ -58,4 +59,7 @@ internal sealed class RemoteProjectFile
 
     public Task SaveAsync(CancellationToken cancellationToken)
         => _client.InvokeAsync(_remoteProjectFileTargetObject, nameof(IProjectFile.Save), parameters: [], cancellationToken);
+
+    public async ValueTask DisposeAsync()
+        => await _client.InvokeAsync(_remoteProjectFileTargetObject, nameof(IProjectFile.Dispose), parameters: [], CancellationToken.None).ConfigureAwait(false);
 }

--- a/src/Workspaces/MSBuild/Test/VisualStudioMSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuild/Test/VisualStudioMSBuildWorkspaceTests.cs
@@ -3099,7 +3099,7 @@ public sealed class VisualStudioMSBuildWorkspaceTests : MSBuildWorkspaceTestBase
         await using var buildHostProcessManager = new BuildHostProcessManager(knownCommandLineParserLanguages: [LanguageNames.CSharp], ImmutableDictionary<string, string>.Empty);
 
         var buildHost = await buildHostProcessManager.GetBuildHostWithFallbackAsync(projectFilePath, CancellationToken.None);
-        var projectFile = await buildHost.LoadProjectFileAsync(projectFilePath, LanguageNames.CSharp, CancellationToken.None);
+        await using var projectFile = await buildHost.LoadProjectFileAsync(projectFilePath, LanguageNames.CSharp, CancellationToken.None);
         var projectFileInfo = (await projectFile.GetProjectFileInfosAsync(CancellationToken.None)).Single();
 
         var commandLineParser = workspace.Services


### PR DESCRIPTION
Right now our BuildHost is one giant memory leak: we make no effort to unload projects or state, so the process memory will grow until we're done loading the entire solution/workspace, and then we'll get rid of the process all at once. This is quite wasteful, so there's two things we can we do:

1. First simply unload projects from the ProjectCollection when we're done with them. Testing with dotnet/runtime with --autoLoadProjects and no limit (so it's loading nearly 6,000 projects), this reduces peak memory by 45% -- on my machine that goes from 16 gigabytes down to 10.
2. Every so often, clear the MSBuild caches. Unfortunately there aren't more precise caching APIs to use, so as heuristic we just have to completely reset all caches entirely, and we'll do that every so many unloads. I went with every 500 projects because that's a fairly large number so it should only kick in for very large workspaces. This means our memory is now steady state, and in practice once the GC kicked in our memory often stayed under a gigabyte. There is a downside that this _does_ increase total time a bit -- in my quick test with dotnet/runtime it went from 280 seconds of loading to 340 seconds of loading. So that's not ideal and we could tweak the heuristic further, but the significant decrease in memory offsets this downside.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84524)