### PR TITLE
Compiler: Guard EditorConfig section matching recursion

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
@@ -591,6 +591,16 @@ RoOt = TruE");
         }
 
         [Fact]
+        public void ExcessivelyNestedChoiceIsInvalid()
+        {
+            var sectionName = new string('{', 100_000);
+            var config = ParseConfigFile($"[{sectionName}]\nmy_prop = my_val");
+            var configSet = AnalyzerConfigSet.Create(ImmutableArray.Create(config));
+
+            Assert.Empty(configSet.GetOptionsForSourcePath("/test.cs").AnalyzerOptions);
+        }
+
+        [Fact]
         public void CommaOutsideBraces()
         {
             SectionNameMatcher? matcher = TryCreateSectionNameMatcher("abc,def");

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.SectionNameMatching.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.SectionNameMatching.cs
@@ -107,7 +107,15 @@ namespace Microsoft.CodeAnalysis
 
             var lexer = new SectionNameLexer(sectionName);
             var numberRangePairs = ArrayBuilder<(int minValue, int maxValue)>.GetInstance();
-            if (!TryCompilePathList(ref lexer, sb, parsingChoice: false, numberRangePairs))
+            try
+            {
+                if (!TryCompilePathList(ref lexer, sb, parsingChoice: false, numberRangePairs, recursionDepth: 0))
+                {
+                    numberRangePairs.Free();
+                    return null;
+                }
+            }
+            catch (InsufficientExecutionStackException)
             {
                 numberRangePairs.Free();
                 return null;
@@ -231,8 +239,11 @@ namespace Microsoft.CodeAnalysis
             ref SectionNameLexer lexer,
             StringBuilder sb,
             bool parsingChoice,
-            ArrayBuilder<(int minValue, int maxValue)> numberRangePairs)
+            ArrayBuilder<(int minValue, int maxValue)> numberRangePairs,
+            int recursionDepth)
         {
+            StackGuard.EnsureSufficientExecutionStack(recursionDepth);
+
             while (!lexer.IsDone)
             {
                 var tokenKind = lexer.Lex();
@@ -268,7 +279,7 @@ namespace Microsoft.CodeAnalysis
                         if (rangeOpt is null)
                         {
                             // Not a number range. Try a choice expression
-                            if (!TryCompileChoice(ref lexer, sb, numberRangePairs))
+                            if (!TryCompileChoice(ref lexer, sb, numberRangePairs, recursionDepth + 1))
                             {
                                 return false;
                             }
@@ -371,8 +382,11 @@ namespace Microsoft.CodeAnalysis
         private static bool TryCompileChoice(
             ref SectionNameLexer lexer,
             StringBuilder sb,
-            ArrayBuilder<(int, int)> numberRangePairs)
+            ArrayBuilder<(int, int)> numberRangePairs,
+            int recursionDepth)
         {
+            StackGuard.EnsureSufficientExecutionStack(recursionDepth);
+
             if (lexer.Lex() != TokenKind.OpenCurly)
             {
                 return false;
@@ -383,7 +397,7 @@ namespace Microsoft.CodeAnalysis
 
             // We start immediately after a '{'
             // Try to compile the nested <path-list>
-            while (TryCompilePathList(ref lexer, sb, parsingChoice: true, numberRangePairs))
+            while (TryCompilePathList(ref lexer, sb, parsingChoice: true, numberRangePairs, recursionDepth + 1))
             {
                 // If we've successfully compiled a <path-list> the last token should
                 // have been a ',' or a '}'


### PR DESCRIPTION
## Summary

- add a regression test for an EditorConfig section with excessive nested choices
- guard the mutually recursive section-name parser with `StackGuard.EnsureSufficientExecutionStack`
- treat insufficient stack as a malformed section instead of allowing a process-level stack overflow

## Validation

- `dotnet test src/Compilers/Core/CodeAnalysisTest/Microsoft.CodeAnalysis.UnitTests.csproj -f net10.0 --no-restore --filter 'FullyQualifiedName~Microsoft.CodeAnalysis.UnitTests.EditorConfigTests'` (208 passed, 4 skipped)
- `dotnet build src/Compilers/Core/Portable/Microsoft.CodeAnalysis.csproj --no-restore`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84606)