### PR TITLE
File-based apps: avoid running a few irrelevant editor features

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/ConvertProgram/ConvertProgramAnalysis_ProgramMain.cs
+++ b/src/Analyzers/CSharp/Analyzers/ConvertProgram/ConvertProgramAnalysis_ProgramMain.cs
@@ -30,6 +30,11 @@ internal static partial class ConvertProgramAnalysis
         if (!root.IsTopLevelProgram())
             return false;
 
+        // File-based programs are built around top-level statements, so don't offer to convert to a
+        // 'Program.Main' style program.
+        if (root.SyntaxTree.IsFileBasedProgram())
+            return false;
+
         if (!CanOfferUseProgramMain(option, forAnalyzer))
             return false;
 

--- a/src/Analyzers/CSharp/Tests/MatchFolderAndNamespace/CSharpMatchFolderAndNamespaceTests.cs
+++ b/src/Analyzers/CSharp/Tests/MatchFolderAndNamespace/CSharpMatchFolderAndNamespaceTests.cs
@@ -268,7 +268,7 @@ public sealed class CSharpMatchFolderAndNamespaceTests
             var project = solution.GetRequiredProject(projectId);
             var parseOptions = (CSharpParseOptions)project.ParseOptions!;
             return solution
-                .WithProjectParseOptions(projectId, parseOptions.WithFeatures([.. parseOptions.Features, new("FileBasedProgram", "")]))
+                .WithProjectParseOptions(projectId, parseOptions.WithFeatures([.. parseOptions.Features, new("FileBasedProgram", "true")]))
                 .GetRequiredProject(projectId)
                 .WithDefaultNamespace(DefaultNamespace)
                 .Solution;

--- a/src/Analyzers/CSharp/Tests/MatchFolderAndNamespace/CSharpMatchFolderAndNamespaceTests.cs
+++ b/src/Analyzers/CSharp/Tests/MatchFolderAndNamespace/CSharpMatchFolderAndNamespaceTests.cs
@@ -239,6 +239,44 @@ public sealed class CSharpMatchFolderAndNamespaceTests
             fixedCode: fixedCode);
     }
 
+    [Fact, WorkItem("https://github.com/dotnet/vscode-csharp/issues/9550")]
+    public async Task FileBasedProgram_NoDiagnostic()
+    {
+        // The namespace does not match the folder structure, but the document is part of a file-based
+        // program, so IDE0130 should not fire.
+        var folder = CreateFolderPath("B", "C");
+        var filePath = Path.Combine(folder, "Class1.cs");
+
+        var testState = new VerifyCS.Test
+        {
+            EditorConfig = EditorConfig,
+            CodeFixTestBehaviors = CodeAnalysis.Testing.CodeFixTestBehaviors.SkipFixAllInDocumentCheck,
+            LanguageVersion = LanguageVersion.CSharp10,
+        };
+
+        testState.TestState.Sources.Add((filePath, """
+            namespace A.B
+            {
+                class Class1
+                {
+                }
+            }
+            """));
+
+        testState.SolutionTransforms.Add((solution, projectId) =>
+        {
+            var project = solution.GetRequiredProject(projectId);
+            var parseOptions = (CSharpParseOptions)project.ParseOptions!;
+            return solution
+                .WithProjectParseOptions(projectId, parseOptions.WithFeatures([.. parseOptions.Features, new("FileBasedProgram", "")]))
+                .GetRequiredProject(projectId)
+                .WithDefaultNamespace(DefaultNamespace)
+                .Solution;
+        });
+
+        await testState.RunAsync();
+    }
+
     [Fact]
     public async Task SingleDocumentNoReference_NoDefaultNamespace()
     {

--- a/src/Analyzers/Core/Analyzers/MatchFolderAndNamespace/AbstractMatchFolderAndNamespaceDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/MatchFolderAndNamespace/AbstractMatchFolderAndNamespaceDiagnosticAnalyzer.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.LanguageService;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Roslyn.Utilities;
 
@@ -53,6 +54,12 @@ internal abstract class AbstractMatchFolderAndNamespaceDiagnosticAnalyzer<TSynta
     {
         var option = context.GetAnalyzerOptions().PreferNamespaceAndFolderMatchStructure;
         if (!option.Value || ShouldSkipAnalysis(context, option.Notification))
+        {
+            return;
+        }
+
+        // File-based programs don't follow the "namespace matches folder structure" convention.
+        if (context.Node.SyntaxTree.IsFileBasedProgram())
         {
             return;
         }

--- a/src/Features/CSharpTest/ConvertProgram/ConvertToProgramMainAnalyzerTests.cs
+++ b/src/Features/CSharpTest/ConvertProgram/ConvertToProgramMainAnalyzerTests.cs
@@ -88,7 +88,7 @@ public sealed class ConvertToProgramMainAnalyzerTests
                     var project = solution.GetProject(projectId)!;
                     var parseOptions = (CSharpParseOptions)project.ParseOptions!;
                     return solution.WithProjectParseOptions(projectId,
-                        parseOptions.WithFeatures([.. parseOptions.Features, new("FileBasedProgram", "")]));
+                        parseOptions.WithFeatures([.. parseOptions.Features, new("FileBasedProgram", "true")]));
                 },
             },
         }.RunAsync();

--- a/src/Features/CSharpTest/ConvertProgram/ConvertToProgramMainAnalyzerTests.cs
+++ b/src/Features/CSharpTest/ConvertProgram/ConvertToProgramMainAnalyzerTests.cs
@@ -71,6 +71,28 @@ public sealed class ConvertToProgramMainAnalyzerTests
             Options = { { CSharpCodeStyleOptions.PreferTopLevelStatements, false, NotificationOption2.Silent } },
         }.RunAsync();
 
+    [Fact, WorkItem("https://github.com/dotnet/vscode-csharp/issues/9550")]
+    public Task NotOfferedForFileBasedProgram()
+        => new VerifyCS.Test
+        {
+            TestCode = """
+            System.Console.WriteLine(0);
+            """,
+            LanguageVersion = LanguageVersion.CSharp9,
+            TestState = { OutputKind = OutputKind.ConsoleApplication },
+            Options = { { CSharpCodeStyleOptions.PreferTopLevelStatements, false, NotificationOption2.Silent } },
+            SolutionTransforms =
+            {
+                static (solution, projectId) =>
+                {
+                    var project = solution.GetProject(projectId)!;
+                    var parseOptions = (CSharpParseOptions)project.ParseOptions!;
+                    return solution.WithProjectParseOptions(projectId,
+                        parseOptions.WithFeatures([.. parseOptions.Features, new("FileBasedProgram", "")]));
+                },
+            },
+        }.RunAsync();
+
     [Fact]
     public Task TestHeader1()
         => new VerifyCS.Test

--- a/src/Features/CSharpTest/ConvertProgram/ConvertToProgramMainRefactoringTests.cs
+++ b/src/Features/CSharpTest/ConvertProgram/ConvertToProgramMainRefactoringTests.cs
@@ -90,7 +90,7 @@ public sealed class ConvertToProgramMainRefactoringTests
                     var project = solution.GetProject(projectId)!;
                     var parseOptions = (CSharpParseOptions)project.ParseOptions!;
                     return solution.WithProjectParseOptions(projectId,
-                        parseOptions.WithFeatures([.. parseOptions.Features, new("FileBasedProgram", "")]));
+                        parseOptions.WithFeatures([.. parseOptions.Features, new("FileBasedProgram", "true")]));
                 },
             },
         }.RunAsync();

--- a/src/Features/CSharpTest/ConvertProgram/ConvertToProgramMainRefactoringTests.cs
+++ b/src/Features/CSharpTest/ConvertProgram/ConvertToProgramMainRefactoringTests.cs
@@ -75,6 +75,27 @@ public sealed class ConvertToProgramMainRefactoringTests
         }.RunAsync();
 
     [Fact]
+    public Task TestNotOfferedForFileBasedProgram()
+        => new VerifyCS.Test
+        {
+            TestCode = """
+            $$System.Console.WriteLine(0);
+            """,
+            LanguageVersion = LanguageVersion.CSharp10,
+            TestState = { OutputKind = OutputKind.ConsoleApplication },
+            SolutionTransforms =
+            {
+                static (solution, projectId) =>
+                {
+                    var project = solution.GetProject(projectId)!;
+                    var parseOptions = (CSharpParseOptions)project.ParseOptions!;
+                    return solution.WithProjectParseOptions(projectId,
+                        parseOptions.WithFeatures([.. parseOptions.Features, new("FileBasedProgram", "")]));
+                },
+            },
+        }.RunAsync();
+
+    [Fact]
     public Task TestNotOfferedInLibrary()
         => new VerifyCS.Test
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/SyntaxTreeExtensions.cs
@@ -38,6 +38,10 @@ internal static partial class SyntaxTreeExtensions
     public static bool IsScript(this SyntaxTree syntaxTree)
         => syntaxTree.Options.Kind != SourceCodeKind.Regular;
 
+    public static bool IsFileBasedProgram(this SyntaxTree syntaxTree)
+        // See also internal 'CSharpParseOptions.FileBasedProgram' helper.
+        => syntaxTree.Options.Features.TryGetValue("FileBasedProgram", out var value) && value is not null;
+
     /// <summary>
     /// Returns the identifier, keyword, contextual keyword or preprocessor keyword touching this
     /// position, or a token of Kind = None if the caret is not touching either.


### PR DESCRIPTION
Closes [dotnet/vscode-csharp#9550](https://github.com/dotnet/vscode-csharp/issues/9550)

Note: this change will go into effect, for any scenario where we avoid reporting errors on `#:` directives. So, miscellaneous files, will also not run these features, for example.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84575)