### PR TITLE
Reduce LSP request handling allocations

### DIFF
--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/RequestExecutionQueue.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/RequestExecutionQueue.cs
@@ -78,7 +78,7 @@ internal class RequestExecutionQueue<TRequestContext> : IRequestExecutionQueue<T
 
     /// <summary>
     /// Map of method to the handler info for each language.
-    /// The handler info is created lazily to avoid instantiating any types or handlers until a request is recieved for
+    /// The handler info is created lazily to avoid instantiating any types or handlers until a request is received for
     /// that particular method and language.
     /// </summary>
     private readonly FrozenDictionary<string, FrozenDictionary<string, Lazy<(RequestHandlerMetadata Metadata, IMethodHandler Handler, ProcessQueueCoreAsyncDelegate ProcessQueueCoreAsync)>>> _handlerInfoMap;

--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/RequestExecutionQueue.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/RequestExecutionQueue.cs
@@ -54,6 +54,14 @@ namespace Microsoft.CommonLanguageServerProtocol.Framework;
 /// </remarks>
 internal class RequestExecutionQueue<TRequestContext> : IRequestExecutionQueue<TRequestContext>
 {
+    private delegate Task ProcessQueueCoreAsyncDelegate(
+        QueueItem<TRequestContext> work,
+        IMethodHandler handler,
+        RequestHandlerMetadata metadata,
+        ConcurrentDictionary<Task, CancellationTokenSource> concurrentlyExecutingTasks,
+        CancellationTokenSource? currentWorkCts,
+        CancellationToken cancellationToken);
+
     private static readonly MethodInfo s_processQueueCoreAsync = typeof(RequestExecutionQueue<TRequestContext>)
         .GetMethod(nameof(RequestExecutionQueue<>.ProcessQueueCoreAsync), BindingFlags.NonPublic | BindingFlags.Instance)!;
 
@@ -73,7 +81,7 @@ internal class RequestExecutionQueue<TRequestContext> : IRequestExecutionQueue<T
     /// The handler info is created lazily to avoid instantiating any types or handlers until a request is recieved for
     /// that particular method and language.
     /// </summary>
-    private readonly FrozenDictionary<string, FrozenDictionary<string, Lazy<(RequestHandlerMetadata Metadata, IMethodHandler Handler, MethodInfo MethodInfo)>>> _handlerInfoMap;
+    private readonly FrozenDictionary<string, FrozenDictionary<string, Lazy<(RequestHandlerMetadata Metadata, IMethodHandler Handler, ProcessQueueCoreAsyncDelegate ProcessQueueCoreAsync)>>> _handlerInfoMap;
 
     /// <summary>
     /// For test purposes only.
@@ -91,16 +99,16 @@ internal class RequestExecutionQueue<TRequestContext> : IRequestExecutionQueue<T
         _handlerInfoMap = BuildHandlerMap(handlerProvider, languageServer.TypeRefResolver);
     }
 
-    private static FrozenDictionary<string, FrozenDictionary<string, Lazy<(RequestHandlerMetadata, IMethodHandler, MethodInfo)>>> BuildHandlerMap(AbstractHandlerProvider handlerProvider, AbstractTypeRefResolver typeRefResolver)
+    private FrozenDictionary<string, FrozenDictionary<string, Lazy<(RequestHandlerMetadata, IMethodHandler, ProcessQueueCoreAsyncDelegate)>>> BuildHandlerMap(AbstractHandlerProvider handlerProvider, AbstractTypeRefResolver typeRefResolver)
     {
-        var genericMethodMap = new Dictionary<string, FrozenDictionary<string, Lazy<(RequestHandlerMetadata, IMethodHandler, MethodInfo)>>>();
+        var genericMethodMap = new Dictionary<string, FrozenDictionary<string, Lazy<(RequestHandlerMetadata, IMethodHandler, ProcessQueueCoreAsyncDelegate)>>>();
         var noValueType = NoValue.Instance.GetType();
         // Get unique set of methods from the handler provider for the default language.
         foreach (var methodGroup in handlerProvider
             .GetRegisteredMethods()
             .GroupBy(m => m.MethodName))
         {
-            var languages = new Dictionary<string, Lazy<(RequestHandlerMetadata, IMethodHandler, MethodInfo)>>();
+            var languages = new Dictionary<string, Lazy<(RequestHandlerMetadata, IMethodHandler, ProcessQueueCoreAsyncDelegate)>>();
             foreach (var metadata in methodGroup)
             {
                 languages.Add(metadata.Language, new(() =>
@@ -113,8 +121,9 @@ internal class RequestExecutionQueue<TRequestContext> : IRequestExecutionQueue<T
                             : noValueType;
 
                     var method = s_processQueueCoreAsync.MakeGenericMethod(requestType, responseType);
+                    var processQueueCoreAsync = (ProcessQueueCoreAsyncDelegate)method.CreateDelegate(typeof(ProcessQueueCoreAsyncDelegate), this);
                     var handler = handlerProvider.GetMethodHandler(metadata.MethodName, metadata.RequestTypeRef, metadata.ResponseTypeRef, metadata.Language);
-                    return (metadata, handler, method);
+                    return (metadata, handler, processQueueCoreAsync);
                 }));
             }
 
@@ -262,7 +271,7 @@ internal class RequestExecutionQueue<TRequestContext> : IRequestExecutionQueue<T
                         continue;
                     }
 
-                    var (metadata, handler, methodInfo) = handlerResult;
+                    var (metadata, handler, processQueueCoreAsync) = handlerResult;
 
                     // We had an issue determining the language.  Generally this is very rare and only occurs
                     // when a client sends us requests for files where we haven't saved the languageId.
@@ -285,7 +294,7 @@ internal class RequestExecutionQueue<TRequestContext> : IRequestExecutionQueue<T
                     }
 
                     // We now have the actual handler and language, so we can process the work item using the concrete types defined by the metadata.
-                    await InvokeProcessCoreAsync(work, metadata, handler, methodInfo, concurrentlyExecutingTasks, currentWorkCts, cancellationToken).ConfigureAwait(false);
+                    await processQueueCoreAsync(work, handler, metadata, concurrentlyExecutingTasks, currentWorkCts, cancellationToken).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
                 {
@@ -311,29 +320,6 @@ internal class RequestExecutionQueue<TRequestContext> : IRequestExecutionQueue<T
             await DisposeAsync().ConfigureAwait(false);
             return;
         }
-    }
-
-    /// <summary>
-    /// Reflection invokes <see cref="ProcessQueueCoreAsync{TRequest, TResponse}(QueueItem{TRequestContext}, IMethodHandler, RequestHandlerMetadata, ConcurrentDictionary{Task, CancellationTokenSource}, CancellationTokenSource?, CancellationToken)"/>
-    /// using the concrete types defined by the handler's metadata.
-    /// </summary>
-    private async Task InvokeProcessCoreAsync(
-        QueueItem<TRequestContext> work,
-        RequestHandlerMetadata metadata,
-        IMethodHandler handler,
-        MethodInfo methodInfo,
-        ConcurrentDictionary<Task, CancellationTokenSource> concurrentlyExecutingTasks,
-        CancellationTokenSource? currentWorkCts,
-        CancellationToken cancellationToken)
-    {
-        var result = methodInfo.Invoke(this, [work, handler, metadata, concurrentlyExecutingTasks, currentWorkCts, cancellationToken]);
-        if (result is null)
-        {
-            throw new InvalidOperationException($"ProcessQueueCoreAsync result task cannot be null");
-        }
-
-        var task = (Task)result;
-        await task.ConfigureAwait(false);
     }
 
     /// <summary>
@@ -424,7 +410,7 @@ internal class RequestExecutionQueue<TRequestContext> : IRequestExecutionQueue<T
         return;
     }
 
-    private bool TryGetHandlerForRequest(QueueItem<TRequestContext> work, string language, out (RequestHandlerMetadata Metadata, IMethodHandler Handler, MethodInfo MethodInfo) result)
+    private bool TryGetHandlerForRequest(QueueItem<TRequestContext> work, string language, out (RequestHandlerMetadata Metadata, IMethodHandler Handler, ProcessQueueCoreAsyncDelegate ProcessQueueCoreAsync) result)
     {
         var handlersForMethod = _handlerInfoMap[work.MethodName];
         if (handlersForMethod.TryGetValue(language, out var lazyData) ||

--- a/src/LanguageServer/Protocol/Handler/IDocumentChangeTracker.cs
+++ b/src/LanguageServer/Protocol/Handler/IDocumentChangeTracker.cs
@@ -24,6 +24,12 @@ internal interface IDocumentChangeTracker
 
 internal sealed class NonMutatingDocumentChangeTracker : IDocumentChangeTracker
 {
+    public static readonly NonMutatingDocumentChangeTracker Instance = new();
+
+    private NonMutatingDocumentChangeTracker()
+    {
+    }
+
     public ValueTask StartTrackingAsync(DocumentUri documentUri, SourceText initialText, string languageId, int lspVersion, CancellationToken cancellationToken)
     {
         throw new InvalidOperationException("Mutating documents not allowed in a non-mutating request handler");

--- a/src/LanguageServer/Protocol/Handler/RequestContext.cs
+++ b/src/LanguageServer/Protocol/Handler/RequestContext.cs
@@ -233,7 +233,7 @@ internal readonly struct RequestContext
         CancellationToken cancellationToken)
     {
         var lspWorkspaceManager = lspServices.GetRequiredService<LspWorkspaceManager>();
-        var documentChangeTracker = mutatesSolutionState ? (IDocumentChangeTracker)lspWorkspaceManager : new NonMutatingDocumentChangeTracker();
+        var documentChangeTracker = mutatesSolutionState ? (IDocumentChangeTracker)lspWorkspaceManager : NonMutatingDocumentChangeTracker.Instance;
 
         // Retrieve the current LSP tracked text as of this request.
         // This is safe as all creation of request contexts cannot happen concurrently.

--- a/src/LanguageServer/Protocol/RoslynRequestExecutionQueue.cs
+++ b/src/LanguageServer/Protocol/RoslynRequestExecutionQueue.cs
@@ -41,7 +41,9 @@ internal sealed class RoslynRequestExecutionQueue : RequestExecutionQueue<Reques
     protected internal override void BeforeRequest<TRequest>(TRequest request)
     {
         // Update the locale for this request to the desired LSP locale.
-        CultureInfo.CurrentUICulture = GetCultureForRequest();
+        var culture = GetCultureForRequest();
+        if (!ReferenceEquals(CultureInfo.CurrentUICulture, culture))
+            CultureInfo.CurrentUICulture = culture;
     }
 
     /// <summary>


### PR DESCRIPTION
Cache typed request dispatch delegates, reuse the stateless non-mutating document tracker, and avoid redundant UI culture assignments.

Reduces per-request LSP allocations by ~300 bytes:
Per request | 8,202 B | 7,897 B | −304 B
-- | -- | -- | --

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84623)