### PR TITLE
Fix linked editing for empty tag pairs

### DIFF
--- a/.github/memory/known-issues/razor.md
+++ b/.github/memory/known-issues/razor.md
@@ -37,3 +37,15 @@ won't be built/tested by the importing projects.
 **Description:** The same key in two global configs causes compiler error
 `MultipleGlobalAnalyzerKeys`, and the key is left unset.
 **Workaround:** Don't redefine a key already present in the base config.
+
+## Empty tag pairs use missing name tokens
+
+**Affected area:** Razor syntax consumers such as linked editing
+**Description:** The parser represents `<></>` with start- and end-tag name
+tokens that are both missing and have zero-width spans. The general
+`SyntaxToken.IsValid()` helper rejects these tokens.
+**Workaround:** Features that intentionally support editing an empty tag pair
+must recognize both missing name tokens together and use their zero-width spans.
+Do not accept only one missing name token when producing LSP linked-editing
+ranges because the protocol requires all ranges to have identical content and
+length.

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/LinkedEditingRange/RemoteLinkedEditingRangeService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/LinkedEditingRange/RemoteLinkedEditingRangeService.cs
@@ -51,7 +51,7 @@ internal sealed class RemoteLinkedEditingRangeService(in ServiceArgs args) : Raz
 
         var syntaxTree = codeDocument.GetRequiredTagHelperRewrittenSyntaxTree();
 
-        // We only care if the user is within a TagHelper or HTML tag with a valid start and end tag.
+        // We only care if the user is within a TagHelper or HTML tag with a start and end tag.
         if (TryGetNearestMarkupNameTokens(syntaxTree, validLocation, out var startTagNameToken, out var endTagNameToken) &&
             (startTagNameToken.Span.Contains(validLocation.AbsoluteIndex) || endTagNameToken.Span.Contains(validLocation.AbsoluteIndex) ||
             startTagNameToken.Span.End == validLocation.AbsoluteIndex || endTagNameToken.Span.End == validLocation.AbsoluteIndex))
@@ -87,7 +87,9 @@ internal sealed class RemoteLinkedEditingRangeService(in ServiceArgs args) : Raz
             startTagNameToken = startTag?.Name ?? default;
             endTagNameToken = endTag?.Name ?? default;
 
-            return startTagNameToken.IsValid() && endTagNameToken.IsValid();
+            // Empty tag pairs use missing name tokens whose zero-width spans start linked editing.
+            return (startTagNameToken.IsValid() && endTagNameToken.IsValid()) ||
+                (startTagNameToken.IsMissing && endTagNameToken.IsMissing);
         }
 
         throw new InvalidOperationException("Element is expected to be a MarkupTagHelperElement or MarkupElement.");

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostLinkedEditingRangeEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostLinkedEditingRangeEndpointTest.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
 using Xunit;
 using Xunit.Abstractions;
+using WorkItemAttribute = Roslyn.Test.Utilities.WorkItemAttribute;
 
 namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 
@@ -31,6 +32,34 @@ public class CohostLinkedEditingRangeEndpointTest(ITestOutputHelper testOutputHe
             """;
 
         await VerifyLinkedEditingRangeAsync(input);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13203")]
+    public async Task Html_StartAndEndTagNamesMissing_RequestFromStartTag_ReturnsLinkedEditingRanges()
+    {
+        await VerifyLinkedEditingRangeAsync("<[|$$|]></[||]>");
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13203")]
+    public async Task Html_StartAndEndTagNamesMissing_RequestFromEndTag_ReturnsLinkedEditingRanges()
+    {
+        await VerifyLinkedEditingRangeAsync("<[||]></[|$$|]>");
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13203")]
+    public async Task Html_OnlyStartTagNameMissing_DoesNotReturnLinkedEditingRanges()
+    {
+        await VerifyLinkedEditingRangeAsync("<$$></div>");
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13203")]
+    public async Task Html_OnlyEndTagNameMissing_DoesNotReturnLinkedEditingRanges()
+    {
+        await VerifyLinkedEditingRangeAsync("<div></$$>");
     }
 
     [Theory]

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostOnAutoInsertEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostOnAutoInsertEndpointTest.cs
@@ -13,6 +13,7 @@ using Microsoft.VisualStudio.LanguageServices.Razor.LanguageClient.Cohost;
 using Roslyn.Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
+using WorkItemAttribute = Roslyn.Test.Utilities.WorkItemAttribute;
 
 namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 
@@ -39,6 +40,16 @@ public class CohostOnAutoInsertEndpointTest(ITestOutputHelper testOutputHelper) 
 
                 The end.
                 """,
+            triggerCharacter: ">");
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13203")]
+    public async Task EndTag_EmptyTagName()
+    {
+        await VerifyOnAutoInsertAsync(
+            input: "<>$$",
+            output: "<>$0</>",
             triggerCharacter: ">");
     }
 


### PR DESCRIPTION
Razor parses `<></>` with two missing, zero-width name tokens. Linked editing treated those tokens as invalid, so typing in the empty opening tag wasn't mirrored to the closing tag.

This accepts the pair when both tag names are missing, while still rejecting cases where only one name is missing. The tests cover requests from both empty names, the asymmetric cases, and end-tag auto-insert.

Fixes dotnet/razor#13203
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84562)