### PR TITLE
Free `ArrayBuilder` in a `Finally` section to prevent a pool leak

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.vb
@@ -666,36 +666,39 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                 Dim methodHandleToSymbol As Dictionary(Of MethodDefinitionHandle, PEMethodSymbol) = CreateMethods()
                 Dim members = ArrayBuilder(Of Symbol).GetInstance()
 
-                Dim ensureParameterlessConstructor As Boolean = (TypeKind = TypeKind.Structure OrElse TypeKind = TypeKind.Enum) AndAlso Not IsShared
+                Dim withEventNames As HashSet(Of String) = Nothing
+                Dim membersDict As Dictionary(Of String, ImmutableArray(Of Symbol))
 
-                For Each member In methodHandleToSymbol.Values
-                    members.Add(member)
+                Try
+                    Dim ensureParameterlessConstructor As Boolean = (TypeKind = TypeKind.Structure OrElse TypeKind = TypeKind.Enum) AndAlso Not IsShared
+
+                    For Each member In methodHandleToSymbol.Values
+                        members.Add(member)
+
+                        If ensureParameterlessConstructor Then
+                            ensureParameterlessConstructor = Not member.IsParameterlessConstructor()
+                        End If
+                    Next
 
                     If ensureParameterlessConstructor Then
-                        ensureParameterlessConstructor = Not member.IsParameterlessConstructor()
+                        members.Add(New SynthesizedConstructorSymbol(Nothing, Me, Me.IsShared, False, Nothing, Nothing))
                     End If
-                Next
 
-                If ensureParameterlessConstructor Then
-                    members.Add(New SynthesizedConstructorSymbol(Nothing, Me, Me.IsShared, False, Nothing, Nothing))
-                End If
+                    CreateProperties(methodHandleToSymbol, members)
+                    ' CreateFields will add withEvent names here if there are any.
+                    ' Otherwise stays Nothing
+                    CreateFields(members, withEventNames)
+                    CreateEvents(methodHandleToSymbol, members)
 
-                ' CreateFields will add withEvent names here if there are any.
-                ' Otherwise stays Nothing
-                Dim withEventNames As HashSet(Of String) = Nothing
+                    membersDict = New Dictionary(Of String, ImmutableArray(Of Symbol))(CaseInsensitiveComparison.Comparer)
+                    Dim groupedMembers = members.GroupBy(Function(m) m.Name, CaseInsensitiveComparison.Comparer)
 
-                CreateProperties(methodHandleToSymbol, members)
-                CreateFields(members, withEventNames)
-                CreateEvents(methodHandleToSymbol, members)
-
-                Dim membersDict As New Dictionary(Of String, ImmutableArray(Of Symbol))(CaseInsensitiveComparison.Comparer)
-                Dim groupedMembers = members.GroupBy(Function(m) m.Name, CaseInsensitiveComparison.Comparer)
-
-                For Each g In groupedMembers
-                    membersDict.Add(g.Key, ImmutableArray.CreateRange(g))
-                Next
-
-                members.Free()
+                    For Each g In groupedMembers
+                        membersDict.Add(g.Key, ImmutableArray.CreateRange(g))
+                    Next
+                Finally
+                    members.Free()
+                End Try
 
                 ' tell WithEvents properties that they are WithEvents properties
                 If withEventNames IsNot Nothing Then


### PR DESCRIPTION
In my other PR I got an [interesting CI failure](https://github.com/dotnet/roslyn/runs/89833312950):
```
Pool leak detected! The following pooled objects were not returned:
  Microsoft.CodeAnalysis.PooledObjects.ArrayBuilder`1[Microsoft.CodeAnalysis.VisualBasic.Symbol] (from ArrayBuilder.cs:508) (allocated at PENamedTypeSymbol.vb:667): 1
```

Since that PR didn't touch anything on the VB side at all, I guess this is some kind of a rare issue. It won't hurt if we put `Free` call into a `Finally` section to prevent this in the future
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84644)