### PR TITLE
Remove per-feature Razor code generation opt-ins

### DIFF
--- a/src/Analyzers/Core/CodeFixes/GenerateConstructor/AbstractGenerateConstructorService.State.cs
+++ b/src/Analyzers/Core/CodeFixes/GenerateConstructor/AbstractGenerateConstructorService.State.cs
@@ -104,8 +104,7 @@ internal abstract partial class AbstractGenerateConstructorService<TService, TEx
 
             Contract.ThrowIfNull(TypeToGenerateIn);
             var codeGenerationContext = new CodeGenerationContext(
-                contextLocation: Token.GetLocation(),
-                allowGenerationIntoHiddenCode: static document => document.IsRazorSourceGeneratedDocument());
+                contextLocation: Token.GetLocation());
             if (!CodeGenerator.CanAdd(_document.Project.Solution, TypeToGenerateIn, codeGenerationContext, cancellationToken))
                 return false;
 
@@ -447,8 +446,7 @@ internal abstract partial class AbstractGenerateConstructorService<TService, TEx
             var context = new CodeGenerationSolutionContext(
                 document.Project.Solution,
                 new CodeGenerationContext(
-                    contextLocation: Token.GetLocation(),
-                    allowGenerationIntoHiddenCode: static document => document.IsRazorSourceGeneratedDocument()));
+                    contextLocation: Token.GetLocation()));
 
             return await CodeGenerator.AddMemberDeclarationsAsync(
                 context,
@@ -495,8 +493,7 @@ internal abstract partial class AbstractGenerateConstructorService<TService, TEx
                 new CodeGenerationSolutionContext(
                     document.Project.Solution,
                     new CodeGenerationContext(
-                        contextLocation: Token.GetLocation(),
-                        allowGenerationIntoHiddenCode: static document => document.IsRazorSourceGeneratedDocument())),
+                        contextLocation: Token.GetLocation())),
                 TypeToGenerateIn,
                 GetRequiredLanguageService<SyntaxGenerator>(TypeToGenerateIn.Language).CreateMemberDelegatingConstructor(
                     GetRequiredLanguageService<SyntaxGeneratorInternal>(TypeToGenerateIn.Language),

--- a/src/Analyzers/Core/CodeFixes/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.CodeAction.cs
+++ b/src/Analyzers/Core/CodeFixes/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.CodeAction.cs
@@ -89,8 +89,7 @@ internal abstract partial class AbstractGenerateParameterizedMemberService<TServ
                        _document.Project.Solution,
                         new CodeGenerationContext(
                             afterThisLocation: _state.Location,
-                            generateMethodBodies: _state.TypeToGenerateIn.TypeKind != TypeKind.Interface,
-                            allowGenerationIntoHiddenCode: static document => document.IsRazorSourceGeneratedDocument())),
+                            generateMethodBodies: _state.TypeToGenerateIn.TypeKind != TypeKind.Interface)),
                     _state.TypeToGenerateIn,
                     method,
                     cancellationToken).ConfigureAwait(false);

--- a/src/Analyzers/Core/CodeFixes/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.State.cs
+++ b/src/Analyzers/Core/CodeFixes/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.State.cs
@@ -70,8 +70,7 @@ internal abstract partial class AbstractGenerateParameterizedMemberService<TServ
 
             var codeGenerationContext = new CodeGenerationContext(
                 afterThisLocation: Location,
-                generateMethodBodies: TypeToGenerateIn.TypeKind != TypeKind.Interface,
-                allowGenerationIntoHiddenCode: static document => document.IsRazorSourceGeneratedDocument());
+                generateMethodBodies: TypeToGenerateIn.TypeKind != TypeKind.Interface);
             if (!CodeGenerator.CanAdd(document.Project.Solution, TypeToGenerateIn, codeGenerationContext, cancellationToken))
             {
                 return false;

--- a/src/Analyzers/Core/CodeFixes/GenerateVariable/AbstractGenerateVariableService.CodeAction.cs
+++ b/src/Analyzers/Core/CodeFixes/GenerateVariable/AbstractGenerateVariableService.CodeAction.cs
@@ -54,8 +54,7 @@ internal abstract partial class AbstractGenerateVariableService<TService, TSimpl
                 new CodeGenerationContext(
                     afterThisLocation: _state.AfterThisLocation,
                     beforeThisLocation: _state.BeforeThisLocation,
-                    contextLocation: _state.IdentifierToken.GetLocation(),
-                    allowGenerationIntoHiddenCode: static document => document.IsRazorSourceGeneratedDocument()));
+                    contextLocation: _state.IdentifierToken.GetLocation()));
 
             if (_generateProperty)
             {

--- a/src/Analyzers/Core/CodeFixes/GenerateVariable/AbstractGenerateVariableService.State.cs
+++ b/src/Analyzers/Core/CodeFixes/GenerateVariable/AbstractGenerateVariableService.State.cs
@@ -161,8 +161,7 @@ internal abstract partial class AbstractGenerateVariableService<TService, TSimpl
             IsContainedInUnsafeType = _service.ContainingTypesOrSelfHasUnsafeKeyword(TypeToGenerateIn);
 
             var codeGenerationContext = new CodeGenerationContext(
-                contextLocation: IdentifierToken.GetLocation(),
-                allowGenerationIntoHiddenCode: static document => document.IsRazorSourceGeneratedDocument());
+                contextLocation: IdentifierToken.GetLocation());
 
             return CanGenerateLocal() || CodeGenerator.CanAdd(_document.Project.Solution, TypeToGenerateIn, codeGenerationContext, cancellationToken);
         }

--- a/src/Analyzers/Core/CodeFixes/GenerateVariable/AbstractGenerateVariableService.cs
+++ b/src/Analyzers/Core/CodeFixes/GenerateVariable/AbstractGenerateVariableService.cs
@@ -45,8 +45,7 @@ internal abstract partial class AbstractGenerateVariableService<TService, TSimpl
             using var _ = ArrayBuilder<CodeAction>.GetInstance(out var actions);
 
             var codeGenerationContext = new CodeGenerationContext(
-                contextLocation: state.IdentifierToken.GetLocation(),
-                allowGenerationIntoHiddenCode: static document => document.IsRazorSourceGeneratedDocument());
+                contextLocation: state.IdentifierToken.GetLocation());
             var canGenerateMember = CodeGenerator.CanAdd(document.Project.Solution, state.TypeToGenerateIn, codeGenerationContext, cancellationToken);
 
             if (canGenerateMember && state.CanGeneratePropertyOrField())

--- a/src/Analyzers/Core/CodeFixes/ImplementAbstractClass/ImplementAbstractClassData.cs
+++ b/src/Analyzers/Core/CodeFixes/ImplementAbstractClass/ImplementAbstractClassData.cs
@@ -52,8 +52,7 @@ internal sealed class ImplementAbstractClassData(
             return null;
 
         var codeGenerationContext = new CodeGenerationContext(
-            contextLocation: classIdentifier.GetLocation(),
-            allowGenerationIntoHiddenCode: static document => document.IsRazorSourceGeneratedDocument());
+            contextLocation: classIdentifier.GetLocation());
 
         if (!CodeGenerator.CanAdd(document.Project.Solution, classType, codeGenerationContext, cancellationToken))
             return null;
@@ -105,8 +104,7 @@ internal sealed class ImplementAbstractClassData(
         var context = new CodeGenerationContext(
             contextLocation: classNodeToAddMembersTo.GetLocation(),
             autoInsertionLocation: groupMembers,
-            sortMembers: groupMembers,
-            allowGenerationIntoHiddenCode: static document => document.IsRazorSourceGeneratedDocument());
+            sortMembers: groupMembers);
 
         var info = await _document.GetCodeGenerationInfoAsync(context, cancellationToken).ConfigureAwait(false);
 

--- a/src/Analyzers/Core/CodeFixes/ImplementInterface/AbstractImplementInterfaceService.State.cs
+++ b/src/Analyzers/Core/CodeFixes/ImplementInterface/AbstractImplementInterfaceService.State.cs
@@ -53,8 +53,7 @@ internal abstract partial class AbstractImplementInterfaceService<TTypeDeclarati
             }
 
             var codeGenerationContext = new CodeGenerationContext(
-                contextLocation: classOrStructDecl.GetLocation(),
-                allowGenerationIntoHiddenCode: static document => document.IsRazorSourceGeneratedDocument());
+                contextLocation: classOrStructDecl.GetLocation());
 
             if (!CodeGenerator.CanAdd(document.Project.Solution, classOrStructType, codeGenerationContext, cancellationToken))
             {

--- a/src/Analyzers/Core/CodeFixes/ImplementInterface/ImplementInterfaceGenerator.cs
+++ b/src/Analyzers/Core/CodeFixes/ImplementInterface/ImplementInterfaceGenerator.cs
@@ -91,8 +91,7 @@ internal abstract partial class AbstractImplementInterfaceService<TTypeDeclarati
                     new CodeGenerationContext(
                         contextLocation: State.ContextNode.GetLocation(),
                         autoInsertionLocation: groupMembers,
-                        sortMembers: groupMembers,
-                        allowGenerationIntoHiddenCode: static document => document.IsRazorSourceGeneratedDocument())),
+                        sortMembers: groupMembers)),
                 State.ClassOrStructType,
                 [.. memberDefinitions, .. extraMembers],
                 cancellationToken).ConfigureAwait(false);

--- a/src/Analyzers/Core/CodeFixes/ImplementInterface/ImplementInterfaceGenerator_DisposePattern.cs
+++ b/src/Analyzers/Core/CodeFixes/ImplementInterface/ImplementInterfaceGenerator_DisposePattern.cs
@@ -65,8 +65,7 @@ internal abstract partial class AbstractImplementInterfaceService<TTypeDeclarati
             var context = new CodeGenerationContext(
                 addImports: false,
                 sortMembers: false,
-                autoInsertionLocation: false,
-                allowGenerationIntoHiddenCode: static document => document.IsRazorSourceGeneratedDocument());
+                autoInsertionLocation: false);
 
             var info = await document.GetCodeGenerationInfoAsync(context, cancellationToken).ConfigureAwait(false);
 

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.Editor.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.Editor.cs
@@ -552,8 +552,7 @@ internal abstract partial class AbstractGenerateTypeService<TService, TSimpleNam
                 new CodeGenerationSolutionContext(
                     solution,
                     new CodeGenerationContext(
-                        contextLocation: _state.SimpleName.GetLocation(),
-                        allowGenerationIntoHiddenCode: static document => document.IsRazorSourceGeneratedDocument())),
+                        contextLocation: _state.SimpleName.GetLocation())),
                 _state.TypeToGenerateInOpt,
                 namedType,
                 _cancellationToken)

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.State.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.State.cs
@@ -338,8 +338,7 @@ internal abstract partial class AbstractGenerateTypeService<TService, TSimpleNam
             if (TypeToGenerateInOpt != null)
             {
                 var codeGenerationContext = new CodeGenerationContext(
-                    contextLocation: SimpleName.GetLocation(),
-                    allowGenerationIntoHiddenCode: static document => document.IsRazorSourceGeneratedDocument());
+                    contextLocation: SimpleName.GetLocation());
 
                 if (!CodeGenerator.CanAdd(document.Project.Solution, TypeToGenerateInOpt, codeGenerationContext, cancellationToken))
                 {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/AbstractCodeGenerationService_FindDeclaration.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/AbstractCodeGenerationService_FindDeclaration.cs
@@ -83,12 +83,13 @@ internal abstract partial class AbstractCodeGenerationService<TCodeGenerationCon
             return false;
         }
 
-        if (context.AllowGenerationIntoHiddenCode?.Invoke(document) == true)
+        // Razor maps edits to its source-generated documents back to the corresponding Razor document.
+        if (document.IsRazorSourceGeneratedDocument())
         {
             return true;
         }
 
-        // We can never generate into a document from a source generator, because those are immutable
+        // Other source-generated documents are immutable and cannot be generation targets.
         if (document is SourceGeneratedDocument)
         {
             return false;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/CodeGenerationContext.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/CodeGenerationContext.cs
@@ -130,11 +130,6 @@ internal sealed class CodeGenerationContext
     /// </summary>
     public bool ReuseSyntax { get; }
 
-    /// <summary>
-    /// Allows code generation into locations that would otherwise be rejected for being hidden or source-generated.
-    /// </summary>
-    public Func<Document, bool>? AllowGenerationIntoHiddenCode { get; }
-
     public CodeGenerationContext(
         Location? contextLocation = null,
         Location? afterThisLocation = null,
@@ -149,8 +144,7 @@ internal sealed class CodeGenerationContext
         bool generateDocumentationComments = false,
         bool autoInsertionLocation = true,
         bool sortMembers = true,
-        bool reuseSyntax = false,
-        Func<Document, bool>? allowGenerationIntoHiddenCode = null)
+        bool reuseSyntax = false)
     {
         CheckLocation(contextLocation, nameof(contextLocation));
         CheckLocation(afterThisLocation, nameof(afterThisLocation));
@@ -169,7 +163,6 @@ internal sealed class CodeGenerationContext
         AutoInsertionLocation = autoInsertionLocation;
         SortMembers = sortMembers;
         ReuseSyntax = reuseSyntax;
-        AllowGenerationIntoHiddenCode = allowGenerationIntoHiddenCode;
     }
 
     private static void CheckLocation(Location? location, string name)
@@ -197,8 +190,7 @@ internal sealed class CodeGenerationContext
         Optional<bool> generateDocumentationComments = default,
         Optional<bool> autoInsertionLocation = default,
         Optional<bool> sortMembers = default,
-        Optional<bool> reuseSyntax = default,
-        Optional<Func<Document, bool>?> allowGenerationIntoHiddenCode = default)
+        Optional<bool> reuseSyntax = default)
     {
         var newContextLocation = contextLocation.HasValue ? contextLocation.Value : this.ContextLocation;
         var newAfterThisLocation = afterThisLocation.HasValue ? afterThisLocation.Value : this.AfterThisLocation;
@@ -214,7 +206,6 @@ internal sealed class CodeGenerationContext
         var newAutoInsertionLocation = autoInsertionLocation.HasValue ? autoInsertionLocation.Value : this.AutoInsertionLocation;
         var newSortMembers = sortMembers.HasValue ? sortMembers.Value : this.SortMembers;
         var newReuseSyntax = reuseSyntax.HasValue ? reuseSyntax.Value : this.ReuseSyntax;
-        var newAllowGenerationIntoHiddenCode = allowGenerationIntoHiddenCode.HasValue ? allowGenerationIntoHiddenCode.Value : this.AllowGenerationIntoHiddenCode;
 
         return new CodeGenerationContext(
             newContextLocation,
@@ -230,7 +221,6 @@ internal sealed class CodeGenerationContext
             newGenerateDocumentationComments,
             newAutoInsertionLocation,
             newSortMembers,
-            newReuseSyntax,
-            newAllowGenerationIntoHiddenCode);
+            newReuseSyntax);
     }
 }


### PR DESCRIPTION
Follow up from previous PRs.

Razor now supports all of the code-generation edits we enable, so the per-feature `AllowGenerationIntoHiddenCode` filter isn't doing anything useful any more. It was added when Generate Method support was added, then reused for Generate Property, Type, etc. Should be unnecessary now.

Existing tests already cover all of this, this is just moving the check lower.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84567)