### PR TITLE
Use System.Text.Json for LiveShare LSP types

### DIFF
--- a/src/VisualStudio/LiveShare/Impl/Client/LanguageServiceUtils.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/LanguageServiceUtils.cs
@@ -5,8 +5,6 @@
 #nullable disable
 
 using System.Linq;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client;
 
@@ -27,23 +25,4 @@ internal static class LanguageServicesUtils
 
     public static bool IsContentTypeRemote(string contentType)
         => contentType.EndsWith("-remote");
-
-    public static bool TryParseJson<T>(object json, out T t)
-    {
-        t = default;
-        if (json == null)
-        {
-            return true;
-        }
-
-        try
-        {
-            t = ((JObject)json).ToObject<T>();
-            return true;
-        }
-        catch (JsonException)
-        {
-            return false;
-        }
-    }
 }

--- a/src/VisualStudio/LiveShare/Impl/Client/RoslynLSPClientService.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/RoslynLSPClientService.cs
@@ -7,9 +7,11 @@
 using System;
 using System.ComponentModel.Composition;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.VisualStudio.LiveShare;
 using Newtonsoft.Json.Linq;
 using Roslyn.LanguageServer.Protocol;
@@ -59,29 +61,31 @@ internal abstract class AbstractLspClientServiceFactory : ICollaborationServiceF
             [StringConstants.TypeScriptLanguageName],
             new LS.LanguageServerClientMetadata(
                 true,
-                JObject.FromObject(new ServerCapabilities
-                {
-                    // Uses Roslyn client.
-                    DocumentSymbolProvider = true,
+                JObject.Parse(JsonSerializer.Serialize(
+                    new ServerCapabilities
+                    {
+                        // Uses Roslyn client.
+                        DocumentSymbolProvider = true,
 
-                    // Uses LSP SDK client.
-                    DocumentLinkProvider = null,
-                    RenameProvider = false,
-                    DocumentOnTypeFormattingProvider = null,
-                    DocumentRangeFormattingProvider = false,
-                    DocumentFormattingProvider = false,
-                    CodeLensProvider = null,
-                    CodeActionProvider = false,
-                    ExecuteCommandProvider = null,
-                    WorkspaceSymbolProvider = false,
-                    DocumentHighlightProvider = false,
-                    ReferencesProvider = false,
-                    DefinitionProvider = false,
-                    SignatureHelpProvider = null,
-                    CompletionProvider = null,
-                    HoverProvider = false,
-                    TextDocumentSync = null,
-                })));
+                        // Uses LSP SDK client.
+                        DocumentLinkProvider = null,
+                        RenameProvider = false,
+                        DocumentOnTypeFormattingProvider = null,
+                        DocumentRangeFormattingProvider = false,
+                        DocumentFormattingProvider = false,
+                        CodeLensProvider = null,
+                        CodeActionProvider = false,
+                        ExecuteCommandProvider = null,
+                        WorkspaceSymbolProvider = false,
+                        DocumentHighlightProvider = false,
+                        ReferencesProvider = false,
+                        DefinitionProvider = false,
+                        SignatureHelpProvider = null,
+                        CompletionProvider = null,
+                        HoverProvider = false,
+                        TextDocumentSync = null,
+                    },
+                    ProtocolConversions.LspJsonSerializerOptions))));
 
         var lifeTimeService = LspClientLifeTimeService;
         lifeTimeService.Disposed += (s, e) =>

--- a/src/VisualStudio/LiveShare/Impl/CustomProtocol/LspRequestExtensions.cs
+++ b/src/VisualStudio/LiveShare/Impl/CustomProtocol/LspRequestExtensions.cs
@@ -4,6 +4,8 @@
 
 #nullable disable
 
+using System.Text.Json;
+using Microsoft.CodeAnalysis.LanguageServer;
 using LS = Microsoft.VisualStudio.LiveShare.LanguageServices;
 using LSP = Roslyn.LanguageServer.Protocol;
 
@@ -15,5 +17,7 @@ public static class LspRequestExtensions
         => new(lspRequest.Name);
 
     internal static LSP.ClientCapabilities GetClientCapabilities(this LS.RequestContext requestContext)
-        => requestContext.ClientCapabilities?.ToObject<LSP.ClientCapabilities>() ?? new LSP.VSInternalClientCapabilities();
+        => requestContext.ClientCapabilities is { } clientCapabilities
+            ? JsonSerializer.Deserialize<LSP.ClientCapabilities>(clientCapabilities.ToString(), ProtocolConversions.LspJsonSerializerOptions)
+            : new LSP.VSInternalClientCapabilities();
 }

--- a/src/VisualStudio/LiveShare/Test/AbstractLiveShareRequestHandlerTests.cs
+++ b/src/VisualStudio/LiveShare/Test/AbstractLiveShareRequestHandlerTests.cs
@@ -51,13 +51,13 @@ public abstract class AbstractLiveShareRequestHandlerTests(ITestOutputHelper tes
 
     protected static async Task<ResponseType> TestHandleAsync<RequestType, ResponseType>(Solution solution, RequestType request, string methodName)
     {
-        var requestContext = new RequestContext<Solution>(solution, new MockHostProtocolConverter(), JObject.FromObject(new ClientCapabilities()));
+        var requestContext = new RequestContext<Solution>(solution, new MockHostProtocolConverter(), new JObject());
         return await GetHandler<RequestType, ResponseType>(solution, methodName).HandleAsync(request, requestContext, CancellationToken.None);
     }
 
     protected static async Task<ResponseType> TestHandleAsync<RequestType, ResponseType>(Solution solution, RequestType request, string methodName, Func<Uri, Uri> uriMappingFunc)
     {
-        var requestContext = new RequestContext<Solution>(solution, new MockHostProtocolConverter(uriMappingFunc), JObject.FromObject(new ClientCapabilities()));
+        var requestContext = new RequestContext<Solution>(solution, new MockHostProtocolConverter(uriMappingFunc), new JObject());
         return await GetHandler<RequestType, ResponseType>(solution, methodName).HandleAsync(request, requestContext, CancellationToken.None);
     }
 


### PR DESCRIPTION
liveshare public API requires newtonsoft in a couple places.  we no longer support newtonsoft serialization on our LSP types, so conversions can fail.  instead where the public API requires newtonsoft, we use string as an intermediary and use STJ to do conversions to types.  while this does have a small perf impact, these operations do not happen frequently


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84525)