### PR TITLE
Preserve line breaks after collapsed Razor blocks

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/FoldingRanges/AbstractSyntaxNodeFoldingProvider.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/FoldingRanges/AbstractSyntaxNodeFoldingProvider.cs
@@ -22,6 +22,15 @@ internal abstract class AbstractSyntaxNodeFoldingProvider<TNode> : IRazorFolding
         foreach (var node in nodes)
         {
             var (start, end) = sourceText.GetLinePositionSpan(node.Span);
+
+            // Razor nodes can include the line break after their closing brace. Folding that line break
+            // pulls the following content onto the collapsed line.
+            if (end.Character == 0 && end.Line > start.Line)
+            {
+                var previousLine = sourceText.Lines[end.Line - 1];
+                end = new(end.Line - 1, previousLine.Span.Length);
+            }
+
             var foldingRange = new FoldingRange()
             {
                 StartCharacter = start.Character,

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostFoldingRangeEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostFoldingRangeEndpointTest.cs
@@ -27,15 +27,15 @@ public class CohostFoldingRangeEndpointTest(ITestOutputHelper testOutputHelper) 
                 <div>
                   Hello World
                 </div>
-              }
-            |]</div>
+              }|]
+            </div>
 
             @if (true) {[|
               <div>
                 Hello World
               </div>
-            }
-            |]
+            }|]
+
             @if (true) {[|
             }|]
             """,
@@ -52,19 +52,34 @@ public class CohostFoldingRangeEndpointTest(ITestOutputHelper testOutputHelper) 
                 <div>
                   Hello World
                 </div>
-              }
-            |]</div>
+              }|]
+            </div>
 
             @if (true) {[|
               <div>
                 Hello World
               </div>
-            }
-            |]
+            }|]
+
             @if (true) {[|
             }|]
             """,
             miscellaneousFile: miscellaneousFile);
+
+    [Fact]
+    public Task IfStatements_Adjacent()
+        => VerifyFoldingRangesAsync("""
+            @if (true) {[|
+              <div>
+                Hello World
+              </div>
+            }|]
+            @if (false) {[|
+              <div>
+                Goodbye World
+              </div>
+            }|]
+            """);
 
     [Fact]
     public Task LockStatement()
@@ -92,8 +107,7 @@ public class CohostFoldingRangeEndpointTest(ITestOutputHelper testOutputHelper) 
                 <div>
                     Goodbye World
                 </div>
-                }|]
-            |]  }
+                }|]|]
             </div>
             """);
 
@@ -285,8 +299,7 @@ public class CohostFoldingRangeEndpointTest(ITestOutputHelper testOutputHelper) 
                 <div>
                     Goodbye World
                 </div>
-            |]    }
-            |]  }
+            |]    }|]
             </div>
 
             @code[|

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/CodeFoldingTests.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/CodeFoldingTests.cs
@@ -178,7 +178,7 @@ public class CodeFoldingTests(ITestOutputHelper testOutputHelper) : AbstractRazo
             """);
     }
 
-    [IdeFact(Skip = "https://github.com/dotnet/razor/issues/10860")] // FUSE changes whitespace on folding ranges
+    [IdeFact]
     public async Task CodeFolding_IfBlock()
     {
         await TestServices.SolutionExplorer.AddFileAsync(


### PR DESCRIPTION
Fixes #84617
Fixes dotnet/razor#10860

This broke with FUSE, and we logged the Razor issue to follow up, but I think we weren't sure what the "right" behaviour was. Well, the users have decided and for folding ranges at least, our current behaviour is wrong. So this fixes that. Sadly its really hard to see in tests that the current behaviour was ugly.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84630)