### PR TITLE
Prevent generated Razor methods from being mapped as user edits

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/RazorEditService.CSharpMember.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/RazorEditService.CSharpMember.cs
@@ -3,6 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 
@@ -24,9 +26,11 @@ internal partial class RazorEditService
             Text = text;
         }
 
-        public static CSharpMember? TryCreate(MemberDeclarationSyntax member, SourceText sourceText)
+        public static CSharpMember? TryCreate(MemberDeclarationSyntax member, SourceText sourceText, RazorFileKind fileKind)
             => member switch
             {
+                // We never want to consider the primary method (eg BuildRenderTree) as being added, since it's never user code
+                MethodDeclarationSyntax method when IsGeneratedPrimaryMethod(method, fileKind) => null,
                 BaseMethodDeclarationSyntax method => new(method, GetComparisonSpan(method), sourceText),
                 TypeDeclarationSyntax typeDeclaration => new(typeDeclaration, GetComparisonSpan(typeDeclaration), sourceText),
                 IndexerDeclarationSyntax indexer => new(indexer, GetComparisonSpan(indexer), sourceText),
@@ -36,6 +40,24 @@ internal partial class RazorEditService
                 FieldDeclarationSyntax field => new(field, GetComparisonSpan(field), sourceText),
                 _ => null,
             };
+
+        private static bool IsGeneratedPrimaryMethod(MethodDeclarationSyntax method, RazorFileKind fileKind)
+        {
+            if (fileKind == RazorFileKind.Legacy)
+            {
+                return method is
+                {
+                    Identifier.ValueText: "ExecuteAsync",
+                    ParameterList.Parameters: [],
+                };
+            }
+
+            return method is
+            {
+                Identifier.ValueText: ComponentsApi.ComponentBase.BuildRenderTree,
+                ParameterList.Parameters: [{ Identifier.ValueText: ComponentsApi.RenderTreeBuilder.BuilderParameter }],
+            };
+        }
 
         public bool Equals(CSharpMember? other)
         {

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/RazorEditService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/RazorEditService.cs
@@ -85,8 +85,8 @@ internal abstract partial class RazorEditService(
 
         AddUsingsChanges(ref edits, codeDocument, addedUsings, removedUsings, cancellationToken);
 
-        var oldMembers = FindMembers(originalCSharpSyntaxRoot, originalCSharpSourceText);
-        var newMembers = FindMembers(newCSharpSyntaxRoot, newCSharpSourceText);
+        var oldMembers = FindMembers(originalCSharpSyntaxRoot, originalCSharpSourceText, codeDocument.FileKind);
+        var newMembers = FindMembers(newCSharpSyntaxRoot, newCSharpSourceText, codeDocument.FileKind);
         var addedMembers = Delta.Compute(oldMembers, newMembers);
 
         AddMemberChanges(ref edits, codeDocument, addedMembers, options);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/RazorEditService_Members.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/RazorEditService_Members.cs
@@ -186,7 +186,7 @@ internal partial class RazorEditService
         }
     }
 
-    private static ImmutableArray<CSharpMember> FindMembers(RoslynSyntaxNode syntaxRoot, SourceText sourceText)
+    private static ImmutableArray<CSharpMember> FindMembers(RoslynSyntaxNode syntaxRoot, SourceText sourceText, RazorFileKind fileKind)
     {
         if (!syntaxRoot.TryGetClassDeclaration(out var classDecl))
         {
@@ -196,7 +196,7 @@ internal partial class RazorEditService
         using var members = new PooledArrayBuilder<CSharpMember>();
         foreach (var member in classDecl.Members)
         {
-            if (CSharpMember.TryCreate(member, sourceText) is { } csharpMember)
+            if (CSharpMember.TryCreate(member, sourceText, fileKind) is { } csharpMember)
             {
                 members.Add(csharpMember);
             }

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostDocumentCompletionEndpointTest.cs
@@ -1704,6 +1704,60 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
                 """);
     }
 
+    [RoslynConditionalFact(typeof(IsEnglishLocal))]
+    [WorkItem("https://github.com/dotnet/razor/issues/13202")]
+    public async Task CSharp_AwaitKeyword_OutsideCodeBlock()
+    {
+        await VerifyCompletionListAsync(
+            input: """
+                @if (awai$$)
+                {
+                }
+                """,
+            completionContext: new VSInternalCompletionContext()
+            {
+                InvokeKind = VSInternalCompletionInvokeKind.Explicit,
+                TriggerCharacter = null,
+                TriggerKind = CompletionTriggerKind.Invoked
+            },
+            expectedItemLabels: ["char", "DateTime", "await"],
+            itemToResolve: "await",
+            expectedResolvedItemDescription: "await Keyword\r\nAsynchronously waits for the task to finish.",
+            expected: """
+                @using System.Threading.Tasks
+                @if (await)
+                {
+                }
+                """);
+    }
+
+    [RoslynConditionalFact(typeof(IsEnglishLocal))]
+    [WorkItem("https://github.com/dotnet/razor/issues/13202")]
+    public async Task CSharp_AwaitKeyword_OutsideCodeBlock_Legacy()
+    {
+        await VerifyCompletionListAsync(
+            input: """
+                @if (awai$$)
+                {
+                }
+                """,
+            completionContext: new VSInternalCompletionContext()
+            {
+                InvokeKind = VSInternalCompletionInvokeKind.Explicit,
+                TriggerCharacter = null,
+                TriggerKind = CompletionTriggerKind.Invoked
+            },
+            expectedItemLabels: ["char", "DateTime", "await"],
+            itemToResolve: "await",
+            expectedResolvedItemDescription: "await Keyword\r\nAsynchronously waits for the task to finish.",
+            expected: """
+                @if (await)
+                {
+                }
+                """,
+            fileKind: RazorFileKind.Legacy);
+    }
+
     [Fact]
     public async Task RazorHelpersFilteredOut()
     {

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Mapping/RazorEditServiceTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Mapping/RazorEditServiceTest.cs
@@ -18,6 +18,7 @@ using Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 using Roslyn.Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
+using WorkItemAttribute = Roslyn.Test.Utilities.WorkItemAttribute;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Mapping;
 
@@ -514,6 +515,186 @@ public class RazorEditServiceTest(ITestOutputHelper testOutput) : CohostEndpoint
                     public int NewCounter { get; set; } 
                 }
                 """);
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13202")]
+    public Task GeneratedBuildRenderTree_SignatureChange_IsNotAdded()
+        => TestAsync(
+            csharpSource: """
+                class MyComponent : ComponentBase
+                {
+                    protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
+                    {
+                        if ({|map1:awa|})
+                        {
+                        }
+                    }
+                }
+                """,
+            razorSource: """
+                @if({|map1:awa|})
+                {
+                }
+                """,
+            newCSharpSource: """
+                class MyComponent : ComponentBase
+                {
+                    protected override async Task BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
+                    {
+                        if (await)
+                        {
+                        }
+                    }
+                }
+                """,
+            expectedRazorSource: """
+                @if(await)
+                {
+                }
+                """);
+
+    [Fact]
+    public Task UserBuildRenderTreeOverload_IsAdded()
+        => TestAsync(
+            csharpSource: """
+                class MyComponent : ComponentBase
+                {
+                    protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
+                    {
+                    }
+                }
+                """,
+            razorSource: """
+                <div></div>
+                """,
+            newCSharpSource: """
+                class MyComponent : ComponentBase
+                {
+                    protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
+                    {
+                    }
+
+                    private void BuildRenderTree(int value)
+                    {
+                    }
+                }
+                """,
+            expectedRazorSource: """
+                <div></div>
+                @code {
+                    private void BuildRenderTree(int value)
+                    {
+                    }
+                }
+                """);
+
+    [Fact]
+    public Task Component_UserExecuteAsync_IsAdded()
+        => TestAsync(
+            csharpSource: """
+                class MyComponent : ComponentBase
+                {
+                    protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
+                    {
+                    }
+                }
+                """,
+            razorSource: """
+                <div></div>
+                """,
+            newCSharpSource: """
+                class MyComponent : ComponentBase
+                {
+                    protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
+                    {
+                    }
+
+                    private void ExecuteAsync()
+                    {
+                    }
+                }
+                """,
+            expectedRazorSource: """
+                <div></div>
+                @code {
+                    private void ExecuteAsync()
+                    {
+                    }
+                }
+                """);
+
+    [Fact]
+    public Task Legacy_UserBuildRenderTree_IsAdded()
+        => TestAsync(
+            csharpSource: """
+                class MyPage : RazorPage
+                {
+                    public override async Task ExecuteAsync()
+                    {
+                    }
+                }
+                """,
+            razorSource: """
+                <div></div>
+                """,
+            newCSharpSource: """
+                class MyPage : RazorPage
+                {
+                    public override async Task ExecuteAsync()
+                    {
+                    }
+
+                    private void BuildRenderTree(int __builder)
+                    {
+                    }
+                }
+                """,
+            expectedRazorSource: """
+                <div></div>
+                @functions {
+                    private void BuildRenderTree(int __builder)
+                    {
+                    }
+                }
+                """,
+            fileKind: RazorFileKind.Legacy);
+
+    [Fact]
+    public Task GeneratedExecuteAsync_SignatureChange_IsNotAdded()
+        => TestAsync(
+            csharpSource: """
+                class MyPage : RazorPage
+                {
+                    public override void ExecuteAsync()
+                    {
+                        if ({|map1:awa|})
+                        {
+                        }
+                    }
+                }
+                """,
+            razorSource: """
+                @if({|map1:awa|})
+                {
+                }
+                """,
+            newCSharpSource: """
+                class MyPage : RazorPage
+                {
+                    public override async Task ExecuteAsync()
+                    {
+                        if (await)
+                        {
+                        }
+                    }
+                }
+                """,
+            expectedRazorSource: """
+                @if(await)
+                {
+                }
+                """,
+            fileKind: RazorFileKind.Legacy);
 
     [Fact]
     public Task NewMethod_ExpressionBodied()
@@ -1974,15 +2155,18 @@ public class RazorEditServiceTest(ITestOutputHelper testOutput) : CohostEndpoint
         TestCode csharpSource,
         TestCode razorSource,
         string newCSharpSource,
-        string expectedRazorSource)
+        string expectedRazorSource,
+        RazorFileKind? fileKind = null)
     {
         var csharpSpans = csharpSource.NamedSpans;
         var razorSpans = razorSource.NamedSpans;
 
         AssertEx.SetEqual(csharpSpans.Keys.OrderAsArray(), razorSpans.Keys.OrderAsArray());
 
-        var csharpPath = @"C:\path\to\document.razor.g.cs";
-        var razorPath = @"C:\path\to\document.razor";
+        var razorPath = fileKind == RazorFileKind.Legacy
+            ? @"C:\path\to\document.cshtml"
+            : @"C:\path\to\document.razor";
+        var csharpPath = razorPath + ".g.cs";
         var csharpSourceText = SourceText.From(csharpSource.Text);
         var razorSourceText = SourceText.From(razorSource.Text);
 
@@ -2016,7 +2200,7 @@ public class RazorEditServiceTest(ITestOutputHelper testOutput) : CohostEndpoint
         var changes = GetChanges(csharpSource.Text, newCSharpSource);
         Assert.NotEmpty(changes);
 
-        var document = CreateProjectAndRazorDocument(razorSource.Text, documentFilePath: razorPath);
+        var document = CreateProjectAndRazorDocument(razorSource.Text, fileKind, documentFilePath: razorPath);
 
         var snapshotManager = OOPExportProvider.GetExportedValue<RemoteSnapshotManager>();
         var codeDocument = await snapshotManager.GetSnapshot(document).GetGeneratedOutputAsync(DisposalToken);


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/13202

Completing `await` in component markup can change the generated `BuildRenderTree` method from `void` to `async Task`. `RazorEditService` then treated that signature change as newly added user code and inserted the generated method into the Razor document.

This change excludes the supported generated primary-method signatures during member differencing:

- Parameterless `ExecuteAsync` in legacy documents
- `BuildRenderTree` with the generated `__builder` parameter in non-legacy documents

It also adds direct edit-mapping regressions, opposite-file-kind controls that preserve user-authored methods, and cohost completion coverage for `await` outside code blocks in component and legacy documents.

The legacy completion case is a control because `ExecuteAsync` is already generated as `async Task`; the component completion test reproduces the original failure without the product fix.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84526)