### PR TITLE
Remove feedUrl from NuGetAuthenticate task

### DIFF
--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -228,7 +228,6 @@ extends:
         - task: NuGetAuthenticate@1
           inputs:
             azureDevOpsServiceConnection: dnceng-devdiv-dotnet-core-internal-tooling-feed-rw-wif
-            feedUrl: https://pkgs.dev.azure.com/devdiv/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json
 
         # Needed because the build fails the NuGet Tools restore without it
         - task: UseDotNet@2


### PR DESCRIPTION
Removed feedUrl from NuGetAuthenticate task in pipeline.

Failed with
```
##[error]Error: FeedUrl must belong to an external organization. To authenticate to a feed in your organization with a 'Azure DevOps' service connection type, remove the `feedUrl` input.
```
https://dev.azure.com/devdiv/DevDiv/DevDiv%20Team/_build/results?buildId=14737790&view=logs&j=d8f66498-7756-5707-3b43-f2312930a35f&t=3b5f73c7-9c21-5b51-1012-48550287b1d8&l=26

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84592)