### PR TITLE
Remove obsolete diff overview margin workaround

### DIFF
--- a/src/EditorFeatures/Core/Preview/PreviewFactoryService.cs
+++ b/src/EditorFeatures/Core/Preview/PreviewFactoryService.cs
@@ -67,8 +67,6 @@ internal sealed class PreviewFactoryService : AbstractPreviewFactoryService<IWpf
 
         try
         {
-            const string DiffOverviewMarginName = "deltadifferenceViewerOverview";
-
             diffViewer.ViewMode = mode;
 
             IWpfTextView view;
@@ -97,9 +95,8 @@ internal sealed class PreviewFactoryService : AbstractPreviewFactoryService<IWpf
             view.Options.SetOptionValue(DefaultTextViewHostOptions.SelectionMarginId, false);
             view.Options.SetOptionValue(DefaultTextViewHostOptions.SuggestionMarginId, false);
 
-            // Enable tab stop for the diff view host and collapse couple of unwanted margins.
+            // Enable tab stop for the diff view host and collapse the unwanted bottom margin.
             host.HostControl.IsTabStop = true;
-            host.GetTextViewMargin(DiffOverviewMarginName).VisualElement.Visibility = Visibility.Collapsed;
             host.GetTextViewMargin(PredefinedMarginNames.Bottom).VisualElement.Visibility = Visibility.Collapsed;
 
             // Enable focus for the diff viewer.


### PR DESCRIPTION
The editor no longer creates the `deltadifferenceViewerOverview` margin for views with the `ChangePreview` role after [VS PR 758795](https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/758795). Remove the now-unnecessary margin lookup and collapse operation.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/3033405