### PR TITLE
Keep agent documentation state-based

### DIFF
--- a/.github/skills/update-agent-docs/SKILL.md
+++ b/.github/skills/update-agent-docs/SKILL.md
@@ -28,6 +28,14 @@ Run at the end of every task that changes code. This is not optional.
 
 **Any doc updated?** → No additional tracking needed. Git history tracks changes automatically.
 
+## Documentation Quality
+
+Documentation must describe the repository's current state, not the history or mechanics of the
+change being made. Do not add guidance that only makes sense in the context of the current diff,
+mentions behavior removed by the task, or warns against a workaround that no longer exists. Before
+adding guidance, ask whether it would help a future contributor starting from a clean checkout; if
+not, leave it out.
+
 ## Creating New Doc Files
 
 If knowledge doesn't fit existing files:


### PR DESCRIPTION
At least in Razor, it kept on providing technical details like "Don't prefix paths with forward slashes" because the session was about removing a forward slash at the start of a path. Hoping this helps.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84545)