### PR TITLE
Do not report hidden pattern diagnostics

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder_CheckOrReachability.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder_CheckOrReachability.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
-            if (!EnableRedundantPatternsCheckForSpecificPattern(compilation, syntax))
+            if (!EnableRedundantPatternsCheckForSpecificPattern(syntax))
             {
                 return;
             }
@@ -94,13 +94,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return compilation.LanguageVersion >= LanguageVersion.CSharp14;
         }
 
-        private static bool EnableRedundantPatternsCheckForSpecificPattern(CSharpCompilation compilation, SyntaxNode patternSyntax)
+        /// <seealso cref="ShouldWarn"/>
+        private static bool EnableRedundantPatternsCheckForSpecificPattern(SyntaxNode patternSyntax)
         {
-            if (compilation.AreHiddenRedundantPatternDiagnosticsEnabled)
-                return true;
-
             // Easy out to avoid work in cases when the diagnostics would never be visible to the user.
-            // See also 'ReportRedundant().shouldWarn(SyntaxNode)'.
+            // See also 'ShouldWarn(SyntaxNode)'.
             var hasWarningSeveritySyntaxForm = patternSyntax.DescendantNodesAndSelf().Any(static node => node is BinaryPatternSyntax binary && FindNotInBinary(binary.Left));
             return hasWarningSeveritySyntaxForm;
         }
@@ -115,7 +113,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundSwitchExpressionArm> switchArms,
             BindingDiagnosticBag diagnostics)
         {
-            if (!switchArms.Any(static (switchArm, compilation) => EnableRedundantPatternsCheckForSpecificPattern(compilation, switchArm.Pattern.Syntax), compilation))
+            if (!switchArms.Any(static (switchArm) => EnableRedundantPatternsCheckForSpecificPattern(switchArm.Pattern.Syntax)))
             {
                 return;
             }
@@ -171,7 +169,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundSwitchSection> switchSections,
             BindingDiagnosticBag diagnostics)
         {
-            if (!shouldCheck(compilation, switchSections))
+            if (!shouldCheck(switchSections))
             {
                 return;
             }
@@ -184,13 +182,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             existingCases.Free();
             redundantNodes.Free();
 
-            static bool shouldCheck(CSharpCompilation compilation, ImmutableArray<BoundSwitchSection> switchSections)
+            static bool shouldCheck(ImmutableArray<BoundSwitchSection> switchSections)
             {
                 foreach (var switchSection in switchSections)
                 {
                     foreach (var switchLabel in switchSection.SwitchLabels)
                     {
-                        if (EnableRedundantPatternsCheckForSpecificPattern(compilation, switchLabel.Pattern.Syntax))
+                        if (EnableRedundantPatternsCheckForSpecificPattern(switchLabel.Pattern.Syntax))
                         {
                             return true;
                         }
@@ -250,64 +248,60 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             foreach (var node in redundantNodes)
             {
-                ErrorCode errorCode = shouldWarn(node) ? ErrorCode.WRN_RedundantPattern : ErrorCode.HDN_RedundantPattern;
-                diagnostics.Add(errorCode, node);
+                diagnostics.Add(ErrorCode.WRN_RedundantPattern, node);
             }
+        }
 
-            return;
-
-            // We need to reduce the break introduced by reporting redundant patterns
-            // and we never want to affect people who express their patterns thoroughly (but correctly)
-            // such as `switch { < 0 => -1, 0 => 0, > 0 => 1 }`.
-            // So we're only reporting a warning for situations that syntactically look hazardous.
-            // Others are reported as a hidden diagnostic.
-            // At the moment, we're only interested in patterns in a binary pattern with a `not` before the redundant pattern.
-            static bool shouldWarn(SyntaxNode syntax)
-            {
+        // We need to reduce the break introduced by reporting redundant patterns
+        // and we never want to affect people who express their patterns thoroughly (but correctly)
+        // such as `switch { < 0 => -1, 0 => 0, > 0 => 1 }`.
+        // So we're only reporting a warning for situations that syntactically look hazardous.
+        // At the moment, we're only interested in patterns in a binary pattern with a `not` before the redundant pattern.
+        private static bool ShouldWarn(SyntaxNode syntax)
+        {
 start:
-                if (syntax.Parent is ParenthesizedPatternSyntax parens)
-                {
-                    syntax = parens;
-                    goto start;
-                }
-
-                if (syntax.Parent is BinaryPatternSyntax binary)
-                {
-                    if (binary.Right == syntax && FindNotInBinary(binary.Left))
-                    {
-                        return true;
-                    }
-
-                    syntax = binary;
-                    goto start;
-                }
-
-                // If the syntax is the whole sub-pattern, we walk up to the recursive pattern.
-                // For example: `not A or { Prop: <redundant> }`
-                if (syntax.Parent is SubpatternSyntax subpatternSyntax
-                    && subpatternSyntax.Parent is (PropertyPatternClauseSyntax or PositionalPatternClauseSyntax) and var patternClause
-                    && patternClause.Parent is RecursivePatternSyntax recursive)
-                {
-                    syntax = recursive;
-                    goto start;
-                }
-
-                // If the syntax is the whole list element pattern, we walk up to the list pattern.
-                // For example: `not A or [<redundant>, ...]`
-                if (syntax.Parent is ListPatternSyntax listPattern)
-                {
-                    syntax = listPattern;
-                    goto start;
-                }
-
-                if (syntax.Parent is SlicePatternSyntax slicePattern)
-                {
-                    syntax = slicePattern;
-                    goto start;
-                }
-
-                return false;
+            if (syntax.Parent is ParenthesizedPatternSyntax parens)
+            {
+                syntax = parens;
+                goto start;
             }
+
+            if (syntax.Parent is BinaryPatternSyntax binary)
+            {
+                if (binary.Right == syntax && FindNotInBinary(binary.Left))
+                {
+                    return true;
+                }
+
+                syntax = binary;
+                goto start;
+            }
+
+            // If the syntax is the whole sub-pattern, we walk up to the recursive pattern.
+            // For example: `not A or { Prop: <redundant> }`
+            if (syntax.Parent is SubpatternSyntax subpatternSyntax
+                && subpatternSyntax.Parent is (PropertyPatternClauseSyntax or PositionalPatternClauseSyntax) and var patternClause
+                && patternClause.Parent is RecursivePatternSyntax recursive)
+            {
+                syntax = recursive;
+                goto start;
+            }
+
+            // If the syntax is the whole list element pattern, we walk up to the list pattern.
+            // For example: `not A or [<redundant>, ...]`
+            if (syntax.Parent is ListPatternSyntax listPattern)
+            {
+                syntax = listPattern;
+                goto start;
+            }
+
+            if (syntax.Parent is SlicePatternSyntax slicePattern)
+            {
+                syntax = slicePattern;
+                goto start;
+            }
+
+            return false;
         }
 
         // Detect a `not` at top-level or inside a tree of binary patterns
@@ -569,7 +563,7 @@ start:
                 for (int i = 0; i < casesBuilder.Count; i++)
                 {
                     StateForCase @case = casesBuilder[i];
-                    bool shouldReport = !dag.ReachableLabels.Contains(@case.CaseLabel) && !labelsToIgnore.Contains(@case.CaseLabel);
+                    bool shouldReport = !dag.ReachableLabels.Contains(@case.CaseLabel) && !labelsToIgnore.Contains(@case.CaseLabel) && ShouldWarn(@case.Syntax);
                     if (shouldReport)
                     {
                         context.RedundantNodes.Add(@case.Syntax);

--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder_CheckOrReachability.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder_CheckOrReachability.cs
@@ -94,7 +94,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Detect if 'patternSyntax' contains a 'not A or B'/'not A and B' syntactic form,
         /// and that <see cref="ErrorCode.WRN_RedundantPattern"/> is enabled at its location.
         /// </summary>
-        /// <seealso cref="ShouldWarn"/>
+        /// <remarks>
+        /// This and <see cref="ShouldWarn"/> methods are sensitive to parens.
+        /// So, for example, they will return false for '(not A) or B' as well as 'not (A or B)'.
+        /// These forms are thought to not be hazardous and to not warrant warnings.
+        /// </remarks>
         private static bool ShouldAnalyze(CSharpCompilation compilation, SyntaxNode patternSyntax)
         {
             var hasWarningSeveritySyntaxForm = patternSyntax.DescendantNodesAndSelf().Any(

--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder_CheckOrReachability.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder_CheckOrReachability.cs
@@ -65,12 +65,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool hasUnionMatching,
             BindingDiagnosticBag diagnostics)
         {
-            if (pattern.HasErrors)
-            {
-                return;
-            }
-
-            if (!EnableRedundantPatternsCheckForSpecificPattern(syntax))
+            if (pattern.HasErrors || !ShouldAnalyze(syntax))
             {
                 return;
             }
@@ -94,10 +89,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             return compilation.LanguageVersion >= LanguageVersion.CSharp14;
         }
 
+        /// <summary>Detect if 'patternSyntax' contains a 'not A or B'/'not A and B' syntactic form which we could possibly report a redundancy warning on.</summary>
         /// <seealso cref="ShouldWarn"/>
-        private static bool EnableRedundantPatternsCheckForSpecificPattern(SyntaxNode patternSyntax)
+        private static bool ShouldAnalyze(SyntaxNode patternSyntax)
         {
-            // Easy out to avoid work in cases when the diagnostics would never be visible to the user.
             var hasWarningSeveritySyntaxForm = patternSyntax.DescendantNodesAndSelf().Any(static node => node is BinaryPatternSyntax binary && FindNotInBinary(binary.Left));
             return hasWarningSeveritySyntaxForm;
         }
@@ -112,7 +107,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundSwitchExpressionArm> switchArms,
             BindingDiagnosticBag diagnostics)
         {
-            if (!switchArms.Any(static (switchArm) => EnableRedundantPatternsCheckForSpecificPattern(switchArm.Pattern.Syntax)))
+            if (!switchArms.Any(static (switchArm) => ShouldAnalyze(switchArm.Pattern.Syntax)))
             {
                 return;
             }
@@ -151,7 +146,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 for (int patternIndex = 0; patternIndex < switchArms.Length; patternIndex++)
                 {
                     BoundSwitchExpressionArm switchArm = switchArms[patternIndex];
-                    CheckOrAndAndReachability(existingCases, patternIndex, switchArm.Pattern, switchArm.HasUnionMatching, builder, rootIdentifier, syntax, diagnostics, redundantNodes);
+                    if (ShouldAnalyze(switchArm.Syntax))
+                    {
+                        CheckOrAndAndReachability(existingCases, patternIndex, switchArm.Pattern, switchArm.HasUnionMatching, builder, rootIdentifier, syntax, diagnostics, redundantNodes);
+                    }
                 }
 
                 ReportRedundant(redundantNodes, diagnostics);
@@ -168,7 +166,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundSwitchSection> switchSections,
             BindingDiagnosticBag diagnostics)
         {
-            if (!shouldCheck(switchSections))
+            if (!shouldAnalyzeAny(switchSections))
             {
                 return;
             }
@@ -181,13 +179,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             existingCases.Free();
             redundantNodes.Free();
 
-            static bool shouldCheck(ImmutableArray<BoundSwitchSection> switchSections)
+            static bool shouldAnalyzeAny(ImmutableArray<BoundSwitchSection> switchSections)
             {
                 foreach (var switchSection in switchSections)
                 {
                     foreach (var switchLabel in switchSection.SwitchLabels)
                     {
-                        if (EnableRedundantPatternsCheckForSpecificPattern(switchLabel.Pattern.Syntax))
+                        if (ShouldAnalyze(switchLabel.Pattern.Syntax))
                         {
                             return true;
                         }
@@ -233,7 +231,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         if (label.Syntax.Kind() != SyntaxKind.DefaultSwitchLabel)
                         {
-                            CheckOrAndAndReachability(existingCases, patternIndex, label.Pattern, label.HasUnionMatching, builder, rootIdentifier, syntax, diagnostics, redundantNodes);
+                            if (ShouldAnalyze(label.Pattern.Syntax))
+                            {
+                                CheckOrAndAndReachability(existingCases, patternIndex, label.Pattern, label.HasUnionMatching, builder, rootIdentifier, syntax, diagnostics, redundantNodes);
+                            }
+
                             patternIndex++;
                         }
                     }
@@ -247,6 +249,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             foreach (var node in redundantNodes)
             {
+                Debug.Assert(ShouldWarn(node));
                 diagnostics.Add(ErrorCode.WRN_RedundantPattern, node);
             }
         }

--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder_CheckOrReachability.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder_CheckOrReachability.cs
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 for (int patternIndex = 0; patternIndex < switchArms.Length; patternIndex++)
                 {
                     BoundSwitchExpressionArm switchArm = switchArms[patternIndex];
-                    if (ShouldAnalyze(switchArm.Syntax))
+                    if (ShouldAnalyze(switchArm.Pattern.Syntax))
                     {
                         CheckOrAndAndReachability(existingCases, patternIndex, switchArm.Pattern, switchArm.HasUnionMatching, builder, rootIdentifier, syntax, diagnostics, redundantNodes);
                     }

--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder_CheckOrReachability.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder_CheckOrReachability.cs
@@ -70,6 +70,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
+            if (!EnableRedundantPatternsCheckForSpecificPattern(compilation, syntax))
+            {
+                return;
+            }
+
             LabelSymbol defaultLabel = new GeneratedLabelSymbol("defaultLabel");
             var builder = new DecisionDagBuilder(compilation, defaultLabel: defaultLabel, forLowering: false, BindingDiagnosticBag.Discarded);
             BoundDagTemp rootIdentifier = BoundDagTemp.ForOriginalInput(inputExpression);
@@ -82,6 +87,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             redundantNodes.Free();
             Debug.Assert(noPreviousCases.Count == 0);
             noPreviousCases.Free();
+        }
+
+        private static bool EnableRedundantPatternsCheckForSpecificPattern(CSharpCompilation compilation, SyntaxNode patternSyntax)
+        {
+            if (compilation.AreRedundantPatternDiagnosticsElevated)
+                return true;
+
+            // Easy out to avoid work in cases when the diagnostics would never be visible to the user.
+            // See also 'ReportRedundant().shouldWarn()'.
+            var hasWarningSeveritySyntaxForm = patternSyntax.DescendantNodesAndSelf().Any(static node => node is BinaryPatternSyntax binary && binary.Left.IsKind(SyntaxKind.NotPattern));
+            return hasWarningSeveritySyntaxForm;
         }
 
         internal static bool EnableRedundantPatternsCheck(CSharpCompilation compilation)
@@ -99,6 +115,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundSwitchExpressionArm> switchArms,
             BindingDiagnosticBag diagnostics)
         {
+            if (!switchArms.Any(static (switchArm, compilation) => EnableRedundantPatternsCheckForSpecificPattern(compilation, switchArm.Pattern.Syntax), compilation))
+            {
+                return;
+            }
+
             var redundantNodes = PooledHashSet<SyntaxNode>.GetInstance();
             var existingCases = ArrayBuilder<StateForCase>.GetInstance(switchArms.Length);
 
@@ -150,6 +171,24 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundSwitchSection> switchSections,
             BindingDiagnosticBag diagnostics)
         {
+            bool anyPatternMayHaveRedundantSubpatterns = false;
+            foreach (var switchSection in switchSections)
+            {
+                foreach (var switchLabel in switchSection.SwitchLabels)
+                {
+                    if (EnableRedundantPatternsCheckForSpecificPattern(compilation, switchLabel.Pattern.Syntax))
+                    {
+                        anyPatternMayHaveRedundantSubpatterns = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!anyPatternMayHaveRedundantSubpatterns)
+            {
+                return;
+            }
+
             var redundantNodes = PooledHashSet<SyntaxNode>.GetInstance();
             var existingCases = ArrayBuilder<StateForCase>.GetInstance();
 

--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder_CheckOrReachability.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder_CheckOrReachability.cs
@@ -89,20 +89,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             noPreviousCases.Free();
         }
 
-        private static bool EnableRedundantPatternsCheckForSpecificPattern(CSharpCompilation compilation, SyntaxNode patternSyntax)
-        {
-            if (compilation.AreRedundantPatternDiagnosticsElevated)
-                return true;
-
-            // Easy out to avoid work in cases when the diagnostics would never be visible to the user.
-            // See also 'ReportRedundant().shouldWarn()'.
-            var hasWarningSeveritySyntaxForm = patternSyntax.DescendantNodesAndSelf().Any(static node => node is BinaryPatternSyntax binary && binary.Left.IsKind(SyntaxKind.NotPattern));
-            return hasWarningSeveritySyntaxForm;
-        }
-
         internal static bool EnableRedundantPatternsCheck(CSharpCompilation compilation)
         {
             return compilation.LanguageVersion >= LanguageVersion.CSharp14;
+        }
+
+        private static bool EnableRedundantPatternsCheckForSpecificPattern(CSharpCompilation compilation, SyntaxNode patternSyntax)
+        {
+            if (compilation.AreHiddenRedundantPatternDiagnosticsEnabled)
+                return true;
+
+            // Easy out to avoid work in cases when the diagnostics would never be visible to the user.
+            // See also 'ReportRedundant().shouldWarn(SyntaxNode)'.
+            var hasWarningSeveritySyntaxForm = patternSyntax.DescendantNodesAndSelf().Any(static node => node is BinaryPatternSyntax binary && FindNotInBinary(binary.Left));
+            return hasWarningSeveritySyntaxForm;
         }
 
         /// <summary>
@@ -270,7 +270,7 @@ start:
 
                 if (syntax.Parent is BinaryPatternSyntax binary)
                 {
-                    if (binary.Right == syntax && findNotInBinary(binary.Left))
+                    if (binary.Right == syntax && FindNotInBinary(binary.Left))
                     {
                         return true;
                     }
@@ -305,23 +305,23 @@ start:
 
                 return false;
             }
+        }
 
-            // Detect a `not` at top-level or inside a tree of binary patterns
-            // Note: we don't dig into parenthesized patterns as the meaning of `not` is not problematic then
-            static bool findNotInBinary(SyntaxNode syntax)
+        // Detect a `not` at top-level or inside a tree of binary patterns
+        // Note: we don't dig into parenthesized patterns as the meaning of `not` is not problematic then
+        private static bool FindNotInBinary(SyntaxNode syntax)
+        {
+            while (syntax is BinaryPatternSyntax binarySyntax)
             {
-                while (syntax is BinaryPatternSyntax binarySyntax)
+                if (FindNotInBinary(binarySyntax.Right))
                 {
-                    if (findNotInBinary(binarySyntax.Right))
-                    {
-                        return true;
-                    }
-
-                    syntax = binarySyntax.Left;
+                    return true;
                 }
 
-                return syntax.Kind() == SyntaxKind.NotPattern;
+                syntax = binarySyntax.Left;
             }
+
+            return syntax.Kind() == SyntaxKind.NotPattern;
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder_CheckOrReachability.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder_CheckOrReachability.cs
@@ -171,20 +171,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundSwitchSection> switchSections,
             BindingDiagnosticBag diagnostics)
         {
-            bool anyPatternMayHaveRedundantSubpatterns = false;
-            foreach (var switchSection in switchSections)
-            {
-                foreach (var switchLabel in switchSection.SwitchLabels)
-                {
-                    if (EnableRedundantPatternsCheckForSpecificPattern(compilation, switchLabel.Pattern.Syntax))
-                    {
-                        anyPatternMayHaveRedundantSubpatterns = true;
-                        break;
-                    }
-                }
-            }
-
-            if (!anyPatternMayHaveRedundantSubpatterns)
+            if (!shouldCheck(compilation, switchSections))
             {
                 return;
             }
@@ -196,6 +183,22 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             existingCases.Free();
             redundantNodes.Free();
+
+            static bool shouldCheck(CSharpCompilation compilation, ImmutableArray<BoundSwitchSection> switchSections)
+            {
+                foreach (var switchSection in switchSections)
+                {
+                    foreach (var switchLabel in switchSection.SwitchLabels)
+                    {
+                        if (EnableRedundantPatternsCheckForSpecificPattern(compilation, switchLabel.Pattern.Syntax))
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                return false;
+            }
 
             static void checkRedundantPatternsForSwitchStatement(
                 CSharpCompilation compilation,

--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder_CheckOrReachability.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder_CheckOrReachability.cs
@@ -9,6 +9,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis.Collections;
 
 #if ROSLYN_TEST_REDUNDANT_PATTERN
@@ -65,7 +66,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool hasUnionMatching,
             BindingDiagnosticBag diagnostics)
         {
-            if (pattern.HasErrors || !ShouldAnalyze(syntax))
+            if (pattern.HasErrors || !ShouldAnalyze(compilation, syntax))
             {
                 return;
             }
@@ -89,12 +90,39 @@ namespace Microsoft.CodeAnalysis.CSharp
             return compilation.LanguageVersion >= LanguageVersion.CSharp14;
         }
 
-        /// <summary>Detect if 'patternSyntax' contains a 'not A or B'/'not A and B' syntactic form which we could possibly report a redundancy warning on.</summary>
+        /// <summary>
+        /// Detect if 'patternSyntax' contains a 'not A or B'/'not A and B' syntactic form,
+        /// and that <see cref="ErrorCode.WRN_RedundantPattern"/> is enabled at its location.
+        /// </summary>
         /// <seealso cref="ShouldWarn"/>
-        private static bool ShouldAnalyze(SyntaxNode patternSyntax)
+        private static bool ShouldAnalyze(CSharpCompilation compilation, SyntaxNode patternSyntax)
         {
-            var hasWarningSeveritySyntaxForm = patternSyntax.DescendantNodesAndSelf().Any(static node => node is BinaryPatternSyntax binary && FindNotInBinary(binary.Left));
+            var hasWarningSeveritySyntaxForm = patternSyntax.DescendantNodesAndSelf().Any(
+                node => node is BinaryPatternSyntax binary && FindNotInBinary(binary.Left) && IsRedundantPatternWarningEnabled(compilation, binary.Right));
             return hasWarningSeveritySyntaxForm;
+        }
+
+        private static bool IsRedundantPatternWarningEnabled(CSharpCompilation compilation, SyntaxNode syntax)
+        {
+            const ErrorCode code = ErrorCode.WRN_RedundantPattern;
+            var options = compilation.Options;
+            ReportDiagnostic report = CSharpDiagnosticFilter.GetDiagnosticReport(
+                ErrorFacts.GetSeverity(code),
+                MessageProvider.Instance.GetIsEnabledByDefault((int)code),
+                (int)code,
+                MessageProvider.Instance.GetIdForErrorCode((int)code),
+                ErrorFacts.GetWarningLevel(code),
+                syntax.Location,
+                customTags: [],
+                options.WarningLevel,
+                options.NullableContextOptions,
+                options.GeneralDiagnosticOption,
+                options.SpecificDiagnosticOptions,
+                options.SyntaxTreeOptionsProvider,
+                CancellationToken.None,
+                out bool hasPragmaSuppression);
+
+            return report != ReportDiagnostic.Suppress && !hasPragmaSuppression;
         }
 
         /// <summary>
@@ -107,7 +135,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundSwitchExpressionArm> switchArms,
             BindingDiagnosticBag diagnostics)
         {
-            if (!switchArms.Any(static (switchArm) => ShouldAnalyze(switchArm.Pattern.Syntax)))
+            if (!switchArms.Any(static (switchArm, compilation) => ShouldAnalyze(compilation, switchArm.Pattern.Syntax), compilation))
             {
                 return;
             }
@@ -146,7 +174,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 for (int patternIndex = 0; patternIndex < switchArms.Length; patternIndex++)
                 {
                     BoundSwitchExpressionArm switchArm = switchArms[patternIndex];
-                    if (ShouldAnalyze(switchArm.Pattern.Syntax))
+                    if (ShouldAnalyze(compilation, switchArm.Pattern.Syntax))
                     {
                         CheckOrAndAndReachability(existingCases, patternIndex, switchArm.Pattern, switchArm.HasUnionMatching, builder, rootIdentifier, syntax, diagnostics, redundantNodes);
                     }
@@ -166,7 +194,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundSwitchSection> switchSections,
             BindingDiagnosticBag diagnostics)
         {
-            if (!shouldAnalyzeAny(switchSections))
+            if (!shouldAnalyzeAny(compilation, switchSections))
             {
                 return;
             }
@@ -179,13 +207,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             existingCases.Free();
             redundantNodes.Free();
 
-            static bool shouldAnalyzeAny(ImmutableArray<BoundSwitchSection> switchSections)
+            static bool shouldAnalyzeAny(CSharpCompilation compilation, ImmutableArray<BoundSwitchSection> switchSections)
             {
                 foreach (var switchSection in switchSections)
                 {
                     foreach (var switchLabel in switchSection.SwitchLabels)
                     {
-                        if (ShouldAnalyze(switchLabel.Pattern.Syntax))
+                        if (ShouldAnalyze(compilation, switchLabel.Pattern.Syntax))
                         {
                             return true;
                         }
@@ -231,7 +259,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         if (label.Syntax.Kind() != SyntaxKind.DefaultSwitchLabel)
                         {
-                            if (ShouldAnalyze(label.Pattern.Syntax))
+                            if (ShouldAnalyze(compilation, label.Pattern.Syntax))
                             {
                                 CheckOrAndAndReachability(existingCases, patternIndex, label.Pattern, label.HasUnionMatching, builder, rootIdentifier, syntax, diagnostics, redundantNodes);
                             }

--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder_CheckOrReachability.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder_CheckOrReachability.cs
@@ -98,7 +98,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         private static bool EnableRedundantPatternsCheckForSpecificPattern(SyntaxNode patternSyntax)
         {
             // Easy out to avoid work in cases when the diagnostics would never be visible to the user.
-            // See also 'ShouldWarn(SyntaxNode)'.
             var hasWarningSeveritySyntaxForm = patternSyntax.DescendantNodesAndSelf().Any(static node => node is BinaryPatternSyntax binary && FindNotInBinary(binary.Left));
             return hasWarningSeveritySyntaxForm;
         }

--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder_CheckOrReachability.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder_CheckOrReachability.cs
@@ -102,31 +102,31 @@ namespace Microsoft.CodeAnalysis.CSharp
         private static bool ShouldAnalyze(CSharpCompilation compilation, SyntaxNode patternSyntax)
         {
             var hasWarningSeveritySyntaxForm = patternSyntax.DescendantNodesAndSelf().Any(
-                node => node is BinaryPatternSyntax binary && FindNotInBinary(binary.Left) && IsRedundantPatternWarningEnabled(compilation, binary.Right));
+                node => node is BinaryPatternSyntax binary && FindNotInBinary(binary.Left) && isRedundantPatternWarningEnabled(compilation, binary.Right));
             return hasWarningSeveritySyntaxForm;
-        }
 
-        private static bool IsRedundantPatternWarningEnabled(CSharpCompilation compilation, SyntaxNode syntax)
-        {
-            const ErrorCode code = ErrorCode.WRN_RedundantPattern;
-            var options = compilation.Options;
-            ReportDiagnostic report = CSharpDiagnosticFilter.GetDiagnosticReport(
-                ErrorFacts.GetSeverity(code),
-                MessageProvider.Instance.GetIsEnabledByDefault((int)code),
-                (int)code,
-                MessageProvider.Instance.GetIdForErrorCode((int)code),
-                ErrorFacts.GetWarningLevel(code),
-                syntax.Location,
-                customTags: [],
-                options.WarningLevel,
-                options.NullableContextOptions,
-                options.GeneralDiagnosticOption,
-                options.SpecificDiagnosticOptions,
-                options.SyntaxTreeOptionsProvider,
-                CancellationToken.None,
-                out bool hasPragmaSuppression);
+            static bool isRedundantPatternWarningEnabled(CSharpCompilation compilation, SyntaxNode syntax)
+            {
+                const ErrorCode code = ErrorCode.WRN_RedundantPattern;
+                var options = compilation.Options;
+                ReportDiagnostic report = CSharpDiagnosticFilter.GetDiagnosticReport(
+                    ErrorFacts.GetSeverity(code),
+                    MessageProvider.Instance.GetIsEnabledByDefault((int)code),
+                    (int)code,
+                    MessageProvider.Instance.GetIdForErrorCode((int)code),
+                    ErrorFacts.GetWarningLevel(code),
+                    syntax.Location,
+                    customTags: [],
+                    options.WarningLevel,
+                    options.NullableContextOptions,
+                    options.GeneralDiagnosticOption,
+                    options.SpecificDiagnosticOptions,
+                    options.SyntaxTreeOptionsProvider,
+                    CancellationToken.None,
+                    out bool hasPragmaSuppression);
 
-            return report != ReportDiagnostic.Suppress && !hasPragmaSuppression;
+                return report != ReportDiagnostic.Suppress && !hasPragmaSuppression;
+            }
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -8219,12 +8219,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>'node' is not an 'await using' statement</value>
     <comment>node and await using are not localizable</comment>
   </data>
-  <data name="HDN_RedundantPattern" xml:space="preserve">
-    <value>The pattern is redundant.</value>
-  </data>
-  <data name="HDN_RedundantPattern_Title" xml:space="preserve">
-    <value>The pattern is redundant.</value>
-  </data>
   <data name="WRN_RedundantPattern" xml:space="preserve">
     <value>The pattern is redundant.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -132,8 +132,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private ThreeState _lazyEmitNullablePublicOnly;
 
-        private ThreeState _lazyAreHiddenRedundantPatternDiagnosticsEnabled;
-
         /// <summary>
         /// The set of trees for which a <see cref="CompilationUnitCompletedEvent"/> has been added to the queue.
         /// </summary>
@@ -4911,22 +4909,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     _lazyEmitNullablePublicOnly = value.ToThreeState();
                 }
                 return _lazyEmitNullablePublicOnly.Value();
-            }
-        }
-
-        /// <summary>Check if <see cref="ErrorCode.HDN_RedundantPattern"/> has been enabled.</summary>
-        internal bool AreHiddenRedundantPatternDiagnosticsEnabled
-        {
-            get
-            {
-                if (!_lazyAreHiddenRedundantPatternDiagnosticsEnabled.HasValue())
-                {
-                    var diagnosticInfo = new DiagnosticInfo(MessageProvider, (int)ErrorCode.HDN_RedundantPattern);
-                    var reportDiagnostic = MessageProvider.GetDiagnosticReport(diagnosticInfo, Options);
-                    bool isEnabled = reportDiagnostic != ReportDiagnostic.Suppress;
-                    _lazyAreHiddenRedundantPatternDiagnosticsEnabled = isEnabled.ToThreeState();
-                }
-                return _lazyAreHiddenRedundantPatternDiagnosticsEnabled.Value();
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -132,6 +132,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private ThreeState _lazyEmitNullablePublicOnly;
 
+        private ThreeState _lazyAreRedundantPatternDiagnosticsElevated;
+
         /// <summary>
         /// The set of trees for which a <see cref="CompilationUnitCompletedEvent"/> has been added to the queue.
         /// </summary>
@@ -4909,6 +4911,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                     _lazyEmitNullablePublicOnly = value.ToThreeState();
                 }
                 return _lazyEmitNullablePublicOnly.Value();
+            }
+        }
+
+        /// <summary>Check if <see cref="ErrorCode.HDN_RedundantPattern"/> has been elevated to higher severity.</summary>
+        internal bool AreRedundantPatternDiagnosticsElevated
+        {
+            get
+            {
+                if (!_lazyAreRedundantPatternDiagnosticsElevated.HasValue())
+                {
+                    var diagnosticInfo = new DiagnosticInfo(MessageProvider, (int)ErrorCode.HDN_RedundantPattern);
+                    var reportDiagnostic = MessageProvider.GetDiagnosticReport(diagnosticInfo, Options);
+                    bool isElevated = reportDiagnostic is not (ReportDiagnostic.Default or ReportDiagnostic.Hidden or ReportDiagnostic.Suppress);
+                    _lazyAreRedundantPatternDiagnosticsElevated = isElevated.ToThreeState();
+                }
+                return _lazyAreRedundantPatternDiagnosticsElevated.Value();
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private ThreeState _lazyEmitNullablePublicOnly;
 
-        private ThreeState _lazyAreRedundantPatternDiagnosticsElevated;
+        private ThreeState _lazyAreHiddenRedundantPatternDiagnosticsEnabled;
 
         /// <summary>
         /// The set of trees for which a <see cref="CompilationUnitCompletedEvent"/> has been added to the queue.
@@ -4914,19 +4914,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        /// <summary>Check if <see cref="ErrorCode.HDN_RedundantPattern"/> has been elevated to higher severity.</summary>
-        internal bool AreRedundantPatternDiagnosticsElevated
+        /// <summary>Check if <see cref="ErrorCode.HDN_RedundantPattern"/> has been enabled.</summary>
+        internal bool AreHiddenRedundantPatternDiagnosticsEnabled
         {
             get
             {
-                if (!_lazyAreRedundantPatternDiagnosticsElevated.HasValue())
+                if (!_lazyAreHiddenRedundantPatternDiagnosticsEnabled.HasValue())
                 {
                     var diagnosticInfo = new DiagnosticInfo(MessageProvider, (int)ErrorCode.HDN_RedundantPattern);
                     var reportDiagnostic = MessageProvider.GetDiagnosticReport(diagnosticInfo, Options);
-                    bool isElevated = reportDiagnostic is not (ReportDiagnostic.Default or ReportDiagnostic.Hidden or ReportDiagnostic.Suppress);
-                    _lazyAreRedundantPatternDiagnosticsElevated = isElevated.ToThreeState();
+                    bool isEnabled = reportDiagnostic != ReportDiagnostic.Suppress;
+                    _lazyAreHiddenRedundantPatternDiagnosticsEnabled = isEnabled.ToThreeState();
                 }
-                return _lazyAreRedundantPatternDiagnosticsElevated.Value();
+                return _lazyAreHiddenRedundantPatternDiagnosticsEnabled.Value();
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2431,7 +2431,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_ExplicitInterfaceMemberTypeMismatch = 9333,
         ERR_ExplicitInterfaceMemberReturnTypeMismatch = 9334,
 
-        HDN_RedundantPattern = 9335,
+        // HDN_RedundantPattern = 9335,  // no longer reported
         WRN_RedundantPattern = 9336,
         HDN_RedundantPatternStackGuard = 9337,
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -2544,7 +2544,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 or ErrorCode.ERR_BadSpreadInCatchFilter
                 or ErrorCode.ERR_ExplicitInterfaceMemberTypeMismatch
                 or ErrorCode.ERR_ExplicitInterfaceMemberReturnTypeMismatch
-                or ErrorCode.HDN_RedundantPattern
                 or ErrorCode.WRN_RedundantPattern
                 or ErrorCode.HDN_RedundantPatternStackGuard
                 or ErrorCode.ERR_BadVisBaseType

--- a/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             bool hasPragmaSuppression;
             return CSharpDiagnosticFilter.GetDiagnosticReport(diagnosticInfo.Severity,
-                                                              true,
+                                                              GetIsEnabledByDefault(diagnosticInfo.Code),
                                                               diagnosticInfo.Code,
                                                               diagnosticInfo.MessageIdentifier,
                                                               diagnosticInfo.WarningLevel,

--- a/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
@@ -115,7 +115,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 or ErrorCode.WRN_UnassignedThisSupportedVersion
                 or ErrorCode.WRN_CollectionExpressionRefStructMayAllocate
                 or ErrorCode.WRN_CollectionExpressionRefStructSpreadMayAllocate
-                or ErrorCode.HDN_RedundantPattern
             );
 
         public override ReportDiagnostic GetDiagnosticReport(DiagnosticInfo diagnosticInfo, CompilationOptions options)

--- a/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
@@ -115,6 +115,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 or ErrorCode.WRN_UnassignedThisSupportedVersion
                 or ErrorCode.WRN_CollectionExpressionRefStructMayAllocate
                 or ErrorCode.WRN_CollectionExpressionRefStructSpreadMayAllocate
+                or ErrorCode.HDN_RedundantPattern
             );
 
         public override ReportDiagnostic GetDiagnosticReport(DiagnosticInfo diagnosticInfo, CompilationOptions options)

--- a/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             bool hasPragmaSuppression;
             return CSharpDiagnosticFilter.GetDiagnosticReport(diagnosticInfo.Severity,
-                                                              GetIsEnabledByDefault(diagnosticInfo.Code),
+                                                              true,
                                                               diagnosticInfo.Code,
                                                               diagnosticInfo.MessageIdentifier,
                                                               diagnosticInfo.WarningLevel,

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -388,7 +388,6 @@
                 case ErrorCode.HDN_UnusedUsingDirective:
                 case ErrorCode.HDN_UnusedExternAlias:
                 case ErrorCode.HDN_DuplicateWithGlobalUsing:
-                case ErrorCode.HDN_RedundantPattern:
                 case ErrorCode.HDN_RedundantPatternStackGuard:
                     return true;
                 default:

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -2942,11 +2942,6 @@
         <target state="translated">Direktiva using se dříve zobrazovala jako globální direktiva using</target>
         <note />
       </trans-unit>
-      <trans-unit id="HDN_RedundantPattern">
-        <source>The pattern is redundant.</source>
-        <target state="translated">Vzor je redundantní.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HDN_RedundantPatternStackGuard">
         <source>The pattern is too complex to analyze for redundancy.</source>
         <target state="translated">Vzor je příliš složitý na analýzu redundance.</target>
@@ -2955,11 +2950,6 @@
       <trans-unit id="HDN_RedundantPatternStackGuard_Title">
         <source>The pattern is too complex to analyze for redundancy.</source>
         <target state="translated">Vzor je příliš složitý na analýzu redundance.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="HDN_RedundantPattern_Title">
-        <source>The pattern is redundant.</source>
-        <target state="translated">Vzor je redundantní.</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ArrayAccess">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -2942,11 +2942,6 @@
         <target state="translated">Die Verwenden-Anweisung wurde zuvor als „Global verwenden“ angezeigt</target>
         <note />
       </trans-unit>
-      <trans-unit id="HDN_RedundantPattern">
-        <source>The pattern is redundant.</source>
-        <target state="translated">Das Muster ist redundant.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HDN_RedundantPatternStackGuard">
         <source>The pattern is too complex to analyze for redundancy.</source>
         <target state="translated">Das Muster ist zu komplex, um auf Redundanz analysiert zu werden.</target>
@@ -2955,11 +2950,6 @@
       <trans-unit id="HDN_RedundantPatternStackGuard_Title">
         <source>The pattern is too complex to analyze for redundancy.</source>
         <target state="translated">Das Muster ist zu komplex, um auf Redundanz analysiert zu werden.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="HDN_RedundantPattern_Title">
-        <source>The pattern is redundant.</source>
-        <target state="translated">Das Muster ist redundant.</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ArrayAccess">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -2942,11 +2942,6 @@
         <target state="translated">La directiva using aparecía anteriormente como using global</target>
         <note />
       </trans-unit>
-      <trans-unit id="HDN_RedundantPattern">
-        <source>The pattern is redundant.</source>
-        <target state="translated">El patrón es redundante.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HDN_RedundantPatternStackGuard">
         <source>The pattern is too complex to analyze for redundancy.</source>
         <target state="translated">El patrón es demasiado complejo para analizar la redundancia.</target>
@@ -2955,11 +2950,6 @@
       <trans-unit id="HDN_RedundantPatternStackGuard_Title">
         <source>The pattern is too complex to analyze for redundancy.</source>
         <target state="translated">El patrón es demasiado complejo para analizar la redundancia.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="HDN_RedundantPattern_Title">
-        <source>The pattern is redundant.</source>
-        <target state="translated">El patrón es redundante.</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ArrayAccess">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -2942,11 +2942,6 @@
         <target state="translated">La directive using est apparue précédemment comme using global</target>
         <note />
       </trans-unit>
-      <trans-unit id="HDN_RedundantPattern">
-        <source>The pattern is redundant.</source>
-        <target state="translated">Le modèle est redondant.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HDN_RedundantPatternStackGuard">
         <source>The pattern is too complex to analyze for redundancy.</source>
         <target state="translated">Le modèle est trop complexe pour être analysé en vue de détecter des redondances.</target>
@@ -2955,11 +2950,6 @@
       <trans-unit id="HDN_RedundantPatternStackGuard_Title">
         <source>The pattern is too complex to analyze for redundancy.</source>
         <target state="translated">Le modèle est trop complexe pour être analysé en vue de détecter des redondances.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="HDN_RedundantPattern_Title">
-        <source>The pattern is redundant.</source>
-        <target state="translated">Le modèle est redondant.</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ArrayAccess">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -2942,11 +2942,6 @@
         <target state="translated">La direttiva using è già presente come using globale</target>
         <note />
       </trans-unit>
-      <trans-unit id="HDN_RedundantPattern">
-        <source>The pattern is redundant.</source>
-        <target state="translated">Il modello è ridondante.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HDN_RedundantPatternStackGuard">
         <source>The pattern is too complex to analyze for redundancy.</source>
         <target state="translated">Il modello è troppo complesso per l'analisi della ridondanza.</target>
@@ -2955,11 +2950,6 @@
       <trans-unit id="HDN_RedundantPatternStackGuard_Title">
         <source>The pattern is too complex to analyze for redundancy.</source>
         <target state="translated">Il modello è troppo complesso per l'analisi della ridondanza.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="HDN_RedundantPattern_Title">
-        <source>The pattern is redundant.</source>
-        <target state="translated">Il modello è ridondante.</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ArrayAccess">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -2942,11 +2942,6 @@
         <target state="translated">using ディレクティブは、以前に global using として使用されています</target>
         <note />
       </trans-unit>
-      <trans-unit id="HDN_RedundantPattern">
-        <source>The pattern is redundant.</source>
-        <target state="translated">パターンは冗長です。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HDN_RedundantPatternStackGuard">
         <source>The pattern is too complex to analyze for redundancy.</source>
         <target state="translated">パターンが複雑すぎるため、冗長性を分析する必要があります。</target>
@@ -2955,11 +2950,6 @@
       <trans-unit id="HDN_RedundantPatternStackGuard_Title">
         <source>The pattern is too complex to analyze for redundancy.</source>
         <target state="translated">パターンが複雑すぎるため、冗長性を分析する必要があります。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="HDN_RedundantPattern_Title">
-        <source>The pattern is redundant.</source>
-        <target state="translated">パターンは冗長です。</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ArrayAccess">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -2942,11 +2942,6 @@
         <target state="translated">using 지시문은 이전에 전역 using으로 나타났습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="HDN_RedundantPattern">
-        <source>The pattern is redundant.</source>
-        <target state="translated">이 패턴은 중복입니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HDN_RedundantPatternStackGuard">
         <source>The pattern is too complex to analyze for redundancy.</source>
         <target state="translated">패턴이 너무 복잡하여 중복성을 분석할 수 없습니다.</target>
@@ -2955,11 +2950,6 @@
       <trans-unit id="HDN_RedundantPatternStackGuard_Title">
         <source>The pattern is too complex to analyze for redundancy.</source>
         <target state="translated">패턴이 너무 복잡하여 중복성을 분석할 수 없습니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="HDN_RedundantPattern_Title">
-        <source>The pattern is redundant.</source>
-        <target state="translated">이 패턴은 중복입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ArrayAccess">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -2942,11 +2942,6 @@
         <target state="translated">Dyrektywa użycia pojawiła się wcześniej jako użycie globalne</target>
         <note />
       </trans-unit>
-      <trans-unit id="HDN_RedundantPattern">
-        <source>The pattern is redundant.</source>
-        <target state="translated">Wzorzec jest zbędny.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HDN_RedundantPatternStackGuard">
         <source>The pattern is too complex to analyze for redundancy.</source>
         <target state="translated">Wzorzec jest zbyt złożony, aby można go było przeanalizować pod kątem nadmiarowości.</target>
@@ -2955,11 +2950,6 @@
       <trans-unit id="HDN_RedundantPatternStackGuard_Title">
         <source>The pattern is too complex to analyze for redundancy.</source>
         <target state="translated">Wzorzec jest zbyt złożony, aby można go było przeanalizować pod kątem nadmiarowości.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="HDN_RedundantPattern_Title">
-        <source>The pattern is redundant.</source>
-        <target state="translated">Wzorzec jest zbędny.</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ArrayAccess">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -2942,11 +2942,6 @@
         <target state="translated">A diretiva using apareceu anteriormente como using global</target>
         <note />
       </trans-unit>
-      <trans-unit id="HDN_RedundantPattern">
-        <source>The pattern is redundant.</source>
-        <target state="translated">O padrão é redundante.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HDN_RedundantPatternStackGuard">
         <source>The pattern is too complex to analyze for redundancy.</source>
         <target state="translated">O padrão é muito complexo para analisar a redundância.</target>
@@ -2955,11 +2950,6 @@
       <trans-unit id="HDN_RedundantPatternStackGuard_Title">
         <source>The pattern is too complex to analyze for redundancy.</source>
         <target state="translated">O padrão é muito complexo para analisar a redundância.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="HDN_RedundantPattern_Title">
-        <source>The pattern is redundant.</source>
-        <target state="translated">O padrão é redundante.</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ArrayAccess">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -2942,11 +2942,6 @@
         <target state="translated">Директива using ранее использовалась в качестве глобальной</target>
         <note />
       </trans-unit>
-      <trans-unit id="HDN_RedundantPattern">
-        <source>The pattern is redundant.</source>
-        <target state="translated">Избыточный шаблон.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HDN_RedundantPatternStackGuard">
         <source>The pattern is too complex to analyze for redundancy.</source>
         <target state="translated">Слишком сложный шаблон для анализа на избыточность.</target>
@@ -2955,11 +2950,6 @@
       <trans-unit id="HDN_RedundantPatternStackGuard_Title">
         <source>The pattern is too complex to analyze for redundancy.</source>
         <target state="translated">Слишком сложный шаблон для анализа на избыточность.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="HDN_RedundantPattern_Title">
-        <source>The pattern is redundant.</source>
-        <target state="translated">Избыточный шаблон.</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ArrayAccess">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -2942,11 +2942,6 @@
         <target state="translated">Daha önce genel kullanım olarak görünen kullanım yönergesi</target>
         <note />
       </trans-unit>
-      <trans-unit id="HDN_RedundantPattern">
-        <source>The pattern is redundant.</source>
-        <target state="translated">Desen yedekli.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HDN_RedundantPatternStackGuard">
         <source>The pattern is too complex to analyze for redundancy.</source>
         <target state="translated">Desen, yedeklilik analizi için çok karmaşık.</target>
@@ -2955,11 +2950,6 @@
       <trans-unit id="HDN_RedundantPatternStackGuard_Title">
         <source>The pattern is too complex to analyze for redundancy.</source>
         <target state="translated">Desen, yedeklilik analizi için çok karmaşık.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="HDN_RedundantPattern_Title">
-        <source>The pattern is redundant.</source>
-        <target state="translated">Desen yedekli.</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ArrayAccess">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -2942,11 +2942,6 @@
         <target state="translated">Using 指令在以前显示为全局使用</target>
         <note />
       </trans-unit>
-      <trans-unit id="HDN_RedundantPattern">
-        <source>The pattern is redundant.</source>
-        <target state="translated">模式是冗余的。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HDN_RedundantPatternStackGuard">
         <source>The pattern is too complex to analyze for redundancy.</source>
         <target state="translated">模式太复杂，无法分析冗余。</target>
@@ -2955,11 +2950,6 @@
       <trans-unit id="HDN_RedundantPatternStackGuard_Title">
         <source>The pattern is too complex to analyze for redundancy.</source>
         <target state="translated">模式太复杂，无法分析冗余。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="HDN_RedundantPattern_Title">
-        <source>The pattern is redundant.</source>
-        <target state="translated">模式是冗余的。</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ArrayAccess">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -2942,11 +2942,6 @@
         <target state="translated">Using 指示詞先前顯示為全域 using</target>
         <note />
       </trans-unit>
-      <trans-unit id="HDN_RedundantPattern">
-        <source>The pattern is redundant.</source>
-        <target state="translated">此模式是多餘的。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HDN_RedundantPatternStackGuard">
         <source>The pattern is too complex to analyze for redundancy.</source>
         <target state="translated">此模式過於複雜，無法分析是否存在冗餘。</target>
@@ -2955,11 +2950,6 @@
       <trans-unit id="HDN_RedundantPatternStackGuard_Title">
         <source>The pattern is too complex to analyze for redundancy.</source>
         <target state="translated">此模式過於複雜，無法分析是否存在冗餘。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="HDN_RedundantPattern_Title">
-        <source>The pattern is redundant.</source>
-        <target state="translated">此模式是多餘的。</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ArrayAccess">

--- a/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
@@ -2307,11 +2307,8 @@ public sealed class ClosedClassesTests : CSharpTestBase
             class D2 : C { public int Value; }
             """;
 
-        var comp = CreateCompilation([source, IsClosedTypeAttributeDefinition], targetFramework: TargetFramework.Net100, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
-        comp.VerifyDiagnostics(
-            // (11,25): hidden CS9335: The pattern is redundant.
-            //             D2 { Value: < 1 } => 4,
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "< 1").WithLocation(11, 25));
+        var comp = CreateCompilation([source, IsClosedTypeAttributeDefinition], targetFramework: TargetFramework.Net100, options: TestOptions.ReleaseDll);
+        comp.VerifyDiagnostics();
     }
 
     [Fact]
@@ -6830,14 +6827,14 @@ public sealed class ClosedClassesTests : CSharpTestBase
             }
             """;
 
-        var comp = CreateCompilation([source1, source2, IsClosedTypeAttributeDefinition], targetFramework: TargetFramework.Net100, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+        var comp = CreateCompilation([source1, source2, IsClosedTypeAttributeDefinition], targetFramework: TargetFramework.Net100, options: TestOptions.ReleaseDll);
         verify(comp);
 
         var comp0 = CreateCompilation([source1, IsClosedTypeAttributeDefinition], targetFramework: TargetFramework.Net100);
-        comp = CreateCompilation([source2], references: [comp0.ToMetadataReference()], targetFramework: TargetFramework.Net100, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+        comp = CreateCompilation([source2], references: [comp0.ToMetadataReference()], targetFramework: TargetFramework.Net100, options: TestOptions.ReleaseDll);
         verify(comp);
 
-        comp = CreateCompilation([source2], references: [comp0.EmitToImageReference()], targetFramework: TargetFramework.Net100, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+        comp = CreateCompilation([source2], references: [comp0.EmitToImageReference()], targetFramework: TargetFramework.Net100, options: TestOptions.ReleaseDll);
         verify(comp);
 
         static void verify(CSharpCompilation comp)
@@ -6846,15 +6843,9 @@ public sealed class ClosedClassesTests : CSharpTestBase
                 // (100,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'Y' is not covered.
                 //         return y switch
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("Y").WithLocation(100, 18),
-                // (200,19): hidden CS9335: The pattern is redundant.
-                //             F2 or Y => 3,
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "Y").WithLocation(200, 19),
                 // (300,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'Y' is not covered.
                 //         return y switch
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("Y").WithLocation(300, 18),
-                // (400,20): hidden CS9335: The pattern is redundant.
-                //             F1 and X => 1,
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "X").WithLocation(400, 20)
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("Y").WithLocation(300, 18)
                 );
         }
     }

--- a/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
@@ -2307,7 +2307,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
             class D2 : C { public int Value; }
             """;
 
-        var comp = CreateCompilation([source, IsClosedTypeAttributeDefinition], targetFramework: TargetFramework.Net100, options: TestOptions.ReleaseDll);
+        var comp = CreateCompilation([source, IsClosedTypeAttributeDefinition], targetFramework: TargetFramework.Net100);
         comp.VerifyDiagnostics();
     }
 
@@ -6827,14 +6827,14 @@ public sealed class ClosedClassesTests : CSharpTestBase
             }
             """;
 
-        var comp = CreateCompilation([source1, source2, IsClosedTypeAttributeDefinition], targetFramework: TargetFramework.Net100, options: TestOptions.ReleaseDll);
+        var comp = CreateCompilation([source1, source2, IsClosedTypeAttributeDefinition], targetFramework: TargetFramework.Net100);
         verify(comp);
 
         var comp0 = CreateCompilation([source1, IsClosedTypeAttributeDefinition], targetFramework: TargetFramework.Net100);
-        comp = CreateCompilation([source2], references: [comp0.ToMetadataReference()], targetFramework: TargetFramework.Net100, options: TestOptions.ReleaseDll);
+        comp = CreateCompilation([source2], references: [comp0.ToMetadataReference()], targetFramework: TargetFramework.Net100);
         verify(comp);
 
-        comp = CreateCompilation([source2], references: [comp0.EmitToImageReference()], targetFramework: TargetFramework.Net100, options: TestOptions.ReleaseDll);
+        comp = CreateCompilation([source2], references: [comp0.EmitToImageReference()], targetFramework: TargetFramework.Net100);
         verify(comp);
 
         static void verify(CSharpCompilation comp)

--- a/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ClosedClassesTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -2307,7 +2307,7 @@ public sealed class ClosedClassesTests : CSharpTestBase
             class D2 : C { public int Value; }
             """;
 
-        var comp = CreateCompilation([source, IsClosedTypeAttributeDefinition], targetFramework: TargetFramework.Net100);
+        var comp = CreateCompilation([source, IsClosedTypeAttributeDefinition], targetFramework: TargetFramework.Net100, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
         comp.VerifyDiagnostics(
             // (11,25): hidden CS9335: The pattern is redundant.
             //             D2 { Value: < 1 } => 4,
@@ -6830,14 +6830,14 @@ public sealed class ClosedClassesTests : CSharpTestBase
             }
             """;
 
-        var comp = CreateCompilation([source1, source2, IsClosedTypeAttributeDefinition], targetFramework: TargetFramework.Net100);
+        var comp = CreateCompilation([source1, source2, IsClosedTypeAttributeDefinition], targetFramework: TargetFramework.Net100, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
         verify(comp);
 
         var comp0 = CreateCompilation([source1, IsClosedTypeAttributeDefinition], targetFramework: TargetFramework.Net100);
-        comp = CreateCompilation([source2], references: [comp0.ToMetadataReference()], targetFramework: TargetFramework.Net100);
+        comp = CreateCompilation([source2], references: [comp0.ToMetadataReference()], targetFramework: TargetFramework.Net100, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
         verify(comp);
 
-        comp = CreateCompilation([source2], references: [comp0.EmitToImageReference()], targetFramework: TargetFramework.Net100);
+        comp = CreateCompilation([source2], references: [comp0.EmitToImageReference()], targetFramework: TargetFramework.Net100, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
         verify(comp);
 
         static void verify(CSharpCompilation comp)

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
@@ -22429,17 +22429,11 @@ public static class E
     }
 }
 ";
-        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net100, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net100, options: TestOptions.ReleaseDll);
         comp.VerifyDiagnostics(
             // 0.cs(3,5): error CS8518: An expression of type 'object' can never match the provided pattern.
             // _ = o is { Length: -1 }; // 1
             Diagnostic(ErrorCode.ERR_IsPatternImpossible, "o is { Length: -1 }").WithArguments("object").WithLocation(3, 5),
-            // 0.cs(4,20): hidden CS9335: The pattern is redundant.
-            // _ = o is { Length: -1 or 1 }; // 2
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "-1").WithLocation(4, 20),
-            // 0.cs(5,10): hidden CS9335: The pattern is redundant.
-            // _ = o is { Length: -1 } or { Length: 1 }; // 3
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "{ Length: -1 }").WithLocation(5, 10),
             // 0.cs(7,7): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '_' is not covered.
             // _ = o switch // 4
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("_").WithLocation(7, 7),
@@ -22500,17 +22494,11 @@ public static class E
     }
 }
 ";
-        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net100, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net100, options: TestOptions.ReleaseDll);
         comp.VerifyDiagnostics(
             // 0.cs(3,5): error CS8518: An expression of type 'int?' can never match the provided pattern.
             // _ = i is { Length: -1 }; // 1
             Diagnostic(ErrorCode.ERR_IsPatternImpossible, "i is { Length: -1 }").WithArguments("int?").WithLocation(3, 5),
-            // 0.cs(4,20): hidden CS9335: The pattern is redundant.
-            // _ = i is { Length: -1 or 1 }; // 2
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "-1").WithLocation(4, 20),
-            // 0.cs(5,10): hidden CS9335: The pattern is redundant.
-            // _ = i is { Length: -1 } or { Length: 1 }; // 3
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "{ Length: -1 }").WithLocation(5, 10),
             // 0.cs(7,7): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '_' is not covered.
             // _ = i switch // 4
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("_").WithLocation(7, 7),

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 #nullable disable
@@ -22429,7 +22429,7 @@ public static class E
     }
 }
 ";
-        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net100);
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net100, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
         comp.VerifyDiagnostics(
             // 0.cs(3,5): error CS8518: An expression of type 'object' can never match the provided pattern.
             // _ = o is { Length: -1 }; // 1
@@ -22500,7 +22500,7 @@ public static class E
     }
 }
 ";
-        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net100);
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net100, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
         comp.VerifyDiagnostics(
             // 0.cs(3,5): error CS8518: An expression of type 'int?' can never match the provided pattern.
             // _ = i is { Length: -1 }; // 1

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 #nullable disable

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
@@ -22429,7 +22429,7 @@ public static class E
     }
 }
 ";
-        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net100, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net100, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
         comp.VerifyDiagnostics(
             // 0.cs(3,5): error CS8518: An expression of type 'object' can never match the provided pattern.
             // _ = o is { Length: -1 }; // 1
@@ -22500,7 +22500,7 @@ public static class E
     }
 }
 ";
-        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net100, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net100, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
         comp.VerifyDiagnostics(
             // 0.cs(3,5): error CS8518: An expression of type 'int?' can never match the provided pattern.
             // _ = i is { Length: -1 }; // 1

--- a/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/ExtensionIndexersTests.cs
@@ -22429,7 +22429,7 @@ public static class E
     }
 }
 ";
-        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net100, options: TestOptions.ReleaseDll);
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net100);
         comp.VerifyDiagnostics(
             // 0.cs(3,5): error CS8518: An expression of type 'object' can never match the provided pattern.
             // _ = o is { Length: -1 }; // 1
@@ -22494,7 +22494,7 @@ public static class E
     }
 }
 ";
-        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net100, options: TestOptions.ReleaseDll);
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net100);
         comp.VerifyDiagnostics(
             // 0.cs(3,5): error CS8518: An expression of type 'int?' can never match the provided pattern.
             // _ = i is { Length: -1 }; // 1

--- a/src/Compilers/CSharp/Test/CSharp15/UnionsTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/UnionsTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Compilers/CSharp/Test/CSharp15/UnionsTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/UnionsTests.cs
@@ -4585,7 +4585,7 @@ struct S1
     public object Value => _value;
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDll);
+            var comp = CreateCompilation([src, UnionAttributeSource]);
             // There is an implicit null check for class union types and for Nullable<Union>.  
             comp.VerifyDiagnostics(
                 // (29,16): error CS0165: Use of unassigned local variable 'y'
@@ -8129,7 +8129,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDll);
+            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp);
             comp.VerifyDiagnostics(
                 // (101,25): error CS8121: An expression of type 'C1' cannot be handled by a pattern of type 'C3'.
                 //         _ = u is C1 and C3;
@@ -8197,7 +8197,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDll);
+            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp);
             comp.VerifyDiagnostics(
                 // (401,29): error CS8121: An expression of type 'string' cannot be handled by a pattern of type 'int'.
                 //         _ = u is string and int;
@@ -8395,7 +8395,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDll);
+            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp);
             comp.VerifyDiagnostics(
                 // (202,25): error CS8121: An expression of type 'S1' cannot be handled by a pattern of type 'C4'.
                 //         _ = u is {} and C4 {};
@@ -8460,7 +8460,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDll);
+            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp);
             comp.VerifyDiagnostics(
                 // (1001,28): error CS8121: An expression of type 'C1' cannot be handled by a pattern of type 'C3'.
                 //         _ = u is C1 {} and C3;
@@ -8566,7 +8566,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDll);
+            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp);
             comp.VerifyDiagnostics(
                 // (302,25): error CS8121: An expression of type 'S1' cannot be handled by a pattern of type 'C4'.
                 //         _ = u is {} and C4 c;
@@ -8627,7 +8627,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDll);
+            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp);
             comp.VerifyDiagnostics(
                 // (901,27): error CS8121: An expression of type 'C1' cannot be handled by a pattern of type 'C3'.
                 //         _ = u is C1 b and C3;
@@ -8731,7 +8731,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDll);
+            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp);
             comp.VerifyDiagnostics(
                 // (702,29): error CS8121: An expression of type 'S1' cannot be handled by a pattern of type 'C4'.
                 //         _ = u is {} and not C4;
@@ -9074,7 +9074,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDll);
+            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp);
             comp.VerifyDiagnostics(
                 // (100,25): error CS9372: An expression of type 'S1' cannot be handled by this pattern, see additional errors at this location.
                 //         _ = u is {} and "1";
@@ -9379,7 +9379,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDll);
+            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp);
             comp.VerifyDiagnostics(
                 // (100,27): error CS9372: An expression of type 'S1' cannot be handled by this pattern, see additional errors at this location.
                 //         _ = u is {} and > 1;
@@ -10617,7 +10617,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDll);
+            var comp = CreateCompilation([src, UnionAttributeSource]);
             var verifier = CompileAndVerify(comp).VerifyDiagnostics(
                 // (500,18): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
                 //         return u switch { int => 1, string => 2 };
@@ -10754,7 +10754,7 @@ class Program
     }   
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDll);
+            var comp = CreateCompilation([src, UnionAttributeSource]);
             comp.VerifyDiagnostics(
                 // (500,18): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
                 //         return u switch { int => 1, string => 2 };
@@ -10809,7 +10809,7 @@ class Program
     }   
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDll);
+            var comp = CreateCompilation([src, UnionAttributeSource]);
             comp.VerifyDiagnostics(
                 );
         }
@@ -10864,7 +10864,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDll);
+            var comp = CreateCompilation([src, UnionAttributeSource]);
             comp.VerifyDiagnostics(
                 // (300,18): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
                 //         return u switch { true => 1, false => 4, string => 2 };
@@ -10946,7 +10946,7 @@ class C2
 }
 
 ";
-            var comp1 = CreateCompilation([src1, UnionAttributeSource], options: TestOptions.ReleaseExe);
+            var comp1 = CreateCompilation([src1, UnionAttributeSource]);
             CompileAndVerify(comp1, expectedOutput: "1323 -1-3-2-3").VerifyDiagnostics(
                 // (46,18): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '{ Value: null }' is not covered.
                 //         return u switch { null => -4, { Value: int } => -1, { Value: string } => -2, { Value: object } => -3 };
@@ -11088,7 +11088,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDll);
+            var comp = CreateCompilation([src, UnionAttributeSource]);
             comp.VerifyDiagnostics(
                 );
         }
@@ -11134,7 +11134,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDll);
+            var comp = CreateCompilation([src, UnionAttributeSource]);
             comp.VerifyDiagnostics(
                 // (18,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'C2' is not covered.
                 //         return u switch { int => 1, I1 => 2, null => 3 };
@@ -11345,7 +11345,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDll);
+            var comp = CreateCompilation([src, UnionAttributeSource]);
             var verifier = CompileAndVerify(comp).VerifyDiagnostics(
                 );
         }
@@ -11393,7 +11393,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDll);
+            var comp = CreateCompilation([src, UnionAttributeSource]);
             var verifier = CompileAndVerify(comp).VerifyDiagnostics(
                 );
         }
@@ -11516,7 +11516,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDll);
+            var comp = CreateCompilation([src, UnionAttributeSource]);
 
             var expected = new[]
             {
@@ -11777,7 +11777,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDll);
+            var comp = CreateCompilation([src, UnionAttributeSource]);
 
             var expected = new[]
             {
@@ -12054,7 +12054,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDll);
+            var comp = CreateCompilation([src, UnionAttributeSource]);
 
             var expected = new[]
             {
@@ -12369,7 +12369,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilationWithIL([src, UnionAttributeSource], ilSource, options: TestOptions.ReleaseDll);
+            var comp = CreateCompilationWithIL([src, UnionAttributeSource], ilSource);
             comp.VerifyDiagnostics(
                 // (100,27): error CS8121: An expression of type 'S1' cannot be handled by a pattern of type 'int'.
                 //         return u switch { int => 1, null => 3 };
@@ -19741,7 +19741,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource, MemberNotNullAttributeDefinition], options: TestOptions.ReleaseDll);
+            var comp = CreateCompilation([src, UnionAttributeSource, MemberNotNullAttributeDefinition]);
 
             comp.VerifyDiagnostics(
                 // (300,51): warning CS8602: Dereference of a possibly null reference.
@@ -20939,7 +20939,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDll);
+            var comp = CreateCompilation([src, UnionAttributeSource]);
             comp.VerifyDiagnostics(
                 // (200,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.S.Value.ToString();
@@ -23685,7 +23685,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource, MemberNotNullAttributeDefinition], options: TestOptions.ReleaseDll);
+            var comp = CreateCompilation([src, UnionAttributeSource, MemberNotNullAttributeDefinition]);
 
             comp.VerifyDiagnostics(
                 // (200,33): warning CS8602: Dereference of a possibly null reference.
@@ -58808,7 +58808,7 @@ class Program
 }
 ";
 
-            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition], options: TestOptions.ReleaseDll);
+            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition]);
 
             VerifyDecisionDagDump<SwitchExpressionSyntax>(comp,
 @"[0]: t0 is Y ? [3] : [1]
@@ -58877,7 +58877,7 @@ class Program
 }
 ";
 
-            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition], options: TestOptions.ReleaseDll);
+            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition]);
 
             VerifyDecisionDagDump<SwitchExpressionSyntax>(comp,
 @"[0]: t0 is Y ? [3] : [1]
@@ -58950,7 +58950,7 @@ class Program
 }
 ";
 
-            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition], options: TestOptions.ReleaseDll);
+            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition]);
 
             VerifyDecisionDagDump<SwitchExpressionSyntax>(comp,
 @"[0]: t0 is Y ? [3] : [1]
@@ -59019,7 +59019,7 @@ class Program
 }
 ";
 
-            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition], options: TestOptions.ReleaseDll);
+            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition]);
 
             VerifyDecisionDagDump<SwitchExpressionSyntax>(comp,
 @"[0]: t0 is Y ? [3] : [1]
@@ -59088,7 +59088,7 @@ class Program
 }
 ";
 
-            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition], options: TestOptions.ReleaseDll);
+            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition]);
 
             VerifyDecisionDagDump<SwitchExpressionSyntax>(comp,
 @"[0]: t0 is Y ? [3] : [1]
@@ -59134,7 +59134,7 @@ class Program
 }
 ";
 
-            var comp = CreateCompilation([source1 + source2, UnionAttributeSource], options: TestOptions.ReleaseDll);
+            var comp = CreateCompilation([source1 + source2, UnionAttributeSource]);
 
             VerifyDecisionDagDump<SwitchExpressionSyntax>(comp,
 @"[0]: t0 is Y ? [4] : [1]

--- a/src/Compilers/CSharp/Test/CSharp15/UnionsTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/UnionsTests.cs
@@ -4231,21 +4231,15 @@ class Program
     }   
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
+            var comp = CreateCompilation([src, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe);
             CompileAndVerify(comp, expectedOutput: ExecutionConditionUtil.IsMonoOrCoreClr ? "FalseTrueTrueTrue FalseTrueTrueTrueFalse TrueTrueFalse TrueFalseTrue FalseTrueTrueFalse" : null, verify: Verification.FailsPEVerify).VerifyDiagnostics(
-                // (66,26): hidden CS9335: The pattern is redundant.
-                //         return u is not ({ } and int);
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(66, 26)
                 );
 
-            comp = CreateCompilation([src, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns, parseOptions: TestOptions.RegularNext);
+            comp = CreateCompilation([src, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe, parseOptions: TestOptions.RegularNext);
             CompileAndVerify(comp, expectedOutput: ExecutionConditionUtil.IsMonoOrCoreClr ? "FalseTrueTrueTrue FalseTrueTrueTrueFalse TrueTrueFalse TrueFalseTrue FalseTrueTrueFalse" : null, verify: Verification.FailsPEVerify).VerifyDiagnostics(
-                // (66,26): hidden CS9335: The pattern is redundant.
-                //         return u is not ({ } and int);
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(66, 26)
                 );
 
-            comp = CreateCompilation([src, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns, parseOptions: TestOptions.Regular14);
+            comp = CreateCompilation([src, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular14);
             comp.VerifyDiagnostics(
                 // (46,25): error CS8652: The feature 'unions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         return u is not 10;
@@ -4264,10 +4258,7 @@ class Program
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "null").WithArguments("unions").WithLocation(61, 25),
                 // (66,34): error CS8652: The feature 'unions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         return u is not ({ } and int);
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "int").WithArguments("unions").WithLocation(66, 34),
-                // (66,26): hidden CS9335: The pattern is redundant.
-                //         return u is not ({ } and int);
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(66, 26)
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "int").WithArguments("unions").WithLocation(66, 34)
                 );
         }
 
@@ -4594,15 +4585,12 @@ struct S1
     public object Value => _value;
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDll);
             // There is an implicit null check for class union types and for Nullable<Union>.  
             comp.VerifyDiagnostics(
                 // (29,16): error CS0165: Use of unassigned local variable 'y'
                 //         return y;
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "y").WithArguments("y").WithLocation(29, 16),
-                // (44,26): hidden CS9335: The pattern is redundant.
-                //         return u is not (S1 and int);
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "S1").WithLocation(44, 26),
                 // (100,16): error CS0165: Use of unassigned local variable 'y'
                 //         return y;
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "y").WithArguments("y").WithLocation(100, 16)
@@ -8141,20 +8129,14 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDll);
             comp.VerifyDiagnostics(
-                // (100,25): hidden CS9335: The pattern is redundant.
-                //         _ = u is C1 and C2;
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "C2").WithLocation(100, 25),
                 // (101,25): error CS8121: An expression of type 'C1' cannot be handled by a pattern of type 'C3'.
                 //         _ = u is C1 and C3;
                 Diagnostic(ErrorCode.ERR_PatternWrongType, "C3").WithArguments("C1", "C3").WithLocation(101, 25),
                 // (103,24): error CS8121: An expression of type 'S1' cannot be handled by a pattern of type 'C4'.
                 //         _ = u switch { C4 => 1, _ => 0 };
                 Diagnostic(ErrorCode.ERR_PatternWrongType, "C4").WithArguments("S1", "C4").WithLocation(103, 24),
-                // (200,25): hidden CS9335: The pattern is redundant.
-                //         _ = u is C1 and C2;
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "C2").WithLocation(200, 25),
                 // (201,25): error CS8121: An expression of type 'C1' cannot be handled by a pattern of type 'C3'.
                 //         _ = u is C1 and C3;
                 Diagnostic(ErrorCode.ERR_PatternWrongType, "C3").WithArguments("C1", "C3").WithLocation(201, 25),
@@ -8215,7 +8197,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDll);
             comp.VerifyDiagnostics(
                 // (401,29): error CS8121: An expression of type 'string' cannot be handled by a pattern of type 'int'.
                 //         _ = u is string and int;
@@ -8223,9 +8205,6 @@ class Program
                 // (403,24): error CS8121: An expression of type 'S1' cannot be handled by a pattern of type 'byte'.
                 //         _ = u switch { byte => 1, _ => 0 };
                 Diagnostic(ErrorCode.ERR_PatternWrongType, "byte").WithArguments("S1", "byte").WithLocation(403, 24),
-                // (450,18): hidden CS9335: The pattern is redundant.
-                //         _ = x is System.IComparable and byte;
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "System.IComparable").WithLocation(450, 18),
                 // (501,29): error CS8121: An expression of type 'string' cannot be handled by a pattern of type 'int'.
                 //         _ = u is string and int;
                 Diagnostic(ErrorCode.ERR_PatternWrongType, "int").WithArguments("string", "int").WithLocation(501, 29),
@@ -8416,14 +8395,8 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDll);
             comp.VerifyDiagnostics(
-                // (200,18): hidden CS9335: The pattern is redundant.
-                //         _ = u is {} and C2 {};
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{}").WithLocation(200, 18),
-                // (201,18): hidden CS9335: The pattern is redundant.
-                //         _ = u is {} and C3 {};
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{}").WithLocation(201, 18),
                 // (202,25): error CS8121: An expression of type 'S1' cannot be handled by a pattern of type 'C4'.
                 //         _ = u is {} and C4 {};
                 Diagnostic(ErrorCode.ERR_PatternWrongType, "C4").WithArguments("S1", "C4").WithLocation(202, 25),
@@ -8487,20 +8460,14 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDll);
             comp.VerifyDiagnostics(
-                // (1000,28): hidden CS9335: The pattern is redundant.
-                //         _ = u is C1 {} and C2;
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "C2").WithLocation(1000, 28),
                 // (1001,28): error CS8121: An expression of type 'C1' cannot be handled by a pattern of type 'C3'.
                 //         _ = u is C1 {} and C3;
                 Diagnostic(ErrorCode.ERR_PatternWrongType, "C3").WithArguments("C1", "C3").WithLocation(1001, 28),
                 // (1002,25): error CS8121: An expression of type 'S1' cannot be handled by a pattern of type 'C4'.
                 //         _ = u is {} and C4;
                 Diagnostic(ErrorCode.ERR_PatternWrongType, "C4").WithArguments("S1", "C4").WithLocation(1002, 25),
-                // (2000,28): hidden CS9335: The pattern is redundant.
-                //         _ = u is C1 {} and C2;
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "C2").WithLocation(2000, 28),
                 // (2001,28): error CS8121: An expression of type 'C1' cannot be handled by a pattern of type 'C3'.
                 //         _ = u is C1 {} and C3;
                 Diagnostic(ErrorCode.ERR_PatternWrongType, "C3").WithArguments("C1", "C3").WithLocation(2001, 28),
@@ -8599,14 +8566,8 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDll);
             comp.VerifyDiagnostics(
-                // (300,18): hidden CS9335: The pattern is redundant.
-                //         _ = u is {} and C2 a;
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{}").WithLocation(300, 18),
-                // (301,18): hidden CS9335: The pattern is redundant.
-                //         _ = u is {} and C3 b;
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{}").WithLocation(301, 18),
                 // (302,25): error CS8121: An expression of type 'S1' cannot be handled by a pattern of type 'C4'.
                 //         _ = u is {} and C4 c;
                 Diagnostic(ErrorCode.ERR_PatternWrongType, "C4").WithArguments("S1", "C4").WithLocation(302, 25),
@@ -8666,17 +8627,11 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDll);
             comp.VerifyDiagnostics(
-                // (900,27): hidden CS9335: The pattern is redundant.
-                //         _ = u is C1 a and C2;
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "C2").WithLocation(900, 27),
                 // (901,27): error CS8121: An expression of type 'C1' cannot be handled by a pattern of type 'C3'.
                 //         _ = u is C1 b and C3;
                 Diagnostic(ErrorCode.ERR_PatternWrongType, "C3").WithArguments("C1", "C3").WithLocation(901, 27),
-                // (950,27): hidden CS9335: The pattern is redundant.
-                //         _ = u is C1 a and C2;
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "C2").WithLocation(950, 27),
                 // (951,27): error CS8121: An expression of type 'C1' cannot be handled by a pattern of type 'C3'.
                 //         _ = u is C1 b and C3;
                 Diagnostic(ErrorCode.ERR_PatternWrongType, "C3").WithArguments("C1", "C3").WithLocation(951, 27)
@@ -8776,14 +8731,8 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDll);
             comp.VerifyDiagnostics(
-                // (700,18): hidden CS9335: The pattern is redundant.
-                //         _ = u is {} and not C5;
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{}").WithLocation(700, 18),
-                // (701,18): hidden CS9335: The pattern is redundant.
-                //         _ = u is {} and not C3;
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{}").WithLocation(701, 18),
                 // (702,29): error CS8121: An expression of type 'S1' cannot be handled by a pattern of type 'C4'.
                 //         _ = u is {} and not C4;
                 Diagnostic(ErrorCode.ERR_PatternWrongType, "C4").WithArguments("S1", "C4").WithLocation(702, 29),
@@ -9125,11 +9074,8 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDll);
             comp.VerifyDiagnostics(
-                // (100,18): hidden CS9335: The pattern is redundant.
-                //         _ = u is {} and "1";
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{}").WithLocation(100, 18),
                 // (100,25): error CS9372: An expression of type 'S1' cannot be handled by this pattern, see additional errors at this location.
                 //         _ = u is {} and "1";
                 Diagnostic(ErrorCode.ERR_UnionMatchingWrongPattern, @"""1""").WithArguments("S1").WithLocation(100, 25),
@@ -9139,9 +9085,6 @@ class Program
                 // (100,25): error CS0029: Cannot implicitly convert type 'string' to 'int'
                 //         _ = u is {} and "1";
                 Diagnostic(ErrorCode.ERR_NoImplicitConv, @"""1""").WithArguments("string", "int").WithLocation(100, 25),
-                // (101,18): hidden CS9335: The pattern is redundant.
-                //         _ = u is {} and (C2)null;
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{}").WithLocation(101, 18),
                 // (101,25): error CS9372: An expression of type 'S1' cannot be handled by this pattern, see additional errors at this location.
                 //         _ = u is {} and (C2)null;
                 Diagnostic(ErrorCode.ERR_UnionMatchingWrongPattern, "(C2)null").WithArguments("S1").WithLocation(101, 25),
@@ -9436,11 +9379,8 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDll);
             comp.VerifyDiagnostics(
-                // (100,18): hidden CS9335: The pattern is redundant.
-                //         _ = u is {} and > 1;
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{}").WithLocation(100, 18),
                 // (100,27): error CS9372: An expression of type 'S1' cannot be handled by this pattern, see additional errors at this location.
                 //         _ = u is {} and > 1;
                 Diagnostic(ErrorCode.ERR_UnionMatchingWrongPattern, "1").WithArguments("S1").WithLocation(100, 27),
@@ -10677,17 +10617,8 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDll);
             var verifier = CompileAndVerify(comp).VerifyDiagnostics(
-                // (100,50): hidden CS9335: The pattern is redundant.
-                //         return u switch { int => 1, string => 2, null => 3 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(100, 50),
-                // (200,48): hidden CS9335: The pattern is redundant.
-                //         return u switch { int => 1, null => 3, string => 2 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "string").WithLocation(200, 48),
-                // (300,48): hidden CS9335: The pattern is redundant.
-                //         return u switch { null => 3, int => 1, string => 2 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "string").WithLocation(300, 48),
                 // (500,18): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
                 //         return u switch { int => 1, string => 2 };
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(500, 18),
@@ -10708,10 +10639,7 @@ class Program
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("int").WithLocation(1000, 18),
                 // (1150,18): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
                 //         return u switch { not null => 1 };
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(1150, 18),
-                // (1300,42): hidden CS9335: The pattern is redundant.
-                //         return u switch { not null => 3, null => 1 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(1300, 42)
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(1150, 18)
                 );
 
             verifier.VerifyIL("Program.Test1", @"
@@ -10826,17 +10754,8 @@ class Program
     }   
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDll);
             comp.VerifyDiagnostics(
-                // (100,50): hidden CS9335: The pattern is redundant.
-                //         return u switch { int => 1, string => 2, null => 3 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(100, 50),
-                // (200,48): hidden CS9335: The pattern is redundant.
-                //         return u switch { int => 1, null => 3, string => 2 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "string").WithLocation(200, 48),
-                // (300,48): hidden CS9335: The pattern is redundant.
-                //         return u switch { null => 3, int => 1, string => 2 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "string").WithLocation(300, 48),
                 // (500,18): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
                 //         return u switch { int => 1, string => 2 };
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(500, 18),
@@ -10890,14 +10809,8 @@ class Program
     }   
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDll);
             comp.VerifyDiagnostics(
-                // (100,42): hidden CS9335: The pattern is redundant.
-                //         return u switch { not null => 2, null => 3 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(100, 42),
-                // (200,42): hidden CS9335: The pattern is redundant.
-                //         return u switch { not null => 2, null => 3 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(200, 42)
                 );
         }
 
@@ -10951,11 +10864,8 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDll);
             comp.VerifyDiagnostics(
-                // (100,63): hidden CS9335: The pattern is redundant.
-                //         return u switch { true => 1, false => 4, string => 2, null => 3 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(100, 63),
                 // (300,18): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
                 //         return u switch { true => 1, false => 4, string => 2 };
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(300, 18),
@@ -11036,11 +10946,8 @@ class C2
 }
 
 ";
-            var comp1 = CreateCompilation([src1, UnionAttributeSource], options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
+            var comp1 = CreateCompilation([src1, UnionAttributeSource], options: TestOptions.ReleaseExe);
             CompileAndVerify(comp1, expectedOutput: "1323 -1-3-2-3").VerifyDiagnostics(
-                // (26,50): hidden CS9335: The pattern is redundant.
-                //         return u switch { int => 1, string => 2, null => 3 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(26, 50),
                 // (46,18): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '{ Value: null }' is not covered.
                 //         return u switch { null => -4, { Value: int } => -1, { Value: string } => -2, { Value: object } => -3 };
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("{ Value: null }").WithLocation(46, 18)
@@ -11181,11 +11088,8 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDll);
             comp.VerifyDiagnostics(
-                // (17,46): hidden CS9335: The pattern is redundant.
-                //         return u switch { int => 1, C1 => 2, null => 3 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(17, 46)
                 );
         }
 
@@ -11230,20 +11134,14 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDll);
             comp.VerifyDiagnostics(
                 // (18,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'C2' is not covered.
                 //         return u switch { int => 1, I1 => 2, null => 3 };
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C2").WithLocation(18, 18),
-                // (23,55): hidden CS9335: The pattern is redundant.
-                //         return u switch { int => 1, I1 => 2, C2 => 4, null => 3 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(23, 55),
                 // (28,46): error CS8121: An expression of type 'S1' cannot be handled by a pattern of type 'C3'.
                 //         return u switch { int => 1, I1 => 2, C3 => 5, C2 => 4, null => 3 };
-                Diagnostic(ErrorCode.ERR_PatternWrongType, "C3").WithArguments("S1", "C3").WithLocation(28, 46),
-                // (33,57): hidden CS9335: The pattern is redundant.
-                //         return u switch { int => 1, I1 => 2, null => 3, C2 => 4 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "C2").WithLocation(33, 57)
+                Diagnostic(ErrorCode.ERR_PatternWrongType, "C3").WithArguments("S1", "C3").WithLocation(28, 46)
                 );
         }
 
@@ -11447,14 +11345,8 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDll);
             var verifier = CompileAndVerify(comp).VerifyDiagnostics(
-                // (100,40): hidden CS9335: The pattern is redundant.
-                //         return u switch { string => 2, null => 3 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(100, 40),
-                // (600,38): hidden CS9335: The pattern is redundant.
-                //         return u switch { null => 3, string => 2 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "string").WithLocation(600, 38)
                 );
         }
 
@@ -11501,14 +11393,8 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDll);
             var verifier = CompileAndVerify(comp).VerifyDiagnostics(
-                // (100,37): hidden CS9335: The pattern is redundant.
-                //         return u switch { int => 1, null => 3 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(100, 37),
-                // (600,38): hidden CS9335: The pattern is redundant.
-                //         return u switch { null => 3, int => 1 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "int").WithLocation(600, 38)
                 );
         }
 
@@ -11630,19 +11516,10 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDll);
 
             var expected = new[]
             {
-                // (100,90): hidden CS9335: The pattern is redundant.
-                //         return u switch { S1 { Value: int } => 1, S1 { Value: string } => 2, S1 { Value: null } => 3, not S1 => -100 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(100, 90),
-                // (200,88): hidden CS9335: The pattern is redundant.
-                //         return u switch { S1 { Value: int } => 1, S1 { Value: null } => 3, S1 { Value: string } => 2, not S1 => -100 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "string").WithLocation(200, 88),
-                // (300,88): hidden CS9335: The pattern is redundant.
-                //         return u switch { S1 { Value: null } => 3, S1 { Value: int } => 1, S1 { Value: string } => 2, not S1 => -100 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "string").WithLocation(300, 88),
                 // (500,18): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'S1{ Value: null }' is not covered.
                 //         return u switch { S1 { Value: int } => 1, S1 { Value: string } => 2, not S1 => -100 };
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("S1{ Value: null }").WithLocation(500, 18),
@@ -11664,15 +11541,6 @@ class Program
                 // (1150,18): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'S1{ Value: null }' is not covered.
                 //         return u switch { S1 { Value: not null } => 1, not S1 => -100 };
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("S1{ Value: null }").WithLocation(1150, 18),
-                // (1200,68): hidden CS9335: The pattern is redundant.
-                //         return u switch { S1 { Value: null } => 3, S1 { Value: not null } => 1, not S1 => -100 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(1200, 68),
-                // (1300,68): hidden CS9335: The pattern is redundant.
-                //         return u switch { S1 { Value: not null } => 3, S1 { Value: null } => 1, not S1 => -100 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(1300, 68),
-                // (1400,63): hidden CS9335: The pattern is redundant.
-                //         return u switch { S1 { Value: { } } => 1, S1 { Value: null } => 3, not S1 => -100 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(1400, 63)
             };
 
             CompileAndVerify(comp).VerifyDiagnostics(expected);
@@ -11909,19 +11777,10 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDll);
 
             var expected = new[]
             {
-                // (100,90): hidden CS9335: The pattern is redundant.
-                //         return u switch { { S1.Value: int } => 1, { S1.Value: string } => 2, { S1.Value: null } => 3 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(100, 90),
-                // (200,88): hidden CS9335: The pattern is redundant.
-                //         return u switch { { S1.Value: int } => 1, { S1.Value: null } => 3, { S1.Value: string } => 2 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "string").WithLocation(200, 88),
-                // (300,88): hidden CS9335: The pattern is redundant.
-                //         return u switch { { S1.Value: null } => 3, { S1.Value: int } => 1, { S1.Value: string } => 2 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "string").WithLocation(300, 88),
                 // (500,18): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '{ S1: null }' is not covered.
                 //         return u switch { { S1.Value: int } => 1, { S1.Value: string } => 2 };
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("{ S1: null }").WithLocation(500, 18),
@@ -11943,15 +11802,6 @@ class Program
                 // (1150,18): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '{ S1: null }' is not covered.
                 //         return u switch { { S1.Value: not null } => 1 };
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("{ S1: null }").WithLocation(1150, 18),
-                // (1200,68): hidden CS9335: The pattern is redundant.
-                //         return u switch { { S1.Value: null } => 3, { S1.Value: not null } => 1 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(1200, 68),
-                // (1300,68): hidden CS9335: The pattern is redundant.
-                //         return u switch { { S1.Value: not null } => 3, { S1.Value: null } => 1 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(1300, 68),
-                // (1400,63): hidden CS9335: The pattern is redundant.
-                //         return u switch { { S1.Value: { } } => 1, { S1.Value: null } => 3 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(1400, 63)
             };
 
             CompileAndVerify(comp).VerifyDiagnostics(expected);
@@ -12204,19 +12054,10 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDll);
 
             var expected = new[]
             {
-                // (100,90): hidden CS9335: The pattern is redundant.
-                //         return u switch { { S1.Value: int } => 1, { S1.Value: string } => 2, { S1.Value: null } => 3 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(100, 90),
-                // (200,88): hidden CS9335: The pattern is redundant.
-                //         return u switch { { S1.Value: int } => 1, { S1.Value: null } => 3, { S1.Value: string } => 2 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "string").WithLocation(200, 88),
-                // (300,88): hidden CS9335: The pattern is redundant.
-                //         return u switch { { S1.Value: null } => 3, { S1.Value: int } => 1, { S1.Value: string } => 2 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "string").WithLocation(300, 88),
                 // (500,18): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '{ S1: null }' is not covered.
                 //         return u switch { { S1.Value: int } => 1, { S1.Value: string } => 2 };
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("{ S1: null }").WithLocation(500, 18),
@@ -12238,27 +12079,12 @@ class Program
                 // (1150,18): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '{ S1: null }' is not covered.
                 //         return u switch { { S1.Value: not null } => 1 };
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("{ S1: null }").WithLocation(1150, 18),
-                // (1200,68): hidden CS9335: The pattern is redundant.
-                //         return u switch { { S1.Value: null } => 3, { S1.Value: not null } => 1 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(1200, 68),
-                // (1300,68): hidden CS9335: The pattern is redundant.
-                //         return u switch { { S1.Value: not null } => 3, { S1.Value: null } => 1 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(1300, 68),
-                // (1400,63): hidden CS9335: The pattern is redundant.
-                //         return u switch { { S1.Value: { } } => 1, { S1.Value: null } => 3 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(1400, 63),
                 // (1600,18): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '{ S1: null }' is not covered.
                 //         return u switch { { S1.Value: int } => 1, { S1.Value: string } => 2, { S1.Value: null } => 3 };
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("{ S1: null }").WithLocation(1600, 18),
-                // (1600,90): hidden CS9335: The pattern is redundant.
-                //         return u switch { { S1.Value: int } => 1, { S1.Value: string } => 2, { S1.Value: null } => 3 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(1600, 90),
                 // (1700,18): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '{ S1: null }' is not covered.
                 //         return u switch { { S1.Value: int } => 1, { S1.Value: null } => 3, { S1.Value: string } => 2 };
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("{ S1: null }").WithLocation(1700, 18),
-                // (1700,88): hidden CS9335: The pattern is redundant.
-                //         return u switch { { S1.Value: int } => 1, { S1.Value: null } => 3, { S1.Value: string } => 2 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "string").WithLocation(1700, 88)
             };
 
             CompileAndVerify(comp).VerifyDiagnostics(expected);
@@ -12543,7 +12369,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilationWithIL([src, UnionAttributeSource], ilSource, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilationWithIL([src, UnionAttributeSource], ilSource, options: TestOptions.ReleaseDll);
             comp.VerifyDiagnostics(
                 // (100,27): error CS8121: An expression of type 'S1' cannot be handled by a pattern of type 'int'.
                 //         return u switch { int => 1, null => 3 };
@@ -12572,9 +12398,6 @@ class Program
                 // (900,18): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
                 //         return u switch { not null => 1 };
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(900, 18),
-                // (1100,42): hidden CS9335: The pattern is redundant.
-                //         return u switch { not null => 3, null => 1 };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(1100, 42),
                 // (1200,37): error CS8510: The pattern is unreachable. It has already been handled by a previous arm of the switch expression or it is impossible to match.
                 //         return u switch { { } => 1, null => 3 };
                 Diagnostic(ErrorCode.ERR_SwitchArmSubsumed, "null").WithLocation(1200, 37)
@@ -19918,12 +19741,9 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource, MemberNotNullAttributeDefinition], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation([src, UnionAttributeSource, MemberNotNullAttributeDefinition], options: TestOptions.ReleaseDll);
 
             comp.VerifyDiagnostics(
-                // (300,25): hidden CS9335: The pattern is redundant.
-                //          _ = s switch { I1 and { Value: bool } => s.OtherProp.ToString(), _ => "" };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "I1").WithLocation(300, 25),
                 // (300,51): warning CS8602: Dereference of a possibly null reference.
                 //          _ = s switch { I1 and { Value: bool } => s.OtherProp.ToString(), _ => "" };
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.OtherProp").WithLocation(300, 51)
@@ -21119,11 +20939,8 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDll);
             comp.VerifyDiagnostics(
-                // (26,23): hidden CS9335: The pattern is redundant.
-                //         if (s is { S: object }) return;
-                Diagnostic(ErrorCode.HDN_RedundantPattern, typeNameSyntax).WithLocation(26, 23),
                 // (200,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.S.Value.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.S.Value").WithLocation(200, 9)
@@ -23868,15 +23685,12 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource, MemberNotNullAttributeDefinition], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation([src, UnionAttributeSource, MemberNotNullAttributeDefinition], options: TestOptions.ReleaseDll);
 
             comp.VerifyDiagnostics(
                 // (200,33): warning CS8602: Dereference of a possibly null reference.
                 //          _ = s switch { bool => s.OtherProp.ToString(), _ => "" };
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.OtherProp").WithLocation(200, 33),
-                // (300,25): hidden CS9335: The pattern is redundant.
-                //          _ = s switch { I1 and { Value: bool } => s.OtherProp.ToString(), _ => "" };
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "I1").WithLocation(300, 25),
                 // (300,51): warning CS8602: Dereference of a possibly null reference.
                 //          _ = s switch { I1 and { Value: bool } => s.OtherProp.ToString(), _ => "" };
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.OtherProp").WithLocation(300, 51)
@@ -57694,7 +57508,7 @@ class Program
     }   
 }
 ";
-            comp = CreateCompilation([src3, src0, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            comp = CreateCompilation([src3, src0, UnionAttributeSource], options: TestOptions.ReleaseDll);
 
             comp.VerifyDiagnostics(
                 // (300,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'C1{ Value: int }' is not covered.
@@ -57702,10 +57516,7 @@ class Program
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C1{ Value: int }").WithLocation(300, 18),
                 // (400,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'C1' is not covered.
                 //         return u switch
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C1").WithLocation(400, 18),
-                // (503,37): hidden CS9335: The pattern is redundant.
-                //             C1 and I1 and { Value1: true } => 2,
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "true").WithLocation(503, 37)
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("C1").WithLocation(400, 18)
                 );
 
             var src4 = @"
@@ -57745,7 +57556,7 @@ class Program
     }   
 }
 ";
-            comp = CreateCompilation([src5, src0, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            comp = CreateCompilation([src5, src0, UnionAttributeSource], options: TestOptions.ReleaseDll);
 
             VerifyDecisionDagDump<SwitchExpressionSyntax>(comp,
 @"[0]: t0 is I1 ? [1] : [2]
@@ -57763,12 +57574,6 @@ class Program
 forLowering: true);
 
             comp.VerifyDiagnostics(
-                // (9,13): hidden CS9335: The pattern is redundant.
-                //             C1 and I1 and { Value1: true } => 2,
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "C1 and I1 and { Value1: true }").WithLocation(9, 13),
-                // (9,37): hidden CS9335: The pattern is redundant.
-                //             C1 and I1 and { Value1: true } => 2,
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "true").WithLocation(9, 37)
                 );
 
             var src6 = @"
@@ -57785,7 +57590,7 @@ class Program
     }   
 }
 ";
-            comp = CreateCompilation([src6, src0, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            comp = CreateCompilation([src6, src0, UnionAttributeSource], options: TestOptions.ReleaseDll);
 
             VerifyDecisionDagDump<SwitchExpressionSyntax>(comp,
 @"[0]: t0 is C1 ? [1] : [10]
@@ -57803,12 +57608,6 @@ class Program
 forLowering: true);
 
             comp.VerifyDiagnostics(
-                // (9,13): hidden CS9335: The pattern is redundant.
-                //             C1 and I1 and { Value1: true } => 2,
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "C1 and I1 and { Value1: true }").WithLocation(9, 13),
-                // (9,37): hidden CS9335: The pattern is redundant.
-                //             C1 and I1 and { Value1: true } => 2,
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "true").WithLocation(9, 37)
                 );
 
             var src7 = @"
@@ -57826,7 +57625,7 @@ class Program
     }   
 }
 ";
-            comp = CreateCompilation([src7, src0, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            comp = CreateCompilation([src7, src0, UnionAttributeSource], options: TestOptions.ReleaseDll);
 
             VerifyDecisionDagDump<SwitchExpressionSyntax>(comp,
 @"[0]: t0 is I1 ? [1] : [9]
@@ -57852,9 +57651,6 @@ class Program
 forLowering: true);
 
             comp.VerifyDiagnostics(
-                // (10,37): hidden CS9335: The pattern is redundant.
-                //             C1 and I1 and { Value1: true } => 2,
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "true").WithLocation(10, 37)
                 );
 
             var src8 = @"
@@ -57872,7 +57668,7 @@ class Program
     }   
 }
 ";
-            comp = CreateCompilation([src8, src0, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            comp = CreateCompilation([src8, src0, UnionAttributeSource], options: TestOptions.ReleaseDll);
 
             VerifyDecisionDagDump<SwitchExpressionSyntax>(comp,
 @"[0]: t0 is I1 ? [1] : [2]
@@ -57891,12 +57687,6 @@ class Program
 forLowering: true);
 
             comp.VerifyDiagnostics(
-                // (10,13): hidden CS9335: The pattern is redundant.
-                //             C1 and I1 and { Value1: true } => 2,
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "C1 and I1 and { Value1: true }").WithLocation(10, 13),
-                // (10,37): hidden CS9335: The pattern is redundant.
-                //             C1 and I1 and { Value1: true } => 2,
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "true").WithLocation(10, 37)
                 );
 
             var src9 = @"
@@ -57914,7 +57704,7 @@ class Program
     }   
 }
 ";
-            comp = CreateCompilation([src9, src0, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            comp = CreateCompilation([src9, src0, UnionAttributeSource], options: TestOptions.ReleaseDll);
 
             VerifyDecisionDagDump<SwitchExpressionSyntax>(comp,
 @"[0]: t0 is I1 ? [1] : [10]
@@ -57937,12 +57727,6 @@ class Program
 forLowering: true);
 
             comp.VerifyDiagnostics(
-                // (10,13): hidden CS9335: The pattern is redundant.
-                //             C1 and I1 and { Value1: true } => 2,
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "C1 and I1 and { Value1: true }").WithLocation(10, 13),
-                // (10,37): hidden CS9335: The pattern is redundant.
-                //             C1 and I1 and { Value1: true } => 2,
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "true").WithLocation(10, 37)
                 );
         }
 
@@ -59024,7 +58808,7 @@ class Program
 }
 ";
 
-            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition], options: TestOptions.ReleaseDll);
 
             VerifyDecisionDagDump<SwitchExpressionSyntax>(comp,
 @"[0]: t0 is Y ? [3] : [1]
@@ -59036,9 +58820,6 @@ class Program
 forLowering: false);
 
             comp.VerifyEmitDiagnostics(
-                // (13,13): hidden CS9335: The pattern is redundant.
-                //             null => 2,
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(13, 13)
                 );
         }
 
@@ -59096,7 +58877,7 @@ class Program
 }
 ";
 
-            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition], options: TestOptions.ReleaseDll);
 
             VerifyDecisionDagDump<SwitchExpressionSyntax>(comp,
 @"[0]: t0 is Y ? [3] : [1]
@@ -59108,9 +58889,6 @@ class Program
 forLowering: false);
 
             comp.VerifyEmitDiagnostics(
-                // (13,13): hidden CS9335: The pattern is redundant.
-                //             null => 2,
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(13, 13)
                 );
         }
 
@@ -59172,7 +58950,7 @@ class Program
 }
 ";
 
-            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition], options: TestOptions.ReleaseDll);
 
             VerifyDecisionDagDump<SwitchExpressionSyntax>(comp,
 @"[0]: t0 is Y ? [3] : [1]
@@ -59184,9 +58962,6 @@ class Program
 forLowering: false);
 
             comp.VerifyEmitDiagnostics(
-                // (13,13): hidden CS9335: The pattern is redundant.
-                //             null => 2,
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(13, 13)
                 );
         }
 
@@ -59244,7 +59019,7 @@ class Program
 }
 ";
 
-            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition], options: TestOptions.ReleaseDll);
 
             VerifyDecisionDagDump<SwitchExpressionSyntax>(comp,
 @"[0]: t0 is Y ? [3] : [1]
@@ -59256,9 +59031,6 @@ class Program
 forLowering: false);
 
             comp.VerifyEmitDiagnostics(
-                // (13,13): hidden CS9335: The pattern is redundant.
-                //             null => 2,
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(13, 13)
                 );
         }
 
@@ -59316,7 +59088,7 @@ class Program
 }
 ";
 
-            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition], options: TestOptions.ReleaseDll);
 
             VerifyDecisionDagDump<SwitchExpressionSyntax>(comp,
 @"[0]: t0 is Y ? [3] : [1]
@@ -59328,9 +59100,6 @@ class Program
 forLowering: false);
 
             comp.VerifyEmitDiagnostics(
-                // (13,13): hidden CS9335: The pattern is redundant.
-                //             null => 2,
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(13, 13)
                 );
         }
 
@@ -59365,7 +59134,7 @@ class Program
 }
 ";
 
-            var comp = CreateCompilation([source1 + source2, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation([source1 + source2, UnionAttributeSource], options: TestOptions.ReleaseDll);
 
             VerifyDecisionDagDump<SwitchExpressionSyntax>(comp,
 @"[0]: t0 is Y ? [4] : [1]
@@ -59387,10 +59156,7 @@ forLowering: false);
             comp.VerifyEmitDiagnostics(
                 // (100,18): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
                 //         return y switch
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(100, 18),
-                // (400,13): hidden CS9335: The pattern is redundant.
-                //             X => 2,
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "X").WithLocation(400, 13)
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(100, 18)
                 );
 
             var source3 = @"

--- a/src/Compilers/CSharp/Test/CSharp15/UnionsTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/UnionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -4231,21 +4231,21 @@ class Program
     }   
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilation([src, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             CompileAndVerify(comp, expectedOutput: ExecutionConditionUtil.IsMonoOrCoreClr ? "FalseTrueTrueTrue FalseTrueTrueTrueFalse TrueTrueFalse TrueFalseTrue FalseTrueTrueFalse" : null, verify: Verification.FailsPEVerify).VerifyDiagnostics(
                 // (66,26): hidden CS9335: The pattern is redundant.
                 //         return u is not ({ } and int);
                 Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(66, 26)
                 );
 
-            comp = CreateCompilation([src, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe, parseOptions: TestOptions.RegularNext);
+            comp = CreateCompilation([src, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns, parseOptions: TestOptions.RegularNext);
             CompileAndVerify(comp, expectedOutput: ExecutionConditionUtil.IsMonoOrCoreClr ? "FalseTrueTrueTrue FalseTrueTrueTrueFalse TrueTrueFalse TrueFalseTrue FalseTrueTrueFalse" : null, verify: Verification.FailsPEVerify).VerifyDiagnostics(
                 // (66,26): hidden CS9335: The pattern is redundant.
                 //         return u is not ({ } and int);
                 Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(66, 26)
                 );
 
-            comp = CreateCompilation([src, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular14);
+            comp = CreateCompilation([src, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns, parseOptions: TestOptions.Regular14);
             comp.VerifyDiagnostics(
                 // (46,25): error CS8652: The feature 'unions' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         return u is not 10;
@@ -4594,7 +4594,7 @@ struct S1
     public object Value => _value;
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource]);
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             // There is an implicit null check for class union types and for Nullable<Union>.  
             comp.VerifyDiagnostics(
                 // (29,16): error CS0165: Use of unassigned local variable 'y'
@@ -8141,7 +8141,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp);
+            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyDiagnostics(
                 // (100,25): hidden CS9335: The pattern is redundant.
                 //         _ = u is C1 and C2;
@@ -8215,7 +8215,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp);
+            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyDiagnostics(
                 // (401,29): error CS8121: An expression of type 'string' cannot be handled by a pattern of type 'int'.
                 //         _ = u is string and int;
@@ -8416,7 +8416,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp);
+            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyDiagnostics(
                 // (200,18): hidden CS9335: The pattern is redundant.
                 //         _ = u is {} and C2 {};
@@ -8487,7 +8487,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp);
+            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyDiagnostics(
                 // (1000,28): hidden CS9335: The pattern is redundant.
                 //         _ = u is C1 {} and C2;
@@ -8599,7 +8599,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp);
+            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyDiagnostics(
                 // (300,18): hidden CS9335: The pattern is redundant.
                 //         _ = u is {} and C2 a;
@@ -8666,7 +8666,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp);
+            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyDiagnostics(
                 // (900,27): hidden CS9335: The pattern is redundant.
                 //         _ = u is C1 a and C2;
@@ -8776,7 +8776,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp);
+            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyDiagnostics(
                 // (700,18): hidden CS9335: The pattern is redundant.
                 //         _ = u is {} and not C5;
@@ -9125,7 +9125,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp);
+            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyDiagnostics(
                 // (100,18): hidden CS9335: The pattern is redundant.
                 //         _ = u is {} and "1";
@@ -9436,7 +9436,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp);
+            var comp = CreateCompilation([src2, src1, UnionAttributeSource], targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyDiagnostics(
                 // (100,18): hidden CS9335: The pattern is redundant.
                 //         _ = u is {} and > 1;
@@ -10677,7 +10677,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource]);
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             var verifier = CompileAndVerify(comp).VerifyDiagnostics(
                 // (100,50): hidden CS9335: The pattern is redundant.
                 //         return u switch { int => 1, string => 2, null => 3 };
@@ -10826,7 +10826,7 @@ class Program
     }   
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource]);
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyDiagnostics(
                 // (100,50): hidden CS9335: The pattern is redundant.
                 //         return u switch { int => 1, string => 2, null => 3 };
@@ -10890,7 +10890,7 @@ class Program
     }   
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource]);
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyDiagnostics(
                 // (100,42): hidden CS9335: The pattern is redundant.
                 //         return u switch { not null => 2, null => 3 };
@@ -10951,7 +10951,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource]);
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyDiagnostics(
                 // (100,63): hidden CS9335: The pattern is redundant.
                 //         return u switch { true => 1, false => 4, string => 2, null => 3 };
@@ -11036,7 +11036,7 @@ class C2
 }
 
 ";
-            var comp1 = CreateCompilation([src1, UnionAttributeSource], options: TestOptions.ReleaseExe);
+            var comp1 = CreateCompilation([src1, UnionAttributeSource], options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             CompileAndVerify(comp1, expectedOutput: "1323 -1-3-2-3").VerifyDiagnostics(
                 // (26,50): hidden CS9335: The pattern is redundant.
                 //         return u switch { int => 1, string => 2, null => 3 };
@@ -11181,7 +11181,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource]);
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyDiagnostics(
                 // (17,46): hidden CS9335: The pattern is redundant.
                 //         return u switch { int => 1, C1 => 2, null => 3 };
@@ -11230,7 +11230,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource]);
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyDiagnostics(
                 // (18,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'C2' is not covered.
                 //         return u switch { int => 1, I1 => 2, null => 3 };
@@ -11447,7 +11447,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource]);
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             var verifier = CompileAndVerify(comp).VerifyDiagnostics(
                 // (100,40): hidden CS9335: The pattern is redundant.
                 //         return u switch { string => 2, null => 3 };
@@ -11501,7 +11501,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource]);
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             var verifier = CompileAndVerify(comp).VerifyDiagnostics(
                 // (100,37): hidden CS9335: The pattern is redundant.
                 //         return u switch { int => 1, null => 3 };
@@ -11630,7 +11630,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource]);
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
 
             var expected = new[]
             {
@@ -11909,7 +11909,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource]);
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
 
             var expected = new[]
             {
@@ -12204,7 +12204,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource]);
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
 
             var expected = new[]
             {
@@ -12543,7 +12543,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilationWithIL([src, UnionAttributeSource], ilSource);
+            var comp = CreateCompilationWithIL([src, UnionAttributeSource], ilSource, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyDiagnostics(
                 // (100,27): error CS8121: An expression of type 'S1' cannot be handled by a pattern of type 'int'.
                 //         return u switch { int => 1, null => 3 };
@@ -19918,7 +19918,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource, MemberNotNullAttributeDefinition]);
+            var comp = CreateCompilation([src, UnionAttributeSource, MemberNotNullAttributeDefinition], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
 
             comp.VerifyDiagnostics(
                 // (300,25): hidden CS9335: The pattern is redundant.
@@ -21119,7 +21119,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource]);
+            var comp = CreateCompilation([src, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyDiagnostics(
                 // (26,23): hidden CS9335: The pattern is redundant.
                 //         if (s is { S: object }) return;
@@ -23868,7 +23868,7 @@ class Program
     } 
 }
 ";
-            var comp = CreateCompilation([src, UnionAttributeSource, MemberNotNullAttributeDefinition]);
+            var comp = CreateCompilation([src, UnionAttributeSource, MemberNotNullAttributeDefinition], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
 
             comp.VerifyDiagnostics(
                 // (200,33): warning CS8602: Dereference of a possibly null reference.
@@ -57694,7 +57694,7 @@ class Program
     }   
 }
 ";
-            comp = CreateCompilation([src3, src0, UnionAttributeSource], options: TestOptions.ReleaseDll);
+            comp = CreateCompilation([src3, src0, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
 
             comp.VerifyDiagnostics(
                 // (300,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'C1{ Value: int }' is not covered.
@@ -57745,7 +57745,7 @@ class Program
     }   
 }
 ";
-            comp = CreateCompilation([src5, src0, UnionAttributeSource], options: TestOptions.ReleaseDll);
+            comp = CreateCompilation([src5, src0, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
 
             VerifyDecisionDagDump<SwitchExpressionSyntax>(comp,
 @"[0]: t0 is I1 ? [1] : [2]
@@ -57785,7 +57785,7 @@ class Program
     }   
 }
 ";
-            comp = CreateCompilation([src6, src0, UnionAttributeSource], options: TestOptions.ReleaseDll);
+            comp = CreateCompilation([src6, src0, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
 
             VerifyDecisionDagDump<SwitchExpressionSyntax>(comp,
 @"[0]: t0 is C1 ? [1] : [10]
@@ -57826,7 +57826,7 @@ class Program
     }   
 }
 ";
-            comp = CreateCompilation([src7, src0, UnionAttributeSource], options: TestOptions.ReleaseDll);
+            comp = CreateCompilation([src7, src0, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
 
             VerifyDecisionDagDump<SwitchExpressionSyntax>(comp,
 @"[0]: t0 is I1 ? [1] : [9]
@@ -57872,7 +57872,7 @@ class Program
     }   
 }
 ";
-            comp = CreateCompilation([src8, src0, UnionAttributeSource], options: TestOptions.ReleaseDll);
+            comp = CreateCompilation([src8, src0, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
 
             VerifyDecisionDagDump<SwitchExpressionSyntax>(comp,
 @"[0]: t0 is I1 ? [1] : [2]
@@ -57914,7 +57914,7 @@ class Program
     }   
 }
 ";
-            comp = CreateCompilation([src9, src0, UnionAttributeSource], options: TestOptions.ReleaseDll);
+            comp = CreateCompilation([src9, src0, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
 
             VerifyDecisionDagDump<SwitchExpressionSyntax>(comp,
 @"[0]: t0 is I1 ? [1] : [10]
@@ -59024,7 +59024,7 @@ class Program
 }
 ";
 
-            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition]);
+            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
 
             VerifyDecisionDagDump<SwitchExpressionSyntax>(comp,
 @"[0]: t0 is Y ? [3] : [1]
@@ -59096,7 +59096,7 @@ class Program
 }
 ";
 
-            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition]);
+            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
 
             VerifyDecisionDagDump<SwitchExpressionSyntax>(comp,
 @"[0]: t0 is Y ? [3] : [1]
@@ -59172,7 +59172,7 @@ class Program
 }
 ";
 
-            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition]);
+            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
 
             VerifyDecisionDagDump<SwitchExpressionSyntax>(comp,
 @"[0]: t0 is Y ? [3] : [1]
@@ -59244,7 +59244,7 @@ class Program
 }
 ";
 
-            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition]);
+            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
 
             VerifyDecisionDagDump<SwitchExpressionSyntax>(comp,
 @"[0]: t0 is Y ? [3] : [1]
@@ -59316,7 +59316,7 @@ class Program
 }
 ";
 
-            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition]);
+            comp = CreateCompilation([source2, UnionAttributeSource, IUnionSource, IsClosedTypeAttributeDefinition], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
 
             VerifyDecisionDagDump<SwitchExpressionSyntax>(comp,
 @"[0]: t0 is Y ? [3] : [1]
@@ -59365,7 +59365,7 @@ class Program
 }
 ";
 
-            var comp = CreateCompilation([source1 + source2, UnionAttributeSource]);
+            var comp = CreateCompilation([source1 + source2, UnionAttributeSource], options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
 
             VerifyDecisionDagDump<SwitchExpressionSyntax>(comp,
 @"[0]: t0 is Y ? [4] : [1]

--- a/src/Compilers/CSharp/Test/CSharp15/UnionsTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/UnionsTests.cs
@@ -10946,7 +10946,7 @@ class C2
 }
 
 ";
-            var comp1 = CreateCompilation([src1, UnionAttributeSource]);
+            var comp1 = CreateCompilation([src1, UnionAttributeSource], options: TestOptions.ReleaseExe);
             CompileAndVerify(comp1, expectedOutput: "1323 -1-3-2-3").VerifyDiagnostics(
                 // (46,18): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '{ Value: null }' is not covered.
                 //         return u switch { null => -4, { Value: int } => -1, { Value: string } => -2, { Value: object } => -3 };

--- a/src/Compilers/CSharp/Test/CSharp15/UnionsTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/UnionsTests.cs
@@ -11677,10 +11677,10 @@ class Program
 
             CompileAndVerify(comp).VerifyDiagnostics(expected);
 
-            comp = CreateCompilation([src, UnionAttributeSource], parseOptions: TestOptions.RegularNext);
+            comp = CreateCompilation([src, UnionAttributeSource], parseOptions: TestOptions.RegularNext, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             CompileAndVerify(comp).VerifyDiagnostics(expected);
 
-            comp = CreateCompilation([src, UnionAttributeSource], parseOptions: TestOptions.Regular14);
+            comp = CreateCompilation([src, UnionAttributeSource], parseOptions: TestOptions.Regular14, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyDiagnostics(
                 [
                     ..expected,
@@ -11956,10 +11956,10 @@ class Program
 
             CompileAndVerify(comp).VerifyDiagnostics(expected);
 
-            comp = CreateCompilation([src, UnionAttributeSource], parseOptions: TestOptions.RegularNext);
+            comp = CreateCompilation([src, UnionAttributeSource], parseOptions: TestOptions.RegularNext, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             CompileAndVerify(comp).VerifyDiagnostics(expected);
 
-            comp = CreateCompilation([src, UnionAttributeSource], parseOptions: TestOptions.Regular14);
+            comp = CreateCompilation([src, UnionAttributeSource], parseOptions: TestOptions.Regular14, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyDiagnostics(
                 [
                     ..expected,
@@ -12263,10 +12263,10 @@ class Program
 
             CompileAndVerify(comp).VerifyDiagnostics(expected);
 
-            comp = CreateCompilation([src, UnionAttributeSource], parseOptions: TestOptions.RegularNext);
+            comp = CreateCompilation([src, UnionAttributeSource], parseOptions: TestOptions.RegularNext, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             CompileAndVerify(comp).VerifyDiagnostics(expected);
 
-            comp = CreateCompilation([src, UnionAttributeSource], parseOptions: TestOptions.Regular14);
+            comp = CreateCompilation([src, UnionAttributeSource], parseOptions: TestOptions.Regular14, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyDiagnostics(
                 [
                     ..expected,

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -28529,7 +28529,7 @@ class C
 }
 " + trivial2uple + tupleattributes_cs;
 
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyDiagnostics(
                 // (10,40): hidden CS9335: The pattern is redundant.
                 //             (message: null, isColInit: false) => 43,

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -28530,19 +28530,7 @@ class C
 " + trivial2uple + tupleattributes_cs;
 
             var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics(
-                // (10,40): hidden CS9335: The pattern is redundant.
-                //             (message: null, isColInit: false) => 43,
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "false").WithLocation(10, 40),
-                // (11,23): hidden CS9335: The pattern is redundant.
-                //             (message: { }, isColInit: true) => 44,
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(11, 23),
-                // (12,23): hidden CS9335: The pattern is redundant.
-                //             (message: { }, isColInit: false) => 45,
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(12, 23),
-                // (12,39): hidden CS9335: The pattern is redundant.
-                //             (message: { }, isColInit: false) => 45,
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "false").WithLocation(12, 39));
+            comp.VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit3/FlowAnalysis/FlowTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/FlowAnalysis/FlowTests.cs
@@ -4544,7 +4544,7 @@ class C
     }
 }
 ";
-            CreateCompilation(source).VerifyDiagnostics(
+            CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns).VerifyDiagnostics(
                 // (13,15): error CS0165: Use of unassigned local variable 'x'
                 //             ? x.ToString() // 1
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(13, 15),
@@ -4875,7 +4875,7 @@ class C
     }
 }
 ";
-            CreateCompilation(source).VerifyDiagnostics(
+            CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns).VerifyDiagnostics(
                 // (13,15): error CS0165: Use of unassigned local variable 'x'
                 //             ? x.ToString() // 1
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(13, 15),

--- a/src/Compilers/CSharp/Test/Emit3/FlowAnalysis/FlowTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/FlowAnalysis/FlowTests.cs
@@ -4557,21 +4557,12 @@ class C
                 // (30,15): error CS0165: Use of unassigned local variable 'y'
                 //             : y.ToString(); // 4
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "y").WithArguments("y").WithLocation(30, 15),
-                // (36,45): hidden CS9335: The pattern is redundant.
-                //         _ = (b && M0(x = y = 0)) is true or true // 5
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "true").WithLocation(36, 45),
                 // (38,15): error CS0165: Use of unassigned local variable 'y'
                 //             : y.ToString(); // 6
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "y").WithArguments("y").WithLocation(38, 15),
-                // (44,46): hidden CS9335: The pattern is redundant.
-                //         _ = (b && M0(x = y = 0)) is true and true // 7
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "true").WithLocation(44, 46),
                 // (46,15): error CS0165: Use of unassigned local variable 'y'
                 //             : y.ToString(); // 8
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "y").WithArguments("y").WithLocation(46, 15),
-                // (52,46): hidden CS9335: The pattern is redundant.
-                //         _ = (b && M0(x = y = 0)) is false or false // 9
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "false").WithLocation(52, 46),
                 // (53,15): error CS0165: Use of unassigned local variable 'x'
                 //             ? x.ToString() // 10
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(53, 15),
@@ -4584,9 +4575,6 @@ class C
                 // (69,15): error CS0165: Use of unassigned local variable 'x'
                 //             ? x.ToString() // 13
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(69, 15),
-                // (76,52): hidden CS9335: The pattern is redundant.
-                //         _ = (b && M0(x = y = 0)) is not (false and false) // 14
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "false").WithLocation(76, 52),
                 // (78,15): error CS0165: Use of unassigned local variable 'y'
                 //             : y.ToString(); // 15
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "y").WithArguments("y").WithLocation(78, 15)
@@ -4891,9 +4879,6 @@ class C
                 // (37,15): error CS0165: Use of unassigned local variable 'x'
                 //             ? x.ToString() // 5
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(37, 15),
-                // (44,43): hidden CS9335: The pattern is redundant.
-                //         _ = c?.M0(x = y = 0) is not (C or { }) // 6
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(44, 43),
                 // (45,15): error CS0165: Use of unassigned local variable 'x'
                 //             ? x.ToString() // 7
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(45, 15),

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests.cs
@@ -6820,9 +6820,6 @@ public class C
         throw null;
     }
 }").VerifyDiagnostics(
-                // (10,18): hidden CS9335: The pattern is redundant.
-                //             case {} and Span<int> inner:
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{}").WithLocation(10, 18),
                 // (12,28): error CS8352: Cannot use variable 'inner' in this context because it may expose referenced variables outside of their declaration scope
                 //                 return ref inner[5];
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "inner").WithArguments("inner").WithLocation(12, 28));
@@ -8876,18 +8873,6 @@ class C
 ";
             var compilation = CreateCompilationWithSpanAndMemoryExtensions(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.RegularPreview)
                 .VerifyEmitDiagnostics(
-                    // (13,55): hidden CS9335: The pattern is redundant.
-                    //         Console.WriteLine("1." + (chars is "" and not " "));
-                    Diagnostic(ErrorCode.HDN_RedundantPattern, @""" """).WithLocation(13, 55),
-                    // (14,52): hidden CS9335: The pattern is redundant.
-                    //         Console.WriteLine("2." + (chars is "" and (" " or "")));
-                    Diagnostic(ErrorCode.HDN_RedundantPattern, @""" """).WithLocation(14, 52),
-                    // (14,52): hidden CS9335: The pattern is redundant.
-                    //         Console.WriteLine("2." + (chars is "" and (" " or "")));
-                    Diagnostic(ErrorCode.HDN_RedundantPattern, @""" "" or """"").WithLocation(14, 52),
-                    // (15,50): hidden CS9335: The pattern is redundant.
-                    //         Console.WriteLine("3." + (chars is "" or ""));
-                    Diagnostic(ErrorCode.HDN_RedundantPattern, @"""""").WithLocation(15, 50),
                     // (16,35): warning CS8794: An expression of type 'ReadOnlySpan<char>' always matches the provided pattern.
                     //         Console.WriteLine("4." + (chars is "" or not ""));
                     Diagnostic(ErrorCode.WRN_IsPatternAlways, @"chars is """" or not """"").WithArguments("System.ReadOnlySpan<char>").WithLocation(16, 35));
@@ -10491,18 +10476,6 @@ class C
 ";
             var compilation = CreateCompilationWithSpanAndMemoryExtensions(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.RegularPreview)
                 .VerifyEmitDiagnostics(
-                    // (15,55): hidden CS9335: The pattern is redundant.
-                    //         Console.WriteLine("1." + (chars is "" and not " "));
-                    Diagnostic(ErrorCode.HDN_RedundantPattern, @""" """).WithLocation(15, 55),
-                    // (16,52): hidden CS9335: The pattern is redundant.
-                    //         Console.WriteLine("2." + (chars is "" and (" " or "")));
-                    Diagnostic(ErrorCode.HDN_RedundantPattern, @""" """).WithLocation(16, 52),
-                    // (16,52): hidden CS9335: The pattern is redundant.
-                    //         Console.WriteLine("2." + (chars is "" and (" " or "")));
-                    Diagnostic(ErrorCode.HDN_RedundantPattern, @""" "" or """"").WithLocation(16, 52),
-                    // (17,50): hidden CS9335: The pattern is redundant.
-                    //         Console.WriteLine("3." + (chars is "" or ""));
-                    Diagnostic(ErrorCode.HDN_RedundantPattern, @"""""").WithLocation(17, 50),
                     // (18,35): warning CS8794: An expression of type 'Span<char>' always matches the provided pattern.
                     //         Console.WriteLine("4." + (chars is "" or not ""));
                     Diagnostic(ErrorCode.WRN_IsPatternAlways, @"chars is """" or not """"").WithArguments("System.Span<char>").WithLocation(18, 35));

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests.cs
@@ -6802,7 +6802,7 @@ public class C
         [WorkItem(27218, "https://github.com/dotnet/roslyn/issues/27218")]
         public void CasePatternMatchingDoesNotCopyEscapeScopes_03()
         {
-            CreateCompilationWithMscorlibAndSpan(parseOptions: TestOptions.RegularWithPatternCombinators, text: @"
+            CreateCompilationWithMscorlibAndSpan(parseOptions: TestOptions.RegularWithPatternCombinators, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns, text: @"
 using System;
 public class C
 {
@@ -8874,7 +8874,7 @@ class C
     }
 }
 ";
-            var compilation = CreateCompilationWithSpanAndMemoryExtensions(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.RegularPreview)
+            var compilation = CreateCompilationWithSpanAndMemoryExtensions(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns, parseOptions: TestOptions.RegularPreview)
                 .VerifyEmitDiagnostics(
                     // (13,55): hidden CS9335: The pattern is redundant.
                     //         Console.WriteLine("1." + (chars is "" and not " "));
@@ -10489,7 +10489,7 @@ class C
     }
 }
 ";
-            var compilation = CreateCompilationWithSpanAndMemoryExtensions(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.RegularPreview)
+            var compilation = CreateCompilationWithSpanAndMemoryExtensions(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns, parseOptions: TestOptions.RegularPreview)
                 .VerifyEmitDiagnostics(
                     // (15,55): hidden CS9335: The pattern is redundant.
                     //         Console.WriteLine("1." + (chars is "" and not " "));

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests2.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests2.cs
@@ -161,15 +161,9 @@ class Program
                 // 0.cs(11,22): error CS8518: An expression of type '(int x, int y)' can never match the provided pattern.
                 //         Check(false, p is (3, 4) { x: 1 });
                 Diagnostic(ErrorCode.ERR_IsPatternImpossible, "p is (3, 4) { x: 1 }").WithArguments("(int x, int y)").WithLocation(11, 22),
-                // 0.cs(12,38): hidden CS9335: The pattern is redundant.
-                //         Check(true, p is (3, 4) { x: 3 } q2 && Check(p, q2));
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "3").WithLocation(12, 38),
                 // 0.cs(13,22): error CS8518: An expression of type '(int x, int y)' can never match the provided pattern.
                 //         Check(false, p is (1, 4) { x: 3 });
                 Diagnostic(ErrorCode.ERR_IsPatternImpossible, "p is (1, 4) { x: 3 }").WithArguments("(int x, int y)").WithLocation(13, 22),
-                // 0.cs(14,39): hidden CS9335: The pattern is redundant.
-                //         Check(false, p is (3, 1) { x: 3 });
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "3").WithLocation(14, 39),
                 // 0.cs(15,22): error CS8518: An expression of type '(int x, int y)' can never match the provided pattern.
                 //         Check(false, p is (3, 4) { x: 1 });
                 Diagnostic(ErrorCode.ERR_IsPatternImpossible, "p is (3, 4) { x: 1 }").WithArguments("(int x, int y)").WithLocation(15, 22)
@@ -199,12 +193,6 @@ class Program
 }";
             var compilation = CreatePatternCompilation(source);
             compilation.VerifyDiagnostics(
-                // 0.cs(9,38): hidden CS9335: The pattern is redundant.
-                //         Check(true, p is (3, 4) { x: 3 } q2 && Check(p, q2));
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "3").WithLocation(9, 38),
-                // 0.cs(10,39): hidden CS9335: The pattern is redundant.
-                //         Check(false, p is (3, 1) { x: 3 });
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "3").WithLocation(10, 39)
                 );
             var comp = CompileAndVerify(compilation, expectedOutput: "");
         }
@@ -296,18 +284,12 @@ class Program
             testErrorCase(c1, c3, c2);
             testErrorCase(c3, c2, c1);
             testErrorCase(c2, c1, c3);
-            testGoodCase(c1, c2,
-                // 0.cs(10,19): hidden CS9335: The pattern is redundant.
-                //             case (false, false):
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "false").WithLocation(10, 19));
+            testGoodCase(c1, c2);
             testGoodCase(c1, c3);
             testGoodCase(c2, c3);
             testGoodCase(c2, c1);
             testGoodCase(c3, c1);
-            testGoodCase(c3, c2,
-                // 0.cs(10,26): hidden CS9335: The pattern is redundant.
-                //             case (false, false):
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "false").WithLocation(10, 26));
+            testGoodCase(c3, c2);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests2.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests2.cs
@@ -150,7 +150,7 @@ class Program
         return true;
     }
 }";
-            var compilation = CreatePatternCompilation(source);
+            var compilation = CreatePatternCompilation(source, TestOptions.DebugExeWithHiddenRedundantPatterns);
             compilation.VerifyDiagnostics(
                 // 0.cs(9,22): error CS8518: An expression of type '(int x, int y)' can never match the provided pattern.
                 //         Check(false, p is (1, 4) { x: 3 });
@@ -197,7 +197,7 @@ class Program
         return true;
     }
 }";
-            var compilation = CreatePatternCompilation(source);
+            var compilation = CreatePatternCompilation(source, TestOptions.DebugExeWithHiddenRedundantPatterns);
             compilation.VerifyDiagnostics(
                 // 0.cs(9,38): hidden CS9335: The pattern is redundant.
                 //         Check(true, p is (3, 4) { x: 3 } q2 && Check(p, q2));
@@ -274,7 +274,7 @@ class Program
             void testErrorCase(string s1, string s2, string s3)
             {
                 var source = string.Format(sourceTemplate, s1, s2, s3);
-                var compilation = CreatePatternCompilation(source);
+                var compilation = CreatePatternCompilation(source, TestOptions.DebugExeWithHiddenRedundantPatterns);
                 compilation.VerifyDiagnostics(
                     // (12,18): error CS8120: The switch case is unreachable. It has already been handled by a previous case or it is impossible to match.
                     //             case (_, _): // error - subsumed
@@ -284,7 +284,7 @@ class Program
             void testGoodCase(string s1, string s2, params DiagnosticDescription[] expected)
             {
                 var source = string.Format(sourceTemplate, s1, s2, string.Empty);
-                var compilation = CreatePatternCompilation(source);
+                var compilation = CreatePatternCompilation(source, TestOptions.DebugExeWithHiddenRedundantPatterns);
                 compilation.VerifyDiagnostics(expected);
             }
             var c1 = "case (true, _):";

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests3.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests3.cs
@@ -7409,7 +7409,7 @@ class C
     bool b => true;
 }
 ";
-            var compilation = CreateCompilation(source, parseOptions: TestOptions.RegularWithPatternCombinators);
+            var compilation = CreateCompilation(source, parseOptions: TestOptions.RegularWithPatternCombinators, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             compilation.VerifyDiagnostics(
                 // (4,47): warning CS8847: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '(null, true, false, true)' is not covered. However, a pattern with a 'when' clause might successfully match this value.
                 //     int M((object?, bool, bool, bool) t) => t switch

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests3.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests3.cs
@@ -7413,13 +7413,7 @@ class C
             compilation.VerifyDiagnostics(
                 // (4,47): warning CS8847: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '(null, true, false, true)' is not covered. However, a pattern with a 'when' clause might successfully match this value.
                 //     int M((object?, bool, bool, bool) t) => t switch
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNullWithWhen, "switch").WithArguments("(null, true, false, true)").WithLocation(4, 47),
-                // (11,18): hidden CS9271: The pattern is redundant.
-                //         ({ }, _, true, _) => 2,
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "true").WithLocation(11, 18),
-                // (12,10): hidden CS9271: The pattern is redundant.
-                //         (null, _, _, false) => 7,
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(12, 10)
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNullWithWhen, "switch").WithArguments("(null, true, false, true)").WithLocation(4, 47)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests4.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests4.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests4.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests4.cs
@@ -4890,7 +4890,7 @@ _ = o switch
 class A { }
 class B { }
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,19): warning CS9336: The pattern is redundant.
                 // _ = o is not A or B; // 1
@@ -4997,7 +4997,7 @@ _ = o switch
 class A { }
 class Derived : A { }
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (3,5): warning CS8794: An expression of type 'object' always matches the provided pattern.
                 // _ = o is not Derived or A; // 1
@@ -5125,7 +5125,7 @@ _ = o switch
     _ => 44
 };
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (3,22): warning CS9336: The pattern is redundant.
                 // _ = o is not null or string; // 1
@@ -5167,7 +5167,7 @@ _ = s switch
     _ => 44
 };
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (3,22): warning CS9336: The pattern is redundant.
                 // _ = s is not null or { Length: >0 }; // 1, 2
@@ -5519,7 +5519,7 @@ switch (s)
     default: break;
 };
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,21): warning CS9336: The pattern is redundant.
                 // _ = s is (not 42 or 43, not 44 or 45); // 1, 2
@@ -5640,7 +5640,7 @@ _ = i switch
     _ => 44
 };
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (3,22): warning CS9336: The pattern is redundant.
                 // _ = i is not null or 0; // 1
@@ -5679,7 +5679,7 @@ _ = b switch
     _ => 44
 };
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (3,22): warning CS9336: The pattern is redundant.
                 // _ = b is not null or false; // 1
@@ -5747,7 +5747,7 @@ _ = i switch
     _ => 44
 };
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (3,22): warning CS9336: The pattern is redundant.
                 // _ = i is not null or []; // 1
@@ -5965,7 +5965,7 @@ _ = o switch
     _ => 43
 };
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,20): hidden CS9335: The pattern is redundant.
                 // _ = o is object or string; // 1
@@ -6272,7 +6272,7 @@ public class S
     public void Deconstruct(out int x, out int y) => throw null;
 }
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,28): hidden CS9335: The pattern is redundant.
                 // _ = o is not S (42 and not 43, 44 and not 45); // 1, 2
@@ -6302,7 +6302,7 @@ public class S
     public int Prop2 { get; set; }
 }
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,36): hidden CS9335: The pattern is redundant.
                 // _ = o is not S { Prop1: 42 and not 43, Prop2: 44 and not 45 }; // 1, 2
@@ -6332,7 +6332,7 @@ public class S
     public int Prop2 { get; set; }
 }
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,34): hidden CS9335: The pattern is redundant.
                 // _ = s is not { Prop1: 42 and not 43, Prop2: 44 and not 45 }; // 1, 2
@@ -6398,7 +6398,7 @@ public class S
     public int Prop2 { get; set; }
 }
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,21): warning CS9336: The pattern is redundant.
                 // _ = s is not { } or null; // 1
@@ -6471,7 +6471,7 @@ public class C
     public int P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             compilation.VerifyDiagnostics(
                 // (3,18): hidden CS9335: The pattern is redundant.
                 // _ = s is { Prop: { } and { P: 42 or 43 } }; // 1
@@ -6518,7 +6518,7 @@ struct S
     public C P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             compilation.VerifyEmitDiagnostics(
                 // (18,27): hidden CS9335: The pattern is redundant.
                 // _ = s is S { P: C { Prop: int and var s12 } }; // 1
@@ -6558,7 +6558,7 @@ struct S
     public C P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             compilation.VerifyEmitDiagnostics(
                 // (3,26): hidden CS9335: The pattern is redundant.
                 // _ = ss is S { P: { } and { } }; // 1
@@ -6613,7 +6613,7 @@ struct S
     public C P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             compilation.VerifyEmitDiagnostics(
                 // (3,25): hidden CS9335: The pattern is redundant.
                 // _ = sss is S { P: C and { } }; // 1
@@ -6669,7 +6669,7 @@ struct S
     public S2 P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             compilation.VerifyEmitDiagnostics(
                 // (2,17): hidden CS9335: The pattern is redundant.
                 // _ = s is S { P: { } }; // 1
@@ -6727,7 +6727,7 @@ struct S
     public S2 P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             compilation.VerifyEmitDiagnostics(
                 // (3,18): hidden CS9335: The pattern is redundant.
                 // _ = ss is S { P: { } and { } }; // 1, 2
@@ -6824,7 +6824,7 @@ struct S
     public S2 P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             compilation.VerifyEmitDiagnostics(
                 // (3,19): hidden CS9335: The pattern is redundant.
                 // _ = sss is S { P: S2 and { } }; // 1, 2
@@ -6980,7 +6980,7 @@ struct S
     public C P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             compilation.VerifyEmitDiagnostics(
                 // (2,24): hidden CS9335: The pattern is redundant.
                 // _ = s is S { P: [] and [..] }; // 1
@@ -7028,7 +7028,7 @@ struct S
     public C P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             compilation.VerifyEmitDiagnostics(
                 // (2,25): hidden CS9335: The pattern is redundant.
                 // _ = s is S { P: [_] and [..] }; // 1
@@ -7070,7 +7070,7 @@ struct S
     public S2 P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             compilation.VerifyEmitDiagnostics(
                 // (2,17): hidden CS9335: The pattern is redundant.
                 // _ = s is S { P: [..] }; // 1
@@ -7106,7 +7106,7 @@ struct S
     public S2 P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             compilation.VerifyEmitDiagnostics(
                 // (2,24): hidden CS9335: The pattern is redundant.
                 // _ = s is S { P: [] and [..] }; // 1
@@ -7154,7 +7154,7 @@ struct S
     public S2 P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             compilation.VerifyEmitDiagnostics(
                 // (2,25): hidden CS9335: The pattern is redundant.
                 // _ = s is S { P: [_] and [..] }; // 1
@@ -7204,7 +7204,7 @@ _ = s is (_, _, _) and (_, _); // 4
 _ = s is (_, _, _) and (_, var s7); // 5
 _ = s is { Length: 3 } and (_, _); // 6
 """;
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             compilation.VerifyEmitDiagnostics(
                 // (10,21): hidden CS9335: The pattern is redundant.
                 // _ = s is (_, _) and (_, _); // 1
@@ -7290,7 +7290,7 @@ public struct S
     public void Deconstruct(out object x, out object y) => throw null;
 }
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (4,28): hidden CS9335: The pattern is redundant.
                 // _ = o is not S (42 and not 43, int x2); // 1
@@ -7333,7 +7333,7 @@ public class C
     public void Deconstruct(out int x, out int y) => throw null;
 }
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,17): hidden CS9335: The pattern is redundant.
                 // _ = o is C and (int, int); // 1, 2
@@ -7377,7 +7377,7 @@ _ = o is [not 42 or 43, not 44 or 45]; // 3, 4
 _ = o is not [_, _];
 _ = o is not [.._]; // 5
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,26): hidden CS9335: The pattern is redundant.
                 // _ = o is not [42 and not 43, 44 and not 45]; // 1, 2
@@ -7406,7 +7406,7 @@ public class C
     public object Prop { get; set; }
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,34): hidden CS9335: The pattern is redundant.
                 // _ = o is not [{ Prop: 42 and not 43 }, { Prop: 44 and not 45 }]; // 1, 2
@@ -7505,7 +7505,7 @@ switch (o)
         break;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,22): hidden CS9335: The pattern is redundant.
                 // _ = o is [42 and not 43, 44 and not 45]; // 1, 2
@@ -7547,7 +7547,7 @@ switch (t)
         break;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,22): hidden CS9335: The pattern is redundant.
                 // _ = t is (42 and not 43, 44 and not 45); // 1, 2
@@ -7595,7 +7595,7 @@ class C
     public void Deconstruct(out int x, out int y) => throw null;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (3,22): hidden CS9335: The pattern is redundant.
                 // _ = c is (42 and not 43, 44 and not 45); // 1, 2
@@ -7644,7 +7644,7 @@ class C
     public int Prop2 { get; set; }
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (3,30): hidden CS9335: The pattern is redundant.
                 // _ = c is { Prop1: 42 and not 43, Prop2: 44 and not 45 }; // 1, 2
@@ -7686,7 +7686,7 @@ public struct S
     public int this[System.Range r] => throw null;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,26): hidden CS9335: The pattern is redundant.
                 // _ = o is not [42 and not 43, 44 and not 45, ..]; // 1, 2
@@ -7742,7 +7742,7 @@ public struct S
     public int this[System.Range r] => throw null;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,26): hidden CS9335: The pattern is redundant.
                 // _ = o is not [42 and not 43, .._]; // 1, 2
@@ -7812,7 +7812,7 @@ public struct S
     public S this[System.Range r] => throw null;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (3,29): hidden CS9335: The pattern is redundant.
                 // _ = s is not [..[42 and not 43]]; // 1
@@ -7873,7 +7873,7 @@ public struct S
     public int this[System.Range r] => throw null;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,26): hidden CS9335: The pattern is redundant.
                 // _ = o is not [42 and not 43, _]; // 1
@@ -7940,7 +7940,7 @@ public struct S
     public int this[System.Range r] => throw null;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,26): hidden CS9335: The pattern is redundant.
                 // _ = o is not [42 and not 43, _, ..44 and not 45]; // 1, 2
@@ -7998,7 +7998,7 @@ struct S
     public int this[System.Range r] => throw null;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,27): warning CS9336: The pattern is redundant.
                 // _ = o is C and [not 42 or 43, ..(not 44 or 45)]; // 1, 2
@@ -8056,7 +8056,7 @@ public struct S
     public int this[System.Range r] => throw null;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,15): error CS0029: Cannot implicitly convert type 'int' to 'S'
                 // _ = o is not (42 and not 43 and var x1); // 1, 2
@@ -8155,7 +8155,7 @@ switch (i)
     default: break; // 11
 }
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,20): hidden CS9335: The pattern is redundant.
                 // _ = i is 1 or 2 or 1; // 1
@@ -8611,7 +8611,7 @@ _ = i is (string or not 42) or 0;
 _ = i is 42 or (42 or not 0);
 _ = i is (not 42) or 43;
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,34): warning CS9336: The pattern is redundant.
                 // _ = i is not (42 or 43) or 43 or 0; // warn
@@ -8680,7 +8680,7 @@ class C
 }
 class Derived : C { }
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (3,31): hidden CS9335: The pattern is redundant.
                 // _ = s is { Prop1: not 42 } or { Prop1: 43 }; // 1
@@ -8942,7 +8942,7 @@ public class C
     public string P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             compilation.VerifyDiagnostics(
                 // (2,15): hidden CS9335: The pattern is redundant.
                 // _ = s is { P: string or null }; // 1
@@ -8984,7 +8984,7 @@ public class C
     public object O;
 }
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (3,12): hidden CS9335: The pattern is redundant.
                 // _ =  c is ({F: 1 and not 1} and {O: not A or B}) or {F: 2}; // 1
@@ -9099,7 +9099,7 @@ _ = o is Base x17 and Derived;
 class Base { }
 class Derived : Base { }
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,17): error CS8780: A variable may not be declared within a 'not' or an 'or' pattern or a union matching involving matching against either the instance, or its underlying value.
                 // _ = o is string x1 or string; // 1, 2
@@ -9254,7 +9254,7 @@ class C
     public int Prop2 { get; set; }
 }
 ";
-            var compilation = CreateCompilation(source);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             compilation.VerifyEmitDiagnostics(
                 // (3,30): hidden CS9335: The pattern is redundant.
                 // _ = o is C { Prop1: 0 } and (not null or (C and ({ Prop1: 0 } or { Prop2: 1 })));

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests4.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests4.cs
@@ -9344,5 +9344,25 @@ _ = i is 42 or not 43;
             var compilation = CreateCompilation(source);
             compilation.VerifyEmitDiagnostics();
         }
+
+        [Fact]
+        public void RedundantPattern_EasyOut_01()
+        {
+            var source = """
+                int i = 0;
+                _ = i is 42 or 42;
+                """;
+
+            var options = TestOptions.ReleaseExe.WithSpecificDiagnosticOptions(MessageProvider.Instance.GetIdForErrorCode((int)ErrorCode.HDN_RedundantPattern), ReportDiagnostic.Hidden);
+            var compilation = CreateCompilation(source, options: options);
+            compilation.VerifyEmitDiagnostics(
+                // (2,16): hidden CS9335: The pattern is redundant.
+                // _ = i is 42 or 42;
+                Diagnostic(ErrorCode.HDN_RedundantPattern, "42").WithLocation(2, 16));
+
+            options = TestOptions.ReleaseExe.WithSpecificDiagnosticOptions([]);
+            compilation = CreateCompilation(source, options: options);
+            compilation.VerifyEmitDiagnostics();
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests4.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests4.cs
@@ -4481,14 +4481,8 @@ public class C
     }
 }
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
-            comp.VerifyDiagnostics(
-                // (10,22): hidden CS9335: The pattern is redundant.
-                //             >= 0 and < 10.0 => "Acceptable",
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "< 10.0").WithLocation(10, 22),
-                // (11,26): hidden CS9335: The pattern is redundant.
-                //             >= -40.0 and < 0 => "Low",
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "< 0").WithLocation(11, 26));
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
 
             var verifier = CompileAndVerify(comp, expectedOutput: "NaN");
 
@@ -4570,14 +4564,8 @@ public class C
     }
 }
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
-            comp.VerifyDiagnostics(
-                // (11,13): hidden CS9335: The pattern is redundant.
-                //             >= -40.0 and < 0 => "Low",
-                Diagnostic(ErrorCode.HDN_RedundantPattern, ">= -40.0").WithLocation(11, 13),
-                // (12,13): hidden CS9335: The pattern is redundant.
-                //             >= 0 and < 10.0 => "Acceptable",
-                Diagnostic(ErrorCode.HDN_RedundantPattern, ">= 0").WithLocation(12, 13));
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
 
             var verifier = CompileAndVerify(comp, expectedOutput: "NaN");
 
@@ -4890,7 +4878,7 @@ _ = o switch
 class A { }
 class B { }
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics(
                 // (2,19): warning CS9336: The pattern is redundant.
                 // _ = o is not A or B; // 1
@@ -4898,9 +4886,6 @@ class B { }
                 // (3,25): error CS8121: An expression of type 'A' cannot be handled by a pattern of type 'B'.
                 // _ = o is not (A and not B); // 2
                 Diagnostic(ErrorCode.ERR_PatternWrongType, "B").WithArguments("A", "B").WithLocation(3, 25),
-                // (5,21): hidden CS9335: The pattern is redundant.
-                // _ = o is (not A) or B; // 3
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "B").WithLocation(5, 21),
                 // (6,5): warning CS8794: An expression of type 'object' always matches the provided pattern.
                 // _ = o is (not A) or (not B); // 4
                 Diagnostic(ErrorCode.WRN_IsPatternAlways, "o is (not A) or (not B)").WithArguments("object").WithLocation(6, 5),
@@ -4997,17 +4982,11 @@ _ = o switch
 class A { }
 class Derived : A { }
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics(
                 // (3,5): warning CS8794: An expression of type 'object' always matches the provided pattern.
                 // _ = o is not Derived or A; // 1
                 Diagnostic(ErrorCode.WRN_IsPatternAlways, "o is not Derived or A").WithArguments("object").WithLocation(3, 5),
-                // (4,20): hidden CS9335: The pattern is redundant.
-                // _ = o is not (A or Derived); // 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "Derived").WithLocation(4, 20),
-                // (7,15): hidden CS9335: The pattern is redundant.
-                // _ = o is A or Derived; // 3
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "Derived").WithLocation(7, 15),
                 // (9,5): warning CS8794: An expression of type 'object' always matches the provided pattern.
                 // _ = o is A or not Derived; // 4
                 Diagnostic(ErrorCode.WRN_IsPatternAlways, "o is A or not Derived").WithArguments("object").WithLocation(9, 5),
@@ -5125,17 +5104,11 @@ _ = o switch
     _ => 44
 };
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics(
                 // (3,22): warning CS9336: The pattern is redundant.
                 // _ = o is not null or string; // 1
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "string").WithLocation(3, 22),
-                // (4,24): hidden CS9335: The pattern is redundant.
-                // _ = o is (not null) or string; // 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "string").WithLocation(4, 24),
-                // (5,31): hidden CS9335: The pattern is redundant.
-                // _ = o is not null or (not not string); // 3
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "string").WithLocation(5, 31),
                 // (11,5): error CS8510: The pattern is unreachable. It has already been handled by a previous arm of the switch expression or it is impossible to match.
                 //     string => 43, // 4
                 Diagnostic(ErrorCode.ERR_SwitchArmSubsumed, "string").WithLocation(11, 5));
@@ -5167,7 +5140,7 @@ _ = s switch
     _ => 44
 };
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics(
                 // (3,22): warning CS9336: The pattern is redundant.
                 // _ = s is not null or { Length: >0 }; // 1, 2
@@ -5175,24 +5148,6 @@ _ = s switch
                 // (3,32): warning CS9336: The pattern is redundant.
                 // _ = s is not null or { Length: >0 }; // 1, 2
                 Diagnostic(ErrorCode.WRN_RedundantPattern, ">0").WithLocation(3, 32),
-                // (4,23): hidden CS9335: The pattern is redundant.
-                // _ = s is null and not { Length: >0 }; // 3, 4
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ Length: >0 }").WithLocation(4, 23),
-                // (4,33): hidden CS9335: The pattern is redundant.
-                // _ = s is null and not { Length: >0 }; // 3, 4
-                Diagnostic(ErrorCode.HDN_RedundantPattern, ">0").WithLocation(4, 33),
-                // (5,24): hidden CS9335: The pattern is redundant.
-                // _ = s is (not null) or { Length: >0 }; // 5, 6
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ Length: >0 }").WithLocation(5, 24),
-                // (5,34): hidden CS9335: The pattern is redundant.
-                // _ = s is (not null) or { Length: >0 }; // 5, 6
-                Diagnostic(ErrorCode.HDN_RedundantPattern, ">0").WithLocation(5, 34),
-                // (7,23): hidden CS9335: The pattern is redundant.
-                // _ = s is null and not { Length: >0 }; // 7, 8
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ Length: >0 }").WithLocation(7, 23),
-                // (7,33): hidden CS9335: The pattern is redundant.
-                // _ = s is null and not { Length: >0 }; // 7, 8
-                Diagnostic(ErrorCode.HDN_RedundantPattern, ">0").WithLocation(7, 33),
                 // (12,5): error CS8510: The pattern is unreachable. It has already been handled by a previous arm of the switch expression or it is impossible to match.
                 //     "" => 43, // 9
                 Diagnostic(ErrorCode.ERR_SwitchArmSubsumed, @"""""").WithLocation(12, 5),
@@ -5519,7 +5474,7 @@ switch (s)
     default: break;
 };
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
             comp.VerifyEmitDiagnostics(
                 // (2,21): warning CS9336: The pattern is redundant.
                 // _ = s is (not 42 or 43, not 44 or 45); // 1, 2
@@ -5527,18 +5482,6 @@ switch (s)
                 // (2,35): warning CS9336: The pattern is redundant.
                 // _ = s is (not 42 or 43, not 44 or 45); // 1, 2
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "45").WithLocation(2, 35),
-                // (3,26): hidden CS9335: The pattern is redundant.
-                // _ = s is not (42 and not 43, 44 and not 45); // 3, 4
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(3, 26),
-                // (3,41): hidden CS9335: The pattern is redundant.
-                // _ = s is not (42 and not 43, 44 and not 45); // 3, 4
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(3, 41),
-                // (4,26): hidden CS9335: The pattern is redundant.
-                // _ = s is not (42 and not 43, _ and var x); // 5, 6
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(4, 26),
-                // (5,40): hidden CS9335: The pattern is redundant.
-                // _ = s is not (_ and var x2, 42 and not 43); // 7
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(5, 40),
                 // (11,16): warning CS9336: The pattern is redundant.
                 //     (not 42 or 43, not 44 or 45) => 42, // 8, 9
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(11, 16),
@@ -5640,14 +5583,11 @@ _ = i switch
     _ => 44
 };
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics(
                 // (3,22): warning CS9336: The pattern is redundant.
                 // _ = i is not null or 0; // 1
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "0").WithLocation(3, 22),
-                // (4,24): hidden CS9335: The pattern is redundant.
-                // _ = i is (not null) or 0; // 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "0").WithLocation(4, 24),
                 // (10,5): error CS8510: The pattern is unreachable. It has already been handled by a previous arm of the switch expression or it is impossible to match.
                 //     0 => 43, // 3
                 Diagnostic(ErrorCode.ERR_SwitchArmSubsumed, "0").WithLocation(10, 5));
@@ -5679,20 +5619,14 @@ _ = b switch
     _ => 44
 };
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics(
                 // (3,22): warning CS9336: The pattern is redundant.
                 // _ = b is not null or false; // 1
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "false").WithLocation(3, 22),
-                // (4,24): hidden CS9335: The pattern is redundant.
-                // _ = b is (not null) or false; // 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "false").WithLocation(4, 24),
                 // (5,22): warning CS9336: The pattern is redundant.
                 // _ = b is not null or true; // 3
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "true").WithLocation(5, 22),
-                // (6,24): hidden CS9335: The pattern is redundant.
-                // _ = b is (not null) or true; // 4
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "true").WithLocation(6, 24),
                 // (13,5): error CS8510: The pattern is unreachable. It has already been handled by a previous arm of the switch expression or it is impossible to match.
                 //     false => 43, // 5
                 Diagnostic(ErrorCode.ERR_SwitchArmSubsumed, "false").WithLocation(13, 5),
@@ -5747,14 +5681,11 @@ _ = i switch
     _ => 44
 };
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
             comp.VerifyEmitDiagnostics(
                 // (3,22): warning CS9336: The pattern is redundant.
                 // _ = i is not null or []; // 1
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "[]").WithLocation(3, 22),
-                // (4,24): hidden CS9335: The pattern is redundant.
-                // _ = i is (not null) or []; // 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "[]").WithLocation(4, 24),
                 // (10,5): error CS8510: The pattern is unreachable. It has already been handled by a previous arm of the switch expression or it is impossible to match.
                 //     [] => 43, // 3
                 Diagnostic(ErrorCode.ERR_SwitchArmSubsumed, "[]").WithLocation(10, 5));
@@ -5965,11 +5896,8 @@ _ = o switch
     _ => 43
 };
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics(
-                // (2,20): hidden CS9335: The pattern is redundant.
-                // _ = o is object or string; // 1
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "string").WithLocation(2, 20),
                 // (7,5): error CS8510: The pattern is unreachable. It has already been handled by a previous arm of the switch expression or it is impossible to match.
                 //     string => 42, // 2
                 Diagnostic(ErrorCode.ERR_SwitchArmSubsumed, "string").WithLocation(7, 5));
@@ -6038,14 +5966,8 @@ class C
 }
 class Derived : C { }
 """;
-            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var compilation = CreateCompilation(source);
             compilation.VerifyDiagnostics(
-                // (5,29): hidden CS9335: The pattern is redundant.
-                //         if (o is not (1 and int)) { } // 1
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "int").WithLocation(5, 29),
-                // (6,34): hidden CS9335: The pattern is redundant.
-                //         if (o is (not 1) or (not int)) { } // 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "int").WithLocation(6, 34),
                 // (8,13): warning CS8794: An expression of type 'object' always matches the provided pattern.
                 //         if (o is not (1 and not int x2)) { } // 3, 4
                 Diagnostic(ErrorCode.WRN_IsPatternAlways, "o is not (1 and not int x2)").WithArguments("object").WithLocation(8, 13),
@@ -6055,9 +5977,6 @@ class Derived : C { }
                 // (9,41): error CS8780: A variable may not be declared within a 'not' or an 'or' pattern or a union matching involving matching against either the instance, or its underlying value.
                 //         if (o is not (1 and not not int x3)) { } // 5
                 Diagnostic(ErrorCode.ERR_DesignatorBeneathPatternCombinator, "x3").WithLocation(9, 41),
-                // (11,24): hidden CS9335: The pattern is redundant.
-                //         if (o is (C or Derived) and var x5) { } // 6
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "Derived").WithLocation(11, 24),
                 // (15,13): warning CS8794: An expression of type 'C' always matches the provided pattern.
                 //         if (c is not (Derived and null)) { } else { y1.ToString(); } // 7
                 Diagnostic(ErrorCode.WRN_IsPatternAlways, "c is not (Derived and null)").WithArguments("C").WithLocation(15, 13),
@@ -6128,7 +6047,7 @@ public struct S
     public int Prop3 { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var compilation = CreateCompilation(source);
             compilation.VerifyDiagnostics(
                 // (6,37): warning CS9336: The pattern is redundant.
                 //         if (s is { Prop1: not 42 or 43 } or { Prop2: not 44 or 45 }) { } // 1, 2
@@ -6142,15 +6061,9 @@ public struct S
                 // (8,45): warning CS9336: The pattern is redundant.
                 //         if (s is { Prop1: (42 or (not 43 or 44)) or 45 } or { Prop2: (46 or (not 44 or 45)) or 46 }) { } // 4, 5, 6, 7
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "44").WithLocation(8, 45),
-                // (8,53): hidden CS9335: The pattern is redundant.
-                //         if (s is { Prop1: (42 or (not 43 or 44)) or 45 } or { Prop2: (46 or (not 44 or 45)) or 46 }) { } // 4, 5, 6, 7
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(8, 53),
                 // (8,88): warning CS9336: The pattern is redundant.
                 //         if (s is { Prop1: (42 or (not 43 or 44)) or 45 } or { Prop2: (46 or (not 44 or 45)) or 46 }) { } // 4, 5, 6, 7
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "45").WithLocation(8, 88),
-                // (8,96): hidden CS9335: The pattern is redundant.
-                //         if (s is { Prop1: (42 or (not 43 or 44)) or 45 } or { Prop2: (46 or (not 44 or 45)) or 46 }) { } // 4, 5, 6, 7
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "46").WithLocation(8, 96),
                 // (10,38): warning CS9336: The pattern is redundant.
                 //         if (s is ({ Prop1: not 42 or 43 } or { Prop2: not 44 or 45 }) or { Prop3: not 46 or 47 }) { } // 8, 9, 10
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(10, 38),
@@ -6272,14 +6185,8 @@ public class S
     public void Deconstruct(out int x, out int y) => throw null;
 }
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics(
-                // (2,28): hidden CS9335: The pattern is redundant.
-                // _ = o is not S (42 and not 43, 44 and not 45); // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(2, 28),
-                // (2,43): hidden CS9335: The pattern is redundant.
-                // _ = o is not S (42 and not 43, 44 and not 45); // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(2, 43),
                 // (3,23): warning CS9336: The pattern is redundant.
                 // _ = o is S (not 42 or 43, not 44 or 45); // 3, 4
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(3, 23),
@@ -6302,14 +6209,8 @@ public class S
     public int Prop2 { get; set; }
 }
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics(
-                // (2,36): hidden CS9335: The pattern is redundant.
-                // _ = o is not S { Prop1: 42 and not 43, Prop2: 44 and not 45 }; // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(2, 36),
-                // (2,58): hidden CS9335: The pattern is redundant.
-                // _ = o is not S { Prop1: 42 and not 43, Prop2: 44 and not 45 }; // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(2, 58),
                 // (3,31): warning CS9336: The pattern is redundant.
                 // _ = o is S { Prop1: not 42 or 43, Prop2: not 44 or 45 }; // 3, 4
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(3, 31),
@@ -6332,14 +6233,8 @@ public class S
     public int Prop2 { get; set; }
 }
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics(
-                // (2,34): hidden CS9335: The pattern is redundant.
-                // _ = s is not { Prop1: 42 and not 43, Prop2: 44 and not 45 }; // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(2, 34),
-                // (2,56): hidden CS9335: The pattern is redundant.
-                // _ = s is not { Prop1: 42 and not 43, Prop2: 44 and not 45 }; // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(2, 56),
                 // (3,29): warning CS9336: The pattern is redundant.
                 // _ = s is { Prop1: not 42 or 43, Prop2: not 44 or 45 }; // 3, 4
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(3, 29),
@@ -6398,20 +6293,11 @@ public class S
     public int Prop2 { get; set; }
 }
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics(
                 // (2,21): warning CS9336: The pattern is redundant.
                 // _ = s is not { } or null; // 1
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "null").WithLocation(2, 21),
-                // (3,22): hidden CS9335: The pattern is redundant.
-                // _ = s is null or not { }; // 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(3, 22),
-                // (4,27): hidden CS9335: The pattern is redundant.
-                // _ = s is not ({ } and not null); // 3
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(4, 27),
-                // (5,21): hidden CS9335: The pattern is redundant.
-                // _ = s is { } or not null; // 4
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(5, 21),
                 // (6,22): warning CS9336: The pattern is redundant.
                 // _ = s is not null or { }; // 5
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "{ }").WithLocation(6, 22),
@@ -6421,9 +6307,6 @@ public class S
                 // (8,23): warning CS9336: The pattern is redundant.
                 // _ = s is not S { } or null; // 7
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "null").WithLocation(8, 23),
-                // (9,22): hidden CS9335: The pattern is redundant.
-                // _ = s is null or not S { }; // 8
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "S { }").WithLocation(9, 22),
                 // (14,5): error CS8510: The pattern is unreachable. It has already been handled by a previous arm of the switch expression or it is impossible to match.
                 //     not { } => 1, // 9
                 Diagnostic(ErrorCode.ERR_SwitchArmSubsumed, "not { }").WithLocation(14, 5));
@@ -6471,14 +6354,8 @@ public class C
     public int P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
-            compilation.VerifyDiagnostics(
-                // (3,18): hidden CS9335: The pattern is redundant.
-                // _ = s is { Prop: { } and { P: 42 or 43 } }; // 1
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(3, 18),
-                // (4,18): hidden CS9335: The pattern is redundant.
-                // _ = s is { Prop: S2 { } }; // 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "S2 { }").WithLocation(4, 18));
+            var compilation = CreateCompilation(source);
+            compilation.VerifyDiagnostics();
         }
 
         [Fact]
@@ -6518,11 +6395,8 @@ struct S
     public C P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
-            compilation.VerifyEmitDiagnostics(
-                // (18,27): hidden CS9335: The pattern is redundant.
-                // _ = s is S { P: C { Prop: int and var s12 } }; // 1
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "int").WithLocation(18, 27));
+            var compilation = CreateCompilation(source);
+            compilation.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -6558,26 +6432,8 @@ struct S
     public C P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
-            compilation.VerifyEmitDiagnostics(
-                // (3,26): hidden CS9335: The pattern is redundant.
-                // _ = ss is S { P: { } and { } }; // 1
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(3, 26),
-                // (5,26): hidden CS9335: The pattern is redundant.
-                // _ = ss is S { P: { } and { Prop: _ } }; // 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ Prop: _ }").WithLocation(5, 26),
-                // (7,26): hidden CS9335: The pattern is redundant.
-                // _ = ss is S { P: { } and (_, _) }; // 3
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "(_, _)").WithLocation(7, 26),
-                // (11,26): hidden CS9335: The pattern is redundant.
-                // _ = ss is S { P: { } and C { } }; // 4
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "C { }").WithLocation(11, 26),
-                // (13,26): hidden CS9335: The pattern is redundant.
-                // _ = ss is S { P: { } and C { Prop: _ } }; // 5
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "C { Prop: _ }").WithLocation(13, 26),
-                // (15,26): hidden CS9335: The pattern is redundant.
-                // _ = ss is S { P: { } and C (_, _) }; // 6
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "C (_, _)").WithLocation(15, 26));
+            var compilation = CreateCompilation(source);
+            compilation.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -6613,26 +6469,8 @@ struct S
     public C P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
-            compilation.VerifyEmitDiagnostics(
-                // (3,25): hidden CS9335: The pattern is redundant.
-                // _ = sss is S { P: C and { } }; // 1
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(3, 25),
-                // (5,25): hidden CS9335: The pattern is redundant.
-                // _ = sss is S { P: C and { Prop: _ } }; // 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ Prop: _ }").WithLocation(5, 25),
-                // (7,25): hidden CS9335: The pattern is redundant.
-                // _ = sss is S { P: C and (_, _) }; // 3
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "(_, _)").WithLocation(7, 25),
-                // (11,25): hidden CS9335: The pattern is redundant.
-                // _ = sss is S { P: C and C { } }; // 4
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "C { }").WithLocation(11, 25),
-                // (13,25): hidden CS9335: The pattern is redundant.
-                // _ = sss is S { P: C and C { Prop: _ } }; // 5
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "C { Prop: _ }").WithLocation(13, 25),
-                // (15,25): hidden CS9335: The pattern is redundant.
-                // _ = sss is S { P: C and C (_, _) }; // 6
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "C (_, _)").WithLocation(15, 25));
+            var compilation = CreateCompilation(source);
+            compilation.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -6669,29 +6507,8 @@ struct S
     public S2 P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
-            compilation.VerifyEmitDiagnostics(
-                // (2,17): hidden CS9335: The pattern is redundant.
-                // _ = s is S { P: { } }; // 1
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(2, 17),
-                // (4,17): hidden CS9335: The pattern is redundant.
-                // _ = s is S { P: { Prop: _ } }; // 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ Prop: _ }").WithLocation(4, 17),
-                // (6,17): hidden CS9335: The pattern is redundant.
-                // _ = s is S { P: (_, _) }; // 3
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "(_, _)").WithLocation(6, 17),
-                // (10,17): hidden CS9335: The pattern is redundant.
-                // _ = s is S { P: S2 { } }; // 4
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "S2 { }").WithLocation(10, 17),
-                // (12,17): hidden CS9335: The pattern is redundant.
-                // _ = s is S { P: S2 { Prop: _ } }; // 5
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "S2 { Prop: _ }").WithLocation(12, 17),
-                // (14,17): hidden CS9335: The pattern is redundant.
-                // _ = s is S { P: S2 (_, _) }; // 6
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "S2 (_, _)").WithLocation(14, 17),
-                // (18,28): hidden CS9335: The pattern is redundant.
-                // _ = s is S { P: S2 { Prop: int and var s12 } }; // 7
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "int").WithLocation(18, 28));
+            var compilation = CreateCompilation(source);
+            compilation.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -6727,68 +6544,8 @@ struct S
     public S2 P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
-            compilation.VerifyEmitDiagnostics(
-                // (3,18): hidden CS9335: The pattern is redundant.
-                // _ = ss is S { P: { } and { } }; // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(3, 18),
-                // (3,26): hidden CS9335: The pattern is redundant.
-                // _ = ss is S { P: { } and { } }; // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(3, 26),
-                // (4,18): hidden CS9335: The pattern is redundant.
-                // _ = ss is S { P: { } and { } ss1 }; // 3
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(4, 18),
-                // (5,18): hidden CS9335: The pattern is redundant.
-                // _ = ss is S { P: { } and { Prop: _ } }; // 4, 5
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(5, 18),
-                // (5,26): hidden CS9335: The pattern is redundant.
-                // _ = ss is S { P: { } and { Prop: _ } }; // 4, 5
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ Prop: _ }").WithLocation(5, 26),
-                // (6,18): hidden CS9335: The pattern is redundant.
-                // _ = ss is S { P: { } and { Prop: var ss2 } }; // 6
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(6, 18),
-                // (7,18): hidden CS9335: The pattern is redundant.
-                // _ = ss is S { P: { } and (_, _) }; // 7, 8
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(7, 18),
-                // (7,26): hidden CS9335: The pattern is redundant.
-                // _ = ss is S { P: { } and (_, _) }; // 7, 8
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "(_, _)").WithLocation(7, 26),
-                // (8,18): hidden CS9335: The pattern is redundant.
-                // _ = ss is S { P: { } and (_, _) ss3 }; // 9
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(8, 18),
-                // (9,18): hidden CS9335: The pattern is redundant.
-                // _ = ss is S { P: { } and (var ss4, _) ss5 }; // 10
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(9, 18),
-                // (11,18): hidden CS9335: The pattern is redundant.
-                // _ = ss is S { P: { } and S2 { } }; // 11, 12
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(11, 18),
-                // (11,26): hidden CS9335: The pattern is redundant.
-                // _ = ss is S { P: { } and S2 { } }; // 11, 12
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "S2 { }").WithLocation(11, 26),
-                // (12,18): hidden CS9335: The pattern is redundant.
-                // _ = ss is S { P: { } and S2 { } ss6 }; // 13
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(12, 18),
-                // (13,18): hidden CS9335: The pattern is redundant.
-                // _ = ss is S { P: { } and S2 { Prop: _ } }; // 14, 15
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(13, 18),
-                // (13,26): hidden CS9335: The pattern is redundant.
-                // _ = ss is S { P: { } and S2 { Prop: _ } }; // 14, 15
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "S2 { Prop: _ }").WithLocation(13, 26),
-                // (14,18): hidden CS9335: The pattern is redundant.
-                // _ = ss is S { P: { } and S2 { Prop: var ss7 } }; // 16
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(14, 18),
-                // (15,18): hidden CS9335: The pattern is redundant.
-                // _ = ss is S { P: { } and S2 (_, _) }; // 17, 18
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(15, 18),
-                // (15,26): hidden CS9335: The pattern is redundant.
-                // _ = ss is S { P: { } and S2 (_, _) }; // 17, 18
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "S2 (_, _)").WithLocation(15, 26),
-                // (16,18): hidden CS9335: The pattern is redundant.
-                // _ = ss is S { P: { } and S2 (_, _) ss8 }; // 19
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(16, 18),
-                // (17,18): hidden CS9335: The pattern is redundant.
-                // _ = ss is S { P: { } and S2 (var ss9_, _) ss10 }; // 20
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(17, 18));
+            var compilation = CreateCompilation(source);
+            compilation.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -6824,68 +6581,8 @@ struct S
     public S2 P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
-            compilation.VerifyEmitDiagnostics(
-                // (3,19): hidden CS9335: The pattern is redundant.
-                // _ = sss is S { P: S2 and { } }; // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "S2").WithLocation(3, 19),
-                // (3,26): hidden CS9335: The pattern is redundant.
-                // _ = sss is S { P: S2 and { } }; // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ }").WithLocation(3, 26),
-                // (4,19): hidden CS9335: The pattern is redundant.
-                // _ = sss is S { P: S2 and { } sss1 }; // 3
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "S2").WithLocation(4, 19),
-                // (5,19): hidden CS9335: The pattern is redundant.
-                // _ = sss is S { P: S2 and { Prop: _ } }; // 4, 5
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "S2").WithLocation(5, 19),
-                // (5,26): hidden CS9335: The pattern is redundant.
-                // _ = sss is S { P: S2 and { Prop: _ } }; // 4, 5
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ Prop: _ }").WithLocation(5, 26),
-                // (6,19): hidden CS9335: The pattern is redundant.
-                // _ = sss is S { P: S2 and { Prop: var sss2 } }; // 6
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "S2").WithLocation(6, 19),
-                // (7,19): hidden CS9335: The pattern is redundant.
-                // _ = sss is S { P: S2 and (_, _) }; // 7, 8
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "S2").WithLocation(7, 19),
-                // (7,26): hidden CS9335: The pattern is redundant.
-                // _ = sss is S { P: S2 and (_, _) }; // 7, 8
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "(_, _)").WithLocation(7, 26),
-                // (8,19): hidden CS9335: The pattern is redundant.
-                // _ = sss is S { P: S2 and (_, _) sss3 }; // 9
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "S2").WithLocation(8, 19),
-                // (9,19): hidden CS9335: The pattern is redundant.
-                // _ = sss is S { P: S2 and (var sss4, _) sss5 }; // 10
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "S2").WithLocation(9, 19),
-                // (11,19): hidden CS9335: The pattern is redundant.
-                // _ = sss is S { P: S2 and S2 { } }; // 11, 12
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "S2").WithLocation(11, 19),
-                // (11,26): hidden CS9335: The pattern is redundant.
-                // _ = sss is S { P: S2 and S2 { } }; // 11, 12
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "S2 { }").WithLocation(11, 26),
-                // (12,19): hidden CS9335: The pattern is redundant.
-                // _ = sss is S { P: S2 and S2 { } sss6 }; // 13
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "S2").WithLocation(12, 19),
-                // (13,19): hidden CS9335: The pattern is redundant.
-                // _ = sss is S { P: S2 and S2 { Prop: _ } }; // 14, 15
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "S2").WithLocation(13, 19),
-                // (13,26): hidden CS9335: The pattern is redundant.
-                // _ = sss is S { P: S2 and S2 { Prop: _ } }; // 14, 15
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "S2 { Prop: _ }").WithLocation(13, 26),
-                // (14,19): hidden CS9335: The pattern is redundant.
-                // _ = sss is S { P: S2 and S2 { Prop: var sss7 } }; // 16
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "S2").WithLocation(14, 19),
-                // (15,19): hidden CS9335: The pattern is redundant.
-                // _ = sss is S { P: S2 and S2 (_, _) }; // 17, 18
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "S2").WithLocation(15, 19),
-                // (15,26): hidden CS9335: The pattern is redundant.
-                // _ = sss is S { P: S2 and S2 (_, _) }; // 17, 18
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "S2 (_, _)").WithLocation(15, 26),
-                // (16,19): hidden CS9335: The pattern is redundant.
-                // _ = sss is S { P: S2 and S2 (_, _) sss8 }; // 19
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "S2").WithLocation(16, 19),
-                // (17,19): hidden CS9335: The pattern is redundant.
-                // _ = sss is S { P: S2 and S2 (var sss9, _) sss10 }; // 20
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "S2").WithLocation(17, 19));
+            var compilation = CreateCompilation(source);
+            compilation.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -6980,14 +6677,8 @@ struct S
     public C P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80);
             compilation.VerifyEmitDiagnostics(
-                // (2,24): hidden CS9335: The pattern is redundant.
-                // _ = s is S { P: [] and [..] }; // 1
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "[..]").WithLocation(2, 24),
-                // (3,24): hidden CS9335: The pattern is redundant.
-                // _ = s is S { P: [] and [.._] }; // 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "[.._]").WithLocation(3, 24),
                 // (6,5): error CS8518: An expression of type 'object' can never match the provided pattern.
                 // _ = s is S { P: [] and [_, ..] }; // 3
                 Diagnostic(ErrorCode.ERR_IsPatternImpossible, "s is S { P: [] and [_, ..] }").WithArguments("object").WithLocation(6, 5),
@@ -7028,20 +6719,8 @@ struct S
     public C P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
-            compilation.VerifyEmitDiagnostics(
-                // (2,25): hidden CS9335: The pattern is redundant.
-                // _ = s is S { P: [_] and [..] }; // 1
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "[..]").WithLocation(2, 25),
-                // (3,25): hidden CS9335: The pattern is redundant.
-                // _ = s is S { P: [_] and [.._] }; // 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "[.._]").WithLocation(3, 25),
-                // (6,25): hidden CS9335: The pattern is redundant.
-                // _ = s is S { P: [_] and [_, ..] }; // 3
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "[_, ..]").WithLocation(6, 25),
-                // (7,25): hidden CS9335: The pattern is redundant.
-                // _ = s is S { P: [_] and [_, .._] }; // 4
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "[_, .._]").WithLocation(7, 25));
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            compilation.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -7070,14 +6749,8 @@ struct S
     public S2 P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
-            compilation.VerifyEmitDiagnostics(
-                // (2,17): hidden CS9335: The pattern is redundant.
-                // _ = s is S { P: [..] }; // 1
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "[..]").WithLocation(2, 17),
-                // (3,17): hidden CS9335: The pattern is redundant.
-                // _ = s is S { P: [.._] }; // 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "[.._]").WithLocation(3, 17));
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            compilation.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -7106,14 +6779,8 @@ struct S
     public S2 P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80);
             compilation.VerifyEmitDiagnostics(
-                // (2,24): hidden CS9335: The pattern is redundant.
-                // _ = s is S { P: [] and [..] }; // 1
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "[..]").WithLocation(2, 24),
-                // (3,24): hidden CS9335: The pattern is redundant.
-                // _ = s is S { P: [] and [.._] }; // 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "[.._]").WithLocation(3, 24),
                 // (6,5): error CS8518: An expression of type 'object' can never match the provided pattern.
                 // _ = s is S { P: [] and [_, ..] }; // 3
                 Diagnostic(ErrorCode.ERR_IsPatternImpossible, "s is S { P: [] and [_, ..] }").WithArguments("object").WithLocation(6, 5),
@@ -7154,20 +6821,8 @@ struct S
     public S2 P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
-            compilation.VerifyEmitDiagnostics(
-                // (2,25): hidden CS9335: The pattern is redundant.
-                // _ = s is S { P: [_] and [..] }; // 1
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "[..]").WithLocation(2, 25),
-                // (3,25): hidden CS9335: The pattern is redundant.
-                // _ = s is S { P: [_] and [.._] }; // 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "[.._]").WithLocation(3, 25),
-                // (6,25): hidden CS9335: The pattern is redundant.
-                // _ = s is S { P: [_] and [_, ..] }; // 3
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "[_, ..]").WithLocation(6, 25),
-                // (7,25): hidden CS9335: The pattern is redundant.
-                // _ = s is S { P: [_] and [_, .._] }; // 4
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "[_, .._]").WithLocation(7, 25));
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            compilation.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -7204,23 +6859,14 @@ _ = s is (_, _, _) and (_, _); // 4
 _ = s is (_, _, _) and (_, var s7); // 5
 _ = s is { Length: 3 } and (_, _); // 6
 """;
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80);
             compilation.VerifyEmitDiagnostics(
-                // (10,21): hidden CS9335: The pattern is redundant.
-                // _ = s is (_, _) and (_, _); // 1
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "(_, _)").WithLocation(10, 21),
                 // (12,21): error CS1061: 'ITuple' does not contain a definition for 'Deconstruct' and no accessible extension method 'Deconstruct' accepting a first argument of type 'ITuple' could be found (are you missing a using directive or an assembly reference?)
                 // _ = s is (_, _) and (_, _) s6; // 2, 3
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "(_, _)").WithArguments("System.Runtime.CompilerServices.ITuple", "Deconstruct").WithLocation(12, 21),
                 // (12,21): error CS8129: No suitable 'Deconstruct' instance or extension method was found for type 'ITuple', with 2 out parameters and a void return type.
                 // _ = s is (_, _) and (_, _) s6; // 2, 3
                 Diagnostic(ErrorCode.ERR_MissingDeconstruct, "(_, _)").WithArguments("System.Runtime.CompilerServices.ITuple", "2").WithLocation(12, 21),
-                // (13,28): hidden CS9335: The pattern is redundant.
-                // _ = s is { Length: 2 } and (_, _);
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "(_, _)").WithLocation(13, 28),
-                // (14,33): hidden CS9335: The pattern is redundant.
-                // _ = s is not ({ Length: 2 } and (_, _));
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "(_, _)").WithLocation(14, 33),
                 // (20,5): error CS8510: The pattern is unreachable. It has already been handled by a previous arm of the switch expression or it is impossible to match.
                 //     not (_, _) => 1,
                 Diagnostic(ErrorCode.ERR_SwitchArmSubsumed, "not (_, _)").WithLocation(20, 5),
@@ -7290,14 +6936,8 @@ public struct S
     public void Deconstruct(out object x, out object y) => throw null;
 }
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics(
-                // (4,28): hidden CS9335: The pattern is redundant.
-                // _ = o is not S (42 and not 43, int x2); // 1
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(4, 28),
-                // (5,36): hidden CS9335: The pattern is redundant.
-                // _ = o is not S { Prop1: 42 and not 43, Prop2: _ and var x3 }; // 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(5, 36),
                 // (10,5): error CS8518: An expression of type 'S' can never match the provided pattern.
                 // _ = s is not { Prop1: _ }; // 3
                 Diagnostic(ErrorCode.ERR_IsPatternImpossible, "s is not { Prop1: _ }").WithArguments("S").WithLocation(10, 5),
@@ -7333,26 +6973,8 @@ public class C
     public void Deconstruct(out int x, out int y) => throw null;
 }
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics(
-                // (2,17): hidden CS9335: The pattern is redundant.
-                // _ = o is C and (int, int); // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "int").WithLocation(2, 17),
-                // (2,22): hidden CS9335: The pattern is redundant.
-                // _ = o is C and (int, int); // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "int").WithLocation(2, 22),
-                // (6,17): hidden CS9335: The pattern is redundant.
-                // _ = c is C and (int, int); // 3, 4
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "int").WithLocation(6, 17),
-                // (6,22): hidden CS9335: The pattern is redundant.
-                // _ = c is C and (int, int); // 3, 4
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "int").WithLocation(6, 22),
-                // (9,11): hidden CS9335: The pattern is redundant.
-                // _ = c is (int, int); // 5, 6
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "int").WithLocation(9, 11),
-                // (9,16): hidden CS9335: The pattern is redundant.
-                // _ = c is (int, int); // 5, 6
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "int").WithLocation(9, 16),
                 // (13,5): warning CS8794: An expression of type 'C' always matches the provided pattern.
                 // _ = c is not object or (int x4, int y4); // 7, 8, 9
                 Diagnostic(ErrorCode.WRN_IsPatternAlways, "c is not object or (int x4, int y4)").WithArguments("C").WithLocation(13, 5),
@@ -7377,14 +6999,8 @@ _ = o is [not 42 or 43, not 44 or 45]; // 3, 4
 _ = o is not [_, _];
 _ = o is not [.._]; // 5
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
             comp.VerifyEmitDiagnostics(
-                // (2,26): hidden CS9335: The pattern is redundant.
-                // _ = o is not [42 and not 43, 44 and not 45]; // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(2, 26),
-                // (2,41): hidden CS9335: The pattern is redundant.
-                // _ = o is not [42 and not 43, 44 and not 45]; // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(2, 41),
                 // (3,21): warning CS9336: The pattern is redundant.
                 // _ = o is [not 42 or 43, not 44 or 45]; // 3, 4
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(3, 21),
@@ -7406,14 +7022,8 @@ public class C
     public object Prop { get; set; }
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
             comp.VerifyEmitDiagnostics(
-                // (2,34): hidden CS9335: The pattern is redundant.
-                // _ = o is not [{ Prop: 42 and not 43 }, { Prop: 44 and not 45 }]; // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(2, 34),
-                // (2,59): hidden CS9335: The pattern is redundant.
-                // _ = o is not [{ Prop: 42 and not 43 }, { Prop: 44 and not 45 }]; // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(2, 59),
                 // (3,29): warning CS9336: The pattern is redundant.
                 // _ = o is [{ Prop: not 42 or 43 }, { Prop: not 44 or 45 }]; // 3, 4
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(3, 29),
@@ -7505,26 +7115,8 @@ switch (o)
         break;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
-            comp.VerifyEmitDiagnostics(
-                // (2,22): hidden CS9335: The pattern is redundant.
-                // _ = o is [42 and not 43, 44 and not 45]; // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(2, 22),
-                // (2,37): hidden CS9335: The pattern is redundant.
-                // _ = o is [42 and not 43, 44 and not 45]; // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(2, 37),
-                // (5,17): hidden CS9335: The pattern is redundant.
-                //     [42 and not 43, 44 and not 45] => 0, // 3, 4
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(5, 17),
-                // (5,32): hidden CS9335: The pattern is redundant.
-                //     [42 and not 43, 44 and not 45] => 0, // 3, 4
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(5, 32),
-                // (11,22): hidden CS9335: The pattern is redundant.
-                //     case [42 and not 43, 44 and not 45]: // 5, 6
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(11, 22),
-                // (11,37): hidden CS9335: The pattern is redundant.
-                //     case [42 and not 43, 44 and not 45]: // 5, 6
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(11, 37));
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75506")]
@@ -7547,26 +7139,8 @@ switch (t)
         break;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
-            comp.VerifyEmitDiagnostics(
-                // (2,22): hidden CS9335: The pattern is redundant.
-                // _ = t is (42 and not 43, 44 and not 45); // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(2, 22),
-                // (2,37): hidden CS9335: The pattern is redundant.
-                // _ = t is (42 and not 43, 44 and not 45); // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(2, 37),
-                // (5,17): hidden CS9335: The pattern is redundant.
-                //     (42 and not 43, 44 and not 45) => 0, // 3, 4
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(5, 17),
-                // (5,32): hidden CS9335: The pattern is redundant.
-                //     (42 and not 43, 44 and not 45) => 0, // 3, 4
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(5, 32),
-                // (11,22): hidden CS9335: The pattern is redundant.
-                //     case (42 and not 43, 44 and not 45): // 5, 6
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(11, 22),
-                // (11,37): hidden CS9335: The pattern is redundant.
-                //     case (42 and not 43, 44 and not 45): // 5, 6
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(11, 37));
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75506")]
@@ -7595,26 +7169,8 @@ class C
     public void Deconstruct(out int x, out int y) => throw null;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
-            comp.VerifyEmitDiagnostics(
-                // (3,22): hidden CS9335: The pattern is redundant.
-                // _ = c is (42 and not 43, 44 and not 45); // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(3, 22),
-                // (3,37): hidden CS9335: The pattern is redundant.
-                // _ = c is (42 and not 43, 44 and not 45); // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(3, 37),
-                // (6,17): hidden CS9335: The pattern is redundant.
-                //     (42 and not 43, 44 and not 45) => 0, // 3, 4
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(6, 17),
-                // (6,32): hidden CS9335: The pattern is redundant.
-                //     (42 and not 43, 44 and not 45) => 0, // 3, 4
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(6, 32),
-                // (12,22): hidden CS9335: The pattern is redundant.
-                //     case (42 and not 43, 44 and not 45): // 5, 6
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(12, 22),
-                // (12,37): hidden CS9335: The pattern is redundant.
-                //     case (42 and not 43, 44 and not 45): // 5, 6
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(12, 37));
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75506")]
@@ -7644,26 +7200,8 @@ class C
     public int Prop2 { get; set; }
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
-            comp.VerifyEmitDiagnostics(
-                // (3,30): hidden CS9335: The pattern is redundant.
-                // _ = c is { Prop1: 42 and not 43, Prop2: 44 and not 45 }; // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(3, 30),
-                // (3,52): hidden CS9335: The pattern is redundant.
-                // _ = c is { Prop1: 42 and not 43, Prop2: 44 and not 45 }; // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(3, 52),
-                // (6,25): hidden CS9335: The pattern is redundant.
-                //     { Prop1: 42 and not 43, Prop2: 44 and not 45 } => 0, // 3, 4
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(6, 25),
-                // (6,47): hidden CS9335: The pattern is redundant.
-                //     { Prop1: 42 and not 43, Prop2: 44 and not 45 } => 0, // 3, 4
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(6, 47),
-                // (12,30): hidden CS9335: The pattern is redundant.
-                //     case { Prop1: 42 and not 43, Prop2: 44 and not 45 }: // 5, 6
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(12, 30),
-                // (12,52): hidden CS9335: The pattern is redundant.
-                //     case { Prop1: 42 and not 43, Prop2: 44 and not 45 }: // 5, 6
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(12, 52));
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75506")]
@@ -7686,26 +7224,14 @@ public struct S
     public int this[System.Range r] => throw null;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
             comp.VerifyEmitDiagnostics(
-                // (2,26): hidden CS9335: The pattern is redundant.
-                // _ = o is not [42 and not 43, 44 and not 45, ..]; // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(2, 26),
-                // (2,41): hidden CS9335: The pattern is redundant.
-                // _ = o is not [42 and not 43, 44 and not 45, ..]; // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(2, 41),
                 // (3,21): warning CS9336: The pattern is redundant.
                 // _ = o is [not 42 or 43, not 44 or 45, ..]; // 3, 4
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(3, 21),
                 // (3,35): warning CS9336: The pattern is redundant.
                 // _ = o is [not 42 or 43, not 44 or 45, ..]; // 3, 4
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "45").WithLocation(3, 35),
-                // (5,26): hidden CS9335: The pattern is redundant.
-                // _ = o is not [42 and not 43, .., 44 and not 45]; // 5, 6
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(5, 26),
-                // (5,45): hidden CS9335: The pattern is redundant.
-                // _ = o is not [42 and not 43, .., 44 and not 45]; // 5, 6
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(5, 45),
                 // (6,21): warning CS9336: The pattern is redundant.
                 // _ = o is [not 42 or 43, .., not 44 or 45]; // 7, 8
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(6, 21),
@@ -7742,44 +7268,17 @@ public struct S
     public int this[System.Range r] => throw null;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
             comp.VerifyEmitDiagnostics(
-                // (2,26): hidden CS9335: The pattern is redundant.
-                // _ = o is not [42 and not 43, .._]; // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(2, 26),
                 // (3,21): warning CS9336: The pattern is redundant.
                 // _ = o is [not 42 or 43, .._]; // 3, 4
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(3, 21),
-                // (4,26): hidden CS9335: The pattern is redundant.
-                // _ = o is not [42 and not 43, ..(_ or _)]; // 5, 6, 7
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(4, 26),
-                // (4,33): hidden CS9335: The pattern is redundant.
-                // _ = o is not [42 and not 43, ..(_ or _)]; // 5, 6, 7
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "_ or _").WithLocation(4, 33),
-                // (4,38): hidden CS9335: The pattern is redundant.
-                // _ = o is not [42 and not 43, ..(_ or _)]; // 5, 6, 7
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "_").WithLocation(4, 38),
-                // (5,26): hidden CS9335: The pattern is redundant.
-                // _ = o is not [42 and not 43, ..(_ and _)]; // 8, 9, 10
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(5, 26),
-                // (7,26): hidden CS9335: The pattern is redundant.
-                // _ = o is not [42 and not 43, ..var x]; // 11
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(7, 26),
                 // (8,21): warning CS9336: The pattern is redundant.
                 // _ = o is [not 42 or 43, ..var y]; // 12
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(8, 21),
-                // (10,36): hidden CS9335: The pattern is redundant.
-                // _ = o is not [..var x2, 42 and not 43]; // 13
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(10, 36),
                 // (11,31): warning CS9336: The pattern is redundant.
                 // _ = o is [..var y2, not 42 or 43]; // 14
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(11, 31),
-                // (13,26): hidden CS9335: The pattern is redundant.
-                // _ = o is not [42 and not 43, ..var z or var t]; // 15, 16, 17, 18
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(13, 26),
-                // (13,32): hidden CS9335: The pattern is redundant.
-                // _ = o is not [42 and not 43, ..var z or var t]; // 15, 16, 17, 18
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "var z or var t").WithLocation(13, 32),
                 // (13,36): error CS8780: A variable may not be declared within a 'not' or an 'or' pattern or a union matching involving matching against either the instance, or its underlying value.
                 // _ = o is not [42 and not 43, ..var z or var t]; // 15, 16, 17, 18
                 Diagnostic(ErrorCode.ERR_DesignatorBeneathPatternCombinator, "z").WithLocation(13, 36),
@@ -7812,29 +7311,14 @@ public struct S
     public S this[System.Range r] => throw null;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
             comp.VerifyEmitDiagnostics(
-                // (3,29): hidden CS9335: The pattern is redundant.
-                // _ = s is not [..[42 and not 43]]; // 1
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(3, 29),
                 // (4,24): warning CS9336: The pattern is redundant.
                 // _ = s is [..[not 42 or 43]]; // 2
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(4, 24),
-                // (5,29): hidden CS9335: The pattern is redundant.
-                // _ = s is not [..[42 and not 43]]; // 3
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(5, 29),
-                // (6,29): hidden CS9335: The pattern is redundant.
-                // _ = s is not [..[42 and not 43]]; // 4
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(6, 29),
-                // (8,29): hidden CS9335: The pattern is redundant.
-                // _ = s is not [..[42 and not 43, ..var x]]; // 5
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(8, 29),
                 // (9,24): warning CS9336: The pattern is redundant.
                 // _ = s is [..[not 42 or 43]]; // 6
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(9, 24),
-                // (11,29): hidden CS9335: The pattern is redundant.
-                // _ = s is not [..[42 and not 43]]; // 7
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(11, 29),
                 // (12,25): warning CS9336: The pattern is redundant.
                 // _ = s is [.. [not 42 or 43]]; // 8
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(12, 25));
@@ -7873,35 +7357,20 @@ public struct S
     public int this[System.Range r] => throw null;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
             comp.VerifyEmitDiagnostics(
-                // (2,26): hidden CS9335: The pattern is redundant.
-                // _ = o is not [42 and not 43, _]; // 1
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(2, 26),
                 // (3,21): warning CS9336: The pattern is redundant.
                 // _ = o is [not 42 or 43, _]; // 2
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(3, 21),
-                // (5,26): hidden CS9335: The pattern is redundant.
-                // _ = o is not [42 and not 43, var x]; // 3
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(5, 26),
                 // (6,21): warning CS9336: The pattern is redundant.
                 // _ = o is [not 42 or 43, var y]; // 4
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(6, 21),
-                // (8,34): hidden CS9335: The pattern is redundant.
-                // _ = o is not [var x2, 42 and not 43]; // 5
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(8, 34),
                 // (9,29): warning CS9336: The pattern is redundant.
                 // _ = o is [var y2, not 42 or 43]; // 6
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(9, 29),
-                // (11,26): hidden CS9335: The pattern is redundant.
-                // _ = o is not [42 and not 43, _ and var x3]; // 7, 8
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(11, 26),
                 // (12,21): warning CS9336: The pattern is redundant.
                 // _ = o is [not 42 or 43, _ and var y3]; // 9, 10
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(12, 21),
-                // (14,26): hidden CS9335: The pattern is redundant.
-                // _ = o is not [42 and not 43, var x4 and _]; // 11, 12
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(14, 26),
                 // (15,21): warning CS9336: The pattern is redundant.
                 // _ = o is [not 42 or 43, var y4 and _]; // 13, 14
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(15, 21),
@@ -7913,13 +7382,7 @@ public struct S
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(18, 21),
                 // (19,21): warning CS9336: The pattern is redundant.
                 // _ = o is [not 42 or 43, int y7]; // 18
-                Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(19, 21),
-                // (21,26): hidden CS9335: The pattern is redundant.
-                // _ = o is not [42 and not 43, int and var y8]; // 19, 20
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(21, 26),
-                // (21,30): hidden CS9335: The pattern is redundant.
-                // _ = o is not [42 and not 43, int and var y8]; // 19, 20
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "int").WithLocation(21, 30));
+                Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(19, 21));
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75506")]
@@ -7940,26 +7403,14 @@ public struct S
     public int this[System.Range r] => throw null;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
             comp.VerifyEmitDiagnostics(
-                // (2,26): hidden CS9335: The pattern is redundant.
-                // _ = o is not [42 and not 43, _, ..44 and not 45]; // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(2, 26),
-                // (2,46): hidden CS9335: The pattern is redundant.
-                // _ = o is not [42 and not 43, _, ..44 and not 45]; // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(2, 46),
                 // (3,21): warning CS9336: The pattern is redundant.
                 // _ = o is [not 42 or 43, _, ..not 44 or 45]; // 3, 4
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(3, 21),
                 // (3,40): warning CS9336: The pattern is redundant.
                 // _ = o is [not 42 or 43, _, ..not 44 or 45]; // 3, 4
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "45").WithLocation(3, 40),
-                // (5,26): hidden CS9335: The pattern is redundant.
-                // _ = o is not [42 and not 43, var x, ..44 and not 45]; // 5, 6
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(5, 26),
-                // (5,50): hidden CS9335: The pattern is redundant.
-                // _ = o is not [42 and not 43, var x, ..44 and not 45]; // 5, 6
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(5, 50),
                 // (6,21): warning CS9336: The pattern is redundant.
                 // _ = o is [not 42 or 43, var y, ..not 44 or 45]; // 7, 8
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(6, 21),
@@ -7998,7 +7449,7 @@ struct S
     public int this[System.Range r] => throw null;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
             comp.VerifyEmitDiagnostics(
                 // (2,27): warning CS9336: The pattern is redundant.
                 // _ = o is C and [not 42 or 43, ..(not 44 or 45)]; // 1, 2
@@ -8006,9 +7457,6 @@ struct S
                 // (2,44): warning CS9336: The pattern is redundant.
                 // _ = o is C and [not 42 or 43, ..(not 44 or 45)]; // 1, 2
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "45").WithLocation(2, 44),
-                // (3,31): hidden CS9335: The pattern is redundant.
-                // _ = o is C and [..(42 and not 43), not 44 or 45]; // 3, 4
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(3, 31),
                 // (3,46): warning CS9336: The pattern is redundant.
                 // _ = o is C and [..(42 and not 43), not 44 or 45]; // 3, 4
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "45").WithLocation(3, 46),
@@ -8018,24 +7466,15 @@ struct S
                 // (6,52): warning CS9336: The pattern is redundant.
                 // _ = c is not object or [not 42 or 43, ..(not 44 or 45)]; // 5, 6
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "45").WithLocation(6, 52),
-                // (7,39): hidden CS9335: The pattern is redundant.
-                // _ = c is not object or [..(42 and not 43), not 44 or 45]; // 7, 8
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(7, 39),
                 // (7,54): warning CS9336: The pattern is redundant.
                 // _ = c is not object or [..(42 and not 43), not 44 or 45]; // 7, 8
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "45").WithLocation(7, 54),
                 // (10,35): warning CS9336: The pattern is redundant.
                 // _ = s is not object or [not 42 or 43, ..(44 and not 45)]; // 9, 10
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(10, 35),
-                // (10,53): hidden CS9335: The pattern is redundant.
-                // _ = s is not object or [not 42 or 43, ..(44 and not 45)]; // 9, 10
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(10, 53),
                 // (11,38): warning CS9336: The pattern is redundant.
                 // _ = s is not object or [..(not 42 or 43), 44 and not 45]; // 11, 12
-                Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(11, 38),
-                // (11,54): hidden CS9335: The pattern is redundant.
-                // _ = s is not object or [..(not 42 or 43), 44 and not 45]; // 11, 12
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(11, 54));
+                Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(11, 38));
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75506")]
@@ -8056,7 +7495,7 @@ public struct S
     public int this[System.Range r] => throw null;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
             comp.VerifyEmitDiagnostics(
                 // (2,15): error CS0029: Cannot implicitly convert type 'int' to 'S'
                 // _ = o is not (42 and not 43 and var x1); // 1, 2
@@ -8070,12 +7509,6 @@ public struct S
                 // (3,40): warning CS9336: The pattern is redundant.
                 // _ = o is [not 42 or 43, _, ..not 44 or 45]; // 3, 4
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "45").WithLocation(3, 40),
-                // (5,26): hidden CS9335: The pattern is redundant.
-                // _ = o is not [42 and not 43, var x2, ..44 and not 45]; // 5, 6
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(5, 26),
-                // (5,51): hidden CS9335: The pattern is redundant.
-                // _ = o is not [42 and not 43, var x2, ..44 and not 45]; // 5, 6
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(5, 51),
                 // (6,21): warning CS9336: The pattern is redundant.
                 // _ = o is [not 42 or 43, var x3, ..not 44 or 45]; // 7, 8
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(6, 21),
@@ -8155,17 +7588,11 @@ switch (i)
     default: break; // 11
 }
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics(
-                // (2,20): hidden CS9335: The pattern is redundant.
-                // _ = i is 1 or 2 or 1; // 1
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "1").WithLocation(2, 20),
                 // (3,5): warning CS8794: An expression of type 'int' always matches the provided pattern.
                 // _ = i is 1 or 2 or not 1; // 2
                 Diagnostic(ErrorCode.WRN_IsPatternAlways, "i is 1 or 2 or not 1").WithArguments("int").WithLocation(3, 5),
-                // (5,25): hidden CS9335: The pattern is redundant.
-                // _ = i is not (1 or 2 or 1); // 3
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "1").WithLocation(5, 25),
                 // (6,5): error CS8518: An expression of type 'int' can never match the provided pattern.
                 // _ = i is not (1 or 2 or not 1); // 4
                 Diagnostic(ErrorCode.ERR_IsPatternImpossible, "i is not (1 or 2 or not 1)").WithArguments("int").WithLocation(6, 5),
@@ -8260,14 +7687,8 @@ public {{typeKind}} S
     public int this[System.Range r] => throw null;
 }
 """;
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80);
             compilation.VerifyDiagnostics(
-                // (5,38): hidden CS9335: The pattern is redundant.
-                //         if (s is { Prop1: 42 and not 43 } or { Prop2: 44 and not 45 }) { } // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(5, 38),
-                // (5,66): hidden CS9335: The pattern is redundant.
-                //         if (s is { Prop1: 42 and not 43 } or { Prop2: 44 and not 45 }) { } // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(5, 66),
                 // (6,37): warning CS9336: The pattern is redundant.
                 //         if (s is { Prop1: not 42 or 43 } and { Prop2: not 44 or 45 }) { } // 3, 4
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(6, 37),
@@ -8289,21 +7710,12 @@ public {{typeKind}} S
                 // (10,43): warning CS9336: The pattern is redundant.
                 //         if (s is (not 42 or 43, not 44 or 45)) { } // 8, 9
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "45").WithLocation(10, 43),
-                // (11,30): hidden CS9335: The pattern is redundant.
-                //         if (s is (42 and not 43, 44 and not 45)) { } // 10, 11
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(11, 30),
-                // (11,45): hidden CS9335: The pattern is redundant.
-                //         if (s is (42 and not 43, 44 and not 45)) { } // 10, 11
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(11, 45),
                 // (12,29): warning CS9336: The pattern is redundant.
                 //         if (s is (not 42 or 43, _) and var (x2, x3)) { } // 12
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(12, 29),
                 // (13,29): warning CS9336: The pattern is redundant.
                 //         if (s is (not 42 or 43, _) and (_, _)) { } // 13, 14
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(13, 29),
-                // (13,40): hidden CS9335: The pattern is redundant.
-                //         if (s is (not 42 or 43, _) and (_, _)) { } // 13, 14
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "(_, _)").WithLocation(13, 40),
                 // (14,29): warning CS9336: The pattern is redundant.
                 //         if (s is (not 42 or 43, not 44 or 45) and (var x4, var x5)) { } // 15, 16
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(14, 29),
@@ -8316,12 +7728,6 @@ public {{typeKind}} S
                 // (16,43): warning CS9336: The pattern is redundant.
                 //         if (s is [not 42 or 43, not 44 or 45]) { } // 17, 18
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "45").WithLocation(16, 43),
-                // (17,30): hidden CS9335: The pattern is redundant.
-                //         if (s is [42 and not 43, 44 and not 45]) { } // 19, 20
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(17, 30),
-                // (17,45): hidden CS9335: The pattern is redundant.
-                //         if (s is [42 and not 43, 44 and not 45]) { } // 19, 20
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(17, 45),
                 // (18,29): warning CS9336: The pattern is redundant.
                 //         if (s is [not 42 or 43, not 44 or 45] and [var x6, var x7]) { } // 21, 22
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(18, 29),
@@ -8334,12 +7740,6 @@ public {{typeKind}} S
                 // (20,43): warning CS9336: The pattern is redundant.
                 //         if (t is (not 42 or 43, not 44 or 45)) { } // 23, 24
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "45").WithLocation(20, 43),
-                // (21,30): hidden CS9335: The pattern is redundant.
-                //         if (t is (42 and not 43, 44 and not 45)) { } // 25, 26
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(21, 30),
-                // (21,45): hidden CS9335: The pattern is redundant.
-                //         if (t is (42 and not 43, 44 and not 45)) { } // 25, 26
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(21, 45),
                 // (22,29): warning CS9336: The pattern is redundant.
                 //         if (t is (not 42 or 43, not 44 or 45) and (var x8, var x9)) { } // 27, 28
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(22, 29),
@@ -8391,14 +7791,8 @@ public {{typeKind}} S
     public object this[System.Range r] => throw null;
 }
 """;
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80);
             compilation.VerifyDiagnostics(
-                // (5,38): hidden CS9335: The pattern is redundant.
-                //         if (s is { Prop1: 42 and not 43 } or { Prop2: 44 and not 45 }) { } // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(5, 38),
-                // (5,66): hidden CS9335: The pattern is redundant.
-                //         if (s is { Prop1: 42 and not 43 } or { Prop2: 44 and not 45 }) { } // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(5, 66),
                 // (6,37): warning CS9336: The pattern is redundant.
                 //         if (s is { Prop1: not 42 or 43 } and { Prop2: not 44 or 45 }) { } // 3, 4
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(6, 37),
@@ -8420,21 +7814,12 @@ public {{typeKind}} S
                 // (10,43): warning CS9336: The pattern is redundant.
                 //         if (s is (not 42 or 43, not 44 or 45)) { } // 8, 9
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "45").WithLocation(10, 43),
-                // (11,30): hidden CS9335: The pattern is redundant.
-                //         if (s is (42 and not 43, 44 and not 45)) { } // 10, 11
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(11, 30),
-                // (11,45): hidden CS9335: The pattern is redundant.
-                //         if (s is (42 and not 43, 44 and not 45)) { } // 10, 11
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(11, 45),
                 // (12,29): warning CS9336: The pattern is redundant.
                 //         if (s is (not 42 or 43, _) and var (x2, x3)) { } // 12
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(12, 29),
                 // (13,29): warning CS9336: The pattern is redundant.
                 //         if (s is (not 42 or 43, _) and (_, _)) { } // 13, 14
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(13, 29),
-                // (13,40): hidden CS9335: The pattern is redundant.
-                //         if (s is (not 42 or 43, _) and (_, _)) { } // 13, 14
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "(_, _)").WithLocation(13, 40),
                 // (14,29): warning CS9336: The pattern is redundant.
                 //         if (s is (not 42 or 43, not 44 or 45) and (var x4, var x5)) { } // 15, 16
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(14, 29),
@@ -8447,12 +7832,6 @@ public {{typeKind}} S
                 // (16,43): warning CS9336: The pattern is redundant.
                 //         if (s is [not 42 or 43, not 44 or 45]) { } // 17, 18
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "45").WithLocation(16, 43),
-                // (17,30): hidden CS9335: The pattern is redundant.
-                //         if (s is [42 and not 43, 44 and not 45]) { } // 19, 20
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(17, 30),
-                // (17,45): hidden CS9335: The pattern is redundant.
-                //         if (s is [42 and not 43, 44 and not 45]) { } // 19, 20
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "45").WithLocation(17, 45),
                 // (18,29): warning CS9336: The pattern is redundant.
                 //         if (s is [not 42 or 43, not 44 or 45] and [var x6, var x7]) { } // 21, 22
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "43").WithLocation(18, 29),
@@ -8611,7 +7990,7 @@ _ = i is (string or not 42) or 0;
 _ = i is 42 or (42 or not 0);
 _ = i is (not 42) or 43;
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics(
                 // (2,34): warning CS9336: The pattern is redundant.
                 // _ = i is not (42 or 43) or 43 or 0; // warn
@@ -8619,9 +7998,6 @@ _ = i is (not 42) or 43;
                 // (3,34): warning CS9336: The pattern is redundant.
                 // _ = i is not (42 or 43) or 43 or (0); // warn
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "(0)").WithLocation(3, 34),
-                // (4,28): hidden CS9335: The pattern is redundant.
-                // _ = i is (42 or not 43) or 0;
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "0").WithLocation(4, 28),
                 // (5,26): warning CS9336: The pattern is redundant.
                 // _ = i is 42 or not 43 or 0; // warn
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "0").WithLocation(5, 26),
@@ -8634,9 +8010,6 @@ _ = i is (not 42) or 43;
                 // (7,40): warning CS9336: The pattern is redundant.
                 // _ = i is not (42 or 43) or 43 or (0 or 1); // warn
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "1").WithLocation(7, 40),
-                // (8,36): hidden CS9335: The pattern is redundant.
-                // _ = i is (not (42 or 43) or 43) or 0;
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "0").WithLocation(8, 36),
                 // (9,35): warning CS9336: The pattern is redundant.
                 // _ = i is not (42 or 43) or (43 or 0); // warn
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "0").WithLocation(9, 35),
@@ -8651,16 +8024,7 @@ _ = i is (not 42) or 43;
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "0").WithLocation(12, 44),
                 // (13,38): warning CS9336: The pattern is redundant.
                 // _ = i is string or not (42 or 43) or 0; // warn
-                Diagnostic(ErrorCode.WRN_RedundantPattern, "0").WithLocation(13, 38),
-                // (14,32): hidden CS9335: The pattern is redundant.
-                // _ = i is (string or not 42) or 0;
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "0").WithLocation(14, 32),
-                // (15,17): hidden CS9335: The pattern is redundant.
-                // _ = i is 42 or (42 or not 0);
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "42").WithLocation(15, 17),
-                // (16,22): hidden CS9335: The pattern is redundant.
-                // _ = i is (not 42) or 43;
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(16, 22));
+                Diagnostic(ErrorCode.WRN_RedundantPattern, "0").WithLocation(13, 38));
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75506")]
@@ -8680,14 +8044,8 @@ class C
 }
 class Derived : C { }
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics(
-                // (3,31): hidden CS9335: The pattern is redundant.
-                // _ = s is { Prop1: not 42 } or { Prop1: 43 }; // 1
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ Prop1: 43 }").WithLocation(3, 31),
-                // (4,30): hidden CS9335: The pattern is redundant.
-                // _ = s is (not 42, _) or (not 43, _); // 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(4, 30)
                 );
         }
 
@@ -8871,14 +8229,8 @@ public struct S
     public int P3 { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var compilation = CreateCompilation(source);
             compilation.VerifyDiagnostics(
-                // (5,64): hidden CS9335: The pattern is redundant.
-                //         if (s is { P0: 0 } or { P2: > -1 } or (({ P1: > 1 } or { P2: 2 }) and { P3: 3 })) { } // 1
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ P2: 2 }").WithLocation(5, 64),
-                // (7,49): hidden CS9335: The pattern is redundant.
-                //         if (s is { P0: 0 } or { P2: > -1 } or (({ P2: 2 } or { P1: > 1 }) and { P3: 3 })) { } // 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{ P2: 2 }").WithLocation(7, 49)
                 );
         }
 
@@ -8942,29 +8294,17 @@ public class C
     public string P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var compilation = CreateCompilation(source);
             compilation.VerifyDiagnostics(
-                // (2,15): hidden CS9335: The pattern is redundant.
-                // _ = s is { P: string or null }; // 1
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "string or null").WithLocation(2, 15),
                 // (3,5): error CS8518: An expression of type 'S' can never match the provided pattern.
                 // _ = s is { P: string and null }; // 2
                 Diagnostic(ErrorCode.ERR_IsPatternImpossible, "s is { P: string and null }").WithArguments("S").WithLocation(3, 5),
-                // (7,15): hidden CS9335: The pattern is redundant.
-                // _ = c is { P: string or null }; // 3
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "string or null").WithLocation(7, 15),
                 // (8,5): error CS8518: An expression of type 'C' can never match the provided pattern.
                 // _ = c is { P: string and null }; // 4
                 Diagnostic(ErrorCode.ERR_IsPatternImpossible, "c is { P: string and null }").WithArguments("C").WithLocation(8, 5),
                 // (10,28): warning CS9336: The pattern is redundant.
                 // _ = c is not null and { P: string or null }; // 5
-                Diagnostic(ErrorCode.WRN_RedundantPattern, "string or null").WithLocation(10, 28),
-                // (13,17): hidden CS9335: The pattern is redundant.
-                // _ = o is S { P: string or null }; // 6
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "string or null").WithLocation(13, 17),
-                // (14,17): hidden CS9335: The pattern is redundant.
-                // _ = o is C { P: string or null }; // 7
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "string or null").WithLocation(14, 17));
+                Diagnostic(ErrorCode.WRN_RedundantPattern, "string or null").WithLocation(10, 28));
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75506")]
@@ -8984,17 +8324,8 @@ public class C
     public object O;
 }
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics(
-                // (3,12): hidden CS9335: The pattern is redundant.
-                // _ =  c is ({F: 1 and not 1} and {O: not A or B}) or {F: 2}; // 1
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{F: 1 and not 1} and {O: not A or B}").WithLocation(3, 12),
-                // (3,37): hidden CS9335: The pattern is redundant.
-                // _ =  c is ({F: 1 and not 1} and {O: not A or B}) or {F: 2}; // 1
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "not A or B").WithLocation(3, 37),
-                // (3,41): hidden CS9335: The pattern is redundant.
-                // _ =  c is ({F: 1 and not 1} and {O: not A or B}) or {F: 2}; // 1
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "A").WithLocation(3, 41),
                 // (3,46): warning CS9336: The pattern is redundant.
                 // _ =  c is ({F: 1 and not 1} and {O: not A or B}) or {F: 2}; // 1
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "B").WithLocation(3, 46)
@@ -9099,20 +8430,14 @@ _ = o is Base x17 and Derived;
 class Base { }
 class Derived : Base { }
 """;
-            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+            var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics(
                 // (2,17): error CS8780: A variable may not be declared within a 'not' or an 'or' pattern or a union matching involving matching against either the instance, or its underlying value.
                 // _ = o is string x1 or string; // 1, 2
                 Diagnostic(ErrorCode.ERR_DesignatorBeneathPatternCombinator, "x1").WithLocation(2, 17),
-                // (2,23): hidden CS9335: The pattern is redundant.
-                // _ = o is string x1 or string; // 1, 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "string").WithLocation(2, 23),
                 // (3,17): error CS8780: A variable may not be declared within a 'not' or an 'or' pattern or a union matching involving matching against either the instance, or its underlying value.
                 // _ = o is object x2 or string; // 3, 4
                 Diagnostic(ErrorCode.ERR_DesignatorBeneathPatternCombinator, "x2").WithLocation(3, 17),
-                // (3,23): hidden CS9335: The pattern is redundant.
-                // _ = o is object x2 or string; // 3, 4
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "string").WithLocation(3, 23),
                 // (8,5): error CS8510: The pattern is unreachable. It has already been handled by a previous arm of the switch expression or it is impossible to match.
                 //     string => 1, // 5
                 Diagnostic(ErrorCode.ERR_SwitchArmSubsumed, "string").WithLocation(8, 5),
@@ -9122,9 +8447,6 @@ class Derived : Base { }
                 // (21,17): error CS8780: A variable may not be declared within a 'not' or an 'or' pattern or a union matching involving matching against either the instance, or its underlying value.
                 // _ = b is object x5 or Derived; // 7, 8
                 Diagnostic(ErrorCode.ERR_DesignatorBeneathPatternCombinator, "x5").WithLocation(21, 17),
-                // (21,23): hidden CS9335: The pattern is redundant.
-                // _ = b is object x5 or Derived; // 7, 8
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "Derived").WithLocation(21, 23),
                 // (26,5): error CS8510: The pattern is unreachable. It has already been handled by a previous arm of the switch expression or it is impossible to match.
                 //     Derived => 1, // 9
                 Diagnostic(ErrorCode.ERR_SwitchArmSubsumed, "Derived").WithLocation(26, 5),
@@ -9139,19 +8461,7 @@ class Derived : Base { }
                 Diagnostic(ErrorCode.ERR_DesignatorBeneathPatternCombinator, "x9").WithLocation(32, 28),
                 // (35,5): error CS8518: An expression of type 'object' can never match the provided pattern.
                 // _ = o is string x11 and not string; // 13
-                Diagnostic(ErrorCode.ERR_IsPatternImpossible, "o is string x11 and not string").WithArguments("object").WithLocation(35, 5),
-                // (37,23): hidden CS9335: The pattern is redundant.
-                // _ = b is Base x12 and object; // 14
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "object").WithLocation(37, 23),
-                // (38,23): hidden CS9335: The pattern is redundant.
-                // _ = b is Base x13 and Base; // 15
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "Base").WithLocation(38, 23),
-                // (41,23): hidden CS9335: The pattern is redundant.
-                // _ = o is Base x15 and object; // 16
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "object").WithLocation(41, 23),
-                // (42,23): hidden CS9335: The pattern is redundant.
-                // _ = o is Base x16 and Base; // 17
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "Base").WithLocation(42, 23));
+                Diagnostic(ErrorCode.ERR_IsPatternImpossible, "o is string x11 and not string").WithArguments("object").WithLocation(35, 5));
         }
 
         [Fact]
@@ -9256,9 +8566,6 @@ class C
 ";
             var compilation = CreateCompilation(source);
             compilation.VerifyEmitDiagnostics(
-                // (3,30): hidden CS9335: The pattern is redundant.
-                // _ = o is C { Prop1: 0 } and (not null or (C and ({ Prop1: 0 } or { Prop2: 1 })));
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "not null or (C and ({ Prop1: 0 } or { Prop2: 1 }))").WithLocation(3, 30),
                 // (3,43): warning CS9336: The pattern is redundant.
                 // _ = o is C { Prop1: 0 } and (not null or (C and ({ Prop1: 0 } or { Prop2: 1 })));
                 Diagnostic(ErrorCode.WRN_RedundantPattern, "C and ({ Prop1: 0 } or { Prop2: 1 })").WithLocation(3, 43),
@@ -9342,27 +8649,6 @@ int i = 0;
 _ = i is 42 or not 43;
 ";
             var compilation = CreateCompilation(source);
-            compilation.VerifyEmitDiagnostics();
-        }
-
-        [Fact]
-        public void RedundantPattern_EasyOut_01()
-        {
-            var source = """
-                int i = 0;
-                _ = i is (not 42) or 43;
-                """;
-
-            // Note: severity is hidden rather than warning because the '(not 42)' has parentheses.
-            var options = TestOptions.ReleaseExeWithHiddenRedundantPatterns;
-            var compilation = CreateCompilation(source, options: options);
-            compilation.VerifyEmitDiagnostics(
-                // (2,22): hidden CS9335: The pattern is redundant.
-                // _ = i is (not 42) or 43;
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(2, 22));
-
-            options = TestOptions.ReleaseExe;
-            compilation = CreateCompilation(source, options: options);
             compilation.VerifyEmitDiagnostics();
         }
     }

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests4.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests4.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -4481,7 +4481,7 @@ public class C
     }
 }
 """;
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyDiagnostics(
                 // (10,22): hidden CS9335: The pattern is redundant.
                 //             >= 0 and < 10.0 => "Acceptable",
@@ -4570,7 +4570,7 @@ public class C
     }
 }
 """;
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyDiagnostics(
                 // (11,13): hidden CS9335: The pattern is redundant.
                 //             >= -40.0 and < 0 => "Low",
@@ -4890,7 +4890,7 @@ _ = o switch
 class A { }
 class B { }
 """;
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,19): warning CS9336: The pattern is redundant.
                 // _ = o is not A or B; // 1
@@ -4997,7 +4997,7 @@ _ = o switch
 class A { }
 class Derived : A { }
 """;
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (3,5): warning CS8794: An expression of type 'object' always matches the provided pattern.
                 // _ = o is not Derived or A; // 1
@@ -5125,7 +5125,7 @@ _ = o switch
     _ => 44
 };
 """;
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (3,22): warning CS9336: The pattern is redundant.
                 // _ = o is not null or string; // 1
@@ -5167,7 +5167,7 @@ _ = s switch
     _ => 44
 };
 """;
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (3,22): warning CS9336: The pattern is redundant.
                 // _ = s is not null or { Length: >0 }; // 1, 2
@@ -5519,7 +5519,7 @@ switch (s)
     default: break;
 };
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,21): warning CS9336: The pattern is redundant.
                 // _ = s is (not 42 or 43, not 44 or 45); // 1, 2
@@ -5640,7 +5640,7 @@ _ = i switch
     _ => 44
 };
 """;
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (3,22): warning CS9336: The pattern is redundant.
                 // _ = i is not null or 0; // 1
@@ -5679,7 +5679,7 @@ _ = b switch
     _ => 44
 };
 """;
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (3,22): warning CS9336: The pattern is redundant.
                 // _ = b is not null or false; // 1
@@ -5747,7 +5747,7 @@ _ = i switch
     _ => 44
 };
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (3,22): warning CS9336: The pattern is redundant.
                 // _ = i is not null or []; // 1
@@ -5965,7 +5965,7 @@ _ = o switch
     _ => 43
 };
 """;
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,20): hidden CS9335: The pattern is redundant.
                 // _ = o is object or string; // 1
@@ -6038,7 +6038,7 @@ class C
 }
 class Derived : C { }
 """;
-            var compilation = CreateCompilation(source);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             compilation.VerifyDiagnostics(
                 // (5,29): hidden CS9335: The pattern is redundant.
                 //         if (o is not (1 and int)) { } // 1
@@ -6128,7 +6128,7 @@ public struct S
     public int Prop3 { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             compilation.VerifyDiagnostics(
                 // (6,37): warning CS9336: The pattern is redundant.
                 //         if (s is { Prop1: not 42 or 43 } or { Prop2: not 44 or 45 }) { } // 1, 2
@@ -6272,7 +6272,7 @@ public class S
     public void Deconstruct(out int x, out int y) => throw null;
 }
 """;
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,28): hidden CS9335: The pattern is redundant.
                 // _ = o is not S (42 and not 43, 44 and not 45); // 1, 2
@@ -6302,7 +6302,7 @@ public class S
     public int Prop2 { get; set; }
 }
 """;
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,36): hidden CS9335: The pattern is redundant.
                 // _ = o is not S { Prop1: 42 and not 43, Prop2: 44 and not 45 }; // 1, 2
@@ -6332,7 +6332,7 @@ public class S
     public int Prop2 { get; set; }
 }
 """;
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,34): hidden CS9335: The pattern is redundant.
                 // _ = s is not { Prop1: 42 and not 43, Prop2: 44 and not 45 }; // 1, 2
@@ -6398,7 +6398,7 @@ public class S
     public int Prop2 { get; set; }
 }
 """;
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,21): warning CS9336: The pattern is redundant.
                 // _ = s is not { } or null; // 1
@@ -6471,7 +6471,7 @@ public class C
     public int P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             compilation.VerifyDiagnostics(
                 // (3,18): hidden CS9335: The pattern is redundant.
                 // _ = s is { Prop: { } and { P: 42 or 43 } }; // 1
@@ -6518,7 +6518,7 @@ struct S
     public C P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             compilation.VerifyEmitDiagnostics(
                 // (18,27): hidden CS9335: The pattern is redundant.
                 // _ = s is S { P: C { Prop: int and var s12 } }; // 1
@@ -6558,7 +6558,7 @@ struct S
     public C P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             compilation.VerifyEmitDiagnostics(
                 // (3,26): hidden CS9335: The pattern is redundant.
                 // _ = ss is S { P: { } and { } }; // 1
@@ -6613,7 +6613,7 @@ struct S
     public C P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             compilation.VerifyEmitDiagnostics(
                 // (3,25): hidden CS9335: The pattern is redundant.
                 // _ = sss is S { P: C and { } }; // 1
@@ -6669,7 +6669,7 @@ struct S
     public S2 P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             compilation.VerifyEmitDiagnostics(
                 // (2,17): hidden CS9335: The pattern is redundant.
                 // _ = s is S { P: { } }; // 1
@@ -6727,7 +6727,7 @@ struct S
     public S2 P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             compilation.VerifyEmitDiagnostics(
                 // (3,18): hidden CS9335: The pattern is redundant.
                 // _ = ss is S { P: { } and { } }; // 1, 2
@@ -6824,7 +6824,7 @@ struct S
     public S2 P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             compilation.VerifyEmitDiagnostics(
                 // (3,19): hidden CS9335: The pattern is redundant.
                 // _ = sss is S { P: S2 and { } }; // 1, 2
@@ -6980,7 +6980,7 @@ struct S
     public C P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             compilation.VerifyEmitDiagnostics(
                 // (2,24): hidden CS9335: The pattern is redundant.
                 // _ = s is S { P: [] and [..] }; // 1
@@ -7028,7 +7028,7 @@ struct S
     public C P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             compilation.VerifyEmitDiagnostics(
                 // (2,25): hidden CS9335: The pattern is redundant.
                 // _ = s is S { P: [_] and [..] }; // 1
@@ -7070,7 +7070,7 @@ struct S
     public S2 P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             compilation.VerifyEmitDiagnostics(
                 // (2,17): hidden CS9335: The pattern is redundant.
                 // _ = s is S { P: [..] }; // 1
@@ -7106,7 +7106,7 @@ struct S
     public S2 P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             compilation.VerifyEmitDiagnostics(
                 // (2,24): hidden CS9335: The pattern is redundant.
                 // _ = s is S { P: [] and [..] }; // 1
@@ -7154,7 +7154,7 @@ struct S
     public S2 P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             compilation.VerifyEmitDiagnostics(
                 // (2,25): hidden CS9335: The pattern is redundant.
                 // _ = s is S { P: [_] and [..] }; // 1
@@ -7204,7 +7204,7 @@ _ = s is (_, _, _) and (_, _); // 4
 _ = s is (_, _, _) and (_, var s7); // 5
 _ = s is { Length: 3 } and (_, _); // 6
 """;
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             compilation.VerifyEmitDiagnostics(
                 // (10,21): hidden CS9335: The pattern is redundant.
                 // _ = s is (_, _) and (_, _); // 1
@@ -7290,7 +7290,7 @@ public struct S
     public void Deconstruct(out object x, out object y) => throw null;
 }
 """;
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (4,28): hidden CS9335: The pattern is redundant.
                 // _ = o is not S (42 and not 43, int x2); // 1
@@ -7333,7 +7333,7 @@ public class C
     public void Deconstruct(out int x, out int y) => throw null;
 }
 """;
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,17): hidden CS9335: The pattern is redundant.
                 // _ = o is C and (int, int); // 1, 2
@@ -7377,7 +7377,7 @@ _ = o is [not 42 or 43, not 44 or 45]; // 3, 4
 _ = o is not [_, _];
 _ = o is not [.._]; // 5
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,26): hidden CS9335: The pattern is redundant.
                 // _ = o is not [42 and not 43, 44 and not 45]; // 1, 2
@@ -7406,7 +7406,7 @@ public class C
     public object Prop { get; set; }
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,34): hidden CS9335: The pattern is redundant.
                 // _ = o is not [{ Prop: 42 and not 43 }, { Prop: 44 and not 45 }]; // 1, 2
@@ -7505,7 +7505,7 @@ switch (o)
         break;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,22): hidden CS9335: The pattern is redundant.
                 // _ = o is [42 and not 43, 44 and not 45]; // 1, 2
@@ -7547,7 +7547,7 @@ switch (t)
         break;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,22): hidden CS9335: The pattern is redundant.
                 // _ = t is (42 and not 43, 44 and not 45); // 1, 2
@@ -7595,7 +7595,7 @@ class C
     public void Deconstruct(out int x, out int y) => throw null;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (3,22): hidden CS9335: The pattern is redundant.
                 // _ = c is (42 and not 43, 44 and not 45); // 1, 2
@@ -7644,7 +7644,7 @@ class C
     public int Prop2 { get; set; }
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (3,30): hidden CS9335: The pattern is redundant.
                 // _ = c is { Prop1: 42 and not 43, Prop2: 44 and not 45 }; // 1, 2
@@ -7686,7 +7686,7 @@ public struct S
     public int this[System.Range r] => throw null;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,26): hidden CS9335: The pattern is redundant.
                 // _ = o is not [42 and not 43, 44 and not 45, ..]; // 1, 2
@@ -7742,7 +7742,7 @@ public struct S
     public int this[System.Range r] => throw null;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,26): hidden CS9335: The pattern is redundant.
                 // _ = o is not [42 and not 43, .._]; // 1, 2
@@ -7812,7 +7812,7 @@ public struct S
     public S this[System.Range r] => throw null;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (3,29): hidden CS9335: The pattern is redundant.
                 // _ = s is not [..[42 and not 43]]; // 1
@@ -7873,7 +7873,7 @@ public struct S
     public int this[System.Range r] => throw null;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,26): hidden CS9335: The pattern is redundant.
                 // _ = o is not [42 and not 43, _]; // 1
@@ -7940,7 +7940,7 @@ public struct S
     public int this[System.Range r] => throw null;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,26): hidden CS9335: The pattern is redundant.
                 // _ = o is not [42 and not 43, _, ..44 and not 45]; // 1, 2
@@ -7998,7 +7998,7 @@ struct S
     public int this[System.Range r] => throw null;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,27): warning CS9336: The pattern is redundant.
                 // _ = o is C and [not 42 or 43, ..(not 44 or 45)]; // 1, 2
@@ -8056,7 +8056,7 @@ public struct S
     public int this[System.Range r] => throw null;
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,15): error CS0029: Cannot implicitly convert type 'int' to 'S'
                 // _ = o is not (42 and not 43 and var x1); // 1, 2
@@ -8155,7 +8155,7 @@ switch (i)
     default: break; // 11
 }
 """;
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,20): hidden CS9335: The pattern is redundant.
                 // _ = i is 1 or 2 or 1; // 1
@@ -8260,7 +8260,7 @@ public {{typeKind}} S
     public int this[System.Range r] => throw null;
 }
 """;
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             compilation.VerifyDiagnostics(
                 // (5,38): hidden CS9335: The pattern is redundant.
                 //         if (s is { Prop1: 42 and not 43 } or { Prop2: 44 and not 45 }) { } // 1, 2
@@ -8391,7 +8391,7 @@ public {{typeKind}} S
     public object this[System.Range r] => throw null;
 }
 """;
-            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            var compilation = CreateCompilation(source, targetFramework: TargetFramework.Net80, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             compilation.VerifyDiagnostics(
                 // (5,38): hidden CS9335: The pattern is redundant.
                 //         if (s is { Prop1: 42 and not 43 } or { Prop2: 44 and not 45 }) { } // 1, 2
@@ -8611,7 +8611,7 @@ _ = i is (string or not 42) or 0;
 _ = i is 42 or (42 or not 0);
 _ = i is (not 42) or 43;
 """;
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,34): warning CS9336: The pattern is redundant.
                 // _ = i is not (42 or 43) or 43 or 0; // warn
@@ -8680,7 +8680,7 @@ class C
 }
 class Derived : C { }
 """;
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (3,31): hidden CS9335: The pattern is redundant.
                 // _ = s is { Prop1: not 42 } or { Prop1: 43 }; // 1
@@ -8871,7 +8871,7 @@ public struct S
     public int P3 { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             compilation.VerifyDiagnostics(
                 // (5,64): hidden CS9335: The pattern is redundant.
                 //         if (s is { P0: 0 } or { P2: > -1 } or (({ P1: > 1 } or { P2: 2 }) and { P3: 3 })) { } // 1
@@ -8942,7 +8942,7 @@ public class C
     public string P { get; set; }
 }
 """;
-            var compilation = CreateCompilation(source);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             compilation.VerifyDiagnostics(
                 // (2,15): hidden CS9335: The pattern is redundant.
                 // _ = s is { P: string or null }; // 1
@@ -8984,7 +8984,7 @@ public class C
     public object O;
 }
 """;
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (3,12): hidden CS9335: The pattern is redundant.
                 // _ =  c is ({F: 1 and not 1} and {O: not A or B}) or {F: 2}; // 1
@@ -9099,7 +9099,7 @@ _ = o is Base x17 and Derived;
 class Base { }
 class Derived : Base { }
 """;
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,17): error CS8780: A variable may not be declared within a 'not' or an 'or' pattern or a union matching involving matching against either the instance, or its underlying value.
                 // _ = o is string x1 or string; // 1, 2

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests4.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests4.cs
@@ -9350,17 +9350,18 @@ _ = i is 42 or not 43;
         {
             var source = """
                 int i = 0;
-                _ = i is 42 or 42;
+                _ = i is (not 42) or 43;
                 """;
 
-            var options = TestOptions.ReleaseExe.WithSpecificDiagnosticOptions(MessageProvider.Instance.GetIdForErrorCode((int)ErrorCode.HDN_RedundantPattern), ReportDiagnostic.Hidden);
+            // Note: severity is hidden rather than warning because the '(not 42)' has parentheses.
+            var options = TestOptions.ReleaseExeWithHiddenRedundantPatterns;
             var compilation = CreateCompilation(source, options: options);
             compilation.VerifyEmitDiagnostics(
-                // (2,16): hidden CS9335: The pattern is redundant.
-                // _ = i is 42 or 42;
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "42").WithLocation(2, 16));
+                // (2,22): hidden CS9335: The pattern is redundant.
+                // _ = i is (not 42) or 43;
+                Diagnostic(ErrorCode.HDN_RedundantPattern, "43").WithLocation(2, 22));
 
-            options = TestOptions.ReleaseExe.WithSpecificDiagnosticOptions([]);
+            options = TestOptions.ReleaseExe;
             compilation = CreateCompilation(source, options: options);
             compilation.VerifyEmitDiagnostics();
         }

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests5.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests5.cs
@@ -1912,7 +1912,7 @@ class C
     public bool True { get => throw null!; }
 }
 ";
-            var comp = CreateCompilation(program, parseOptions: TestOptions.RegularWithExtendedPropertyPatterns);
+            var comp = CreateCompilation(program, parseOptions: TestOptions.RegularWithExtendedPropertyPatterns, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
             comp.VerifyEmitDiagnostics(
                 // (2,13): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '{ Prop: { True: false } }' is not covered.
                 // _ = new C() switch // 1
@@ -4821,7 +4821,7 @@ class Program
     }   
 }
 ";
-            var comp = CreateCompilation(src, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilation(src, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
 
             VerifyDecisionDagDump<IsPatternExpressionSyntax>(comp,
 @"[0]: t1 = t0.Item1; [1]

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests5.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests5.cs
@@ -1917,9 +1917,6 @@ class C
                 // (2,13): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '{ Prop: { True: false } }' is not covered.
                 // _ = new C() switch // 1
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("{ Prop: { True: false } }").WithLocation(2, 13),
-                // (10,18): hidden CS9335: The pattern is redundant.
-                //     { Prop.True: false } => 0
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "false").WithLocation(10, 18),
                 // (14,13): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '{ Prop: { Prop: not null } }' is not covered.
                 // _ = new C() switch // 2
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("{ Prop: { Prop: not null } }").WithLocation(14, 13)
@@ -4867,9 +4864,6 @@ Evaluated C14.F False
 Evaluated C14.F False
 Evaluated C14.F False
 ").VerifyDiagnostics(
-                // (49,30): hidden CS9335: The pattern is redundant.
-                //         return u is (C12 and I1 and { F: 1 }, 2) or ({ F: 1 or 2 }, 1);
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "I1").WithLocation(49, 30)
                 );
 
             verifier.VerifyIL("Program.Test1", @"

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests_ListPatterns.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests_ListPatterns.cs
@@ -2680,36 +2680,18 @@ class X
             // 0.cs(7,13): error CS8518: An expression of type 'int[]' can never match the provided pattern.
             //         _ = a is [] and [1];          // 1
             Diagnostic(ErrorCode.ERR_IsPatternImpossible, "a is [] and [1]").WithArguments("int[]").WithLocation(7, 13),
-            // 0.cs(8,27): hidden CS9335: The pattern is redundant.
-            //         _ = a is [1] and [1];         // 2
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "1").WithLocation(8, 27),
             // 0.cs(9,13): error CS8518: An expression of type 'int[]' can never match the provided pattern.
             //         _ = a is {Length:0} and [1];  // 3
             Diagnostic(ErrorCode.ERR_IsPatternImpossible, "a is {Length:0} and [1]").WithArguments("int[]").WithLocation(9, 13),
             // 0.cs(11,13): error CS8518: An expression of type 'int[]' can never match the provided pattern.
             //         _ = a is [1,2,3] and [1,2,4]; // 4
             Diagnostic(ErrorCode.ERR_IsPatternImpossible, "a is [1,2,3] and [1,2,4]").WithArguments("int[]").WithLocation(11, 13),
-            // 0.cs(12,31): hidden CS9335: The pattern is redundant.
-            //         _ = a is [1,2,3] and [1,2,3]; // 5, 6, 7
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "1").WithLocation(12, 31),
-            // 0.cs(12,33): hidden CS9335: The pattern is redundant.
-            //         _ = a is [1,2,3] and [1,2,3]; // 5, 6, 7
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "2").WithLocation(12, 33),
-            // 0.cs(12,35): hidden CS9335: The pattern is redundant.
-            //         _ = a is [1,2,3] and [1,2,3]; // 5, 6, 7
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "3").WithLocation(12, 35),
             // 0.cs(13,13): error CS8518: An expression of type 'int[]' can never match the provided pattern.
             //         _ = a is ([>0]) and ([<0]);   // 8
             Diagnostic(ErrorCode.ERR_IsPatternImpossible, "a is ([>0]) and ([<0])").WithArguments("int[]").WithLocation(13, 13),
-            // 0.cs(14,31): hidden CS9335: The pattern is redundant.
-            //         _ = a is ([>0]) and ([>=0]);  // 9
-            Diagnostic(ErrorCode.HDN_RedundantPattern, ">=0").WithLocation(14, 31),
             // 0.cs(15,13): error CS8518: An expression of type 'int[]' can never match the provided pattern.
             //         _ = a is [>0] and [<0];       // 10
             Diagnostic(ErrorCode.ERR_IsPatternImpossible, "a is [>0] and [<0]").WithArguments("int[]").WithLocation(15, 13),
-            // 0.cs(16,28): hidden CS9335: The pattern is redundant.
-            //         _ = a is [>0] and [>=0];      // 11
-            Diagnostic(ErrorCode.HDN_RedundantPattern, ">=0").WithLocation(16, 28),
             // 0.cs(17,13): error CS8518: An expression of type 'int[]' can never match the provided pattern.
             //         _ = a is {Length:-1};         // 12
             Diagnostic(ErrorCode.ERR_IsPatternImpossible, "a is {Length:-1}").WithArguments("int[]").WithLocation(17, 13),
@@ -2728,24 +2710,12 @@ class X
             // 0.cs(23,13): error CS8518: An expression of type 'int[]' can never match the provided pattern.
             //         _ = a is [..{ Length: <= -1 }]; // 17
             Diagnostic(ErrorCode.ERR_IsPatternImpossible, "a is [..{ Length: <= -1 }]").WithArguments("int[]").WithLocation(23, 13),
-            // 0.cs(24,31): hidden CS9335: The pattern is redundant.
-            //         _ = a is [..{ Length: >= -1 }]; // 18
-            Diagnostic(ErrorCode.HDN_RedundantPattern, ">= -1").WithLocation(24, 31),
-            // 0.cs(25,31): hidden CS9335: The pattern is redundant.
-            //         _ = a is [..{ Length: > -1 }];  // 19
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "> -1").WithLocation(25, 31),
             // 0.cs(26,13): error CS8518: An expression of type 'int[]' can never match the provided pattern.
             //         _ = a is [_, _, ..{ Length: int.MaxValue - 1 }]; // 20
             Diagnostic(ErrorCode.ERR_IsPatternImpossible, "a is [_, _, ..{ Length: int.MaxValue - 1 }]").WithArguments("int[]").WithLocation(26, 13),
-            // 0.cs(27,37): hidden CS9335: The pattern is redundant.
-            //         _ = a is [_, _, ..{ Length: <= int.MaxValue - 1 }]; // 21
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "<= int.MaxValue - 1").WithLocation(27, 37),
             // 0.cs(28,13): error CS8518: An expression of type 'int[]' can never match the provided pattern.
             //         _ = a is [_, _, ..{ Length: >= int.MaxValue - 1 }]; // 22
             Diagnostic(ErrorCode.ERR_IsPatternImpossible, "a is [_, _, ..{ Length: >= int.MaxValue - 1 }]").WithArguments("int[]").WithLocation(28, 13),
-            // 0.cs(29,37): hidden CS9335: The pattern is redundant.
-            //         _ = a is [_, _, ..{ Length: < int.MaxValue - 1 }]; // 23
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "< int.MaxValue - 1").WithLocation(29, 37),
             // 0.cs(30,13): error CS8518: An expression of type 'int[]' can never match the provided pattern.
             //         _ = a is [_, _, ..{ Length: > int.MaxValue - 1 }]; // 24
             Diagnostic(ErrorCode.ERR_IsPatternImpossible, "a is [_, _, ..{ Length: > int.MaxValue - 1 }]").WithArguments("int[]").WithLocation(30, 13)
@@ -2968,18 +2938,6 @@ class X
             // 0.cs(7,25): error CS0029: Cannot implicitly convert type 'int[]' to 'int'
             //         const int bad = a;
             Diagnostic(ErrorCode.ERR_NoImplicitConv, "a").WithArguments("int[]", "int").WithLocation(7, 25),
-            // 0.cs(11,31): hidden CS9335: The pattern is redundant.
-            //         _ = a is [..{ Length: < bad }];
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "< bad").WithLocation(11, 31),
-            // 0.cs(12,31): hidden CS9335: The pattern is redundant.
-            //         _ = a is [..{ Length: <= bad }];
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "<= bad").WithLocation(12, 31),
-            // 0.cs(13,31): hidden CS9335: The pattern is redundant.
-            //         _ = a is [..{ Length: >= bad }];
-            Diagnostic(ErrorCode.HDN_RedundantPattern, ">= bad").WithLocation(13, 31),
-            // 0.cs(14,31): hidden CS9335: The pattern is redundant.
-            //         _ = a is [..{ Length: > bad }];
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "> bad").WithLocation(14, 31),
             // 0.cs(28,13): error CS8510: The pattern is unreachable. It has already been handled by a previous arm of the switch expression or it is impossible to match.
             //             [.. { Length: not < bad}]  => 2,
             Diagnostic(ErrorCode.ERR_SwitchArmSubsumed, "[.. { Length: not < bad}]").WithLocation(28, 13));
@@ -3739,10 +3697,7 @@ class X
     }
 }";
         var compilation = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range, TestSources.GetSubArray });
-        compilation.VerifyDiagnostics(
-            // 0.cs(8,26): hidden CS9335: The pattern is redundant.
-            //         _ = integers is [{}];
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "{}").WithLocation(8, 26));
+        compilation.VerifyDiagnostics();
 
         var tree = compilation.SyntaxTrees[0];
         var nodes = tree.GetRoot().DescendantNodes()
@@ -5099,39 +5054,21 @@ _ = o switch // didn't test for [null] // 15
 ";
         var compilation = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range, TestSources.GetSubArray });
         compilation.VerifyEmitDiagnostics(
-            // 0.cs(9,10): hidden CS9335: The pattern is redundant.
-            //     [not null] => 0, // 1
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(9, 10),
-            // 0.cs(10,15): hidden CS9335: The pattern is redundant.
-            //     { Length: 0 or > 1 } => 0, // 2
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "0 or > 1").WithLocation(10, 15),
             // 0.cs(13,7): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
             // _ = o switch // didn't test for null // 3
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(13, 7),
-            // 0.cs(16,10): hidden CS9335: The pattern is redundant.
-            //     [not null] => 0, // 4
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(16, 10),
-            // 0.cs(17,15): hidden CS9335: The pattern is redundant.
-            //     { Length: 0 or > 1 } => 0, // 5
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "0 or > 1").WithLocation(17, 15),
             // 0.cs(20,7): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '[null]' is not covered.
             // _ = o switch // didn't test for [null] // 6
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("[null]").WithLocation(20, 7),
             // 0.cs(27,7): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '[not null]' is not covered.
             // _ = o switch // didn't test for [not null] // 7
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("[not null]").WithLocation(27, 7),
-            // 0.cs(39,14): hidden CS9335: The pattern is redundant.
-            //     [.., not null] => 0, // 8
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(39, 14),
             // 0.cs(42,7): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '[null]' is not covered.
             // _ = o switch // didn't test for [null] // 9
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("[null]").WithLocation(42, 7),
             // 0.cs(49,7): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '[not null]' is not covered.
             // _ = o switch // didn't test for [not null] // 10
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("[not null]").WithLocation(49, 7),
-            // 0.cs(61,15): hidden CS9335: The pattern is redundant.
-            //     { Length: 0 or > 1 } => 0, // 11
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "0 or > 1").WithLocation(61, 15),
             // 0.cs(64,7): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '[_, null]' is not covered.
             // _ = o switch // didn't test for [_, null] // 12
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("[_, null]").WithLocation(64, 7),
@@ -5211,9 +5148,6 @@ class C
 ";
         var compilation = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range });
         compilation.VerifyEmitDiagnostics(
-            // 0.cs(17,21): hidden CS9335: The pattern is redundant.
-            //             [.. not null] => 0, // 1
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(17, 21),
             // 0.cs(20,18): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '[.. null, _]' is not covered.
             //         _ = this switch // no tests for [.. null, _]
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("[.. null, _]").WithLocation(20, 18),
@@ -5350,12 +5284,6 @@ class C
         // Note: we don't try to explain nested slice patterns right now so all these just produce a fallback example
         var compilation = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range });
         compilation.VerifyEmitDiagnostics(
-            // 0.cs(17,18): hidden CS9335: The pattern is redundant.
-            //             [not null] => 0, // 1
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(17, 18),
-            // 0.cs(24,18): hidden CS9335: The pattern is redundant.
-            //             [not null] => 0, // 2
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(24, 18),
             // 0.cs(27,18): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '_' is not covered.
             //         _ = this switch // didn't test for [.. [not null]] // 3
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("_").WithLocation(27, 18),
@@ -5368,9 +5296,6 @@ class C
             // 0.cs(46,18): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '_' is not covered.
             //         _ = this switch // didn't test for [_, .. null, _, _, _] // we're trying to construct an example with Length=4, the slice may not be null // 6
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("_").WithLocation(46, 18),
-            // 0.cs(55,20): hidden CS9335: The pattern is redundant.
-            //             [_, .. [_, _], _] => 0, // 7
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "[_, _]").WithLocation(55, 20),
             // 0.cs(58,18): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '_' is not covered.
             //         _ = this switch // didn't test for [_, .. [_, null], _] // 8
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("_").WithLocation(58, 18),
@@ -5379,10 +5304,7 @@ class C
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("_").WithLocation(64, 18),
             // 0.cs(70,18): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '_' is not covered.
             //         _ = this switch // didn't test for [_, .. [_, null, _], _] // 10
-            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("_").WithLocation(70, 18),
-            // 0.cs(79,27): hidden CS9335: The pattern is redundant.
-            //             [.. { Length: 1 }] => 0, // 11
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "1").WithLocation(79, 27)
+            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("_").WithLocation(70, 18)
             );
     }
 
@@ -5942,10 +5864,7 @@ class C
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("{ Count: 1 }").WithLocation(9, 13),
             // 0.cs(16,13): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '{ Count: 1 }' is not covered.
             // _ = new C() switch // 3
-            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("{ Count: 1 }").WithLocation(16, 13),
-            // 0.cs(29,14): hidden CS9335: The pattern is redundant.
-            //     { Count: > 2 } => 3, // 4
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "> 2").WithLocation(29, 14)
+            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("{ Count: 1 }").WithLocation(16, 13)
             );
 
         comp = CreateCompilation(src);
@@ -5988,10 +5907,7 @@ class C
             Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "[_, _]").WithArguments("System.Index").WithLocation(28, 5),
             // (28,5): error CS0656: Missing compiler required member 'System.Index.GetOffset'
             //     [_, _] => 2,
-            Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[_, _]").WithArguments("System.Index", "GetOffset").WithLocation(28, 5),
-            // (29,14): hidden CS9335: The pattern is redundant.
-            //     { Count: > 2 } => 3, // 4
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "> 2").WithLocation(29, 14)
+            Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "[_, _]").WithArguments("System.Index", "GetOffset").WithLocation(28, 5)
             );
     }
 
@@ -6032,10 +5948,7 @@ class C
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("{ Count: 0 }").WithLocation(2, 13),
             // 0.cs(8,13): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '[0]' is not covered.
             // _ = new C() switch // 2
-            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("[0]").WithLocation(8, 13),
-            // 0.cs(20,6): hidden CS9335: The pattern is redundant.
-            //     [0] => 4, // 3
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "0").WithLocation(20, 6)
+            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("[0]").WithLocation(8, 13)
             );
     }
 
@@ -6082,21 +5995,9 @@ class C
             // 0.cs(3,13): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '[null]' is not covered.
             // _ = new C() switch // 1
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("[null]").WithLocation(3, 13),
-            // 0.cs(14,6): hidden CS9335: The pattern is redundant.
-            //     [null] => 2, // 2
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(14, 6),
-            // 0.cs(15,14): hidden CS9335: The pattern is redundant.
-            //     { Count: 0 or > 1 } => 3, // 3
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "0 or > 1").WithLocation(15, 14),
             // 0.cs(18,13): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '[null]' is not covered.
             // _ = new C() switch // 6
-            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("[null]").WithLocation(18, 13),
-            // 0.cs(27,6): hidden CS9335: The pattern is redundant.
-            //     [null] => 2, // 5
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "null").WithLocation(27, 6),
-            // 0.cs(28,14): hidden CS9335: The pattern is redundant.
-            //     { Count: 0 or > 1 } => 3, // 6
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "0 or > 1").WithLocation(28, 14)
+            Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("[null]").WithLocation(18, 13)
             );
     }
 
@@ -6234,13 +6135,7 @@ class C
     public int this[int i] => throw null;
 }";
         var comp = CreateCompilation(new[] { src, TestSources.Index });
-        comp.VerifyEmitDiagnostics(
-            // 0.cs(5,6): hidden CS9335: The pattern is redundant.
-            //     [< 0] => 2,
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "< 0").WithLocation(5, 6),
-            // 0.cs(6,14): hidden CS9335: The pattern is redundant.
-            //     { Count: 0 or > 1 } => 3,
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "0 or > 1").WithLocation(6, 14));
+        comp.VerifyEmitDiagnostics();
     }
 
     [Fact]
@@ -6261,13 +6156,7 @@ class C
     public C Slice(int i, int j) => throw null;
 }";
         var comp = CreateCompilation(new[] { src, TestSources.Index, TestSources.Range });
-        comp.VerifyEmitDiagnostics(
-            // 0.cs(5,9): hidden CS9335: The pattern is redundant.
-            //     [..[< 0]] => 2,
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "< 0").WithLocation(5, 9),
-            // 0.cs(6,14): hidden CS9335: The pattern is redundant.
-            //     { Count: 0 or > 1 } => 3,
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "0 or > 1").WithLocation(6, 14));
+        comp.VerifyEmitDiagnostics();
     }
 
     [Fact]
@@ -7032,10 +6921,7 @@ class C
 2
 ";
         var comp = CreateCompilationWithIndexAndRange(src, parseOptions: TestOptions.RegularWithListPatterns, options: TestOptions.ReleaseExe);
-        CompileAndVerify(comp, expectedOutput: expectedOutput).VerifyDiagnostics(
-            // (11,20): hidden CS9335: The pattern is redundant.
-            //             case [[>=0]]:
-            Diagnostic(ErrorCode.HDN_RedundantPattern, ">=0").WithLocation(11, 20));
+        CompileAndVerify(comp, expectedOutput: expectedOutput).VerifyDiagnostics();
     }
 
     [Fact]
@@ -7252,12 +7138,6 @@ class Derived : Base, I2
                 // 0.cs(120,18): error CS8120: The switch case is unreachable. It has already been handled by a previous case or it is impossible to match.
                 //             case Derived and [Derived s]: // 13
                 Diagnostic(ErrorCode.ERR_SwitchCaseSubsumed, "Derived and [Derived s]").WithLocation(120, 18),
-                // 0.cs(126,27): hidden CS9335: The pattern is redundant.
-                //             case Base and I1 and [.., Base and I1]: // 14, 15
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "I1").WithLocation(126, 27),
-                // 0.cs(126,48): hidden CS9335: The pattern is redundant.
-                //             case Base and I1 and [.., Base and I1]: // 14, 15
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "I1").WithLocation(126, 48),
                 // 0.cs(136,18): error CS8120: The switch case is unreachable. It has already been handled by a previous case or it is impossible to match.
                 //             case Derived and [Derived s]: // 16
                 Diagnostic(ErrorCode.ERR_SwitchCaseSubsumed, "Derived and [Derived s]").WithLocation(136, 18),
@@ -7518,40 +7398,7 @@ class C
     }
 }";
         var comp = CreateCompilationWithIndexAndRangeAndSpan(src, parseOptions: TestOptions.RegularWithListPatterns);
-        comp.VerifyEmitDiagnostics(
-            // (10,27): hidden CS9335: The pattern is redundant.
-            //             [.., >=0] or [<0] or { Length: 0 or >1 } => 0
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "<0").WithLocation(10, 27),
-            // (10,44): hidden CS9335: The pattern is redundant.
-            //             [.., >=0] or [<0] or { Length: 0 or >1 } => 0
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "0 or >1").WithLocation(10, 44),
-            // (15,34): hidden CS9335: The pattern is redundant.
-            //             [.., >=0] or [..[.., <0]] or [] => 0
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "<0").WithLocation(15, 34),
-            // (20,27): hidden CS9335: The pattern is redundant.
-            //             [..[>=0]] or [<0] or
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "<0").WithLocation(20, 27),
-            // (21,23): hidden CS9335: The pattern is redundant.
-            //             { Length: 0 or >1 } => 0
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "0 or >1").WithLocation(21, 23),
-            // (31,70): hidden CS9335: The pattern is redundant.
-            //             [_, ..{ Length: < int.MaxValue - 1 }] or [] or { Length: int.MaxValue } => 0
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "int.MaxValue").WithLocation(31, 70),
-            // (36,26): hidden CS9335: The pattern is redundant.
-            //             [..{ Length: <= int.MaxValue - 1 }, _] or []  => 0
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "<= int.MaxValue - 1").WithLocation(36, 26),
-            // (41,29): hidden CS9335: The pattern is redundant.
-            //             [_, ..{ Length: <= int.MaxValue - 2 }, _] or { Length: 0 or 1 } => 0
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "<= int.MaxValue - 2").WithLocation(41, 29),
-            // (41,68): hidden CS9335: The pattern is redundant.
-            //             [_, ..{ Length: <= int.MaxValue - 2 }, _] or { Length: 0 or 1 } => 0
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "0 or 1").WithLocation(41, 68),
-            // (50,18): hidden CS9335: The pattern is redundant.
-            //             [{ X:0, Y:0 }] => 1,
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "0").WithLocation(50, 18),
-            // (50,23): hidden CS9335: The pattern is redundant.
-            //             [{ X:0, Y:0 }] => 1,
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "0").WithLocation(50, 23));
+        comp.VerifyEmitDiagnostics();
     }
 
     [Fact]
@@ -7581,10 +7428,7 @@ class C
     }
 }";
         var comp = CreateCompilationWithIndexAndRangeAndSpan(src, parseOptions: TestOptions.RegularWithListPatterns);
-        comp.VerifyEmitDiagnostics(
-            // (20,23): hidden CS9335: The pattern is redundant.
-            //             { Length: >=1 } => 3,
-            Diagnostic(ErrorCode.HDN_RedundantPattern, ">=1").WithLocation(20, 23));
+        comp.VerifyEmitDiagnostics();
 
         var verifier = CompileAndVerify(comp);
         string expectedIl = @"
@@ -7663,12 +7507,6 @@ _ = a switch // 8
             // 0.cs(3,5): error CS8518: An expression of type 'int[]' can never match the provided pattern.
             // _ = a is { Length: -1 }; // 1
             Diagnostic(ErrorCode.ERR_IsPatternImpossible, "a is { Length: -1 }").WithArguments("int[]").WithLocation(3, 5),
-            // 0.cs(4,20): hidden CS9335: The pattern is redundant.
-            // _ = a is { Length: -1 or 1 }; // 2
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "-1").WithLocation(4, 20),
-            // 0.cs(5,10): hidden CS9335: The pattern is redundant.
-            // _ = a is { Length: -1 } or { Length: 1 }; // 3
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "{ Length: -1 }").WithLocation(5, 10),
             // 0.cs(7,7): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '_' is not covered.
             // _ = a switch // 4
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("_").WithLocation(7, 7),
@@ -7705,9 +7543,6 @@ _ = a switch // 2
 ";
         var comp = CreateCompilation(new[] { src, TestSources.Index });
         comp.VerifyDiagnostics(
-            // 0.cs(3,18): hidden CS9335: The pattern is redundant.
-            // _ = a is null or { Length: -1 }; // 1
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "{ Length: -1 }").WithLocation(3, 18),
             // 0.cs(5,7): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'not null' is not covered.
             // _ = a switch // 2
             Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("not null").WithLocation(5, 7),
@@ -9739,10 +9574,7 @@ class C : System.Collections.ICollection
             """ + TestSources.GetSubArray;
 
         var compilation = CreateCompilationWithIndexAndRange(source, options: TestOptions.ReleaseExe);
-        compilation.VerifyDiagnostics(
-            // (5,69): hidden CS9335: The pattern is redundant.
-            //     static bool Test(int[] input) => input is [_, .. { Length: 1 or 2147483647 }];
-            Diagnostic(ErrorCode.HDN_RedundantPattern, "2147483647").WithLocation(5, 69));
+        compilation.VerifyDiagnostics();
 
         VerifyDecisionDagDump<IsPatternExpressionSyntax>(compilation,
 @"[0]: t0 != null ? [1] : [5]

--- a/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests_ListPatterns.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Semantics/PatternMatchingTests_ListPatterns.cs
@@ -2675,7 +2675,7 @@ class X
     } 
 }
 ";
-        var compilation = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range, TestSources.GetSubArray });
+        var compilation = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range, TestSources.GetSubArray }, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
         compilation.VerifyEmitDiagnostics(
             // 0.cs(7,13): error CS8518: An expression of type 'int[]' can never match the provided pattern.
             //         _ = a is [] and [1];          // 1
@@ -2963,7 +2963,7 @@ class X
     } 
 }
 ";
-        var compilation = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range, TestSources.GetSubArray });
+        var compilation = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range, TestSources.GetSubArray }, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
         compilation.VerifyEmitDiagnostics(
             // 0.cs(7,25): error CS0029: Cannot implicitly convert type 'int[]' to 'int'
             //         const int bad = a;
@@ -3738,7 +3738,7 @@ class X
         _ = integers is [..{}];
     }
 }";
-        var compilation = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range, TestSources.GetSubArray });
+        var compilation = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range, TestSources.GetSubArray }, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
         compilation.VerifyDiagnostics(
             // 0.cs(8,26): hidden CS9335: The pattern is redundant.
             //         _ = integers is [{}];
@@ -5097,7 +5097,7 @@ _ = o switch // didn't test for [null] // 15
     [..var x, not null] => 0,
 };
 ";
-        var compilation = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range, TestSources.GetSubArray });
+        var compilation = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range, TestSources.GetSubArray }, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
         compilation.VerifyEmitDiagnostics(
             // 0.cs(9,10): hidden CS9335: The pattern is redundant.
             //     [not null] => 0, // 1
@@ -5209,7 +5209,7 @@ class C
     }
 }
 ";
-        var compilation = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range });
+        var compilation = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range }, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
         compilation.VerifyEmitDiagnostics(
             // 0.cs(17,21): hidden CS9335: The pattern is redundant.
             //             [.. not null] => 0, // 1
@@ -5348,7 +5348,7 @@ class C
 }
 ";
         // Note: we don't try to explain nested slice patterns right now so all these just produce a fallback example
-        var compilation = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range });
+        var compilation = CreateCompilation(new[] { source, TestSources.Index, TestSources.Range }, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
         compilation.VerifyEmitDiagnostics(
             // 0.cs(17,18): hidden CS9335: The pattern is redundant.
             //             [not null] => 0, // 1
@@ -5932,7 +5932,7 @@ class C
     public int Count => throw null;
     public int this[int i] => throw null;
 }";
-        var comp = CreateCompilation(new[] { src, TestSources.Index });
+        var comp = CreateCompilation(new[] { src, TestSources.Index }, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
         comp.VerifyEmitDiagnostics(
             // 0.cs(2,13): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '{ Count: 2 }' is not covered.
             // _ = new C() switch // 1
@@ -5948,7 +5948,7 @@ class C
             Diagnostic(ErrorCode.HDN_RedundantPattern, "> 2").WithLocation(29, 14)
             );
 
-        comp = CreateCompilation(src);
+        comp = CreateCompilation(src, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
         comp.VerifyEmitDiagnostics(
             // (2,13): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '{ Count: 2 }' is not covered.
             // _ = new C() switch // 1
@@ -6025,7 +6025,7 @@ class C
     public int Count => throw null;
     public int this[int i] => throw null;
 }";
-        var comp = CreateCompilation(new[] { src, TestSources.Index });
+        var comp = CreateCompilation(new[] { src, TestSources.Index }, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
         comp.VerifyEmitDiagnostics(
             // 0.cs(2,13): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '{ Count: 0 }' is not covered.
             // _ = new C() switch // 1
@@ -6077,7 +6077,7 @@ class C
     public int Count => throw null!;
     public string? this[int i] => throw null!;
 }";
-        var comp = CreateCompilation(new[] { src, TestSources.Index });
+        var comp = CreateCompilation(new[] { src, TestSources.Index }, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
         comp.VerifyEmitDiagnostics(
             // 0.cs(3,13): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '[null]' is not covered.
             // _ = new C() switch // 1
@@ -6233,7 +6233,7 @@ class C
     public int Count => throw null;
     public int this[int i] => throw null;
 }";
-        var comp = CreateCompilation(new[] { src, TestSources.Index });
+        var comp = CreateCompilation(new[] { src, TestSources.Index }, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
         comp.VerifyEmitDiagnostics(
             // 0.cs(5,6): hidden CS9335: The pattern is redundant.
             //     [< 0] => 2,
@@ -6260,7 +6260,7 @@ class C
     public int this[int i] => throw null;
     public C Slice(int i, int j) => throw null;
 }";
-        var comp = CreateCompilation(new[] { src, TestSources.Index, TestSources.Range });
+        var comp = CreateCompilation(new[] { src, TestSources.Index, TestSources.Range }, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
         comp.VerifyEmitDiagnostics(
             // 0.cs(5,9): hidden CS9335: The pattern is redundant.
             //     [..[< 0]] => 2,
@@ -7031,7 +7031,7 @@ class C
 1
 2
 ";
-        var comp = CreateCompilationWithIndexAndRange(src, parseOptions: TestOptions.RegularWithListPatterns, options: TestOptions.ReleaseExe);
+        var comp = CreateCompilationWithIndexAndRange(src, parseOptions: TestOptions.RegularWithListPatterns, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
         CompileAndVerify(comp, expectedOutput: expectedOutput).VerifyDiagnostics(
             // (11,20): hidden CS9335: The pattern is redundant.
             //             case [[>=0]]:
@@ -7211,7 +7211,7 @@ class Derived : Base, I2
 {
 }
 ";
-        var compilation = CreateCompilation(new[] { source, TestSources.Index, _iTupleSource }, options: TestOptions.DebugExe);
+        var compilation = CreateCompilation(new[] { source, TestSources.Index, _iTupleSource }, options: TestOptions.DebugExeWithHiddenRedundantPatterns);
         compilation.VerifyDiagnostics(
                 // 0.cs(11,18): error CS8120: The switch case is unreachable. It has already been handled by a previous case or it is impossible to match.
                 //             case [Derived s]: // 1
@@ -7517,7 +7517,7 @@ class C
         };
     }
 }";
-        var comp = CreateCompilationWithIndexAndRangeAndSpan(src, parseOptions: TestOptions.RegularWithListPatterns);
+        var comp = CreateCompilationWithIndexAndRangeAndSpan(src, parseOptions: TestOptions.RegularWithListPatterns, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
         comp.VerifyEmitDiagnostics(
             // (10,27): hidden CS9335: The pattern is redundant.
             //             [.., >=0] or [<0] or { Length: 0 or >1 } => 0
@@ -7580,7 +7580,7 @@ class C
         };
     }
 }";
-        var comp = CreateCompilationWithIndexAndRangeAndSpan(src, parseOptions: TestOptions.RegularWithListPatterns);
+        var comp = CreateCompilationWithIndexAndRangeAndSpan(src, parseOptions: TestOptions.RegularWithListPatterns, options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
         comp.VerifyEmitDiagnostics(
             // (20,23): hidden CS9335: The pattern is redundant.
             //             { Length: >=1 } => 3,
@@ -7658,7 +7658,7 @@ _ = a switch // 8
     { Length: 1 } => 0,
 };
 ";
-        var comp = CreateCompilation(new[] { src, TestSources.Index });
+        var comp = CreateCompilation(new[] { src, TestSources.Index }, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
         comp.VerifyDiagnostics(
             // 0.cs(3,5): error CS8518: An expression of type 'int[]' can never match the provided pattern.
             // _ = a is { Length: -1 }; // 1
@@ -7703,7 +7703,7 @@ _ = a switch // 2
     { Length: -1 } => 0, // 3
 };
 ";
-        var comp = CreateCompilation(new[] { src, TestSources.Index });
+        var comp = CreateCompilation(new[] { src, TestSources.Index }, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
         comp.VerifyDiagnostics(
             // 0.cs(3,18): hidden CS9335: The pattern is redundant.
             // _ = a is null or { Length: -1 }; // 1
@@ -9738,7 +9738,7 @@ class C : System.Collections.ICollection
             }
             """ + TestSources.GetSubArray;
 
-        var compilation = CreateCompilationWithIndexAndRange(source, options: TestOptions.ReleaseExe);
+        var compilation = CreateCompilationWithIndexAndRange(source, options: TestOptions.ReleaseExeWithHiddenRedundantPatterns);
         compilation.VerifyDiagnostics(
             // (5,69): hidden CS9335: The pattern is redundant.
             //     static bool Test(int[] input) => input is [_, .. { Length: 1 or 2147483647 }];

--- a/src/Compilers/CSharp/Test/EndToEnd/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/EndToEnd/EndToEndTests.cs
@@ -1105,7 +1105,7 @@ or E._{i}
         public void ManyTupleSwitchArms_01()
         {
             const int fieldsPerEntity = 25;
-            const int tupleConstantArmCount = 10_000;
+            const int tupleConstantArmCount = 500;
             var sb = new StringBuilder();
             sb.AppendLine("public static class P");
             sb.AppendLine("{");
@@ -1126,7 +1126,7 @@ or E._{i}
             {
                 var comp = CreateCompilation(source, options: TestOptions.DebugDll.WithConcurrentBuild(false));
                 comp.VerifyDiagnostics();
-            });
+            }, timeout: TimeSpan.FromSeconds(10));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/EndToEnd/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/EndToEnd/EndToEndTests.cs
@@ -1033,13 +1033,13 @@ or E._{i}
         public void ManyTupleSwitchArms_01()
         {
             const int fieldsPerEntity = 25;
-            const int TupleConstantArmCount = 10_000;
+            const int tupleConstantArmCount = 10_000;
             var sb = new StringBuilder();
             sb.AppendLine("public static class P");
             sb.AppendLine("{");
             sb.AppendLine("    public static int Get(string entity, string field) => (entity, field) switch");
             sb.AppendLine("    {");
-            for (var i = 0; i < TupleConstantArmCount; i++)
+            for (var i = 0; i < tupleConstantArmCount; i++)
             {
                 var entityIndex = i / fieldsPerEntity;
                 sb.AppendLine($"        (\"Entity{entityIndex}\", \"Field{i}\") => {i},");

--- a/src/Compilers/CSharp/Test/EndToEnd/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/EndToEnd/EndToEndTests.cs
@@ -1064,7 +1064,7 @@ or E._{i}
             }, timeout: TimeSpan.FromSeconds(10));
         }
 
-        [Fact]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75506")]
         public void ManyBinaryPatterns_05_RedundantPatternCheckRespectsSpecificDiagnosticOption()
         {
             // Same as ManyBinaryPatterns_04, but disables the warning via WithSpecificDiagnosticOptions
@@ -1101,7 +1101,7 @@ or E._{i}
             }, timeout: TimeSpan.FromSeconds(10));
         }
 
-        [Fact]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75506")]
         public void ManyTupleSwitchArms_01()
         {
             const int fieldsPerEntity = 25;

--- a/src/Compilers/CSharp/Test/EndToEnd/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/EndToEnd/EndToEndTests.cs
@@ -1030,6 +1030,34 @@ or E._{i}
         }
 
         [Fact]
+        public void ManyTupleSwitchArms_01()
+        {
+            const int fieldsPerEntity = 25;
+            const int TupleConstantArmCount = 10_000;
+            var sb = new StringBuilder();
+            sb.AppendLine("public static class P");
+            sb.AppendLine("{");
+            sb.AppendLine("    public static int Get(string entity, string field) => (entity, field) switch");
+            sb.AppendLine("    {");
+            for (var i = 0; i < TupleConstantArmCount; i++)
+            {
+                var entityIndex = i / fieldsPerEntity;
+                sb.AppendLine($"        (\"Entity{entityIndex}\", \"Field{i}\") => {i},");
+            }
+
+            sb.AppendLine("        _ => -1");
+            sb.AppendLine("    };");
+            sb.AppendLine("}");
+
+            var source = sb.ToString();
+            RunInThread(() =>
+            {
+                var comp = CreateCompilation(source, options: TestOptions.DebugDll.WithConcurrentBuild(false));
+                comp.VerifyDiagnostics();
+            });
+        }
+
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/pull/83087")]
         public void ManyUnreferencedSuppressMessageAttributes()
         {

--- a/src/Compilers/CSharp/Test/EndToEnd/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/EndToEnd/EndToEndTests.cs
@@ -1029,6 +1029,78 @@ or E._{i}
             });
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/75506")]
+        public void ManyBinaryPatterns_04_RedundantPatternCheckRespectsPragmaSuppression()
+        {
+            // Ensure that redundant pattern analysis is not performed when the associated warning is disabled.
+            const int numArms = 300;
+
+            var builder = new StringBuilder();
+            builder.AppendLine("#pragma warning disable CS9336");
+            builder.AppendLine("class C");
+            builder.AppendLine("{");
+            builder.AppendLine("    static int M(int x) => x switch");
+            builder.AppendLine("    {");
+
+            for (int i = 0; i < numArms; i++)
+            {
+                int lo = i * 10;
+                int hi = lo + 9;
+                int redundant = lo + 1;
+                builder.AppendLine($"        >= {lo} and <= {hi} and not {lo} or {redundant} => {i},");
+            }
+
+            builder.AppendLine("        _ => -1");
+            builder.AppendLine("    };");
+            builder.AppendLine("}");
+            builder.AppendLine("#pragma warning restore CS9336");
+
+            var source = builder.ToString();
+
+            RunInThread(() =>
+            {
+                var comp = CreateCompilation(source, options: TestOptions.DebugDll.WithConcurrentBuild(false));
+                comp.GetDiagnostics().Verify();
+            }, timeout: TimeSpan.FromSeconds(10));
+        }
+
+        [Fact]
+        public void ManyBinaryPatterns_05_RedundantPatternCheckRespectsSpecificDiagnosticOption()
+        {
+            // Same as ManyBinaryPatterns_04, but disables the warning via WithSpecificDiagnosticOptions
+            // instead of #pragma, to exercise the non-pragma suppression path.
+            const int numArms = 300;
+
+            var builder = new StringBuilder();
+            builder.AppendLine("class C");
+            builder.AppendLine("{");
+            builder.AppendLine("    static int M(int x) => x switch");
+            builder.AppendLine("    {");
+
+            for (int i = 0; i < numArms; i++)
+            {
+                int lo = i * 10;
+                int hi = lo + 9;
+                int redundant = lo + 1;
+                builder.AppendLine($"        >= {lo} and <= {hi} and not {lo} or {redundant} => {i},");
+            }
+
+            builder.AppendLine("        _ => -1");
+            builder.AppendLine("    };");
+            builder.AppendLine("}");
+
+            var source = builder.ToString();
+
+            RunInThread(() =>
+            {
+                var comp = CreateCompilation(
+                    source,
+                    options: TestOptions.DebugDll.WithConcurrentBuild(false)
+                        .WithSpecificDiagnosticOptions("CS9336", ReportDiagnostic.Suppress));
+                comp.GetDiagnostics().Verify();
+            }, timeout: TimeSpan.FromSeconds(10));
+        }
+
         [Fact]
         public void ManyTupleSwitchArms_01()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesVsPatterns.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesVsPatterns.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesVsPatterns.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesVsPatterns.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1316,7 +1316,7 @@ class Program
     }
 }
 ";
-            var comp = CreateNullableCompilation(source);
+            var comp = CreateCompilation(new[] { source }, options: WithNullableEnable(TestOptions.ReleaseDllWithHiddenRedundantPatterns));
             comp.VerifyDiagnostics(
                 // 0.cs(10,20): hidden CS9271: The pattern is redundant.
                 //             (null, {}) => 2, // 1
@@ -2714,7 +2714,7 @@ public class C
             (_, (_, C)) => a.ToString() // 13
         };
 }
-");
+", options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
 
             comp.VerifyDiagnostics(
                 // (9,18): warning CS8602: Dereference of a possibly null reference.

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesVsPatterns.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesVsPatterns.cs
@@ -1316,20 +1316,8 @@ class Program
     }
 }
 ";
-            var comp = CreateCompilation(new[] { source }, options: WithNullableEnable(TestOptions.ReleaseDllWithHiddenRedundantPatterns));
+            var comp = CreateNullableCompilation(source);
             comp.VerifyDiagnostics(
-                // 0.cs(10,20): hidden CS9271: The pattern is redundant.
-                //             (null, {}) => 2, // 1
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{}").WithLocation(10, 20),
-                // 0.cs(11,14): hidden CS9271: The pattern is redundant.
-                //             ({}, null) => 3, // 2
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{}").WithLocation(11, 14),
-                // 0.cs(12,14): hidden CS9271: The pattern is redundant.
-                //             ({}, {}) => 4, // 3, 4
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{}").WithLocation(12, 14),
-                // 0.cs(12,18): hidden CS9271: The pattern is redundant.
-                //             ({}, {}) => 4, // 3, 4
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "{}").WithLocation(12, 18),
                 // 0.cs(18,15): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '(null, _)' is not covered.
                 //         _ = t switch // 1 not exhaustive
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("(null, _)").WithLocation(18, 15),
@@ -2714,7 +2702,7 @@ public class C
             (_, (_, C)) => a.ToString() // 13
         };
 }
-", options: TestOptions.ReleaseDllWithHiddenRedundantPatterns);
+");
 
             comp.VerifyDiagnostics(
                 // (9,18): warning CS8602: Dereference of a possibly null reference.
@@ -2729,9 +2717,6 @@ public class C
                 // (29,23): warning CS8602: Dereference of a possibly null reference.
                 //             (_, C) => a.ToString() // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a").WithLocation(29, 23),
-                // (36,17): hidden CS9271: The pattern is redundant.
-                //             (_, C) => a.ToString() // 5, 6
-                Diagnostic(ErrorCode.HDN_RedundantPattern, "C").WithLocation(36, 17),
                 // (36,23): warning CS8602: Dereference of a possibly null reference.
                 //             (_, C) => a.ToString() // 5, 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a").WithLocation(36, 23),

--- a/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
@@ -78,6 +78,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
         public static readonly CSharpCompilationOptions DebugDll = CreateTestOptions(OutputKind.DynamicallyLinkedLibrary, OptimizationLevel.Debug);
         public static readonly CSharpCompilationOptions DebugExe = CreateTestOptions(OutputKind.ConsoleApplication, OptimizationLevel.Debug);
 
+        public static readonly CSharpCompilationOptions DebugExeWithHiddenRedundantPatterns = DebugExe.WithSpecificDiagnosticOptions(MessageProvider.Instance.GetIdForErrorCode((int)ErrorCode.HDN_RedundantPattern), ReportDiagnostic.Hidden);
+
         public static readonly CSharpCompilationOptions DebugDllThrowing = DebugDll.WithMetadataReferenceResolver(new ThrowingMetadataReferenceResolver());
         public static readonly CSharpCompilationOptions DebugExeThrowing = DebugExe.WithMetadataReferenceResolver(new ThrowingMetadataReferenceResolver());
 

--- a/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
@@ -68,9 +68,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
         public static readonly CSharpCompilationOptions ReleaseDll = CreateTestOptions(OutputKind.DynamicallyLinkedLibrary, OptimizationLevel.Release);
         public static readonly CSharpCompilationOptions ReleaseExe = CreateTestOptions(OutputKind.ConsoleApplication, OptimizationLevel.Release);
 
-        public static readonly CSharpCompilationOptions ReleaseDllWithHiddenRedundantPatterns = ReleaseDll.WithSpecificDiagnosticOptions(MessageProvider.Instance.GetIdForErrorCode((int)ErrorCode.HDN_RedundantPattern), ReportDiagnostic.Hidden);
-        public static readonly CSharpCompilationOptions ReleaseExeWithHiddenRedundantPatterns = ReleaseExe.WithSpecificDiagnosticOptions(MessageProvider.Instance.GetIdForErrorCode((int)ErrorCode.HDN_RedundantPattern), ReportDiagnostic.Hidden);
-
         public static readonly CSharpCompilationOptions ReleaseDebugDll = ReleaseDll.WithDebugPlusMode(true);
 
         public static readonly CSharpCompilationOptions ReleaseDebugExe = ReleaseExe.WithDebugPlusMode(true);

--- a/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
@@ -68,6 +68,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
         public static readonly CSharpCompilationOptions ReleaseDll = CreateTestOptions(OutputKind.DynamicallyLinkedLibrary, OptimizationLevel.Release);
         public static readonly CSharpCompilationOptions ReleaseExe = CreateTestOptions(OutputKind.ConsoleApplication, OptimizationLevel.Release);
 
+        public static readonly CSharpCompilationOptions ReleaseDllWithHiddenRedundantPatterns = ReleaseDll.WithSpecificDiagnosticOptions(MessageProvider.Instance.GetIdForErrorCode((int)ErrorCode.HDN_RedundantPattern), ReportDiagnostic.Hidden);
+        public static readonly CSharpCompilationOptions ReleaseExeWithHiddenRedundantPatterns = ReleaseExe.WithSpecificDiagnosticOptions(MessageProvider.Instance.GetIdForErrorCode((int)ErrorCode.HDN_RedundantPattern), ReportDiagnostic.Hidden);
+
         public static readonly CSharpCompilationOptions ReleaseDebugDll = ReleaseDll.WithDebugPlusMode(true);
 
         public static readonly CSharpCompilationOptions ReleaseDebugExe = ReleaseExe.WithDebugPlusMode(true);

--- a/src/Tools/Benchmarks/DecisionDagBenchmarks.IsBuildOnlyDiagnosticSource.cs
+++ b/src/Tools/Benchmarks/DecisionDagBenchmarks.IsBuildOnlyDiagnosticSource.cs
@@ -2450,7 +2450,7 @@ public partial class DecisionDagBenchmarks
                 ERR_ExplicitInterfaceMemberTypeMismatch = 9333,
                 ERR_ExplicitInterfaceMemberReturnTypeMismatch = 9334,
 
-                HDN_RedundantPattern = 9335,
+                // HDN_RedundantPattern = 9335,  // no longer reported
                 WRN_RedundantPattern = 9336,
                 HDN_RedundantPatternStackGuard = 9337,
 
@@ -4509,7 +4509,6 @@ public partial class DecisionDagBenchmarks
                         or ErrorCode.ERR_BadSpreadInCatchFilter
                         or ErrorCode.ERR_ExplicitInterfaceMemberTypeMismatch
                         or ErrorCode.ERR_ExplicitInterfaceMemberReturnTypeMismatch
-                        or ErrorCode.HDN_RedundantPattern
                         or ErrorCode.WRN_RedundantPattern
                         or ErrorCode.HDN_RedundantPatternStackGuard
                         or ErrorCode.ERR_BadVisBaseType

--- a/src/Tools/Benchmarks/DecisionDagBenchmarks.IsBuildOnlyDiagnosticSource.cs
+++ b/src/Tools/Benchmarks/DecisionDagBenchmarks.IsBuildOnlyDiagnosticSource.cs
@@ -2450,7 +2450,7 @@ public partial class DecisionDagBenchmarks
                 ERR_ExplicitInterfaceMemberTypeMismatch = 9333,
                 ERR_ExplicitInterfaceMemberReturnTypeMismatch = 9334,
 
-                // HDN_RedundantPattern = 9335,  // no longer reported
+                HDN_RedundantPattern = 9335,
                 WRN_RedundantPattern = 9336,
                 HDN_RedundantPatternStackGuard = 9337,
 
@@ -4509,6 +4509,7 @@ public partial class DecisionDagBenchmarks
                         or ErrorCode.ERR_BadSpreadInCatchFilter
                         or ErrorCode.ERR_ExplicitInterfaceMemberTypeMismatch
                         or ErrorCode.ERR_ExplicitInterfaceMemberReturnTypeMismatch
+                        or ErrorCode.HDN_RedundantPattern
                         or ErrorCode.WRN_RedundantPattern
                         or ErrorCode.HDN_RedundantPatternStackGuard
                         or ErrorCode.ERR_BadVisBaseType

--- a/src/Tools/Benchmarks/RedundantPatternsBenchmarks.cs
+++ b/src/Tools/Benchmarks/RedundantPatternsBenchmarks.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Tools/Benchmarks/RedundantPatternsBenchmarks.cs
+++ b/src/Tools/Benchmarks/RedundantPatternsBenchmarks.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Benchmarks;
+
+/// <seealso href="https://github.com/dotnet/roslyn/issues/84529"/>
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+public class RedundantPatternsBenchmarks
+{
+    [Params(500)]
+    public int TupleConstantArmCount { get; set; }
+
+    private string? _tupleConstantSwitchSource;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _tupleConstantSwitchSource = GenerateTupleConstantSwitchSource();
+    }
+
+    [Benchmark]
+    public object EmitWithTupleConstantSwitch() => DecisionDagBenchmarks.EmitCore(_tupleConstantSwitchSource!);
+
+    private string GenerateTupleConstantSwitchSource()
+    {
+        const int fieldsPerEntity = 25;
+        var sb = new StringBuilder();
+        sb.AppendLine("public static class P");
+        sb.AppendLine("{");
+        sb.AppendLine("    public static int Get(string entity, string field) => (entity, field) switch");
+        sb.AppendLine("    {");
+        for (var i = 0; i < TupleConstantArmCount; i++)
+        {
+            var entityIndex = i / fieldsPerEntity;
+            sb.AppendLine($"        (\"Entity{entityIndex}\", \"Field{i}\") => {i},");
+        }
+
+        sb.AppendLine("        _ => -1");
+        sb.AppendLine("    };");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+}

--- a/src/Tools/Benchmarks/RedundantPatternsBenchmarks.cs
+++ b/src/Tools/Benchmarks/RedundantPatternsBenchmarks.cs
@@ -2,19 +2,32 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.IO;
 using System.Text;
+using Basic.Reference.Assemblies;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Diagnosers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Benchmarks;
 
 /// <seealso href="https://github.com/dotnet/roslyn/issues/84529"/>
 [MemoryDiagnoser]
 [EventPipeProfiler(EventPipeProfile.GcVerbose)]
+[WarmupCount(1)]
+[IterationCount(1)]
+[InvocationCount(1)]
 public class RedundantPatternsBenchmarks
 {
-    [Params(500)]
+    [Params(100, 500, 1000)]
     public int TupleConstantArmCount { get; set; }
+
+    [Params(true, false)]
+    public bool EnableHiddenRedundantPatterns { get; set; }
 
     private string? _tupleConstantSwitchSource;
 
@@ -25,7 +38,37 @@ public class RedundantPatternsBenchmarks
     }
 
     [Benchmark]
-    public object EmitWithTupleConstantSwitch() => DecisionDagBenchmarks.EmitCore(_tupleConstantSwitchSource!);
+    public object EmitWithTupleConstantSwitch() => EmitCore(_tupleConstantSwitchSource!);
+
+    public object EmitCore(string sourceCode)
+    {
+        var sourceText = SourceText.From(sourceCode);
+        var syntaxTree = CSharpSyntaxTree.ParseText(sourceText);
+        var compilation = CSharpCompilation.Create(
+            "BenchmarkAssembly",
+            [syntaxTree],
+            Net90.References.All,
+            new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                specificDiagnosticOptions: EnableHiddenRedundantPatterns ? [new("CS9335", ReportDiagnostic.Hidden)] : []));
+
+        var assemblyStream = new MemoryStream();
+        var emitResult = compilation.Emit(
+            assemblyStream,
+            pdbStream: null,
+            xmlDocumentationStream: null,
+            win32Resources: null,
+            manifestResources: [],
+            options: new EmitOptions().WithDebugInformationFormat(DebugInformationFormat.Embedded),
+            cancellationToken: default);
+        if (!emitResult.Success)
+        {
+            throw new Exception("Compilation failed: " + string.Join(Environment.NewLine, emitResult.Diagnostics));
+        }
+
+        assemblyStream.Position = 0;
+        return assemblyStream;
+    }
 
     private string GenerateTupleConstantSwitchSource()
     {

--- a/src/Tools/Benchmarks/RedundantPatternsBenchmarks.cs
+++ b/src/Tools/Benchmarks/RedundantPatternsBenchmarks.cs
@@ -26,9 +26,6 @@ public class RedundantPatternsBenchmarks
     [Params(100, 500, 1000)]
     public int TupleConstantArmCount { get; set; }
 
-    [Params(true, false)]
-    public bool EnableHiddenRedundantPatterns { get; set; }
-
     private string? _tupleConstantSwitchSource;
 
     [GlobalSetup]
@@ -49,8 +46,7 @@ public class RedundantPatternsBenchmarks
             [syntaxTree],
             Net90.References.All,
             new CSharpCompilationOptions(
-                OutputKind.DynamicallyLinkedLibrary,
-                specificDiagnosticOptions: EnableHiddenRedundantPatterns ? [new("CS9335", ReportDiagnostic.Hidden)] : []));
+                OutputKind.DynamicallyLinkedLibrary));
 
         var assemblyStream = new MemoryStream();
         var emitResult = compilation.Emit(

--- a/src/Tools/Benchmarks/RedundantPatternsBenchmarks.cs
+++ b/src/Tools/Benchmarks/RedundantPatternsBenchmarks.cs
@@ -37,7 +37,7 @@ public class RedundantPatternsBenchmarks
     [Benchmark]
     public object EmitWithTupleConstantSwitch() => EmitCore(_tupleConstantSwitchSource!);
 
-    public object EmitCore(string sourceCode)
+    internal static object EmitCore(string sourceCode)
     {
         var sourceText = SourceText.From(sourceCode);
         var syntaxTree = CSharpSyntaxTree.ParseText(sourceText);
@@ -83,6 +83,70 @@ public class RedundantPatternsBenchmarks
         sb.AppendLine("        _ => -1");
         sb.AppendLine("    };");
         sb.AppendLine("}");
+        return sb.ToString();
+    }
+}
+
+/// <summary>
+/// Compares the cost of the redundant-pattern reachability analysis (used to detect
+/// <see cref="Microsoft.CodeAnalysis.CSharp.ErrorCode.WRN_RedundantPattern"/>) when the warning is enabled
+/// versus when it is suppressed at the location of every candidate pattern via '#pragma warning disable'.
+/// Each switch arm below has the syntactic shape 'not A or B', which makes it a candidate for the analysis;
+/// disjoint numeric ranges are used per arm so that no arm makes another arm unreachable.
+/// </summary>
+/// <seealso href="https://github.com/dotnet/roslyn/issues/75506"/>
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+[WarmupCount(1)]
+[IterationCount(1)]
+[InvocationCount(1)]
+public class RedundantPatternsPragmaSuppressionBenchmarks
+{
+    [Params(25, 50, 100)]
+    public int RedundantPatternArmCount { get; set; }
+
+    [Params(false, true)]
+    public bool PragmaDisabled { get; set; }
+
+    private string? _redundantPatternSwitchSource;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _redundantPatternSwitchSource = GenerateRedundantPatternSwitchSource();
+    }
+
+    [Benchmark]
+    public object EmitWithRedundantPatternSwitch() => RedundantPatternsBenchmarks.EmitCore(_redundantPatternSwitchSource!);
+
+    private string GenerateRedundantPatternSwitchSource()
+    {
+        var sb = new StringBuilder();
+        if (PragmaDisabled)
+        {
+            sb.AppendLine("#pragma warning disable CS9336");
+        }
+
+        sb.AppendLine("public static class R");
+        sb.AppendLine("{");
+        sb.AppendLine("    public static int Get(int x) => x switch");
+        sb.AppendLine("    {");
+        for (var i = 0; i < RedundantPatternArmCount; i++)
+        {
+            var lo = i * 10;
+            var hi = lo + 9;
+            var redundant = lo + 1;
+            sb.AppendLine($"        >= {lo} and <= {hi} and not {lo} or {redundant} => {i},");
+        }
+
+        sb.AppendLine("        _ => -1");
+        sb.AppendLine("    };");
+        sb.AppendLine("}");
+        if (PragmaDisabled)
+        {
+            sb.AppendLine("#pragma warning restore CS9336");
+        }
+
         return sb.ToString();
     }
 }


### PR DESCRIPTION
Closes #84529.

Recommend turning whitespace off for review.

This ensures that redundant pattern diagnostics are only reported as warnings, and only when the hazardous syntactic form is involved, e.g. `not A or B`. This lets us avoid doing the work in other cases, and, since some other cases can be relatively complex (large numbers of switch arms, large patterns, etc.), it can help us avoid the non-linear algorithmic complexity of the redundancy check.

Users who observe perf degradations as a result of analyzing complex patterns using `not A or B` or similar syntactic form, can disable the redundant pattern analysis, by disabling the associated warning. For example, by putting `#pragma warning disable CS9336` in source code.

Benchmark results (outdated, but, `EnableHiddenRedundantPatterns` can effectively be treated as "true" being "before" the change and "false" being "after"):
```
| Method                      | TupleConstantArmCount | EnableHiddenRedundantPatterns | Mean         | Error | Gen0        | Gen1        | Gen2       | Allocated  |
|---------------------------- |---------------------- |------------------------------ |-------------:|------:|------------:|------------:|-----------:|-----------:|
| EmitWithTupleConstantSwitch | 100                   | False                         |     25.63 ms |    NA |           - |           - |          - |    4.28 MB |
| EmitWithTupleConstantSwitch | 100                   | True                          |    140.34 ms |    NA |   2000.0000 |           - |          - |   20.73 MB |
| EmitWithTupleConstantSwitch | 500                   | False                         |    127.92 ms |    NA |   1000.0000 |           - |          - |   11.57 MB |
| EmitWithTupleConstantSwitch | 500                   | True                          |  3,038.38 ms |    NA |  94000.0000 |  18000.0000 |  2000.0000 |  740.31 MB |
| EmitWithTupleConstantSwitch | 1000                  | False                         |    302.09 ms |    NA |   2000.0000 |           - |          - |   22.37 MB |
| EmitWithTupleConstantSwitch | 1000                  | True                          | 16,627.40 ms |    NA | 484000.0000 | 144000.0000 | 28000.0000 | 3639.46 MB |
```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84576)