### PR TITLE
Stop advertising unavailable previews for dialog code actions

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/PreviewExceptionTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/PreviewExceptionTests.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Extensions;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.VisualStudio.Language.Intellisense;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -61,6 +62,27 @@ public sealed partial class PreviewTests
 
         // No exception is thrown in the call to GetActionSetsAsync because the preview is only lazily evaluated.
         Assert.False(errorReported);
+    }
+
+    [WpfFact]
+    public void TestCodeActionWithOptionsDoesNotHaveFlavors()
+    {
+        using var workspace = CreateWorkspaceFromOptions("class D {}", TestParameters.Default);
+        var document = GetDocument(workspace);
+        var textBuffer = workspace.GetTestDocument(document.Id).GetTextBuffer();
+        var suggestedAction = EditorSuggestedAction.Create(
+            workspace.ExportProvider.GetExportedValue<IThreadingContext>(),
+            workspace.ExportProvider.GetExportedValue<SuggestedActionsSourceProvider>(),
+            document,
+            textBuffer,
+            provider: this,
+            new TestCodeActionWithOptions(),
+            fixAllFlavors: null,
+            diagnostics: []);
+
+        Assert.IsNotAssignableFrom<ISuggestedActionWithFlavors>(suggestedAction);
+        Assert.False(suggestedAction.HasActionSets);
+        Assert.False(suggestedAction.HasPreview);
     }
 
     private static async Task GetPreview(EditorTestWorkspace workspace, CodeRefactoringProvider provider)
@@ -111,5 +133,13 @@ public sealed partial class PreviewTests
         provider.ComputeRefactoringsAsync(context).Wait();
         var action = codeActions.Single();
         extensionManager = document.Project.Solution.Services.GetService<IExtensionManager>() as EditorLayerExtensionManager.ExtensionManager;
+    }
+
+    private sealed class TestCodeActionWithOptions : CodeActionWithOptions
+    {
+        public override string Title => "Test action with options";
+
+        public override object GetOptions(CancellationToken cancellationToken)
+            => new();
     }
 }

--- a/src/EditorFeatures/Core/Suggestions/SuggestedActions/EditorSuggestedAction.cs
+++ b/src/EditorFeatures/Core/Suggestions/SuggestedActions/EditorSuggestedAction.cs
@@ -319,6 +319,21 @@ internal abstract partial class EditorSuggestedAction(
         CodeAction codeAction)
         => new TrivialSuggestedAction(action.ThreadingContext, action.SourceProvider, action.OriginalSolution, action.SubjectBuffer, action.Provider, codeAction);
 
+    public static EditorSuggestedAction Create(
+        IThreadingContext threadingContext,
+        SuggestedActionsSourceProvider sourceProvider,
+        TextDocument originalDocument,
+        ITextBuffer subjectBuffer,
+        object provider,
+        CodeAction codeAction,
+        SuggestedActionSet fixAllFlavors,
+        ImmutableArray<Diagnostic> diagnostics)
+        => codeAction is CodeActionWithOptions && fixAllFlavors is null && codeAction.AdditionalPreviewFlavors.IsEmpty
+            ? new TrivialSuggestedAction(
+                threadingContext, sourceProvider, originalDocument.Project.Solution, subjectBuffer, provider, codeAction)
+            : new EditorSuggestedActionWithNestedFlavors(
+                threadingContext, sourceProvider, originalDocument, subjectBuffer, provider, codeAction, fixAllFlavors, diagnostics);
+
     private sealed class TrivialSuggestedAction(
         IThreadingContext threadingContext,
         SuggestedActionsSourceProvider sourceProvider,

--- a/src/EditorFeatures/Core/Suggestions/SuggestedActionsSource_Async.cs
+++ b/src/EditorFeatures/Core/Suggestions/SuggestedActionsSource_Async.cs
@@ -292,7 +292,7 @@ internal sealed partial class SuggestedActionsSourceProvider
                     }
                     else
                     {
-                        return new EditorSuggestedActionWithNestedFlavors(
+                        return EditorSuggestedAction.Create(
                             _threadingContext, owner, originalDocument, subjectBuffer, action.Provider, action.CodeAction,
                             ConvertFlavors(action.Flavors), action.Diagnostics);
                     }


### PR DESCRIPTION
Dialog-based `CodeActionWithOptions` instances cannot compute preview operations until their options UI runs. Roslyn nevertheless exposes a nonfunctional Preview Changes flavor, causing hosts to report expandable state for actions such as Extract Base Class even though no preview can open.

Option-based actions now remain plain suggested actions unless they provide genuine Fix All or custom flavors. This preserves explicit flavors while keeping the host contract aligned with available UI.

Related: [DevDiv bug 3028472](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/3028472)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84568)