### PR TITLE
Provide ProcDump to Helix Windows Desktop test work items

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -726,7 +726,9 @@ function Ensure-ProcDump() {
     Unzip $zipFilePath $outDir
   }
 
-  return $filePath
+  # Always return the containing directory (not the exe itself) so callers can use this
+  # uniformly, e.g. as a Helix correlation payload or a PROCDUMP_PATH value.
+  return $outDir
 }
 
 # Setup the CI machine for running our integration tests.

--- a/src/Tools/RunTests/HelixTestRunner.cs
+++ b/src/Tools/RunTests/HelixTestRunner.cs
@@ -332,7 +332,8 @@ internal sealed partial class HelixTestRunner
             options.HelixQueueName,
             options.ArtifactsDirectory,
             payloadsDir,
-            timeout);
+            timeout,
+            options.ProcDumpFilePath);
 
         var helixFilePath = Path.Combine(options.ArtifactsDirectory, "helix.proj");
         File.WriteAllText(helixFilePath, helixProjectFileContent);
@@ -412,6 +413,15 @@ internal sealed partial class HelixTestRunner
     }
 
     /// <summary>
+    /// The name of the Helix correlation payload directory that ProcDump is placed into (relative to
+    /// %HELIX_CORRELATION_PAYLOAD%), when <see cref="Options.ProcDumpFilePath"/> is set. Used so that
+    /// VSTest's Blame data collector (which can otherwise fail to find procdump.exe on Windows and
+    /// silently skip crash dump collection) can be pointed at it via the PROCDUMP_PATH environment
+    /// variable. See https://github.com/microsoft/vstest/blob/main/docs/extensions/blame-datacollector.md.
+    /// </summary>
+    private const string ProcDumpCorrelationPayloadDestination = "ProcDump";
+
+    /// <summary>
     /// Build up the contents of the helix project file. All paths should be relative to <paramref name="artifactsDir"/>.
     /// </summary>
     private static string GetHelixProjectFileContent(
@@ -422,7 +432,8 @@ internal sealed partial class HelixTestRunner
         string helixQueueName,
         string artifactsDir,
         string payloadsDir,
-        TimeSpan timeout)
+        TimeSpan timeout,
+        string? procDumpDirectory)
     {
         // Setup the environment variables that are required for the helix project.
         //
@@ -465,9 +476,22 @@ internal sealed partial class HelixTestRunner
                 <HelixCorrelationPayload Include="{duplicateDir}" />
             """);
 
+        // VSTest's Blame data collector (used to capture dumps of crashed/hung test hosts) needs procdump on
+        // Windows. It isn't guaranteed to be present on every Helix queue image, so ship it as a correlation
+        // payload and point VSTest at it via PROCDUMP_PATH (set in the generated command file below).
+        var includeProcDump = testOS == TestOS.Windows && !string.IsNullOrEmpty(procDumpDirectory) && Directory.Exists(procDumpDirectory);
+        if (includeProcDump)
+        {
+            builder.AppendLine($"""
+                    <HelixCorrelationPayload Include="{procDumpDirectory}">
+                      <Destination>{ProcDumpCorrelationPayloadDestination}</Destination>
+                    </HelixCorrelationPayload>
+                """);
+        }
+
         foreach (var helixWorkItem in helixWorkItems)
         {
-            AppendHelixWorkItemProject(builder, helixWorkItem, platform, artifactsDir, payloadsDir, testOS, timeout);
+            AppendHelixWorkItemProject(builder, helixWorkItem, platform, artifactsDir, payloadsDir, testOS, timeout, includeProcDump);
         }
 
         builder.AppendLine("""
@@ -494,7 +518,8 @@ internal sealed partial class HelixTestRunner
             string artifactsDir,
             string payloadsDir,
             TestOS testOS,
-            TimeSpan timeout)
+            TimeSpan timeout,
+            bool includeProcDump)
         {
             var isUnix = testOS != TestOS.Windows;
 
@@ -530,7 +555,7 @@ internal sealed partial class HelixTestRunner
                 path: Path.Combine(workItemPayloadDir, "global.json"),
                 pathToTarget: Path.Combine(artifactsDir, "..", "global.json"));
 
-            var (commandFileName, commandContent) = GetHelixCommandContent(assemblyRelativeFilePaths, rspFileName, testOS);
+            var (commandFileName, commandContent) = GetHelixCommandContent(assemblyRelativeFilePaths, rspFileName, testOS, includeProcDump);
             File.WriteAllText(Path.Combine(workItemPayloadDir, commandFileName), commandContent);
 
             var (postCommandFileName, postCommandContent) = GetHelixPostCommandContent(testOS);
@@ -551,7 +576,8 @@ internal sealed partial class HelixTestRunner
         static (string FileName, string Content) GetHelixCommandContent(
             IEnumerable<string> assemblyRelativeFilePaths,
             string vstestRspFileName,
-            TestOS testOS)
+            TestOS testOS,
+            bool includeProcDump)
         {
             var isUnix = testOS != TestOS.Windows;
             var isMac = testOS == TestOS.Mac;
@@ -595,6 +621,17 @@ internal sealed partial class HelixTestRunner
                 ? @"$HELIX_DUMP_FOLDER/crash.%d.%e.dmp"
                 : @"%HELIX_DUMP_FOLDER%\crash.%d.%e.dmp";
             command.AppendLine($"{setEnvironmentVariable} DOTNET_DbgMiniDumpName=\"{helixDumpFolder}\"");
+
+            // VSTest's Blame data collector (/Blame:CollectDump, set below) needs procdump.exe to be on PATH or
+            // pointed to via PROCDUMP_PATH in order to actually capture a dump when the test host crashes; some
+            // Helix queue images don't have it preinstalled. When available we ship it as a correlation payload
+            // (see GetHelixProjectFileContent) and point VSTest at it here.
+            // https://github.com/microsoft/vstest/blob/main/docs/extensions/blame-datacollector.md
+            if (includeProcDump)
+            {
+                Contract.ThrowIfTrue(isUnix);
+                command.AppendLine($@"set PROCDUMP_PATH=%HELIX_CORRELATION_PAYLOAD%\{ProcDumpCorrelationPayloadDestination}");
+            }
 
             command.AppendLine(isUnix ? "env | sort" : "set");
 

--- a/src/Tools/RunTests/Options.cs
+++ b/src/Tools/RunTests/Options.cs
@@ -66,7 +66,7 @@ namespace RunTests
         public bool CollectDumps { get; set; }
 
         /// <summary>
-        /// The path to procdump.exe
+        /// The path to the directory containing the procdump binaries (procdump.exe / procdump64.exe / procdump64a.exe).
         /// </summary>
         public string? ProcDumpFilePath { get; set; }
 


### PR DESCRIPTION
## Problem

`Test_Windows_Desktop_Release_32` (and other Windows Desktop test legs) have had recurring, hard-to-diagnose `Test host process crashed` failures on Helix (e.g. dotnet/roslyn#84579, and previously closed dotnet/roslyn#82135 / #83640). Every time, the console log shows:

```
The active test run was aborted. Reason: Test host process crashed
Data collector 'Blame' message: procdump.exe could not be found, please make sure that the executable is available on PATH. Alternatively set PROCDUMP_PATH environment variable to a directory that contains procdump.exe executable.
```

VSTest's Blame data collector (`/Blame:CollectDump`, which we already pass for Helix work items) needs `procdump.exe`/`procdump64.exe` to be discoverable via `PATH` or `PROCDUMP_PATH` in order to actually capture a memory dump when the test host crashes. Some Helix Windows queue images (e.g. `windows.amd64.vs2026.pre.scout.open`) don't have it preinstalled, so we get zero diagnostic data for these crashes.

Separately, `RunTests.dll` was already being handed a `--procdumppath` (via `eng/build.ps1`'s `Ensure-ProcDump`, downloaded whenever `-collectDumps` is passed), but that value was only ever parsed into `Options.ProcDumpFilePath` and printed to the console — it was never actually wired up to anything for Helix runs.

## Fix

- `src/Tools/RunTests/HelixTestRunner.cs`: ship the local ProcDump directory to Helix as a `<HelixCorrelationPayload>` (destination `ProcDump`) for Windows work items, and set `PROCDUMP_PATH=%HELIX_CORRELATION_PAYLOAD%\ProcDump` in the generated work item command file before invoking `vstest.console`.
- `eng/build.ps1`: fix `Ensure-ProcDump` to consistently return the **directory** containing the ProcDump binaries (it previously returned the `procdump.exe` file path in the download-and-cache branch, but the containing directory in the `C:\SysInternals` branch) — this directory is now actually consumed downstream.
- `src/Tools/RunTests/Options.cs`: corrected the `ProcDumpFilePath` doc comment to reflect it's a directory.

## Testing

Validated `dotnet build src/Tools/RunTests/RunTests.csproj` builds clean (0 warnings/errors). This only affects Helix work item generation for Windows test legs (gated so it's a no-op if the ProcDump directory isn't present); I have not been able to trigger and observe an actual crash-with-dump-capture on Helix since the failure is intermittent, so please keep an eye on `Test_Windows_Desktop_*` legs after this merges to confirm dumps are now attached when `Test host process crashed` recurs.

Related: dotnet/roslyn#84579 (Known Build Error tracking issue for the crash itself).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84584)