### PR TITLE
Honour C# new line settings in Razor auto insert

### DIFF
--- a/src/LanguageServer/Protocol/Handler/OnAutoInsert/OnAutoInsertHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/OnAutoInsert/OnAutoInsertHandler.cs
@@ -62,7 +62,10 @@ internal sealed class OnAutoInsertHandler(
         // We want adjust the braces after enter for non-VS clients.
         // We don't do this via on type formatting as it does not support snippets.
         var includeNewLineBraceFormatting = !supportsVSExtensions;
-        return await GetOnAutoInsertResponseAsync(_globalOptions, servicesForDocument, document, position, request.Character, request.Options, includeNewLineBraceFormatting, cancellationToken).ConfigureAwait(false);
+
+        // We should use the options passed in by LSP instead of the document's options.
+        var formattingOptions = await ProtocolConversions.GetFormattingOptionsAsync(request.Options, document, cancellationToken).ConfigureAwait(false);
+        return await GetOnAutoInsertResponseAsync(_globalOptions, servicesForDocument, document, position, request.Character, formattingOptions, includeNewLineBraceFormatting, cancellationToken).ConfigureAwait(false);
     }
 
     internal static async Task<LSP.VSInternalDocumentOnAutoInsertResponseItem?> GetOnAutoInsertResponseAsync(
@@ -71,14 +74,11 @@ internal sealed class OnAutoInsertHandler(
         Document document,
         LinePosition linePosition,
         string character,
-        LSP.FormattingOptions lspFormattingOptions,
+        SyntaxFormattingOptions formattingOptions,
         bool includeNewLineBraceFormatting,
         CancellationToken cancellationToken)
     {
         var service = document.GetRequiredLanguageService<IDocumentationCommentSnippetService>();
-
-        // We should use the options passed in by LSP instead of the document's options.
-        var formattingOptions = await ProtocolConversions.GetFormattingOptionsAsync(lspFormattingOptions, document, cancellationToken).ConfigureAwait(false);
 
         // The editor calls this handler for C# and VB comment characters, but we only need to process the one for the language that matches the document
         if (character == "\n" || character == service.DocumentationCommentCharacter)

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/OnAutoInsert/CohostOnAutoInsertEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/OnAutoInsert/CohostOnAutoInsertEndpoint.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Microsoft.CodeAnalysis.Razor.CohostingShared;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CodeAnalysis.Razor.AutoInsert;
@@ -86,12 +87,33 @@ internal sealed class CohostOnAutoInsertEndpoint(
     protected override TextDocumentIdentifier? GetRazorTextDocumentIdentifier(VSInternalDocumentOnAutoInsertParams request)
         => request.TextDocument;
 
-    protected override async Task<VSInternalDocumentOnAutoInsertResponseItem?> HandleRequestAsync(VSInternalDocumentOnAutoInsertParams request, TextDocument razorDocument, CancellationToken cancellationToken)
+    protected override Task<VSInternalDocumentOnAutoInsertResponseItem?> HandleRequestAsync(VSInternalDocumentOnAutoInsertParams request, TextDocument razorDocument, CancellationToken cancellationToken)
+    {
+        var csharpSyntaxFormattingOptions = CSharpFormatter.GetCSharpSyntaxFormattingOptions(razorDocument.Project.Solution.Services, csharpSyntaxFormattingOptions: null);
+        return HandleRequestAsync(request, razorDocument, csharpSyntaxFormattingOptions, cancellationToken);
+    }
+
+    private async Task<VSInternalDocumentOnAutoInsertResponseItem?> HandleRequestAsync(
+        VSInternalDocumentOnAutoInsertParams request,
+        TextDocument razorDocument,
+        CSharpSyntaxFormattingOptions csharpSyntaxFormattingOptions,
+        CancellationToken cancellationToken)
     {
         _logger.LogDebug($"Resolving auto-insertion for {razorDocument.FilePath}");
 
         var clientSettings = _clientSettingsManager.GetClientSettings();
-        var razorFormattingOptions = RazorFormattingOptions.From(request.Options, codeBlockBraceOnNextLine: clientSettings.AdvancedSettings.CodeBlockBraceOnNextLine, attributeIndentStyle: clientSettings.AdvancedSettings.AttributeIndentStyle);
+        var razorFormattingOptions = RazorFormattingOptions.From(
+            request.Options,
+            codeBlockBraceOnNextLine: clientSettings.AdvancedSettings.CodeBlockBraceOnNextLine,
+            attributeIndentStyle: clientSettings.AdvancedSettings.AttributeIndentStyle,
+            csharpSyntaxFormattingOptions);
+        var resolvedCSharpSyntaxFormattingOptions = CSharpFormatter.GetResolvedCSharpSyntaxFormattingOptions(
+            razorDocument.Project.Solution.Services,
+            razorFormattingOptions);
+        razorFormattingOptions = razorFormattingOptions with
+        {
+            CSharpSyntaxFormattingOptions = resolvedCSharpSyntaxFormattingOptions
+        };
 
         _logger.LogDebug($"Calling OOP to resolve insertion at {request.Position} invoked by typing '{request.Character}'");
         var data = await _remoteServiceInvoker.TryInvokeAsync<IRemoteAutoInsertService, Response>(
@@ -163,7 +185,8 @@ internal sealed class CohostOnAutoInsertEndpoint(
         public Task<VSInternalDocumentOnAutoInsertResponseItem?> HandleRequestAsync(
             VSInternalDocumentOnAutoInsertParams request,
             TextDocument razorDocument,
+            CSharpSyntaxFormattingOptions csharpSyntaxFormattingOptions,
             CancellationToken cancellationToken)
-                => instance.HandleRequestAsync(request, razorDocument, cancellationToken);
+                => instance.HandleRequestAsync(request, razorDocument, csharpSyntaxFormattingOptions, cancellationToken);
     }
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/AutoInsert/RemoteAutoInsertService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/AutoInsert/RemoteAutoInsertService.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.BraceCompletion;
@@ -150,6 +151,8 @@ internal sealed class RemoteAutoInsertService(in ServiceArgs args)
             .SelectAsArray(
                 predicate: s => s.Metadata.Language == LanguageNames.CSharp,
                 selector: s => s.Value);
+        var csharpSyntaxFormattingOptions = options.CSharpSyntaxFormattingOptions
+            ?? throw new InvalidOperationException("C# syntax formatting options were not provided for auto insert.");
 
         var autoInsertResponseItem = await OnAutoInsertHandler.GetOnAutoInsertResponseAsync(
             globalOptions,
@@ -157,7 +160,7 @@ internal sealed class RemoteAutoInsertService(in ServiceArgs args)
             generatedDocument,
             mappedPosition,
             character,
-            options.ToLspFormattingOptions(),
+            csharpSyntaxFormattingOptions,
             includeNewLineBraceFormatting: true,
             cancellationToken
         ).ConfigureAwait(false);

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostOnAutoInsertEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostOnAutoInsertEndpointTest.cs
@@ -527,6 +527,184 @@ public class CohostOnAutoInsertEndpointTest(ITestOutputHelper testOutputHelper) 
     }
 
     [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/12703")]
+    public async Task CSharp_OnEnter_KAndRBraces_NestedType()
+    {
+        await VerifyOnAutoInsertAsync(
+            input: """
+                @code {
+                    private class C {
+                $$}
+                }
+                """,
+            output: """
+                @code {
+                    private class C {
+                        $0
+                    }
+                }
+                """,
+            triggerCharacter: "\n",
+            csharpSyntaxFormattingOptions: CSharpSyntaxFormattingOptions.Default with
+            {
+                NewLines = default
+            });
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/12703")]
+    public async Task CSharp_OnEnter_KAndRBraces_Method()
+    {
+        await VerifyCSharpOnEnterKAndRBracesAsync(
+            input: """
+                @code {
+                    private void M() {
+                $$}
+                }
+                """,
+            output: """
+                @code {
+                    private void M() {
+                        $0
+                    }
+                }
+                """,
+            NewLinePlacement.BeforeOpenBraceInMethods);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/12703")]
+    public async Task CSharp_OnEnter_KAndRBraces_Property()
+    {
+        await VerifyCSharpOnEnterKAndRBracesAsync(
+            input: """
+                @code {
+                    private int P {
+                $$}
+                }
+                """,
+            output: """
+                @code {
+                    private int P {
+                        $0
+                    }
+                }
+                """,
+            NewLinePlacement.BeforeOpenBraceInProperties);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/12703")]
+    public async Task CSharp_OnEnter_KAndRBraces_Accessor()
+    {
+        await VerifyCSharpOnEnterKAndRBracesAsync(
+            input: """
+                @code {
+                    private int P
+                    {
+                        get {
+                $$}
+                    }
+                }
+                """,
+            output: """
+                @code {
+                    private int P
+                    {
+                        get {
+                            $0
+                        }
+                    }
+                }
+                """,
+            NewLinePlacement.BeforeOpenBraceInAccessors);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/12703")]
+    public async Task CSharp_OnEnter_KAndRBraces_Lambda()
+    {
+        await VerifyCSharpOnEnterKAndRBracesAsync(
+            input: """
+                @code {
+                    private System.Action A = () => {
+                $$};
+                }
+                """,
+            output: """
+                @code {
+                    private System.Action A = () => {
+                        $0
+                    };
+                }
+                """,
+            NewLinePlacement.BeforeOpenBraceInLambdaExpressionBody);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/12703")]
+    public async Task CSharp_OnEnter_KAndRBraces_AnonymousMethod()
+    {
+        await VerifyCSharpOnEnterKAndRBracesAsync(
+            input: """
+                @code {
+                    private System.Action A = delegate {
+                $$};
+                }
+                """,
+            output: """
+                @code {
+                    private System.Action A = delegate {
+                        $0
+                    };
+                }
+                """,
+            NewLinePlacement.BeforeOpenBraceInAnonymousMethods);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/12703")]
+    public async Task CSharp_OnEnter_KAndRBraces_ObjectInitializer()
+    {
+        await VerifyCSharpOnEnterKAndRBracesAsync(
+            input: """
+                @code {
+                    private object O = new object {
+                $$};
+                }
+                """,
+            output: """
+                @code {
+                    private object O = new object {
+                        $0
+                    };
+                }
+                """,
+            NewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/12703")]
+    public async Task CSharp_OnEnter_KAndRBraces_AnonymousType()
+    {
+        await VerifyCSharpOnEnterKAndRBracesAsync(
+            input: """
+                @code {
+                    private object O = new {
+                $$};
+                }
+                """,
+            output: """
+                @code {
+                    private object O = new {
+                        $0
+                    };
+                }
+                """,
+            NewLinePlacement.BeforeOpenBraceInAnonymousTypes);
+    }
+
+    [Fact]
     public async Task CSharp_OnEnter_TwoSpaceIndent()
     {
         await VerifyOnAutoInsertAsync(

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostOnAutoInsertEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostOnAutoInsertEndpointTest.cs
@@ -4,6 +4,7 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.Razor.AutoInsert;
 using Microsoft.CodeAnalysis.Razor.Settings;
@@ -505,6 +506,27 @@ public class CohostOnAutoInsertEndpointTest(ITestOutputHelper testOutputHelper) 
     }
 
     [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/12703")]
+    public async Task CSharp_OnEnter_KAndRBraces_ControlBlock()
+    {
+        await VerifyCSharpOnEnterKAndRBracesAsync(
+            input: """
+                @{
+                    if (true) {
+                $$}
+                }
+                """,
+            output: """
+                @{
+                    if (true) {
+                        $0
+                    }
+                }
+                """,
+            NewLinePlacement.BeforeOpenBraceInControlBlocks);
+    }
+
+    [Fact]
     public async Task CSharp_OnEnter_TwoSpaceIndent()
     {
         await VerifyOnAutoInsertAsync(
@@ -549,6 +571,19 @@ public class CohostOnAutoInsertEndpointTest(ITestOutputHelper testOutputHelper) 
             insertSpaces: false);
     }
 
+    private Task VerifyCSharpOnEnterKAndRBracesAsync(
+        TestCode input,
+        string output,
+        NewLinePlacement newLinePlacement)
+        => VerifyOnAutoInsertAsync(
+            input,
+            output,
+            triggerCharacter: "\n",
+            csharpSyntaxFormattingOptions: CSharpSyntaxFormattingOptions.Default with
+            {
+                NewLines = CSharpSyntaxFormattingOptions.Default.NewLines & ~newLinePlacement
+            });
+
     private async Task VerifyOnAutoInsertAsync(
         TestCode input,
         string? output,
@@ -558,9 +593,11 @@ public class CohostOnAutoInsertEndpointTest(ITestOutputHelper testOutputHelper) 
         int tabSize = 4,
         bool formatOnType = true,
         bool autoClosingTags = true,
-        RazorFileKind? fileKind = null)
+        RazorFileKind? fileKind = null,
+        CSharpSyntaxFormattingOptions? csharpSyntaxFormattingOptions = null)
     {
         fileKind ??= RazorFileKind.Component;
+        csharpSyntaxFormattingOptions ??= CSharpSyntaxFormattingOptions.Default;
         var document = CreateProjectAndRazorDocument(input.Text, fileKind: fileKind);
         var sourceText = await document.GetTextAsync(DisposalToken);
 
@@ -609,7 +646,7 @@ public class CohostOnAutoInsertEndpointTest(ITestOutputHelper testOutputHelper) 
             Options = formattingOptions
         };
 
-        var result = await endpoint.GetTestAccessor().HandleRequestAsync(request, document, DisposalToken);
+        var result = await endpoint.GetTestAccessor().HandleRequestAsync(request, document, csharpSyntaxFormattingOptions, DisposalToken);
 
         if (output is not null)
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/12703

Just copying the approach we use in formatting, to override the C# formatting options that Roslyn would use (which are default for generated documents) with the ones we pull from the project.

As a follow up, I think this can all be cleaned up a little, as the "override" options aren't optional any more, with cohosting being the only entry point, but that's best left for another PR, and probably after Sonic merges. This will cause a conflict anyway, but it should be a simple enough one hopefully.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84632)